### PR TITLE
fix(TypeScript): Fix return type for block()

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -269,9 +269,9 @@ declare module 'react-native-reanimated' {
       ifNode: Adaptable<T1>,
       elseNode?: Adaptable<T2>,
     ): AnimatedNode<T1 | T2>;
-    export function block<T>(
-      items: ReadonlyArray<Adaptable<T>>,
-    ): AnimatedNode<T>;
+    export function block<T1 extends Value = number, T2 extends Value = any>(
+      items: ReadonlyArray<Adaptable<T2>>,
+    ): AnimatedNode<T1>;
     export function call<T>(
       args: ReadonlyArray<T | AnimatedNode<T>>,
       callback: (args: ReadonlyArray<T>) => void,


### PR DESCRIPTION
Currently the return type for `block()` is the same as the parameter type. This is a problem because the parameter type can be quite heterogeneous. For instance:

```
block([
  set(value, 1),
  not(value)
])
```
Has a return type of `Value | Node`. With this patch, it will have a return type of `Node`