### PR TITLE
Transition Api Alternative (Proposal)

### DIFF
--- a/Example/src/transitions/ticket.js
+++ b/Example/src/transitions/ticket.js
@@ -1,13 +1,8 @@
 import React, { useState, useRef } from 'react';
-import { Text, View, StyleSheet, Button, StatusBar } from 'react-native';
-import { Transitioning, Transition } from 'react-native-reanimated';
+import { Text, View, Button } from 'react-native';
+import { Transitioning, TransitionApi } from 'react-native-reanimated';
 
-function shuffleArray(array) {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]];
-  }
-}
+const { Sequence, Together, Out, In, Change } = TransitionApi;
 
 const Hour = ({ hour, min, pm }) => (
   <View
@@ -62,37 +57,30 @@ const Tix = () => (
 );
 
 function Ticket() {
-  let [refreshed, setRefreshed] = useState(1);
+  const [refreshed, setRefreshed] = useState(1);
   const ref = useRef();
 
-  const transition = (
-    <Transition.Sequence>
-      <Transition.Out type="fade" durationMs={400} interpolation="easeIn" />
-      <Transition.Change />
-      <Transition.Together>
-        <Transition.In
-          type="slide-bottom"
-          durationMs={400}
-          interpolation="easeOut"
-          propagation="bottom"
-        />
-        <Transition.In type="fade" durationMs={200} delayMs={200} />
-      </Transition.Together>
-    </Transition.Sequence>
-  );
   return (
     <View style={{ flex: 1 }}>
       <Button
         title="refresh"
         color="#FF5252"
         onPress={() => {
-          ref.current.animateNextTransition();
+          ref.current.animateNextTransition(
+            Sequence([
+              Out({ type: 'fade', durationMs: 400, interpolation: 'easeIn' }),
+              Change(),
+              Together([
+                In({ type: 'slide-bottom', durationMs: 400, interpolation: 'easeOut', propagation: 'bottom' }),
+                In({ type: 'fade', durationMs: 200, delayMs: 200 })
+              ])
+            ])
+          );
           setRefreshed(refreshed + 1);
         }}
       />
       <Transitioning.View
         ref={ref}
-        transition={transition}
         style={{
           flexGrow: 1,
           justifyContent: 'center',
@@ -102,7 +90,5 @@ function Ticket() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({});
 
 export default Ticket;

--- a/docs/pages/04.transitions.md
+++ b/docs/pages/04.transitions.md
@@ -10,17 +10,17 @@ Transitions is an experimental API distributed as a part of reanimated which ser
 
 Transitions API consists of two main building blocks. First one being `Transitioning.View` which is an extension of regular react-native view, so you can use any `View` props you'd like. The `Transitioning.View` is a root of all the transition animations that will be happening and is used to scope the changes to its children. In order to have next transition animated you'd need to call `animateNextTransition()` on the `Transitioning.View` instance.
 
-The second main building block is transition definition. Transitioning API uses JSX syntax that allows you to define how the transition animation should perform. You can use all the components from `Transition` object to combine the animation you want. Please see the below list for the documentation of transition components.
+The second main building block is transition definition. Transitioning API uses JSX syntax that allows you to define how the transition animation should perform. You can use all the components from `Transition` object to combine the animation you want. Please see the below list for the documentation of transition components. Alternatively, a non-JSX syntax is provided via the `TransitionApi` object.
 
 ## Transition groups
 
 The below set of components can be used to group one or more transitions. You can also nest transition groups in order to achieve desirable effects.
 
-### `<Transition.Together>`
+### `<Transition.Together>` or `TransitionApi.Together`
 
 Transitions nested under this component will run in parallel when the animation starts.
 
-### `<Transition.Sequence>`
+### `<Transition.Sequence>` or `TransitionApi.Sequence`
 
 Transitions nested under this component will run in sequence in the order at which they are listed
 
@@ -44,15 +44,15 @@ Specify the transition timing curve. Possible values are: `linear`, `easeIn`, `e
 
 Allows for the framework to automatically delay beginning of transitions across a set of different views depending on their position. The possible values are `top`, `bottom`, `left` and `right`. When `propagation="top"` it means that the first element that will start animating is the one that is closest to the top of `Transitioning.View` container, then the other views will be delayed by the amount which depends on their distance from the top edge.
 
-### `<Transition.In>`
+### `<Transition.In>` or `TransitionApi.In`
 
 Allows to specify how views that get mounted during animation transition get animated. In addition to the above parameters you can specify the type of animation using `type` prop. The possible values are: `fade`, `scale`, `slide-top`, `slide-bottom`, `slide-left`, `slide-right`.
 
-### `<Transition.Out>`
+### `<Transition.Out>` or `TransitionApi.Out`
 
 Allows to specify how the framework should animate views that are being removed during transition. In addition to the above parameters you can specify the type of animation using `type` prop. The possible values are: `fade`, `scale`, `slide-top`, `slide-bottom`, `slide-left`, `slide-right`.
 
-### `<Transition.Change>`
+### `<Transition.Change>` or `TransitionApi.Change`
 
 Use `Transition.Change` component to specify how components' which properties get changed during transition should be animated. The framework currently supports an animating position, bounds and transforms.
 

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -21,10 +21,10 @@ import backwardCompatibleAnimWrapper from './animations/backwardCompatibleAnimWr
 import {
   Transition,
   Transitioning,
+  TransitionApi,
   createTransitioningComponent,
 } from './Transitioning';
 import SpringUtils from './animations/SpringUtils';
-
 
 const decayWrapper = backwardCompatibleAnimWrapper(decay, DecayAnimation);
 const timingWrapper = backwardCompatibleAnimWrapper(timing, TimingAnimation);
@@ -68,13 +68,12 @@ export {
   Easing,
   Transitioning,
   Transition,
-  createTransitioningComponent, 
-
+  TransitionApi,
+  createTransitioningComponent,
   // classes
   AnimatedClock as Clock,
   AnimatedValue as Value,
   AnimatedNode as Node,
-
   // animations
   decayWrapper as decay,
   timingWrapper as timing,

--- a/src/Transitioning.js
+++ b/src/Transitioning.js
@@ -123,9 +123,9 @@ function createTransitioningComponent(Component) {
 
     animateNextTransition(transitionConfig) {
       const transitions =
-        transitionConfig && Array.isArray(transitionConfig)
+        transitionConfig && (Array.isArray(transitionConfig)
           ? transitionConfig
-          : [transitionConfig];
+          : [transitionConfig]);
 
       const viewTag = findNodeHandle(this.viewRef.current);
       ReanimatedModule.animateNextTransition(viewTag, {


### PR DESCRIPTION
Originally, my goal was to fix #328. After a lot of fiddling around around with the Transition Api I landed on instead passing the desired transition config directly through `animateNextTransition` rather than using the `Transition` and `Transitioning.View` `transition` prop. While this doesn't necessarily fix #328 it does provide a working alternative.

Feedback would be great! Thoughts on other strategies to fix #328 would also be appreciated. 

```
function component() {
  const [state, setState] = React.useState(false);
  const viewRef = Reac.useRef()

  return (
    <>
      <Button onPress={() =>
         viewRef.current.animateNextTransition(
           TransitionApi.Together([
              TransitionApi.Out({ type: 'fade', durationMs: 400, interpolation: 'easeIn' }),
              TransitionApi.Change(),
              TransitionApi.In({ type: 'slide-right', durationMs: 200, interpolation: 'linear' }),
           ])
         )
        }
      />
      <Transitioning.View
        ref={viewRef}
      >
        {state ? <Thing1/> : <Thing2/>}
      </Transitioning.View>
    </>
    
  )
}

```