### PR TITLE
Fixes transitioning API delay when delayMs is not set

### DIFF
--- a/ios/Transitioning/REATransitionAnimation.m
+++ b/ios/Transitioning/REATransitionAnimation.m
@@ -42,6 +42,11 @@ CGFloat SimAnimationDragCoefficient()
 
 - (void)play
 {
+  /*
+  CACurrentMediaTime introduces some kind of delay  even if _delay is set to 0
+  it calls mach_absolute_time() which is based on the last time the device booted
+  which might cause the delay
+  */
   if (_delay > 0){
     _animation.beginTime = CACurrentMediaTime() + _delay * SimAnimationDragCoefficient();
   }

--- a/ios/Transitioning/REATransitionAnimation.m
+++ b/ios/Transitioning/REATransitionAnimation.m
@@ -42,8 +42,10 @@ CGFloat SimAnimationDragCoefficient()
 
 - (void)play
 {
+  if (_delay > 0){
+    _animation.beginTime = CACurrentMediaTime() + _delay * SimAnimationDragCoefficient();
+  }
   _animation.duration = self.duration * SimAnimationDragCoefficient();
-  _animation.beginTime = CACurrentMediaTime() + _delay * SimAnimationDragCoefficient();
   [_layer addAnimation:_animation forKey:_keyPath];
 }
 

--- a/src/animations/backwardCompatibleAnimWrapper.js
+++ b/src/animations/backwardCompatibleAnimWrapper.js
@@ -8,7 +8,7 @@ import {
   startClock,
   stopClock,
 } from '../base';
-import { clock as Clock } from '../core/AnimatedClock';
+import { default as Clock } from '../core/AnimatedClock';
 import { evaluateOnce } from '../derived/evaluateOnce';
 
 function createOldAnimationObject(node, AnimationClass, value, config) {


### PR DESCRIPTION
After implamenting "Slow Transitions" feature an issue was introduced with Transitioning API as you can see here https://github.com/tomasgcs/react-native-reanimated/commit/4ef8b81df3f8981cb1dbd9ef0b7867165f2236c0#diff-a7ea5763fc80cde0b741dca6a5095a18R46

Previously `beginTime` variable was not set at all which was equal to 0, but after this specific line was added the value is different, and it causes animations to delay even if `delayMs` value is not set, this happens only when animation is is being executed multiple times.

Not sure why this is happening but most likely that `CACurrentMediaTime()` introduces delay even if it takes current time. In my case it is very important to run animations as fast as possible so I've sumbitted a fix here.