### PR TITLE
Remove the undefined (and unused) toValue variable from withDecay

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -214,7 +214,6 @@ export function withSpring(toValue, userConfig, callback) {
 }
 
 export function withDecay(userConfig, callback) {
-  toValue = (typeof toValue === 'object' && toValue.value) ? toValue.value : toValue
   'worklet';
   return defineAnimation(0, () => {
     'worklet';


### PR DESCRIPTION
The commit message really says it all: remove the undefined (and unused) toValue variable from withDecay.