### PR TITLE
Handle rerender behaviour

### DIFF
--- a/Example/test/FastRefreshTest.js
+++ b/Example/test/FastRefreshTest.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Button, View } from 'react-native';
+import React, { useState } from 'react';
+import { Button, View, StyleSheet, Text } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -7,16 +7,60 @@ import Animated, {
 } from 'react-native-reanimated';
 
 const FastRefreshTest = () => {
-    // check if certain hooks work
-    const sv = useSharedValue(50)
+  const [state, setState] = useState(21);
 
-    // ...
+  const shared = useSharedValue(state);
 
-    return (
-        <View>
-            <Animated.View />
-        </View>
-    );
-}
+  const derived = useDerivedValue(() => {
+    return state;
+  }, [state]);
+
+  const uas = useAnimatedStyle(() => {
+    return {
+      width: shared.value,
+    };
+  });
+
+  const uas2 = useAnimatedStyle(() => {
+    return {
+      width: state,
+    };
+  }, [state]);
+
+  const uas3 = useAnimatedStyle(() => {
+    return {
+      width: state,
+    };
+  });
+
+  return (
+    <View>
+      <Button
+        title="change"
+        onPress={() => {
+          setState(Math.floor(Math.random() * 300));
+        }}
+      />
+      <Text>
+        All numbers should be the same: {state} / {derived.value} /{' '}
+        {shared.value}
+      </Text>
+      <Text>The lengths of the following containers should be the same</Text>
+      <Animated.View style={[styles.box, uas]} />
+      <Animated.View style={[styles.box, uas2]} />
+      <Text>But this should not update</Text>
+      <Animated.View style={[styles.box, uas3]} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  box: {
+    width: 20,
+    height: 20,
+    backgroundColor: 'orange',
+    margin: 10,
+  },
+});
 
 export default FastRefreshTest;

--- a/Example/test/FastRefreshTest.js
+++ b/Example/test/FastRefreshTest.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  useDerivedValue,
+} from 'react-native-reanimated';
+
+const FastRefreshTest = () => {
+    // check if certain hooks work
+    const sv = useSharedValue(50)
+
+    // ...
+
+    return (
+        <View>
+            <Animated.View />
+        </View>
+    );
+}
+
+export default FastRefreshTest;

--- a/Example/test/FastRefreshTest.js
+++ b/Example/test/FastRefreshTest.js
@@ -4,52 +4,108 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   useDerivedValue,
+  useEvent,
 } from 'react-native-reanimated';
