### PR TITLE
@karol/fix error handling

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -180,16 +180,23 @@ void NativeReanimatedModule::maybeRequestRender() {
 }
 
 void NativeReanimatedModule::onRender(double timestampMs) {
-  mapperRegistry->execute(*runtime);
+  try {
+    mapperRegistry->execute(*runtime);
 
-  std::vector<FrameCallback> callbacks = frameCallbacks;
-  frameCallbacks.clear();
-  for (auto callback : callbacks) {
-    callback(timestampMs);
+    std::vector<FrameCallback> callbacks = frameCallbacks;
+    frameCallbacks.clear();
+    for (auto callback : callbacks) {
+      callback(timestampMs);
+    }
+
+    if (mapperRegistry->needRunOnRender()) {
+      maybeRequestRender();
+    }
   }
-
-  if (mapperRegistry->needRunOnRender()) {
-    maybeRequestRender();
+  catch(...) {
+    if (!errorHandler->raise()) {
+      throw;
+    }
   }
 }
 

--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -80,6 +80,12 @@ jsi::Value MutableValue::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
   return jsi::Value::undefined();
 }
 
+std::vector<jsi::PropNameID> MutableValue::getPropertyNames(jsi::Runtime &rt) {
+  std::vector<jsi::PropNameID> result;
+  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("value")));
+  return result;
+}
+
 MutableValue::MutableValue(jsi::Runtime &rt, const jsi::Value &initial, NativeReanimatedModule *module):
 module(module), value(ShareableValue::adapt(rt, initial, module)) {}
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -195,7 +195,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           return jsi::Value(rt, *funPtr);
         }
 
-        auto clb = [=, &module](
+        auto clb = [=](
                    jsi::Runtime &rt,
                    const jsi::Value &thisValue,
                    const jsi::Value *args,

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -212,11 +212,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
                res = funPtr->call(rt, args, count);
              }
            } catch(std::exception &e) {
-             std::string str = e.what();
-             module->errorHandler->setError(str.c_str());
-             if (!module->errorHandler->raise()) {
-               throw;
-             }
+               std::string str = e.what();
+             this->module->errorHandler->setError(str);
+             this->module->errorHandler->raise();
            }
 
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
@@ -264,10 +262,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             
             } catch(std::exception &e) {
               std::string str = e.what();
-              module->errorHandler->setError(str.c_str());
-              if (!module->errorHandler->raise()) {
-                throw;
-              }
+              module->errorHandler->setError(str);
+              module->errorHandler->raise();
             }
             rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
             

--- a/Common/cpp/Tools/Mapper.cpp
+++ b/Common/cpp/Tools/Mapper.cpp
@@ -25,14 +25,7 @@ outputs(outputs) {
 
 void Mapper::execute(jsi::Runtime &rt) {
   dirty = false;
-  try {
-    mapper.callWithThis(rt, mapper);
-  }
-  catch(...) {
-    if (!module->errorHandler->raise()) {
-      throw;
-    }
-  }
+  mapper.callWithThis(rt, mapper);
 }
 
 }

--- a/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/Common/cpp/headers/SharedItems/MutableValue.h
@@ -28,6 +28,7 @@ class MutableValue : public jsi::HostObject, public std::enable_shared_from_this
   public:
   void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
   unsigned long addListener(std::function<void()> listener);
   void removeListener(unsigned long listenerId);
 };

--- a/Common/cpp/headers/SpecTools/ErrorHandler.h
+++ b/Common/cpp/headers/SpecTools/ErrorHandler.h
@@ -21,7 +21,7 @@ class ErrorHandler {
     }
     virtual std::shared_ptr<Scheduler> getScheduler() = 0;
     virtual std::shared_ptr<ErrorWrapper> getError() = 0;
-    virtual void setError(const char *message) = 0;
+    virtual void setError(std::string message) = 0;
     virtual ~ErrorHandler() {}
   protected:
     virtual void raiseSpec() = 0;

--- a/android/src/main/cpp/AndroidErrorHandler.cpp
+++ b/android/src/main/cpp/AndroidErrorHandler.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<ErrorWrapper> AndroidErrorHandler::getError() {
     return this->error;
 }
 
