### PR TITLE
Handle issue in eq and neq when any of params is null

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/OperatorNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/OperatorNode.java
@@ -189,6 +189,9 @@ public class OperatorNode extends Node {
   private static final Operator EQ = new CompOperator() {
     @Override
     public boolean eval(Double x, Double y) {
+      if (x == null || y == null) {
+        return x == y;
+      }
       return x.doubleValue() == y.doubleValue();
     }
   };
@@ -213,6 +216,9 @@ public class OperatorNode extends Node {
   private static final Operator NEQ = new CompOperator() {
     @Override
     public boolean eval(Double x, Double y) {
+      if (x == null || y == null) {
+        return x == y;
+      }
       return x.doubleValue() != y.doubleValue();
     }
   };


### PR DESCRIPTION
Fixes regression made by https://github.com/software-mansion/react-native-reanimated/commit/59bd12106286aa967bfb7ad534373e8c2289c550

Closes https://github.com/software-mansion/react-native-reanimated/issues/551

We have observed that while evaluating neq or eq, the second param might be `null`. After https://github.com/software-mansion/react-native-reanimated/pull/498 it started causing  `NullPointerException` so I made a special check for that. Additionally, I allowed the first param to be nullable as well.