### PR TITLE
fix useCode signature

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -349,7 +349,7 @@ declare module 'react-native-reanimated' {
 
     // hooks
     export function useCode(
-      exec: () => Nullable< AnimatedNode<number>[] | AnimatedNode<number> > | boolean,
+      exec: () => ReadonlyArray<Adaptable<T>>,
       deps: Array<any>,
     ): void
 


### PR DESCRIPTION
This allows for the array syntax: `useCode(() => [set(foo, bar)], [])`