### PR TITLE
Fix CI for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,6 +86,14 @@ def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 // and the build will use that.
 def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 
+def follyReplaceContent = '''
+  ssize_t r;
+  do {
+    r = open(name, flags, mode);
+  } while (r == -1 && errno == EINTR);
+  return r;
+'''
+
 task Log {
     print("building Reanimated2")
 }
@@ -141,6 +149,9 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     from("$reactNativeThirdParty/folly/Android.mk")
     include("folly-${FOLLY_VERSION}/folly/**/*", "Android.mk")
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
+    // Fixes problem with Folly failing to build on certain systems. See
+    // https://github.com/software-mansion/react-native-reanimated/issues/1024
+    filter { line -> line.replaceAll('return int\\(wrapNoInt\\(open, name, flags, mode\\)\\);', follyReplaceContent) }
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/folly")
 }


### PR DESCRIPTION
## Description

Fixes #1024 

Solution was taken from https://github.com/facebook/react-native/issues/28298.
I was able to successfully build all required files on Fedora 32
```bash
android-npm/react-native-reanimated-62.aar
android-npm/react-native-reanimated-63.aar
react-native-reanimated-2.0.0-alpha.4.tgz
```

## Changes

- Change `wrapNoInt` template function invocation to it's code, after downloading folly
