### PR TITLE
Fix misspelling in installation.md

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -118,8 +118,8 @@ If not, after making those changes your app will be compatible with Turbo Module
   ```
 
 
-3. Rename `AppDelegate.m` to `AppDelagate.mm`.
-4. Add AppDelegate category in `AppDelagate.mm`.
+3. Rename `AppDelegate.m` to `AppDelegate.mm`.
+4. Add AppDelegate category in `AppDelegate.mm`.
 
   ```objectivec {1-2,4-7}
   #import <React/RCTCxxBridgeDelegate.h>
@@ -131,7 +131,7 @@ If not, after making those changes your app will be compatible with Turbo Module
   @end
   ```
 
-5. Enable TurboModules in `AppDelagate.mm`.
+5. Enable TurboModules in `AppDelegate.mm`.
 
   ```objectivec {3}
     + (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -139,7 +139,7 @@ If not, after making those changes your app will be compatible with Turbo Module
       RCTEnableTurboModule(YES); // <- add
   ```
 
-6. Replace bridge initialization in `AppDelagate.mm`.
+6. Replace bridge initialization in `AppDelegate.mm`.
 
   ```objectivec {4-8}
     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -153,7 +153,7 @@ If not, after making those changes your app will be compatible with Turbo Module
       ...
   ```
 
-7. Add remaining methods needed to configure Turbo Modules and Reanimated module in particular – all changes should be made in `AppDelagate.mm`.
+7. Add remaining methods needed to configure Turbo Modules and Reanimated module in particular – all changes should be made in `AppDelegate.mm`.
 
   ```objectivec
   // add headers


### PR DESCRIPTION


## Description

Based on the [playground diff](https://github.com/software-mansion-labs/reanimated-2-playground/commit/f6f2b77496bc00601150f98ea19a341f844d06a3), `AppDelegate.m` should be changed to *.mm filename and hence renamed to `AppDelegate.mm`.  But the docs seem to add a second change, which is to also use "a" instead of "e" in the otherwise correct spelling of "delegate" and hence `AppDelagate.mm`.

Figured that this was an unintentional misspelling that may lead to some small but unnecessary confusion and worth fixing.

## Changes

In installation docs, change new filename from `AppDelagate.mm` to `AppDelegate.mm` in order to remain consistent with the change in Reanimated Playground example and avoid confusion.
