### PR TITLE
Use CallInvoker to fix Promises in callbacks.

### DIFF
--- a/Common/cpp/Tools/Scheduler.cpp
+++ b/Common/cpp/Tools/Scheduler.cpp
@@ -8,7 +8,7 @@ void Scheduler::scheduleOnUI(std::function<void()> job) {
 }
 
 void Scheduler::scheduleOnJS(std::function<void()> job) {
-  jsJobs.push(std::move(job));
+  jsCallInvoker_->invokeAsync(std::move(job));
 }
 
 void Scheduler::triggerUI() {
@@ -16,9 +16,8 @@ void Scheduler::triggerUI() {
   job();
 }
 
-void Scheduler::triggerJS() {
-  auto job = jsJobs.pop();
-  job();
+void Scheduler::setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker) {
+  jsCallInvoker_ = jsCallInvoker;
 }
 
 Scheduler::~Scheduler() {}

--- a/Common/cpp/headers/Tools/Scheduler.h
+++ b/Common/cpp/headers/Tools/Scheduler.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <functional>
+#include <ReactCommon/CallInvoker.h>
 
 namespace reanimated
 {
@@ -72,17 +73,16 @@ class Queue
   std::condition_variable cond_;
 };
 
-
 class Scheduler {
   public:
+    void scheduleOnJS(std::function<void()> job);
+    void setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker);
     virtual void scheduleOnUI(std::function<void()> job);
-    virtual void scheduleOnJS(std::function<void()> job);
     virtual void triggerUI();
-    virtual void triggerJS();
     virtual ~Scheduler();
-  //protected:
+  protected:
     Queue<std::function<void()>> uiJobs;
-    Queue<std::function<void()>> jsJobs;
+    std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
 };
 
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -418,6 +418,7 @@ task cleanNdkLibs(type: Exec) {
 task packageNdkLibs(dependsOn: buildReanimated, type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
+    include("**/libturbomodulejsijni.so")
     into("$projectDir/src/main/JNILibs")
 }
 

--- a/android/src/main/JNI/Android.mk
+++ b/android/src/main/JNI/Android.mk
@@ -24,9 +24,40 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH) \
 
 LOCAL_CFLAGS += -DONANDROID -fexceptions -frtti
 
-LOCAL_STATIC_LIBRARIES := libjsi 
+LOCAL_STATIC_LIBRARIES := libjsi callinvokerholder
 LOCAL_SHARED_LIBRARIES := libhermes libfolly_json libfbjni libreactnativejni
 
 include $(BUILD_SHARED_LIBRARY)
+
+# start
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := turbomodulejsijni
+
+PROJECT_FILES := $(wildcard $(LOCAL_PATH)/../cpp/*.cpp)
+PROJECT_FILES += $(wildcard $(LOCAL_PATH)/../Common/cpp/*.cpp)
+PROJECT_FILES += $(wildcard $(LOCAL_PATH)/../Common/cpp/**/*.cpp)
+
+PROJECT_FILES := $(PROJECT_FILES:$(LOCAL_PATH)/%=%)
+
+LOCAL_SRC_FILES := $(PROJECT_FILES)
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH) \
+	$(LOCAL_PATH)/../cpp/headers \
+	$(LOCAL_PATH)/../Common/cpp/headers \
+	$(LOCAL_PATH)/../Common/cpp/headers/NativeModules \
+	$(LOCAL_PATH)/../Common/cpp/headers/Registries \
+	$(LOCAL_PATH)/../Common/cpp/headers/SharedItems \
+	$(LOCAL_PATH)/../Common/cpp/headers/SpecTools \
+	$(LOCAL_PATH)/../Common/cpp/headers/Tools \
+	$(HERMES_ENGINE)/android/include \
+
+LOCAL_CFLAGS += -DONANDROID -fexceptions -frtti
+
+LOCAL_STATIC_LIBRARIES := libjsi
+LOCAL_SHARED_LIBRARIES := libhermes libfolly_json libfbjni libreactnativejni
+
+include $(BUILD_SHARED_LIBRARY)
+# end
 
 include $(LOCAL_PATH)/react/Android.mk

--- a/android/src/main/JNI/Android.mk
+++ b/android/src/main/JNI/Android.mk
@@ -29,7 +29,7 @@ LOCAL_SHARED_LIBRARIES := libhermes libfolly_json libfbjni libreactnativejni
 
 include $(BUILD_SHARED_LIBRARY)
 
-# start build empty library which is needed by CallInvokerHolderImpl.java
+# start | build empty library which is needed by CallInvokerHolderImpl.java
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := turbomodulejsijni

