### PR TITLE
Avoid unnecessary babel polyfills and fix problem with nested worklets.

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -7,6 +7,20 @@ namespace reanimated {
 
 void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt, UpdaterFunction updater, RequestFrameFunction requestFrame) {
   rt.global().setProperty(rt, "_WORKLET", jsi::Value(true));
+  
+  jsi::Object dummyGlobal(rt);
+  auto dummyFunction = [requestFrame](
+     jsi::Runtime &rt,
+     const jsi::Value &thisValue,
+     const jsi::Value *args,
+     size_t count
+     ) -> jsi::Value {
+   return jsi::Value::undefined();
+  };
+  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"), 1, dummyFunction);
+  
+  dummyGlobal.setProperty(rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
+  rt.global().setProperty(rt, "global", dummyGlobal);
 
   auto callback = [](
       jsi::Runtime &rt,

--- a/plugin.js
+++ b/plugin.js
@@ -31,9 +31,11 @@ const globals = new Set([
   'UIManager',
   'requestAnimationFrame',
   '_WORKLET',
+  'arguments',
   '_log',
   '_updateProps',
   'RegExp',
+  'Error',
 ]);
 
 function buildWorkletString(t, fun, closureVariables) {
@@ -52,7 +54,7 @@ function buildWorkletString(t, fun, closureVariables) {
         t.variableDeclaration('const', [
           t.variableDeclarator(
             t.objectPattern(
-              closureVariables.map(variable =>
+              closureVariables.map((variable) =>
                 t.objectProperty(
                   t.identifier(variable.name),
                   t.identifier(variable.name),
@@ -171,7 +173,7 @@ function processWorkletFunction(t, fun) {
             false
           ),
           t.objectExpression(
-            variables.map(variable =>
+            variables.map((variable) =>
               t.objectProperty(
                 t.identifier(variable.name),
                 variable,
@@ -238,10 +240,6 @@ function processWorkletFunction(t, fun) {
 function processIfWorkletNode(t, path) {
   const fun = path;
 
-  if (path.node.type === 'FuncionDeclaration' && path.node.id.name === 'siakaka') {
-    console.log(fun.toString());
-  }
-
   fun.traverse({
     DirectiveLiteral(path) {
       const value = path.node.value;
@@ -254,52 +252,90 @@ function processIfWorkletNode(t, path) {
           directives &&
           directives.length > 0 &&
           directives.some(
-            directive =>
+            (directive) =>
               t.isDirectiveLiteral(directive.value) &&
               directive.value.value === 'worklet'
           )
         ) {
-          processWorkletFunction(t, fun)
+          processWorkletFunction(t, fun);
         }
       }
     },
   });
 }
 
-module.exports = function({ types: t }) {
+function processWorklets(t, path, processor) {
+  const name = path.node.callee.name;
+  if (
+    objectHooks.has(name) &&
+    path.get('arguments.0').type === 'ObjectExpression'
+  ) {
+    const objectPath = path.get('arguments.0.properties.0');
+    for (let i = 0; i < objectPath.container.length; i++) {
+      processor(t, objectPath.getSibling(i).get('value'));
+    }
+  } else if (functionHooks.has(name)) {
+    processor(t, path.get('arguments.0'));
+  }
+}
+
+function removeWorkletLabelFromSubtrees(path) {
+  const parentFunction = path.getFunctionParent();
+  if (parentFunction != null) {
+    parentFunction.traverse({
+      Directive(innerPath) {
+        if (
+          innerPath.node.value != path.node &&
+          innerPath.node.value.value === 'worklet'
+        ) {
+          innerPath.remove();
+        }
+      },
+    });
+  }
+}
+
+module.exports = function ({ types: t }) {
   return {
     visitor: {
       CallExpression: {
-        exit(path) {
-          const name = path.node.callee.name;
-          if (
-            objectHooks.has(name) &&
-            path.get('arguments.0').type === 'ObjectExpression'
-          ) {
-            const objectPath = path.get('arguments.0.properties.0');
-            for (let i = 0; i < objectPath.container.length; i++) {
-              processWorkletFunction(t, objectPath.getSibling(i).get('value'))
-            }
-          } else if (functionHooks.has(name)) {
-            processWorkletFunction(t, path.get('arguments.0'))
+        enter(path) {
+          if (path.get('callee').matchesPattern('Object.assign')) {
+            // @babel/plugin-transform-object-assign
+            path.node.callee.object.name = 'random_temp_name';
           }
-        }
+        },
+        exit(path) {
+          if (path.get('callee').matchesPattern('random_temp_name.assign')) {
+            // @babel/plugin-transform-object-assign
+            path.node.callee.object.name = 'Object';
+          }
+
+          processWorklets(t, path, processWorkletFunction);
+        },
       },
       FunctionDeclaration: {
         exit(path) {
           processIfWorkletNode(t, path);
-        }
+        },
       },
       FunctionExpression: {
         exit(path) {
           processIfWorkletNode(t, path);
-        }
+        },
       },
       ArrowFunctionExpression: {
         exit(path) {
-          processIfWorkletNode(t,path);
-        }
-      }
+          processIfWorkletNode(t, path);
+        },
+      },
+      DirectiveLiteral: {
+        enter(path) {
+          if (path.node.value === 'worklet') {
+            removeWorkletLabelFromSubtrees(path);
+          }
+        },
+      },
     },
   };
 };

--- a/plugin.js
+++ b/plugin.js
@@ -36,6 +36,7 @@ const globals = new Set([
   '_updateProps',
   'RegExp',
   'Error',
+  'global',
 ]);
 
 function buildWorkletString(t, fun, closureVariables) {
@@ -279,22 +280,6 @@ function processWorklets(t, path, processor) {
   }
 }
 
-function removeWorkletLabelFromSubtrees(path) {
-  const parentFunction = path.getFunctionParent();
-  if (parentFunction != null) {
-    parentFunction.traverse({
-      Directive(innerPath) {
-        if (
-          innerPath.node.value != path.node &&
-          innerPath.node.value.value === 'worklet'
-        ) {
-          innerPath.remove();
-        }
-      },
-    });
-  }
-}
-
 module.exports = function ({ types: t }) {
   return {
     visitor: {
@@ -319,13 +304,6 @@ module.exports = function ({ types: t }) {
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
         exit(path) {
           processIfWorkletNode(t, path);
-        },
-      },
-      DirectiveLiteral: {
-        enter(path) {
-          if (path.node.value === 'worklet') {
-            removeWorkletLabelFromSubtrees(path);
-          }
         },
       },
     },

--- a/plugin.js
+++ b/plugin.js
@@ -306,7 +306,9 @@ module.exports = function ({ types: t }) {
           }
         },
         exit(path) {
-          if (path.get('callee').matchesPattern('Object__DO_NOT_TRANSFORM.assign')) {
+          if (
+            path.get('callee').matchesPattern('Object__DO_NOT_TRANSFORM.assign')
+          ) {
             // @babel/plugin-transform-object-assign
             path.node.callee.object.name = 'Object';
           }

--- a/plugin.js
+++ b/plugin.js
@@ -302,11 +302,11 @@ module.exports = function ({ types: t }) {
         enter(path) {
           if (path.get('callee').matchesPattern('Object.assign')) {
             // @babel/plugin-transform-object-assign
-            path.node.callee.object.name = 'random_temp_name';
+            path.node.callee.object.name = 'Object__DO_NOT_TRANSFORM';
           }
         },
         exit(path) {
-          if (path.get('callee').matchesPattern('random_temp_name.assign')) {
+          if (path.get('callee').matchesPattern('Object__DO_NOT_TRANSFORM.assign')) {
             // @babel/plugin-transform-object-assign
             path.node.callee.object.name = 'Object';
           }

--- a/plugin.js
+++ b/plugin.js
@@ -314,17 +314,7 @@ module.exports = function ({ types: t }) {
           processWorklets(t, path, processWorkletFunction);
         },
       },
-      FunctionDeclaration: {
-        exit(path) {
-          processIfWorkletNode(t, path);
-        },
-      },
-      FunctionExpression: {
-        exit(path) {
-          processIfWorkletNode(t, path);
-        },
-      },
-      ArrowFunctionExpression: {
+      'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
         exit(path) {
           processIfWorkletNode(t, path);
         },


### PR DESCRIPTION
The Typescript [fix](https://github.com/software-mansion/react-native-reanimated/pull/862) revealed another issue with overzealous babel polyfills. The pull-request solves two most important problems caused by  @babel/plugin-transform-object-assign and @babel/plugin-transform-parameters.

Fixes problem with nested worklets by adding 'global' to our blacklist and providing dummy __reanimatedWorkletInit implementation on UI side.

Additional info: 

1 "Object.assign" 
Babel plugin "@babel/plugin-transform-object-assign" transforms Object.assign() call into (0, _extend.default)() where _extend is a module with Object.assign polyfill. Because the plugin do that we capture _extend object and bad things happen.  This pr renames "Object" to "Object__DO_NOT_TRANSFOR" in each Object.assign call on entry and reverts this change on exit.

2 "function(...args)"
Babel plugin @babel/plugin-transform-parameters transforms spread syntax and uses arguments instead. To prevent "arguments" variable from being captured the pr add it to the blacklist.

3 Nested Worklets problem
```Js
function out(easing) {
  'worklet';
  return t => {
    'worklet';
    return 1 - easing(1 - t);
  };
}
``` 
-> 
```JS
var out = function () {
    var _f = function _f(easing) {
      return function () {
        var _f = function _f(t) {
          return 1 - easing(1 - t);
        };

        _f._closure = {
          easing: easing
        };
        _f.asString = "function(t){const{easing}=this._closure;{return 1-easing(1-t);}}";
        _f.__workletID = 615968805831595100;

        global.__reanimatedWorkletInit(_f);

        return _f;
      }();
    };

    _f._closure = {
      global: global
    };
    _f.asString = "function(easing){const{global}=this._closure;{return function(){var _f=function _f(t){return 1-easing(1-t);};_f._closure={easing:easing};_f.asString=\"function(t){const{easing}=this._closure;{return 1-easing(1-t);}}\";_f.__workletID=615968805831595100;global.__reanimatedWorkletInit(_f);return _f;}();}}";
    _f.__workletID = 571397156231203700;

    global.__reanimatedWorkletInit(_f);

    return _f;
  }();
```

As we can see global is captured.  
