### PR TITLE
Update docs for running examples on iOS

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -1,8 +1,9 @@
 ## Run the example
 
-+ Clone the repository
-+ Run `yarn` to install the dependencies of library
-+ `cd` to this directory
-+ Run `yarn` to install the dependencies of example 
-+ Run `yarn start` to start the packager with custom config
-+ `react-native run-ios` or `react-native run-android`
+- Clone the repository
+- Run `yarn` to install the dependencies of library
+- `cd` to this directory
+- Run `yarn` to install the dependencies of example
+- Run `yarn start` to start the packager with custom config
+- Run `pod install` in the `ios` folder for running on iOS
+- `react-native run-ios` or `react-native run-android`


### PR DESCRIPTION
closes: #480 

- Add instructions to `pod install` before `react-native run-ios`