### PR TITLE
[web] Changed how values are updated with Animated.event to prevent freezing

### DIFF
--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -82,16 +82,6 @@ export default class AnimatedEvent extends AnimatedNode {
     const { eventMappings, alwaysNodes } = sanitizeArgMapping(argMapping);
     super({ type: 'event', argMapping: eventMappings });
     this._alwaysNodes = alwaysNodes;
-    if (Platform.OS === 'web') {
-      this._argMapping = eventMappings;
-      this.__getHandler = () => {
-        return ({ nativeEvent }) => {
-          for (const [key, value] of this._argMapping) {
-            if (key in nativeEvent) value.setValue(nativeEvent[key]);
-          }
-        };
-      };
-    }
   }
 
   toString() {

--- a/src/core/AnimatedNode.js
+++ b/src/core/AnimatedNode.js
@@ -1,4 +1,5 @@
 import ReanimatedModule from '../ReanimatedModule';
+import { Platform } from 'react-native';
 
 const UPDATED_NODES = [];
 
@@ -6,6 +7,9 @@ let loopID = 1;
 let propUpdatesEnqueued = null;
 
 function sanitizeConfig(config) {
+  if (Platform.OS === 'web') {
+    return config;
+  }
   for (const key in config) {
     const value = config[key];
     if (value instanceof AnimatedNode) {


### PR DESCRIPTION
# Why

- the purpose of this PR is to remove the non-standard method call in favor of an API that has more parity with native. This should also fix some issues where gesture updates freeze.

This change won't be backwards compatible and will require a version of RNGH with this https://github.com/software-mansion/react-native-gesture-handler/pull/905. However RNGH will be fully backwards compatible with reanimated. This shouldn't be a huge issue as reanimated barely works on the web currently.