### PR TITLE
Fix getValue() and call() in the mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -138,7 +138,7 @@ const Reanimated = {
     }
   },
   block: (a) => a[a.length - 1],
-  call: (a, b) => b(a),
+  call: (a, b) => b(a.map(getValue)),
   debug: NOOP,
   onChange: NOOP,
   startClock: NOOP,

--- a/mock.js
+++ b/mock.js
@@ -23,7 +23,7 @@ const getValue = node => {
   if (typeof node === "number") {
     return node;
   }
-  return node && node[" __value"];
+  return node && node[" __value"] || 0;
 };
 
 class AnimatedValue {


### PR DESCRIPTION
## Description
Fixes #621 
We also came across this issue when trying to write our jest tests for our components that use `react-navigation` v5 and material top tabs.
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- Added default value for getValue in parity with `#val`  https://github.com/software-mansion/react-native-reanimated/blob/9c0e3c8a6fff9283f9365d87fd205898caa6a3b9/src/val.js#L2
- Properly map call nodes in parity with `#call` https://github.com/software-mansion/react-native-reanimated/blob/9c0e3c8a6fff9283f9365d87fd205898caa6a3b9/src/core/AnimatedCall.js#L48

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
