### PR TITLE
v2 types: Fix animation callback parameter name

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -387,16 +387,16 @@ declare module 'react-native-reanimated' {
     export function withTiming(
       toValue: number,
       userConfig?: WithTimingConfig,
-      callback?: (isCancelled: boolean) => void,
+      callback?: (isFinished: boolean) => void,
     ): number;
     export function withSpring(
       toValue: number,
       userConfig?: WithSpringConfig,
-      callback?: (isCancelled: boolean) => void,
+      callback?: (isFinished: boolean) => void,
     ): number;
     export function withDecay(
       userConfig: WithDecayConfig,
-      callback?: (isCancelled: boolean) => void
+      callback?: (isFinished: boolean) => void
     ): number;
     export function cancelAnimation<T extends SharedValue<SharedValueType>>(
         sharedValue: T


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Even though we use the term "finished" in the documentation, for some reason in TS types we had "isCanceled" as a callback param name which led to confusion for users.

This PR fixes it.

Fixes https://github.com/software-mansion/react-native-reanimated/pull/1199 and https://github.com/software-mansion/react-native-reanimated/issues/1198

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- v2 types: Fix animation callback name (isCanceled => isFinished)

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
