### PR TITLE
V2 fix withSpring user config velocity usage

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -161,7 +161,6 @@ export function withSpring(toValue, userConfig, callback) {
       animation.velocity = previousAnimation.velocity || 0;
       animation.lastTimestamp = previousAnimation.lastTimestamp || now;
     } else {
-      animation.velocity = 0;
       animation.lastTimestamp = now;
     }
   }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -158,7 +158,7 @@ export function withSpring(toValue, userConfig, callback) {
   function start(animation, value, now, previousAnimation) {
     animation.current = value;
     if (previousAnimation) {
-      animation.velocity = previousAnimation.velocity || 0;
+      animation.velocity = previousAnimation.velocity || animation.velocity || 0;
       animation.lastTimestamp = previousAnimation.lastTimestamp || now;
     } else {
       animation.lastTimestamp = now;


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Noticed my velocity isn't getting applied to withSpring. Then noticed it resets it on start.

This change fixes this. ChatHeads example works great with that change.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- Fix usage of passed velocity to withSpring

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
