### PR TITLE
Support recursive worklets

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -21,6 +21,8 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt, UpdaterFunction update
   
   dummyGlobal.setProperty(rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
+  
+  rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());
 
   auto callback = [](
       jsi::Runtime &rt,

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -264,7 +264,7 @@ PODS:
     - React
   - RNGestureHandler (1.5.2):
     - React
-  - RNReanimated (2.0.0-alpha.1):
+  - RNReanimated (2.0.0-alpha.3):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -428,7 +428,7 @@ SPEC CHECKSUMS:
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
   RNCMaskedView: 76c40a1d41c3e2535df09246a2b5487f04de0814
   RNGestureHandler: 946a7691e41df61e2c4b1884deab41a4cdc3afff
-  RNReanimated: cb0dce8f8375ff485c6d4760553ae831500e7787
+  RNReanimated: c7c95835ae5490a0bca3761b84771594bcb8a6f0
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 


### PR DESCRIPTION
1 Pass closure by global object instead of "this expression".   
2 Use function name in function expression.

Before:
```JS
function () { const { } = this.closure_;
```
After
``` JS
function name () { const {} = jsThis.closure_; { name(sth)}
```

Additional Info:
"jsThis" is a global's property that is changed just before function call and reverted after.
We have to restore a previous value because it may be needed later.
Example
```JS 
function worklet1(x) {
  'worklet';
  worklet2();
  // sth from closure
}
```
remember old jsThis -> set worklet1's jsThis -> call worklet1 -> remember old jsThis (worklet1's) 
-> set worklets2's jsThis -> call worklet2 -> restore old jsThis -> restore old jsThis.

Why do we need this change?
Example:
```JS
function fib(n) {
  'worklet';
  console.log("fib", n);
  if (n == 0) {
     return 1;
  } 
  if (n == 1) {
     return 1;
  }
  return fib(n-1) + fib(n-2);
}
```
We do not pass "this" value while calling fib (for instance like: fib.apply(this, [n]) ). Because of that fib will get null as "this" object and it will impossible to get console variable from this._closure.
