### PR TITLE
Remove useless exports of the main clock

### DIFF
--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -89,5 +89,3 @@ export default class AnimatedClock extends AnimatedNode {
   }
 }
 
-const clock = mainClock;
-export { clock };


### PR DESCRIPTION
This value is not used anywhere and might lead to confusions 