### PR TITLE
Use animated reaction

### DIFF
--- a/Example/test/AnimatedReactionTest.js
+++ b/Example/test/AnimatedReactionTest.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Button, View, StyleSheet, Text } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  useAnimatedReaction,
+} from 'react-native-reanimated';
+
+const AnimatedReactionTest = () => {
+  const x = useSharedValue(0);
+  const x2 = useSharedValue(0);
+
+  const maxX2 = 80;
+
+  useAnimatedReaction(
+    () => {
+      'worklet';
+      return x.value / 1.5;
+    },
+    data => {
+      'worklet';
+      if (x2.value < maxX2) {
+        x2.value = data;
+      }
+    }
+  );
+
+  const uas = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      transform: [
+        {
+          translateX: withTiming(x.value),
+        },
+      ],
+    };
+  });
+  const uas2 = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      transform: [
+        {
+          translateX: withTiming(x2.value),
+        },
+      ],
+    };
+  });
+
+  const handle = () => {
+    x.value = x.value + 25;
+  };
+
+  const styles = StyleSheet.create({
+    box: {
+      height: 25,
+      width: 50,
+      backgroundColor: 'black',
+      marginTop: 10,
+    },
+  });
+
+  return (
+    <View>
+      <Text>
+        The second box should follow the first one for the first 5 moves(then it
+        should stop)
+      </Text>
+      <Button title="Move" onPress={handle} />
+      <Animated.View style={[styles.box, uas]} />
+      <Animated.View style={[styles.box, uas2]} />
+    </View>
+  );
+};
+
+export default AnimatedReactionTest;

--- a/Example/test/TestApp.js
+++ b/Example/test/TestApp.js
@@ -11,6 +11,7 @@ import SimpleTest from './SimpleTest';
 import MeasureTest from './MeasureTest';
 import FastRefreshTest from './FastRefreshTest';
 import ScrollToTest from './scrollToTest';
+import AnimatedReactionTest from './AnimatedReactionTest';
 
 YellowBox.ignoreWarnings(['Calling `getNode()`']);
 
@@ -31,23 +32,27 @@ const SCREENS = {
     screen: ScrollToTest,
     title: '🆕 ScrollTo test',
   },
