### PR TITLE
Fix broken link on 2.0 docs home page

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -15,7 +15,7 @@ const boxes = [
     title: <>Animate with more ease than ever before👍</>,
     description: (
       <>
-        Complexity reduced from tens to just a few methods. Try it out today: Check out our <a href="docs">Documentation</a>.
+        Complexity reduced from tens to just a few methods. Try it out today: Check out our <a href="docs/about">Documentation</a>.
       </>
     ),
   },


### PR DESCRIPTION
## Description

The link now goes to the first page in the docs instead of a 404.
