### PR TITLE
Fix reload once again.

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <thread>
 #include <memory>
+#include "JSIStoreValueUser.h"
 
 using namespace facebook;
 
@@ -247,7 +248,7 @@ void NativeReanimatedModule::onRender(double timestampMs)
 
 NativeReanimatedModule::~NativeReanimatedModule()
 {
-  // noop
+  StoreUser::clearStore();
 }
 
 } // namespace reanimated

--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -58,7 +58,10 @@ void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi:
       .callWithThis(rt, setterProxy, newValue);
   } else if (propName == "_animation") {
     // TODO: assert to allow animation to be set from UI only
-    animation = jsi::Value(rt, newValue);
+    if (animation.expired()) {
+      animation = getWeakRef(rt);
+    }
+    *animation.lock() = jsi::Value(rt, newValue);
   }
 }
 
@@ -74,8 +77,11 @@ jsi::Value MutableValue::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     if (propName == "_value") {
       return getValue(rt);
     } else if (propName == "_animation") {
-      // TODO: assert to allow animation to be read from UI onlu
-      return jsi::Value(rt, animation);
+      // TODO: assert to allow animation to be read from UI only
+      if (animation.expired()) {
+        animation = getWeakRef(rt);
+      }
+      return jsi::Value(rt, *(animation.lock()));
     }
   }
 

--- a/Common/cpp/SharedItems/MutableValueSetterProxy.cpp
+++ b/Common/cpp/SharedItems/MutableValueSetterProxy.cpp
@@ -15,7 +15,10 @@ void MutableValueSetterProxy::set(jsi::Runtime &rt, const jsi::PropNameID &name,
     mutableValue->setValue(rt, newValue);
   } else if (propName == "_animation") {
     // TODO: assert to allow animation to be set from UI only
-    mutableValue->animation = jsi::Value(rt, newValue);
+    if (mutableValue->animation.expired()) {
+      mutableValue->animation = mutableValue->getWeakRef(rt);
+    }
+    *mutableValue->animation.lock() = jsi::Value(rt, newValue);
   }
 }
 
@@ -27,7 +30,10 @@ jsi::Value MutableValueSetterProxy::get(jsi::Runtime &rt, const jsi::PropNameID 
   } else if (propName == "_value") {
     return mutableValue->getValue(rt);
   } else if (propName == "_animation") {
-    return jsi::Value(rt, mutableValue->animation);
+    if (mutableValue->animation.expired()) {
+      mutableValue->animation = mutableValue->getWeakRef(rt);
+    }
+    return jsi::Value(rt, *mutableValue->animation.lock());
   }
 
   return jsi::Value::undefined();

--- a/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -1,0 +1,34 @@
+#include "JSIStoreValueUser.h"
+
+namespace reanimated {
+
+int identifier = 0;
+std::atomic<int> StoreUser::ctr;
+std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> StoreUser::store;
+
+std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
+  if (StoreUser::store.count(identifier) == 0) {
+    StoreUser::store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
+  }
+  std::shared_ptr<jsi::Value> sv = std::make_shared<jsi::Value>(rt, jsi::Value::undefined());
+  StoreUser::store[identifier].push_back(sv);
+  
+  return sv;
+}
+
+void StoreUser::removeRefs() {
+  if (StoreUser::store.count(identifier) > 0) {
+    StoreUser::store.erase(identifier);
+  }
+}
+
+StoreUser::~StoreUser() {
+  removeRefs();
+}
+
+
+void StoreUser::clearStore() {
+  StoreUser::store.clear();
+}
+
+}

--- a/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/Common/cpp/headers/SharedItems/MutableValue.h
@@ -5,19 +5,19 @@
 #include <mutex>
 #include <jsi/jsi.h>
 #include <map>
+#include "JSIStoreValueUser.h"
 
 using namespace facebook;
 
 namespace reanimated {
 
-class MutableValue : public jsi::HostObject, public std::enable_shared_from_this<MutableValue> {
+class MutableValue : public jsi::HostObject, public std::enable_shared_from_this<MutableValue>, public StoreUser {
   private:
   friend MutableValueSetterProxy;
   NativeReanimatedModule *module;
   std::mutex readWriteMutex;
   std::shared_ptr<ShareableValue> value;
-  jsi::Value setter;
-  jsi::Value animation;
+  std::weak_ptr<jsi::Value> animation;
   std::map<unsigned long, std::function<void()>> listeners;
 
   void setValue(jsi::Runtime &rt, const jsi::Value &newValue);

--- a/Common/cpp/headers/SharedItems/RemoteObject.h
+++ b/Common/cpp/headers/SharedItems/RemoteObject.h
@@ -2,6 +2,7 @@
 
 #include "SharedParent.h"
 #include "FrozenObject.h"
+#include "JSIStoreValueUser.h"
 
 using namespace facebook;
 

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -7,12 +7,13 @@
 #include <mutex>
 #include <unordered_map>
 #include <jsi/jsi.h>
+#include <JSIStoreValueUser.h>
 
 using namespace facebook;
 
 namespace reanimated {
 
-class ShareableValue: public std::enable_shared_from_this<ShareableValue> {
+class ShareableValue: public std::enable_shared_from_this<ShareableValue>, public StoreUser {
 friend WorkletsCache;
 friend void extractMutables(jsi::Runtime &rt,
                             std::shared_ptr<ShareableValue> sv,
@@ -30,7 +31,7 @@ private:
   std::vector<std::shared_ptr<ShareableValue>> frozenArray;
 
   std::unique_ptr<jsi::Value> hostValue;
-  std::unique_ptr<jsi::Value> remoteValue;
+  std::weak_ptr<jsi::Value> remoteValue;
 
   jsi::Value toJSValue(jsi::Runtime &rt);
 

--- a/Common/cpp/headers/Tools/JSIStoreValueUser.h
+++ b/Common/cpp/headers/Tools/JSIStoreValueUser.h
@@ -1,0 +1,33 @@
+#ifndef JSIStoreValueUser_h
+#define JSIStoreValueUser_h
+
+#include <stdio.h>
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <jsi/jsi.h>
+
+using namespace facebook;
+
+namespace reanimated {
+
+class StoreUser {
+  int identifier = 0;
+  static std::atomic<int> ctr;
+  static std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
+  
+public:
+  StoreUser() {
+    identifier = StoreUser::ctr++;
+  }
+  
+  std::weak_ptr<jsi::Value> getWeakRef(jsi::Runtime &rt);
+  void removeRefs();
+  
+  static void clearStore();
+  virtual ~StoreUser();
+};
+
+}
+
+#endif /* JSIStoreValueUser_h */


### PR DESCRIPTION
## HOW
Because we cache jsi::Value in our host objects and we don't have control over their destruction we sometimes leave dangling jsi values. It results in reload problems. To fix the problem this pull-request changes all direct references to indirect weak ones that can be easily cleared on UI runtime destruction. StoreUser is a class responsible for those indirect references. Every our host object that uses jsi::value from UI runtime extends StoreUser class. Each indirect reference is bond to UI runtime and a host object lifecycles and is released on runtime or the host object destruction, whatever comes first.

