### PR TITLE
Fix Reanimated 1 examples

### DIFF
--- a/Example/reanimated1/colors/index.js
+++ b/Example/reanimated1/colors/index.js
@@ -3,12 +3,6 @@ import { StyleSheet, View, Dimensions } from 'react-native';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 
-// setInterval(() => {
-//   let iters = 1e8,
-//     sum = 0;
-//   while (iters-- > 0) sum += iters;
-// }, 300);
-
 const {
   set,
   cond,
@@ -19,7 +13,7 @@ const {
   abs,
   modulo,
   round,
-  interpolate,
+  interpolateNode,
   divide,
   sub,
   color,
@@ -106,12 +100,12 @@ export default class Example extends Component {
       set(offsetY, add(offsetY, dragY))
     );
 
-    const h = interpolate(this._transX, {
+    const h = interpolateNode(this._transX, {
       inputRange: [0, PICKER_WIDTH],
       outputRange: [0, 360],
       extrapolate: 'clamp',
     });
-    const s = interpolate(this._transY, {
+    const s = interpolateNode(this._transY, {
       inputRange: [0, PICKER_HEIGHT],
       outputRange: [1, 0],
       extrapolate: 'clamp',
@@ -134,7 +128,8 @@ export default class Example extends Component {
               {
                 backgroundColor: this._color,
                 transform: [
-                  { translateX: this._transX }, { translateY: this._transY },
+                  { translateX: this._transX },
+                  { translateY: this._transY },
                 ],
               },
             ]}

--- a/Example/reanimated1/differentSpringConfigs/index.js
+++ b/Example/reanimated1/differentSpringConfigs/index.js
@@ -41,6 +41,7 @@ class Snappable extends Component {
     const clock = new Clock();
     this._transX = runSpring(clock, transX, props.config);
   }
+
   render() {
     const { children } = this.props;
     return (

--- a/Example/reanimated1/imageViewer/index.js
+++ b/Example/reanimated1/imageViewer/index.js
@@ -6,13 +6,7 @@ import {
   PinchGestureHandler,
 } from 'react-native-gesture-handler';
 
-import Animated, { Easing } from 'react-native-reanimated';
-
-// setInterval(() => {
-//   let iters = 1e8,
-//     sum = 0;
-//   while (iters-- > 0) sum += iters;
-// }, 300);
+import Animated, { EasingNode } from 'react-native-reanimated';
 
 const {
   set,
@@ -21,23 +15,16 @@ const {
   or,
   add,
   sub,
-  pow,
   min,
   max,
-  debug,
   multiply,
   divide,
   lessThan,
-  spring,
-  defined,
   decay,
   timing,
-  call,
   diff,
-  acc,
   not,
   abs,
-  block,
   startClock,
   stopClock,
   clockRunning,
@@ -118,7 +105,7 @@ function runTiming(clock, value, dest, startStopClock = true) {
   const config = {
     toValue: new Value(0),
     duration: 300,
-    easing: Easing.inOut(Easing.cubic),
+    easing: EasingNode.inOut(EasingNode.cubic),
   };
 
   return [
@@ -373,6 +360,7 @@ class Viewer extends Component {
       )
     );
   }
+
   render() {
     // The below two animated values makes it so that scale appears to be done
     // from the top left corner of the image view instead of its center. This
@@ -424,6 +412,7 @@ export default class Example extends Component {
   static navigationOptions = {
     title: 'Image Viewer Example',
   };
+
   render() {
     return (
       <View style={styles.container}>

--- a/Example/reanimated1/imperative/index.js
+++ b/Example/reanimated1/imperative/index.js
@@ -9,6 +9,7 @@ export default class Example extends Component {
   state = {
     visible: true,
   };
+
   _transX = new Value(0);
   _toggleVisibility = () => this.setState(prev => ({ visible: !prev.visible }));
   render() {

--- a/Example/reanimated1/interactablePlayground/examples/IconDrawer.js
+++ b/Example/reanimated1/interactablePlayground/examples/IconDrawer.js
@@ -8,6 +8,7 @@ export default class IconDrawer extends Component {
     super(props);
     this._deltaX = new Animated.Value(0);
   }
+
   render() {
     return (
       <View style={styles.container}>
@@ -24,13 +25,13 @@ export default class IconDrawer extends Component {
               style={[
                 styles.button,
                 {
-                  opacity: Animated.interpolate(this._deltaX, {
+                  opacity: Animated.interpolateNode(this._deltaX, {
                     inputRange: [-230, -230, -180, -180],
                     outputRange: [1, 1, 0, 0],
                   }),
                   transform: [
                     {
-                      scale: Animated.interpolate(this._deltaX, {
+                      scale: Animated.interpolateNode(this._deltaX, {
                         inputRange: [-230, -230, -180, -180],
                         outputRange: [1, 1, 0.8, 0.8],
                       }),
@@ -43,13 +44,13 @@ export default class IconDrawer extends Component {
               style={[
                 styles.button,
                 {
-                  opacity: Animated.interpolate(this._deltaX, {
+                  opacity: Animated.interpolateNode(this._deltaX, {
                     inputRange: [-165, -165, -115, -115],
                     outputRange: [1, 1, 0, 0],
                   }),
                   transform: [
                     {
-                      scale: Animated.interpolate(this._deltaX, {
+                      scale: Animated.interpolateNode(this._deltaX, {
                         inputRange: [-165, -165, -115, -115],
                         outputRange: [1, 1, 0.8, 0.8],
                       }),
@@ -62,13 +63,13 @@ export default class IconDrawer extends Component {
               style={[
                 styles.button,
                 {
-                  opacity: Animated.interpolate(this._deltaX, {
+                  opacity: Animated.interpolateNode(this._deltaX, {
                     inputRange: [-100, -100, -50, -50],
                     outputRange: [1, 1, 0, 0],
                   }),
                   transform: [
                     {
-                      scale: Animated.interpolate(this._deltaX, {
+                      scale: Animated.interpolateNode(this._deltaX, {
                         inputRange: [-100, -100, -50, -50],
                         outputRange: [1, 1, 0.8, 0.8],
                       }),
@@ -97,6 +98,7 @@ export default class IconDrawer extends Component {
       </View>
     );
   }
+
   onDrawerSnap(event) {
     const snapPointId = event.nativeEvent.id;
     console.log(`drawer state is ${snapPointId}`);

--- a/Example/reanimated1/interactablePlayground/real-life-examples/RealChatHeads.js
+++ b/Example/reanimated1/interactablePlayground/real-life-examples/RealChatHeads.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 import { StyleSheet, View, Image, Dimensions } from 'react-native';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 import Interactable from '../../Interactable';
 
 const widthFactor = Dimensions.get('window').width / 375;
@@ -17,6 +17,7 @@ export default class ChatHeads extends Component {
     this._face1Scale = new Animated.Value(1);
     this._face2Scale = new Animated.Value(1);
   }
+
   render() {
     return (
       <View style={styles.container}>
@@ -168,7 +169,7 @@ export default class ChatHeads extends Component {
       Animated.timing(scaleValue, {
         toValue: 0,
         duration: 300,
-        easing: Easing.inOut(Easing.ease),
+        easing: EasingNode.inOut(EasingNode.ease),
       }).start();
     }
   }

--- a/Example/reanimated1/progressBar/ProgressBar.js
+++ b/Example/reanimated1/progressBar/ProgressBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 
 const {
   Clock,
@@ -28,7 +28,7 @@ function runTiming(clock, value, dest) {
   const config = {
     duration: 200,
     toValue: dest,
-    easing: Easing.inOut(Easing.ease),
+    easing: EasingNode.inOut(EasingNode.ease),
   };
 
   return block([

--- a/Example/reanimated1/rotations/index.js
+++ b/Example/reanimated1/rotations/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 
 const {
   set,
@@ -29,7 +29,7 @@ function runTiming(clock, value, dest) {
   const config = {
     duration: 5000,
     toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease),
+    easing: EasingNode.inOut(EasingNode.ease),
   };
 
   return block([

--- a/Example/reanimated1/src/interpolate/AnimatedBounds.js
+++ b/Example/reanimated1/src/interpolate/AnimatedBounds.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
 import Box from '../Box';
 import Row from '../Row';
@@ -12,18 +12,14 @@ const {
   eq,
   and,
   add,
-  multiply,
-  lessThan,
   startClock,
-  stopClock,
   clockRunning,
   block,
   timing,
   Value,
   Clock,
   event,
-  interpolate,
-  defined,
+  interpolateNode,
   Extrapolate,
 } = Animated;
 
@@ -39,7 +35,7 @@ const getAnimation = (min, max) => {
   const config = {
     duration: 500,
     toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease),
+    easing: EasingNode.inOut(EasingNode.ease),
   };
 
   const reset = [
@@ -87,7 +83,7 @@ export default class AnimatedBounds extends Component {
       [set(prevDragX, 0), transX]
     );
 
-    this._transX = interpolate(this._transX, {
+    this._transX = interpolateNode(this._transX, {
       inputRange: [-100, 100],
       outputRange: [-100, 100],
       extrapolate: Extrapolate.CLAMP,
@@ -95,7 +91,7 @@ export default class AnimatedBounds extends Component {
 
     const min = getAnimation(-100, -50);
     const max = getAnimation(100, 50);
-    this._transXA = interpolate(this._transX, {
+    this._transXA = interpolateNode(this._transX, {
       inputRange: [-100, 100],
       outputRange: [min, max],
       extrapolate: Extrapolate.CLAMP,

--- a/Example/reanimated1/src/interpolate/Basic.js
+++ b/Example/reanimated1/src/interpolate/Basic.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 import Box from '../Box';
 import Row from '../Row';
 
@@ -14,7 +14,7 @@ const {
   timing,
   Value,
   Clock,
-  interpolate,
+  interpolateNode,
 } = Animated;
 
 function runTiming(clock, value, dest) {
@@ -28,7 +28,7 @@ function runTiming(clock, value, dest) {
   const config = {
     duration: 500,
     toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease),
+    easing: EasingNode.inOut(EasingNode.ease),
   };
 
   const reset = [
@@ -57,7 +57,7 @@ export default class Basic extends Component {
     super(props);
     const clock = new Clock();
     const base = runTiming(clock, -1, 1);
-    this._transX = interpolate(base, {
+    this._transX = interpolateNode(base, {
       inputRange: [-1, 1],
       outputRange: [-100, 100],
     });

--- a/Example/reanimated1/src/interpolate/InterpolateColorsExample.js
+++ b/Example/reanimated1/src/interpolate/InterpolateColorsExample.js
@@ -1,5 +1,5 @@
-import React, {Component} from 'react';
-import Animated, {Easing} from 'react-native-reanimated';
+import React, { Component } from 'react';
+import Animated, { EasingNode } from 'react-native-reanimated';
 import Box from '../Box';
 import Row from '../Row';
 
@@ -28,7 +28,7 @@ function runTiming(clock, value, dest) {
   const config = {
     duration: 500,
     toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease),
+    easing: EasingNode.inOut(EasingNode.ease),
   };
 
   const reset = [
@@ -66,7 +66,7 @@ export default class InterpolateColorsExample extends Component {
   render() {
     return (
       <Row>
-        <Box style={{backgroundColor: this.color}} />
+        <Box style={{ backgroundColor: this.color }} />
       </Row>
     );
   }

--- a/Example/reanimated1/src/interpolate/WithDrag.js
+++ b/Example/reanimated1/src/interpolate/WithDrag.js
@@ -1,32 +1,15 @@
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
 import Box from '../Box';
 import Row from '../Row';
 
-const {
-  set,
-  cond,
-  sub,
-  eq,
-  add,
-  multiply,
-  lessThan,
-  startClock,
-  stopClock,
-  clockRunning,
-  Value,
-  Clock,
-  event,
-  interpolate,
-  defined,
-} = Animated;
+const { set, cond, sub, eq, add, Value, event, interpolateNode } = Animated;
 
 export default class WithDrag extends Component {
   constructor(props) {
     super(props);
-    const TOSS_SEC = 0.2;
 
     const dragX = new Value(0);
     const state = new Value(-1);
@@ -47,11 +30,11 @@ export default class WithDrag extends Component {
       [set(prevDragX, 0), transX]
     );
 
-    this._transXA = interpolate(this._transX, {
+    this._transXA = interpolateNode(this._transX, {
       inputRange: [-120, 120],
       outputRange: [-100, 100],
     });
-    this._transXB = interpolate(this._transX, {
+    this._transXB = interpolateNode(this._transX, {
       inputRange: [-120, -60, 60, 120],
       outputRange: [-60, -10, 10, 60],
     });
@@ -78,8 +61,6 @@ export default class WithDrag extends Component {
     );
   }
 }
-
-const BOX_SIZE = 44;
 
 const styles = StyleSheet.create({
   container: {

--- a/Example/reanimated1/startAPI/index.js
+++ b/Example/reanimated1/startAPI/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Button, StyleSheet, View, Alert } from 'react-native';
 
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated, { EasingNode } from 'react-native-reanimated';
 
 const { timing, spring, color, multiply, round, Value } = Animated;
 
@@ -21,7 +21,7 @@ export default class Example extends Component {
     this._config2 = {
       duration: 5000,
       toValue: 1,
-      easing: Easing.inOut(Easing.ease),
+      easing: EasingNode.inOut(EasingNode.ease),
     };
     this._anim2 = spring(this._transX, this._config);
     this._anim = timing(this._transX, this._config2);

--- a/Example/reanimated1/test/index.js
+++ b/Example/reanimated1/test/index.js
@@ -2,26 +2,19 @@
 import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import Animated, { Easing } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 
 const {
   set,
   cond,
-  eq,
-  add,
-  call,
-  multiply,
-  lessThan,
   startClock,
   stopClock,
   clockRunning,
   block,
-  timing,
   debug,
   spring,
   Value,
   Clock,
-  event,
   proc,
 } = Animated;
 
@@ -79,8 +72,8 @@ function springFill(clock, state, config) {
     clock
   );
 }
-const stopClockProc = proc(clock => stopClock(clock))
-const startClockProc = proc(clock => startClock(clock))
+const stopClockProc = proc(clock => stopClock(clock));
+const startClockProc = proc(clock => startClock(clock));
 
 function runSpring(clock, value, dest) {
   const state = {
@@ -115,54 +108,13 @@ function runSpring(clock, value, dest) {
   ]);
 }
 
-
-function runTiming(clock, value, dest) {
-  const state = {
-    finished: new Value(0),
-    position: new Value(0),
-    time: new Value(0),
-    frameTime: new Value(0),
-  };
-
-  const config = {
-    duration: 5000,
-    toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease),
-  };
-
-  return block([
-    cond(clockRunning(clock), 0, [
-      set(state.finished, 0),
-      set(state.time, 0),
-      set(state.position, value),
-      set(state.frameTime, 0),
-      set(config.toValue, dest),
-      startClockProc(clock),
-    ]),
-    timing(clock, state, config),
-    cond(state.finished, debug('stop clock', stopClockProc(clock))),
-    state.position,
-  ]);
-}
-
 export default class Example extends Component {
   constructor(props) {
     super(props);
 
-    // const transX = new Value(0);
-    const clock = new Clock();
-    // const twenty = new Value(20);
     this.t = Array.from(Array(40)).map(() =>
       runSpring(new Clock(), Math.random() * -200, Math.random() * 200)
     );
-  }
-
-  componentDidMount() {
-    // Animated.spring(this._transX, {
-    //   duration: 300,
-    //   velocity: -300,
-    //   toValue: 150,
-    // }).start();
   }
 
   render() {


### PR DESCRIPTION
## Description

Reanimated 2 changes `interpolate` and `Easing` to `interpolateNode` and `EasingNode` respectively.
When making that change examples weren't updated and didn't work.

This PR fixes this

## Changes

- Renamed interpolate and Easing functions
- Removed dead code from examples
