### PR TITLE
Revert "Update deprecated use of `GuardedRunnable`"

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -168,7 +168,8 @@ public class NodesManager implements EventDispatcherListener {
       final Queue<NativeUpdateOperation> copiedOperationsQueue = mOperationsInBatch;
       mOperationsInBatch = new LinkedList<>();
       mContext.runOnNativeModulesQueueThread(
-              new GuardedRunnable(mContext.getExceptionHandler()) {
+              // FIXME replace `mContext` with `mContext.getExceptionHandler()` after RN 0.59 support is dropped
+              new GuardedRunnable(mContext) {
                 @Override
                 public void runGuarded() {
                   boolean shouldDispatchUpdates = UIManagerReanimatedHelper.isOperationQueueEmpty(mUIImplementation);


### PR DESCRIPTION
## Description

This change breaks projects using Reanimated with RN 0.59 where the second overload of the `GuardedRunnable` c-tor didn't exist. Reverting this ensures backward compatibility.