### PR TITLE
Fix scrollTo for horizontal scroll on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
@@ -2,11 +2,13 @@ package com.swmansion.reanimated;
 
 import android.graphics.Matrix;
 import android.graphics.RectF;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewParent;
 
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.RootViewUtil;
+import com.facebook.react.views.scroll.ReactHorizontalScrollView;
 import com.facebook.react.views.scroll.ReactScrollView;
 
 public class NativeMethodsHelper {
@@ -37,12 +39,29 @@ public class NativeMethodsHelper {
   public static void scrollTo(View view, double argX, double argY, boolean animated) {
     int x = Math.round(PixelUtil.toPixelFromDIP(argX));
     int y = Math.round(PixelUtil.toPixelFromDIP(argY));
-    ReactScrollView scrollView = (ReactScrollView)view;
-    if (animated) {
-      scrollView.smoothScrollTo((int)x, (int)y);
-    } else {
-      scrollView.scrollTo((int)x, (int)y);
+    boolean horizontal = false;
+    
+    if (view instanceof ReactHorizontalScrollView) {
+      horizontal = true;
+    } else if (!(view instanceof ReactScrollView)) {
+      Log.w("REANIMATED", "NativeMethodsHelper: Unhandled scroll view type - allowed only {ReactScrollView, ReactHorizontalScrollView}");
+      return;
     }
+
+    if (animated) {
+      if (horizontal) {
+        ((ReactHorizontalScrollView)view).smoothScrollTo((int)x, (int)y);
+      } else {
+        ((ReactScrollView)view).smoothScrollTo((int)x, (int)y);
+      }
+    } else {
+      if (horizontal) {
+        ((ReactHorizontalScrollView)view).scrollTo((int)x, (int)y);
+      } else {
+        ((ReactScrollView)view).scrollTo((int)x, (int)y);
+      }
+    }
+
   }
 
   private static void computeBoundingBox(View view, int[] outputBuffer) {


### PR DESCRIPTION
## Description

In `scrollTo` on Android, horizontal scroll views were not supported. This PR fixes it.

You can create a horizontal scroll view by adding `horizontal` prop like this:
`<Animated.ScrollView ref={sv1} style={svStyle} horizontal>`

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1108
