### PR TITLE
Rename `Easing` to `EasingNode` in TS types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -527,7 +527,7 @@ declare module 'react-native-reanimated' {
     out(easing: Animated.EasingFunction): Animated.EasingFunction;
     inOut(easing: Animated.EasingFunction): Animated.EasingFunction;
   }
-  export const Easing: EasingStatic;
+  export const EasingNode: EasingStatic;
 
   export interface TransitioningViewProps extends ViewProps {
     transition: ReactNode;


### PR DESCRIPTION
## Description

`Easing` was renamed to `EasingNode` after the release of v2 but types weren't updated. 