### PR TITLE
Add useValue hook

### DIFF
--- a/docs/pages/05.value.md
+++ b/docs/pages/05.value.md
@@ -13,3 +13,11 @@ const v = new Value(0);
 /// ...
 v.setValue(100);
 ```
+
+While using `Animated.Value` in functional components it's recommended that one should wrap instantiation with `useRef(...)` or `useMemo(...)` to use the same instance on re-render, or just simply use `useValue` hook:
+
+```js
+const v = useValue(0);
+/// ...
+v.setValue(100);
+```

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -366,6 +366,9 @@ declare module 'react-native-reanimated' {
       exec: () => Nullable< AnimatedNode<number>[] | AnimatedNode<number> > | boolean,
       deps: Array<any>,
     ): void
+    export function useValue<T extends Value>(
+      initialValue: T
+    ): AnimatedValue<T>;
 
     // configuration
     export function addWhitelistedNativeProps(props: { [key: string]: true }): void;
@@ -485,4 +488,5 @@ declare module 'react-native-reanimated' {
   export const timing: typeof Animated.timing
   export const spring: typeof Animated.spring
   export const SpringUtils: typeof Animated.SpringUtils
+  export const useValue: typeof Animated.useValue
 }

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -24,6 +24,7 @@ import {
   createTransitioningComponent,
 } from './Transitioning';
 import SpringUtils from './animations/SpringUtils';
+import useValue from './useValue';
 
 
 const decayWrapper = backwardCompatibleAnimWrapper(decay, DecayAnimation);
@@ -56,6 +57,9 @@ const Animated = {
   // configuration
   addWhitelistedNativeProps,
   addWhitelistedUIProps,
+
+  // hooks
+  useValue,
 };
 
 export default Animated;
@@ -80,4 +84,7 @@ export {
   timingWrapper as timing,
   springWrapper as spring,
   SpringUtils,
+
+  // hooks
+  useValue,
 };

--- a/src/useValue.js
+++ b/src/useValue.js
@@ -2,5 +2,9 @@ import React from 'react';
 import AnimatedValue from './core/AnimatedValue';
 
 export default function useValue(initialValue) {
-  return React.useRef(new AnimatedValue(initialValue)).current;
+  const ref = React.useRef(null);
+  if (ref.current === null) {
+    ref.current = new AnimatedValue(initialValue);
+  }
+  return ref.current;
 }

--- a/src/useValue.js
+++ b/src/useValue.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import AnimatedValue from './core/AnimatedValue';
+
+export default function useValue(initialValue) {
+  return React.useRef(new AnimatedValue(initialValue)).current;
+}


### PR DESCRIPTION
## Description

When working with functional components this is easy to make bugs with statement, that I already saw several times from different people:

```ts
function MyComponent() {
  const value = new Value(...);
}
```

This will lead to creating new value instance for every re-render. And components, that use internal value of previous instance will be reset to the new one, and this will lead to visual bugs. So one should always keep the same instance wrapping it either in `useRef(new Value(...))` or `useMemo(() => new Value(...), [])`

## Changes

This PR adds hook, that could be used in very often simple case of creating instance of `Value` without extra wrap:

```ts
function MyComponent() {
  const value = useValue(0);
}
```