### PR TITLE
V2: Fix Color interpolation 🎨

### DIFF
--- a/src/reanimated2/Colors.js
+++ b/src/reanimated2/Colors.js
@@ -388,7 +388,7 @@ function normalizeColor(color) {
 
 export default function processColor(color) {
   'worklet';
-  if (color === null || color === undefined) {
+  if (color === null || color === undefined  || typeof color === "number") {
     return color;
   }
 


### PR DESCRIPTION
This example fixes color interpolation. If the shared value is a number, it is a pass-through via UpdateProps. This small change enables this example: https://www.dropbox.com/s/zy7rv95ax5w5bzp/demo.mov?dl=0 that leverages color interpolation on a View but also an SVG component. 