### PR TITLE
Add another ways to mark function as worklet.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -15,6 +15,8 @@ const functionHooks = new Map([
   ['useDerivedValue', [0]],
   ['useAnimatedScrollHandler', [0]],
   ['useAnimatedReaction', [0, 1]],
+  ['useWorkletCallback', [0]],
+  ['createWorklet', [0]],
 ]);
 
 const objectHooks = new Set([

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -22,6 +22,9 @@ import Animated, {
   repeat,
   sequence,
   withDecay,
+  useWorkletCallback,
+  createWorklet,
+  runOnUI,
 } from 'react-native-reanimated';
 
 const styles = StyleSheet.create({
@@ -359,4 +362,34 @@ function WithDecayTest() {
       <Animated.View style={[styles.box, animatedStyle]} />
     </PanGestureHandler>
   );
+}
+
+// useWorkletCallback
+function UseWorkletCallbackTest() {
+  const callback = useWorkletCallback((a: number, b: number) => {
+    return a + b;
+  });
+
+  runOnUI(() => {
+    const res = callback(1, 1);
+
+    console.log(res);
+  })();
+
+  return <Animated.View style={styles.container} />;
+}
+
+// createWorklet
+function CreateWorkletTest() {
+  const callback = createWorklet((a: number, b: number) => {
+    return a + b;
+  });
+
+  runOnUI(() => {
+    const res = callback(1, 1);
+
+    console.log(res);
+  })();
+
+  return <Animated.View style={styles.container} />;
 }

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -368,7 +368,7 @@ function WithDecayTest() {
 function UseWorkletCallbackTest() {
   const callback = useWorkletCallback((a: number, b: number) => {
     return a + b;
-  });
+  }, []);
 
   runOnUI(() => {
     const res = callback(1, 1);

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -446,8 +446,7 @@ declare module 'react-native-reanimated' {
     ): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
     export function createWorklet<A extends any[], R>(
-      fn: (...args: A) => R,
-      deps?: DependencyList
+      fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => R;
 
     type DependencyList = ReadonlyArray<any>;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -445,6 +445,10 @@ declare module 'react-native-reanimated' {
       fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
+    export function createWorklet<A extends any[], R>(
+      fn: (...args: A) => R,
+      deps?: DependencyList
+    ): (...args: Parameters<typeof fn>) => R;
 
     type DependencyList = ReadonlyArray<any>;
 
@@ -480,6 +484,10 @@ declare module 'react-native-reanimated' {
       handlers: ScrollHandlers<TContext>,
       deps?: DependencyList
     ): OnScroll;
+    export function useWorkletCallback<A extends any[], R>(
+      fn: (...args: A) => R,
+      deps?: DependencyList
+    ): (...args: Parameters<typeof fn>) => R;
 
     export function useAnimatedRef<T extends Component>(): RefObject<T>;
     export function measure<T extends Component>(

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -713,6 +713,8 @@ declare module 'react-native-reanimated' {
   export const useAnimatedStyle: typeof Animated.useAnimatedStyle;
   export const useAnimatedProps: typeof Animated.useAnimatedProps;
   export const useDerivedValue: typeof Animated.useDerivedValue;
+  export const useWorkletCallback: typeof Animated.useWorkletCallback;
+  export const createWorklet: typeof Animated.createWorklet;
   export const useAnimatedGestureHandler: typeof Animated.useAnimatedGestureHandler;
   export const useAnimatedScrollHandler: typeof Animated.useAnimatedScrollHandler;
   export const useAnimatedRef: typeof Animated.useAnimatedRef;

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -598,3 +598,7 @@ export function useAnimatedReaction(prepare, react) {
 export function useWorkletCallback(fun) {
   return useCallback(fun);
 }
+
+export function createWorklet(fun) {
+  return fun;
+}

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 
 import WorkletEventHandler from './WorkletEventHandler';
 import {
@@ -593,4 +593,8 @@ export function useAnimatedReaction(prepare, react) {
       stopMapper(mapperId);
     };
   }, inputs);
+}
+
+export function useWorkletCallback(fun) {
+  return useCallback(fun);
 }

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -595,8 +595,8 @@ export function useAnimatedReaction(prepare, react) {
   }, inputs);
 }
 
-export function useWorkletCallback(fun) {
-  return useCallback(fun);
+export function useWorkletCallback(fun, deps) {
+  return useCallback(fun, deps);
 }
 
 export function createWorklet(fun) {


### PR DESCRIPTION
The pull-request adds two methods which are the new ways for telling babel that is should transform the function into a worklet. The first is `useWorkletCallback`:
```JS
useWorkletCallback(() => {...});
```
which is equivalent to
```JS
useCallback(() => {
  'worklet'
})
``` 

The second one is `createWorklet` which just lets us omit 'worklet' mark.
```JS
const worklet = createWorklet(() => {
  ...
});
```
behaves the same as
```
const worklet = () => {
   'worklet'
    ...
}