+import { PanGestureHandler } from 'react-native-gesture-handler';
+
+const Child = ({ expanded }) => {
+  const uas = useAnimatedStyle(() => {
+    return {
+      width: expanded ? 10 : 300,
+    };
+  }, [expanded]);
+  return (
+    <View>
+      <Animated.View style={[styles.box, uas]} />
+    </View>
+  );
+};
 
 const FastRefreshTest = () => {
-  const [state, setState] = useState(21);
+  const [state, setState] = useState(-1);
+  const [expanded, setExpanded] = useState(true);
 
   const shared = useSharedValue(state);
 
+  // test useDerivedValue
   const derived = useDerivedValue(() => {
     return state;
   }, [state]);
 
-  const uas = useAnimatedStyle(() => {
+  const derivedNotListening = useDerivedValue(() => {
+    return state;
+  });
+
+  // test useAnimatedStyle
+  const uasShared = useAnimatedStyle(() => {
     return {
       width: shared.value,
     };
   });
 
-  const uas2 = useAnimatedStyle(() => {
+  const uasListening = useAnimatedStyle(() => {
     return {
       width: state,
     };
   }, [state]);
 
-  const uas3 = useAnimatedStyle(() => {
+  const uasNotListening = useAnimatedStyle(() => {
     return {
       width: state,
     };
   });
 
+  const update = () => {
+    setState(Math.floor(Math.random() * 300));
+    setExpanded(!expanded);
+  };
+
+  if (shared.value === -1) {
+    update();
+  }
+
+  // test useEvent
+  const flag = useSharedValue(1);
+  const eventHandler = useEvent(
+    event => {
+      if (flag.value === 1) {
+        setState(Math.floor(Math.random() * 300));
+        flag.value = 0;
+        setTimeout(() => {
+          flag.value = 1;
+        }, 100);
+      }
+    },
+    ['onGestureHandlerStateChange', 'onGestureHandlerEvent']
+  );
+
+  const bgColor =
+    state === derived.value &&
+    state === shared.value &&
+    state !== derivedNotListening.value
+      ? 'green'
+      : 'red';
+
   return (
     <View>
-      <Button
-        title="change"
-        onPress={() => {
-          setState(Math.floor(Math.random() * 300));
-        }}
-      />
-      <Text>
-        All numbers should be the same: {state} / {derived.value} /{' '}
-        {shared.value}
+      <Button title="change state" onPress={update} />
+      <Text style={{ padding: 10, backgroundColor: bgColor }}>
+        Those should be the same: {state}/{derived.value}/{shared.value} but not
+        this one: {derivedNotListening.value}
       </Text>
       <Text>The lengths of the following containers should be the same</Text>
-      <Animated.View style={[styles.box, uas]} />
-      <Animated.View style={[styles.box, uas2]} />
+      <Animated.View style={[styles.box, uasShared]} />
+      <Animated.View style={[styles.box, uasListening]} />
+      <Text>This should alternate(long/short)</Text>
+      <Child expanded={expanded} />
       <Text>But this should not update</Text>
-      <Animated.View style={[styles.box, uas3]} />
+      <Animated.View style={[styles.box, uasNotListening]} />
+      <Text>Event test, try to drag the box below to trigger changes</Text>
+      <PanGestureHandler onGestureEvent={eventHandler}>
+        <Animated.View
+          style={[{ backgroundColor: 'green', width: 100, height: 100 }]}
+        />
+      </PanGestureHandler>
     </View>
   );
 };

--- a/Example/test/FastRefreshTest.js
+++ b/Example/test/FastRefreshTest.js
@@ -4,9 +4,7 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   useDerivedValue,
-  useEvent,
 } from 'react-native-reanimated';
-import { PanGestureHandler } from 'react-native-gesture-handler';
 
 const Child = ({ expanded }) => {
   const uas = useAnimatedStyle(() => {
@@ -26,14 +24,17 @@ const FastRefreshTest = () => {
   const [expanded, setExpanded] = useState(true);
 
   const shared = useSharedValue(state);
+  const testResult = useSharedValue(0);
 
-  // test useDerivedValue
   const derived = useDerivedValue(() => {
     return state;
-  }, [state]);
+  });
 
-  const derivedNotListening = useDerivedValue(() => {
-    return state;
+  const resultUas = useAnimatedStyle(() => {
+    const color = testResult.value === 1 ? 'green' : 'red';
+    return {
+      backgroundColor: color,
+    };
   });
 
   // test useAnimatedStyle
@@ -43,39 +44,29 @@ const FastRefreshTest = () => {
     };
   });
 
-  const uasListening = useAnimatedStyle(() => {
+  const uasListeningOne = useAnimatedStyle(() => {
     return {
       width: state,
     };
   }, [state]);
 
-  const uasNotListening = useAnimatedStyle(() => {
+  const uasListeningAll = useAnimatedStyle(() => {
     return {
       width: state,
     };
   });
 
+  const uasNotListening = useAnimatedStyle(() => {
+    return {
+      width: state,
+    };
+  }, []);
+
   const update = () => {
+    testResult.value = 0;
     setState(Math.floor(Math.random() * 300));
     setExpanded(!expanded);
   };
-
-  // test useEvent
-  const flag = useSharedValue(1);
-  const eventHandler = useEvent(
-    (event) => {
-      if (flag.value === 1) {
-        setState(Math.floor(Math.random() * 300));
-        flag.value = 0;
-        setTimeout(() => {
-          flag.value = 1;
-        }, 100);
-      }
-    },
-    ['onGestureHandlerStateChange', 'onGestureHandlerEvent']
-  );
-
-  let bgColor;
 
   // sometimes we have to wait for shared value to be set and then read properly
   const waitingTimeout = 100;
@@ -84,43 +75,36 @@ const FastRefreshTest = () => {
     const delay = Date.now() - startCounting;
     if (delay > waitingTimeout) {
       console.log('timeout exceeded waiting for shared value: ' + delay);
-      bgColor = 'red';
       break;
     }
   }
 
-  if (bgColor === undefined) {
-    bgColor =
-      state === derived.value &&
-      state === shared.value &&
-      state !== derivedNotListening.value
-        ? 'green'
-        : 'red';
-  }
-
   return (
     <View>
-      <Text>
-        Press the button or try to drag the box on the bottom to do testing
-      </Text>
+      <Text>Press the button to do testing</Text>
       <Button title="change state" onPress={update} />
-      <Text style={{ padding: 10, backgroundColor: bgColor }}>
-        Those should be the same: {state}/{derived.value}/{shared.value} but not
-        this one: {derivedNotListening.value}
-      </Text>
+      <Button
+        title="check derived values"
+        onPress={() => {
+          if (derived.value === state) {
+            testResult.value = 1;
+          } else {
+            testResult.value = 0;
+          }
+        }}
+      />
+      <Text>This box should be green after pressing checking button</Text>
+      <Animated.View
+        style={[{ width: 100, height: 20, backgroundColor: 'gray' }, resultUas]}
+      />
       <Text>The lengths of the following containers should be the same</Text>
       <Animated.View style={[styles.box, uasShared]} />
-      <Animated.View style={[styles.box, uasListening]} />
+      <Animated.View style={[styles.box, uasListeningOne]} />
+      <Animated.View style={[styles.box, uasListeningAll]} />
       <Text>This should alternate(long/short) on button press</Text>
       <Child expanded={expanded} />
       <Text>But this should not update</Text>
       <Animated.View style={[styles.box, uasNotListening]} />
-      <Text>Event test, try to drag the box below to trigger changes</Text>
-      <PanGestureHandler onGestureEvent={eventHandler}>
-        <Animated.View
-          style={[{ backgroundColor: 'green', width: 100, height: 100 }]}
-        />
-      </PanGestureHandler>
     </View>
   );
 };

--- a/Example/test/TestApp.js
+++ b/Example/test/TestApp.js
@@ -29,20 +29,20 @@ const SCREENS = {
 };
 
 function MainScreen({ navigation }) {
-  const data = Object.keys(SCREENS).map(key => ({ key }));
+  const data = Object.keys(SCREENS).map((key) => ({ key }));
   return (
     <FlatList
       style={styles.list}
       data={data}
       ItemSeparatorComponent={ItemSeparator}
-      renderItem={props => (
+      renderItem={(props) => (
         <MainScreenItem
           {...props}
           screens={SCREENS}
           onPressItem={({ key }) => navigation.navigate(key)}
         />
       )}
-      renderScrollComponent={props => <ScrollView {...props} />}
+      renderScrollComponent={(props) => <ScrollView {...props} />}
     />
   );
 }
@@ -67,8 +67,8 @@ const TestApp = createSwitchNavigator({
 });
 
 const createApp = Platform.select({
-  web: input => createBrowserApp(input, { history: 'hash' }),
-  default: input => createAppContainer(input),
+  web: (input) => createBrowserApp(input, { history: 'hash' }),
+  default: (input) => createAppContainer(input),
 });
 
 export default createApp(TestApp);

--- a/Example/test/TestApp.js
+++ b/Example/test/TestApp.js
@@ -9,6 +9,7 @@ import { styles, ItemSeparator, MainScreenItem } from '../src/App';
 
 import SimpleTest from './SimpleTest';
 import MeasureTest from './MeasureTest';
+import FastRefreshTest from './FastRefreshTest';
 
 YellowBox.ignoreWarnings(['Calling `getNode()`']);
 
@@ -21,23 +22,27 @@ const SCREENS = {
     screen: MeasureTest,
     title: '🆕 Measure test',
   },
+  FastRefreshTest: {
+    screen: FastRefreshTest,
+    title: '🆕 Fast refresh test',
+  },
 };
 
 function MainScreen({ navigation }) {
-  const data = Object.keys(SCREENS).map((key) => ({ key }));
+  const data = Object.keys(SCREENS).map(key => ({ key }));
   return (
     <FlatList
       style={styles.list}
       data={data}
       ItemSeparatorComponent={ItemSeparator}
-      renderItem={(props) => (
+      renderItem={props => (
         <MainScreenItem
           {...props}
           screens={SCREENS}
           onPressItem={({ key }) => navigation.navigate(key)}
         />
       )}
-      renderScrollComponent={(props) => <ScrollView {...props} />}
+      renderScrollComponent={props => <ScrollView {...props} />}
     />
   );
 }
@@ -62,8 +67,8 @@ const TestApp = createSwitchNavigator({
 });
 
 const createApp = Platform.select({
-  web: (input) => createBrowserApp(input, { history: 'hash' }),
-  default: (input) => createAppContainer(input),
+  web: input => createBrowserApp(input, { history: 'hash' }),
+  default: input => createAppContainer(input),
 });
 
 export default createApp(TestApp);

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -256,14 +256,10 @@ function styleUpdater(viewTag, updater, state) {
   }
 }
 
-export function useAnimatedStyle(updater, dependencies = []) {
+export function useAnimatedStyle(updater, dependencies) {
   const viewTag = useSharedValue(-1);
 
   const initRef = useRef(null);
-
-  if (dependencies === null) {
-    dependencies = undefined;
-  }
   /**
    * create(or recreate) the object if
    *  it has not been created yet
@@ -321,12 +317,9 @@ export function useAnimatedStyle(updater, dependencies = []) {
 // when you need styles to animated you should always use useAS
 export const useAnimatedProps = useAnimatedStyle;
 
-export function useDerivedValue(processor, dependencies = []) {
+export function useDerivedValue(processor, dependencies) {
   const initRef = useRef(null);
 
-  if (dependencies === null) {
-    dependencies = undefined;
-  }
   /**
    * create(or recreate) the object if
    *  it has not been created yet

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -261,10 +261,13 @@ export function useAnimatedStyle(updater, dependencies = []) {
 
   const initRef = useRef(null);
 
+  if (dependencies === null) {
+    dependencies = undefined;
+  }
   /**
    * create(or recreate) the object if
    *  it has not been created yet
-   *  any provided dependencies changes(or there have not been any provided which is equal to listen to any change)
+   *  any provided dependencies changed(or there have not been any provided which is equal to listen to any change)
    *  worklet hash changed(which means worklet body changed)
    */
   if (
@@ -321,10 +324,13 @@ export const useAnimatedProps = useAnimatedStyle;
 export function useDerivedValue(processor, dependencies = []) {
   const initRef = useRef(null);
 
+  if (dependencies === null) {
+    dependencies = undefined;
+  }
   /**
    * create(or recreate) the object if
    *  it has not been created yet
-   *  any provided dependencies changes(or there have not been any provided which is equal to listen to any change)
+   *  any provided dependencies changed(or there have not been any provided which is equal to listen to any change)
    *  worklet hash changed(which means worklet body changed)
    */
   if (

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -33,12 +33,10 @@ export function useMapper(fun, inputs = [], outputs = [], dependencies = []) {
 export function useEvent(handler, eventNames = []) {
   const initRef = useRef(null);
   if (initRef.current === null) {
-    initRef.current = {
-      worklet: new WorkletEventHandler(handler, eventNames),
-    };
+    initRef.current = new WorkletEventHandler(handler, eventNames);
   }
 
-  return initRef.current.worklet;
+  return initRef.current;
 }
 
 function prepareAnimation(animatedProp, lastAnimation, lastValue) {
@@ -73,12 +71,12 @@ function prepareAnimation(animatedProp, lastAnimation, lastValue) {
         }
       }
 
-      animation.callStart = timestamp => {
+      animation.callStart = (timestamp) => {
         animation.start(animation, value, timestamp, lastAnimation);
       };
     } else if (typeof animatedProp === 'object') {
       // it is an object
-      Object.keys(animatedProp).forEach(key =>
+      Object.keys(animatedProp).forEach((key) =>
         prepareAnimation(
           animatedProp[key],
           lastAnimation && lastAnimation[key],
@@ -119,7 +117,7 @@ function runAnimations(animation, timestamp, key, result) {
     } else if (typeof animation === 'object') {
       result[key] = {};
       let allFinished = true;
-      Object.keys(animation).forEach(k => {
+      Object.keys(animation).forEach((k) => {
         if (!runAnimations(animation[k], timestamp, k, result[key])) {
           allFinished = false;
         }
@@ -144,7 +142,7 @@ function isAnimated(prop) {
       if (prop.animation) {
         return true;
       }
-      return Object.keys(prop).some(key => isAnimated(prop[key]));
+      return Object.keys(prop).some((key) => isAnimated(prop[key]));
     }
     return false;
   }
@@ -154,12 +152,12 @@ function isAnimated(prop) {
 function styleDiff(oldStyle, newStyle) {
   'worklet';
   const diff = {};
-  Object.keys(oldStyle).forEach(key => {
+  Object.keys(oldStyle).forEach((key) => {
     if (newStyle[key] === undefined) {
       diff[key] = null;
     }
   });
-  Object.keys(newStyle).forEach(key => {
+  Object.keys(newStyle).forEach((key) => {
     const value = newStyle[key];
     const oldValue = oldStyle[key];
 
@@ -187,13 +185,13 @@ function styleUpdater(viewTag, updater, state) {
 
   // extract animated props
   let hasAnimations = false;
-  Object.keys(animations).forEach(key => {
+  Object.keys(animations).forEach((key) => {
     const value = newValues[key];
     if (!isAnimated(value)) {
       delete animations[key];
     }
   });
-  Object.keys(newValues).forEach(key => {
+  Object.keys(newValues).forEach((key) => {
     const value = newValues[key];
     if (isAnimated(value)) {
       prepareAnimation(value, animations[key], oldValues[key]);
@@ -211,7 +209,7 @@ function styleUpdater(viewTag, updater, state) {
 
     const updates = {};
     let allFinished = true;
-    Object.keys(animations).forEach(propName => {
+    Object.keys(animations).forEach((propName) => {
       const finished = runAnimations(
         animations[propName],
         timestamp,
@@ -367,7 +365,7 @@ export function useAnimatedGestureHandler(handlers) {
   const { context } = initRef.current;
 
   return useEvent(
-    event => {
+    (event) => {
       'worklet';
       const FAILED = 1;
       const BEGAN = 2;
@@ -429,7 +427,7 @@ export function useAnimatedScrollHandler(handlers) {
     subscribeForEvents.push('onMomentumScrollEnd');
   }
 
-  return useEvent(event => {
+  return useEvent((event) => {
     'worklet';
     const {
       onScroll,


### PR DESCRIPTION
## Description

This is supposed to provide a proper way to handle React Native's [Fast refresh](https://reactnative.dev/docs/fast-refresh) and also rerender of a component containing certain animations.

## Problem 🦯 

On component rerender all of the worklets which are included into that component are not rebuilt. This introduces following problems:
1. If someone changes worklet's body it will not be updated using React Native's [Fast refresh](https://reactnative.dev/docs/fast-refresh)
2. When worklet uses component's state and this state changes(causing rerender) that worklet will use outdated state value
<details>
<summary>ad. 2 example</summary>

``` JS
const Comp = () => {
  const [state, setState] = useState(0)
  const udv = useDerivedValue(() => {
    return state
  })
  return (
    <>
      <Button title="press" onPress={ () => {
        setState(state + 1)
      } } />
      <Text>Value(will not update): { udv.value }</Text>
    </>
  )
}
```
</details>

## Solutions

### Solution 1 👎 

As a first solution we came up with an idea of rebuilding everything on every hook call considering:
- `useSharedValue`
- `useAnimatedStyle`
- `useDerivedValue`

However after running some performance tests we noticed that `useSharedValue`'s performance has not changed that much but as for the other mentioned hooks they have slowed significantly. That led us to another solution.

### Solution 2 👍 

This is what is presented in this PR.
Shared value is reconstructed in `useSharedValue` when:
- it has not been created yet
- the hook is called with a different init value than in the previous render

`useAnimatedStyle` and `useDerivedValue` act different(but in the same manner as each other). They receive an array of dependencies like `useEffect` hook. The worklet inside is being reconstructed in following cases:
- it has not been created yet(this is first hook call)
- any provided dependencies changed(or there have not been any provided which is equal to listen to any change - for now `null` has to be passed, default is `[]`)
- worklet hash changed(which means worklet body changed)

### Changes

In `Hooks.js` three hooks has been modified as described above.
`FastRefreshTest.js` a testing screen has been added to check some of the most common use cases.
