### PR TITLE
Fix broken installation link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ comes to gesture based interactions.
 
 ## Installation
 
-Check out [installation](https://docs.swmansion.com/react-native-reanimated/docs/installation) section of our docs for the detailed installation instructions.
+Check out [installation](https://docs.swmansion.com/react-native-reanimated/docs/next/installation) section of our docs for the detailed installation instructions.
 
 ## Documentation
 


### PR DESCRIPTION
Installation link was broken on Readme. Page not found on [swmansion.com](https://docs.swmansion.com/react-native-reanimated/docs/installation)

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- Installation link changed in Readme
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
