### PR TITLE
Add the converting code of deg at animated value

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -28,17 +28,16 @@ export default class AnimatedValue extends InternalAnimatedValue {
   }
 
   interpolate(config) {
-    _convertToRadians(config);
+    this._convertToRadians(config);
     return interpolate(this, config);
   }
 
   // FIXME: Where to put this code???
   _convertToRadians(config) {
-    if (typeof config.outputRange[0] == 'string' && config.outputRange.some(v => v.includes('deg'))) {
+    if (typeof config.outputRange[0] == 'string' && config.outputRange[0].includes('deg')) {
       config.outputRange = config.outputRange
-        .map(v => v.slice(0, v.indexOf('deg')))
-        .map(Number)
-        .map(v => v * Math.PI / 180)
+        .map(value => Number(value.slice(0, value.indexOf('deg'))))
+        .map(value => value * Math.PI / 180)
     }
   }
 }

--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -28,6 +28,17 @@ export default class AnimatedValue extends InternalAnimatedValue {
   }
 
   interpolate(config) {
+    _convertToRadians(config);
     return interpolate(this, config);
+  }
+
+  // FIXME: Where to put this code???
+  _convertToRadians(config) {
+    if (typeof config.outputRange[0] == 'string' && config.outputRange.some(v => v.includes('deg'))) {
+      config.outputRange = config.outputRange
+        .map(v => v.slice(0, v.indexOf('deg')))
+        .map(Number)
+        .map(v => v * Math.PI / 180)
+    }
   }
 }

--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -28,17 +28,6 @@ export default class AnimatedValue extends InternalAnimatedValue {
   }
 
   interpolate(config) {
-    _convertToRadians(config);
     return interpolate(this, config);
-  }
-
-  // FIXME: Where to put this code???
-  _convertToRadians(config) {
-    if (typeof config.outputRange[0] == 'string' && config.outputRange.some(v => v.includes('deg'))) {
-      config.outputRange = config.outputRange
-        .map(v => v.slice(0, v.indexOf('deg')))
-        .map(Number)
-        .map(v => v * Math.PI / 180)
-    }
   }
 }

--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -28,16 +28,17 @@ export default class AnimatedValue extends InternalAnimatedValue {
   }
 
   interpolate(config) {
-    this._convertToRadians(config);
+    _convertToRadians(config);
     return interpolate(this, config);
   }
 
   // FIXME: Where to put this code???
   _convertToRadians(config) {
-    if (typeof config.outputRange[0] == 'string' && config.outputRange[0].includes('deg')) {
+    if (typeof config.outputRange[0] == 'string' && config.outputRange.some(v => v.includes('deg'))) {
       config.outputRange = config.outputRange
-        .map(value => Number(value.slice(0, value.indexOf('deg'))))
-        .map(value => value * Math.PI / 180)
+        .map(v => v.slice(0, v.indexOf('deg')))
+        .map(Number)
+        .map(v => v * Math.PI / 180)
     }
   }
 }

--- a/src/derived/interpolate.js
+++ b/src/derived/interpolate.js
@@ -97,7 +97,7 @@ function checkValidNumbers(name, arr) {
 function convertToRadians(outputRange) {
   for (const [i, value] of outputRange.entries()) {
     if (typeof value === 'string' && value.endsWith('deg')) {
-      outputRange[i] = Number(value.slice(0, -3)) * (Math.PI / 180);
+      outputRange[i] = parseFloat(value) * (Math.PI / 180);
     }
   }
 }

--- a/src/derived/interpolate.js
+++ b/src/derived/interpolate.js
@@ -24,7 +24,11 @@ const interpolateInternalSingleProc = proc(function(
   const progress = divide(sub(value, inS), sub(inE, inS));
   // logic below was made in order to provide a compatibility witn an Animated API
   const resultForNonZeroRange = add(outS, multiply(progress, sub(outE, outS)));
-  const result = cond(eq(inS, inE), cond(lessOrEq(value, inS), outS, outE), resultForNonZeroRange);
+  const result = cond(
+    eq(inS, inE),
+    cond(lessOrEq(value, inS), outS, outE),
+    resultForNonZeroRange
+  );
   return result;
 });
 
@@ -79,7 +83,7 @@ function checkMinElements(name, arr) {
 function checkValidNumbers(name, arr) {
   for (let i = 0; i < arr.length; i++) {
     // We can't validate animated nodes in JS.
-    if (arr[i] instanceof AnimatedNode) continue;
+    if (arr[i] instanceof AnimatedNode || typeof arr[i] !== 'number') continue;
     invariant(
       Number.isFinite(arr[i]),
       '%s cannot include %s. (%s)',
@@ -87,6 +91,14 @@ function checkValidNumbers(name, arr) {
       arr[i],
       arr
     );
+  }
+}
+
+function convertToRadians(outputRange) {
+  for (const [i, value] of outputRange.entries()) {
+    if (typeof value === 'string' && value.endsWith('deg')) {
+      outputRange[i] = Number(value.slice(0, -3)) * (Math.PI / 180);
+    }
   }
 }
 
@@ -98,6 +110,7 @@ export default function interpolate(value, config) {
     extrapolateLeft,
     extrapolateRight,
   } = config;
+
   checkMinElements('inputRange', inputRange);
   checkValidNumbers('inputRange', inputRange);
   checkMinElements('outputRange', outputRange);
@@ -108,6 +121,7 @@ export default function interpolate(value, config) {
     'inputRange and outputRange must be the same length.'
   );
 
+  convertToRadians(outputRange);
   const left = extrapolateLeft || extrapolate;
   const right = extrapolateRight || extrapolate;
   let output = interpolateInternal(value, inputRange, outputRange);


### PR DESCRIPTION
<img width="250" alt="Screen Shot 2020-01-24 at 3 30 04 PM" src="https://user-images.githubusercontent.com/24269591/73049028-6fe1d180-3ebe-11ea-82f5-e620cea7cefa.png">

```
Invariant Violation: outputRange cannot include 0deg. (0deg,360deg)

This error is located at:
    in Test (at App.js:46)
    in RCTSafeAreaView (at SafeAreaView.js:55)
    in SafeAreaView (at App.js:45)
    in App (at renderApplication.js:40)
    in RCTView (at AppContainer.js:101)
    in RCTView (at AppContainer.js:119)
    in AppContainer (at renderApplication.js:39)

checkValidNumbers
    interpolate.js:84:6
interpolate
    interpolate.js:107:20
interpolate
    AnimatedValue.js:31:23
componentWillMount
    Test.js:36:47

```

I think it's used often, but there's an error.
The goal is to be compatible with Animated, so I added it once.

But I don't know the structure of this project.
So I added FIXME.

```typescript
      <Animated.View
        style={[
          styles.box,
          { transform: [{ rotate: concat(this.trans, 'deg') }] },
        ]}
      />
```
I found out later. there are the above options, but wouldn't it be better to do an automatic converting?


Let me know what you think 👍

