### PR TITLE
Fixed incorrect transform style prop typings

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -149,7 +149,7 @@ declare module 'react-native-reanimated' {
 
     export type TransformStyleTypes = TransformsStyle['transform'] extends readonly (infer T)[] ? T : never
     export type AdaptTransforms<T> = { [P in keyof T]: Animated.Adaptable<T[P]> }
-    export type AnimatedTransform = AdaptTransforms<TransformStyleTypes>
+    export type AnimatedTransform = (AdaptTransforms<TransformStyleTypes>)[]
 
     export type AnimateStyle<S extends object> = {
       [K in keyof S]: K extends 'transform' ? AnimatedTransform : (S[K] extends ReadonlyArray<any>

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -147,7 +147,9 @@ declare module 'react-native-reanimated' {
 
     export const SpringUtils: SpringUtils
 
-    export type AnimatedTransform = { [P in keyof TransformsStyle["transform"]]: Animated.Adaptable<TransformsStyle["transform"][P]> };
+    export type TransformStyleTypes = TransformsStyle['transform'] extends readonly (infer T)[] ? T : never
+    export type AdaptTransforms<T> = { [P in keyof T]: Animated.Adaptable<T[P]> }
+    export type AnimatedTransform = AdaptTransforms<TransformStyleTypes>
 
     export type AnimateStyle<S extends object> = {
       [K in keyof S]: K extends 'transform' ? AnimatedTransform : (S[K] extends ReadonlyArray<any>


### PR DESCRIPTION
`TransformsStyle["transform"]` is an array prop so we should infer it's element type, apply `Animated.Adaptable` and construct it back. Otherwise `Animated.Adaptable` applies to `Array` keys (`length`, `map`, `forEach`, etc).

Truly fixes #297 
