### PR TITLE
Make `interpolate` `type` optional

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -367,7 +367,7 @@ declare module 'react-native-reanimated' {
       x: number,
       input: Array<number>,
       output: Array<number>,
-      type: Extrapolate
+      type?: Extrapolate
     ): number;
 
     // animations


### PR DESCRIPTION
I believe that it is optional in the JS implementation.