### PR TITLE
Use className instead of class in Navbar (docs)

### DIFF
--- a/docs/src/theme/Navbar/index.js
+++ b/docs/src/theme/Navbar/index.js
@@ -226,7 +226,7 @@ function Navbar() {
                   [styles.hideLogoText]: isSearchBarExpanded,
                 })}>
                 {title}
-                <span class="badge badge--info">V2 alpha</span>
+                <span className="badge badge--info">V2 alpha</span>
               </strong>
             )}
           </Link>


### PR DESCRIPTION
## Description

Fix `Navbar` component to correctly use `className` instead of `class`