--- a/android/src/main/JNI/Android.mk
+++ b/android/src/main/JNI/Android.mk
@@ -29,34 +29,10 @@ LOCAL_SHARED_LIBRARIES := libhermes libfolly_json libfbjni libreactnativejni
 
 include $(BUILD_SHARED_LIBRARY)
 
-# start
+# start build empty library which is needed by CallInvokerHolderImpl.java
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := turbomodulejsijni
-
-PROJECT_FILES := $(wildcard $(LOCAL_PATH)/../cpp/*.cpp)
-PROJECT_FILES += $(wildcard $(LOCAL_PATH)/../Common/cpp/*.cpp)
-PROJECT_FILES += $(wildcard $(LOCAL_PATH)/../Common/cpp/**/*.cpp)
-
-PROJECT_FILES := $(PROJECT_FILES:$(LOCAL_PATH)/%=%)
-
-LOCAL_SRC_FILES := $(PROJECT_FILES)
-
-LOCAL_C_INCLUDES := $(LOCAL_PATH) \
-	$(LOCAL_PATH)/../cpp/headers \
-	$(LOCAL_PATH)/../Common/cpp/headers \
-	$(LOCAL_PATH)/../Common/cpp/headers/NativeModules \
-	$(LOCAL_PATH)/../Common/cpp/headers/Registries \
-	$(LOCAL_PATH)/../Common/cpp/headers/SharedItems \
-	$(LOCAL_PATH)/../Common/cpp/headers/SpecTools \
-	$(LOCAL_PATH)/../Common/cpp/headers/Tools \
-	$(HERMES_ENGINE)/android/include \
-
-LOCAL_CFLAGS += -DONANDROID -fexceptions -frtti
-
-LOCAL_STATIC_LIBRARIES := libjsi
-LOCAL_SHARED_LIBRARIES := libhermes libfolly_json libfbjni libreactnativejni
-
 include $(BUILD_SHARED_LIBRARY)
 # end
 

--- a/android/src/main/cpp/AndroidScheduler.cpp
+++ b/android/src/main/cpp/AndroidScheduler.cpp
@@ -25,8 +25,9 @@ public:
    }
 
    void scheduleOnJS(std::function<void()> job) override {
-     Scheduler::scheduleOnJS(job);
-     scheduler_->cthis()->scheduleOnJS();
+     scheduler_->cthis()->jsCallInvoker_->invokeAsync(std::move(job));
+     //Scheduler::scheduleOnJS(job);
+     //scheduler_->cthis()->scheduleOnJS();
    }
 
    ~SchedulerWrapper() {};
@@ -62,6 +63,10 @@ void AndroidScheduler::scheduleOnUI() {
 void AndroidScheduler::scheduleOnJS() {
   static auto method = javaPart_->getClass()->getMethod<void()>("scheduleOnJS");
   method(javaPart_.get());
+}
+
+void AndroidScheduler::setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker) {
+  jsCallInvoker_ = jsCallInvoker;
 }
 
 void AndroidScheduler::registerNatives() {

--- a/android/src/main/cpp/AndroidScheduler.cpp
+++ b/android/src/main/cpp/AndroidScheduler.cpp
@@ -24,12 +24,6 @@ public:
      scheduler_->cthis()->scheduleOnUI();
    }
 
-   void scheduleOnJS(std::function<void()> job) override {
-     scheduler_->cthis()->jsCallInvoker_->invokeAsync(std::move(job));
-     //Scheduler::scheduleOnJS(job);
-     //scheduler_->cthis()->scheduleOnJS();
-   }
-
    ~SchedulerWrapper() {};
 
 };
@@ -51,29 +45,15 @@ void AndroidScheduler::triggerUI() {
   scheduler_->triggerUI();
 }
 
-void AndroidScheduler::triggerJS() {
-  scheduler_->triggerJS();
-}
-
 void AndroidScheduler::scheduleOnUI() {
   static auto method = javaPart_->getClass()->getMethod<void()>("scheduleOnUI");
   method(javaPart_.get());
-}
-
-void AndroidScheduler::scheduleOnJS() {
-  static auto method = javaPart_->getClass()->getMethod<void()>("scheduleOnJS");
-  method(javaPart_.get());
-}
-
-void AndroidScheduler::setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker) {
-  jsCallInvoker_ = jsCallInvoker;
 }
 
 void AndroidScheduler::registerNatives() {
   registerHybrid({
     makeNativeMethod("initHybrid", AndroidScheduler::initHybrid),
     makeNativeMethod("triggerUI", AndroidScheduler::triggerUI),
-    makeNativeMethod("triggerJS", AndroidScheduler::triggerJS),
   });
 }
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -24,8 +24,10 @@ using namespace react;
 NativeProxy::NativeProxy(
     jni::alias_ref<NativeProxy::javaobject> jThis,
     jsi::Runtime *rt,
+    std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker,
     std::shared_ptr<Scheduler> scheduler) : javaPart_(jni::make_global(jThis)),
                                             runtime_(rt),
