### PR TITLE
Forbid using null in Animated.Value

### DIFF
--- a/src/core/AnimatedBlock.js
+++ b/src/core/AnimatedBlock.js
@@ -33,7 +33,7 @@ export function createAnimatedBlock(items) {
 }
 
 function nodify(v) {
-  if (typeof v === 'object' && v.__isProxy) {
+  if (typeof v === 'object' && v?.__isProxy) {
     if (!v.__val) {
       v.__val = new InternalAnimatedValue(0);
     }

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -1,6 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 import ReanimatedModule from '../ReanimatedModule';
+import invariant from 'fbjs/lib/invariant';
 
 function sanitizeValue(value) {
   return value === null || value === undefined || typeof value === 'string'
@@ -32,6 +33,10 @@ export default class InternalAnimatedValue extends AnimatedNode {
   }
 
   constructor(value, constant = false) {
+    invariant(
+      value !== null,
+      'you are trying to set null on animated value'
+    );
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;
     this._animation = null;

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -35,7 +35,7 @@ export default class InternalAnimatedValue extends AnimatedNode {
   constructor(value, constant = false) {
     invariant(
       value !== null,
-      'you are trying to set null on animated value'
+      'you are trying to set null on Animated.Value'
     );
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -35,7 +35,7 @@ export default class InternalAnimatedValue extends AnimatedNode {
   constructor(value, constant = false) {
     invariant(
       value !== null,
-      'you are trying to set null on Animated.Value'
+      'Animated.Value cannot be set to the null'
     );
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;


### PR DESCRIPTION
## Description

Reanimated doesn't have any use case for holding `null` value in the `Animated.Value` besides using `defined` node to set it to some initial state, so we're relying on `undefined` being treated as that "empty" value. 
In order to prevent some obscure errors when `null` is used we introduce explicit check for creating Value with `null` - it works when instantiating new Value and using imperative `value.setValue()`. 

We don't need to change the `set` node, because it expects `double | AnimatedValue` to be used as it's second argument.