### PR TITLE
feat: Add `interpolateColors` function

### DIFF
--- a/Example/.gitignore
+++ b/Example/.gitignore
@@ -57,3 +57,6 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+
+.expo
+web-build

--- a/Example/src/src/interpolate/InterpolateColorsExample.js
+++ b/Example/src/src/interpolate/InterpolateColorsExample.js
@@ -1,0 +1,73 @@
+import React, {Component} from 'react';
+import Animated, {Easing} from 'react-native-reanimated';
+import Box from '../Box';
+import Row from '../Row';
+
+const {
+  set,
+  cond,
+  eq,
+  and,
+  startClock,
+  clockRunning,
+  block,
+  timing,
+  Value,
+  Clock,
+  interpolateColors,
+} = Animated;
+
+function runTiming(clock, value, dest) {
+  const state = {
+    finished: new Value(1),
+    position: new Value(value),
+    time: new Value(0),
+    frameTime: new Value(0),
+  };
+
+  const config = {
+    duration: 500,
+    toValue: new Value(0),
+    easing: Easing.inOut(Easing.ease),
+  };
+
+  const reset = [
+    set(state.finished, 0),
+    set(state.time, 0),
+    set(state.frameTime, 0),
+  ];
+
+  return block([
+    cond(and(state.finished, eq(state.position, value)), [
+      ...reset,
+      set(config.toValue, dest),
+    ]),
+    cond(and(state.finished, eq(state.position, dest)), [
+      ...reset,
+      set(config.toValue, value),
+    ]),
+    cond(clockRunning(clock), 0, startClock(clock)),
+    timing(clock, state, config),
+    state.position,
+  ]);
+}
+
+export default class InterpolateColorsExample extends Component {
+  constructor(props) {
+    super(props);
+    const clock = new Clock();
+    const base = runTiming(clock, -1, 1);
+    this.color = interpolateColors(base, {
+      inputRange: [-1, 1],
+      outputColorRange: ['blue', 'rgba(255, 0, 0, 0.5)'],
+    });
+  }
+
+  render() {
+    return (
+      <Row>
+        <Box style={{backgroundColor: this.color}} />
+      </Row>
+    );
+  }
+}

--- a/Example/src/src/interpolate/index.js
+++ b/Example/src/src/interpolate/index.js
@@ -1,10 +1,16 @@
 import React from 'react';
-import { Text, View, FlatList, StyleSheet } from 'react-native';
+import {Text, View, FlatList, StyleSheet} from 'react-native';
 import Basic from './Basic';
 import WithDrag from './WithDrag';
 import AnimatedBounds from './AnimatedBounds';
+import InterpolateColorsExample from './InterpolateColorsExample';
 
