### PR TITLE
Add possibility to pass array of nodes to Animated.code and nativeEvent

### DIFF
--- a/Example/PanRotateAndZoom/index.js
+++ b/Example/PanRotateAndZoom/index.js
@@ -24,15 +24,16 @@ export default class Example extends Component {
 
     this.handlePan = event([
       {
-        nativeEvent: ({ translationX: x, translationY: y, state }) =>
+        nativeEvent: ({ translationX: x, translationY: y, state }) => [
           block([
             set(this.X, add(x, offsetX)),
-            set(this.Y, add(y, offsetY)),
-            cond(eq(state, State.END), [
-              set(offsetX, add(offsetX, x)),
-              set(offsetY, add(offsetY, y)),
-            ]),
+            cond(eq(state, State.END), set(offsetX, add(offsetX, x))),
           ]),
+          block([
+            set(this.Y, add(y, offsetY)),
+            cond(eq(state, State.END), set(offsetY, add(offsetY, y))),
+          ]),
+        ],
       },
     ]);
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ block([
 
 ## Event handling with reanimated nodes
 
-With reanimated new syntax is possible to be used with `Animated.event`. Instead of providing only a mapping from event fields to animated nodes it is allowed to write a function that takes reanimated values map as an input and returns a block (or any other reanimated function) that will be then used to handle the event.
+With reanimated new syntax is possible to be used with `Animated.event`. Instead of providing only a mapping from event fields to animated nodes it is allowed to write a function that takes reanimated values map as an input and returns a block or any other reanimated function (on even array of them) that will be then used to handle the event.
 
 This syntax allows for providing some post-processing for the event data that does not fit well as a dependency of other nodes we connect to `Animated.View` component props.
 [See example](https://github.com/kmagiera/react-native-reanimated/blob/master/Example/movable/index.js)
@@ -185,10 +185,16 @@ If you'd like to use more than one event attribute in your reanimated code it is
   onGestureEvent={event([
     {
       nativeEvent: ({ translationX: x, translationY: y, state }) =>
-        block([
-          set(this._transX, add(x, offsetX)), set(this._transY, add(y, offsetY)),
-          cond(eq(state, State.END), [set(this.offsetX, add(this.offsetX, x)), set(this.offsetY, add(this.offsetY, y))]),
-        ]),
+        [
+          block([
+            set(this.X, add(x, offsetX)),
+            cond(eq(state, State.END), set(offsetX, add(offsetX, x))),
+          ]),
+          block([
+            set(this.Y, add(y, offsetY)),
+            cond(eq(state, State.END), set(offsetY, add(offsetY, y))),
+          ])
+        ],
     },
   ])}
 >

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -137,9 +137,12 @@ declare module 'react-native-reanimated' {
         : P[K] | AnimatedNode<P[K]>
     };
 
+    type SingleCode = AnimatedNode<any> | ((...args: any[]) => AnimatedNode<any>);
+    type SingleCodeWrapped = ReadonlyArray<SingleCode> | SingleCode;
+
     type CodeProps = {
-      exec?: AnimatedNode<number>
-      children?: () => AnimatedNode<number>
+      exec?: (...args: any[]) => SingleCodeWrapped | SingleCodeWrapped
+      children?: (...args: any[]) => SingleCodeWrapped | SingleCodeWrapped
     };
 
     // components

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -2,15 +2,21 @@ import React from 'react';
 import AnimatedAlways from './AnimatedAlways';
 
 class Code extends React.Component {
+  evaluateIfNeeded = node => (typeof node === 'function' ? node() : node);
+  alwaysNodes = [];
+  always = node => new AnimatedAlways(this.evaluateIfNeeded(node));
   componentDidMount() {
-    this.always = new AnimatedAlways(
-      this.props.exec ? this.props.exec : this.props.children()
+    const nodes = this.evaluateIfNeeded(
+      this.props.exec ? this.props.exec : this.props.children
     );
-    this.always.__attach();
+    this.alwaysNodes = Array.isArray(nodes)
+      ? nodes.map(this.always)
+      : [this.always(nodes)];
+    this.alwaysNodes.forEach(n => n.__attach);
   }
 
   componentWillUnmount() {
-    this.always.__detach();
+    this.alwaysNodes.forEach(n => n.__detach());
   }
 
   render() {

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -63,6 +63,7 @@ function sanitizeArgMapping(argMapping) {
         : createEventObjectProxyPolyfill();
 
     const result = ev(proxy);
+    // result could be either array of node or single node.
     if (Array.isArray(result)) {
       alwaysNodes.push(...result.map(e => new AnimatedAlways(e)));
     } else {

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -52,7 +52,7 @@ function sanitizeArgMapping(argMapping) {
     'Native driven events only support animated values contained inside `nativeEvent`.'
   );
 
-  // Assume that the event containing `nativeEvent` is always the first argument
+  // Assume that the event containing `nativeEvent` is always the first argument.
   const ev = argMapping[0].nativeEvent;
   if (typeof ev === 'object') {
     traverse(ev, []);

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -62,11 +62,11 @@ function sanitizeArgMapping(argMapping) {
         ? new Proxy({}, proxyHandler)
         : createEventObjectProxyPolyfill();
 
-    const functionResult = ev(proxy);
-    if (Array.isArray(functionResult)) {
-      alwaysNodes.push(...functionResult.map(e => new AnimatedAlways(e)));
+    const result = ev(proxy);
+    if (Array.isArray(result)) {
+      alwaysNodes.push(...result.map(e => new AnimatedAlways(e)));
     } else {
-      alwaysNodes.push(new AnimatedAlways(functionResult));
+      alwaysNodes.push(new AnimatedAlways(result));
     }
     traverse(proxy, []);
   }


### PR DESCRIPTION
## Motivation 
Being inspired by https://github.com/kmagiera/react-native-reanimated/issues/144 I noticed a minor problem in `nativeEvent` and `Animated.Code` code.
It's allowed to pass only one animated node to them (since `block` is just a single node as well). Then if there's some change in value of even one `inputNode` of any of block's children, we has to calculate each block's children once more even if there's any change in single node's input, which could give some sive effects.

## Changes

The solution is to add possibility to attach one `Animated.Code` or `nativeEvent` to more than one `alwaysNode` which are responsible for forcing evaluation of their children. In this PR array passes to `Animated.Code` or `nativeEvent` creates `always` nodes for each element. However, it does not affect on old logic and single node passed gives one `always` node. 

I also modified example app and readme in order to inform about this change.


## Make `Animated.Code` more flexible
This is a minor feature, but from not very clear reasons in current logic child of `Animated.Code` has to be a function and `exec` prop has to be a node. It's no a big deal to make it more flexible and allow children for being node and `exec` to a function as well just with simple check.  