### PR TITLE
Use native measure in lightbox example

### DIFF
--- a/Example/src/LightboxExample.js
+++ b/Example/src/LightboxExample.js
@@ -109,21 +109,16 @@ function ImageTransition({ activeImage, onClose }) {
   );
   const x = useSharedValue(0);
   const y = useSharedValue(0);
-  const isMeasured = useSharedValue(false);
 
   function measureStuff() {
     'worklet';
 
-    if (isMeasured.value) {
-      return;
-    }
+    const measurements = measure(animatedRef);
 
-    const m = measure(animatedRef);
-
-    width.value = m.width;
-    height.value = m.height;
-    x.value = m.pageX;
-    y.value = m.pageY - HEADER_HEIGHT;
+    width.value = measurements.width;
+    height.value = measurements.height;
+    x.value = measurements.pageX;
+    y.value = measurements.pageY - HEADER_HEIGHT;
   }
 
   const translateX = useSharedValue(0);

--- a/Example/src/LightboxExample.js
+++ b/Example/src/LightboxExample.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -16,7 +16,6 @@ import {
   ScrollView,
   PanGestureHandler,
   TouchableWithoutFeedback,
-  TapGestureHandler,
 } from 'react-native-gesture-handler';
 import { Header } from 'react-navigation-stack';
 

--- a/Example/src/LightboxExample.js
+++ b/Example/src/LightboxExample.js
@@ -107,7 +107,7 @@ function ListItem({ item, index, onPress }) {
 }
 
 const timingConfig = {
-  duration: 350,
+  duration: 240,
   easing: Easing.bezier(0.33, 0.01, 0, 1),
 };
 
@@ -163,12 +163,13 @@ function ImageTransition({ activeImage, onClose }) {
         translateY.value = 0;
 
         animationProgress.value = withTiming(0, timingConfig, () => {
-          imageOpacity.value = 1;
-
-          // fixes flickering
-          setTimeout(() => {
-            onClose();
-          }, 16);
+          imageOpacity.value = withTiming(
+            1,
+            {
+              duration: 16,
+            },
+            onClose
+          );
         });
 
         backdropOpacity.value = withTiming(0, timingConfig);


### PR DESCRIPTION
## Description

The react-native-reanimated@alpha.5 release introduced measure function in the worklet. Previously we used RN's async measure for that. Now we can measure things just before the actual animation. This change helps us to run the animation 10-25ms faster on my Pixel 3.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

- Migrate lightbox example to native measure

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