+                                            jsCallInvoker_(jsCallInvoker),
                                             scheduler_(scheduler)
 {
 }
@@ -33,10 +35,13 @@ NativeProxy::NativeProxy(
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
     jni::alias_ref<jhybridobject> jThis,
     jlong jsContext,
+    jni::alias_ref<facebook::react::CallInvokerHolder::javaobject> jsCallInvokerHolder,
     jni::alias_ref<AndroidScheduler::javaobject> androidScheduler)
 {
+  auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
+  androidScheduler->cthis()->setJSCallInvoker(jsCallInvoker);
   auto scheduler = androidScheduler->cthis()->getScheduler();
-  return makeCxxInstance(jThis, (jsi::Runtime *)jsContext, scheduler);
+  return makeCxxInstance(jThis, (jsi::Runtime *)jsContext, jsCallInvoker, scheduler);
 }
 
 void NativeProxy::installJSIBindings()
@@ -79,7 +84,7 @@ void NativeProxy::installJSIBindings()
     measuringFunction
   };
 
-  auto module = std::make_shared<NativeReanimatedModule>(nullptr,
+  auto module = std::make_shared<NativeReanimatedModule>(jsCallInvoker_,
                                                          scheduler_,
                                                          std::move(animatedRuntime),
                                                          errorHandler,

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -39,8 +39,8 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
     jni::alias_ref<AndroidScheduler::javaobject> androidScheduler)
 {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
-  androidScheduler->cthis()->setJSCallInvoker(jsCallInvoker);
   auto scheduler = androidScheduler->cthis()->getScheduler();
+  scheduler->setJSCallInvoker(jsCallInvoker);
   return makeCxxInstance(jThis, (jsi::Runtime *)jsContext, jsCallInvoker, scheduler);
 }
 

--- a/android/src/main/cpp/headers/AndroidScheduler.h
+++ b/android/src/main/cpp/headers/AndroidScheduler.h
@@ -5,6 +5,7 @@
 #include <jsi/jsi.h>
 #include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JMessageQueueThread.h>
+#include <ReactCommon/CallInvoker.h>
 #include "Scheduler.h"
 
 namespace reanimated {
@@ -16,8 +17,11 @@ class AndroidScheduler : public jni::HybridClass<AndroidScheduler> {
    static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/Scheduler;";
    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
    static void registerNatives();
+   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
 
    std::shared_ptr<Scheduler> getScheduler() { return scheduler_; }
+
+   void setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker);
 
    void scheduleOnUI();
    void scheduleOnJS();

--- a/android/src/main/cpp/headers/AndroidScheduler.h
+++ b/android/src/main/cpp/headers/AndroidScheduler.h
@@ -5,7 +5,6 @@
 #include <jsi/jsi.h>
 #include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JMessageQueueThread.h>
-#include <ReactCommon/CallInvoker.h>
 #include "Scheduler.h"
 
 namespace reanimated {
@@ -17,20 +16,15 @@ class AndroidScheduler : public jni::HybridClass<AndroidScheduler> {
    static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/Scheduler;";
    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
    static void registerNatives();
-   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
 
    std::shared_ptr<Scheduler> getScheduler() { return scheduler_; }
 
-   void setJSCallInvoker(std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker);
-
    void scheduleOnUI();
-   void scheduleOnJS();
 
   private:
    friend HybridBase;
 
    void triggerUI();
-   void triggerJS();
 
    jni::global_ref<AndroidScheduler::javaobject> javaPart_;
    std::shared_ptr<Scheduler> scheduler_;

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -91,7 +91,6 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
   std::shared_ptr<Scheduler> scheduler_;
 
-
   void installJSIBindings();
   void requestRender(std::function<void(double)> onRender);
   void registerEventHandler(std::function<void(std::string,std::string)> handler);

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -5,6 +5,7 @@
 #include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JMessageQueueThread.h>
 #include <react/jni/WritableNativeMap.h>
+#include <ReactCommon/CallInvokerHolder.h>
 #include <memory>
 #include <unordered_map>
 
@@ -78,6 +79,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   static jni::local_ref<jhybriddata> initHybrid(
         jni::alias_ref<jhybridobject> jThis,
         jlong jsContext,
+        jni::alias_ref<facebook::react::CallInvokerHolder::javaobject> jsCallInvokerHolder,
         jni::alias_ref<AndroidScheduler::javaobject> scheduler);
   static void registerNatives();
 
@@ -86,7 +88,9 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   friend HybridBase;
   jni::global_ref<NativeProxy::javaobject> javaPart_;
   jsi::Runtime *runtime_;
+  std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
   std::shared_ptr<Scheduler> scheduler_;
+
 
   void installJSIBindings();
   void requestRender(std::function<void(double)> onRender);
@@ -98,6 +102,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   explicit NativeProxy(
       jni::alias_ref<NativeProxy::jhybridobject> jThis,
       jsi::Runtime *rt,
+      std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker,
       std::shared_ptr<Scheduler> scheduler);
 };
 

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.JSIModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -73,12 +74,13 @@ public class NativeProxy {
   private final WeakReference<ReactApplicationContext> mContext;
 
   public NativeProxy(ReactApplicationContext context) {
-    mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), new Scheduler(context));
+    CallInvokerHolderImpl holder = (CallInvokerHolderImpl)context.getCatalystInstance().getJSCallInvokerHolder();
+    mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), holder, new Scheduler(context));
     mContext = new WeakReference<>(context);
     prepare();
   }
 
