### PR TITLE
Fix procs handling by removing parentNode check

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -285,10 +285,6 @@ public class NodesManager implements EventDispatcherListener {
 
   public void connectNodes(int parentID, int childID) {
     Node parentNode = mAnimatedNodes.get(parentID);
-    if (parentNode == null) {
-      throw new JSApplicationIllegalArgumentException("Animated node with ID " + parentID +
-              " does not exists");
-    }
     Node childNode = mAnimatedNodes.get(childID);
     if (childNode == null) {
       throw new JSApplicationIllegalArgumentException("Animated node with ID " + childID +
@@ -299,10 +295,6 @@ public class NodesManager implements EventDispatcherListener {
 
   public void disconnectNodes(int parentID, int childID) {
     Node parentNode = mAnimatedNodes.get(parentID);
-    if (parentNode == null) {
-      throw new JSApplicationIllegalArgumentException("Animated node with ID " + parentID +
-              " does not exists");
-    }
     Node childNode = mAnimatedNodes.get(childID);
     if (childNode == null) {
       throw new JSApplicationIllegalArgumentException("Animated node with ID " + childID +

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -270,7 +270,6 @@
   REANode *parentNode = _nodes[parentID];
   REANode *childNode = _nodes[childID];
 
-  RCTAssertParam(parentNode);
   RCTAssertParam(childNode);
 
   [parentNode addChild:childNode];
@@ -284,7 +283,6 @@
   REANode *parentNode = _nodes[parentID];
   REANode *childNode = _nodes[childID];
 
-  RCTAssertParam(parentNode);
   RCTAssertParam(childNode);
 
   [parentNode removeChild:childNode];


### PR DESCRIPTION
In procs it happens, that parent might not be present and this should not be breaking