### PR TITLE
Adjust workflow

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -1,0 +1,39 @@
+name: Autosquash
+on:
+  check_run:
+    types:
+      # Check runs completing successfully can unblock the
+      # corresponding pull requests and make them mergeable.
+      - completed
+  pull_request:
+    types:
+      # A closed pull request makes the checks on the other
+      # pull request on the same base outdated.
+      - closed
+      # Adding the autosquash label to a pull request can
+      # trigger an update or a merge.
+      - labeled
+  pull_request_review:
+    types:
+      # Review approvals can unblock the pull request and
+      # make it mergeable.
+      - submitted
+  # Success statuses can unblock the corresponding
+  # pull requests and make them mergeable.
+  status: {}
+
+jobs:
+  autosquash:
+    name: Autosquash
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: tibdex/autosquash@v2
+        with:
+          # We can't use the built-in secrets.GITHUB_TOKEN yet because of this limitation:
+          # https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
+          # In the meantime, use a token granting write access on the repo:
+          # - a GitHub App token
+          #   See https://github.com/marketplace/actions/github-app-token.
+          # - a personal access token
+          #   See https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line.
+          github_token: ${{ secrets.AUTOSQUASH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Set publishing name & email
-        run: >-
-          git config --local user.email "action@github.com"
-          && git config --local user.name "GitHub Action"
-
       - name: Check out
         uses: actions/checkout@v1
 
       - name: Generate awesome content
         run: >-
-          cd docs
+          git config --local user.email "action@github.com"
+          && git config --local user.name "GitHub Action"
+          && cd docs
           && yarn
           && yarn deploy
 


### PR DESCRIPTION
## Description

Placing `git config --local` commands before checkout wasn't the best idea, so I moved it right before docs generation.

I also added the autosquash workflow to simplify the merging process, mainly by generating useful commit messages consisting of PR description instead of listing all commits (we squash them anyway).

## Notes

We need to add `AUTOSQUASH_TOKEN` to secrets which will be Personal Access Token or App Token (described in a comment inside workflow).
