### PR TITLE
Fix passing nodes directly to the Animated.Code

### DIFF
--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,4 +1,5 @@
 import useCode from '../derived/useCode';
+import AnimatedNode from './AnimatedNode';
 
 function assertNodesNotNull(code, children, exec) {
   if (!code) {

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,8 +1,30 @@
 import useCode from '../derived/useCode';
 
-function Code({ exec, children, dependencies = [] }) {
-  useCode(children || exec, dependencies);
+function assertNodesNotNull(code, children, exec) {
+  if (!code) {
+    const error = !children
+      ? `Got "${typeof children}" type passed to children`
+      : `Got "${typeof exec}" type passed to exec`;
 
+    throw new Error(
+      `<Animated.Code /> expects the 'exec' prop or children to be an animated node or a function returning an animated node. ${error}`
+    );
+  }
+}
+
+function Code({ exec, children, dependencies = [] }) {
+  const nodes = children || exec;
+
+  let code = null;
+  if (nodes instanceof AnimatedNode) {
+    code = () => nodes;
+  } else if (typeof nodes === 'function') {
+    code = nodes;
+  }
+
+  assertNodesNotNull(code, children, exec);
+
+  useCode(code, dependencies);
   return null;
 }
 


### PR DESCRIPTION
## Description

#952 notably simplified `Animated.Code`, but introduced regression - when passing nodes directly it shows a warning coming from `useCode`. To fix that we wrap those nodes into a function.

Fixes #1008 

## Changes

- Check if passed nodes are wrapped in a function
- Re-add some error handling for `Animated.Code`

Changes were tested against `useCode` example (nodes extracted from the function) 
