### PR TITLE
Use double instead of CGFloat in iOS operators

### DIFF
--- a/ios/Nodes/REAOperatorNode.m
+++ b/ios/Nodes/REAOperatorNode.m
@@ -6,22 +6,22 @@
 typedef id (^REAOperatorBlock)(NSArray<REANode *> *inputNodes);
 
 #define REA_REDUCE(OP) ^(NSArray<REANode *> *inputNodes) { \
-CGFloat acc = [[inputNodes[0] value] doubleValue]; \
+double acc = [[inputNodes[0] value] doubleValue]; \
 for (NSUInteger i = 1; i < inputNodes.count; i++) { \
-  CGFloat a = acc, b = [[inputNodes[i] value] doubleValue]; \
+  double a = acc, b = [[inputNodes[i] value] doubleValue]; \
   acc = OP; \
 } \
 return @(acc); \
 }
 
 #define REA_SINGLE(OP) ^(NSArray<REANode *> *inputNodes) { \
-CGFloat a = [[inputNodes[0] value] doubleValue]; \
+double a = [[inputNodes[0] value] doubleValue]; \
 return @(OP); \
 }
 
 #define REA_INFIX(OP) ^(NSArray<REANode *> *inputNodes) { \
-CGFloat a = [[inputNodes[0] value] doubleValue]; \
-CGFloat b = [[inputNodes[1] value] doubleValue]; \
+double a = [[inputNodes[0] value] doubleValue]; \
+double b = [[inputNodes[1] value] doubleValue]; \
 return @(OP); \
 }
 
@@ -43,7 +43,7 @@ return @(OP); \
             @"multiply": REA_REDUCE(a * b),
             @"divide": REA_REDUCE(a / b),
             @"pow": REA_REDUCE(pow(a, b)),
-            @"modulo": REA_REDUCE(fmodf(fmodf(a, b) + b, b)),
+            @"modulo": REA_REDUCE(fmod(fmod(a, b) + b, b)),
             @"sqrt": REA_SINGLE(sqrt(a)),
             @"log": REA_SINGLE(log(a)),
             @"sin": REA_SINGLE(sin(a)),


### PR DESCRIPTION
## Description

Fixes #797

iOS operators implementation used `CGFloat` which is a typedef for `double` / `float` depending on OS architecture. This caused some precision errors on big numbers, so this PR fixes that by changing the type to double.

Transitions and Bezier node wasn't changed, because they're responsible for visuals and not calculations - doesn't need to be exact.

## Changes

- change type from `CGFloat` to `double` in operator macros.
- change `fmodf` to `fmod` in `modulo` node

Tested on [snack](https://snack.expo.io/@levibuzolic/reanimated-math) provided by @levibuzolic