### PR TITLE
Fix Android Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,27 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+buildscript {
+    if (project == rootProject) {
+        // The Android Gradle plugin is only required when opening the android folder stand-alone.
+        // This avoids unnecessary downloads and potential conflicts when the library is included as a
+        // module dependency in an application project.
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.2'
+        }
+    }
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
@@ -20,17 +35,22 @@ android {
 }
 
 repositories {
+    mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        // Matches the RN Hello World template
-        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
-        url "$projectDir/../node_modules/react-native/android"
+        url "$rootDir/../node_modules/react-native/android"
     }
-    mavenCentral()
+    maven {
+        // Android JSC is installed from npm
+        url "$rootDir/../node_modules/jsc-android/dist"
+    }
+    google()
+    jcenter()
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "androidx.transition:transition:1.1.0"
 }
 


### PR DESCRIPTION
Trying to open or build the `android/` folder was not possible, due to a missing `buildscript` block:

```
ERROR: Plugin with id 'com.android.library' not found.
```

After adding the reference to the source of the `library` plugin, the following error showed up:

```
ERROR: Failed to resolve: androidx.transition:transition:1.1.0
```

This was caused by missing entries in the `repositories` block. Added the necessary references to resolve the errors.

It is now possible to individually open and build the `android/` folder in Android Studio (or build it on command line, after generating a Gradle wrapper).

Note that these changes will not affect consumer (app) projects - The Android Gradle plugin is included _conditionally_, meaning the dependency classpath _only_ gets added when the project is opened standalone. This is better than simply removing it (as seen in #148)