### PR TITLE
Add NodeJS version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report-v2.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report-v2.md
@@ -40,3 +40,4 @@ List other libraries if relevant.
 - React:
 - React Native:
 - React Native Reanimated:
+- NodeJS:


### PR DESCRIPTION
There are a few issues where the problem was in the node version. The minimum required version of React Native itself is 12, but many users use 10.
