### PR TITLE
Add hooks deps to TS types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -426,29 +426,37 @@ declare module 'react-native-reanimated' {
     export function runOnUI<A extends any[], R>(fn: (...args: A) => R): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
 
+    type Dependencies = any[];
+
     // reanimated2 hooks
     export function useSharedValue<T>(
         initialValue: T
     ): T extends SharedValueType ? SharedValue<T> : never;
 
     export function useDerivedValue<T extends SharedValueType>(
-      processor: () => T
+      processor: () => T,
+      dependencies?: Dependencies,
     ): SharedValue<T>;
 
     export function useAnimatedStyle<T extends StyleProp<AnimateStyle<ViewStyle | ImageStyle | TextStyle>>>(
-      updater: () => T
+      updater: () => T,
+      dependencies?: Dependencies,
     ): T;
     export function useAnimatedProps<T extends {}>(
-      updater: () => T
+      updater: () => T,
+      dependencies?: Dependencies,
     ): T;
     export function useAnimatedGestureHandler<TContext extends Context>(
-      handlers: GestureHandlers<TContext>
+      handlers: GestureHandlers<TContext>,
+      dependencies?: Dependencies,
     ): OnGestureEvent;
     export function useAnimatedScrollHandler<TContext extends Context>(
-      handler: ScrollHandler<TContext>
+      handler: ScrollHandler<TContext>,
+      dependencies?: Dependencies,
     ): OnScroll;
     export function useAnimatedScrollHandler<TContext extends Context>(
-      handlers: ScrollHandlers<TContext>
+      handlers: ScrollHandlers<TContext>,
+      dependencies?: Dependencies,
     ): OnScroll;
 
     export function useAnimatedRef<T extends Component>(): RefObject<T>;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -426,7 +426,7 @@ declare module 'react-native-reanimated' {
     export function runOnUI<A extends any[], R>(fn: (...args: A) => R): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
 
-    type Dependencies = any[];
+    type DependencyList = ReadonlyArray<any>;
 
     // reanimated2 hooks
     export function useSharedValue<T>(
@@ -435,28 +435,28 @@ declare module 'react-native-reanimated' {
 
     export function useDerivedValue<T extends SharedValueType>(
       processor: () => T,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): SharedValue<T>;
 
     export function useAnimatedStyle<T extends StyleProp<AnimateStyle<ViewStyle | ImageStyle | TextStyle>>>(
       updater: () => T,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): T;
     export function useAnimatedProps<T extends {}>(
       updater: () => T,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): T;
     export function useAnimatedGestureHandler<TContext extends Context>(
       handlers: GestureHandlers<TContext>,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): OnGestureEvent;
     export function useAnimatedScrollHandler<TContext extends Context>(
       handler: ScrollHandler<TContext>,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): OnScroll;
     export function useAnimatedScrollHandler<TContext extends Context>(
       handlers: ScrollHandlers<TContext>,
-      dependencies?: Dependencies,
+      deps?: DependencyList,
     ): OnScroll;
 
     export function useAnimatedRef<T extends Component>(): RefObject<T>;


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

In the latest release (alpha.6) dependencies have been added to hooks in order to make sure worklets stay up to date with the rest of the react code. But they are missing in types. This PR fixes it.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- Add hooks deps to TS types

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
