### PR TITLE
[withTiming] Check if previousAnimation has been started

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -66,7 +66,8 @@ export function withTiming(toValue, userConfig, callback) {
       if (
         previousAnimation &&
         previousAnimation.type === 'timing' &&
-        previousAnimation.toValue === toValue
+        previousAnimation.toValue === toValue &&
+        previousAnimation.startTime
       ) {
         // to maintain continuity of timing animations we check if we are starting
         // new timing over the old one with the same parameters. If so, we want


### PR DESCRIPTION
WHY:
When we call withTiming twice in a row then nothing will happen because the first animation won't be started and as a result, we will copy undefined values from it.