### PR TITLE
Fix defined node

### DIFF
--- a/ios/Nodes/REANode.m
+++ b/ios/Nodes/REANode.m
@@ -70,13 +70,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   if (![_lastLoopID objectForKey:_updateContext.callID] || [[_lastLoopID objectForKey:_updateContext.callID] longValue] < [_updateContext.loopID longValue]) {
     [_lastLoopID setObject:_updateContext.loopID forKey:_updateContext.callID];
     id val = [self evaluate];
-    if (val == 0) {
-      val = [[NSNumber alloc] initWithInt:0];
-    }
-    [_memoizedValue setObject:val forKey:_updateContext.callID];
+    [_memoizedValue setObject:(val == nil ? [NSNull null] : val) forKey:_updateContext.callID];
     return val;
   }
-  return [_memoizedValue objectForKey:_updateContext.callID];
+  id memoizedValue = [_memoizedValue objectForKey:_updateContext.callID];
+  return [memoizedValue isKindOfClass:[NSNull class]] ? nil : memoizedValue;
 }
 
 - (void)addChild:(REANode *)child


### PR DESCRIPTION
## Description

Fixes #793 

Previously, `nil`s were replaced with 0's when memoized inside `[Node value]` (`NSMutableDictionary` doesn't support `nil`s as keys) and `defined(new Value(0))` returned true.
Now we store NSNull there and return `nil`, which fixes calling defined on the node with the undefined value.

Tested on iOS and android, `defined` returns the correct value in both.
## Tested code
```js
import Animated from 'react-native-reanimated';
const {block, debug, defined, Value, useCode} = Animated;

const Example = () => {
  useCode(() =>
    block([
      debug('undefined:', defined(new Value())),
      debug('0:', defined(new Value(0))),
      debug('1:', defined(new Value(1))),
    ]),
  );
  return null;
};

export default Example;
```

