### PR TITLE
Fix Navigation crash

### DIFF
--- a/Common/cpp/Registries/MapperRegistry.cpp
+++ b/Common/cpp/Registries/MapperRegistry.cpp
@@ -13,8 +13,7 @@ void MapperRegistry::startMapper(std::shared_ptr<Mapper> mapper) {
 
 void MapperRegistry::stopMapper(unsigned long id) {
   mappers.erase(id);
-  updatedSinceLastExecute = true;
-}
+  updatedSinceLastExecute = true;}
 
 void MapperRegistry::execute(jsi::Runtime &rt) {
   if (updatedSinceLastExecute) {

--- a/Common/cpp/Registries/MapperRegistry.cpp
+++ b/Common/cpp/Registries/MapperRegistry.cpp
@@ -13,7 +13,8 @@ void MapperRegistry::startMapper(std::shared_ptr<Mapper> mapper) {
 
 void MapperRegistry::stopMapper(unsigned long id) {
   mappers.erase(id);
-  updatedSinceLastExecute = true;}
+  updatedSinceLastExecute = true;
+}
 
 void MapperRegistry::execute(jsi::Runtime &rt) {
   if (updatedSinceLastExecute) {

--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -8,8 +8,10 @@ namespace reanimated {
 void MutableValue::setValue(jsi::Runtime &rt, const jsi::Value &newValue) {
   std::lock_guard<std::mutex> lock(readWriteMutex);
   value = ShareableValue::adapt(rt, newValue, module);
-  auto notifyListeners = [this] () {
-    for (auto listener : listeners) {
+  
+  std::shared_ptr<MutableValue> thiz = shared_from_this();
+  auto notifyListeners = [thiz] () {
+    for (auto listener : thiz->listeners) {
       listener.second();
     }
   };
@@ -87,18 +89,18 @@ std::vector<jsi::PropNameID> MutableValue::getPropertyNames(jsi::Runtime &rt) {
 }
 
 MutableValue::MutableValue(jsi::Runtime &rt, const jsi::Value &initial, NativeReanimatedModule *module):
-module(module), value(ShareableValue::adapt(rt, initial, module)) {}
+module(module), value(ShareableValue::adapt(rt, initial, module)) {
+}
 
-unsigned long int MutableValue::addListener(std::function<void ()> listener) {
-  unsigned long id = listeners.size() + 1;
-  listeners.push_back(std::make_pair(id, listener));
+unsigned long int MutableValue::addListener(unsigned long id, std::function<void ()> listener) {
+  listeners[id] = listener;
   return id;
 }
 
 void MutableValue::removeListener(unsigned long listenerId) {
-  listeners.erase(std::remove_if(listeners.begin(), listeners.end(), [=](const std::pair<unsigned long, std::function<void()>>& pair) {
-    return pair.first == listenerId;
-  }), listeners.end());
+  if (listeners.count(listenerId) > 0) {
+    listeners.erase(listenerId);
+  }
 }
 
 

--- a/Common/cpp/Tools/Mapper.cpp
+++ b/Common/cpp/Tools/Mapper.cpp
@@ -13,19 +13,24 @@ id(id),
 module(module),
 mapper(std::move(mapper)),
 inputs(inputs),
-outputs(outputs) {
-  auto markDirty = [this, module]() {
+outputs(outputs) {  auto markDirty = [this, module]() {
     this->dirty = true;
     module->maybeRequestRender();
   };
   for (auto input : inputs) {
-    input->addListener(markDirty);
+    input->addListener(id, markDirty);
   }
 }
 
 void Mapper::execute(jsi::Runtime &rt) {
   dirty = false;
   mapper.callWithThis(rt, mapper);
+}
+
+Mapper::~Mapper() {
+  for (auto input : inputs) {
+    input->removeListener(id);
+  }
 }
 
 }

--- a/Common/cpp/Tools/Mapper.cpp
+++ b/Common/cpp/Tools/Mapper.cpp
@@ -13,7 +13,8 @@ id(id),
 module(module),
 mapper(std::move(mapper)),
 inputs(inputs),
-outputs(outputs) {  auto markDirty = [this, module]() {
+outputs(outputs) {
+  auto markDirty = [this, module]() {
     this->dirty = true;
     module->maybeRequestRender();
   };

--- a/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/Common/cpp/headers/SharedItems/MutableValue.h
@@ -4,6 +4,7 @@
 #include "MutableValueSetterProxy.h"
 #include <mutex>
 #include <jsi/jsi.h>
+#include <map>
 
 using namespace facebook;
 
@@ -17,7 +18,7 @@ class MutableValue : public jsi::HostObject, public std::enable_shared_from_this
   std::shared_ptr<ShareableValue> value;
   jsi::Value setter;
   jsi::Value animation;
-  std::vector<std::pair<unsigned long, std::function<void()>>> listeners;
+  std::map<unsigned long, std::function<void()>> listeners;
 
   void setValue(jsi::Runtime &rt, const jsi::Value &newValue);
   jsi::Value getValue(jsi::Runtime &rt);
@@ -29,7 +30,7 @@ class MutableValue : public jsi::HostObject, public std::enable_shared_from_this
   void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
-  unsigned long addListener(std::function<void()> listener);
+  unsigned long addListener(unsigned long listenerId, std::function<void()> listener);
   void removeListener(unsigned long listenerId);
 };
 

--- a/Common/cpp/headers/Tools/Mapper.h
+++ b/Common/cpp/headers/Tools/Mapper.h
@@ -11,7 +11,7 @@ namespace reanimated {
 
 class MapperRegistry;
 
-class Mapper {
+class Mapper : public std::enable_shared_from_this<Mapper> {
   friend MapperRegistry;
 private:
   unsigned long id;
@@ -28,6 +28,7 @@ public:
          std::vector<std::shared_ptr<MutableValue>> inputs,
          std::vector<std::shared_ptr<MutableValue>> outputs);
   void execute(jsi::Runtime &rt);
+  virtual ~Mapper();
 };
 
 }


### PR DESCRIPTION
Fixing: https://github.com/software-mansion/react-native-reanimated/issues/1181
The problem linked above caused crashes in random places and after 1.5d of debugging I came up with an idea that there must be sth wrong with the memory management. Because of the problem could be reproduced with just one mapper and one animation it was clear for me that the root cause of the problem is in the notification of mapper dirtiness. We may want to notify the mapper which has been unregistered. In order to fix the problem, I added a code that removes listeners of unregistered mappers.