### PR TITLE
Feature: Add support for JS node

### DIFF
--- a/Example/test/index.js
+++ b/Example/test/index.js
@@ -167,7 +167,7 @@ export default class Example extends Component {
         {Array.from(Array(40)).map((_, i) => (
           <Animated.View
             key={i}
-            style={[styles.box, { transform: [{ translateX: this.t[i] }] }]}
+            style={[styles.box, { transform: [{ translateX: Animated.js("function(t){return t*0.25}",this.t[i] ) }] }]}
           />
         ))}
       </View>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "androidx.transition:transition:1.1.0"
+    implementation 'com.eclipsesource.j2v8:j2v8_android:3.0.5@aar'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -2,6 +2,7 @@ package com.swmansion.reanimated;
 
 import android.util.SparseArray;
 
+import com.eclipsesource.v8.V8;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.GuardedRunnable;
@@ -78,6 +79,7 @@ public class NodesManager implements EventDispatcherListener {
 
   public double currentFrameTimeMs;
   public final UpdateContext updateContext;
+  public final V8 jsRuntime;
   public Set<String> uiProps = Collections.emptySet();
   public Set<String> nativeProps = Collections.emptySet();
 
@@ -108,6 +110,8 @@ public class NodesManager implements EventDispatcherListener {
         onAnimationFrame(frameTimeNanos);
       }
     };
+
+    jsRuntime = V8.createV8Runtime();
 
     mNoopNode = new NoopNode(this);
   }
@@ -273,6 +277,8 @@ public class NodesManager implements EventDispatcherListener {
       node = new FunctionNode(nodeID, config, this);
     } else if ("callfunc".equals(type)) {
       node = new CallFuncNode(nodeID, config, this);
+    } else if ("jsfunc".equals(type)) {
+      node = new JSNode(nodeID, config, this);
     } else {
       throw new JSApplicationIllegalArgumentException("Unsupported node type: " + type);
     }

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -41,6 +41,7 @@ import com.swmansion.reanimated.nodes.ValueNode;
 import com.swmansion.reanimated.nodes.ParamNode;
 import com.swmansion.reanimated.nodes.FunctionNode;
 import com.swmansion.reanimated.nodes.CallFuncNode;
+import com.swmansion.reanimated.nodes.JSNode;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/android/src/main/java/com/swmansion/reanimated/nodes/JSNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/JSNode.java
@@ -1,0 +1,38 @@
+package com.swmansion.reanimated.nodes;
+
+import android.util.Log;
+
+import com.eclipsesource.v8.V8Array;
+import com.eclipsesource.v8.V8Object;
+import com.facebook.react.bridge.ReadableMap;
+import com.swmansion.reanimated.NodesManager;
+import com.swmansion.reanimated.Utils;
+
+public class JSNode extends Node {
+
+    private final String mCode;
+    private final int[] mArgs;
+    private final String mFuncName;
+
+    public JSNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
+        super(nodeID, config, nodesManager);
+        mCode = config.getString("code");
+        mArgs = Utils.processIntArray(config.getArray("args"));
+        mFuncName = "update" + nodeID;
+        nodesManager.jsRuntime.executeVoidScript("var " + mFuncName + " = " + mCode);
+    }
+
+    @Override
+    protected Object evaluate() {
+
+        V8Array args = new V8Array(mNodesManager.jsRuntime);
+        for (int i = 0; i < mArgs.length; i++) {
+            int argId = mArgs[i];
+            Node argNode = mNodesManager.findNodeById(argId, Node.class);
+            Object val = argNode.value();
+            args.push((Double)val);
+        }
+        Double v = mNodesManager.jsRuntime.executeDoubleFunction(mFuncName, args);
+        return v;
+    }
+}

--- a/ios/Nodes/REAJSNode.h
+++ b/ios/Nodes/REAJSNode.h
@@ -1,0 +1,6 @@
+#import "REANode.h"
+
+@interface REAJSNode : REANode
+
+@end
+

