### PR TITLE
Fix non-animated properties in `transform`

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/TransformNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/TransformNode.java
@@ -56,7 +56,7 @@ public class TransformNode extends Node {
         } else if(type == ReadableType.Array) {
           transformConfig.value = transformConfigMap.getArray("value");
         } else {
-          transformConfigMap.getDouble("value");
+          transformConfig.value = transformConfigMap.getDouble("value");
         }
         configs.add(transformConfig);
       }


### PR DESCRIPTION
## Description

After changing original nested ternary in #538 to if-else chain double case didn't have an assignment, so it was crashing with a null value for transform style error.

## Example

```jsx
import React from 'react';
import {SafeAreaView, Text} from 'react-native';
import Animated from 'react-native-reanimated';

const App = () => {
  return (
    <SafeAreaView>
      <Animated.View
        style={{
          transform: [{translateX: 100.2}],
        }}>
        <Text>Test </Text>
      </Animated.View>
    </SafeAreaView>
  );
};

export default App;
```