### PR TITLE
Check if mNodesManager is null before calling onCatalystInstanceDestroy

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -232,6 +232,9 @@ public class ReanimatedModule extends ReactContextBaseJavaModule implements
   @Override
   public void onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy();
-    mNodesManager.onCatalystInstanceDestroy();
+
+    if (mNodesManager != null) {
+      mNodesManager.onCatalystInstanceDestroy();
+    }
   }
 }


### PR DESCRIPTION
## Description

Copying a fix over from https://github.com/expo/expo/pull/10509

## Changes

In `ReanimatedModule`, check if `mNodesManager` is null before calling `onCatalystInstanceDestroy`

## Screenshots / GIFs

### Before

![Screen Recording 2020-10-01 at 4 37 52 PM](https://user-images.githubusercontent.com/90494/94878422-257fff80-0412-11eb-83e0-0296975d1586.gif)

### After

No redbox when disabling remote JS debugging.
