### PR TITLE
Fix greaterThan and lessThan operators platform differences

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/OperatorNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/OperatorNode.java
@@ -183,6 +183,9 @@ public class OperatorNode extends Node {
   private static final Operator LESS_THAN = new CompOperator() {
     @Override
     public boolean eval(Double x, Double y) {
+      if (x == null || y == null) {
+        return false;
+      }
       return x < y;
     }
   };
@@ -198,6 +201,9 @@ public class OperatorNode extends Node {
   private static final Operator GREATER_THAN = new CompOperator() {
     @Override
     public boolean eval(Double x, Double y) {
+      if (x == null || y == null) {
+        return false;
+      }
       return x > y;
     }
   };


### PR DESCRIPTION
Fixes #609 

Android was throwing an error when number was compared to undefined (due to null to Double cast), whereas iOS was returning false in such situation.
In order to make the behavior the same I added check for null value in lessThan and greaterThan operator nodes. If value is null the operator returns false, if not it proceeds with comparison.