### PR TITLE
Exit `timing` immediately when duration is zero

### DIFF
--- a/src/animations/timing.js
+++ b/src/animations/timing.js
@@ -51,6 +51,10 @@ const internalTiming = proc(function(
 });
 
 export default function(clock, state, config) {
+  if (config.duration === 0) {
+    // when duration is zero we end the timing immediately
+    return block([set(state.position, config.toValue), set(state.finished, 1)]);
+  }
   const lastTime = cond(state.time, state.time, clock);
   const newFrameTime = add(state.frameTime, sub(clock, lastTime));
   const nextProgress = config.easing(divide(newFrameTime, config.duration));


### PR DESCRIPTION
## Description

When investigating [react-native-tab-view bug](https://github.com/react-native-community/react-native-tab-view/issues/967) I noticed that we implicitly rely on `nextPosition` NaN value evaluating to falsy value in `cond` check when the duration is zero (division by 0 in `nextProgress` and `progress`). 

This PR adds explicit check for it and as a byproduct, we create much fewer nodes in duration=0 case.

This may be discussable when using Reanimated directly, but when some library exposes API which can change `duration` I think it's worth doing that check explicitly.

Another strategy may be throwing an error, tell me WDYT.

## Changes

- Added explicit check for `config.duration === 0` when using `timing` node