### PR TITLE
Make cancel animation work from JS thread.

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -32,14 +32,10 @@ function defineAnimation(starting, factory) {
   return factory;
 }
 
-export function cancelAnimation(value) {
+export function cancelAnimation(sharedValue) {
   'worklet';
-  // TODO: this is supported only when run on UI – maybe assert?
-  const previousAnimation = value._animation;
-  if (previousAnimation) {
-    previousAnimation.cancelled = true;
-    value._animation = null;
-  }
+  // setting the current value cancels the animation if one is currently running
+  sharedValue.value = sharedValue.value; // eslint-disable-line no-self-assign
 }
 
 export function withTiming(toValue, userConfig, callback) {


### PR DESCRIPTION
## Description

Update implementation of `cancelAnimation` to make it work from both UI and JS threads. Before this change, cancelling animation would only work from UI thread. Now, we use a simple trick of assigning the current (static) value to the shared value which results in the animation being cancelled.

## Changes

This PR updates the implementation of `cancelAniamtion` to make the provided sharedValue reassign its `.value` prop to its current `.value`. This results in the animation (if it is running on the shared value) to stop at the current point. This change isn't ideal as it may have a side-effect of triggering mappers that depend on the provided value. The previous implementation wouldn't trigger mapper updates as it wasn't modifying the `.value` prop but only some underlying animation-related data kept in the shared value object. I think, however, this side-effect shouldn't be critical and we don't really have enough usecases for `cancelAnimation` to be able to tell if this causes any problems.

## Testing

I tested this by extending the number of loops in WobbleExample to `70`. Then I added a button that'd call `cancelAnimation` on `rotation` SV. I also tried wrapping that call with `runOnUI` to verify it works on both threads.