### PR TITLE
Make osx build quieter, update Podfile.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,12 @@ jobs:
 
       install:
         - nvm --version
+        - rvm --version
         - echo $NODE_VERSION
         - xcodebuild -version
         - sudo launchctl limit maxfiles 2048 unlimited
         - sudo ulimit -n 10000
+        - gem install xcpretty
         - nvm install $NODE_VERSION
         - nvm use $NODE_VERSION
         - nvm alias default $NODE_VERSION
@@ -70,7 +72,7 @@ jobs:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | sed -nE '/error:/,/^[[:digit:]] errors? generated/ p'
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | xcpretty
 
     - language: node_js
       node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | xcpretty
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | xcpretty && exit ${PIPESTATUS[0]}
 
     - language: node_js
       node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | sed -nE '/error:/,/^[[:digit:]] errors? generated/ p'
 
     - language: node_js
       node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,15 +56,15 @@ jobs:
 
       install:
         - nvm --version
-        - rvm --version
         - echo $NODE_VERSION
         - xcodebuild -version
         - sudo launchctl limit maxfiles 2048 unlimited
         - sudo ulimit -n 10000
-        - gem install xcpretty
         - nvm install $NODE_VERSION
         - nvm use $NODE_VERSION
         - nvm alias default $NODE_VERSION
+        - brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
+        - brew install xcbeautify
         - brew install yarn --ignore-dependencies
         - npm install -g react-native-cli
         - cd Example
@@ -72,7 +72,7 @@ jobs:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet | xcpretty && exit ${PIPESTATUS[0]}
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -quiet | xcbeautify && exit ${PIPESTATUS[0]}
 
     - language: node_js
       node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-matrix:
+os: linux
+language: node_js
+dist: xenial
+
+jobs:
   include:
     - language: android
-      sudo: required
       jdk: oraclejdk8
       env:
         - NODE_VERSION=10.15.3
@@ -67,7 +70,7 @@ matrix:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO -quiet
 
     - language: node_js
       node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,6 @@ jobs:
         - nvm install $NODE_VERSION
         - nvm use $NODE_VERSION
         - nvm alias default $NODE_VERSION
-        - brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
-        - brew install xcbeautify
         - brew install yarn --ignore-dependencies
         - npm install -g react-native-cli
         - cd Example
@@ -72,7 +70,7 @@ jobs:
         - cd ios && pod install && cd ..
 
       script:
-        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -quiet | xcbeautify && exit ${PIPESTATUS[0]}
+        - xcodebuild -workspace ./ios/ReanimatedExample.xcworkspace -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -quiet |  egrep '^(/.+:[0-9+:[0-9]+:.error:|fatal|===)' || [[ $? == 1 ]] | uniq && exit ${PIPESTATUS[0]}
 
     - language: node_js
       node_js:

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -294,7 +294,7 @@ PODS:
     - ReactCommon/callinvoker (= 0.62.1)
   - RNGestureHandler (1.6.1):
     - React
-  - RNReanimated (1.7.1):
+  - RNReanimated (1.9.0):
     - React
   - RNScreens (1.0.0-alpha.23):
     - React
@@ -450,11 +450,11 @@ SPEC CHECKSUMS:
   React-RCTVibration: 072c3b427dd29e730c2ee5bfc509cf5054741a50
   ReactCommon: 3585806280c51d5c2c0d3aa5a99014c3badb629d
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
-  RNReanimated: 4e102df74a9674fa943e05f97f3362b6e44d0b48
+  RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 1e4c4494e50da4a7407c3afd59e7b91a4df45654
+PODFILE CHECKSUM: aa5963440c2c27ef05661ddc9581b02eac8776a7
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1


### PR DESCRIPTION
## Description

Travis job for osx was failing when log was too big


## Changes

`.travis.yml`
- add `-quiet` option to `xcodebuild`
- use `xcbeautify` to format output
- add missing keys to root job
- remove deprecated `sudo` key


