### PR TITLE
Adjust docs sidebar width

### DIFF
--- a/docs/src/theme/DocPage/styles.module.css
+++ b/docs/src/theme/DocPage/styles.module.css
@@ -12,7 +12,7 @@
 .docSidebarContainer {
   border-right: 1px solid var(--ifm-toc-border-color);
   box-sizing: border-box;
-  width: 300px;
+  width: 22rem;
   position: relative;
   margin-top: calc(-1 * var(--ifm-navbar-height));
 }


### PR DESCRIPTION
## Description
Some items on docs sidebar didnt fit (api section)
Fixes sidebar width from default 300px to 22rem.

Fixes # .


