### PR TITLE
Simplify installation process on iOS.

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -268,7 +268,7 @@ PODS:
     - React
   - RNGestureHandler (1.5.2):
     - React
-  - RNReanimated (2.0.0-alpha.3):
+  - RNReanimated (2.0.0-alpha.4):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -407,11 +407,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 6f1045c66f816849b33c4ff28930b611e89059a0
   FBReactNativeSpec: e856d5103d749483f86f53afafd8df4ed8a776bd
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   RCTRequired: e46bb77db03887b3e200d34b08515c804669db99
   RCTTypeSafety: 270fed6675c42f80fb87b47d626ef3cede1505e6
   React: e008906ff1328f9bccb345ff4f7826397ad223fc
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   ReactCommon: f63556ee9e41e9802257228237e5e660451a03cf
   RNCMaskedView: 76c40a1d41c3e2535df09246a2b5487f04de0814
   RNGestureHandler: 946a7691e41df61e2c4b1884deab41a4cdc3afff
-  RNReanimated: fd2b6fed9a0ea500e8cf223fc6b13ccd9ff631a6
+  RNReanimated: 5f34111865ab2207dc0dddae854634973ca092ee
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b
 

--- a/Example/ios/ReanimatedExample/AppDelegate.h
+++ b/Example/ios/ReanimatedExample/AppDelegate.h
@@ -12,6 +12,5 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
-@property (nonatomic, readonly) RCTBridge *bridge;
 
 @end

--- a/Example/ios/ReanimatedExample/AppDelegate.mm
+++ b/Example/ios/ReanimatedExample/AppDelegate.mm
@@ -16,6 +16,7 @@
 #import <React/RCTDataRequestHandler.h>
 #import <React/RCTFileRequestHandler.h>
 #import <RNReanimated/RETurboModuleProvider.h>
+#import <RNReanimated/REAModule.h>
 
 @interface AppDelegate() <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate>{
   RCTTurboModuleManager *_turboModuleManager;
@@ -28,8 +29,8 @@
 {
   RCTEnableTurboModule(YES);
 
-  _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:_bridge
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"ReanimatedExample"
                                             initialProperties:nil];
 
@@ -54,6 +55,7 @@
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
+   _bridge_reanimated = bridge;
    _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
                                                               delegate:self
                                                              jsInvoker:bridge.jsCallInvoker];

--- a/ios/REAModule.h
+++ b/ios/REAModule.h
@@ -7,6 +7,8 @@
 
 #import "REAValueNode.h"
 
+extern RCTBridge *_bridge_reanimated;
+
 @interface REAModule : RCTEventEmitter <RCTBridgeModule, RCTEventDispatcherObserver, RCTUIManagerObserver>
 
 @property (nonatomic, readonly) REANodesManager *nodesManager;

--- a/ios/REAModule.m
+++ b/ios/REAModule.m
@@ -6,6 +6,8 @@
 
 typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
+RCTBridge *_bridge_reanimated = nil;
+
 @implementation REAModule
 {
   NSMutableArray<AnimatedOperation> *_operations;
@@ -16,6 +18,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)invalidate
 {
+  _bridge_reanimated = nil;
   _transitionManager = nil;
   [_nodesManager invalidate];
   [self.bridge.eventDispatcher removeDispatchObserver:self];

--- a/ios/native/NativeProxy.h
+++ b/ios/native/NativeProxy.h
@@ -5,7 +5,7 @@
 #import <RNReanimated/NativeReanimatedModule.h>
 
 namespace reanimated {
-
+ 
 std::shared_ptr<reanimated::NativeReanimatedModule> createReanimatedModule(std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
 
 }

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -14,6 +14,7 @@ namespace reanimated {
 using namespace facebook;
 using namespace react;
 
+
 // COPIED FROM RCTTurboModule.mm
 static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
 
@@ -77,11 +78,7 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
 }
 
 std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker) {
-
-  RCTBridge *bridge;
-  if ([[UIApplication sharedApplication].delegate respondsToSelector:@selector(bridge)]) {
-    bridge = [[UIApplication sharedApplication].delegate performSelector:@selector(bridge) withObject:[UIApplication sharedApplication].delegate];
-  }
+  RCTBridge *bridge = _bridge_reanimated;
   REAModule *reanimatedModule = [bridge moduleForClass:[REAModule class]];
 
   auto propUpdater = [reanimatedModule](jsi::Runtime &rt, int viewTag, const jsi::Object &props) -> void {


### PR DESCRIPTION
## How
Initialize global bridge variable in AppDelegate.jsExecutorFactoryForBridge. It's cleared in REAModule.invalidate. 

## Testing
Checked if reload works on iOS.

## Closes
resolves: https://github.com/software-mansion/react-native-reanimated/issues/979