-const examples = [Basic, WithDrag, AnimatedBounds].map(v => ({
+const examples = [
+  Basic,
+  WithDrag,
+  AnimatedBounds,
+  InterpolateColorsExample,
+].map(v => ({
   key: v.displayName,
   title: v.displayName,
   Component: v,

--- a/docs/pages/11.baseNodes/color.md
+++ b/docs/pages/11.baseNodes/color.md
@@ -7,3 +7,5 @@ color(red, green, blue, alpha);
 Creates a color node in RGBA format, where the first three input nodes should have _integer_ values in the range 0-255 (consider using `round` node if needed) and correspond to color components Red, Green and Blue respectively. Last input node should have a value between 0 and 1 and represents alpha channel (value `1` means fully opaque and `0` completely transparent). Alpha parameter can be ommited, then `1` (fully opaque) is used as a default.
 
 The returned node can be mapped to view properties that represents color (e.g. [`backgroundColor`](https://facebook.github.io/react-native/docs/view-style-props.html#backgroundcolor)).
+
+##### Note: In order to interpolate color output values, use [`interpolateColors`](interpolate-colors.html) instead.

--- a/docs/pages/11.baseNodes/interpolate.md
+++ b/docs/pages/11.baseNodes/interpolate.md
@@ -27,3 +27,5 @@ concat(
   'deg'
 );
 ```
+
+##### Note: In order to interpolate color output values, use [`interpolateColors`](interpolate-colors.html) instead.

--- a/docs/pages/11.baseNodes/interpolateColors.md
+++ b/docs/pages/11.baseNodes/interpolateColors.md
@@ -8,9 +8,9 @@ interpolateColors(node, {
   // Output colors range for the interpolation.
   // Should be the same length as the input range.
   //
-  // Each color needs to be a 4-elements number array like `[r, g, b, a]`,
-  // where `r` `g` `b` values are in 0-255 range, and `a` is a float in 0-1 range.
-  outputRgbaRange: [color, ...],
+  // Each color should be a string like "red" "#ff0" "#ff0000" "rgba(255, 0, 0, 1)"
+  // or a number like `0xrrggbbaa`.
+  outputColorRange: [color, ...],
 })
 ```
 
@@ -21,7 +21,7 @@ Example:
 ```js
 const color = Animated.interpolateColors(node, {
   inputRange: [0, 1],
-  outputRgbaRange: [[255, 0, 0, 1], [0, 255, 0, 1]],
+  outputColorRange: ['red', 'blue'],
 });
 
 return <Animated.View style={{ backgroundColor: color }} />;

--- a/docs/pages/11.baseNodes/interpolateColors.md
+++ b/docs/pages/11.baseNodes/interpolateColors.md
@@ -3,10 +3,14 @@
 ```js
 interpolateColors(node, {
   // Input range for the interpolation. Should be monotonically increasing.
-  inputRange: [nodeOrValue...],
-  // Output colors range for the interpolation in a rgba array integer format,
-  // should be the same length as the input range.
-  outputRgbaRange: [nodeOrValue...],
+  inputRange: [nodeOrValue, ...],
+
+  // Output colors range for the interpolation.
+  // Should be the same length as the input range.
+  //
+  // Each color needs to be a 4-elements number array like `[r, g, b, a]`,
+  // where `r` `g` `b` values are in 0-255 range, and `a` is a float in 0-1 range.
+  outputRgbaRange: [color, ...],
 })
 ```
 

--- a/docs/pages/11.baseNodes/interpolateColors.md
+++ b/docs/pages/11.baseNodes/interpolateColors.md
@@ -1,0 +1,24 @@
+## `interpolateColors`
+
+```js
+interpolateColors(node, {
+  // Input range for the interpolation. Should be monotonically increasing.
+  inputRange: [nodeOrValue...],
+  // Output colors range for the interpolation in a rgba array integer format,
+  // should be the same length as the input range.
+  outputRgbaRange: [nodeOrValue...],
+})
+```
+
+Maps an input value within a range to an output value within a color range.
+
+Example:
+
+```js
+const color = Animated.interpolateColors(node, {
+  inputRange: [0, 1],
+  outputRgbaRange: [[255, 0, 0, 1], [0, 255, 0, 1]],
+});
+
+return <Animated.View style={{ backgroundColor: color }} />;
+```

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -328,6 +328,16 @@ declare module 'react-native-reanimated' {
       value: Adaptable<number>,
       config: InterpolationConfig,
     ): AnimatedNode<number>;
+    export function interpolateColors(
+      animationValue: Adaptable<number>,
+      {
+        inputRange,
+        outputRgbaRange: rgbaColors
+      }: {
+        inputRange: ReadonlyArray<Adaptable<number>>;
+        outputRgbaRange: [number, number, number, number][];
+      }
+    ): AnimatedNode<number>;
     export const max: BinaryOperator;
     export const min: BinaryOperator;
 
@@ -471,6 +481,7 @@ declare module 'react-native-reanimated' {
   export const abs: typeof Animated.abs
   export const acc: typeof Animated.acc
   export const color: typeof Animated.color
+  export const interpolateColors: typeof Animated.interpolateColors
   export const diff: typeof Animated.diff
   export const diffClamp: typeof Animated.diffClamp
   export const interpolate: typeof Animated.interpolate

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -332,10 +332,10 @@ declare module 'react-native-reanimated' {
       animationValue: Adaptable<number>,
       {
         inputRange,
-        outputRgbaRange: rgbaColors
+        outputColorRange
       }: {
         inputRange: ReadonlyArray<Adaptable<number>>;
-        outputRgbaRange: [number, number, number, number][];
+        outputColorRange: (string | number)[];
       }
     ): AnimatedNode<number>;
     export const max: BinaryOperator;

--- a/src/derived/index.js
+++ b/src/derived/index.js
@@ -4,6 +4,7 @@ export { default as color } from './color';
 export { default as diff } from './diff';
 export { default as diffClamp } from './diffClamp';
 export { default as interpolate, Extrapolate } from './interpolate';
+export { default as interpolateColors } from './interpolateColors';
 export { default as max } from './max';
 export { default as min } from './min';
 export { default as onChange } from './onChange';

--- a/src/derived/interpolateColors.js
+++ b/src/derived/interpolateColors.js
@@ -1,4 +1,18 @@
+import { processColor } from 'react-native';
 import { round, color, interpolate, Extrapolate } from '../base';
+
+function red(c) {
+  return (c >> 16) & 255;
+}
+function green(c) {
+  return (c >> 8) & 255;
+}
+function blue(c) {
+  return c & 255;
+}
+function opacity(c) {
+  return ((c >> 24) & 255) / 255;
+}
 
 /**
  * Use this if you want to interpolate an `Animated.Value` into color values.
@@ -12,32 +26,33 @@ import { round, color, interpolate, Extrapolate } from '../base';
  * So, for now you can just use this helper instead.
  */
 export default function interpolateColors(animationValue, options) {
-  const { inputRange, outputRgbaRange: rgbaColors } = options;
+  const { inputRange, outputColorRange } = options;
+  const colors = outputColorRange.map(processColor);
 
   const r = round(
     interpolate(animationValue, {
       inputRange,
-      outputRange: rgbaColors.map(c => c[0]),
+      outputRange: colors.map(red),
       extrapolate: Extrapolate.CLAMP,
     })
   );
   const g = round(
     interpolate(animationValue, {
       inputRange,
-      outputRange: rgbaColors.map(c => c[1]),
+      outputRange: colors.map(green),
       extrapolate: Extrapolate.CLAMP,
     })
   );
   const b = round(
     interpolate(animationValue, {
       inputRange,
-      outputRange: rgbaColors.map(c => c[2]),
+      outputRange: colors.map(blue),
       extrapolate: Extrapolate.CLAMP,
     })
   );
   const a = interpolate(animationValue, {
     inputRange,
-    outputRange: rgbaColors.map(c => c[3]),
+    outputRange: colors.map(opacity),
     extrapolate: Extrapolate.CLAMP,
   });
 

--- a/src/derived/interpolateColors.js
+++ b/src/derived/interpolateColors.js
@@ -1,5 +1,7 @@
 import { processColor } from 'react-native';
-import { round, color, interpolate, Extrapolate } from '../base';
+import { round } from '../base';
+import color from './color';
+import interpolate, { Extrapolate } from './interpolate';
 
 function red(c) {
   return (c >> 16) & 255;

--- a/src/derived/interpolateColors.js
+++ b/src/derived/interpolateColors.js
@@ -1,0 +1,45 @@
+import { round, color, interpolate, Extrapolate } from '../base';
+
+/**
+ * Use this if you want to interpolate an `Animated.Value` into color values.
+ *
+ * #### Why is this needed?
+ *
+ * Unfortunately, if you'll pass color values directly into the `outputRange` option
+ * of `interpolate()` function, that won't really work (at least at the moment).
+ * See https://github.com/software-mansion/react-native-reanimated/issues/181 .
+ *
+ * So, for now you can just use this helper instead.
+ */
+export default function interpolateColors(animationValue, options) {
+  const { inputRange, outputRgbaRange: rgbaColors } = options;
+
+  const r = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: rgbaColors.map(c => c[0]),
+      extrapolate: Extrapolate.CLAMP,
+    })
+  );
+  const g = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: rgbaColors.map(c => c[1]),
+      extrapolate: Extrapolate.CLAMP,
+    })
+  );
+  const b = round(
+    interpolate(animationValue, {
+      inputRange,
+      outputRange: rgbaColors.map(c => c[2]),
+      extrapolate: Extrapolate.CLAMP,
+    })
+  );
+  const a = interpolate(animationValue, {
+    inputRange,
+    outputRange: rgbaColors.map(c => c[3]),
+    extrapolate: Extrapolate.CLAMP,
+  });
+
+  return color(r, g, b, a);
+}


### PR DESCRIPTION
## Description

Lets users animate colors with `react-native-reanimated` without the need of additional helper functions like [this one](https://github.com/software-mansion/react-native-reanimated/issues/181#issuecomment-528245794) or [this one](https://github.com/wcandillon/react-native-redash/blob/master/packages/core/src/Colors.ts#L136). 

Also will help avoid people from running into a problem "_why does this color doesn't animate?_ :(" like I did today in the morning in one of my projects. :)

Fixes https://github.com/software-mansion/react-native-reanimated/issues/181 .