### PR TITLE
Fix dead link to v1 docs

### DIFF
--- a/docs/docs/about.md
+++ b/docs/docs/about.md
@@ -5,7 +5,7 @@ sidebar_label: About
 ---
 
 > This is a documentation website of Reanimated 2 alpha release.
-> If you are looking for Reanimated 1 docs [please follow this link](https://docs.swmansion.com/react-native-reanimated/docs/1.x.x/).
+> If you are looking for Reanimated 1 docs [please follow this link](https://docs.swmansion.com/react-native-reanimated/docs/).
 
 Reanimated is a React Native library that allows for creating smooth animations and interactions that runs on the UI thread.
 


### PR DESCRIPTION
The original link leads to a 404 page

## Description

The previous link leads to a 404: https://docs.swmansion.com/react-native-reanimated/docs/1.x.x/

## Changes

Update the link to match the page from using the dropdown on the v2 docs: https://docs.swmansion.com/react-native-reanimated/docs/