### PR TITLE
[v1] Ref forwarding for scroll components (Fixes infinity scroll)

### DIFF
--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,9 +1,14 @@
-import { Image, ScrollView, Text, View } from 'react-native';
 import Easing from './Easing';
 import AnimatedClock from './core/AnimatedClock';
 import AnimatedValue from './core/AnimatedValue';
 import AnimatedNode from './core/AnimatedNode';
 import AnimatedCode from './core/AnimatedCode';
+import AnimatedFlatList from './components/AnimatedFlatList';
+import AnimatedImage from './components/AnimatedImage';
+import AnimatedScrollView from './components/AnimatedScrollView';
+import AnimatedSectionList from './components/AnimatedSectionList';
+import AnimatedText from './components/AnimatedText';
+import AnimatedView from './components/AnimatedView';
 import * as base from './base';
 import * as derived from './derived';
 import createAnimatedComponent from './createAnimatedComponent';
@@ -32,10 +37,12 @@ const timingWrapper = backwardCompatibleAnimWrapper(timing, TimingAnimation);
 const springWrapper = backwardCompatibleAnimWrapper(spring, SpringAnimation);
 const Animated = {
   // components
-  View: createAnimatedComponent(View),
-  Text: createAnimatedComponent(Text),
-  Image: createAnimatedComponent(Image),
-  ScrollView: createAnimatedComponent(ScrollView),
+  View: AnimatedView,
+  Text: AnimatedText,
+  Image: AnimatedImage,
+  ScrollView: AnimatedScrollView,
+  FlatList: AnimatedFlatList,
+  SectionList: AnimatedSectionList,
   Code: AnimatedCode,
   createAnimatedComponent,
 

--- a/src/components/AnimatedFlatList.js
+++ b/src/components/AnimatedFlatList.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { FlatList } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+const FlatListWithEventThrottle = React.forwardRef((props, ref) => (
+    <FlatList scrollEventThrottle={0.0001} {...props} ref={ref} />
+));
+
+module.exports = createAnimatedComponent(
+    FlatListWithEventThrottle,
+);

--- a/src/components/AnimatedImage.js
+++ b/src/components/AnimatedImage.js
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Image } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+module.exports = createAnimatedComponent(Image);

--- a/src/components/AnimatedImage.js
+++ b/src/components/AnimatedImage.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Image } from 'react-native';
 import createAnimatedComponent from '../createAnimatedComponent';
 

--- a/src/components/AnimatedScrollView.js
+++ b/src/components/AnimatedScrollView.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { ScrollView } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+const ScrollViewWithEventThrottle = React.forwardRef((props, ref) => (
+    <ScrollView scrollEventThrottle={0.0001} {...props} ref={ref} />
+));
+
+module.exports = createAnimatedComponent(
+    ScrollViewWithEventThrottle,
+);

--- a/src/components/AnimatedSectionList.js
+++ b/src/components/AnimatedSectionList.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { SectionList } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+const SectionListWithEventThrottle = React.forwardRef((props, ref) => (
+    <SectionList scrollEventThrottle={0.0001} {...props} ref={ref} />
+));
+
+module.exports = createAnimatedComponent(
+    SectionListWithEventThrottle,
+);

--- a/src/components/AnimatedText.js
+++ b/src/components/AnimatedText.js
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Text } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+module.exports = createAnimatedComponent(Text);

--- a/src/components/AnimatedText.js
+++ b/src/components/AnimatedText.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Text } from 'react-native';
 import createAnimatedComponent from '../createAnimatedComponent';
 

--- a/src/components/AnimatedView.js
+++ b/src/components/AnimatedView.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { View } from 'react-native';
 import createAnimatedComponent from '../createAnimatedComponent';
 

--- a/src/components/AnimatedView.js
+++ b/src/components/AnimatedView.js
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import createAnimatedComponent from '../createAnimatedComponent';
+
+module.exports = createAnimatedComponent(View);


### PR DESCRIPTION
## Description

The infinity scroll was not working as expected to when creating a new FlatList with createAnimatedComponent. Once you reach the bottom and try to add more images you are automatically pushed back to the top. Similar behaviour also occurs on ScrollView.  (Using reanimated's Animated.ScrollView)

Fixes #616 .

## Changes

- Added components folder to store all the components in a clean way
- Added FlatList & SectionList components
- Moved existing animated components to the ./components folder so it matches the modified architecture