### PR TITLE
Use only x86 ABI when building on CI

### DIFF
--- a/android/src/main/JNI/Application.mk
+++ b/android/src/main/JNI/Application.mk
@@ -1,4 +1,9 @@
+ifdef $(CI)
+APP_ABI := x86
+else
 APP_ABI := all
+endif
+
 APP_BUILD_SCRIPT := Android.mk
 APP_PLATFORM := android-18
 


### PR DESCRIPTION
## Description

Building on every ABI takes time and it's less efficient for our needs.