-  private native HybridData initHybrid(long jsContext, Scheduler scheduler);
+  private native HybridData initHybrid(long jsContext, CallInvokerHolderImpl jsCallInvokerHolder, Scheduler scheduler);
   private native void installJSIBindings();
 
   @DoNotStrip

--- a/android/src/main/java/com/swmansion/reanimated/Scheduler.java
+++ b/android/src/main/java/com/swmansion/reanimated/Scheduler.java
@@ -11,13 +11,6 @@ public class Scheduler {
   private final HybridData mHybridData;
   private final ReactApplicationContext mContext;
 
-  private final Runnable mJSThreadRunnable = new Runnable() {
-    @Override
-    public void run() {
-      triggerJS();
-    }
-  };
-
   private final Runnable mUIThreadRunnable = new Runnable() {
     @Override
     public void run() {
@@ -34,16 +27,9 @@ public class Scheduler {
 
   private native void triggerUI();
 
-  private native void triggerJS();
-
   @DoNotStrip
   private void scheduleOnUI() {
     mContext.runOnUiQueueThread(mUIThreadRunnable);
-  }
-
-  @DoNotStrip
-  private void scheduleOnJS() {
-    mContext.runOnJSQueueThread(mJSThreadRunnable);
   }
 
 }

--- a/ios/native/REAIOSScheduler.h
+++ b/ios/native/REAIOSScheduler.h
@@ -12,11 +12,9 @@ using namespace facebook;
 using namespace react;
 
 class REAIOSScheduler : public Scheduler {
-  std::shared_ptr<CallInvoker> jsInvoker;
   public:
   REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker);
   void scheduleOnUI(std::function<void()> job) override;
-  void scheduleOnJS(std::function<void()> job) override;
   virtual ~REAIOSScheduler();
 };
 

--- a/ios/native/REAIOSScheduler.mm
+++ b/ios/native/REAIOSScheduler.mm
@@ -6,20 +6,13 @@ using namespace facebook;
 using namespace react;
 
 REAIOSScheduler::REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker) {
-  this->jsInvoker = jsInvoker;
+  this->jsCallInvoker_ = jsInvoker;
 }
 
 void REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
   Scheduler::scheduleOnUI(job);
   dispatch_async(dispatch_get_main_queue(), ^{
     triggerUI();
-  });
-}
-
-void REAIOSScheduler::scheduleOnJS(std::function<void()> job) {
-  Scheduler::scheduleOnJS(job);
-  jsInvoker->invokeAsync([this]{
-    triggerJS();
   });
 }
 


### PR DESCRIPTION
## WHY
fixes: https://github.com/software-mansion/react-native-reanimated/issues/1131

## HOW
Pass CallInvokerHolder to the NativeProxy just like we do with jsContext. The only hack used here is creating an empty shared library `libturbomodulejsijni` that's loaded by `CallInovokerHolderImpl.java`. It's not directly used by The `CallInovokerHolderImpl` so it's safe.

TODO:
 - [x] pr for Expo that updates build.gradle, android.mk and versioning script
 - [x] check if it works with RN 0.62