### PR TITLE
Add return values to Event function Proxy

### DIFF
--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -60,7 +60,9 @@ function sanitizeArgMapping(argMapping) {
       set: function(target, prop, value) {
         if (prop === '__val') {
           target[prop] = value;
+          return true;
         }
+        return false;
       },
     };
 


### PR DESCRIPTION
In 'Pan, rotate and zoom (via native event function)' example we call set() inside event() node using a function. Inside event() we create proxyHandler
which override `get` and `set` method. Set wasn't returning any value, so implicitly returned `undefined` which is a falsy value resulting in a crash.

Now we return true if we updated `__val` and false otherwise

Closes issue #521
(https://github.com/software-mansion/react-native-reanimated/issues/521)

Proxy#set docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set