### PR TITLE
Mark `WithTimingConfig` TS type fields as optional

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -381,8 +381,8 @@ declare module 'react-native-reanimated' {
 
     // reanimated2 animations                   
     export interface WithTimingConfig {
-      duration: number;
-      easing: EasingFunction;
+      duration?: number;
+      easing?: EasingFunction;
     }
     export function withTiming(
       toValue: number,


### PR DESCRIPTION
## Description

According to docs, both those values have defaults so they should be optional.

## Changes

Only changed types in types definition, no executable code is changed.

Please refer to [documentation](https://docs.swmansion.com/react-native-reanimated/docs/next/api/withTiming)
