### PR TITLE
Update proc type

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -234,9 +234,9 @@ declare module 'react-native-reanimated' {
     export const neq: BinaryOperator<0 | 1>;
     export const and: MultiOperator<0 | 1>;
     export const or: MultiOperator<0 | 1>;
-    export function proc<T extends (...args: any[]) => AnimatedNode<number>>(
-      func: T
-    ): (...funcArgs: Parameters<T>) => ReturnType<T>;
+    export function proc<T extends Adaptable<Value>[]>(
+      func: (...args: T) => AnimatedNode<number>
+    ): typeof func;
     export function defined(value: Adaptable<any>): AnimatedNode<0 | 1>;
     export function not(value: Adaptable<any>): AnimatedNode<0 | 1>;
     export function set<T extends Value>(

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -234,7 +234,7 @@ declare module 'react-native-reanimated' {
     export const neq: BinaryOperator<0 | 1>;
     export const and: MultiOperator<0 | 1>;
     export const or: MultiOperator<0 | 1>;
-    export function proc<T extends Adaptable<Value>[]>(
+    export function proc<T extends (Adaptable<Value> | undefined)[]>(
       func: (...args: T) => AnimatedNode<number>
     ): typeof func;
     export function defined(value: Adaptable<any>): AnimatedNode<0 | 1>;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -234,9 +234,9 @@ declare module 'react-native-reanimated' {
     export const neq: BinaryOperator<0 | 1>;
     export const and: MultiOperator<0 | 1>;
     export const or: MultiOperator<0 | 1>;
-    export function proc<A extends Adaptable[]>(
-      cb: (...args: A) => AnimatedNode<number>
-    ): typeof cb;
+    export function proc<T extends (...args: any[]) => AnimatedNode<number>>(
+      func: T
+    ): (...funcArgs: Parameters<T>) => ReturnType<T>;
     export function defined(value: Adaptable<any>): AnimatedNode<0 | 1>;
     export function not(value: Adaptable<any>): AnimatedNode<0 | 1>;
     export function set<T extends Value>(


### PR DESCRIPTION
## Description

Fixes #1021.

This commit fixes regression introduced in #959 (f5eaf18) by specializing a generic parameter.
 
The previous implementation was failing with error:
```
node_modules/react-native-reanimated/react-native-reanimated.d.ts:237:36 - error TS2314: Generic type 'Adaptable' requires 1 type argument(s).
```
because `Adaptable` generic type was not specialized.

References:
www.typescriptlang.org/docs/handbook/utility-types.html#parameterst
www.typescriptlang.org/docs/handbook/utility-types.html#returntypet