### PR TITLE
Set __isProxy after traversing children in createEventObjectProxyPolyfill

### DIFF
--- a/src/core/createEventObjectProxyPolyfill.js
+++ b/src/core/createEventObjectProxyPolyfill.js
@@ -35,8 +35,8 @@ export default function createEventObjectProxyPolyfill() {
   };
   const traverse = obj => {
     for (const key in obj) {
-      obj[key].__isProxy = true;
       traverse(obj[key]);
+      obj[key].__isProxy = true;
     }
   };
   traverse(nodesMap);


### PR DESCRIPTION
As #639 says, when we set __isProxy prior to traversing its children, one of `traverse` calls uses __isProxy as key, so we have obj[__isProxy] === true, so we try to set true.__isProxy

Fixes #639 