### PR TITLE
Remove redundant call on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -120,7 +120,6 @@ public class NodesManager implements EventDispatcherListener {
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {
     mNativeProxy = new NativeProxy(reactApplicationContext);
-    mNativeProxy.prepare();
   }
 
   private final class NativeUpdateOperation {


### PR DESCRIPTION
## Description

`NativeProxy.prepare`(followed by `installJSIBindings`) is called twice one call after another. First call is in `NativeProxy` constructor and the other one is in `NodesManager.initWithContext` right after the `NativeProxy` object is created.

This PR removes one of the calls.