### PR TITLE
Improve caching.

### DIFF
--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -12,31 +12,12 @@ FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeRe
   }
 }
 
-std::shared_ptr<jsi::Object> FrozenObject::shallowClone(jsi::Runtime &rt) {
-  std::shared_ptr<jsi::Object> object(new jsi::Object(rt));
+jsi::Object FrozenObject::shallowClone(jsi::Runtime &rt) {
+  jsi::Object object(rt);
   for (auto prop : map) {
-    object->setProperty(rt, jsi::String::createFromUtf8(rt, prop.first), prop.second->getValue(rt));
+    object.setProperty(rt, jsi::String::createFromUtf8(rt, prop.first), prop.second->getValue(rt));
   }
   return object;
-}
-
-jsi::Value FrozenObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
-  auto propName = name.utf8(rt);
-  if (propName == "$$typeof") {
-    return jsi::Value(rt, jsi::String::createFromAscii(rt, "object"));
-  } else if (propName == "Symbol.toStringTag") {
-    return jsi::Value(rt, jsi::String::createFromAscii(rt, "FrozenObject"));
-  }
-  auto found = map.find(propName);
-  return found == map.end() ? jsi::Value::undefined() : found->second->getValue(rt);
-}
-
-std::vector<jsi::PropNameID> FrozenObject::getPropertyNames(jsi::Runtime &rt) {
-  std::vector<jsi::PropNameID> result;
-  for (auto it = map.begin(); it != map.end(); it++) {
-    result.push_back(jsi::PropNameID::forUtf8(rt, it->first));
-  }
-  return result;
 }
 
 }

