### PR TITLE
Revert RemoteObject changes.

### DIFF
--- a/Common/cpp/SharedItems/RemoteObject.cpp
+++ b/Common/cpp/SharedItems/RemoteObject.cpp
@@ -7,9 +7,35 @@ using namespace facebook;
 
 namespace reanimated {
 
-jsi::Value RemoteObject::returnObject(jsi::Runtime &rt) {
-    jsi::Value res = initializer->shallowClone(rt);
-    return res;
+void RemoteObject::maybeInitializeOnUIRuntime(jsi::Runtime &rt) {
+  if (initializer.get() != nullptr) {
+    backing = getWeakRef(rt);
+    *backing.lock() = initializer->shallowClone(rt);
+    initializer = nullptr;
+  }
+}
+
+jsi::Value RemoteObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
+  if (module->isUIRuntime(rt)) {
+    return backing.lock()->getObject(rt).getProperty(rt, name);
+  }
+  return jsi::Value::undefined();
+}
+
+void RemoteObject::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value) {
+  if (module->isUIRuntime(rt)) {
+    backing.lock()->getObject(rt).setProperty(rt, name, value);
+  }
+  // TODO: we should throw if trying to update remote from host runtime
+}
+
+std::vector<jsi::PropNameID> RemoteObject::getPropertyNames(jsi::Runtime &rt) {
+  std::vector<jsi::PropNameID> res;
+  auto propertyNames = backing.lock()->getObject(rt).getPropertyNames(rt);
+  for (size_t i = 0, size = propertyNames.size(rt); i < size; i++) {
+    res.push_back(jsi::PropNameID::forString(rt, propertyNames.getValueAtIndex(rt, i).asString(rt)));
+  }
+  return res;
 }
 
 }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -193,8 +193,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       return array;
     }
     case ValueType::RemoteObjectType:
-      if (module->isUIRuntime(rt)) {
-        return remoteObject->returnObject(rt);
+     if (module->isUIRuntime(rt)) {
+        remoteObject->maybeInitializeOnUIRuntime(rt);
       }
       return createHost(rt, remoteObject);
     case ValueType::MutableValueType:

--- a/Common/cpp/headers/SharedItems/RemoteObject.h
+++ b/Common/cpp/headers/SharedItems/RemoteObject.h
@@ -8,13 +8,18 @@ using namespace facebook;
 
 namespace reanimated {
 
-class RemoteObject: public jsi::HostObject {
+class RemoteObject: public jsi::HostObject, public StoreUser {
 private:
+  NativeReanimatedModule *module;
+  std::weak_ptr<jsi::Value> backing;
   std::unique_ptr<FrozenObject> initializer;
 public:
-  jsi::Value returnObject(jsi::Runtime &rt);
+  void maybeInitializeOnUIRuntime(jsi::Runtime &rt);
   RemoteObject(jsi::Runtime &rt, jsi::Object &object, NativeReanimatedModule *module):
-    initializer(new FrozenObject(rt, object, module)) {}
+    module(module), initializer(new FrozenObject(rt, object, module)) {}
+  void set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &value);
+  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name);
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
 };
 
 }


### PR DESCRIPTION
In useAnimatedStyle we hardly rely on RemoteObject ability to return the same object everytime we call ToJSValue on UI thread. The pr brings back the ability by reverting all remote object changes introduced by #1236. 