### PR TITLE
A ScrollView component with mixin

### DIFF
--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,4 +1,4 @@
-import { Image, ScrollView, Text, View } from 'react-native';
+import { Image, Text, View } from 'react-native';
 import Easing from './Easing';
 import AnimatedClock from './core/AnimatedClock';
 import AnimatedValue from './core/AnimatedValue';
@@ -24,6 +24,7 @@ import {
   createTransitioningComponent,
 } from './Transitioning';
 import SpringUtils from './animations/SpringUtils';
+import ScrollView from "./component/ScrollView"
 
 
 const decayWrapper = backwardCompatibleAnimWrapper(decay, DecayAnimation);
@@ -34,7 +35,7 @@ const Animated = {
   View: createAnimatedComponent(View),
   Text: createAnimatedComponent(Text),
   Image: createAnimatedComponent(Image),
-  ScrollView: createAnimatedComponent(ScrollView),
+  ScrollView,
   Code: AnimatedCode,
   createAnimatedComponent,
 
@@ -68,7 +69,7 @@ export {
   Easing,
   Transitioning,
   Transition,
-  createTransitioningComponent, 
+  createTransitioningComponent,
 
   // classes
   AnimatedClock as Clock,

--- a/src/component/ScrollView.js
+++ b/src/component/ScrollView.js
@@ -29,6 +29,7 @@ function setRef(refProp, instance){
 
 const mixin = {
 	scrollTo: function scrollTo(...params){
-		this.current.getNode().scrollTo(...params);
+		if (this._component)
+			this._component.scrollTo(...params);
 	}
 };

--- a/src/component/ScrollView.js
+++ b/src/component/ScrollView.js
@@ -1,5 +1,5 @@
 import React, {useCallback} from "react"
-import {RNScrollView} from "react-native";
+import {ScrollView as RNScrollView} from "react-native";
 import createAnimatedComponent from "../createAnimatedComponent";
 
 const DefaultScrollView = createAnimatedComponent(RNScrollView);

--- a/src/component/ScrollView.js
+++ b/src/component/ScrollView.js
@@ -1,0 +1,34 @@
+import React, {useCallback} from "react"
+import {RNScrollView} from "react-native";
+import createAnimatedComponent from "../createAnimatedComponent";
+
+const DefaultScrollView = createAnimatedComponent(RNScrollView);
+
+export default React.forwardRef(
+	function AnimatedScrollView(props, refProp){
+		const addMixin = useCallback(
+			instance => {
+				if (instance)
+					Object.assign(instance, mixin);
+
+				setRef(refProp, instance);
+			},
+			[refProp],
+		)
+
+		return <DefaultScrollView ref={refProp && addMixin} {...props}/>;
+	}
+);
+
+function setRef(refProp, instance){
+	if (refProp instanceof Function)
+		refProp(instance);
+	else if (refProp instanceof Object)
+		refProp.current = instance;
+}
+
+const mixin = {
+	scrollTo: function scrollTo(...params){
+		this.current.getNode().scrollTo(...params);
+	}
+};


### PR DESCRIPTION
This PR is addressed to solve the issue #452.
For now the mixin added to the instance has just `scrollTo()` method, where it simply redirect the call to the original `scrollView.scrollTo`.
Adding methods, like `scrollTo` here, allows a better integration of the animated scrollview component in a `FlatList`.