### PR TITLE
Fix problem with wrong closure and add possibility to blacklist other plugins.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -94,7 +94,7 @@ function processWorkletFunction(t, fun) {
   const outputs = new Set();
 
   // We use copy because some of the plugins don't update bindings and
-  // some even brake them!
+  // some even break them
   const astWorkletCopy = parse('\n(' + fun.toString() + '\n)');
 
   traverse(astWorkletCopy, {

--- a/plugin.js
+++ b/plugin.js
@@ -354,6 +354,8 @@ module.exports = function ({ types: t }) {
         },
       },
     },
+    // In this way we can modify babel options 
+    // https://github.com/babel/babel/blob/eea156b2cb8deecfcf82d52aa1b71ba4995c7d68/packages/babel-core/src/transformation/normalize-opts.js#L64
     manipulateOptions(opts, parserOpts) {
       const plugins = opts.plugins;
       removePluginsFromBlacklist(plugins);

--- a/plugin.js
+++ b/plugin.js
@@ -306,6 +306,7 @@ const PLUGIN_BLACKLIST = PLUGIN_BLACKLIST_NAMES.map((pluginName) => {
   }
 });
 
+// plugin objects are created by babel internals and they don't carry any identifier
 function removePluginsFromBlacklist(plugins) {
   PLUGIN_BLACKLIST.forEach((blacklistedPlugin) => {
     if (!blacklistedPlugin) {


### PR DESCRIPTION
## PROBLEM WITH WRONG CLOSURE

#### WHY:
Some of the plugins that are used by metro-react-native-preset or by babel itself don't update correctly bindings properties in scopes. Because we use bindings in order to find all the missing variables to capture them we have to work with scopes that reflect a current state in AST.

Example:
``` JS
let {x, y} = obj;
``` 
is changed to 
```JS
let _obj = obj,
    x = _obj.x,
    y = _obj.y;
```
by babel-plugin-transform-destructuring.
However, in binding, we only find [x, y].

#### SOLUTION
Work on a copy of worklet tree with proper bindings:
``` JS
const copyWithCorrentBindings = Parser.parse('(' + fun.toString() + '\n)');
traverse(copyWithCorrentBindings, {...visitors}); 
```
----------------------------------------------------
## BLACKLIST OTHER PLUGINS

#### WHY:
Most of the babel presets used by React Native developers contains plugins that polyfills mechanisms that are supported by Hermes and JSC. Additionally, some of the polyfills use external code that cannot be captured by worklets. 

Example:
Object.assign polyfill
```JS
Object.assign(a, b);
```
is changed to 
``` JS
var _extends = ...;
_extends(a, b);
```
by  @babel/plugin-transform-object-assign.

#### SOLUTION
There is something like ```manipulateOptions``` property that plugin can use to access babel configuration. Unfortunately, when a plugin is added within a preset plugin name is replaced by file descriptor name that says nothing. In order to find which plugin should be removed, we get plugin visitors from node_modules and then compare keys. In most cases (always) that step is enough. However, to be sure we additionally compare visitor string representation (but only if keys are the same).

## TESTING
Check [example](https://github.com/software-mansion/react-native-reanimated/pull/915/files)
Check also if Object.assign is visible in stylediff worklet.

## CLOSING
resolves: https://github.com/software-mansion/react-native-reanimated/issues/921
resolves: https://github.com/software-mansion/react-native-reanimated/issues/939