### PR TITLE
Revert "Fix case where `new Animated.Value()` is NaN on web"

### DIFF
--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -32,9 +32,6 @@ export default class InternalAnimatedValue extends AnimatedNode {
   }
 
   constructor(value, constant = false) {
-    if (value === undefined) {
-      value = null;
-    }
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;
     this._animation = null;


### PR DESCRIPTION
Reverts software-mansion/react-native-reanimated#548


`undefined` is not casting to null and that's the reason for the https://github.com/software-mansion/react-native-reanimated/issues/563 regression.  

rel: https://github.com/software-mansion/react-native-reanimated/issues/561