### PR TITLE
Fix issue with skipping animations on nested style objects.

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -86,9 +86,13 @@ function runAnimations(animation, timestamp, key, result) {
   function runAnimations(animation, timestamp, key, result) {
     if (Array.isArray(animation)) {
       result[key] = [];
-      return animation.every((entry, index) =>
-        runAnimations(entry, timestamp, index, result[key])
-      );
+      let allFinished = true;
+      animation.forEach((entry, index) => {
+        if (!runAnimations(entry, timestamp, index, result[key])) {
+          allFinished = false;
+        }
+      });
+      return allFinished;
     } else if (typeof animation === 'object' && animation.animation) {
       if (animation.callStart) {
         animation.callStart(timestamp);
@@ -105,9 +109,13 @@ function runAnimations(animation, timestamp, key, result) {
       return finished;
     } else if (typeof animation === 'object') {
       result[key] = {};
-      return Object.keys(animation).every(k =>
-        runAnimations(animation[k], timestamp, k, result[key])
-      );
+      let allFinished = true;
+      Object.keys(animation).forEach(k => {
+        if (!runAnimations(animation[k], timestamp, k, result[key])) {
+          allFinished = false;
+        }
+      });
+      return allFinished;
     } else {
       result[key] = animation;
       return true;


### PR DESCRIPTION
This PR fixes the problem when animations would be prematurely stopped when part of a nested style object (e.g. transforms).

An example is when we'd use the following structure in `useAnimatedStyle`:
```
{
 transform: [
  { scale: withSpring(something) },
  { translateX: somethingElse }
 ]
}
```

In this case when running updates, and when the spring from scale hasn't finished yet, we'd not take into the account updates made to translateX.

The root cause of that was that we were using `Object.every` when iterating over array. Every would return prematurely when one item return false (which is the case when scale animation is running -> it returns false).

In order to apply the style correctly we need to visit all elements of arrays or objects. This PR changes use of `Object.every` to just a loop done with `forEach` and we have a separate boolean to determine if all the elements of array/object are finished.


### Testing

I updated one of the examples to use the style structure as posted above. Then without this change we'd observe only scale change and no translateX change. Once the spring animation is finished, only then we'd see translate getting the updates. With this fix in, both parameters updates propertly when the animation is running


