### PR TITLE
Fix formatting numbers in concat node

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ConcatNode.java
@@ -1,6 +1,7 @@
 package com.swmansion.reanimated.nodes;
 
 import java.text.NumberFormat;
+import java.util.Locale;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.swmansion.reanimated.NodesManager;
@@ -8,9 +9,10 @@ import com.swmansion.reanimated.Utils;
 
 public class ConcatNode extends Node {
   private final int[] mInputIDs;
-  private final static NumberFormat sFormatter = NumberFormat.getInstance();
+  private final static NumberFormat sFormatter = NumberFormat.getInstance(Locale.ENGLISH);
   static {
     sFormatter.setMinimumFractionDigits(0);
+    sFormatter.setGroupingUsed(false);
   }
 
   public ConcatNode(int nodeID, ReadableMap config, NodesManager nodesManager) {


### PR DESCRIPTION
## Description

It turned out that IOS doesn't take locale into consideration when formatting `NSNumber`, so this commit fixes that on android

## Changes

- Add `Locale.ENGLISH` to enforce formatting with a dot
- Add `setGroupingUsed(false)` to prevent grouping thousands (1000.0 doesn't get formatted into 1,000)


Fixes #718 