### PR TITLE
Unify sanitizing nodes for platform

### DIFF
--- a/src/core/AnimatedAlways.js
+++ b/src/core/AnimatedAlways.js
@@ -10,7 +10,7 @@ class AnimatedAlways extends AnimatedNode {
       what instanceof AnimatedNode,
       `Reanimated: Animated.always node argument should be of type AnimatedNode but got ${what}`
     );
-    super({ type: 'always', what: what.__nodeID }, [what]);
+    super({ type: 'always', what }, [what]);
     this._what = what;
   }
 

--- a/src/core/AnimatedBezier.js
+++ b/src/core/AnimatedBezier.js
@@ -135,7 +135,7 @@ export default class AnimatedBezier extends AnimatedNode {
       value instanceof AnimatedNode,
       `Reanimated: Bezier node argument should be of type AnimatedNode but got ${value}`
     );
-    super({ type: 'bezier', mX1, mY1, mX2, mY2, input: value.__nodeID }, [
+    super({ type: 'bezier', mX1, mY1, mX2, mY2, input: value }, [
       value,
     ]);
     this._value = value;

--- a/src/core/AnimatedBlock.js
+++ b/src/core/AnimatedBlock.js
@@ -11,7 +11,7 @@ class AnimatedBlock extends AnimatedNode {
       array.every(el => el instanceof AnimatedNode),
       `Reanimated: Animated.block node argument should be an array with elements of type AnimatedNode. One or more of them are not AnimatedNodes`
     );
-    super({ type: 'block', block: array.map(n => n.__nodeID) }, array);
+    super({ type: 'block', block: array }, array);
     this._array = array;
   }
 

--- a/src/core/AnimatedCall.js
+++ b/src/core/AnimatedCall.js
@@ -19,7 +19,7 @@ class AnimatedCall extends AnimatedNode {
       args.every(el => el instanceof AnimatedNode),
       `Reanimated: Animated.call node args should be an array with elements of type AnimatedNode. One or more of them are not AnimatedNodes`
     );
-    super({ type: 'call', input: args.map(n => n.__nodeID) }, args);
+    super({ type: 'call', input: args }, args);
     this._callback = jsFunction;
     this._args = args;
   }

--- a/src/core/AnimatedCallFunc.js
+++ b/src/core/AnimatedCallFunc.js
@@ -23,9 +23,9 @@ class AnimatedCallFunc extends AnimatedNode {
     super(
       {
         type: 'callfunc',
-        what: what.__nodeID,
-        args: args.map(n => n.__nodeID),
-        params: params.map(n => n.__nodeID),
+        what,
+        args,
+        params,
       },
       [...args]
     );

--- a/src/core/AnimatedClockTest.js
+++ b/src/core/AnimatedClockTest.js
@@ -4,7 +4,7 @@ class AnimatedClockTest extends AnimatedNode {
   _clockNode;
 
   constructor(clockNode) {
-    super({ type: 'clockTest', clock: clockNode.__nodeID });
+    super({ type: 'clockTest', clock: clockNode });
     this._clockNode = clockNode;
   }
 

--- a/src/core/AnimatedConcat.js
+++ b/src/core/AnimatedConcat.js
@@ -14,7 +14,7 @@ class AnimatedConcat extends AnimatedNode {
       ),
       `Reanimated: Animated.concat node arguments should be of type AnimatedNode or String or Number. One or more of them are not of that type. Node: ${input}`
     );
-    super({ type: 'concat', input: input.map(n => n.__nodeID) }, input);
+    super({ type: 'concat', input }, input);
     this._input = input;
   }
 

--- a/src/core/AnimatedCond.js
+++ b/src/core/AnimatedCond.js
@@ -24,9 +24,9 @@ class AnimatedCond extends AnimatedNode {
     super(
       {
         type: 'cond',
-        cond: condition.__nodeID,
-        ifBlock: ifBlock.__nodeID,
-        elseBlock: elseBlock ? elseBlock.__nodeID : undefined,
+        cond: condition,
+        ifBlock,
+        elseBlock,
       },
       [condition, ifBlock, elseBlock]
     );

--- a/src/core/AnimatedDebug.js
+++ b/src/core/AnimatedDebug.js
@@ -17,7 +17,7 @@ class AnimatedDebug extends AnimatedNode {
       value instanceof AnimatedNode,
       `Reanimated: Animated.debug node second argument should be of type AnimatedNode but got ${value}`
     );
-    super({ type: 'debug', message, value: value.__nodeID }, [value]);
+    super({ type: 'debug', message, value }, [value]);
     this._message = message;
     this._value = value;
   }

