### PR TITLE
Use getEnforcing when loading Reanimated turbo module

### DIFF
--- a/src/reanimated2/NativeReanimated.js
+++ b/src/reanimated2/NativeReanimated.js
@@ -1,7 +1,7 @@
 import { TurboModuleRegistry } from 'react-native';
 
 const InnerNativeModule =
-  global.__reanimatedModuleProxy || TurboModuleRegistry.get('NativeReanimated');
+  global.__reanimatedModuleProxy || TurboModuleRegistry.getEnforcing('NativeReanimated');
 
 export default {
   installCoreFunctions(valueSetter) {


### PR DESCRIPTION
## Description

Since we expect this module exists on the native site and not supporting the opposite case, I believe it's worth throwing as soon as possible and use a dedicated method for that to clearly say that native module is missing.

## Changes

replace `TurboModuleRegistry.get` -> `TurboModuleRegistry.getEnforcing`

