### PR TITLE
Fix issue with some events not propagating correctly via Animated.event

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -323,7 +323,9 @@
   REANode *eventNode = _nodes[eventNodeID];
   RCTAssert([eventNode isKindOfClass:[REAEventNode class]], @"Event node is of an invalid type");
 
-  NSString *key = [NSString stringWithFormat:@"%@%@", viewTag, eventName];
+  NSString *key = [NSString stringWithFormat:@"%@%@",
+                   viewTag,
+                   RCTNormalizeInputEventName(eventName)];
   RCTAssert([_eventMapping objectForKey:key] == nil, @"Event handler already set for the given view and event type");
   [_eventMapping setObject:eventNode forKey:key];
 }
@@ -332,13 +334,17 @@
           eventName:(NSString *)eventName
         eventNodeID:(REANodeID)eventNodeID
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@", viewTag, eventName];
+  NSString *key = [NSString stringWithFormat:@"%@%@",
+                   viewTag,
+                   RCTNormalizeInputEventName(eventName)];
   [_eventMapping removeObjectForKey:key];
 }
 
 - (void)processEvent:(id<RCTEvent>)event
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, event.eventName];
+  NSString *key = [NSString stringWithFormat:@"%@%@",
+                   event.viewTag,
+                   RCTNormalizeInputEventName(event.eventName)];
   REAEventNode *eventNode = [_eventMapping objectForKey:key];
   [eventNode processEvent:event];
 }
@@ -357,21 +363,23 @@
   static dispatch_once_t directEventNamesToken;
   dispatch_once(&directEventNamesToken, ^{
     directEventNames = @[
-      @"onContentSizeChange",
-      @"onMomentumScrollBegin",
-      @"onMomentumScrollEnd",
-      @"onScroll",
-      @"onScrollBeginDrag",
-      @"onScrollEndDrag"
+      @"topContentSizeChange",
+      @"topMomentumScrollBegin",
+      @"topMomentumScrollEnd",
+      @"topScroll",
+      @"topScrollBeginDrag",
+      @"topScrollEndDrag"
     ];
   });
   
-  return [directEventNames containsObject:event.eventName];
+  return [directEventNames containsObject:RCTNormalizeInputEventName(event.eventName)];
 }
 
 - (void)dispatchEvent:(id<RCTEvent>)event
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, event.eventName];
+  NSString *key = [NSString stringWithFormat:@"%@%@",
+                   event.viewTag,
+                   RCTNormalizeInputEventName(event.eventName)];
   REANode *eventNode = [_eventMapping objectForKey:key];
 
   if (eventNode != nil) {

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -15,6 +15,11 @@ function listener(data) {
   component && component._updateFromNative(data.props);
 }
 
+function dummyListener() {
+  // empty listener we use to assign to listener properties for which animated
+  // event is used.
+}
+
 export default function createAnimatedComponent(Component) {
   invariant(
     typeof Component !== 'function' ||
@@ -205,6 +210,12 @@ export default function createAnimatedComponent(Component) {
         const value = inputProps[key];
         if (key === 'style') {
           props[key] = this._filterNonAnimatedStyle(StyleSheet.flatten(value));
+        } else if (value instanceof AnimatedEvent) {
+          // we cannot filter out event listeners completely as some components
+          // rely on having a callback registered in order to generate events
+          // alltogether. Therefore we provide a dummy callback here to allow
+          // native event dispatcher to hijack events.
+          props[key] = dummyListener;
         } else if (!(value instanceof AnimatedNode)) {
           props[key] = value;
         }


### PR DESCRIPTION
The issue has been discovered while testing onScroll listener with react-native-webview. After investigating it turned out that there are two problems:
1) WebView was expecting a listener to be assigned to the native component and only with the listener preset the events would be dispatched
2) On iOS we weren't translating event names properly. Some older component still follow "topSth" naming convention while we were solely relying on "onSth" convention for direct event.

In order to address (1) we now assign an empty listener to component properties that have Animated.event object assigned. This way native component knows there is a listener assigned and can start dispatching events that we hijack on the native side.

To fix (2) we matched the orifinal Animated implementation and adapted RCTNormalizeInputEventName utility method from RN core that normalizes event names (it actually changes all names to "topSth" convetion but at least it is now consistent across the board).

After fixing (1) the Android does not seem to need any more changes.