### PR TITLE
Make diffClamp non-proc'ed

### DIFF
--- a/src/derived/diffClamp.js
+++ b/src/derived/diffClamp.js
@@ -1,15 +1,11 @@
-import { cond, defined, set, add, proc, min, max } from '../base';
+import { cond, defined, set, add, min, max } from '../base';
 import AnimatedValue from '../core/InternalAnimatedValue';
 import diff from './diff';
 
-const procAcc = proc(function(a, minVal, maxVal, value) {
+export default function diffClamp(a, minVal, maxVal) {
+  const value = new AnimatedValue();
   return set(
     value,
     min(max(add(cond(defined(value), value, a), diff(a)), minVal), maxVal)
   );
-});
-
-export default function diffClamp(a, minVal, maxVal) {
-  const value = new AnimatedValue();
-  return procAcc(a, minVal, maxVal, value);
 }


### PR DESCRIPTION
## Description

Fixes #570.
Fixes #767.

Creating procs of stateful functions (like diff or diffClamp) make them effectively a singleton, which means that every instance of it shares nodes (Value nodes in particular). 

In Reanimated most of derived nodes are proc'ed and stateful ones are `diff()`, `diffClamp()`, `acc()` and `onChange()`. We export those as plain JS functions, creating state out of proc'ed functions. This works because every use of them creates a new, non-shared state. When one of those functions is used in proc context, they're created once – they share state.
 
The example below shows this behavior.

## Example

```js
import Animated from 'react-native-reanimated';
const {Value, block, proc, set, useCode, debug, add} = Animated;

const procStateful = proc(x => {
  const state = new Value(0.5);
  return block([set(state, add(state, x)), state]);
});

const Example = () => {
  const a = new Value(2);
  const b = new Value(4);

  const call_1 = procStateful(a);
  const call_2 = procStateful(b);

  useCode(
    () => [
      /* should print 2+0.5=2.5 */
      debug('PROC 1', call_1),
      /* should print 4+0.5=4.5, prints 4+2.5 (prev state) = 6.5 */
      debug('PROC 2', call_2),
    ],
    [],
  );

  return null;
};

export default Example;
```