-void AndroidErrorHandler::setError(const char *message) {
+void AndroidErrorHandler::setError(std::string message) {
   if (error->handled) {
     error->message = message;
     error->handled = false;

--- a/android/src/main/cpp/headers/AndroidErrorHandler.h
+++ b/android/src/main/cpp/headers/AndroidErrorHandler.h
@@ -18,6 +18,6 @@ class AndroidErrorHandler : public JavaClass<AndroidErrorHandler>, public ErrorH
         std::shared_ptr<Scheduler> scheduler);
     std::shared_ptr<Scheduler> getScheduler() override;
     std::shared_ptr<ErrorWrapper> getError() override;
-    void setError(const char *message) override;
+    void setError(std::string message) override;
     virtual ~AndroidErrorHandler() {}
 };

--- a/ios/native/IOSErrorHandler.h
+++ b/ios/native/IOSErrorHandler.h
@@ -11,6 +11,6 @@ class IOSErrorHandler : public ErrorHandler {
       IOSErrorHandler(std::shared_ptr<Scheduler> scheduler);
       std::shared_ptr<Scheduler> getScheduler() override;
       std::shared_ptr<ErrorWrapper> getError() override;
-      void setError(const char *message) override;
+      void setError(std::string message) override;
       virtual ~IOSErrorHandler() {}
 };

--- a/ios/native/IOSErrorHandler.mm
+++ b/ios/native/IOSErrorHandler.mm
@@ -23,7 +23,7 @@ std::shared_ptr<ErrorWrapper> IOSErrorHandler::getError() {
     return this->error;
 }
 
-void IOSErrorHandler::setError(const char *message) {
+void IOSErrorHandler::setError(std::string message) {
   if (error->handled) {
     error->message = message;
     error->handled = false;

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -268,6 +268,19 @@ export function useAnimatedStyle(updater) {
     styleUpdater(viewTag, updater, remoteState);
   }, inputs);
 
+  let wrongKey
+  const isError = Object.keys(initial).some((key) => {
+    const element = initial[key]
+    const result = (typeof element === 'object' && Object.keys(element).length === 0)
+    if (result) {
+      wrongKey = key
+    }
+    return result
+  })
+  if (isError && wrongKey !== undefined) {
+    throw new Error(`invalid value passed to \`${ wrongKey }\`, empty objects are not allowed in useAnimatedStyle, maybe you forgot to use \`.value\`?`)
+  }
+
   return {
     viewTag,
     initial,

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -271,14 +271,14 @@ export function useAnimatedStyle(updater) {
   let wrongKey
   const isError = Object.keys(initial).some((key) => {
     const element = initial[key]
-    const result = (typeof element === 'object' && Object.keys(element).length === 0)
+    const result = (typeof element === 'object' && element.value !== undefined)
     if (result) {
       wrongKey = key
     }
     return result
   })
   if (isError && wrongKey !== undefined) {
-    throw new Error(`invalid value passed to \`${ wrongKey }\`, empty objects are not allowed in useAnimatedStyle, maybe you forgot to use \`.value\`?`)
+    throw new Error(`invalid value passed to \`${ wrongKey }\`, maybe you forgot to use \`.value\`?`)
   }
 
   return {

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -3,6 +3,17 @@ import { Easing } from './Easing';
 
 let IN_STYLE_UPDATER = false;
 
+const assertNumber = (value, callerName) => {
+  const valueType = typeof value
+  if (valueType !== 'number') {
+    let error = `invalid type of toValue passed to ${ callerName }, expected \`number\`, got \`${ valueType }\``;
+    if (valueType === 'object') {
+      error += ', maybe you forgot to add `.value`?'
+    }
+    throw new Error(error);
+  }
+}
+
 export function initialUpdaterRun(updater) {
   IN_STYLE_UPDATER = true;
   const result = updater();
@@ -34,14 +45,7 @@ export function cancelAnimation(value) {
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
   // check toValue
-  const valueType = typeof toValue
-  if (valueType !== 'number') {
-    let error = `invalid type of toValue passed to withTiming, expected \`number\`, got \`${ valueType }\``;
-    if (valueType === 'object') {
-      error += ', maybe you forgot to add `.value`?'
-    }
-    throw new Error(error);
-  }
+  assertNumber(toValue, 'withTiming')
 
   return defineAnimation(toValue, () => {
     'worklet';
@@ -108,14 +112,7 @@ export function withTiming(toValue, userConfig, callback) {
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
   // check toValue
-  const valueType = typeof toValue
-  if (valueType !== 'number') {
-    let error = `invalid type of toValue passed to withSpring, expected \`number\`, got \`${ valueType }\``;
-    if (valueType === 'object') {
-      error += ', maybe you forgot to add `.value`?'
-    }
-    throw new Error(error);
-  }
+  assertNumber(toValue, 'withSpring')
 
   return defineAnimation(toValue, () => {
     'worklet';

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -40,7 +40,7 @@ export function withTiming(toValue, userConfig, callback) {
     if (valueType === 'object') {
       error += ', maybe you forgot to add `.value`?'
     }
-    throw error;
+    throw new Error(error);
   }
 
   return defineAnimation(toValue, () => {
@@ -114,7 +114,7 @@ export function withSpring(toValue, userConfig, callback) {
     if (valueType === 'object') {
       error += ', maybe you forgot to add `.value`?'
     }
-    throw error;
+    throw new Error(error);
   }
 
   return defineAnimation(toValue, () => {

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -33,8 +33,16 @@ export function cancelAnimation(value) {
 
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
-  toValue =
-    typeof toValue === 'object' && toValue.value ? toValue.value : toValue;
+  // check toValue
+  const valueType = typeof toValue
+  if (valueType !== 'number') {
+    let error = `invalid type of toValue passed to withTiming, expected \`number\`, got \`${ valueType }\``;
+    if (valueType === 'object') {
+      error += ', maybe you forgot to add `.value`?'
+    }
+    throw error;
+  }
+
   return defineAnimation(toValue, () => {
     'worklet';
     const config = {
@@ -99,8 +107,16 @@ export function withTiming(toValue, userConfig, callback) {
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
-  toValue =
-    typeof toValue === 'object' && toValue.value ? toValue.value : toValue;
+  // check toValue
+  const valueType = typeof toValue
+  if (valueType !== 'number') {
+    let error = `invalid type of toValue passed to withSpring, expected \`number\`, got \`${ valueType }\``;
+    if (valueType === 'object') {
+      error += ', maybe you forgot to add `.value`?'
+    }
+    throw error;
+  }
+
   return defineAnimation(toValue, () => {
     'worklet';
 


### PR DESCRIPTION
Improve error handling by adding some cases in `Hooks.js` and `animations.js` regarding lack of `.value` field when passing shared value objects.

As a little refactor changed `const char*` to `std::string` in ErrorHandler due to obeying coding best practices.

Also moved catching errors higher in the calling hierarchy, which is not a problem since when there is no error set in error handler it just rethrows. 