### PR TITLE
Add node >=12 note to installation docs

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -60,7 +60,8 @@ Add Reanimated's babel plugin to your `babel.config.js`:
   };
 ```
 
-> **_NOTE:_** Reanimated plugin has to be listed last.
+* **_NOTE:_** Reanimated plugin **only** works with `node >=12`. When adding it, make sure to run `react-native start` with the `--reset-cache` flag
+* **_NOTE:_** Reanimated plugin has to be listed last.
 
 ## Android
 


### PR DESCRIPTION
## Description

Without this, you just get a cryptic error of `Unexpected token =` that you don't know where it is coming from.

## Changes

Note in docs that reanimated plugin needs at least `node@12`.