--- a/ios/Nodes/REAJSNode.m
+++ b/ios/Nodes/REAJSNode.m
@@ -1,0 +1,46 @@
+#import "REAJSNode.h"
+#import "RCTConvert.h"
+#import "REANodesManager.h"
+
+@implementation REAJSNode {
+  NSString *_jsCode;
+  NSArray<NSNumber *> *_args;
+  JSContext *_context;
+  JSValue *_funcPtr;
+}
+
+- (instancetype)initWithID:(REANodeID)nodeID config:(NSDictionary<NSString *,id> *)config
+{
+  if ((self = [super initWithID:nodeID config:config])) {
+    _jsCode = config[@"code"];
+    _args = config[@"args"];
+  }
+  return self;
+}
+
+- (void)setupJSFunc  {
+  NSString *_funcName = [NSString stringWithFormat:@"nodeFunc%@", self.nodeID];
+  NSString *_function = [NSString stringWithFormat:@"var %@ = %@", _funcName, _jsCode];
+  [self.nodesManager.jsContext evaluateScript:_function];
+  _funcPtr = self.nodesManager.jsContext[_funcName];
+  if(self.nodesManager.jsContext.exception) {
+    RCTLogError(@"Error in JS node function: %@", self.nodesManager.jsContext.exception);
+  }
+}
+
+- (id)evaluate
+{
+  if(!_funcPtr) {
+    [self setupJSFunc];
+  }
+  NSMutableArray<NSNumber*>* array = [[NSMutableArray alloc] init];
+  for (NSUInteger i = 0; i < _args.count; i++) {
+    NSNumber *argsId = [_args objectAtIndex:i];
+    REANode *argNode = (REANode *)[self.nodesManager findNodeByID:argsId];
+    [array addObject:argNode.value];
+  }
+  NSNumber* num = [[_funcPtr callWithArguments:array] toNumber];
+  return num;
+}
+
+@end

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -19,6 +19,8 @@ typedef void (^REANativeAnimationOp)(RCTUIManager *uiManager);
 @property (nonatomic, nullable) NSSet<NSString *> *uiProps;
 @property (nonatomic, nullable) NSSet<NSString *> *nativeProps;
 
+@property (nonatomic, strong, nullable) JSContext* jsContext;
+
 - (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
                              uiManager:(nonnull RCTUIManager *)uiManager;
 

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <JavaScriptCore/JavaScriptCore.h>
 
 #import "REANode.h"
 #import <React/RCTBridgeModule.h>

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -1,6 +1,7 @@
 #import "REANodesManager.h"
 
 #import <React/RCTConvert.h>
+#import <JavaScriptCore/JavaScriptCore.h>
 
 #import "Nodes/REANode.h"
 #import "Nodes/REAPropsNode.h"
@@ -22,6 +23,7 @@
 #import "Nodes/REAParamNode.h"
 #import "Nodes/REAFunctionNode.h"
 #import "Nodes/REACallFuncNode.h"
+#import "Nodes/REAJSNode.h"
 
 @interface RCTUIManager ()
 
@@ -240,6 +242,7 @@
             @"param": [REAParamNode class],
             @"func": [REAFunctionNode class],
             @"callfunc": [REACallFuncNode class],
+            @"jsfunc": [REAJSNode class]
 //            @"listener": nil,
             };
   });

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -77,6 +77,10 @@
     _wantRunUpdates = NO;
     _onAnimationCallbacks = [NSMutableArray new];
     _operationsInBatch = [NSMutableArray new];
+    _jsContext = [[JSContext alloc] initWithVirtualMachine:[[JSVirtualMachine alloc] init]];
+    _jsContext.exceptionHandler = ^(JSContext *context, JSValue *exception) {
+      RCTLogError(@"Error executing Reanimated JS Node: %@", exception);
+    };
   }
   return self;
 }

--- a/ios/RNReanimated.xcodeproj/project.pbxproj
+++ b/ios/RNReanimated.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		A12DA6BF22EC22E400E8271A /* REAFunctionNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A12DA6BA22EC22E300E8271A /* REAFunctionNode.m */; };
 		A12DA6C022EC22E400E8271A /* REACallFuncNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A12DA6BC22EC22E300E8271A /* REACallFuncNode.m */; };
 		A12DA6C122EC22E400E8271A /* REACallFuncNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A12DA6BC22EC22E300E8271A /* REACallFuncNode.m */; };
