### PR TITLE
[android] Do not try to call methods NativeProxy if it's null

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -115,8 +115,10 @@ public class NodesManager implements EventDispatcherListener {
   private NativeProxy mNativeProxy;
 
   public void onCatalystInstanceDestroy() {
-    mNativeProxy.onCatalystInstanceDestroy();
-    mNativeProxy = null;
+    if (mNativeProxy != null) {
+      mNativeProxy.onCatalystInstanceDestroy();
+      mNativeProxy = null;
+    }
   }
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {


### PR DESCRIPTION
## Description

While implementing https://github.com/expo/expo/pull/10383 I noticed that if Reanimated doesn't initialize `NodesManager` properly (while React fetches JSI modules from `ReanimatedJSIModulePackage`), when refreshing the app, `NodesManager` tries to call `onCatalystInstanceDestroy` on `mNativeProxy == null`.

## Changes

- Wrapped `mNativeProxy.onCatalystInstanceDestroy` with `if (mNativeProxy != null)`.