### PR TITLE
fix: prevent clock from being set to 0

### DIFF
--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -6,15 +6,15 @@ class AnimatedMainClock extends InternalAnimatedValue {
   _frameCallback;
 
   constructor() {
-    super({ type: 'MAIN_CLOCK' });
+    super(Date.now());
   }
 
   __onEvaluate() {
-    return +new Date();
+    return Date.now();
   }
 
   _runFrame = () => {
-    this._updateValue(0);
+    this._updateValue(this.__onEvaluate());
     if (this.__children.length > 0) {
       this._frameCallback = requestAnimationFrame(this._runFrame);
     }


### PR DESCRIPTION
## Description

In some weird cases the clock jumps to 0 and thus it causes animations to act weird because the frameTime is negative. It also improves the performance of the evaluate function by using `Date.now`:
https://stackoverflow.com/questions/14255664/new-date-is-this-good-practice/14255732#14255732

Fixes #763.

## Changes

For some reason the value was set to 0 but it is now set to `Date.now`.

## Screenshots / GIFs

### Before
![image](https://user-images.githubusercontent.com/5358638/80700873-b73fb580-8ade-11ea-9f21-c42033520fcd.png)

Afterwards it causes an (near) infinite loop:

![image](https://user-images.githubusercontent.com/5358638/80700618-4bf5e380-8ade-11ea-9628-5a3d48d17b07.png)

### After
The animations just runs.
