### PR TITLE
Update mocks for start()/stop() with callback

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -13,6 +13,14 @@ const { View, Text, Image, Animated, Platform } = require('react-native');
 
 function NOOP() {}
 
+function simulateCallbackFactory(...params) {
+  return (callback) => {
+    callback && setTimeout(() => {
+      callback(...params)
+    }, 0);
+  }
+}
+
 class Code extends React.Component {
   render() {
     return null;
@@ -165,16 +173,16 @@ const Reanimated = {
   min: (a, b) => Math.min(getValue(a), getValue(b)),
 
   decay: () => ({
-    start: NOOP,
-    stop: NOOP,
+    start: simulateCallbackFactory({ finished: false }),
+    stop: simulateCallbackFactory({ finished: true }),
   }),
   timing: () => ({
-    start: NOOP,
-    stop: NOOP,
+    start: simulateCallbackFactory({ finished: false }),
+    stop: simulateCallbackFactory({ finished: true }),
   }),
   spring: () => ({
-    start: NOOP,
-    stop: NOOP,
+    start: simulateCallbackFactory({ finished: false }),
+    stop: simulateCallbackFactory({ finished: true }),
   }),
 
   proc: cb => cb,


### PR DESCRIPTION
# Description

For now it we call `Animated.spring(config).start(myCallback)` in tests, `myCallback` will not be called. This makes it difficult to test the callback code.

# Changes

Updated mocks for .timing, .decay and .spring, added `setTimeout()` to simulate the callback, such that we can use Jest fake timers to schedule the callback.