### PR TITLE
Fix case where `new Animated.Value()` is NaN on web

### DIFF
--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -32,6 +32,9 @@ export default class InternalAnimatedValue extends AnimatedNode {
   }
 
   constructor(value, constant = false) {
+    if (value === undefined) {
+      value = null;
+    }
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;
     this._animation = null;


### PR DESCRIPTION
In the `different spring config's` example, the value `const transX = new Value();` resolves to NaN on web, but `null` (and then a proper number) on native. Perform the `undefined -> null` conversion upfront so all platforms function as expected.