--- a/src/core/AnimatedFunction.js
+++ b/src/core/AnimatedFunction.js
@@ -15,7 +15,7 @@ class AnimatedFunction extends AnimatedNode {
     super(
       {
         type: 'func',
-        what: what.__nodeID,
+        what,
       },
       [what, ...params]
     );

--- a/src/core/AnimatedNode.js
+++ b/src/core/AnimatedNode.js
@@ -14,7 +14,7 @@ function sanitizeConfig(config) {
   } else if (config instanceof AnimatedNode) {
     return config.__nodeID;
   } else if (typeof config === 'object') {
-    const output: { [key: string]: any } = {};
+    const output = {};
     for (const property in config) {
       if (property in config) {
         output[property] = sanitizeConfig(config[property]);

--- a/src/core/AnimatedNode.js
+++ b/src/core/AnimatedNode.js
@@ -7,15 +7,22 @@ let loopID = 1;
 let propUpdatesEnqueued = null;
 
 function sanitizeConfig(config) {
-  if (Platform.OS === 'web') {
+  if (Platform.OS === 'web' || ['undefined', 'string', 'function', 'boolean', 'number'].includes(typeof config)) {
     return config;
-  }
-  for (const key in config) {
-    const value = config[key];
-    if (value instanceof AnimatedNode) {
-      config[key] = value.__nodeID;
+  } else if (Array.isArray(config)) {
+    return config.map(sanitizeConfig);
+  } else if (config instanceof AnimatedNode) {
+    return config.__nodeID;
+  } else if (typeof config === 'object') {
+    const output: { [key: string]: any } = {};
+    for (const property in config) {
+      if (property in config) {
+        output[property] = sanitizeConfig(config[property]);
+      }
     }
+    return output;
   }
+  // unhandled
   return config;
 }
 

--- a/src/core/AnimatedOperator.js
+++ b/src/core/AnimatedOperator.js
@@ -76,7 +76,7 @@ class AnimatedOperator extends AnimatedNode {
       `Reanimated: Animated.operator node second argument should be one or more of type AnimatedNode, String or Number but got ${input}`
     );
     super(
-      { type: 'op', op: operator, input: input.map(n => n.__nodeID) },
+      { type: 'op', op: operator, input },
       input
     );
     this._op = operator;

--- a/src/core/AnimatedSet.js
+++ b/src/core/AnimatedSet.js
@@ -16,7 +16,7 @@ class AnimatedSet extends AnimatedNode {
       value instanceof AnimatedNode,
       `Reanimated: Animated.set second argument should be of type AnimatedNode, String or Number but got ${value}`
     );
-    super({ type: 'set', what: what.__nodeID, value: value.__nodeID }, [value]);
+    super({ type: 'set', what, value }, [value]);
     invariant(!what._constant, 'Value to be set cannot be constant');
     this._what = what;
     this._value = value;

--- a/src/core/AnimatedStartClock.js
+++ b/src/core/AnimatedStartClock.js
@@ -11,7 +11,7 @@ class AnimatedStartClock extends AnimatedNode {
       clockNode instanceof AnimatedClock || clockNode instanceof AnimatedParam,
       `Reanimated: Animated.startClock argument should be of type AnimatedClock but got ${clockNode}`
     );
-    super({ type: 'clockStart', clock: clockNode.__nodeID });
+    super({ type: 'clockStart', clock: clockNode });
     this._clockNode = clockNode;
   }
 

--- a/src/core/AnimatedStopClock.js
+++ b/src/core/AnimatedStopClock.js
@@ -11,7 +11,7 @@ class AnimatedStopClock extends AnimatedNode {
       clockNode instanceof AnimatedClock || clockNode instanceof AnimatedParam,
       `Reanimated: Animated.stopClock argument should be of type AnimatedClock but got ${clockNode}`
     );
-    super({ type: 'clockStop', clock: clockNode.__nodeID });
+    super({ type: 'clockStop', clock: clockNode });
     this._clockNode = clockNode;
   }
 


### PR DESCRIPTION
Because there is no node registry on web, we don't want to sanitize the nodes to be just the ID. Unifying the sanitation means we can choose exactly how we want to reference nodes based on platform. 

This will be used for assigning [transform values with `Animated.event` in RNGH](https://github.com/software-mansion/react-native-gesture-handler/blob/8e189f21632bc4d8bc95b0bb2c79d530427c1859/web/GestureHandler.js#L408)