### PR TITLE
enable ios dev menu

### DIFF
--- a/Example/ios/ReanimatedExample/AppDelegate.mm
+++ b/Example/ios/ReanimatedExample/AppDelegate.mm
@@ -55,6 +55,11 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
   _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self];
+
+  #if RCT_DEV
+    [_turboModuleManager moduleForName:"RCTDevMenu"];
+  #endif
+
   __weak __typeof(self) weakSelf = self;
   return std::make_unique<facebook::react::JSCExecutorFactory>([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
     if (!bridge) {

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -232,4 +232,17 @@ If not, after making those changes your app will be compatible with Turbo Module
 @end
 ```
 
+8. Enable developer menu in `AppDelegate.mm`.
+
+```objectivec
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self];
+
+  #if RCT_DEV
+    [_turboModuleManager moduleForName:"RCTDevMenu"]; // <- add
+  #endif
+  ...
+```
+
 You can refer [to this diff](https://github.com/software-mansion-labs/reanimated-2-playground/commit/f6f2b77496bc00601150f98ea19a341f844d06a3) that presents the set of the above changes made to a fresh react native project in our [Playground repo](https://github.com/software-mansion-labs/reanimated-2-playground).

--- a/docs/versioned_docs/version-2.0.0-alpha/installation.md
+++ b/docs/versioned_docs/version-2.0.0-alpha/installation.md
@@ -231,4 +231,18 @@ If not, after making those changes your app will be compatible with Turbo Module
 @end
 ```
 
+8. Enable developer menu in `AppDelegate.mm`.
+
+```objectivec
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:self];
+
+  #if RCT_DEV
+    [_turboModuleManager moduleForName:"RCTDevMenu"]; // <- add
+  #endif
+  ...
+```
+
+
 You can refer [to this diff](https://github.com/software-mansion-labs/reanimated-2-playground/commit/f6f2b77496bc00601150f98ea19a341f844d06a3) that presents the set of the above changes made to a fresh react native project in our [Playground repo](https://github.com/software-mansion-labs/reanimated-2-playground).


### PR DESCRIPTION
Just a small change which enables dev menu on iOS. Useful, for instance, when in need of switching fast refresh on and off or reloading an app.