### PR TITLE
Add note to docs

### DIFF
--- a/docs/docs/api/nativeMethods/measure.md
+++ b/docs/docs/api/nativeMethods/measure.md
@@ -4,6 +4,8 @@ title: measure
 sidebar_label: measure
 ---
 
+> Due to time constraints we weren't able to finish this page.
+
 ### Arguments
 
 #### animatedRef

--- a/docs/docs/api/nativeMethods/scrollTo.md
+++ b/docs/docs/api/nativeMethods/scrollTo.md
@@ -4,6 +4,8 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
+> Due to time constraints we weren't able to finish this page.
+
 ### Arguments
 
 #### `animatedRef`


### PR DESCRIPTION
## Description

Added following note to `measure` and `scrollTo` docs:

> Due to time constraints we weren't able to finish this page.