### PR TITLE
Hide 'Nullable' declaration from global scope

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -1,9 +1,9 @@
 // Project: https://github.com/software-mansion/react-native-reanimated
 // TypeScript Version: 2.8
 
-type Nullable<T> = T | null | undefined;
-
 declare module 'react-native-reanimated' {
+  type Nullable<T> = T | null | undefined;
+
   import { ComponentClass, ReactNode, Component } from 'react';
   import {
     ViewProps,


### PR DESCRIPTION
`Nullable` should be inside the namespace in order to avoid `error TS2300: Duplicate identifier` error which may occur if we already have it within our own projects.