### PR TITLE
docs: rename RETurboModuleProvider

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -135,7 +135,7 @@ If not, after making those changes your app will be compatible with Turbo Module
 #import <React/RCTGIFImageDecoder.h>
 #import <React/RCTImageLoader.h>
 #import <React/JSCExecutorFactory.h>
-#import <RNReanimated/REATurboModuleProvider.h>
+#import <RNReanimated/RETurboModuleProvider.h>
 #import <RNReanimated/REAModule.h>
 // add headers (end)
 ...
@@ -165,20 +165,20 @@ If not, after making those changes your app will be compatible with Turbo Module
 
 - (Class)getModuleClassFromName:(const char *)name
 {
- return facebook::react::REATurboModuleClassProvider(name);
+ return facebook::react::RETurboModuleClassProvider(name);
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
- return facebook::react::REATurboModuleProvider(name, jsInvoker);
+ return facebook::react::RETurboModuleProvider(name, jsInvoker);
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       instance:(id<RCTTurboModule>)instance
                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
- return facebook::react::REATurboModuleProvider(name, instance, jsInvoker);
+ return facebook::react::RETurboModuleProvider(name, instance, jsInvoker);
 }
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass


### PR DESCRIPTION
REATurboModuleProvider couldn't be resolved so I went into the code and didn't find any REATurboModuleProvider header file but I found RETurboModuleProvider, I got it fixed on my installation steps after I renamed to RETurboModuleProvider.

## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
