### PR TITLE
Adds option to specify diffClamp animation

### DIFF
--- a/src/derived/diffClamp.js
+++ b/src/derived/diffClamp.js
@@ -4,12 +4,14 @@ import min from './min';
 import max from './max';
 import diff from './diff';
 
-const procAcc = proc(function(a, minVal, maxVal, value) {
+export function diffClampImPure(a, minVal, maxVal, value) {
   return set(
     value,
     min(max(add(cond(defined(value), value, a), diff(a)), minVal), maxVal)
   );
-});
+}
+
+const procAcc = proc(diffClampImPure);
 
 export default function diffClamp(a, minVal, maxVal) {
   const value = new AnimatedValue();


### PR DESCRIPTION
I needed to use diffClamp for two different components using the same Animation.Value. It didn't work, only one component was able to use the diffClamp Value. I did not look much into it, but I solved the issue with specifying an Animation.Value the clamp should be set to, which allowed me to have several diffClamps Value based on one Animation.Value.