### PR TITLE
Fix issue with interrupting timing animations.

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -63,12 +63,25 @@ export function withTiming(toValue, userConfig, callback) {
     }
 
     function start(animation, value, now, previousAnimation) {
-      animation.startTime = now;
-      animation.progress = 0;
+      if (
+        previousAnimation &&
+        previousAnimation.type === 'timing' &&
+        previousAnimation.toValue === toValue
+      ) {
+        // to maintain continuity of timing animations we check if we are starting
+        // new timing over the old one with the same parameters. If so, we want
+        // to copy animation timeline properties
+        animation.startTime = previousAnimation.startTime;
+        animation.progress = previousAnimation.progress;
+      } else {
+        animation.startTime = now;
+        animation.progress = 0;
+      }
       animation.current = value;
     }
 
     return {
+      type: 'timing',
       animation: timing,
       start,
       progress: 0,


### PR DESCRIPTION
This PR fixes the problem with timing animations being interrupted in `useAnimatedStyle` (e.g. as a result of some shared value triggering style update).

### The problem

An example where the problematic behavior can be seen is when we have the following animated style structure:
```
{
  opacity: withTiming(toggle.value ? 1 : 0.5),
  transform: [ { translateX: valueFromGesture.value } ],
}
```

In the above case, when gesture is active, the style will update in each frame. As a consequence, we will start new timing animation in each frame which is fine. The problem is that timing animation would not handle such interruption well.

What we'd ended up seeing, is that newly spawned timing animation will progress very slowely. This is due to the fact that easing curve makes the animation start slowely. When restarting the animation in each frame we'd end up only making that slow eased progress, and never get to the easing curve point at which the animation speeds up. In that case the animation could only complete when the gesture was over and we stopped triggering style updates to allow and allow timing to progress without interruptions.

Note that the above issue is only relevant to timing animations, because they rely on the altered time curve. By that we mean that timing does not look directly at time deltas in between frames but at the time lasted since the start of the animation. This is not the case for other type of animations. In other words: for timing deltaT at the start is much shorter than deltaT closer to the middle of the animation, whereas for spring deltaT's are constant during the whole animation.

To address this issue we added some additional checks to when the timing animation starts. We changed the logic there, and in case the timing starts while the previousAnimation was also a timing anim with the same target value, we copy the previous animation state that was responsible for time-keeping (that is we copy `progress` and `startTime` attributes)

### Testing

To test this I modified DragAndSnap example. I added `isPanning` SV and set it to `true` when gesture starts and to `false` when it ends. Then added this to animated style: `{ opacity: withTiming(isPanning.value ? 0.5 : 1)`. I expected the opacity to change when I start dragging. This wasn't the case but changing animation to `withSpring` would still work. After this change both spring and timing works.





