### PR TITLE
Remove RCTAssertParam from REANodesManager.m

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -406,8 +406,6 @@
 
   REANode *node = _nodes[nodeID];
 
-  RCTAssertParam(node);
-
   REAValueNode *valueNode = (REAValueNode *)node;
   [valueNode setValue:newValue];
 }


### PR DESCRIPTION
It's a follow-up of this PR #560 fixing this issue i=on iOS. Calling selectors on nil is not an error, but assertion throws and following #560 we should allow it.