### PR TITLE
Fix setting values inside procs

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ParamNode.java
@@ -22,6 +22,7 @@ public class ParamNode extends ValueNode {
     mUpdateContext.callID = mPrevCallID;
     ((ValueNode) node).setValue(value);
     mUpdateContext.callID = callID;
+    forceUpdateMemoizedValue(value);
   }
 
   public void beginContext(Integer ref, String prevCallID) {

--- a/ios/Nodes/REAParamNode.m
+++ b/ios/Nodes/REAParamNode.m
@@ -23,6 +23,7 @@
   self.updateContext.callID = _prevCallID;
   [(REAValueNode*)node setValue:value];
   self.updateContext.callID = callID;
+  [self forceUpdateMemoizedValue:value];
 }
 
 - (void)beginContext:(NSNumber*) ref


### PR DESCRIPTION
## Description

Fixes #809.
Fixes #789.
Fixes #594.

The current implementation of procs creates proxies for every parameter used (which can be any animated node).

Those proxies hold a ref to the params as nodes, forwarding every method which can be used on them (`setValue()` for Values, `start()` and `stop()` for clocks, etc). When proc is called, a context for every param is created (which allows using procs in procs (in particular creating recursive functions)). Those contexts are used for memoization to ensure we don't reevaluate nodes that were calculated previously. 

The problem was in updating this memoized value when using `AnimatedParam.setValue()` - it only updated the value of the underlying node and left `AnimateParam` value unchanged. It's updated in current call ID in opposition to Value which is updated in previous call ID. This ensures that nodes that rely on Value will be updated appropriately. 

Only `AnimatedCallFunction` depends on `AnimatedParam`, so we can update it in the current context which will ensure that the next node evaluated in function will use the updated value of AnimatedValue.


## Example

```js
import Animated from 'react-native-reanimated';

const {Value, block, proc, set, useCode, debug, add} = Animated;

const testProc = proc((a, b) =>
  block([
    set(b, a),
    debug('in proc, b:', b), // should be 1
    set(a, add(b, 2)),
    debug('in proc, a', a), // should be 3, it's 1
  ]),
);

const Example = () => {
  const a = new Value(1);
  const b = new Value(10);

  useCode(
    () => [
      debug('before proc, a:', a),
      debug('before proc, b:', b),
      testProc(a, b),
      debug('after proc, a:', a),
      debug('after proc, b:', b),
    ],
    [],
  );

  return null;
};

export default Example;
```