### PR TITLE
Add shadow color to native props

### DIFF
--- a/src/ConfigHelper.js
+++ b/src/ConfigHelper.js
@@ -102,6 +102,7 @@ let NATIVE_THREAD_PROPS_WHITELIST = {
   /* text color */
   color: true,
   tintColor: true,
+  shadowColor: true,
 };
 
 function configureProps() {


### PR DESCRIPTION
## Description

Added `shadowColor` to `NATIVE_THREAD_PROPS_WHITELIST` in order to make shadow box work with `useAnimatedStyle`

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1296 for iOS