### PR TITLE
Add useAnimatedRef

### DIFF
--- a/Example/src/MeasureExample.js
+++ b/Example/src/MeasureExample.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, {
@@ -7,9 +7,9 @@ import Animated, {
   useAnimatedGestureHandler,
   measure,
   withTiming,
-  getTag,
   Easing,
   useDerivedValue,
+  useAnimatedRef,
 } from 'react-native-reanimated';
 import { TapGestureHandler } from 'react-native-gesture-handler';
 
@@ -84,7 +84,7 @@ export default function MeasureExample() {
 }
 
 function Section({ title, children, height, contentHeight, z, show }) {
-  const [randomComRef, setRef] = useState(null);
+  const aref = useAnimatedRef();
 
   const stylez = useAnimatedStyle(() => {
     return {
@@ -93,28 +93,26 @@ function Section({ title, children, height, contentHeight, z, show }) {
   });
 
   return (
-    <Animated.View style={[styles.section, stylez, { zIndex: z }]}>
-      {randomComRef == null ? null : (
-        <SectionHeader
-          title={title}
-          tag={getTag(randomComRef)}
-          contentHeight={contentHeight}
-          show={show}
-        />
-      )}
+    <Animated.View style={[styles.section, stylez, { zIndex: z }]}> 
+      <SectionHeader
+        title={title}
+        animatedRef={aref}
+        contentHeight={contentHeight}
+        show={show}
+      />
       <View>
         {React.Children.map(children, (element, idx) => {
-          return React.cloneElement(element, { ref: setRef });
+          return React.cloneElement(element, { ref: aref });
         })}
       </View>
     </Animated.View>
   );
 }
 
-function SectionHeader({ title, tag, contentHeight, show }) {
+function SectionHeader({ title, animatedRef, contentHeight, show }) {
   const handler = useAnimatedGestureHandler({
     onActive: (_, ctx) => {
-      const height = measure(tag).height;
+      const height = measure(animatedRef).height;
       if (contentHeight.value === 0) {
         contentHeight.value = withTiming(height, {
           duration: 500,

--- a/Example/src/ScrollToExample.js
+++ b/Example/src/ScrollToExample.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { StyleSheet, View, Text, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, {
@@ -6,8 +6,8 @@ import Animated, {
   useAnimatedStyle,
   useAnimatedGestureHandler,
   scrollTo,
-  getTag,
   useDerivedValue,
+  useAnimatedRef,
 } from 'react-native-reanimated';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 
@@ -62,20 +62,15 @@ function NumberDisplay({ number }) {
 }
 
 function Digit({ digit }) {
-  const tag = useSharedValue(-1);
-  const ref = useRef(null);
-
-  useEffect(() => {
-    tag.value = getTag(ref.current);
-  }, []);
+  const aref = useAnimatedRef();
 
   useDerivedValue(() => {
-    scrollTo(tag.value, 0, digit.value * 200, true);
+    scrollTo(aref, 0, digit.value * 200, true);
   });
 
   return (
     <View style={{ height: 200 }}>
-      <ScrollView ref={ref}>
+      <ScrollView ref={aref}>
         {digits.map((i) => {
           return (
             <View

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -4,6 +4,7 @@ import WorkletEventHandler from './WorkletEventHandler';
 import { startMapper, stopMapper, makeMutable, makeRemote } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
+import { getTag } from './NativeMethods'
 
 export function useSharedValue(init) {
   const ref = useRef(null);
@@ -409,3 +410,17 @@ export function useAnimatedScrollHandler(handlers) {
     }
   }, subscribeForEvents);
 }
+
+export function useAnimatedRef() {
+  const tag = useSharedValue(-1)
+
+  return (component) => {
+    'worklet';
+    // enters when ref is set by attaching to a component
+    if (component !== undefined) {
+      tag.value = getTag(component);
+    }
+    return tag
+  }
+}
+

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -413,14 +413,27 @@ export function useAnimatedScrollHandler(handlers) {
 
 export function useAnimatedRef() {
   const tag = useSharedValue(-1)
+  const ref = useRef(null)
 
-  return (component) => {
-    'worklet';
-    // enters when ref is set by attaching to a component
-    if (component !== undefined) {
-      tag.value = getTag(component);
-    }
-    return tag
+  if (!ref.current) {
+    const fun = function(component) {
+      'worklet';
+      // enters when ref is set by attaching to a component
+      if (component) {
+        tag.value = getTag(component);
+        fun.current = component
+      }
+      return tag.value;
+    };
+
+    Object.defineProperty(fun, 'current', {
+      value: null,
+      writable: true,
+      enumerable: false,
+    });
+    ref.current = fun;
   }
+
+  return ref.current
 }
 

--- a/src/reanimated2/NativeMethods.js
+++ b/src/reanimated2/NativeMethods.js
@@ -21,6 +21,6 @@ export function scrollTo(animatedRef, x, y, animated) {
   if (!_WORKLET) {
     return;
   }
-  const viewTag = animatedRef().value
+  const viewTag = animatedRef()
   _scrollTo(viewTag, x, y, animated);
 }

--- a/src/reanimated2/NativeMethods.js
+++ b/src/reanimated2/NativeMethods.js
@@ -4,11 +4,12 @@ export function getTag(view) {
   return findNodeHandle(view);
 }
 
-export function measure(viewTag) {
+export function measure(animatedRef) {
   'worklet';
   if (!_WORKLET) {
     throw new Error('(measure) method cannot be used on RN side!');
   }
+  const viewTag = animatedRef();
   const result = _measure(viewTag);
   if (result.x === -1234567) {
     throw new Error(`The view with tag ${viewTag} could not be measured`);

--- a/src/reanimated2/NativeMethods.js
+++ b/src/reanimated2/NativeMethods.js
@@ -16,10 +16,11 @@ export function measure(viewTag) {
   return result;
 }
 
-export function scrollTo(viewTag, x, y, animated) {
+export function scrollTo(animatedRef, x, y, animated) {
   'worklet';
   if (!_WORKLET) {
     return;
   }
+  const viewTag = animatedRef().value
   _scrollTo(viewTag, x, y, animated);
 }


### PR DESCRIPTION
## Description
Create new hook `useAnimatedRef` to provide a functionality of animated reference which acts as a normal reference on the javascript thread but at the same time holds a view tag of the component which it is referring to through a shared value.

It was created to simplify code of `scrollTo` example but may be used in other cases as well.