### PR TITLE
Fix key warning in tabbar

### DIFF
--- a/Example/src/AnimatedTabBarExample.js
+++ b/Example/src/AnimatedTabBarExample.js
@@ -185,6 +185,7 @@ const Bar = () => {
             activeIndex={activeIndex}
             item={tab.item}
             width={tabWidth}
+            key={`fg-${index}`}
           />
         ))}
         <Svg width={tabWidth * 2} height={64}>
@@ -201,6 +202,7 @@ const Bar = () => {
             width={tabWidth}
             indicatorPosition={indicatorPosition}
             position={position}
+            key={`bg-${index}`}
           />
         );
       })}


### PR DESCRIPTION
## Description

fixes React's warning `Warning: Each child in a list should have a unique "key” prop` by adding keys in `map` function calls
