### PR TITLE
Make clock ops workable inside procs

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -217,9 +217,9 @@ PODS:
     - React-cxxreact (= 0.61.1)
     - React-jsi (= 0.61.1)
     - ReactCommon/jscallinvoker (= 0.61.1)
-  - RNGestureHandler (1.4.1):
+  - RNGestureHandler (1.5.2):
     - React
-  - RNReanimated (1.3.1):
+  - RNReanimated (1.4.0):
     - React
   - Yoga (1.14.0)
 
@@ -341,8 +341,8 @@ SPEC CHECKSUMS:
   React-RCTText: 81b62b4e7f11531a5154e4daa5617670d5a2d5de
   React-RCTVibration: 8be61459e3749d1fb02cf414edd05b3007622882
   ReactCommon: 4fba5be89efdf0b5720e0adb3d8d7edf6e532db0
-  RNGestureHandler: 4cb47a93019c1a201df2644413a0a1569a51c8aa
-  RNReanimated: 6c221ff761a9dc6ba8f94e9d61738b7006b076da
+  RNGestureHandler: 946a7691e41df61e2c4b1884deab41a4cdc3afff
+  RNReanimated: 8b675a650fc67c87f63d4345a1b2d4a699c25e4f
   Yoga: d8c572ddec8d05b7dba08e4e5f1924004a177078
 
 PODFILE CHECKSUM: 5d33b226bedcf33a9eaa74f8b42fbef1a3877e59

--- a/Example/test/index.js
+++ b/Example/test/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 
@@ -78,6 +79,8 @@ function springFill(clock, state, config) {
     clock
   );
 }
+const stopClockProc = proc(clock => stopClock(clock))
+const startClockProc = proc(clock => startClock(clock))
 
 function runSpring(clock, value, dest) {
   const state = {
@@ -104,13 +107,14 @@ function runSpring(clock, value, dest) {
       set(state.position, value),
       set(state.velocity, -2500),
       set(config.toValue, dest),
-      startClock(clock),
+      startClockProc(clock),
     ]),
     springFill(clock, state, config),
-    cond(state.finished, debug('stop clock', stopClock(clock))),
+    cond(state.finished, debug('stop clock', stopClockProc(clock))),
     state.position,
   ]);
 }
+
 
 function runTiming(clock, value, dest) {
   const state = {
@@ -133,10 +137,10 @@ function runTiming(clock, value, dest) {
       set(state.position, value),
       set(state.frameTime, 0),
       set(config.toValue, dest),
-      startClock(clock),
+      startClockProc(clock),
     ]),
     timing(clock, state, config),
-    cond(state.finished, debug('stop clock', stopClock(clock))),
+    cond(state.finished, debug('stop clock', stopClockProc(clock))),
     state.position,
   ]);
 }
