### PR TITLE
Update stopClock's docs

### DIFF
--- a/docs/versioned_docs/version-1.x.x/nodes/stopClock.md
+++ b/docs/versioned_docs/version-1.x.x/nodes/stopClock.md
@@ -4,4 +4,8 @@
 stopClock(clockNode);
 ```
 
-When evaluated, it will make `Clock` node passed as an argument stop updating its value (if it has been doing that). Then returns `0`.
+When evaluated, it will stop evaluating nodes dependent on `clockNode`.
+
+**NOTE**
+The clock, even after using `stopClock` on it, will keep updating it's value. `stopClock` merely prevents other nodes from evaluation when clock updates.
+To save the moment when clock was stopped please use `Value`.


### PR DESCRIPTION
## Description

Previously, docs were not consistent with implementation (which doesn't prevent the clock from updating when stopped).