### PR TITLE
Fix: links to examples in docs

### DIFF
--- a/docs/pages/10.event.md
+++ b/docs/pages/10.event.md
@@ -9,7 +9,7 @@ title: Event handling with reanimated nodes
 `react-native-reanimated`'s new syntax is possible to be used with `Animated.event`. Instead of providing only a mapping from event fields to animated nodes, it is allowed to write a function that takes reanimated values map as an input and return a block (or any other reanimated function) that will be then used to handle the event.
 
 This syntax allows for providing some post-processing for the event data that does not fit well as a dependency of other nodes we connect to `Animated.View` component props.
-[See example](https://github.com/software-mansion/react-native-reanimated/blob/master/Example/PanRotateAndZoom/index.js)
+[See example](https://github.com/software-mansion/react-native-reanimated/blob/master/Example/src/PanRotateAndZoom/index.js)
 
 ```js
 this.onGestureEvent = event([

--- a/docs/pages/12.animations/springUtils.md
+++ b/docs/pages/12.animations/springUtils.md
@@ -26,4 +26,4 @@ Transforms an object with `bounciness` and `speed` params into config expected b
 
 Transforms an object with `tension` and `friction` params into config expected by the `spring` node. `tension` and `friction` might be nodes or numbers.
 
-See an [Example of different configs](https://github.com/software-mansion/react-native-reanimated/blob/master/Example/differentSpringConfigs/index.js).
+See an [Example of different configs](https://github.com/software-mansion/react-native-reanimated/blob/master/Example/src/differentSpringConfigs/index.js).


### PR DESCRIPTION
## Description

Links are broken since files from Examples were moved to Examples/src in https://github.com/software-mansion/react-native-reanimated/pull/709

## Changes

Fixed links to examples folders
<!--
Please describe things you've changed here.
-->
