### PR TITLE
Throw an error when trying to use new `interpolate` with nodes

### DIFF
--- a/src/Animated.js
+++ b/src/Animated.js
@@ -25,6 +25,7 @@ import {
 } from './Transitioning';
 import SpringUtils from './animations/SpringUtils';
 import useValue from './useValue';
+import * as reanimated2 from './reanimated2'
 
 const decayWrapper = backwardCompatibleAnimWrapper(decay, DecayAnimation);
 const timingWrapper = backwardCompatibleAnimWrapper(timing, TimingAnimation);
@@ -59,6 +60,9 @@ const Animated = {
 
   // hooks
   useValue,
+
+  // reanimated2
+  ...reanimated2
 };
 
 export default Animated;

--- a/src/reanimated2/interpolation.js
+++ b/src/reanimated2/interpolation.js
@@ -30,6 +30,9 @@ function internalInterpolate(x, l, r, ll, rr, type) {
 
 export function interpolate(x, input, output, type) {
   'worklet';
+  if (x && x.__nodeID) {
+    throw new Error('Reanimated: interpolate from V1 has been renamed to interpolateNode.')
+  }
   const length = input.length;
   let narrowedInput = [];
   if (x < input[0]) {


### PR DESCRIPTION
## Description

I've found out I'm using it many times in my codebase (and supportive libraries) and thus it became difficult for me to get it renamed automatically (bc there were different imports' names etc). So I've added an error thrown while calling `interpolate` with a node (duck-typed).

## Changes

Throwing an error in the first argument seems to be a reanimated node. 
Also, I observer that currently it's not possible to use new features with default imports. I've added it because we were doing it previously. 
