### PR TITLE
Remove autolink step from docs

### DIFF
--- a/docs/pages/03.start.md
+++ b/docs/pages/03.start.md
@@ -20,20 +20,14 @@ I. First install the library from npm repository using `yarn`:
   yarn add react-native-reanimated
 ```
 
-II. Link native code with `react-native` cli:
-
-```bash
-  react-native link react-native-reanimated
-```
-
-III. For iOS, go to `ios` folder and run `pod install`:
+II. For iOS, go to `ios` folder and run `pod install`:
 
 ```bash
   cd ios
   pod install
 ```
 
-IV. When you want to use "reanimated" in your project import it from the `react-native-reanimated` package:
+III. When you want to use "reanimated" in your project import it from the `react-native-reanimated` package:
 
 ```js
 import Animated from 'react-native-reanimated';


### PR DESCRIPTION
## Description

Remove auto-link step from docs as mentioned in #391 ([comment](https://github.com/software-mansion/react-native-reanimated/issues/391#issuecomment-568416347))

