### PR TITLE
add Pod install instruction in Getting Started page

### DIFF
--- a/docs/pages/03.start.md
+++ b/docs/pages/03.start.md
@@ -26,7 +26,14 @@ II. Link native code with `react-native` cli:
   react-native link react-native-reanimated
 ```
 
-III. When you want to use "reanimated" in your project import it from the `react-native-reanimated` package:
+III. For iOS, go to `ios` folder and run `pod install`:
+
+```bash
+  cd ios
+  pod install
+```
+
+IV. When you want to use "reanimated" in your project import it from the `react-native-reanimated` package:
 
 ```js
 import Animated from 'react-native-reanimated';


### PR DESCRIPTION
Add `pod install` instruction in Getting Started page.
Regarding this issue https://github.com/software-mansion/react-native-reanimated/issues/519