### PR TITLE
Add callback parameter to repeat()

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -394,7 +394,7 @@ export function repeat(_nextAnimation, numberOfReps = 2, reverse = false, callba
       animation.current = nextAnimation.current;
       if (finished) {
         animation.reps += 1;
-        callback();
+        callback(animation.current);
         if (numberOfReps > 0 && animation.reps >= numberOfReps) {
           return true;
         }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -381,7 +381,7 @@ export function sequence(..._animations) {
   });
 }
 
-export function repeat(_nextAnimation, numberOfReps = 2, reverse = false) {
+export function repeat(_nextAnimation, numberOfReps = 2, reverse = false, callback = () => {}) {
   'worklet';
   return defineAnimation(_nextAnimation, () => {
     'worklet';
@@ -394,6 +394,7 @@ export function repeat(_nextAnimation, numberOfReps = 2, reverse = false) {
       animation.current = nextAnimation.current;
       if (finished) {
         animation.reps += 1;
+        callback();
         if (numberOfReps > 0 && animation.reps >= numberOfReps) {
           return true;
         }


### PR DESCRIPTION
I use this extra parameter so that when I'm "pausing" the loop, I can remember in which direction it was going. The direction is updated at the end of each iteration via callback().

```ts
repeat(
    withTiming(1 - dest.value, {
        duration: 1000,
         easing,
     }),
     -1,
      true,
      () => (dest.value = 1 - dest.value)
)
```