--- a/Common/cpp/SharedItems/RemoteObject.cpp
+++ b/Common/cpp/SharedItems/RemoteObject.cpp
@@ -7,34 +7,9 @@ using namespace facebook;
 
 namespace reanimated {
 
-void RemoteObject::maybeInitializeOnUIRuntime(jsi::Runtime &rt) {
-  if (initializer.get() != nullptr) {
-    backing = initializer->shallowClone(rt);
-    initializer = nullptr;
-  }
-}
-
-jsi::Value RemoteObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
-  if (module->isUIRuntime(rt)) {
-    return backing->getProperty(rt, name);
-  }
-  return jsi::Value::undefined();
-}
-
-void RemoteObject::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value) {
-  if (module->isUIRuntime(rt)) {
-    backing->setProperty(rt, name, value);
-  }
-  // TODO: we should throw if trying to update remote from host runtime
-}
-
-std::vector<jsi::PropNameID> RemoteObject::getPropertyNames(jsi::Runtime &rt) {
-  std::vector<jsi::PropNameID> res;
-  auto propertyNames = backing->getPropertyNames(rt);
-  for (size_t i = 0, size = propertyNames.size(rt); i < size; i++) {
-    res.push_back(jsi::PropNameID::forString(rt, propertyNames.getValueAtIndex(rt, i).asString(rt)));
-  }
-  return res;
+jsi::Value RemoteObject::returnObject(jsi::Runtime &rt) {
+    jsi::Value res = initializer->shallowClone(rt);
+    return res;
 }
 
 }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -9,6 +9,27 @@
 
 namespace reanimated {
 
+const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";
+  
+void addHiddenProperty(jsi::Runtime &rt,
+                       jsi::Value &&value,
+                       jsi::Object &obj,
+                       const char *name) {
+  jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
+  jsi::Function defineProperty = globalObject.getPropertyAsFunction(rt, "defineProperty");
+  jsi::String internalPropName = jsi::String::createFromUtf8(rt, name);
+  jsi::Object paramForDefineProperty(rt);
+  paramForDefineProperty.setProperty(rt, "enumerable", false);
+  paramForDefineProperty.setProperty(rt, "value", value);
+  defineProperty.call(rt, obj, internalPropName, paramForDefineProperty);
+}
+
+void freeze(jsi::Runtime &rt, jsi::Object &obj) {
+  jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
+  jsi::Function freeze = globalObject.getPropertyAsFunction(rt, "freeze");
+  freeze.call(rt, obj);
+}
+
 void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
   // when adapting from host object we can assign cached value immediately such that we avoid
   // running `toJSValue` in the future when given object is accessed
@@ -20,6 +41,20 @@ void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
 }
 
 void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType) {
+  bool isRNRuntime = !(module->isUIRuntime(rt));
+  if (value.isObject()) {
+    jsi::Object object = value.asObject(rt);
+    if (!(object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).isUndefined())) {
+      jsi::Object hiddenProperty = object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).asObject(rt);
+      if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
+        type = objectType;
+        frozenObject = hiddenProperty.getHostObject<FrozenObject>(rt);
+        adaptCache(rt, value);
+        return;
+      }
+    }
+  }
+  
   if (objectType == ValueType::MutableValueType) {
     type = ValueType::MutableValueType;
     mutableValue = std::make_shared<MutableValue>(rt, value, module);
@@ -48,6 +83,10 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         // a worklet
         type = ValueType::WorkletFunctionType;
         frozenObject = std::make_shared<FrozenObject>(rt, object, module);
+        if (isRNRuntime) {
+          addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
+          adaptCache(rt, value);
+        }
       }
     } else if (object.isArray(rt)) {
       type = ValueType::ArrayType;
@@ -63,10 +102,6 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
       type = ValueType::RemoteObjectType;
       remoteObject = object.getHostObject<RemoteObject>(rt);
       adaptCache(rt, value);
-    } else if (object.isHostObject<FrozenObject>(rt)) {
-      type = ValueType::ObjectType;
-      frozenObject = object.getHostObject<FrozenObject>(rt);
-      adaptCache(rt, value);
     } else if (objectType == ValueType::RemoteObjectType) {
       type = ValueType::RemoteObjectType;
       remoteObject = std::make_shared<RemoteObject>(rt, object, module);
@@ -74,6 +109,11 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
       // create frozen object based on a copy of a given object
       type = ValueType::ObjectType;
       frozenObject = std::make_shared<FrozenObject>(rt, object, module);
+      if (isRNRuntime) {
+        addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
+        freeze(rt, object);
+        adaptCache(rt, value);
+      }
     }
   } else if (value.isSymbol()) {
     type = ValueType::StringType;
@@ -109,6 +149,15 @@ jsi::Object ShareableValue::createHost(jsi::Runtime &rt, std::shared_ptr<jsi::Ho
   return jsi::Object::createFromHostObject(rt, host);
 }
 
+jsi::Value createFrozenWrapper(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObject) {
+  jsi::Object __reanimatedHiddenHost = jsi::Object::createFromHostObject(rt, frozenObject);
+  jsi::Object obj = frozenObject->shallowClone(rt);
+  jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
+  jsi::Function freeze = globalObject.getPropertyAsFunction(rt, "freeze");
+  addHiddenProperty(rt, std::move(__reanimatedHiddenHost), obj, HIDDEN_HOST_OBJECT_PROP);
+  return freeze.call(rt, obj);
+}
+
 jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
   switch (type) {
     case ValueType::UndefinedType:
@@ -122,7 +171,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     case ValueType::StringType:
       return jsi::Value(rt, jsi::String::createFromAscii(rt, stringValue));
     case ValueType::ObjectType:
-      return createHost(rt, frozenObject);
+      return createFrozenWrapper(rt, frozenObject);
     case ValueType::ArrayType: {
       jsi::Array array(rt, frozenArray.size());
       for (size_t i = 0; i < frozenArray.size(); i++) {
@@ -132,7 +181,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     }
     case ValueType::RemoteObjectType:
       if (module->isUIRuntime(rt)) {
-        remoteObject->maybeInitializeOnUIRuntime(rt);
+        return remoteObject->returnObject(rt);
       }
       return createHost(rt, remoteObject);
     case ValueType::MutableValueType:
@@ -188,7 +237,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       if (module->isUIRuntime(rt)) {
         // when running on UI thread we prep a function
 
-        auto jsThis = frozenObject->shallowClone(*module->runtime);
+        auto jsThis = std::make_shared<jsi::Object>(frozenObject->shallowClone(*module->runtime));
         std::shared_ptr<jsi::Function> funPtr(module->workletsCache->getFunction(rt, frozenObject));
         
         // HACK ALERT: there is a special case of "setter" function where we don't want to pass

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -47,7 +47,10 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
     if (!(object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).isUndefined())) {
       jsi::Object hiddenProperty = object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).asObject(rt);
       if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
-        type = objectType;
+        type = ValueType::ObjectType;
+        if (object.hasProperty(rt, "__worklet") && object.isFunction(rt)) {
+          type = ValueType::WorkletFunctionType;
+        }
         frozenObject = hiddenProperty.getHostObject<FrozenObject>(rt);
         adaptCache(rt, value);
         return;

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -44,8 +44,9 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
   bool isRNRuntime = !(module->isUIRuntime(rt));
   if (value.isObject()) {
     jsi::Object object = value.asObject(rt);
-    if (!(object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).isUndefined())) {
-      jsi::Object hiddenProperty = object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP).asObject(rt);
+    jsi::Value hiddenValue = object.getProperty(rt, HIDDEN_HOST_OBJECT_PROP);
+    if (!(hiddenValue.isUndefined())) {
+      jsi::Object hiddenProperty = hiddenValue.asObject(rt);
       if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
         type = ValueType::ObjectType;
         if (object.hasProperty(rt, "__worklet") && object.isFunction(rt)) {

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -13,19 +13,17 @@ class FrozenObject : public jsi::HostObject {
   friend void extractMutables(jsi::Runtime &rt,
                               std::shared_ptr<ShareableValue> sv,
                               std::vector<std::shared_ptr<MutableValue>> &res);
+  friend jsi::Value createFrozenWrapper(ShareableValue *sv,
+                                        jsi::Runtime &rt,
+                                        std::shared_ptr<FrozenObject> frozenObject);
+  
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
 
   public:
 
   FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module);
-
-  // set is not available as the object is "read only" (to avoid locking)
-
-  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
-  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
-
-  std::shared_ptr<jsi::Object> shallowClone(jsi::Runtime &rt);
+  jsi::Object shallowClone(jsi::Runtime &rt);
 };
 
 }

--- a/Common/cpp/headers/SharedItems/RemoteObject.h
+++ b/Common/cpp/headers/SharedItems/RemoteObject.h
@@ -10,15 +10,11 @@ namespace reanimated {
 class RemoteObject: public jsi::HostObject {
 private:
   NativeReanimatedModule *module;
-  std::shared_ptr<jsi::Object> backing;
   std::unique_ptr<FrozenObject> initializer;
 public:
-  void maybeInitializeOnUIRuntime(jsi::Runtime &rt);
+  jsi::Value returnObject(jsi::Runtime &rt);
   RemoteObject(jsi::Runtime &rt, jsi::Object &object, NativeReanimatedModule *module):
     module(module), initializer(new FrozenObject(rt, object, module)) {}
-  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
-  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
-  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
 };
 
 }

--- a/Common/cpp/headers/SharedItems/RemoteObject.h
+++ b/Common/cpp/headers/SharedItems/RemoteObject.h
@@ -9,12 +9,11 @@ namespace reanimated {
 
 class RemoteObject: public jsi::HostObject {
 private:
-  NativeReanimatedModule *module;
   std::unique_ptr<FrozenObject> initializer;
 public:
   jsi::Value returnObject(jsi::Runtime &rt);
   RemoteObject(jsi::Runtime &rt, jsi::Object &object, NativeReanimatedModule *module):
-    module(module), initializer(new FrozenObject(rt, object, module)) {}
+    initializer(new FrozenObject(rt, object, module)) {}
 };
 
 }

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -268,7 +268,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.63.0)
   - RNCMaskedView (0.1.10):
     - React
-  - RNGestureHandler (1.5.2):
+  - RNGestureHandler (1.8.0):
     - React
   - RNReanimated (2.0.0-alpha.6):
     - DoubleConversion
@@ -445,7 +445,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 77ab1cf4a5eb854b88ad5ed3e9d8509ed124525e
   ReactCommon: f63556ee9e41e9802257228237e5e660451a03cf
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
-  RNGestureHandler: 946a7691e41df61e2c4b1884deab41a4cdc3afff
+  RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNReanimated: 6bd3347e383cee6eb879a1a7d6c748934a015a05
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e


### PR DESCRIPTION
## WHY
Currently, when we want to use an object in two worklets then we have to covert the object twice. To avoid it this pr saves our jsi::HostObject as a hidden property (Object.defineProperty enumerable: false). Additionally, this pr introduces a different approach to representing FrozenObject and RemoteObject. JSC has problems with jsi::Objects that are created from HostObjects so instead of using them directly we expose frozen(not true with RemoteObject) jsi::Object and save jsi::HostObject as a hidden property.  

## HOW
During makeSherable operation add a hidden property to all objects converted to FrozenObject and WorkletFunction. 
`const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";`
Remove get/set from RemoteObject and return jsi::Object on UI side and frozenObj on JS side. Remove get from FrozenObject and use it only as a C++ representation. We only add a hidden property on JS side. When we convert jsi::Object on UI side in order to send it to RN we don't want to freeze it because it would be torture and it's a rare case.


## BREAKING CHANGE
From now on, all captured objects are frozen. It means if you want to pass a mutable object to the worklet then you have to copy it before.
