### PR TITLE
Make Animated.Code use Animated.useCode internally

### DIFF
--- a/docs/pages/09.code.md
+++ b/docs/pages/09.code.md
@@ -6,7 +6,7 @@ title: Animated.Code
 
 ---
 
-`Animated.Code` component allows you to define reanimated nodes that you want to execute when their input nodes updates, but aren't necessarily strictly related to some view properties and hence it does not feel right to place them under `translate` or other prop of an `Animated.View`. This component renders `null`, so you can place it in any place you want in your render method. It is required that your code is put inside component as we rely on `componentDidMount` and `componentWillUnmount` callbacks to install and cleanup animated nodes. Note that the code you put is going to be executed only once. We currently have no way of telling if your code changes and so it will only be run in `componentDidMount`. If you wish for your reanimated nodes to be updated when the component updates, you can update the `key` property of the `Animated.Code` component, which will effectively unmount old and mount new versions of it in the React tree.
+`Animated.Code` component allows you to define reanimated nodes that you want to execute when their input nodes updates, but aren't necessarily strictly related to some view properties and hence it does not feel right to place them under `translate` or other prop of an `Animated.View`. This component renders `null`, so you can place it in any place you want in your render method. It is required that your code is put inside component as we rely on `componentDidMount` and `componentWillUnmount` callbacks to install and cleanup animated nodes. Note that the code you put is going to be executed only once. We currently have no way of telling if your code changes and so it will only be run in `componentDidMount`. If you wish for your reanimated nodes to be updated when the component updates, you can update the `key` property of the `Animated.Code` component, which will effectively unmount old and mount new versions of it in the React tree. You can provide `dependencies` key which works just like second argueent in `useCode`.
 
 ```js
 <Animated.Code>
@@ -40,7 +40,7 @@ The `useCode` hook acts as an alternative to the `Animated.Code` component.
 
 ```js
 Animated.useCode(
-    () => Node | Node[] | boolean | null | undefined, 
+    () => Node | Node[] | boolean | null | undefined,
     [...dependencies]
 )
 ```
@@ -52,13 +52,12 @@ const [animated, setAnimated] = React.useState(false);
 const [offset, setOffset] = React.useState(20);
 
 Animated.useCode(
-    () => (
-          animated && [
-              //...
-              set(transX1, add(_transX, offset))
-          ]
-    ), 
-    [animated, offset]
+  () =>
+    animated && [
+      //...
+      set(transX1, add(_transX, offset)),
+    ],
+  [animated, offset]
 );
 ```
 

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,53 +1,9 @@
-import React from 'react';
-import { createAnimatedAlways } from './AnimatedAlways';
-import AnimatedNode from './AnimatedNode';
+import useCode from '../derived/useCode';
 
-class Code extends React.PureComponent {
-  static resolveNode = maybeNode => {
-    if (typeof maybeNode === 'function') {
-      return Code.resolveNode(maybeNode());
-    }
+function Code({ exec, children, dependencies = [] }) {
+  useCode(children || exec, dependencies);
 
-    if (maybeNode instanceof AnimatedNode) {
-      return maybeNode;
-    }
-
-    return null;
-  };
-
-  componentDidMount() {
-    const { children, exec } = this.props;
-    const nodeChildren = Code.resolveNode(children);
-    const nodeExec = Code.resolveNode(exec);
-
-    const cantResolveNode = nodeChildren === null && nodeExec === null;
-
-    if (cantResolveNode) {
-      const error =
-        nodeChildren === null
-          ? `Got "${typeof children}" type passed to children`
-          : `Got "${typeof exec}" type passed to exec`;
-
-      throw new Error(
-        `<Animated.Code /> expects the 'exec' prop or children to be an animated node or a function returning an animated node. ${error}`
-      );
-    }
-
-    this.always = createAnimatedAlways(nodeExec || nodeChildren);
-    this.always.__attach();
-  }
-
-  componentWillUnmount() {
-    this.always.__detach();
-  }
-  
-  componentDidUpdate() {
-    this.componentWillUnmount();
-    this.componentDidMount();
-  }
-  
-  render() {
-    return null;
-  }
+  return null;
 }
+
 export default Code;


### PR DESCRIPTION
## Description

`Animated.Code` and `Animated.useCode` were doing basically the same thing, but `Animated.Code` was written using class components and most of its code was error checking. This PR removes `Code` implementation and uses `useCode` instead, which ensures that they're behaving in the same way. We can safely assume that Reanimated users are using RN >0.59.

Fixes #332 

## Changes

- used `useCode` in `Animated.Code` implementation
- added `dependencies` property to `Animated.Code` which serves same purpose as second argument in `useCode`

## Testing

This change was checked against `Animated.Code` example in Example app and with the following example:

```js
import React, { useState } from 'react';
import { SafeAreaView, Text } from 'react-native';
import Animated from 'react-native-reanimated';

const { useCode } = Animated;

const Example = () => {
  const value = new Value(0);
  const [animated, setAnimated] = useState(false);
  useCode(() => {
    animated && set(value, 200);
  }, [animated]);
  return (
    <SafeAreaView>
      <Button title="Move" onPress={setAnimated(true)} />
      <Animated.View
        style={[
          {
            transform: [
              {
                translateX: value,
              },
            ],
          },
        ]}>
        <Text>Rendered</Text>
      </Animated.View>
    </SafeAreaView>
  );
};
export default Example;
```