### PR TITLE
Fix error when style in an array is null

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -247,7 +247,7 @@ export default function createAnimatedComponent(Component) {
         if (key === 'style') {
           const styles = Array.isArray(value) ? value : [value];
           const processedStyle = styles.map(style => {
-            if (style.viewTag) {
+            if (style && style.viewTag) {
               // this is how we recognize styles returned by useAnimatedStyle
               return style.initial;
             } else {


### PR DESCRIPTION
## Description

Maybe it's not obvious but the style in styles' array can also be null and it's handled by RN and the previous version of reanimated. Thus I think we shouldn't make the migration breaking in this aspect. Filtering is quite an easy trick to make it workable. 



btw, I think in the current implementation we're ignoring that styles can also be nested arrays, but it's a nit.