### PR TITLE
Make interpolate consistent with react-native animated lib

### DIFF
--- a/src/derived/interpolate.js
+++ b/src/derived/interpolate.js
@@ -5,6 +5,8 @@ import {
   add,
   divide,
   greaterThan,
+  lessOrEq,
+  eq,
 } from '../operators';
 import invariant from 'fbjs/lib/invariant';
 
@@ -20,7 +22,9 @@ const interpolateInternalSingleProc = proc(function(
   outE
 ) {
   const progress = divide(sub(value, inS), sub(inE, inS));
-  return add(outS, multiply(progress, sub(outE, outS)));
+  const resultForNonZeroRange = add(outS, multiply(progress, sub(outE, outS)));
+  const result = cond(eq(inS, inE), cond(lessOrEq(value, inS), outS, outE), resultForNonZeroRange);
+  return result;
 });
 
 function interpolateInternalSingle(value, inputRange, outputRange, offset) {

--- a/src/derived/interpolate.js
+++ b/src/derived/interpolate.js
@@ -22,6 +22,7 @@ const interpolateInternalSingleProc = proc(function(
   outE
 ) {
   const progress = divide(sub(value, inS), sub(inE, inS));
+  // logic below was made in order to provide a compatibility witn an Animated API
   const resultForNonZeroRange = add(outS, multiply(progress, sub(outE, outS)));
   const result = cond(eq(inS, inE), cond(lessOrEq(value, inS), outS, outE), resultForNonZeroRange);
   return result;


### PR DESCRIPTION
WHY:  
resolves: https://github.com/software-mansion/react-native-reanimated/issues/235

To compute a proper value for an input, we divide in code by input range size which is incorrect for ranges that have sizes equal to zero.  This pull-request fixes this bug.

How it's implemented in Animated:
https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/nodes/AnimatedInterpolation.js#L140