### PR TITLE
Fix `overshootClamping` in `withSpring`

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -174,7 +174,9 @@ export function withSpring(toValue, userConfig, callback) {
 
       const isOvershooting = () => {
         if (config.overshootClamping && config.stiffness !== 0) {
-          return current < toValue ? animation.current > toValue : animation.current < toValue;
+          return current < toValue
+            ? animation.current > toValue
+            : animation.current < toValue;
         } else {
           return false;
         }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -174,7 +174,7 @@ export function withSpring(toValue, userConfig, callback) {
 
       const isOvershooting = () => {
         if (config.overshootClamping && config.stiffness !== 0) {
-          return current > toValue;
+          return current < toValue ? animation.current > toValue : animation.current < toValue;
         } else {
           return false;
         }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -174,7 +174,7 @@ export function withSpring(toValue, userConfig, callback) {
 
       const isOvershooting = () => {
         if (config.overshootClamping && config.stiffness !== 0) {
-          return current < toValue ? current > toValue : current < toValue;
+          return current > toValue;
         } else {
           return false;
         }


### PR DESCRIPTION
I cannot get overshootClamping to work in v2 and it seems to be because of this condition no? I couldn't make sense of it from a logical perspective. My apologies with I missed something.