### PR TITLE
Use function hash as workletID instead of a random number.

### DIFF
--- a/Common/cpp/Registries/WorkletsCache.cpp
+++ b/Common/cpp/Registries/WorkletsCache.cpp
@@ -19,11 +19,11 @@ jsi::Function function(jsi::Runtime &rt, const std::string& code) {
 }
 
 std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObj) {
-  long long workletId = frozenObj->map["__workletID"]->numberValue;
-  if (worklets.count(workletId) == 0) {
+  long long workletHash = frozenObj->map["__workletHash"]->numberValue;
+  if (worklets.count(workletHash) == 0) {
     jsi::Function fun = function(rt, frozenObj->map["asString"]->stringValue);
     std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
-    worklets[workletId] = funPtr;
+    worklets[workletHash] = funPtr;
   }
-  return worklets[workletId];
+  return worklets[workletHash];
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "homepage": "https://github.com/software-mansion/react-native-reanimated#readme",
   "dependencies": {
-    "fbjs": "^1.0.0"
+    "fbjs": "^1.0.0",
+    "string-hash-64": "^1.0.3"
   },
   "peerDependencies": {
     "react": "*",

--- a/plugin.js
+++ b/plugin.js
@@ -158,12 +158,7 @@ function processWorkletFunction(t, fun) {
   const funExpression = t.functionExpression(null, clone.params, clone.body);
 
   const funString = buildWorkletString(t, fun, variables);
-<<<<<<< HEAD
-||||||| constructed merge base
-  const workletID = hash(funString);
-=======
   const workletHash = hash(funString);
->>>>>>> workletID -> workletHash
 
   const newFun = t.functionExpression(
     fun.id,

--- a/plugin.js
+++ b/plugin.js
@@ -149,6 +149,7 @@ function processWorkletFunction(t, fun) {
   const variables = Array.from(closure.values());
 
   const privateFunctionId = t.identifier('_f');
+  const workletHash = hash(funString);
 
   // if we don't clone other modules won't process parts of newFun defined below
   // this is weird but couldn't find a better way to force transform helper to
@@ -157,7 +158,6 @@ function processWorkletFunction(t, fun) {
   const funExpression = t.functionExpression(null, clone.params, clone.body);
 
   const funString = buildWorkletString(t, fun, variables);
-  const workletID = hash(funString);
 
   const newFun = t.functionExpression(
     fun.id,
@@ -202,10 +202,10 @@ function processWorkletFunction(t, fun) {
           '=',
           t.memberExpression(
             privateFunctionId,
-            t.identifier('__workletID'),
+            t.identifier('__workletHash'),
             false
           ),
-          t.numericLiteral(workletID)
+          t.numericLiteral(workletHash)
         )
       ),
       t.expressionStatement(

--- a/plugin.js
+++ b/plugin.js
@@ -149,7 +149,6 @@ function processWorkletFunction(t, fun) {
   const variables = Array.from(closure.values());
 
   const privateFunctionId = t.identifier('_f');
-  const workletID = hash(fun.toString());
 
   // if we don't clone other modules won't process parts of newFun defined below
   // this is weird but couldn't find a better way to force transform helper to
@@ -158,6 +157,7 @@ function processWorkletFunction(t, fun) {
   const funExpression = t.functionExpression(null, clone.params, clone.body);
 
   const funString = buildWorkletString(t, fun, variables);
+  const workletID = hash(funString);
 
   const newFun = t.functionExpression(
     fun.id,

--- a/plugin.js
+++ b/plugin.js
@@ -149,7 +149,6 @@ function processWorkletFunction(t, fun) {
   const variables = Array.from(closure.values());
 
   const privateFunctionId = t.identifier('_f');
-  const workletHash = hash(funString);
 
   // if we don't clone other modules won't process parts of newFun defined below
   // this is weird but couldn't find a better way to force transform helper to

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const generate = require('@babel/generator').default;
+const hash = require('string-hash-64');
 
 const functionHooks = new Set([
   'useAnimatedStyle',
@@ -148,11 +149,11 @@ function processWorkletFunction(t, fun) {
   const variables = Array.from(closure.values());
 
   const privateFunctionId = t.identifier('_f');
+  const workletID = hash(fun.toString());
 
   // if we don't clone other modules won't process parts of newFun defined below
   // this is weird but couldn't find a better way to force transform helper to
   // process the function
-  const workletID = Math.random() * 1e18;
   const clone = t.cloneNode(fun.node);
   const funExpression = t.functionExpression(null, clone.params, clone.body);
 

--- a/plugin.js
+++ b/plugin.js
@@ -158,6 +158,12 @@ function processWorkletFunction(t, fun) {
   const funExpression = t.functionExpression(null, clone.params, clone.body);
 
   const funString = buildWorkletString(t, fun, variables);
+<<<<<<< HEAD
+||||||| constructed merge base
+  const workletID = hash(funString);
+=======
+  const workletHash = hash(funString);
+>>>>>>> workletID -> workletHash
 
   const newFun = t.functionExpression(
     fun.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9236,6 +9236,11 @@ string-argv@^0.3.0:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-hash-64@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
+  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"


### PR DESCRIPTION
WHY:
Because we want reproducible builds.

HOW:
Use a hash function from https://www.npmjs.com/package/string-hash-64.

REMOVE DEBUG CONSOLE.LOG !!!!!!!!!
