### PR TITLE
fix missing `Value.interpolate` in jest mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -88,11 +88,7 @@ const Reanimated = {
 
   Clock: NOOP,
   Node: NOOP,
-  Value: function() {
-    return {
-      setValue: NOOP,
-    };
-  },
+  Value: AnimatedValue,
 
   Extrapolate: {
     EXTEND: 'extend',


### PR DESCRIPTION
## Description
Fixes https://github.com/software-mansion/react-native-reanimated/issues/612

## Changes 

<!--
Please describe things you've changed here.
-->

## Screenshots / GIFs

<!--
Add here screenshots / GIFs documenting your change.

You can add before / after if you're changing some behavior
-->

### Before

### After
