### PR TITLE
Fix reattaching

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -111,6 +111,7 @@ export default function createAnimatedComponent(Component) {
       const attached = new Set();
       const nextEvts = new Set();
       let viewTag;
+
       for (const key in this.props) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
@@ -132,17 +133,19 @@ export default function createAnimatedComponent(Component) {
             // event was in prev and is still in current props
             attached.add(prop.__nodeID);
           }
-        } else if (prop instanceof WorkletEventHandler) {
+        } else if (prop instanceof WorkletEventHandler && prop.reattachNeeded) {
           prop.unregisterFromEvents();
         }
       }
+
       for (const key in this.props) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent && !attached.has(prop.__nodeID)) {
           // not yet attached
           prop.attachEvent(node, key);
-        } else if (prop instanceof WorkletEventHandler) {
+        } else if (prop instanceof WorkletEventHandler && prop.reattachNeeded) {
           prop.registerForEvents(viewTag, key);
+          prop.reattachNeeded = false;
         }
       }
     }

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -35,7 +35,7 @@ export function useEvent(handler, eventNames = [], rebuild = false) {
   if (initRef.current === null) {
     initRef.current = new WorkletEventHandler(handler, eventNames);
   } else if (rebuild) {
-    initRef.current.worklet = handler;
+    initRef.current.updateWorklet(handler);
   }
   return initRef.current;
 }

--- a/src/reanimated2/WorkletEventHandler.js
+++ b/src/reanimated2/WorkletEventHandler.js
@@ -4,6 +4,12 @@ export default class WorkletEventHandler {
   constructor(worklet, eventNames = []) {
     this.worklet = worklet;
     this.eventNames = eventNames;
+    this.reattachNeeded = false;
+  }
+
+  updateWorklet(newWorklet) {
+    this.worklet = newWorklet;
+    this.reattachNeeded = true;
   }
 
   registerForEvents(viewTag, fallbackEventName = undefined) {


### PR DESCRIPTION
## Description

The following problem has been reported: the events are being reattached even when the handlers are not being rebuilt(which basically means reattaching is pointless). That resulted in a significant slowdown. The solution in this PR is to reattach events only for those handlers which body changed(basing on dependencies passed(or not) to the hook).

## Changes

`createAnimatedComponent.js` - reattach conditionally
`WorkletEventHandler.js` - add `reattachNeeded` flag