### PR TITLE
Bump gesture handler from 1.4 to 1.5

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -14,7 +14,7 @@
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "0.61.1",
-    "react-native-gesture-handler": "1.4.1",
+    "react-native-gesture-handler": "^1.5.0",
     "react-native-web": "^0.11.7",
     "react-navigation": "4.0.3",
     "react-navigation-stack": "^1.7.3"

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -5789,10 +5789,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-native-gesture-handler@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz#c38d9e57637b95e221722a79f2bafac62e3aeb21"
-  integrity sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==
+react-native-gesture-handler@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.2.tgz#281111550bf1eee10b7feba5278d142169892731"
+  integrity sha512-Xp03dq4XYVTD0xmWx4DW4eX+ox1NQLjHmbykspTdS5FCNIVIOekVXRLFCw1698/v8dYUHApNo6K3s3BCD8fqPA==
   dependencies:
     hammerjs "^2.0.8"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
Updating gesture-handler removes warning with usage of deprecated `[RCTRootView cancelTouches]`