### PR TITLE
Add callbacks for animations

### DIFF
--- a/docs/docs/api/repeat.md
+++ b/docs/docs/api/repeat.md
@@ -29,11 +29,6 @@ The option is not supported for animation wrapped using other animation modifier
 This function will be called when all repetitions of provided animation are complete or when `repeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
-#### `stepCallback` [function](optional)
-
-This function will be called after each repetition step of the provided animation.
-As an argument it will receive the current value of the animation that is being repeated.
-
 ### Returns
 
 This method returns an animation object. It can be either assigned directly to a Shared Value or can be used as a value for a style object returned from [`useAnimatedStyle`](useAnimatedStyle).
@@ -49,11 +44,22 @@ sharedValue.value = repeat(withTiming(70), 2, true)
 One more example with the callbacks
 
 ```js
-sharedValue.value = repeat(withTiming(70), 10, true, (finished) => {
-    const resultStr = (finished) ? 'All repeats are completed' : 'repeat cancelled';
-    console.log(resultStr);
-}, (currentValue) => {
-    console.log('current repeat value is ' + currentValue);
-})
+sharedValue.value = repeat(
+    withTiming(70, undefined, (finished, currentValue) => {
+        if (finished) {
+            console.log('current repeat value is ' + currentValue);
+        } else {
+            console.log('inner animation cancelled')
+        }
+    }),
+    10,
+    true,
+    (finished) => {
+        const resultStr = (finished) ? 'All repeats are completed' : 'repeat cancelled';
+        console.log(resultStr);
+    }
+)
 ```
 
+The callback passed to the inner animation(here `withTiming`) will be called on every repeat. The first argument tells us whether the animation finished or was cancelled. The second one hold animation's current value(when the animation has been cancelled it is `undefined`). 
+The callback passed to `repeat` is called in the end when animation is finished or cancelled with `finished` set accordingly.

--- a/docs/docs/api/repeat.md
+++ b/docs/docs/api/repeat.md
@@ -24,6 +24,16 @@ When `true`, this will cause the animation to run from the current value to the 
 Note that this option will only work when the provided animation is a plain, non-modified animation like [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
 The option is not supported for animation wrapped using other animation modifiers like `delay` or `sequence`.
 
+#### `callback` [function](optional)
+
+This function will be called when all repetitions of provided animation are complete or when `repeat` is cancelled.
+In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
+
+#### `stepCallback` [function](optional)
+
+This function will be called after each repetition step of the provided animation.
+As an argument it will receive the current value of the animation that is being repeated.
+
 ### Returns
 
 This method returns an animation object. It can be either assigned directly to a Shared Value or can be used as a value for a style object returned from [`useAnimatedStyle`](useAnimatedStyle).
@@ -34,5 +44,16 @@ The provided shared value will animate from its current value to 70 using timing
 
 ```js
 sharedValue.value = repeat(withTiming(70), 2, true)
