### PR TITLE
Fix events dispatching for TapGestureHandler

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -335,7 +335,7 @@ export function useAnimatedGestureHandler(handlers) {
       const ACTIVE = 4;
       const END = 5;
 
-      if (event.oldState === UNDETERMINED && handlers.onStart) {
+      if ((event.oldState === UNDETERMINED || event.oldState === END) && handlers.onStart) {
         handlers.onStart(event, context);
       }
       if (event.state === ACTIVE && handlers.onActive) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -331,6 +331,7 @@ export function useAnimatedGestureHandler(handlers) {
       'worklet';
       const UNDETERMINED = 0;
       const FAILED = 1;
+      const BEGAN = 2;
       const CANCELLED = 3;
       const ACTIVE = 4;
       const END = 5;
@@ -348,7 +349,7 @@ export function useAnimatedGestureHandler(handlers) {
         handlers.onEnd(event, context);
       }
       if (
-        event.oldState === ACTIVE &&
+        (event.oldState === ACTIVE || event.oldState === BEGAN) &&
         event.state === FAILED &&
         handlers.onFail
       ) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -335,7 +335,10 @@ export function useAnimatedGestureHandler(handlers) {
       const ACTIVE = 4;
       const END = 5;
 
-      if ((event.oldState === UNDETERMINED || event.oldState === END) && handlers.onStart) {
+      if (
+        (event.oldState === UNDETERMINED || event.oldState === END) &&
+        handlers.onStart
+      ) {
         handlers.onStart(event, context);
       }
       if (event.state === ACTIVE && handlers.onActive) {


### PR DESCRIPTION
## Description

I observed that `onStart` is called only once and then is not being invoked again. Following my understanding of RNGH's state machine, `TapGestureHandler` finishes gesture with `END` state and is not coming back to `UNDETERMINED`. Also, failing can happen not only from `ACTIVE`, but also `BEGAN` state.

## Changes

- Handle case when `oldState` is `END`.
- Handle case when `oldState` is `BEGAN` and the new one is `FAILED`.


