### PR TITLE
Updated docs fundamentals to include imports

### DIFF
--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -19,7 +19,9 @@ One of the easiest ways of starting an animation in Reanimated 2, is by making a
 Animated Shared Value updates require just a tiny change compared to immediate updates.
 Let us recall the example from the previous article, where we'd update a Shared Value with some random number on every button tap:
 
-```js {13}
+```js {15}
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
 function Box() {
   const offset = useSharedValue(0);
 
@@ -173,11 +175,10 @@ Below we show an example of how a custom spring animation can be defined and how
 Please review [`withSpring`](api/withSpring) documentation for the complete list of configurable options.
 
 ```js
-import {
+import Animated, {
   withSpring,
   useAnimatedStyle,
   useSharedValue,
-  Animated,
 } from 'react-native-reanimated';
 
 function Box() {
@@ -232,6 +233,8 @@ Let us now exercise the use of modifiers in practice and build animation that ca
 We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
 
 ```js
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
 function WobbleExample(props) {
   const rotation = useSharedValue(0);
 

--- a/docs/docs/shared-values.md
+++ b/docs/docs/shared-values.md
@@ -41,7 +41,9 @@ This can be any primitive or nested data like object, array, number, string or b
 
 In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
-```js {2,5}
+```js {4,7}
+import { useSharedValue } from 'react-native-reanimated';
+
 function SomeComponent() {
   const sharedVal = useSharedValue(0);
   return (
@@ -56,7 +58,9 @@ function SomeComponent() {
 In the above example we update value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {3,7}
+```js {5,9}
+import Animated, { useSharedValue, useAnimatedScrollHandler } from 'react-native-reanimated';
+
 function SomeComponent({ children }) {
 
   const scrollOffset = useSharedValue(0);
@@ -94,7 +98,9 @@ For example, when we have a Shared Value `x`, a derived value `y` that uses `x`,
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
 Let us look now at an example code:
-```js {2,6,13}
+```js {4,8,15}
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
 function Box() {
   const offset = useSharedValue(0);
 
@@ -143,7 +149,7 @@ Below is a complete code example which is the modified version of the example fr
 Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
-import { withSpring } from 'react-native-reanimated';
+import Animated, { withSpring } from 'react-native-reanimated';
 
 function Box() {
   const offset = useSharedValue(0);


### PR DESCRIPTION
## Description

Updates docs to include imports in most examples under Fundamentals, and fixes an incorrect import under Fundamentals>Animations>Spring. The error is 
`import {
  withSpring,
  useAnimatedStyle,
  useSharedValue,
  Animated,
} from 'react-native-reanimated';`
when it should be
`import Animated, {
  withSpring,
  useAnimatedStyle,
  useSharedValue,
} from 'react-native-reanimated';`

