### PR TITLE
Hide leading zeroes on int number in concatNode

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -8,6 +8,10 @@ import com.swmansion.reanimated.Utils;
 
 public class ConcatNode extends Node {
   private final int[] mInputIDs;
+  private final static NumberFormat formatter = NumberFormat.getInstance();
+  static {
+    formatter.setMinimumFractionDigits(0);
+  }
 
   public ConcatNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
     super(nodeID, config, nodesManager);
@@ -17,8 +21,6 @@ public class ConcatNode extends Node {
   @Override
   protected String evaluate() {
     StringBuilder builder = new StringBuilder();
-    NumberFormat formatter = NumberFormat.getInstance();
-    formatter.setMinimumFractionDigits(0);
 
     for (int i = 0; i < mInputIDs.length; i++) {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -21,7 +21,6 @@ public class ConcatNode extends Node {
   @Override
   protected String evaluate() {
     StringBuilder builder = new StringBuilder();
-
     for (int i = 0; i < mInputIDs.length; i++) {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);
       Object value = inputNodes.value();

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -24,8 +24,7 @@ public class ConcatNode extends Node {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);
       Object value = inputNodes.value();
       if (value instanceof Double) {
-        Double valueDouble = (Double) value;
-        value = formatter.format(valueDouble);
+        value = formatter.format((Double) value);
       }
       builder.append(value);
     }

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -17,14 +17,14 @@ public class ConcatNode extends Node {
   @Override
   protected String evaluate() {
     StringBuilder builder = new StringBuilder();
+    NumberFormat formatter = NumberFormat.getInstance();
+    formatter.setMinimumFractionDigits(0);
+
     for (int i = 0; i < mInputIDs.length; i++) {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);
       Object value = inputNodes.value();
       if (value instanceof Double) {
         Double valueDouble = (Double) value;
-
-        NumberFormat formatter = NumberFormat.getInstance();
-        formatter.setMinimumFractionDigits(0);
         value = formatter.format(valueDouble);
       }
       builder.append(value);

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -1,5 +1,7 @@
 package com.swmansion.reanimated.nodes;
 
+import java.text.NumberFormat;
+
 import com.facebook.react.bridge.ReadableMap;
 import com.swmansion.reanimated.NodesManager;
 import com.swmansion.reanimated.Utils;
@@ -17,7 +19,15 @@ public class ConcatNode extends Node {
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < mInputIDs.length; i++) {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);
-      builder.append(inputNodes.value());
+      Object value = inputNodes.value();
+      if (value instanceof Double) {
+        Double valueDouble = (Double) value;
+
+        NumberFormat formatter = NumberFormat.getInstance();
+        formatter.setMinimumFractionDigits(0);
+        value = formatter.format(valueDouble);
+      }
+      builder.append(value);
     }
     return builder.toString();
   }

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -8,9 +8,9 @@ import com.swmansion.reanimated.Utils;
 
 public class ConcatNode extends Node {
   private final int[] mInputIDs;
-  private final static NumberFormat formatter = NumberFormat.getInstance();
+  private final static NumberFormat sFormatter = NumberFormat.getInstance();
   static {
-    formatter.setMinimumFractionDigits(0);
+    sFormatter.setMinimumFractionDigits(0);
   }
 
   public ConcatNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
@@ -25,7 +25,7 @@ public class ConcatNode extends Node {
       Node inputNodes = mNodesManager.findNodeById(mInputIDs[i], Node.class);
       Object value = inputNodes.value();
       if (value instanceof Double) {
-        value = formatter.format((Double) value);
+        value = sFormatter.format((Double) value);
       }
       builder.append(value);
     }


### PR DESCRIPTION
## Description

Fixes #677

When using `concat` node on `Value` which is an integer, Reanimated created a string with leading zeroes on Android and string without leading zeroes on IOS.

This PR fixes this and also fixes the localization of formatted numbers.

## Reproduction Example

```jsx
import React from 'react';
import { SafeAreaView, TextInput } from 'react-native';
import Animated from 'react-native-reanimated';
const { Value, concat, createAnimatedComponent } = Animated;

const price = new Value(44.5);
const AnimatedTextInput = createAnimatedComponent(TextInput);
const App = () => {
  return (
    <>
      <SafeAreaView>
        <AnimatedTextInput
          underlineColorAndroid="transparent"
          editable={false}
          {...{ text: concat('', price), style: { color: 'black' } }}
        />
      </SafeAreaView>
    </>
  );
};

export default App;
```

Pre-fix Screenshot:
![image](https://user-images.githubusercontent.com/12465392/78279973-a2d8bf00-7518-11ea-966e-cd6cec8cc7f5.png)

Post-fix screenshots (localization with comma on decimals):
![image](https://user-images.githubusercontent.com/12465392/78280483-77a29f80-7519-11ea-8c73-081c50eb550e.png)

![image](https://user-images.githubusercontent.com/12465392/78280511-81c49e00-7519-11ea-8d01-2bdeea00e71c.png)

