### PR TITLE
Check if node is initialized when detaching

### DIFF
--- a/src/animations/backwardCompatibleAnimWrapper.js
+++ b/src/animations/backwardCompatibleAnimWrapper.js
@@ -73,7 +73,7 @@ function createOldAnimationObject(node, AnimationClass, value, config) {
     __detach: () => {
       animationCallback && animationCallback({ finished: isDone });
       animationCallback = null;
-      alwaysNode.__removeChild(value);
+      value.__initialized && alwaysNode.__removeChild(value);
     },
     stop: () => {
       if (isDone) {


### PR DESCRIPTION
Fixes #899.

## Description

When using backward compatible API to animate unmount of component it showed "Error: Trying to remove a child that doesn't exist" error. This was happening because by the time animation wrapper called `__detach()` on passed value, the Animated component would detach it by `componentWillUnmount()` lifecycle method (detaching styles when the component unmounts). This change checks for if Value is still initialized natively and only then calls `__removeChild(value)`.

## Example:
```jsx
import React, {useState} from 'react';
import {SafeAreaView, Button} from 'react-native';
import Animated, {timing, Value, Easing} from 'react-native-reanimated';

export default function Example() {
  const [showRect, setShowRect] = useState(true);

  const opacity = new Value(1);
  const t = () =>
    timing(opacity, {
      duration: 300,
      toValue: 0,
      easing: Easing.linear,
    }).start(() => {
      setShowRect(false);
    });

  return (
    <SafeAreaView style={{alignItems: 'center'}}>
      <Button onPress={t} title="Opacity" />
      {showRect && (
        <Animated.View
          style={{width: 100, height: 100, backgroundColor: 'green', opacity}}
        />
      )}
    </SafeAreaView>
  );
}
```
