### PR TITLE
Change deprecated maven plugin to newer maven-publish plugin

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath("com.android.tools.build:gradle:3.6.3")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/README.md
+++ b/android/README.md
@@ -11,5 +11,5 @@ ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
 sdk.dir=/Users/{username}/Library/Android/sdk
 ```
 3. Delete the `maven` folder
-4. Run `sudo ./gradlew installArchives`
+4. Run `./gradlew publish`
 5. Verify that latest set of generated files is in the maven folder with the correct version number

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -52,34 +52,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-}
-
-def configureReactNativePom(def pom) {
-    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
-
-    pom.project {
-        name packageJson.title
-        artifactId packageJson.name
-        version = packageJson.version
-        group = "com.swmansion.reanimated"
-        description packageJson.description
-        url packageJson.repository.baseUrl
-
-        licenses {
-            license {
-                name packageJson.license
-                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
-                distribution 'repo'
-            }
-        }
-
-        developers {
-            developer {
-                id packageJson.author.username
-                name packageJson.author.name
-            }
-        }
-    }
 }
 
 afterEvaluate { project ->
@@ -116,18 +88,45 @@ afterEvaluate { project ->
         }
     }
 
-    artifacts {
-        archives androidSourcesJar
-        archives androidJavadocJar
-    }
+    publishing {
+        publications {
+            reanimated(MavenPublication) {
+                def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
+                artifactId = packageJson.name
 
-            configureReactNativePom pom
+                artifact androidJavadocJar
+                artifact androidSourcesJar
+
+                pom {
+                    name = packageJson.title
+                    artifactId = packageJson.name
+                    version = packageJson.version
+                    group = "com.swmansion.reanimated"
+                    description = packageJson.description
+                    url = packageJson.repository.baseUrl
+                    
+                    licenses {
+                        license {
+                            name = packageJson.license
+                            url = packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                            distribution = 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = packageJson.author.username
+                            name = packageJson.author.name
+                        }
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                url = "file://${projectDir}/../android/maven"
+            }
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.2'
+            classpath 'com.android.tools.build:gradle:3.6.3'
         }
     }
 }
@@ -94,6 +94,8 @@ afterEvaluate { project ->
                 def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
 
                 artifactId = packageJson.name
+
+                from components.release
 
                 artifact androidJavadocJar
                 artifact androidSourcesJar

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,6 @@ dependencies {
 }
 
 afterEvaluate { project ->
-
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
@@ -95,8 +94,6 @@ afterEvaluate { project ->
 
                 artifactId = packageJson.name
 
-                from components.release
-
                 artifact androidJavadocJar
                 artifact androidSourcesJar
 
@@ -106,12 +103,12 @@ afterEvaluate { project ->
                     version = packageJson.version
                     group = "com.swmansion.reanimated"
                     description = packageJson.description
-                    url = packageJson.repository.baseUrl
-                    
+                    url = packageJson.repository.url
+
                     licenses {
                         license {
                             name = packageJson.license
-                            url = packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                            url = packageJson.homepage
                             distribution = 'repo'
                         }
                     }


### PR DESCRIPTION
I changed the way of publication of maven dependencies from now deprecated `maven` plugin to the newer and suggested `maven-publish` plugin