+```
+
+One more example with the callbacks
+
+```js
+sharedValue.value = repeat(withTiming(70), 10, true, (finished) => {
+    const resultStr = (finished) ? 'All repeats are completed' : 'repeat cancelled';
+    console.log(resultStr);
+}, (currentValue) => {
+    console.log('current repeat value is ' + currentValue);
+})
 ```
 

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -109,7 +109,6 @@ function runAnimations(animation, timestamp, key, result) {
       animation.timestamp = timestamp;
       if (finished) {
         animation.finished = true;
-        // TODO: also trigger callback when animation is cancelled (overwritten)
         animation.callback && animation.callback(true /* finished */);
       }
       result[key] = animation.current;
@@ -476,4 +475,3 @@ export function useAnimatedRef() {
 
   return ref.current
 }
-

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -475,3 +475,4 @@ export function useAnimatedRef() {
 
   return ref.current
 }
+

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -335,7 +335,9 @@ export function delay(delayMs, _nextAnimation) {
     }
 
     const callback = (finished) => {
-      nextAnimation.callback(finished);
+      if (nextAnimation.callback) {
+        nextAnimation.callback(finished);
+      }
     };
 
     return {
@@ -378,7 +380,9 @@ export function sequence(..._animations) {
       animation.current = currentAnim.current;
       if (finished) {
         // we want to call the callback after every single animation
-        currentAnim.callback(true /* finished */);
+        if (currentAnim.callback) {
+          currentAnim.callback(true /* finished */);
+        }
         currentAnim.finished = true;
         animation.animationIndex += 1;
         if (animation.animationIndex < animations.length) {
@@ -406,7 +410,13 @@ export function sequence(..._animations) {
   });
 }
 
-export function repeat(_nextAnimation, numberOfReps = 2, reverse = false, callback = () => {}) {
+export function repeat(
+  _nextAnimation,
+  numberOfReps = 2,
+  reverse = false,
+  callback,
+  stepCallback
+) {
   'worklet';
   return defineAnimation(_nextAnimation, () => {
     'worklet';
@@ -419,7 +429,9 @@ export function repeat(_nextAnimation, numberOfReps = 2, reverse = false, callba
       animation.current = nextAnimation.current;
       if (finished) {
         animation.reps += 1;
-        callback(animation.current);
+        if (stepCallback) {
+          stepCallback(animation.current);
+        }
         if (numberOfReps > 0 && animation.reps >= numberOfReps) {
           return true;
         }
@@ -448,6 +460,7 @@ export function repeat(_nextAnimation, numberOfReps = 2, reverse = false, callba
       start,
       reps: 0,
       current: nextAnimation.current,
+      callback,
     };
   });
 }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -334,10 +334,15 @@ export function delay(delayMs, _nextAnimation) {
       animation.previousAnimation = previousAnimation;
     }
 
+    const callback = (finished) => {
+      nextAnimation.callback(finished);
+    };
+
     return {
       animation: delay,
       start,
       current: nextAnimation.current,
+      callback,
     };
   });
 }
@@ -346,16 +351,35 @@ export function sequence(..._animations) {
   'worklet';
   return defineAnimation(_animations[0], () => {
     'worklet';
-    const animations = _animations.map((a) =>
-      typeof a === 'function' ? a() : a
-    );
+    const animations = _animations.map((a) => {
+      const result = typeof a === 'function' ? a() : a;
+      result.finished = false;
+      return result;
+    });
     const firstAnimation = animations[0];
+
+    const callback = (finished) => {
+      if (finished) {
+        // we want to call the callback after every single animation
+        // not after all of them
+        return;
+      }
+      // this is going to be called only if sequence has been cancelled
+      animations.forEach((animation) => {
+        if (typeof animation.callback === 'function' && !animation.finished) {
+          animation.callback(finished);
+        }
+      });
+    };
 
     function sequence(animation, now) {
       const currentAnim = animations[animation.animationIndex];
       const finished = currentAnim.animation(currentAnim, now);
       animation.current = currentAnim.current;
       if (finished) {
+        // we want to call the callback after every single animation
+        currentAnim.callback(true /* finished */);
+        currentAnim.finished = true;
         animation.animationIndex += 1;
         if (animation.animationIndex < animations.length) {
           const nextAnim = animations[animation.animationIndex];
@@ -377,6 +401,7 @@ export function sequence(..._animations) {
       start,
       animationIndex: 0,
       current: firstAnimation.current,
+      callback,
     };
   });
 }


### PR DESCRIPTION
## Description

Add callbacks for `delay`, `sequence` and `repeat`.
- for `delay` the callback of the inner animation's now going to be called after that animation ends(finished or being cancelled)
- for `sequence` there are two cases:
  - the sequence finishes - after every animation passed to it that animation's callback is being called
  - the sequence is being cancelled - for those animations which have not been called yet due to cancellation the callbacks are being called(with `finish = false`)
- in repeat, the callback passed to the inner animation will be called on every repeat. The first argument tells us whether the animation finished or was cancelled. The second one hold animation's current value(when the animation has been cancelled it is `undefined`). The callback passed to `repeat` is called in the end when animation is finished or cancelled with `finished` set accordingly.


This PR fixes [this issue](https://github.com/software-mansion/react-native-reanimated/issues/1057)


