### PR TITLE
Add ios/build to npm package.json blacklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "android/src/main/java/",
     "android/build.gradle",
     "ios/",
+    "!ios/build/",
     "RNReanimated.podspec",
     "README.md",
     "react-native-reanimated.d.ts",


### PR DESCRIPTION
Adding ios/build as a negated pattern in the `files` section of `package.json` prevents releasing build artifacts in npm after accidentally building ios project in the root folder.