### PR TITLE
Get rid of FrozenObject limitations and improve caching.

### DIFF
--- a/Common/cpp/SharedItems/Shareable.cpp
+++ b/Common/cpp/SharedItems/Shareable.cpp
@@ -32,8 +32,14 @@ void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
 }
 
 void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType) {
+  bool shouldBeCached  = false;
   if (value.isObject()) {
     jsi::Object object = value.asObject(rt);
+    
+    if (object.getProperty(rt, HIDDEN_SHOULD_BE_CACHED).isBool() and
+        object.getProperty(rt, HIDDEN_SHOULD_BE_CACHED).getBool()) {
+      shouldBeCached = true;
+    }
     
     if (!(object.getProperty(rt, HIDDEN_PROPERTY_NAME).isUndefined())) {
       jsi::Object hiddenProperty = object.getProperty(rt, HIDDEN_PROPERTY_NAME).asObject(rt);
@@ -85,6 +91,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         // a worklet
         type = WorkletFunctionType;
         frozenObject = std::make_shared<FrozenObject>(rt, object, module);
+        shouldBeCached = true;
       }
     } else if (object.isArray(rt)) {
       type = ArrayType;
@@ -115,8 +122,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
   if (value.isObject()) {
     jsi::Object object = value.asObject(rt);
     
-    if (!object.getProperty(rt, HIDDEN_SHOULD_BE_CACHED).isBool() or
-        !object.getProperty(rt, HIDDEN_SHOULD_BE_CACHED).getBool()) {
+    if (!shouldBeCached) {
       return;
     }
     

--- a/Common/cpp/headers/SharedItems/Shareable.h
+++ b/Common/cpp/headers/SharedItems/Shareable.h
@@ -37,6 +37,9 @@ friend WorkletsCache;
 friend void extractMutables(jsi::Runtime &rt,
                             std::shared_ptr<ShareableValue> sv,
                             std::vector<std::shared_ptr<MutableValue>> &res);
+friend jsi::Value createFrozenWrapper(ShareableValue *sv,
+                                      jsi::Runtime &rt,
+                                      std::shared_ptr<FrozenObject> frozenObject);
 private:
   NativeReanimatedModule *module;
   bool boolValue;
@@ -122,17 +125,13 @@ class FrozenObject : public jsi::HostObject {
 };
 
 class RemoteObject: public jsi::HostObject {
+  friend class ShareableValue;
 private:
   NativeReanimatedModule *module;
-  std::shared_ptr<jsi::Object> backing;
   std::unique_ptr<FrozenObject> initializer;
 public:
-  void maybeInitializeOnUIRuntime(jsi::Runtime &rt);
   RemoteObject(jsi::Runtime &rt, jsi::Object &object, NativeReanimatedModule *module):
     module(module), initializer(new FrozenObject(rt, object, module)) {}
-  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
-  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
-  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
 };
 
 }

--- a/Common/cpp/headers/SharedItems/Shareable.h
+++ b/Common/cpp/headers/SharedItems/Shareable.h
@@ -125,7 +125,6 @@ class FrozenObject : public jsi::HostObject {
 };
 
 class RemoteObject: public jsi::HostObject {
-  friend class ShareableValue;
 private:
   NativeReanimatedModule *module;
   std::shared_ptr<jsi::Object> backing;

--- a/Common/cpp/headers/SharedItems/Shareable.h
+++ b/Common/cpp/headers/SharedItems/Shareable.h
@@ -128,10 +128,15 @@ class RemoteObject: public jsi::HostObject {
   friend class ShareableValue;
 private:
   NativeReanimatedModule *module;
+  std::shared_ptr<jsi::Object> backing;
   std::unique_ptr<FrozenObject> initializer;
 public:
+  void maybeInitializeOnUIRuntime(jsi::Runtime &rt);
   RemoteObject(jsi::Runtime &rt, jsi::Object &object, NativeReanimatedModule *module):
     module(module), initializer(new FrozenObject(rt, object, module)) {}
+  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
+  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
 };
 
 }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -1,6 +1,5 @@
 /* global _WORKLET */
 import { Easing } from './Easing';
-import { makeCacheable } from './core';
 
 export function cancelAnimation(value) {
   'worklet';

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -1,5 +1,6 @@
 /* global _WORKLET */
 import { Easing } from './Easing';
+import { makeCacheable } from './core';
 
 export function cancelAnimation(value) {
   'worklet';
@@ -59,6 +60,8 @@ export function withTiming(toValue, userConfig, callback) {
     callback,
   };
 }
+
+makeCacheable(withTiming);
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -61,8 +61,6 @@ export function withTiming(toValue, userConfig, callback) {
   };
 }
 
-makeCacheable(withTiming);
-
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
   if (!_WORKLET) {

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -17,6 +17,16 @@ export function makeShareable(value) {
   return NativeReanimated.makeShareable(value);
 }
 
+export function makeCacheable(obj) {
+  if (typeof obj === 'object') {
+    Object.defineProperty(obj, '__reanimatedShouldBeCached', {
+      value: true,
+      enumerable: false,
+    });
+  }
+  return obj;
+}
+
 function workletValueSetter(value) {
   'worklet';
   const previousAnimation = this._animation;


### PR DESCRIPTION
This pr changes the way in which we store FrozenObj as a jsi::Value. On iOS object created from jsi::HostObject is missing a basic JS method for instance hasOwnProperty and cannot be passed to Object.assign. In order to get rid of these limitations, we can store FrozenObj as a jsi::Object with a hidden property that represents FrozenObject.  

![IMG_20200612_081159](https://user-images.githubusercontent.com/12784455/84470885-8b3e5500-ac84-11ea-803f-01088891a749.jpg)

Why there won't be any cycles?
That's because all the edges that are added points in the same direction as the edge from jsi::Object to FrozenObject.

The second part of PR "Improving caching":
WHY:
If we capture worklet (e.g. withTiming) in two other worklets then withTiming will be converted twice to FrozenObject. To avoid it we add a hidden property to withTiming with reference to the FrozenObject.

HOW:
We cannot automatically add a hidden reference to internal cpp objects because input object can be altered in the meantime. That's why we export makeCacheable function which adds hidden property "__reanimatedShouldBeCached". The function should be called only on constant objects.
Worklet functions are cached automatically cause they are constant.

There are two other hidden properties "__reanimatedSharedRef" and "__reanimatedAdaptable".
The first one keeps a reference to the internal cpp object (e.g. FrozenObject) and the second one tells us if we can save jsi::Value in adapt function.  We need the second property because we want to adaptCache only for copy instance, not the original one. 
Example:

```JS
useSharedValue(5);
```
We don't want to save jsi::Value(5) as our js representation. We createHost(rt, mutableValue) instead.



