### PR TITLE
Add bot publishing creds to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,19 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Set publishing name & email
+        run: >-
+          git config --local user.email "action@github.com"
+          && git config --local user.name "GitHub Action"
+
       - name: Check out
         uses: actions/checkout@v1
 
       - name: Generate awesome content
-        run: cd docs && yarn && yarn deploy
+        run: >-
+          cd docs
+          && yarn
+          && yarn deploy
 
       - name: Publish generated content to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
Workflow fails with error:
```
yarn run v1.22.4
$ component-docs build && gh-pages -d dist
- Building pages…
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
✔ Successfully built pages in 13784ms (dist)

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```