### PR TITLE
Fix initialisation of NodesManager

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -97,8 +97,6 @@ public class NodesManager implements EventDispatcherListener {
     updateContext = new UpdateContext();
     mUIImplementation = mUIManager.getUIImplementation();
     mCustomEventNamesResolver = mUIManager.getDirectEventNamesResolver();
-    mUIManager.getEventDispatcher().addListener(this);
-
     mEventEmitter = context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
 
     mReactChoreographer = ReactChoreographer.getInstance();
@@ -110,6 +108,12 @@ public class NodesManager implements EventDispatcherListener {
     };
 
     mNoopNode = new NoopNode(this);
+
+    // We register as event listener at the end, because we pass `this` and we haven't finished contructing an object yet.
+    // This lead to a crash described in https://github.com/software-mansion/react-native-reanimated/issues/604 which was caused by Nodes Manager being constructed on UI thread and registering for events.
+    // Events are handled in the native modules thread in the `onEventDispatch()` method.
+    // This method indirectly uses `mChoreographerCallback` which was created after event registration, creating race condition
+    mUIManager.getEventDispatcher().addListener(this);
   }
 
   public void onHostPause() {


### PR DESCRIPTION
## Description

Previously, `NodesManager` registered (passing this) as an event listener before ending initialization in c-tor.


`NodesManager` is created by `ReanimatedModule` (when calling `getNodesManager()` for the first time) on [UI thread](https://github.com/software-mansion/react-native-reanimated/blob/9af276693d136b712259fe9dd0126aee6c78bd4b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java#L77-L80).

When `onEventDispatch()` is called on non-UI thread it calls `startUpdatingOnAnimationFrame()`, which in turn uses `mChoreographerCallback`.
`mChoreographerCallback` is initialised **after** listener is registered which causes NPE in React Choreographer's `postFrameCallback()` method after trying adding callback to the queue.

Fixes #604.

References:
https://www.ibm.com/developerworks/java/library/j-jtp0618/index.html#2
https://stackoverflow.com/questions/25281301/what-exactly-are-the-dangers-of-passing-this-from-a-java-constructor
