### PR TITLE
fix: prevent initial flickering in browsers

### DIFF
--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -6,7 +6,7 @@ class AnimatedMainClock extends InternalAnimatedValue {
   _frameCallback;
 
   constructor() {
-    super();
+    super(Date.now());
   }
 
   __onEvaluate() {

--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -6,11 +6,11 @@ class AnimatedMainClock extends InternalAnimatedValue {
   _frameCallback;
 
   constructor() {
-    super({ type: 'MAIN_CLOCK' });
+    super(Date.now());
   }
 
   __onEvaluate() {
-    return +new Date();
+    return Date.now();
   }
 
   _runFrame = () => {

--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -6,7 +6,7 @@ class AnimatedMainClock extends InternalAnimatedValue {
   _frameCallback;
 
   constructor() {
-    super(Date.now());
+    super();
   }
 
   __onEvaluate() {

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -191,10 +191,12 @@ export default function createAnimatedComponent(Component) {
       if (c !== this._component) {
         this._component = c;
 
-        // Set initial animated styles to prevent minimal flickering
-        if (this._component && this._component.setNativeProps) {
+        // Set initial animated styles to prevent minimal flickering in browsers
+        if (Platform.OS === 'web' && this._component && this._component.setNativeProps) {
+          const initialStyle = this._getInitialStyle(StyleSheet.flatten(this.props.style))
+
           this._component.setNativeProps({
-            style: this._getInitialStyle(StyleSheet.flatten(this.props.style))
+            style: initialStyle,
           });
         }
       }
@@ -204,10 +206,10 @@ export default function createAnimatedComponent(Component) {
       const style = {};
       for (const key in inputStyle) {
         const value = inputStyle[key];
-        if (value && typeof value.__getValue === 'function') {
+        if (value instanceof AnimatedNode) {
           style[key] = value.__getValue();
         } else if (Array.isArray(value)) {
-          style.transform = value.map(this._getInitialStyle.bind(this));
+          style[key] = value.map(this._getInitialStyle.bind(this))
         } else {
           style[key] = value;
         }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -194,20 +194,20 @@ export default function createAnimatedComponent(Component) {
         // Set initial animated styles to prevent minimal flickering
         if (this._component && this._component.setNativeProps) {
           this._component.setNativeProps({
-            style: this._filterAnimatedStyle(StyleSheet.flatten(this.props.style))
+            style: this._getInitialStyle(StyleSheet.flatten(this.props.style))
           });
         }
       }
     };
 
-    _filterAnimatedStyle(inputStyle) {
+    _getInitialStyle(inputStyle) {
       const style = {};
       for (const key in inputStyle) {
         const value = inputStyle[key];
         if (value && typeof value.__getValue === 'function') {
           style[key] = value.__getValue();
         } else if (Array.isArray(value)) {
-          style.transform = value.map(this._filterAnimatedStyle.bind(this));
+          style.transform = value.map(this._getInitialStyle.bind(this));
         } else {
           style[key] = value;
         }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -205,8 +205,8 @@ export default function createAnimatedComponent(Component) {
     _filterAnimatedStyle(inputStyle) {
       const style = {};
       for (const key in inputStyle) {
-        const value = inputStyle[key];	       
-        if (value instanceof AnimatedNode) {
+        const value = inputStyle[key];
+        if (value && typeof value.__getValue === 'function') {
           if (this._setAnimatedStylesInRender) {
             style[key] = value.__getValue();
           }
@@ -214,7 +214,7 @@ export default function createAnimatedComponent(Component) {
           style.transform = value.map(this._filterAnimatedStyle.bind(this));
         } else {
           style[key] = value;
-        }	        
+        }
       }
       return style;
     }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -205,18 +205,16 @@ export default function createAnimatedComponent(Component) {
     _filterAnimatedStyle(inputStyle) {
       const style = {};
       for (const key in inputStyle) {
-        const value = inputStyle[key];
+        const value = inputStyle[key];	       
         if (value instanceof AnimatedNode) {
           if (this._setAnimatedStylesInRender) {
             style[key] = value.__getValue();
           }
-        } else if (key === 'transform') {
-          if (this._setAnimatedStylesInRender) {
-            style.transform = value.map(this._filterAnimatedStyle.bind(this));
-          } 
+        } else if (key === 'transform' && Array.isArray(value)) {
+          style.transform = value.map(this._filterAnimatedStyle.bind(this));
         } else {
           style[key] = value;
-        }
+        }	        
       }
       return style;
     }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -206,7 +206,7 @@ export default function createAnimatedComponent(Component) {
         const value = inputStyle[key];
         if (value && typeof value.__getValue === 'function') {
           style[key] = value.__getValue();
-        } else if (key === 'transform' && Array.isArray(value)) {
+        } else if (Array.isArray(value)) {
           style.transform = value.map(this._filterAnimatedStyle.bind(this));
         } else {
           style[key] = value;

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -193,11 +193,15 @@ export default function createAnimatedComponent(Component) {
       }
     };
 
-    _filterNonAnimatedStyle(inputStyle) {
+    _resolveAnimatedStyle(inputStyle) {
       const style = {};
       for (const key in inputStyle) {
         const value = inputStyle[key];
-        if (!(value instanceof AnimatedNode) && key !== 'transform') {
+        if (value instanceof AnimatedNode) {
+          style[key] = value.__getValue();
+        } else if (key === 'transform') {
+          style.transform = value.map(this._resolveAnimatedStyle);
+        } else {
           style[key] = value;
         }
       }
@@ -209,7 +213,7 @@ export default function createAnimatedComponent(Component) {
       for (const key in inputProps) {
         const value = inputProps[key];
         if (key === 'style') {
-          props[key] = this._filterNonAnimatedStyle(StyleSheet.flatten(value));
+          props[key] = this._resolveAnimatedStyle(StyleSheet.flatten(value));
         } else if (value instanceof AnimatedEvent) {
           // we cannot filter out event listeners completely as some components
           // rely on having a callback registered in order to generate events

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -205,9 +205,7 @@ export default function createAnimatedComponent(Component) {
       for (const key in inputStyle) {
         const value = inputStyle[key];
         if (value && typeof value.__getValue === 'function') {
-          if (this._setAnimatedStylesInRender) {
-            style[key] = value.__getValue();
-          }
+          style[key] = value.__getValue();
         } else if (key === 'transform' && Array.isArray(value)) {
           style.transform = value.map(this._filterAnimatedStyle.bind(this));
         } else {


### PR DESCRIPTION
I noticed that animated `View`s initially flicker because there is a minimal delay between when the element is rendered and when the animated styles are applied. This fix uses the current values of the animated styles for the initial rendering and thus avoids flickering.