### PR TITLE
Fix handling useAnimatedStyle in nested styles

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -37,6 +37,26 @@ function hasAnimatedNodes(value) {
   return false;
 }
 
+function flattenArray(array) {
+  const resultArr = [];
+
+  const _flattenArray = (arr) => {
+    if (!Array.isArray(arr)) {
+      resultArr.push(arr);
+      return;
+    }
+    arr.forEach((item) => {
+      if (Array.isArray(item)) {
+        _flattenArray(item);
+      } else {
+        resultArr.push(item);
+      }
+    });
+  };
+  _flattenArray(array);
+  return resultArr;
+}
+
 export default function createAnimatedComponent(Component) {
   invariant(
     typeof Component !== 'function' ||
@@ -205,9 +225,10 @@ export default function createAnimatedComponent(Component) {
     }
 
     _attachAnimatedStyles() {
-      const styles = Array.isArray(this.props.style)
+      let styles = Array.isArray(this.props.style)
         ? this.props.style
         : [this.props.style];
+      styles = flattenArray(styles);
       const viewTag = findNodeHandle(this);
       styles.forEach((style) => {
         if (style && style.viewTag !== undefined) {

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -38,13 +38,12 @@ function hasAnimatedNodes(value) {
 }
 
 function flattenArray(array) {
+  if (!Array.isArray(array)) {
+    return array;
+  }
   const resultArr = [];
 
   const _flattenArray = (arr) => {
-    if (!Array.isArray(arr)) {
-      resultArr.push(arr);
-      return;
-    }
     arr.forEach((item) => {
       if (Array.isArray(item)) {
         _flattenArray(item);


### PR DESCRIPTION
## Description

This PR fixes using `useAnimatedStyle` hook when styles are in nested arrays with depth > 1.
Before something like this worked:
```
<Animated.View style={ animatedStyle } />
<Animated.View style={[ { width: 100, height: 80, backgroundColor: 'black' }, animatedStyle]} />
```
but something like this did not:
```
<Animated.View style={[ { width: 100, height: 80, backgroundColor: 'black' }, [animatedStyle]]} />
```
From now on it's possible to nest the arrays in `style` prop as deep desired, example:
```
<Animated.View
  style={[
    { width: 100, height: 80, backgroundColor: 'black', margin: 30 },
    [
      { backgroundColor: 'green' },
      [
        { backgroundColor: 'yellow' },
        [
          { backgroundColor: 'red' },
          [
            { backgroundColor: 'blue' },
            [{ backgroundColor: 'purple' }, style],
          ],
        ],
      ],
    ],
  ]}
/>
```

This fixes https://github.com/software-mansion/react-native-reanimated/issues/1129