@@ -163,7 +167,7 @@ export default class Example extends Component {
 
   render() {
     return (
-      <View style={styles.container}>        
+      <View style={styles.container}>
         {Array.from(Array(40)).map((_, i) => (
           <Animated.View
             key={i}

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ClockNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ClockNode.java
@@ -5,22 +5,26 @@ import com.swmansion.reanimated.NodesManager;
 
 public class ClockNode extends Node implements NodesManager.OnAnimationFrame {
 
-  public boolean isRunning;
+  private boolean mIsRunning;
 
   public ClockNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
     super(nodeID, config, nodesManager);
   }
 
   public void start() {
-    if (isRunning) {
+    if (mIsRunning) {
       return;
     }
-    isRunning = true;
+    mIsRunning = true;
     mNodesManager.postOnAnimation(this);
   }
 
+  public boolean isRunning() {
+    return mIsRunning;
+  }
+
   public void stop() {
-    isRunning = false;
+    mIsRunning = false;
   }
 
   @Override
@@ -30,7 +34,7 @@ public class ClockNode extends Node implements NodesManager.OnAnimationFrame {
 
   @Override
   public void onAnimationFrame() {
-    if (isRunning) {
+    if (mIsRunning) {
       markUpdated();
       mNodesManager.postOnAnimation(this);
     }

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ClockNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ClockNode.java
@@ -5,26 +5,22 @@ import com.swmansion.reanimated.NodesManager;
 
 public class ClockNode extends Node implements NodesManager.OnAnimationFrame {
 
-  private boolean mIsRunning;
+  public boolean isRunning;
 
   public ClockNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
     super(nodeID, config, nodesManager);
   }
 
   public void start() {
-    if (mIsRunning) {
+    if (isRunning) {
       return;
     }
-    mIsRunning = true;
+    isRunning = true;
     mNodesManager.postOnAnimation(this);
   }
 
-  public boolean isRunning() {
-    return mIsRunning;
-  }
-
   public void stop() {
-    mIsRunning = false;
+    isRunning = false;
   }
 
   @Override
@@ -34,7 +30,7 @@ public class ClockNode extends Node implements NodesManager.OnAnimationFrame {
 
   @Override
   public void onAnimationFrame() {
-    if (mIsRunning) {
+    if (isRunning) {
       markUpdated();
       mNodesManager.postOnAnimation(this);
     }

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ClockOpNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ClockOpNode.java
@@ -12,8 +12,12 @@ public abstract class ClockOpNode extends Node {
     }
 
     @Override
-    protected Double eval(ClockNode clock) {
-      clock.start();
+    protected Double eval(Node clock) {
+      if (clock instanceof ParamNode) {
+        ((ParamNode) clock).start();
+      } else {
+        ((ClockNode) clock).start();
+      }
       return ZERO;
     }
   }
@@ -24,8 +28,12 @@ public abstract class ClockOpNode extends Node {
     }
 
     @Override
-    protected Double eval(ClockNode clock) {
-      clock.stop();
+    protected Double eval(Node clock) {
+      if (clock instanceof ParamNode) {
+        ((ParamNode) clock).stop();
+      } else {
+        ((ClockNode) clock).stop();
+      }
       return ZERO;
     }
   }
@@ -36,8 +44,11 @@ public abstract class ClockOpNode extends Node {
     }
 
     @Override
-    protected Double eval(ClockNode clock) {
-      return clock.isRunning ? 1. : 0.;
+    protected Double eval(Node clock) {
+      if (clock instanceof ParamNode) {
+        return ((ParamNode) clock).isRunning() ? 1. : 0.;
+      }
+      return ((ClockNode) clock).isRunning() ? 1. : 0.;
     }
   }
 
@@ -50,9 +61,9 @@ public abstract class ClockOpNode extends Node {
 
   @Override
   protected Double evaluate() {
-    ClockNode clock = mNodesManager.findNodeById(clockID, ClockNode.class);
+    Node clock = mNodesManager.findNodeById(clockID, Node.class);
     return eval(clock);
   }
 
-  protected abstract Double eval(ClockNode clock);
+  protected abstract Double eval(Node clock);
 }

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ClockOpNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ClockOpNode.java
@@ -48,7 +48,7 @@ public abstract class ClockOpNode extends Node {
       if (clock instanceof ParamNode) {
         return ((ParamNode) clock).isRunning() ? 1. : 0.;
       }
-      return ((ClockNode) clock).isRunning() ? 1. : 0.;
+      return ((ClockNode) clock).isRunning ? 1. : 0.;
     }
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
@@ -44,4 +44,32 @@ public class ParamNode extends ValueNode {
     mUpdateContext.callID = callID;
     return val;
   }
+
+  public void start() {
+    Node node = mNodesManager.findNodeById(mArgsStack.peek(), Node.class);
+    if (node instanceof ParamNode) {
+      ((ParamNode) node).start();
+    } else {
+      ((ClockNode) node).start();
+    }
+  }
+
+  public void stop() {
+    Node node = mNodesManager.findNodeById(mArgsStack.peek(), Node.class);
+    if (node instanceof ParamNode) {
+      ((ParamNode) node).stop();
+    } else {
+      ((ClockNode) node).stop();
+    }
+  }
+
+  public boolean isRunning() {
+    Node node = mNodesManager.findNodeById(mArgsStack.peek(), Node.class);
+    if (node instanceof ParamNode) {
+      return  ((ParamNode) node).isRunning();
+    }
+    return ((ClockNode) node).isRunning();
+  }
 }
+
+

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
@@ -68,7 +68,7 @@ public class ParamNode extends ValueNode {
     if (node instanceof ParamNode) {
       return  ((ParamNode) node).isRunning();
     }
-    return ((ClockNode) node).isRunning();
+    return ((ClockNode) node).isRunning;
   }
 }
 

--- a/ios/Nodes/REAClockNodes.h
+++ b/ios/Nodes/REAClockNodes.h
@@ -1,6 +1,9 @@
 #import "REANode.h"
 
 @interface REAClockNode : REANode
+@property (nonatomic, readonly) BOOL isRunning;
+- (void)start;
+- (void)stop;
 @end
 
 @interface REAClockOpNode : REANode

--- a/ios/Nodes/REAClockNodes.m
+++ b/ios/Nodes/REAClockNodes.m
@@ -1,12 +1,12 @@
 #import "REAClockNodes.h"
 #import "REAUtils.h"
 #import "REANodesManager.h"
+#import "REAParamNode.h"
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 
 @interface REAClockNode ()
 
-@property (nonatomic, readonly) BOOL isRunning;
 @property (nonatomic) NSNumber *lastTimestampMs;
 
 @end
@@ -64,9 +64,9 @@
   return self;
 }
 
-- (REAClockNode*)clockNode
+- (REANode*)clockNode
 {
-  return (REAClockNode*)[self.nodesManager findNodeByID:_clockNodeID];
+  return (REANode*)[self.nodesManager findNodeByID:_clockNodeID];
 }
 
 @end
@@ -75,7 +75,12 @@
 
 - (id)evaluate
 {
-  [[self clockNode] start];
+  REANode* node = [self clockNode];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    [(REAParamNode* )node start];
+  } else {
+    [(REAClockNode* )node start];
+  }
   return @(0);
 }
 
@@ -85,9 +90,15 @@
 
 - (id)evaluate
 {
-  [[self clockNode] stop];
+  REANode* node = [self clockNode];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    [(REAParamNode* )node stop];
+  } else {
+    [(REAClockNode* )node stop];
+  }
   return @(0);
 }
+
 
 @end
 
@@ -95,7 +106,11 @@
 
 - (id)evaluate
 {
-  return @([self clockNode].isRunning ? 1 : 0);
+  REANode* node = [self clockNode];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    return @(((REAParamNode* )node).isRunning ? 1 : 0);
+  }
+  return @([(REAClockNode* )node isRunning] ? 1 : 0);
 }
 
 @end

--- a/ios/Nodes/REAParamNode.h
+++ b/ios/Nodes/REAParamNode.h
@@ -4,7 +4,9 @@
 
 - (void)beginContext:(NSNumber*) ref
           prevCallID:(NSNumber*) prevCallID;
--(void) endContext;
-
+- (void)endContext;
+- (void)start;
+- (void)stop;
+- (BOOL)isRunning;
 @end
 

--- a/ios/Nodes/REAParamNode.m
+++ b/ios/Nodes/REAParamNode.m
@@ -1,6 +1,7 @@
 #import "REAParamNode.h"
 #import "REAValueNode.h"
 #import "REANodesManager.h"
+#import "REAClockNodes.h"
 
 @implementation REAParamNode {
   NSMutableArray<REANodeID> *_argstack;
@@ -45,6 +46,35 @@
   id val = [node value];
   self.updateContext.callID = callID;
   return val;
+}
+
+- (void)start
+{
+  REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    [(REAParamNode* )node start];
+  } else {
+    [(REAClockNode* )node start];
+  }
+}
+
+- (void)stop
+{
+  REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    [(REAParamNode* )node stop];
+  } else {
+    [(REAClockNode* )node stop];
+  }
+}
+
+- (BOOL)isRunning
+{
+  REANode* node = [self.nodesManager findNodeByID:[_argstack lastObject]];
+  if ([node isKindOfClass:[REAParamNode class]]) {
+    return [(REAParamNode* )node isRunning];
+  }
+  return [(REAClockNode* )node isRunning];
 }
 
 @end

--- a/src/core/AnimatedParam.js
+++ b/src/core/AnimatedParam.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 
-class AnimatedParam extends AnimatedNode {
+export class AnimatedParam extends AnimatedNode {
   argsStack = [];
 
   constructor() {

--- a/src/core/AnimatedStartClock.js
+++ b/src/core/AnimatedStartClock.js
@@ -1,5 +1,6 @@
 import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
+import { AnimatedParam } from "./AnimatedParam";
 import invariant from 'fbjs/lib/invariant';
 
 class AnimatedStartClock extends AnimatedNode {
@@ -7,7 +8,7 @@ class AnimatedStartClock extends AnimatedNode {
 
   constructor(clockNode) {
     invariant(
-      clockNode instanceof AnimatedClock,
+      clockNode instanceof AnimatedClock || clockNode instanceof AnimatedParam,
       `Reanimated: Animated.startClock argument should be of type AnimatedClock but got ${clockNode}`
     );
     super({ type: 'clockStart', clock: clockNode.__nodeID });

--- a/src/core/AnimatedStopClock.js
+++ b/src/core/AnimatedStopClock.js
@@ -1,5 +1,6 @@
 import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
+import { AnimatedParam } from "./AnimatedParam";
 import invariant from 'fbjs/lib/invariant';
 
 class AnimatedStopClock extends AnimatedNode {
@@ -7,7 +8,7 @@ class AnimatedStopClock extends AnimatedNode {
 
   constructor(clockNode) {
     invariant(
-      clockNode instanceof AnimatedClock,
+      clockNode instanceof AnimatedClock || clockNode instanceof AnimatedParam,
       `Reanimated: Animated.stopClock argument should be of type AnimatedClock but got ${clockNode}`
     );
     super({ type: 'clockStop', clock: clockNode.__nodeID });


### PR DESCRIPTION
Proc can accept clock as params but previously it was not possible to make clock ops (start and stop) on this bc of some assumptions in native code.

I this PR I handle this case in all places on both platforms.

You can verify it with a test example in the example app.

Tested and verified that there are no regressions.