### PR TITLE
Add displayName to createAnimatedComponent

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -241,5 +241,7 @@ export default function createAnimatedComponent(Component) {
     }
   }
 
+  AnimatedComponent.displayName = `AnimatedComponent(${Component.displayName || Component.name || 'Component'})`
+
   return AnimatedComponent;
 }


### PR DESCRIPTION
Would be nice to add displayName for the createAnimatedComponent. 