### PR TITLE
Fix event handling for reanimated v1

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/CopyingEventEmitter.java
+++ b/android/src/main/java/com/swmansion/reanimated/CopyingEventEmitter.java
@@ -1,0 +1,52 @@
+package com.swmansion.reanimated;
+
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+
+/* package */ class CopyingEventEmitter implements RCTEventEmitter {
+
+    private class CopiedEvent extends Event<CopiedEvent> {
+        String mEventName;
+        WritableMap mEventData;
+
+        private void init(int viewTag, String eventName, @Nullable WritableMap eventData) {
+            super.init(viewTag);
+            mEventName = eventName;
+            mEventData = eventData == null ? null : eventData.copy();
+        }
+
+        @Override
+        public String getEventName() {
+            return mEventName;
+        }
+
+        @Override
+        public void dispatch(RCTEventEmitter rctEventEmitter) {
+            rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEventData);
+        }
+    }
+
+    Event mEvent;
+
+    public synchronized Event copyEvent(Event event) {
+        event.dispatch(this);
+        return mEvent;
+    }
+
+    @Override
+    public void receiveEvent(int targetTag, String eventName, @Nullable WritableMap eventData) {
+        CopiedEvent event = new CopiedEvent();
+        event.init(targetTag, eventName, eventData);
+        mEvent = event;
+    }
+
+    @Override
+    public void receiveTouches(String eventName, WritableArray touches, WritableArray changedIndices) {
+        throw new RuntimeException("receiveTouches is not supported by animated events");
+    }
+}

--- a/android/src/main/java/com/swmansion/reanimated/nodes/EventNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/EventNode.java
@@ -74,7 +74,7 @@ public class EventNode extends Node implements RCTEventEmitter {
 
   @Override
   public void receiveTouches(String eventName, WritableArray touches, WritableArray changedIndices) {
-    throw new RuntimeException("receiveTouches is not support by animated events");
+    throw new RuntimeException("receiveTouches is not supported by animated events");
   }
 
   @Override


### PR DESCRIPTION
## Description

Previously, we were handling dispatched events like so:
```java
@Override
 public void onEventDispatch(Event event) {
   if (UiThreadUtil.isOnUiThread()) {
     handleEvent(event);
   } else {
     mEventQueue.offer(event);
     startUpdatingOnAnimationFrame();
    }
  }
```

Event handling in RN works by utilizing `EventDispatcher.dispatchEvent(event)` which
1. runs `onEventDispatch` callback on any registered listener
2. adds `event` to internal event queue
3. adds frame callback which dispatches and disposes events on JS thread

This approach introduced timing issues - RN's `EventDispatcher` dispatches events on JS thread and Reanimated handles events on UI thread. There's a possibility that `EventDispatcher` will dispose event (possibly destroying it's state in `onDispose()`) before Reanimated would have chance to handle it.
This was found after investigating [pretty popular crash in react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler/pull/1171).

This PR fixes event handling for Reanimated 1 by copying events that we're subscribed to via event nodes. It's done by creating an intermediate class implementing `RCTEventEmitter` which receives event data and creates new events with old data.


## Changes

- created `CopyingEventEmitter` which copies events by creating new events with almost the same data
- added logic for copied events disposal in `handleEvent()`
- extracted logic creating internal event nodes tags to `getEventNodeTag()`

## Caveats

We can't copy events directly, because `Event`'s isn't exposed. We do it by using `Event.init(viewTag)` method which will change the event's timestamp and `mInitialized` field.

Event timestamp is used in event coalescing. Changing it would theoretically prevent copied events from being coalesced if we detach event listener while the stream of events is dispatched. We actually don't use this functionality right now (events coalescing is done after `onEventDispatch` callback had run, to utilize it we would have to change RN core or implement our own coalescing logic) and it doesn't seem like a big problem as event coalescing was primarily introduced to reduce the load in the JS thread.