### PR TITLE
Support wildcard type ES6 imports

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -436,7 +436,10 @@ function processIfWorkletNode(t, path) {
 }
 
 function processWorklets(t, path, processor) {
-  const name = path.node.callee.name;
+  const name =
+    path.node.callee.type === 'MemberExpression'
+      ? path.node.callee.property.name
+      : path.node.callee.name;
   if (
     objectHooks.has(name) &&
     path.get('arguments.0').type === 'ObjectExpression'

--- a/src/reanimated2/plugin.test.js
+++ b/src/reanimated2/plugin.test.js
@@ -46,4 +46,30 @@ describe('babel plugin', () => {
     const { code } = runPlugin(input);
     expect(code).toContain('_closure');
   });
+
+  it('supports default ES6 style imports', () => {
+    const input = `
+    import * as Reanimated from 'react-native-reanimated'
+
+    function Box() {
+        const offset = Reanimated.useSharedValue(0);
+
+        const animatedStyles = Reanimated.useAnimatedStyle(() => {
+          return {
+            transform: [{ translateX: offset.value * 255 }],
+          };
+        });
+
+        return (
+          <>
+            <Animated.View style={[styles.box, animatedStyles]} />
+            <Button onPress={() => (offset.value = Math.random())} title="Move" />
+          </>
+        );
+      }
+    `;
+
+    const { code } = runPlugin(input);
+    expect(code).toContain('_closure');
+  });
 });


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Addresses this comment here: https://github.com/software-mansion/react-native-reanimated/issues/823#issuecomment-688721886

Widens the support for identifying the reanimated2 hooks to also support BuckleScript type imports

```
import * as Reanimated from 'react-native-reanimated'

Reanimated.useAnimatedStyle(...)
```

The tests covering the babel plugin are pretty bare-bones, so I'm happy to extend those tests, or perform any manual tests needed before this goes any further.

## Changes

- Support wildcard ES6 import style with babel plugin

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
