### PR TITLE
chore: export addWhitelistedUIProps type

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -382,6 +382,7 @@ declare module 'react-native-reanimated' {
 
     // configuration
     export function addWhitelistedNativeProps(props: { [key: string]: true }): void;
+    export function addWhitelistedUIProps(props: { [key: string]: true }): void;
   }
 
   export default Animated;


### PR DESCRIPTION
## Description

Hi there 👋

First, thanks for this great library and the work in maintaining it :)

While i was working with `react-native-svg` a drop in FPS on Android, and after investigate all possible solutions and following #537 (@owinter86 ), that it perform not as expected.

but then going throw the code base, i notice that only `addWhitelistedNativeProps` was exported but not `addWhitelistedUIProps`.

## Changes

- Exported `addWhitelistedUIProps` type

### Before
without using `addWhitelistedUIProps`
![ezgif-3-dd229c72472c (1)](https://user-images.githubusercontent.com/4061838/84064077-58fdd080-a9c2-11ea-97e5-3d2023c1cfca.gif)

### After
with using `addWhitelistedUIProps`
![ezgif-3-792d60e99d86](https://user-images.githubusercontent.com/4061838/84064006-39ff3e80-a9c2-11ea-8e49-00e1a46ae4cd.gif)

