### PR TITLE
Update createEventObjectProxyPolyfill.js

### DIFF
--- a/src/core/createEventObjectProxyPolyfill.js
+++ b/src/core/createEventObjectProxyPolyfill.js
@@ -36,7 +36,7 @@ export default function createEventObjectProxyPolyfill() {
   const traverse = obj => {
     for (const key in obj) {
       traverse(obj[key]);
-      obj[key].__isProxy = true;
+      Object.assign(obj[key], { __isProxy: true });
     }
   };
   traverse(nodesMap);


### PR DESCRIPTION
App crashes when hermes is enabled (tested on android).
App sometimes reports an error regarding not being able to assign values to a transient object.
This seems to fix the issue