### PR TITLE
Add tint color to native props

### DIFF
--- a/src/ConfigHelper.js
+++ b/src/ConfigHelper.js
@@ -101,6 +101,7 @@ let NATIVE_THREAD_PROPS_WHITELIST = {
   writingDirection: true,
   /* text color */
   color: true,
+  tintColor: true,
 };
 
 function configureProps() {


### PR DESCRIPTION
## Description

Add tint color to native props white list, that closes https://github.com/software-mansion/react-native-reanimated/issues/1183