### PR TITLE
Enable starting animations from RN thread.

### DIFF
--- a/Common/cpp/SharedItems/Shareable.cpp
+++ b/Common/cpp/SharedItems/Shareable.cpp
@@ -292,14 +292,15 @@ void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi:
 
   if (module->isHostRuntime(rt)) {
     if (propName == "value") {
-      {
-        std::lock_guard<std::mutex> lock(readWriteMutex);
-        value = ShareableValue::adapt(rt, newValue, module);
-      }
-      module->scheduler->scheduleOnUI([this] {
-        for (auto listener : listeners) {
-          listener.second();
-        }
+      auto shareable = ShareableValue::adapt(rt, newValue, module);
+      module->scheduler->scheduleOnUI([this, shareable] {
+        jsi::Runtime &rt = *this->module->runtime.get();
+        auto setterProxy = jsi::Object::createFromHostObject(rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
+        jsi::Value newValue = shareable->getValue(rt);
+        module->valueSetter->getValue(rt)
+          .asObject(rt)
+          .asFunction(rt)
+          .callWithThis(rt, setterProxy, newValue);
       });
     }
     return;

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -15,11 +15,13 @@ namespace reanimated {
 using FrameCallback = std::function<void(double)>;
 
 class ShareableValue;
+class MutableValue;
 class MapperRegistry;
 class EventHandlerRegistry;
 
 class NativeReanimatedModule : public NativeReanimatedModuleSpec {
   friend ShareableValue;
+  friend MutableValue;
   
   public:
     NativeReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker,

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import WorkletEventHandler from './WorkletEventHandler';
 import { startMapper, stopMapper, makeMutable, makeRemote } from './core';
 import updateProps from './UpdateProps';
+import { initialUpdaterRun } from './animations';
 
 export function useSharedValue(init) {
   const ref = useRef(null);
@@ -245,7 +246,7 @@ export function useAnimatedStyle(updater) {
 
   const initRef = useRef(null);
   if (initRef.current === null) {
-    const initial = updater();
+    const initial = initialUpdaterRun(updater);
     initRef.current = {
       initial,
       remoteState: makeRemote({ last: initial }),
@@ -273,7 +274,7 @@ export function useDerivedValue(processor) {
   const initRef = useRef(null);
   if (initRef.current === null) {
     initRef.current = {
-      sharedValue: makeMutable(processor()),
+      sharedValue: makeMutable(initialUpdaterRun(processor)),
       inputs: Object.values(processor._closure),
     };
   }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -1,6 +1,26 @@
 /* global _WORKLET */
 import { Easing } from './Easing';
 
+let IN_STYLE_UPDATER = false;
+
+export function initialUpdaterRun(updater) {
+  IN_STYLE_UPDATER = true;
+  const result = updater();
+  IN_STYLE_UPDATER = false;
+  return result;
+}
+
+function defineAnimation(starting, factory) {
+  'worklet';
+  if (IN_STYLE_UPDATER) {
+    return starting;
+  }
+  if (_WORKLET) {
+    return factory();
+  }
+  return factory;
+}
+
 export function cancelAnimation(value) {
   'worklet';
   // TODO: this is supported only when run on UI – maybe assert?
@@ -13,251 +33,259 @@ export function cancelAnimation(value) {
 
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
-  if (!_WORKLET) {
-    return toValue;
-  }
-
-  const config = {
-    duration: 300,
-    easing: Easing.inOut(Easing.quad),
-  };
-  if (userConfig) {
-    Object.keys(userConfig).forEach(key => (config[key] = userConfig[key]));
-  }
-
-  function timing(animation, now) {
-    const { toValue, progress, startTime, current } = animation;
-
-    const runtime = now - startTime;
-
-    if (runtime >= config.duration) {
-      animation.current = toValue;
-      return true;
+  return defineAnimation(toValue, () => {
+    'worklet';
+    const config = {
+      duration: 300,
+      easing: Easing.inOut(Easing.quad),
+    };
+    if (userConfig) {
+      Object.keys(userConfig).forEach(key => (config[key] = userConfig[key]));
     }
 
-    const newProgress = config.easing(runtime / config.duration);
+    function timing(animation, now) {
+      const { toValue, progress, startTime, current } = animation;
 
-    const dist =
-      ((toValue - current) * (newProgress - progress)) / (1 - progress);
-    animation.current += dist;
-    animation.progress = newProgress;
-    return false;
-  }
+      const runtime = now - startTime;
 
-  function start(animation, value, now, previousAnimation) {
-    animation.startTime = now;
-    animation.progress = 0;
-    animation.current = value;
-  }
+      if (runtime >= config.duration) {
+        animation.current = toValue;
+        return true;
+      }
 
-  return {
-    animation: timing,
-    start,
-    progress: 0,
-    toValue,
-    current: toValue,
-    callback,
-  };
+      const newProgress = config.easing(runtime / config.duration);
+
+      const dist =
+        ((toValue - current) * (newProgress - progress)) / (1 - progress);
+      animation.current += dist;
+      animation.progress = newProgress;
+      return false;
+    }
+
+    function start(animation, value, now, previousAnimation) {
+      animation.startTime = now;
+      animation.progress = 0;
+      animation.current = value;
+    }
+
+    return {
+      animation: timing,
+      start,
+      progress: 0,
+      toValue,
+      current: toValue,
+      callback,
+    };
+  });
 }
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
-  if (!_WORKLET) {
-    return toValue;
-  }
+  return defineAnimation(toValue, () => {
+    'worklet';
 
-  // TODO: figure out why we can't use spread or Object.assign here
-  // when user config is "frozen object" we can't enumerate it (perhaps
-  // something is wrong with the object prototype).
-  const config = {
-    damping: 10,
-    mass: 1,
-    stiffness: 100,
-    overshootClamping: false,
-    restDisplacementThreshold: 0.001,
-    restSpeedThreshold: 0.001,
-  };
-  if (userConfig) {
-    Object.keys(userConfig).forEach(key => (config[key] = userConfig[key]));
-  }
-
-  function spring(animation, now) {
-    const { toValue, lastTimestamp, current, velocity } = animation;
-
-    const deltaTime = Math.min(now - lastTimestamp, 64);
-    animation.lastTimestamp = now;
-
-    const c = config.damping;
-    const m = config.mass;
-    const k = config.stiffness;
-
-    const v0 = -velocity;
-    const x0 = toValue - current;
-
-    const zeta = c / (2 * Math.sqrt(k * m)); // damping ratio
-    const omega0 = Math.sqrt(k / m); // undamped angular frequency of the oscillator (rad/ms)
-    const omega1 = omega0 * Math.sqrt(1 - zeta ** 2); // exponential decay
-
-    const t = deltaTime / 1000;
-
-    const sin1 = Math.sin(omega1 * t);
-    const cos1 = Math.cos(omega1 * t);
-
-    // under damped
-    const underDampedEnvelope = Math.exp(-zeta * omega0 * t);
-    const underDampedFrag1 =
-      underDampedEnvelope *
-      (sin1 * ((v0 + zeta * omega0 * x0) / omega1) + x0 * cos1);
-
-    const underDampedPosition = toValue - underDampedFrag1;
-    // This looks crazy -- it's actually just the derivative of the oscillation function
-    const underDampedVelocity =
-      zeta * omega0 * underDampedFrag1 -
-      underDampedEnvelope *
-        (cos1 * (v0 + zeta * omega0 * x0) - omega1 * x0 * sin1);
-
-    // critically damped
-    const criticallyDampedEnvelope = Math.exp(-omega0 * t);
-    const criticallyDampedPosition =
-      toValue - criticallyDampedEnvelope * (x0 + (v0 + omega0 * x0) * t);
-
-    const criticallyDampedVelocity =
-      criticallyDampedEnvelope *
-      (v0 * (t * omega0 - 1) + t * x0 * omega0 * omega0);
-
-    const isOvershooting = () => {
-      if (config.overshootClamping && config.stiffness !== 0) {
-        return current < toValue ? current > toValue : current < toValue;
-      } else {
-        return false;
-      }
+    // TODO: figure out why we can't use spread or Object.assign here
+    // when user config is "frozen object" we can't enumerate it (perhaps
+    // something is wrong with the object prototype).
+    const config = {
+      damping: 10,
+      mass: 1,
+      stiffness: 100,
+      overshootClamping: false,
+      restDisplacementThreshold: 0.001,
+      restSpeedThreshold: 0.001,
     };
-
-    const isVelocity = Math.abs(velocity) < config.restSpeedThreshold;
-    const isDisplacement =
-      config.stiffness === 0 ||
-      Math.abs(toValue - current) < config.restDisplacementThreshold;
-
-    if (zeta < 1) {
-      animation.current = underDampedPosition;
-      animation.velocity = underDampedVelocity;
-    } else {
-      animation.current = criticallyDampedPosition;
-      animation.velocity = criticallyDampedVelocity;
+    if (userConfig) {
+      Object.keys(userConfig).forEach(key => (config[key] = userConfig[key]));
     }
 
-    if (isOvershooting() || (isVelocity && isDisplacement)) {
-      if (config.stiffness !== 0) {
-        animation.velocity = 0;
-        animation.current = toValue;
-      }
-      return true;
-    }
-  }
+    function spring(animation, now) {
+      const { toValue, lastTimestamp, current, velocity } = animation;
 
-  function start(animation, value, now, previousAnimation) {
-    animation.current = value;
-    if (previousAnimation) {
-      animation.velocity = previousAnimation.velocity || animation.velocity || 0;
-      animation.lastTimestamp = previousAnimation.lastTimestamp || now;
-    } else {
+      const deltaTime = Math.min(now - lastTimestamp, 64);
       animation.lastTimestamp = now;
-    }
-  }
 
-  return {
-    animation: spring,
-    start,
-    toValue,
-    velocity: config.velocity || 0,
-    current: toValue,
-    callback,
-  };
+      const c = config.damping;
+      const m = config.mass;
+      const k = config.stiffness;
+
+      const v0 = -velocity;
+      const x0 = toValue - current;
+
+      const zeta = c / (2 * Math.sqrt(k * m)); // damping ratio
+      const omega0 = Math.sqrt(k / m); // undamped angular frequency of the oscillator (rad/ms)
+      const omega1 = omega0 * Math.sqrt(1 - zeta ** 2); // exponential decay
+
+      const t = deltaTime / 1000;
+
+      const sin1 = Math.sin(omega1 * t);
+      const cos1 = Math.cos(omega1 * t);
+
+      // under damped
+      const underDampedEnvelope = Math.exp(-zeta * omega0 * t);
+      const underDampedFrag1 =
+        underDampedEnvelope *
+        (sin1 * ((v0 + zeta * omega0 * x0) / omega1) + x0 * cos1);
+
+      const underDampedPosition = toValue - underDampedFrag1;
+      // This looks crazy -- it's actually just the derivative of the oscillation function
+      const underDampedVelocity =
+        zeta * omega0 * underDampedFrag1 -
+        underDampedEnvelope *
+          (cos1 * (v0 + zeta * omega0 * x0) - omega1 * x0 * sin1);
+
+      // critically damped
+      const criticallyDampedEnvelope = Math.exp(-omega0 * t);
+      const criticallyDampedPosition =
+        toValue - criticallyDampedEnvelope * (x0 + (v0 + omega0 * x0) * t);
+
+      const criticallyDampedVelocity =
+        criticallyDampedEnvelope *
+        (v0 * (t * omega0 - 1) + t * x0 * omega0 * omega0);
+
+      const isOvershooting = () => {
+        if (config.overshootClamping && config.stiffness !== 0) {
+          return current < toValue ? current > toValue : current < toValue;
+        } else {
+          return false;
+        }
+      };
+
+      const isVelocity = Math.abs(velocity) < config.restSpeedThreshold;
+      const isDisplacement =
+        config.stiffness === 0 ||
+        Math.abs(toValue - current) < config.restDisplacementThreshold;
+
+      if (zeta < 1) {
+        animation.current = underDampedPosition;
+        animation.velocity = underDampedVelocity;
+      } else {
+        animation.current = criticallyDampedPosition;
+        animation.velocity = criticallyDampedVelocity;
+      }
+
+      if (isOvershooting() || (isVelocity && isDisplacement)) {
+        if (config.stiffness !== 0) {
+          animation.velocity = 0;
+          animation.current = toValue;
+        }
+        return true;
+      }
+    }
+
+    function start(animation, value, now, previousAnimation) {
+      animation.current = value;
+      if (previousAnimation) {
+        animation.velocity =
+          previousAnimation.velocity || animation.velocity || 0;
+        animation.lastTimestamp = previousAnimation.lastTimestamp || now;
+      } else {
+        animation.lastTimestamp = now;
+      }
+    }
+
+    return {
+      animation: spring,
+      start,
+      toValue,
+      velocity: config.velocity || 0,
+      current: toValue,
+      callback,
+    };
+  });
 }
 
-export function delay(delayMs, nextAnimation) {
+export function delay(delayMs, _nextAnimation) {
   'worklet';
-  if (!_WORKLET) {
-    return nextAnimation;
-  }
+  return defineAnimation(_nextAnimation, () => {
+    'worklet';
 
-  function delay(animation, now) {
-    const { startTime, started, previousAnimation } = animation;
+    const nextAnimation =
+      typeof _nextAnimation === 'function' ? _nextAnimation() : _nextAnimation;
 
-    if (now - startTime > delayMs) {
-      if (!started) {
-        nextAnimation.start(
-          nextAnimation,
-          animation.current,
-          now,
-          previousAnimation
-        );
-        animation.previousAnimation = null;
-        animation.started = true;
+    function delay(animation, now) {
+      const { startTime, started, previousAnimation } = animation;
+
+      if (now - startTime > delayMs) {
+        if (!started) {
+          nextAnimation.start(
+            nextAnimation,
+            animation.current,
+            now,
+            previousAnimation
+          );
+          animation.previousAnimation = null;
+          animation.started = true;
+        }
+        const finished = nextAnimation.animation(nextAnimation, now);
+        animation.current = nextAnimation.current;
+        return finished;
+      } else if (previousAnimation) {
+        const finished = previousAnimation.animation(previousAnimation, now);
+        animation.current = previousAnimation.current;
+        if (finished) {
+          animation.previousAnimation = null;
+        }
       }
+      return false;
+    }
+
+    function start(animation, value, now, previousAnimation) {
+      animation.startTime = now;
+      animation.started = false;
+      animation.current = value;
+      animation.previousAnimation = previousAnimation;
+    }
+
+    return {
+      animation: delay,
+      start,
+      current: nextAnimation.current,
+    };
+  });
+}
+
+export function loop(_nextAnimation, _numberOfLoops) {
+  'worklet';
+  return defineAnimation(_nextAnimation, () => {
+    'worklet';
+
+    const nextAnimation =
+      typeof _nextAnimation === 'function' ? _nextAnimation() : _nextAnimation;
+    let numberOfLoops = _numberOfLoops;
+
+    if (numberOfLoops === undefined) {
+      // todo: default values for worklet params does not work (perhaps issue with plugin)
+      numberOfLoops = 1;
+    }
+
+    function loop(animation, now) {
       const finished = nextAnimation.animation(nextAnimation, now);
       animation.current = nextAnimation.current;
-      return finished;
-    } else if (previousAnimation) {
-      const finished = previousAnimation.animation(previousAnimation, now);
-      animation.current = previousAnimation.current;
       if (finished) {
-        animation.previousAnimation = null;
+        const finalValue = nextAnimation.current;
+        nextAnimation.toValue = animation.startValue;
+        nextAnimation.start(nextAnimation, finalValue, now, nextAnimation);
+        animation.startValue = finalValue;
+        animation.loops += 1;
+        return (
+          numberOfLoops > 0 && animation.loops >= Math.round(numberOfLoops * 2)
+        );
       }
+      return false;
     }
-    return false;
-  }
 
-  function start(animation, value, now, previousAnimation) {
-    animation.startTime = now;
-    animation.started = false;
-    animation.current = value;
-    animation.previousAnimation = previousAnimation;
-  }
-
-  return {
-    animation: delay,
-    start,
-    current: nextAnimation.current,
-  };
-}
-
-export function loop(nextAnimation, numberOfLoops) {
-  'worklet';
-  if (!_WORKLET) {
-    return nextAnimation;
-  }
-  if (numberOfLoops === undefined) {
-    // todo: default values for worklet params does not work (perhaps issue with plugin)
-    numberOfLoops = 1;
-  }
-
-  function loop(animation, now) {
-    const finished = nextAnimation.animation(nextAnimation, now);
-    animation.current = nextAnimation.current;
-    if (finished) {
-      const finalValue = nextAnimation.current;
-      nextAnimation.toValue = animation.startValue;
-      nextAnimation.start(nextAnimation, finalValue, now, nextAnimation);
-      animation.startValue = finalValue;
-      animation.loops += 1;
-      return (
-        numberOfLoops > 0 && animation.loops >= Math.round(numberOfLoops * 2)
-      );
+    function start(animation, value, now, previousAnimation) {
+      animation.startValue = value;
+      animation.loops = 0;
+      nextAnimation.start(nextAnimation, value, now, previousAnimation);
     }
-    return false;
-  }
 
-  function start(animation, value, now, previousAnimation) {
-    animation.startValue = value;
-    animation.loops = 0;
-    nextAnimation.start(nextAnimation, value, now, previousAnimation);
-  }
-
-  return {
-    animation: loop,
-    start,
-    loops: 0,
-    current: nextAnimation.current,
-  };
+    return {
+      animation: loop,
+      start,
+      loops: 0,
+      current: nextAnimation.current,
+    };
+  });
 }

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -24,9 +24,12 @@ function workletValueSetter(value) {
     previousAnimation.cancelled = true;
     this._animation = null;
   }
-  if (typeof value === 'object' && value !== null && value.animation) {
+  if (
+    typeof value === 'function' ||
+    (value !== null && typeof value === 'object' && value.animation)
+  ) {
     // animated set
-    const animation = value;
+    const animation = typeof value === 'function' ? value() : value;
     let callStart = timestamp => {
       animation.start(animation, this.value, timestamp, previousAnimation);
     };
@@ -39,7 +42,7 @@ function workletValueSetter(value) {
         callStart(timestamp);
         callStart = null; // prevent closure from keeping ref to previous animation
       }
-      const finished = value.animation(animation, timestamp);
+      const finished = animation.animation(animation, timestamp);
       animation.timestamp = timestamp;
       this._value = animation.current;
       if (finished) {


### PR DESCRIPTION
This change makes it possible to start animations using `withTiming` and similar methods directly on the RN JS thread.

For that to work the following changes were made:
1) On the c++ side, when updating mutable value we now need to call setter. As the value is kept on the "remote" side we run the setter on the UI thread using scheduler
2) On the JS side we need to distinguish between cases when `withTiming` and similar methods are called to determine initial style in `useAnimatedStyle` vs when they are called to be set under `.value` prop. To do that we wrap initial updater calls in `useAnimatedStyle` with a method that sets updates global variable, then read that variable and depending on its state we either return the initial value or the animation.
3) All animation definitions needed to be refactored. We now wrap all animations with `defineAnimation` call, that is responsible for doing the check decsribed in (2). On top of that `defineAnimation` wraps the animation definition such that we no longer return animation object but a worklet which generates that object. This is needed because if the animation object was constructed on the RN JS side, it'd be frozen and UI thred wouldn't be able to modify it while running animations. By passing a worklet we can initialize animation object on the UI side.

Because of the new approach for defining animations, the value setter now must consider two separate cases: when it gets animation object, or when it gets a worklet that outputs animation. We allow for those two options to be returned, otherwise we'd need to make adjustments in the useAnimatedStyle updater which are far more complex.

Note that the changes made to animation functions described in (3) are of a smaller scope that it may seem on the diff. This is because after wrapping animations in `defineAnimation` method we had to indent all the existing code. In `delay` and `loop` methods we transform variables passed to those methods to keep the changeset shorter.

#### Testing

To test this change I modified `AnimatedStyleUpdateExample` to use `withTiming`, `withSpring`, `delay` and `loop` directly in `onPress` handler.