### PR TITLE
Fix Transitioning.View in mock.js

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -200,7 +200,7 @@ module.exports = {
   },
 
   Transitioning: {
-    View: createMockComponent('Transitioning.View')
+    View: createTransitioningComponent(View)
   },
 
   Transition: {


### PR DESCRIPTION
**Issue:** Previously `Transitioning.View` in the mock used the `createMockComponent`. The issue is that this function doesn't return a component which has the `animateNextTransition()` function. So when doing `ref.current.animateNextTransition()` in your tests, this line will crash because of the function not existing.

**Fix:** This commit ensures that `Transitioning.View` is mocked by using `createTransitioningComponent` function which provides the `animateNextTransition` function to the ref.