### PR TITLE
Add runOnJS logic.

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -112,6 +112,18 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
   };
   jsi::Value measureFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
   rt.global().setProperty(rt, "_measure", measureFunction);
+  
+  auto clb5 = [](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+      ) -> jsi::Value {
+    rt.global().setProperty(rt, args[0].asString(rt), args[1]);
+    return jsi::Value::undefined();
+  };
+  jsi::Value globalSetter = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_globalSetter"), 1, clb5);
+  rt.global().setProperty(rt, "_globalSetter", globalSetter);
 }
 
 }

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -112,23 +112,6 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
   };
   jsi::Value measureFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
   rt.global().setProperty(rt, "_measure", measureFunction);
-  
-  auto runOnJS = [](
-      jsi::Runtime &rt,
-      const jsi::Value &thisValue,
-      const jsi::Value *args,
-      size_t count
-      ) -> jsi::Value {
-    if (args[0].isObject()) {
-      jsi::Object obj = args[0].getObject(rt);
-      if (obj.hasProperty(rt, "callAsync")) {
-        return obj.getProperty(rt, "callAsync");
-      }
-    }
-    return jsi::Value::undefined();
-  };
-  jsi::Value runOnJSFun = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "runOnJS"), 1, runOnJS);
-  rt.global().setProperty(rt, "runOnJS", runOnJSFun);
 }
 
 }

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -113,6 +113,22 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
   jsi::Value measureFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
   rt.global().setProperty(rt, "_measure", measureFunction);
   
+  auto runOnJS = [](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+      ) -> jsi::Value {
+    if (args[0].isObject()) {
+      jsi::Object obj = args[0].getObject(rt);
+      if (obj.hasProperty(rt, "callAsync")) {
+        return obj.getProperty(rt, "callAsync");
+      }
+    }
+    return jsi::Value::undefined();
+  };
+  jsi::Value runOnJSFun = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "runOnJS"), 1, runOnJS);
+  rt.global().setProperty(rt, "runOnJS", runOnJSFun);
 }
 
 }

--- a/plugin.js
+++ b/plugin.js
@@ -49,7 +49,6 @@ const globals = new Set([
   'global',
   '_measure',
   '_scrollTo',
-  'runOnJS',
 ]);
 
 // leaving way to avoid deep capturing by adding 'stopCapturing' to the blacklist
@@ -103,6 +102,7 @@ const blacklistedFunctions = new Set([
   'bind',
   'apply',
   'call',
+  '__callAsync',
 ]);
 
 class ClosureGenerator {

--- a/plugin.js
+++ b/plugin.js
@@ -49,6 +49,7 @@ const globals = new Set([
   'global',
   '_measure',
   '_scrollTo',
+  'runOnJS',
 ]);
 
 // leaving way to avoid deep capturing by adding 'stopCapturing' to the blacklist

--- a/plugin.js
+++ b/plugin.js
@@ -24,6 +24,8 @@ const objectHooks = new Set([
 
 const globals = new Set([
   'this',
+  'console',
+  '_globalSetter',
   'Date',
   'Array',
   'ArrayBuffer',

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -150,3 +150,7 @@ export function startMapper(mapper, inputs = [], outputs = []) {
 export function stopMapper(mapperId) {
   NativeReanimated.stopMapper(mapperId);
 }
+
+export function runOnJS(fun) {
+  return fun;
+}

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -157,8 +157,7 @@ export let runOnJS = (fun) => fun;
 if (Platform.OS !== 'web') {
   runOnJS = (fun) => {
     'worklet';
-    if (!_WORKLET) {
-      // eslint-disable-line
+    if (!_WORKLET) { // eslint-disable-line
       return fun;
     }
     if (!fun.__callAsync) {

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -1,5 +1,4 @@
 import NativeReanimated from './NativeReanimated';
-import { Platform } from 'react-native';
 
 global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;
@@ -152,24 +151,20 @@ export function stopMapper(mapperId) {
   NativeReanimated.stopMapper(mapperId);
 }
 
-export let runOnJS = (fun) => fun;
-
-if (Platform.OS !== 'web') {
-  runOnJS = (fun) => {
-    'worklet';
-    if (!_WORKLET) {
-      // eslint-disable-line
-      return fun;
-    }
-    if (!fun.__callAsync) {
-      throw new Error(
-        "Attempting to call runOnJS with an object that is not a host function. Using runOnJS is only possible with methods that are defined on the main React-Native Javascript thread and that aren't marked as worklets"
-      );
-    } else {
-      return fun.__callAsync;
-    }
-  };
-}
+export const runOnJS = (fun) => {
+  'worklet';
+  if (!_WORKLET) {
+    // eslint-disable-line
+    return fun;
+  }
+  if (!fun.__callAsync) {
+    throw new Error(
+      "Attempting to call runOnJS with an object that is not a host function. Using runOnJS is only possible with methods that are defined on the main React-Native Javascript thread and that aren't marked as worklets"
+    );
+  } else {
+    return fun.__callAsync;
+  }
+};
 
 const capturableConsole = console;
 runOnUI(() => {

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -1,4 +1,5 @@
 import NativeReanimated from './NativeReanimated';
+import { Platform } from 'react-native';
 
 global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;
@@ -151,6 +152,19 @@ export function stopMapper(mapperId) {
   NativeReanimated.stopMapper(mapperId);
 }
 
-export function runOnJS(fun) {
-  return fun;
+export let runOnJS = (fun) => fun;
+
+if (Platform.OS !== 'web') {
+  runOnJS = (fun) => {
+    'worklet';
+    if (!_WORKLET) {
+      // eslint-disable-line
+      return fun;
+    }
+    if (!fun.__callAsync) {
+      throw new Error("Function couldn't be called by runOnJS");
+    } else {
+      return fun.__callAsync;
+    }
+  };
 }

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -157,13 +157,27 @@ export let runOnJS = (fun) => fun;
 if (Platform.OS !== 'web') {
   runOnJS = (fun) => {
     'worklet';
-    if (!_WORKLET) { // eslint-disable-line
+    if (!_WORKLET) {
+      // eslint-disable-line
       return fun;
     }
     if (!fun.__callAsync) {
-      throw new Error("Function couldn't be called by runOnJS");
+      throw new Error(
+        "Attempting to call runOnJS with an object that is not a host function. Using runOnJS is only possible with methods that are defined on the main React-Native Javascript thread and that aren't marked as worklets"
+      );
     } else {
       return fun.__callAsync;
     }
   };
 }
+
+const capturableConsole = console;
+runOnUI(() => {
+  'worklet';
+  const console = {
+    log: runOnJS(capturableConsole.log),
+    warn: runOnJS(capturableConsole.warn),
+    error: runOnJS(capturableConsole.error),
+  };
+  _globalSetter('console', console); // eslint-disable-line
+})();

--- a/src/reanimated2/js-reanimated/index.js
+++ b/src/reanimated2/js-reanimated/index.js
@@ -18,4 +18,8 @@ global._updatePropsJS = (viewTag, updates, viewRef) => {
   }
 };
 
+global._globalSetter = (name, val) => {
+  global[name] = val;
+};
+
 export default reanimatedJS;


### PR DESCRIPTION
# WHY
When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduce `runOnJS` method which calls a callback asynchronously. If you call a callback without this method then an exception will be thrown.

## HOW
add a hidden property to every hostFunction named `callAsync` and call it in runOnJS.

resolves: https://github.com/software-mansion/react-native-reanimated/issues/1258