### PR TITLE
Fix app freezing when calling scrollTo inside onScroll

### DIFF
--- a/ios/native/RENativeMethods.mm
+++ b/ios/native/RENativeMethods.mm
@@ -34,8 +34,13 @@ std::vector<std::pair<std::string,double>> measure(int viewTag, RCTUIManager *ui
 }
 
 
+NSString *eventDispatcherKey = @"eventDispatcher";
 void scrollTo(int scrollViewTag, RCTUIManager *uiManager, double x, double y, bool animated) {
   UIView *view = [uiManager viewForReactTag:@(scrollViewTag)];
   RCTScrollView *scrollView = (RCTScrollView *) view;
+  RCTEventDispatcher* oldEventDispatcher = [scrollView valueForKey:eventDispatcherKey];
+  [scrollView setValue:nil forKey:eventDispatcherKey];
   [scrollView scrollToOffset:(CGPoint){(CGFloat)x, (CGFloat)y} animated:animated];
+  [scrollView setValue:oldEventDispatcher forKey:eventDispatcherKey];
 }
+

--- a/ios/native/RENativeMethods.mm
+++ b/ios/native/RENativeMethods.mm
@@ -43,4 +43,3 @@ void scrollTo(int scrollViewTag, RCTUIManager *uiManager, double x, double y, bo
   [scrollView scrollToOffset:(CGPoint){(CGFloat)x, (CGFloat)y} animated:animated];
   [scrollView setValue:oldEventDispatcher forKey:eventDispatcherKey];
 }
-


### PR DESCRIPTION
## Description

The issue has been described here https://github.com/software-mansion/react-native-reanimated/issues/1108

The problem happens when we call `scrollTo` inside `onScroll` worklet.

Inside iOS implementation we call synchronously `scrollToOffset` with on `RCTScrollView` 
https://github.com/software-mansion/react-native-reanimated/blob/master/ios/native/RENativeMethods.mm#L40

Then the scroll actually happens emitting `onScroll` event at the same time:

https://github.com/facebook/react-native/blob/fcb667059d3156327c141eadeed7f3cb771d8f79/React/Views/ScrollView/RCTScrollView.m#L1037

Then it calls a method in the event emitter https://github.com/facebook/react-native/blob/ffdfbbec08b1afb1970d2cfe75a78a203d4a79a4/React/Base/RCTEventDispatcher.m#L134

However, this line of code has been already called because our `onScroll` worklet is set as a callback of a scroll event. So technically we're making a recurrence call here and executor stays on mutex here:
https://github.com/facebook/react-native/blob/ffdfbbec08b1afb1970d2cfe75a78a203d4a79a4/React/Base/RCTEventDispatcher.m#L131


Breaking example https://gist.github.com/osdnk/5c621873cf816e251b42debda2515b07


## Changes

Before calling `scrollTo` I remove event emitter for a while to omit a redundant emitting of event. Then we restore it after execution. Then https://github.com/facebook/react-native/blob/fcb667059d3156327c141eadeed7f3cb771d8f79/React/Views/ScrollView/RCTScrollView.m#L1037 this line becomes no-op