+  AnimatedReactionTest: {
+    screen: AnimatedReactionTest,
+    title: '🆕 Animated reaction test',
+  },
 };
 
 function MainScreen({ navigation }) {
-  const data = Object.keys(SCREENS).map((key) => ({ key }));
+  const data = Object.keys(SCREENS).map(key => ({ key }));
   return (
     <FlatList
       style={styles.list}
       data={data}
       ItemSeparatorComponent={ItemSeparator}
-      renderItem={(props) => (
+      renderItem={props => (
         <MainScreenItem
           {...props}
           screens={SCREENS}
           onPressItem={({ key }) => navigation.navigate(key)}
         />
       )}
-      renderScrollComponent={(props) => <ScrollView {...props} />}
+      renderScrollComponent={props => <ScrollView {...props} />}
     />
   );
 }
@@ -72,8 +77,8 @@ const TestApp = createSwitchNavigator({
 });
 
 const createApp = Platform.select({
-  web: (input) => createBrowserApp(input, { history: 'hash' }),
-  default: (input) => createAppContainer(input),
+  web: input => createBrowserApp(input, { history: 'hash' }),
+  default: input => createAppContainer(input),
 });
 
 export default createApp(TestApp);

--- a/Example/test/TestApp.js
+++ b/Example/test/TestApp.js
@@ -39,20 +39,20 @@ const SCREENS = {
 };
 
 function MainScreen({ navigation }) {
-  const data = Object.keys(SCREENS).map(key => ({ key }));
+  const data = Object.keys(SCREENS).map((key) => ({ key }));
   return (
     <FlatList
       style={styles.list}
       data={data}
       ItemSeparatorComponent={ItemSeparator}
-      renderItem={props => (
+      renderItem={(props) => (
         <MainScreenItem
           {...props}
-          screens={SCREENS}
+          screens={ SCREENS }
           onPressItem={({ key }) => navigation.navigate(key)}
         />
       )}
-      renderScrollComponent={props => <ScrollView {...props} />}
+      renderScrollComponent={(props) => <ScrollView {...props} />}
     />
   );
 }
@@ -77,8 +77,8 @@ const TestApp = createSwitchNavigator({
 });
 
 const createApp = Platform.select({
-  web: input => createBrowserApp(input, { history: 'hash' }),
-  default: input => createAppContainer(input),
+  web: (input) => createBrowserApp(input, { history: 'hash' }),
+  default: (input) => createAppContainer(input),
 });
 
 export default createApp(TestApp);

--- a/plugin.js
+++ b/plugin.js
@@ -6,11 +6,14 @@ const { visitors } = require('@babel/traverse');
 const traverse = require('@babel/traverse').default;
 const parse = require('@babel/parser').parse;
 
-const functionHooks = new Set([
-  'useAnimatedStyle',
-  'useAnimatedProps',
-  'useDerivedValue',
-  'useAnimatedScrollHandler',
+/**
+ * holds a map of hooks names as keys and array of argument indexes which are worklets(starting from 0)
+ */
+const functionHooks = new Map([
+  ['useAnimatedStyle', [0]],
+  ['useAnimatedProps', [0]],
+  ['useDerivedValue', [0]],
+  ['useAnimatedReaction', [0, 1]],
 ]);
 
 const objectHooks = new Set([
@@ -289,14 +292,17 @@ function processWorklets(t, path, processor) {
     for (let i = 0; i < objectPath.container.length; i++) {
       processor(t, objectPath.getSibling(i).get('value'));
     }
-  } else if (functionHooks.has(name)) {
-    processor(t, path.get('arguments.0'));
+  } else {
+    const indexes = functionHooks.get(name);
+    if (Array.isArray(indexes)) {
+      indexes.forEach((index) => {
+        processor(t, path.get(`arguments.${index}`));
+      });
+    }
   }
 }
 
-const PLUGIN_BLACKLIST_NAMES = [
-  '@babel/plugin-transform-object-assign',
-];
+const PLUGIN_BLACKLIST_NAMES = ['@babel/plugin-transform-object-assign'];
 
 const PLUGIN_BLACKLIST = PLUGIN_BLACKLIST_NAMES.map((pluginName) => {
   try {
@@ -324,7 +330,7 @@ function removePluginsFromBlacklist(plugins) {
     const toRemove = [];
     for (let i = 0; i < plugins.length; i++) {
       if (
-        JSON.stringify(Object.keys(plugins[i].visitor)) !=
+        JSON.stringify(Object.keys(plugins[i].visitor)) !==
         JSON.stringify(Object.keys(blacklistedPlugin.visitor))
       ) {
         continue;
@@ -332,7 +338,7 @@ function removePluginsFromBlacklist(plugins) {
       let areEqual = true;
       for (const key of Object.keys(blacklistedPlugin.visitor)) {
         if (
-          blacklistedPlugin.visitor[key].toString() !=
+          blacklistedPlugin.visitor[key].toString() !==
           plugins[i].visitor[key].toString()
         ) {
           areEqual = false;
@@ -349,7 +355,7 @@ function removePluginsFromBlacklist(plugins) {
   });
 }
 
-module.exports = function ({ types: t }) {
+module.exports = function({ types: t }) {
   return {
     visitor: {
       CallExpression: {
@@ -363,7 +369,7 @@ module.exports = function ({ types: t }) {
         },
       },
     },
-    // In this way we can modify babel options 
+    // In this way we can modify babel options
     // https://github.com/babel/babel/blob/eea156b2cb8deecfcf82d52aa1b71ba4995c7d68/packages/babel-core/src/transformation/normalize-opts.js#L64
     manipulateOptions(opts, parserOpts) {
       const plugins = opts.plugins;

--- a/plugin.js
+++ b/plugin.js
@@ -13,6 +13,7 @@ const functionHooks = new Map([
   ['useAnimatedStyle', [0]],
   ['useAnimatedProps', [0]],
   ['useDerivedValue', [0]],
+  ['useAnimatedScrollHandler', [0]],
   ['useAnimatedReaction', [0, 1]],
 ]);
 

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -71,12 +71,12 @@ function prepareAnimation(animatedProp, lastAnimation, lastValue) {
         }
       }
 
-      animation.callStart = (timestamp) => {
+      animation.callStart = timestamp => {
         animation.start(animation, value, timestamp, lastAnimation);
       };
     } else if (typeof animatedProp === 'object') {
       // it is an object
-      Object.keys(animatedProp).forEach((key) =>
+      Object.keys(animatedProp).forEach(key =>
         prepareAnimation(
           animatedProp[key],
           lastAnimation && lastAnimation[key],
@@ -116,7 +116,7 @@ function runAnimations(animation, timestamp, key, result) {
     } else if (typeof animation === 'object') {
       result[key] = {};
       let allFinished = true;
-      Object.keys(animation).forEach((k) => {
+      Object.keys(animation).forEach(k => {
         if (!runAnimations(animation[k], timestamp, k, result[key])) {
           allFinished = false;
         }
@@ -141,7 +141,7 @@ function isAnimated(prop) {
       if (prop.animation) {
         return true;
       }
-      return Object.keys(prop).some((key) => isAnimated(prop[key]));
+      return Object.keys(prop).some(key => isAnimated(prop[key]));
     }
     return false;
   }
@@ -151,12 +151,12 @@ function isAnimated(prop) {
 function styleDiff(oldStyle, newStyle) {
   'worklet';
   const diff = {};
-  Object.keys(oldStyle).forEach((key) => {
+  Object.keys(oldStyle).forEach(key => {
     if (newStyle[key] === undefined) {
       diff[key] = null;
     }
   });
-  Object.keys(newStyle).forEach((key) => {
+  Object.keys(newStyle).forEach(key => {
     const value = newStyle[key];
     const oldValue = oldStyle[key];
 
@@ -184,13 +184,13 @@ function styleUpdater(viewTag, updater, state) {
 
   // extract animated props
   let hasAnimations = false;
-  Object.keys(animations).forEach((key) => {
+  Object.keys(animations).forEach(key => {
     const value = newValues[key];
     if (!isAnimated(value)) {
       delete animations[key];
     }
   });
-  Object.keys(newValues).forEach((key) => {
+  Object.keys(newValues).forEach(key => {
     const value = newValues[key];
     if (isAnimated(value)) {
       prepareAnimation(value, animations[key], oldValues[key]);
@@ -208,7 +208,7 @@ function styleUpdater(viewTag, updater, state) {
 
     const updates = {};
     let allFinished = true;
-    Object.keys(animations).forEach((propName) => {
+    Object.keys(animations).forEach(propName => {
       const finished = runAnimations(
         animations[propName],
         timestamp,
@@ -355,7 +355,7 @@ export function useAnimatedGestureHandler(handlers) {
   const { context } = initRef.current;
 
   return useEvent(
-    (event) => {
+    event => {
       'worklet';
       const FAILED = 1;
       const BEGAN = 2;
@@ -417,7 +417,7 @@ export function useAnimatedScrollHandler(handlers) {
     subscribeForEvents.push('onMomentumScrollEnd');
   }
 
-  return useEvent((event) => {
+  return useEvent(event => {
     'worklet';
     const {
       onScroll,
@@ -476,3 +476,17 @@ export function useAnimatedRef() {
   return ref.current
 }
 
+export function useAnimatedReaction(prepare, react) {
+  const inputsRef = useRef(null);
+  if (inputsRef.current === null) {
+    inputsRef.current = {
+      inputs: Object.values(prepare._closure),
+    };
+  }
+  const { inputs } = inputsRef.current;
+  useMapper(() => {
+    'worklet';
+    const input = prepare();
+    react(input);
+  }, inputs);
+}

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -71,12 +71,12 @@ function prepareAnimation(animatedProp, lastAnimation, lastValue) {
         }
       }
 
-      animation.callStart = timestamp => {
+      animation.callStart = (timestamp) => {
         animation.start(animation, value, timestamp, lastAnimation);
       };
     } else if (typeof animatedProp === 'object') {
       // it is an object
-      Object.keys(animatedProp).forEach(key =>
+      Object.keys(animatedProp).forEach((key) =>
         prepareAnimation(
           animatedProp[key],
           lastAnimation && lastAnimation[key],
@@ -116,7 +116,7 @@ function runAnimations(animation, timestamp, key, result) {
     } else if (typeof animation === 'object') {
       result[key] = {};
       let allFinished = true;
-      Object.keys(animation).forEach(k => {
+      Object.keys(animation).forEach((k) => {
         if (!runAnimations(animation[k], timestamp, k, result[key])) {
           allFinished = false;
         }
@@ -141,7 +141,7 @@ function isAnimated(prop) {
       if (prop.animation) {
         return true;
       }
-      return Object.keys(prop).some(key => isAnimated(prop[key]));
+      return Object.keys(prop).some((key) => isAnimated(prop[key]));
     }
     return false;
   }
@@ -151,12 +151,12 @@ function isAnimated(prop) {
 function styleDiff(oldStyle, newStyle) {
   'worklet';
   const diff = {};
-  Object.keys(oldStyle).forEach(key => {
+  Object.keys(oldStyle).forEach((key) => {
     if (newStyle[key] === undefined) {
       diff[key] = null;
     }
   });
-  Object.keys(newStyle).forEach(key => {
+  Object.keys(newStyle).forEach((key) => {
     const value = newStyle[key];
     const oldValue = oldStyle[key];
 
@@ -184,13 +184,13 @@ function styleUpdater(viewTag, updater, state) {
 
   // extract animated props
   let hasAnimations = false;
-  Object.keys(animations).forEach(key => {
+  Object.keys(animations).forEach((key) => {
     const value = newValues[key];
     if (!isAnimated(value)) {
       delete animations[key];
     }
   });
-  Object.keys(newValues).forEach(key => {
+  Object.keys(newValues).forEach((key) => {
     const value = newValues[key];
     if (isAnimated(value)) {
       prepareAnimation(value, animations[key], oldValues[key]);
@@ -208,7 +208,7 @@ function styleUpdater(viewTag, updater, state) {
 
     const updates = {};
     let allFinished = true;
-    Object.keys(animations).forEach(propName => {
+    Object.keys(animations).forEach((propName) => {
       const finished = runAnimations(
         animations[propName],
         timestamp,
@@ -355,7 +355,7 @@ export function useAnimatedGestureHandler(handlers) {
   const { context } = initRef.current;
 
   return useEvent(
-    event => {
+    (event) => {
       'worklet';
       const FAILED = 1;
       const BEGAN = 2;
@@ -417,7 +417,7 @@ export function useAnimatedScrollHandler(handlers) {
     subscribeForEvents.push('onMomentumScrollEnd');
   }
 
-  return useEvent(event => {
+  return useEvent((event) => {
     'worklet';
     const {
       onScroll,
@@ -476,6 +476,12 @@ export function useAnimatedRef() {
   return ref.current
 }
 
+/**
+ * @param prepare - worklet used for data preparation for the second parameter
+ * @param react - worklet which takes data prepared by the one in the first parameter and performs certain actions
+ * the first worklet defines the inputs, in other words on which shared values change will it be called.
+ * the second one can modify any shared values but those which are mentioned in the first worklet. Beware of that, because this may result in endless loop and high cpu usage.
+ */
 export function useAnimatedReaction(prepare, react) {
   const inputsRef = useRef(null);
   if (inputsRef.current === null) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -4,7 +4,7 @@ import WorkletEventHandler from './WorkletEventHandler';
 import { startMapper, stopMapper, makeMutable, makeRemote } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
-import { getTag } from './NativeMethods'
+import { getTag } from './NativeMethods';
 
 export function useSharedValue(init) {
   const ref = useRef(null);
@@ -372,15 +372,24 @@ export function useAnimatedGestureHandler(handlers) {
       if (event.oldState === ACTIVE && event.state === END && handlers.onEnd) {
         handlers.onEnd(event, context);
       }
-      if (event.oldState === BEGAN && event.state === FAILED && handlers.onFail) {
+      if (
+        event.oldState === BEGAN &&
+        event.state === FAILED &&
+        handlers.onFail
+      ) {
         handlers.onFail(event, context);
       }
-      if (event.oldState === ACTIVE && event.state === CANCELLED && handlers.onCancel) {
+      if (
+        event.oldState === ACTIVE &&
+        event.state === CANCELLED &&
+        handlers.onCancel
+      ) {
         handlers.onCancel(event, context);
       }
       if (
         (event.oldState === BEGAN || event.oldState === ACTIVE) &&
-        event.state !== BEGAN && event.state !== ACTIVE &&
+        event.state !== BEGAN &&
+        event.state !== ACTIVE &&
         handlers.onFinish
       ) {
         handlers.onFinish(
@@ -451,8 +460,8 @@ export function useAnimatedScrollHandler(handlers) {
 }
 
 export function useAnimatedRef() {
-  const tag = useSharedValue(-1)
-  const ref = useRef(null)
+  const tag = useSharedValue(-1);
+  const ref = useRef(null);
 
   if (!ref.current) {
     const fun = function(component) {
@@ -460,7 +469,7 @@ export function useAnimatedRef() {
       // enters when ref is set by attaching to a component
       if (component) {
         tag.value = getTag(component);
-        fun.current = component
+        fun.current = component;
       }
       return tag.value;
     };
@@ -473,7 +482,7 @@ export function useAnimatedRef() {
     ref.current = fun;
   }
 
-  return ref.current
+  return ref.current;
 }
 
 /**
@@ -490,9 +499,16 @@ export function useAnimatedReaction(prepare, react) {
     };
   }
   const { inputs } = inputsRef.current;
-  useMapper(() => {
-    'worklet';
-    const input = prepare();
-    react(input);
+
+  useEffect(() => {
+    const fun = () => {
+      'worklet';
+      const input = prepare();
+      react(input);
+    };
+    const mapperId = startMapper(fun, inputs, []);
+    return () => {
+      stopMapper(mapperId);
+    };
   }, inputs);
 }


### PR DESCRIPTION
## Description

Added a new hook - `useAnimatedReaction` which takes 2 arguments(both are worklets):
1. `prepare` - prepares data for the second argument. Value returned from this function is the only one argument passed to the following one
2. `react` - takes one argument which is a result from the previous function's invocation and just performs some specified operations

## Motivation

This hook has been added to allow performing some actions on some shared values' change. The key idea is all of the shared values included in the first worklet are the `inputs` set. Every time any of those change both worklets are triggered in the order specified above. Also the second worklet may modify any shared values excluding those used in the first worklet.

## Usage

```
useAnimatedReaction(
    () => {
        'worklet';
        return (x.value + y.value) / 2; // `data` below
    },
    (data) => {
        'worklet';
        if (sv.value < 100) {
            sv.value = data;
        }
    }
);
```

## Changes

`Hooks.js` - added `useAnimatedReaction` hook
`AnimatedReactionTest.js` - added simple test showing an example of using the new hook
`plugin.js` - added automatic workletization for the new hook