### PR TITLE
Use forward ref in createAnimatedComponent

### DIFF
--- a/Example/src/LightboxExample.js
+++ b/Example/src/LightboxExample.js
@@ -214,7 +214,7 @@ export default function LightboxExample() {
   const [activeImage, setActiveImage] = useState(null);
 
   function onItemPress(imageRef, item, sv) {
-    imageRef.current.getNode().measure((x, y, width, height, pageX, pageY) => {
+    imageRef.current.measure((x, y, width, height, pageX, pageY) => {
       if (width === 0 && height === 0) {
         return;
       }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -9,6 +9,8 @@ import WorkletEventHandler from './reanimated2/WorkletEventHandler';
 
 import invariant from 'fbjs/lib/invariant';
 
+const setAndForwardRef = require('react-native/Libraries/Utilities/setAndForwardRef');
+
 const NODE_MAPPING = new Map();
 
 function listener(data) {
@@ -54,10 +56,6 @@ export default function createAnimatedComponent(Component) {
       this._detachPropUpdater();
       this._propsAnimated && this._propsAnimated.__detach();
       this._detachNativeEvents();
-    }
-
-    setNativeProps(props) {
-      this._component.setNativeProps(props);
     }
 
     componentDidMount() {
@@ -223,11 +221,33 @@ export default function createAnimatedComponent(Component) {
       this._propsAnimated && this._propsAnimated.setNativeView(this._component);
     }
 
-    _setComponentRef = c => {
-      if (c !== this._component) {
-        this._component = c;
-      }
-    };
+    // _setComponentRef = c => {
+    //   if (c !== this._component) {
+    //     this._component = c;
+    //   }
+    // };
+
+    _setComponentRef = setAndForwardRef({
+      getForwardedRef: () => this.props.forwardedRef,
+      setLocalRef: ref => {
+        if (ref !== this._component) {
+          this._component = ref;
+        }
+
+        // TODO: Delete this after React Native also deletes this deprecation helper.
+        if (ref != null && ref.getNode == null) {
+          ref.getNode = () => {
+            console.warn(
+              '%s: Calling `getNode()` on the ref of an Animated component ' +
+                'is no longer necessary. You can now directly use the ref ' +
+                'instead. This method will be removed in a future release.',
+              ref.constructor.name ?? '<<anonymous>>'
+            );
+            return ref;
+          };
+        }
+      },
+    });
 
     _filterNonAnimatedStyle(inputStyle) {
       const style = {};
@@ -292,15 +312,18 @@ export default function createAnimatedComponent(Component) {
         <Component {...props} ref={this._setComponentRef} {...platformProps} />
       );
     }
-
-    // A third party library can use getNode()
-    // to get the node reference of the decorated component
-    getNode() {
-      return this._component;
-    }
   }
 
-  AnimatedComponent.displayName = `AnimatedComponent(${Component.displayName || Component.name || 'Component'})`
+  AnimatedComponent.displayName = `AnimatedComponent(${Component.displayName ||
+    Component.name ||
+    'Component'})`;
 
-  return AnimatedComponent;
+  return React.forwardRef(function AnimatedComponentWrapper(props, ref) {
+    return (
+      <AnimatedComponent
+        {...props}
+        {...(ref == null ? null : { forwardedRef: ref })}
+      />
+    );
+  });
 }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -231,11 +231,12 @@ export default function createAnimatedComponent(Component) {
         // TODO: Delete this after React Native also deletes this deprecation helper.
         if (ref != null && ref.getNode == null) {
           ref.getNode = () => {
-            console.warn(
-              '%s: Calling `getNode()` on the ref of an Animated component ' +
+           console.warn(
+              '%s: Calling %s on the ref of an Animated component ' +
                 'is no longer necessary. You can now directly use the ref ' +
                 'instead. This method will be removed in a future release.',
-              ref.constructor.name ?? '<<anonymous>>'
+              ref.constructor.name ?? '<<anonymous>>',
+              'getNode()'
             );
             return ref;
           };

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -221,12 +221,6 @@ export default function createAnimatedComponent(Component) {
       this._propsAnimated && this._propsAnimated.setNativeView(this._component);
     }
 
-    // _setComponentRef = c => {
-    //   if (c !== this._component) {
-    //     this._component = c;
-    //   }
-    // };
-
     _setComponentRef = setAndForwardRef({
       getForwardedRef: () => this.props.forwardedRef,
       setLocalRef: ref => {


### PR DESCRIPTION
## Description

Fixes #701, fixes #452

This issue gave me motivation #701 
React Native in 0.62 changed the way to perform operations on Animated components like ScrollView.

## Changes

I tried to take a look at
https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
And build something similar.
I managed to reuse some of Facebook's code.

