### PR TITLE
Revert "Use component type in createAnimatedComponent"

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -198,7 +198,7 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
-    export function createAnimatedComponent<T>(component: T): T;
+    export function createAnimatedComponent(component: any): any;
 
     // classes
     export {


### PR DESCRIPTION
Reverts software-mansion/react-native-reanimated#696

Reverting, introduced bug #719 - described in [comment](https://github.com/software-mansion/react-native-reanimated/issues/719#issuecomment-611435860)


Quick fix, may be improved by typings in #723