### PR TITLE
Fallback to old mechanism of setting value if value is a node or string

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -12,16 +12,17 @@ export default class AnimatedValue extends InternalAnimatedValue {
     if (Platform.OS === 'web') {
       this._updateValue(value);
     } else {
-      if (ReanimatedModule.setValue) {
+      if (ReanimatedModule.setValue && typeof value === "number") {
         // FIXME Remove it after some time
         // For OTA-safety
+        // FIXME handle setting value with a node
         ReanimatedModule.setValue(this.__nodeID, value);
       } else {
         evaluateOnce(set(this, value), this);
       }
     }
   }
-  
+
   toString() {
     return `AnimatedValue, id: ${this.__nodeID}`;
   }


### PR DESCRIPTION
The current implementation of setValue is not accepting value as a node so for now, I'd like to revert to the old mechanism in this case in order to limit a regression