### PR TITLE
fix: add react-native new ColorValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/preset-typescript": "^7.7.4",
     "@react-native-community/bob": "^0.14.3",
     "@react-native-community/eslint-config": "^0.0.5",
-    "@types/react-native": "^0.62.13",
+    "@types/react-native": "^0.63.18",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "eslint": "^6.5.1",

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -19,6 +19,7 @@ declare module 'react-native-reanimated' {
     ScrollView as ReactNativeScrollView,
     NativeScrollEvent,
     NativeSyntheticEvent,
+    ColorValue,
   } from 'react-native';
   import {
     GestureHandlerGestureEventNativeEvent,
@@ -187,10 +188,10 @@ declare module 'react-native-reanimated' {
           ? AnimateStyle<S[K]>
           :   
               // allow `number` where `string` normally is to support colors    
-                S[K] extends (string | undefined) ? S[K] | number : S[K]
+                S[K] extends (ColorValue | string | undefined) ? S[K] | number : S[K]
               | AnimatedNode<
                   // allow `number` where `string` normally is to support colors
-                  S[K] extends (string | undefined) ? S[K] | number : S[K]
+                  S[K] extends (ColorValue | string | undefined) ? S[K] | number : S[K]
                 >)
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2720,9 +2720,10 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
 
-"@types/react-native@^0.62.13":
-  version "0.62.18"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.18.tgz#ad63691e7c44edef2beeb6af52b2eb942c3ed8a1"
+"@types/react-native@^0.63.18":
+  version "0.63.18"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.18.tgz#748d82c6453befe97285393ad9530472d8de56af"
+  integrity sha512-WwEWqmHiqFn61M1FZR/+frj+E8e2o8i5cPqu9mjbjtZS/gBfCKVESF2ai/KAlaQECkkWkx/nMJeCc5eHMmLQgw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
## Description
React-native v63 added a new type for every color in style which caused an error in typescript.

## Changes
-  Added ColorValue in AnimateStyle