+		A185A966237FDE0700D437B0 /* REAJSNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A185A964237FDE0600D437B0 /* REAJSNode.m */; };
+		A185A967237FDE1900D437B0 /* REAJSNode.m in Sources */ = {isa = PBXBuildFile; fileRef = A185A964237FDE0600D437B0 /* REAJSNode.m */; };
 		FDBB1777229BF0DE00D1E455 /* REAModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 440FEC2A209062F100EEC73A /* REAModule.m */; };
 		FDBB1778229BF0DE00D1E455 /* REANodesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 440FEC2B209062F100EEC73A /* REANodesManager.m */; };
 		FDBB1779229BF0E700D1E455 /* REATransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 44125DBF22538E6D003C1762 /* REATransitionManager.m */; };
@@ -140,6 +142,8 @@
 		A12DA6BB22EC22E300E8271A /* REACallFuncNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = REACallFuncNode.h; sourceTree = "<group>"; };
 		A12DA6BC22EC22E300E8271A /* REACallFuncNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = REACallFuncNode.m; sourceTree = "<group>"; };
 		A12DA6BD22EC22E300E8271A /* REAFunctionNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = REAFunctionNode.h; sourceTree = "<group>"; };
+		A185A964237FDE0600D437B0 /* REAJSNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = REAJSNode.m; sourceTree = "<group>"; };
+		A185A965237FDE0600D437B0 /* REAJSNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = REAJSNode.h; sourceTree = "<group>"; };
 		FDBB176E229BF04900D1E455 /* libRNReanimated-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRNReanimated-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -172,6 +176,8 @@
 		440FEC0C209062F100EEC73A /* Nodes */ = {
 			isa = PBXGroup;
 			children = (
+				A185A965237FDE0600D437B0 /* REAJSNode.h */,
+				A185A964237FDE0600D437B0 /* REAJSNode.m */,
 				A12DA6B922EC22A900E8271A /* REAParamNode.h */,
 				A12DA6B622EC228D00E8271A /* REAParamNode.m */,
 				A12DA6BB22EC22E300E8271A /* REACallFuncNode.h */,
@@ -336,6 +342,7 @@
 				44125DC022538E6D003C1762 /* REATransitionManager.m in Sources */,
 				440FEC39209062F100EEC73A /* REABlockNode.m in Sources */,
 				A12DA6C022EC22E400E8271A /* REACallFuncNode.m in Sources */,
+				A185A966237FDE0700D437B0 /* REAJSNode.m in Sources */,
 				440FEC33209062F100EEC73A /* REABezierNode.m in Sources */,
 				44125DC322538F68003C1762 /* REATransition.m in Sources */,
 				440FEC2D209062F100EEC73A /* REAStyleNode.m in Sources */,
@@ -370,6 +377,7 @@
 				FDE6D93D229BF70F007F6716 /* REASetNode.m in Sources */,
 				FDE6D93A229BF70F007F6716 /* REABlockNode.m in Sources */,
 				A12DA6C122EC22E400E8271A /* REACallFuncNode.m in Sources */,
+				A185A967237FDE1900D437B0 /* REAJSNode.m in Sources */,
 				FDE6D939229BF70F007F6716 /* REAPropsNode.m in Sources */,
 				FDBB1778229BF0DE00D1E455 /* REANodesManager.m in Sources */,
 				FDE6D937229BF70F007F6716 /* REAStyleNode.m in Sources */,

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -230,6 +230,7 @@ declare module 'react-native-reanimated' {
     export const neq: BinaryOperator<0 | 1>;
     export const and: MultiOperator<0 | 1>;
     export const or: MultiOperator<0 | 1>;
+    export function js(code: string, ...args: Array<Adaptable<number>>): Animated.Node<any>;
     export function proc(
       cb: (...params: Array<Animated.Value<number>>) => Adaptable<number>
     ): (...args: Array<Adaptable<number>>) => AnimatedNode<number>;

--- a/src/base.js
+++ b/src/base.js
@@ -14,4 +14,5 @@ export { createAnimatedAlways as always } from './core/AnimatedAlways';
 export { createAnimatedConcat as concat } from './core/AnimatedConcat';
 export { createAnimatedBlock as block, adapt } from './core/AnimatedBlock';
 export { createAnimatedFunction as proc } from './core/AnimatedFunction';
+export {createAnimatedJSFunc as js} from './core/AnimatedJSFunc';
 export * from './operators';

--- a/src/core/AnimatedJSFunc.js
+++ b/src/core/AnimatedJSFunc.js
@@ -1,0 +1,17 @@
+import AnimatedNode from './AnimatedNode';
+import { adapt } from './AnimatedBlock';
+
+class AnimatedJSFunc extends AnimatedNode {
+
+  constructor(code, args) {
+    super({ 
+      type: 'jsfunc', 
+      args: args.map(n => n.__nodeID),
+      code: code,
+    }, [...args]);
+  }
+}
+
+export function createAnimatedJSFunc(code, ...args) {
+  return new AnimatedJSFunc(code, args.map(p => adapt(p)));
+}


### PR DESCRIPTION
## Intro
In reference to @osdnk's PR #458 about CodeGen, this is a draft showing new node that makes it possible to execute Javascript functions on node evaluation. 

## Background
The reason for this is that we are seeing too many nodes being created in Reanimated when animations are a bit complex, and we would like to move some of the overhead of transporting thousands of nodes across the bridge.

## Example

```js
const a = new Animated.Value(10);
const jsNode = Animated.js("function (a, b) { return a + b }", a, 120);
```

We can write *pure functions* that operates on input nodes - whatever logic we wanted would be available as long as it does not have any side effects. JS could should be evaluated directly (not through the bridge) and return. 

## Technical
The way it is done for now is that the NodeManager has a Javascript context (not using the bridge) that nodes can access. A new node has been added (REAJSNode) which executes a javascript function passed from React Native JS on evaluate. It supports taking other nodes as parameters as well (just like the proc node).

On iOS we're using the JSContext class, whilst on Android I was not able to find a way to execute Javascript on the currently loaded JS engine (Hermes / JSC) without going through the bridge. It seems like the functions for doing this is written in C++ and not exposed through any Java interface at the moment.

## Advanced example
This is an example showing a spring written in Javascript that results in only one node being created for the whole spring. (the spring function is actually implemented as a precomputed easing to be able to know its duration).

```js
function getSpringNode (
  duration: number,
  mass: number,
  stiffness: number,
  damping: number,
) {
  const w0 = Math.sqrt(stiffness / mass);
  const zeta = damping / (2 * Math.sqrt(stiffness * mass));
  const wd = zeta < 1 ? w0 * Math.sqrt(1 - zeta * zeta) : 0;
  const a = 1;
  const b =
    zeta < 1 ? (zeta * w0 + -initialVelocity) / wd : -initialVelocity + w0;

  return (t: Animated.Node) => {
    return Animated.js(
      `function (t) {      
      var progress = (${duration} * t) / 1000;
      if (${zeta} < 1) {
        progress =
          Math.exp(-progress * ${zeta} * ${w0}) *
          (${a} * Math.cos(${wd} * progress) + ${b} * Math.sin(${wd} * progress));
      } else {
        progress = (${a} + ${b} * progress) * Math.exp(-progress * ${w0});
      }
      if (t === 0 || t === 1) {
        return t;
      }
      return 1 - progress;      
    }`,
      t,
    );
}
```

## Discussion
Adding the JS node is a bit radical - it might introduce some issues for devs, as you will not be able to debug your functions directly (you can write tests using `eval()`). 

We also need to discuss wether we think it is correct to use the V8 JS engine on Android, or if we should ask for some help to see if it is possible to execute them outside the bridge on the currently loaded engine. Maybe @kmagiera knows something or someone that could add to this? I don't even know if all Android devices have V8 preinstalled... ;) 