### PR TITLE
[v1] Fix animated value not set if not attached

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -7,15 +7,24 @@ import ReanimatedModule from '../ReanimatedModule';
 
 // Animated value wrapped with extra methods for omit cycle of dependencies
 export default class AnimatedValue extends InternalAnimatedValue {
+  __attach() {
+    super.__attach();
+
+    if (this._value !== this._startingValue) {
+      this.setValue(this._value);
+    }
+  }
+
   setValue(value) {
     this.__detachAnimation(this._animation);
     if (Platform.OS === 'web') {
       this._updateValue(value);
     } else {
-      if (ReanimatedModule.setValue && typeof value === "number") {
+      if (ReanimatedModule.setValue && typeof value === 'number') {
         // FIXME Remove it after some time
         // For OTA-safety
         // FIXME handle setting value with a node
+        this._value = value;
         ReanimatedModule.setValue(this.__nodeID, value);
       } else {
         evaluateOnce(set(this, value), this);


### PR DESCRIPTION
Fixes an edge case where if an `Animated.Value` is not attached yet and `setValue` is called that value will not be set since the node does not exist on the native side.

For me this situation happens during first render where some values are calculated from props inside a `useMemo`

reading the code it also makes me believe that if a value node is detached and reattached it would reset its value to the initial value? is that a bug, or feature? if this is relied upon this might be a breaking change

Let me know what you think 👍 