### PR TITLE
Use component type in createAnimatedComponent

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -196,7 +196,7 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
-    export function createAnimatedComponent(component: any): any;
+    export function createAnimatedComponent<T>(component: T): T;
 
     // classes
     export {


### PR DESCRIPTION
When using `createAnimatedComponent` with Typescript, it would blow away the type of the inner component. This means that JSX code completion and type inference would no longer work.

This solves this by passing back the same type that was input, so that the exported component will have the expected prop types.