### PR TITLE
Remove unnecessary wrapper in scroll example

### DIFF
--- a/Example/src/ScrollEventExample.js
+++ b/Example/src/ScrollEventExample.js
@@ -42,18 +42,16 @@ function ScrollExample() {
         <Animated.View style={[styles.box, stylez]} />
       </View>
       <View style={styles.half}>
-        <View style={styles.half}>
-          <Animated.ScrollView
-            style={styles.scroll}
-            scrollEventThrottle={1}
-            onScroll={scrollHandler}>
-            <View style={styles.placeholder} />
-            <View style={styles.placeholder} />
-            <View style={styles.placeholder} />
-            <View style={styles.placeholder} />
-            <View style={styles.placeholder} />
-          </Animated.ScrollView>
-        </View>
+        <Animated.ScrollView
+          style={styles.scroll}
+          scrollEventThrottle={1}
+          onScroll={scrollHandler}>
+          <View style={styles.placeholder} />
+          <View style={styles.placeholder} />
+          <View style={styles.placeholder} />
+          <View style={styles.placeholder} />
+          <View style={styles.placeholder} />
+        </Animated.ScrollView>
       </View>
     </View>
   );


### PR DESCRIPTION
## Description

One `<View style={styles.half}>` should be enough to get the job done
## Changes

Remove unnecessary wrapper clone

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
