### PR TITLE
Handle empty object in UAGH.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -290,6 +290,10 @@ function processWorklets(t, path, processor) {
     path.get('arguments.0').type === 'ObjectExpression'
   ) {
     const objectPath = path.get('arguments.0.properties.0');
+    if (!objectPath) {
+      // edge case empty object
+      return;
+    }
     for (let i = 0; i < objectPath.container.length; i++) {
       processor(t, objectPath.getSibling(i).get('value'));
     }


### PR DESCRIPTION
fixes: https://github.com/software-mansion/react-native-reanimated/issues/1185
During development, there is always a state where UAGH has an empty object. This pr handles that edge case.