### PR TITLE
Fix: bug in cond() TS typing

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -244,11 +244,11 @@ declare module 'react-native-reanimated' {
     export function concat(
       ...args: Array<Adaptable<string> | Adaptable<number>>,
     ): AnimatedNode<string>;
-    export function cond<T extends Value = number>(
+    export function cond<T1 extends Value = number, T2 extends Value = number>(
       conditionNode: Adaptable<number>,
-      ifNode: Adaptable<T>,
-      elseNode?: Adaptable<T>,
-    ): AnimatedNode<T>;
+      ifNode: Adaptable<T1>,
+      elseNode?: Adaptable<T2>,
+    ): AnimatedNode<T1 | T2>;
     export function block<T>(
       items: ReadonlyArray<Adaptable<T>>,
     ): AnimatedNode<T>;


### PR DESCRIPTION
Without this patch, the following is considered a type error:
```tsx
cond(0, 3, cond(0, 1, 2))
```

```
Argument of type '3' is not assignable to parameter of type 'Adaptable<1 | 2>'.
```