### PR TITLE
Capture only used values and convert symbols to strings.

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -75,6 +75,9 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
       type = ValueType::ObjectType;
       frozenObject = std::make_shared<FrozenObject>(rt, object, module);
     }
+  } else if (value.isSymbol()) {
+    type = ValueType::StringType;
+    stringValue = value.asSymbol(rt).toString(rt);
   } else {
     throw "Invalid value type";
   }

--- a/plugin.js
+++ b/plugin.js
@@ -67,6 +67,10 @@ class ClosureGenerator {
     if (memberExpressionNode.property.type !== 'Identifier') {
       return notFound;
     }
+    if (memberExpressionNode.computed) {
+      // a.b[w] -> a.b.w
+      return notFound;
+    }
     const purePath = [memberExpressionNode.property.name];
     const node = memberExpressionNode;
     const upAns = this.findPrefixRec(path.parentPath);

--- a/plugin.js
+++ b/plugin.js
@@ -36,6 +36,8 @@ const globals = new Set([
   'requestAnimationFrame',
   '_WORKLET',
   'arguments',
+  'Map',
+  'Set',
   '_log',
   '_updateProps',
   'RegExp',
@@ -43,6 +45,58 @@ const globals = new Set([
   'global',
   '_measure',
   '_scrollTo',
+]);
+
+const blacklistedFunctions = new Set([
+  'stopCapturing',
+  'toString',
+  'map',
+  'filter',
+  'forEach',
+  'valueOf',
+  'toPrecision',
+  'toExponential',
+  'constructor',
+  'toFixed',
+  'toLocaleString',
+  'toSource',
+  'charAt',
+  'charCodeAt',
+  'concat',
+  'indexOf',
+  'lastIndexOf',
+  'localeCompare',
+  'length',
+  'match',
+  'replace',
+  'search',
+  'slice',
+  'split',
+  'substr',
+  'substring',
+  'toLocaleLowerCase',
+  'toLocaleUpperCase',
+  'toLowerCase',
+  'toUpperCase',
+  'every',
+  'join',
+  'pop',
+  'push',
+  'reduce',
+  'reduceRight',
+  'reverse',
+  'shift',
+  'slice',
+  'some',
+  'sort',
+  'splice',
+  'unshift',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'bind',
+  'apply',
+  'call',
 ]);
 
 class ClosureGenerator {
@@ -69,10 +123,12 @@ class ClosureGenerator {
     }
     if (
       memberExpressionNode.computed ||
-      memberExpressionNode.property.name === 'value'
+      memberExpressionNode.property.name === 'value' ||
+      blacklistedFunctions.has(memberExpressionNode.property.name)
     ) {
       // a.b[w] -> a.b.w in babel nodes
       // a.v.value
+      // sth.map(() => )
       return notFound;
     }
     if (

--- a/plugin.js
+++ b/plugin.js
@@ -207,7 +207,7 @@ function processWorkletFunction(t, fun) {
 
       if (
         parentNode.type === 'MemberExpression' &&
-        parentNode.object !== path.node
+        (parentNode.property === path.node && !parentNode.computed)
       ) {
         return;
       }

--- a/plugin.js
+++ b/plugin.js
@@ -132,9 +132,9 @@ class ClosureGenerator {
       return notFound;
     }
     if (
-      path.parentNode &&
-      path.parentNode.type === 'AssignmentExpression' &&
-      path.parentNode.left === path.node
+      path.parent &&
+      path.parent.type === 'AssignmentExpression' &&
+      path.parent.left === path.node
     ) {
       /// captured.newProp = 5;
       return notFound;

--- a/plugin.js
+++ b/plugin.js
@@ -71,8 +71,16 @@ class ClosureGenerator {
       memberExpressionNode.computed ||
       memberExpressionNode.property.name === 'value'
     ) {
-      // a.b[w] -> a.b.w
+      // a.b[w] -> a.b.w in babel nodes
       // a.v.value
+      return notFound;
+    }
+    if (
+      path.parentNode &&
+      path.parentNode.type === 'AssignmentExpression' &&
+      path.parentNode.left === path.node
+    ) {
+      /// captured.newProp = 5;
       return notFound;
     }
     const purePath = [memberExpressionNode.property.name];

--- a/plugin.js
+++ b/plugin.js
@@ -67,8 +67,12 @@ class ClosureGenerator {
     if (memberExpressionNode.property.type !== 'Identifier') {
       return notFound;
     }
-    if (memberExpressionNode.computed) {
+    if (
+      memberExpressionNode.computed ||
+      memberExpressionNode.property.name === 'value'
+    ) {
       // a.b[w] -> a.b.w
+      // a.v.value
       return notFound;
     }
     const purePath = [memberExpressionNode.property.name];

--- a/plugin.js
+++ b/plugin.js
@@ -47,6 +47,7 @@ const globals = new Set([
   '_scrollTo',
 ]);
 
+// leaving way to avoid deep capturing by adding 'stopCapturing' to the blacklist
 const blacklistedFunctions = new Set([
   'stopCapturing',
   'toString',

--- a/plugin.js
+++ b/plugin.js
@@ -68,14 +68,12 @@ class ClosureGenerator {
       return notFound;
     }
     const purePath = [memberExpressionNode.property.name];
-    console.log('findRec dla', purePath[0]);
     const node = memberExpressionNode;
     const upAns = this.findPrefixRec(path.parentPath);
     return this.mergeAns([purePath, node], upAns);
   }
 
   findPrefix(base, babelPath) {
-    console.log('find dla', base);
     const purePath = [base];
     const node = babelPath.node;
     const upAns = this.findPrefixRec(babelPath.parentPath);
@@ -83,9 +81,7 @@ class ClosureGenerator {
   }
 
   addPath(base, babelPath) {
-    console.log('dodaje dla', base);
     const [purePath, node] = this.findPrefix(base, babelPath);
-    console.log('po findPref', purePath);
     let parent = this.trie;
     let index = -1;
     for (const current of purePath) {
@@ -104,7 +100,6 @@ class ClosureGenerator {
   }
 
   generateNodeForBase(t, current, parent) {
-    console.log('gen dla', current);
     const currentNode = parent[0][current];
     if (currentNode[1]) {
       return currentNode[0];
@@ -123,7 +118,6 @@ class ClosureGenerator {
 
   generate(t, variables, names) {
     const arrayOfKeys = [...names];
-    console.log('names', names);
     return t.objectExpression(
       variables.map((variable, index) =>
         t.objectProperty(


### PR DESCRIPTION
## Why
Some people like to capture huge objects such as `Animated`. These objects may contain symbols that weren't handled in the past. The problem with symbols can be partially solved by converting symbols to strings. (it's better than nothing). 
Symbols cannot be converted to symbols and it can be seen in the following example: 
A->C, B->C, and C is a symbol. Then  after conversion A->C != B->C.  Another reason to merge the pr is to speed up Reanimated. Converting objects can take a lot of time. By capturing used values only we significantly reduce this time.

## How
I've added `ClosureGenerator` class that's responsible for capturing used paths only. It takes a path with the name of the variable that would be fully captured in the previous implementation and iterates upwards in the babel nodes tree until there is an edge case or the current node's type is different than 'MemberExpression'.  `ClosureGenerator` maintains a Trie tree where all used references are stored. 

## Edge cases

### Assigment operator 
If somebody wants to add a new property to the captured value then obviously we don't want to capture it.
a.b.c.d = 5;
captures a.b.c;

### Mutable  
sth.value

### a.b.c[]
Sometimes we can't tell what property the programmer wants to get. In such a case we capture only `a.b.c`

### Methods that use `this`
The problems only occur with objects that have been sent between threads. However, in Reanimated we only allow for Object|Array|String|Number|Boolean|Function types so it's enough to blacklist functions from their prototypes. The blacklist was base on https://developer.mozilla.org/pl/docs/Web/JavaScript/Referencje/Obiekty/Array/prototype.


## Problems
Update2: 
The problem below has been solved by blacklisting Array|Object|String|Number|Boolean prototype methods. It's a correct solution because in Reanimated2 we do not allow other types to be sent between threads.
Update: 
Currently, there is a problem with methods that use 'this'. For Example:
```JS
sth.map(() =>)
```


_____________
How it works:
```JS
function A() {
  'worklet';
  Animated.withSpring(0);
  Animated.a.b.c = 3;
  const x = Animated.a.b;
  const y = Animated.c.d['szymon'];
  const w = Animated.e.r[getPropName()];
  const ee = Animated.c.r[x];
  const ww = Animated.wer.ty[klocek];
}
```
->
```JS
var A = function () {
    var _f = function _f() {
      _Animated.default.withSpring(0);

      _Animated.default.a.b.c = 3;
      var x = _Animated.default.a.b;
      var y = _Animated.default.c.d['szymon'];

      var w = _Animated.default.e.r[getPropName()];

      var ee = _Animated.default.c.r[x];
      var ww = _Animated.default.wer.ty[klocek];
    };

    _f._closure = {
      Animated: {
        withSpring: _Animated.default.withSpring,
        a: {
          b: _Animated.default.a.b
        },
        c: {
          d: _Animated.default.c.d,
          r: _Animated.default.c.r
        },
        e: {
          r: _Animated.default.e.r
        },
        wer: {
          ty: _Animated.default.wer.ty
        }
      },
      getPropName: getPropName,
      klocek: klocek
    };
    _f.asString = "function A(){const{Animated,getPropName,klocek}=jsThis._closure;{Animated.withSpring(0);Animated.a.b.c=3;var x=Animated.a.b;var y=Animated.c.d['szymon'];var w=Animated.e.r[getPropName()];var ee=Animated.c.r[x];var ww=Animated.wer.ty[klocek];}}";
    _f.__workletHash = 12002772052812;

    global.__reanimatedWorkletInit(_f);

    return _f;
  }();
```

fixes: https://github.com/software-mansion/react-native-reanimated/issues/1132
fixes: https://github.com/software-mansion/react-native-reanimated/issues/1051