### PR TITLE
fix: clockStop not working #467 #182

### DIFF
--- a/Example/Interactable.js
+++ b/Example/Interactable.js
@@ -27,6 +27,7 @@ const {
   sub,
   Clock,
   Value,
+  onChange,
 } = Animated;
 
 const ANIMATOR_PAUSE_CONSECUTIVE_FRAMES = 10;
@@ -411,11 +412,15 @@ class Interactable extends Component {
       }
       const last = new Value(Number.MAX_SAFE_INTEGER);
       const noMoveFrameCount = noMovementFrames[axis];
-      const testMovementFrames = cond(
-        eq(advance, last),
-        set(noMoveFrameCount, add(noMoveFrameCount, 1)),
-        [set(last, advance), set(noMoveFrameCount, 0)]
-      );
+      const testMovementFrames = block([
+        onChange(snapAnchor.x, set(last, Number.MAX_SAFE_INTEGER)),
+        onChange(snapAnchor.y, set(last, Number.MAX_SAFE_INTEGER)),
+        cond(
+          eq(advance, last),
+          set(noMoveFrameCount, add(noMoveFrameCount, 1)),
+          [set(last, advance), set(noMoveFrameCount, 0)]
+        ),
+      ]);
       const step = cond(
         eq(state, State.ACTIVE),
         [
@@ -429,7 +434,6 @@ class Interactable extends Component {
           cond(dt, dragBehaviors[axis]),
         ],
         [
-          cond(clockRunning(clock), 0, startClock(clock)),
           cond(dragging, [updateSnapTo, set(dragging, 0)]),
           cond(dt, snapBehaviors[axis]),
           testMovementFrames,


### PR DESCRIPTION
stopClock was not working on this example.

I base the fix out of this comment: 
https://github.com/software-mansion/react-native-reanimated/issues/182#issuecomment-519632308

I had trouble with the prettier/husky the format might not be perfect: 
![image](https://user-images.githubusercontent.com/5473183/69994193-543ff780-151b-11ea-9311-eb9b331683c5.png)

