### PR TITLE
Update deprecated use of `GuardedRunnable`

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -164,7 +164,7 @@ public class NodesManager implements EventDispatcherListener {
       final Queue<NativeUpdateOperation> copiedOperationsQueue = mOperationsInBatch;
       mOperationsInBatch = new LinkedList<>();
       mContext.runOnNativeModulesQueueThread(
-              new GuardedRunnable(mContext) {
+              new GuardedRunnable(mContext.getExceptionHandler()) {
                 @Override
                 public void runGuarded() {
                   boolean shouldDispatchUpdates = UIManagerReanimatedHelper.isOperationQueueEmpty(mUIImplementation);


### PR DESCRIPTION
## Description

Previously, we were using deprecated c-tor of `GuardedRunnable`. This PR switches to c-tor taking exception handler as an argument.

References:
- [C-tors, notice that deprecated one is using internally `reactContext.getExceptionHandler()`](https://github.com/facebook/react-native/blob/d3ac9fa0c3780b43b73de97831b75cf0a7efe9c4/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedRunnable.java#L19-L26)
