### PR TITLE
Fix color processing on the JS thread

### DIFF
--- a/src/reanimated2/Colors.js
+++ b/src/reanimated2/Colors.js
@@ -1,3 +1,4 @@
+/* global _WORKLET */
 /**
  * Copied from:
  * react-native/Libraries/StyleSheet/normalizeColor.js
@@ -18,10 +19,15 @@ function call(...args) {
   return '\\(\\s*(' + args.join(')\\s*,\\s*(') + ')\\s*\\)';
 }
 
-const cachedMatchers = makeRemote({});
+// matchers use RegExp objects which needs to be created separately on JS and on
+// the UI thread. We keep separate cache of Regexes for UI and JS using the below
+// objects, then pick the right cache in getMatchers() method.
+const jsCachedMatchers = {};
+const uiCachedMatchers = makeRemote({});
 
 function getMatchers() {
   'worklet';
+  const cachedMatchers = _WORKLET ? uiCachedMatchers : jsCachedMatchers;
   if (cachedMatchers.rgb === undefined) {
     cachedMatchers.rgb = new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER));
     cachedMatchers.rgba = new RegExp(


### PR DESCRIPTION
This PR fixes a problem with processColor method crashing when executed on the JS thread.

The reason for the crash was that the cached object containing matches wasn't initialized on the JS thread but only on the UI thread. We used RemoteObject for that purpose, as we needed to make sure that RegEx instances we put in that object are constructed in the right VM (those objects cannot be simply moved between UI and JS). In order for matchers to be available on the JS thread, we also need to have them instantiated on the JS thread.

This PR changes the matchers caching logic such that we select the correct cache with matchers depending on the thread we run in, and we also instantiate the matchers on both JS and UI threads in order to cache them in the correct cache.

### Testing

I tested this by importing and calling `processColor` directly in `useAnimatedStyle` in one of the examples. Before we were getting a crash (undefined is not an object) on the initial run that executes on the JS thread. Now it runs ok on both UI and JS threads.