### PR TITLE
Add createWorklet and useWorkletCallback types

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -22,6 +22,9 @@ import Animated, {
   repeat,
   sequence,
   withDecay,
+  useWorkletCallback,
+  createWorklet,
+  runOnUI,
 } from 'react-native-reanimated';
 
 const styles = StyleSheet.create({
@@ -359,4 +362,34 @@ function WithDecayTest() {
       <Animated.View style={[styles.box, animatedStyle]} />
     </PanGestureHandler>
   );
+}
+
+// useWorkletCallback
+function UseWorkletCallbackTest() {
+  const callback = useWorkletCallback((a: number, b: number) => {
+    return a + b;
+  });
+
+  runOnUI(() => {
+    const res = callback(1, 1);
+
+    console.log(res);
+  })();
+
+  return <Animated.View style={styles.container} />;
+}
+
+// createWorklet
+function CreateWorkletTest() {
+  const callback = createWorklet((a: number, b: number) => {
+    return a + b;
+  });
+
+  runOnUI(() => {
+    const res = callback(1, 1);
+
+    console.log(res);
+  })();
+
+  return <Animated.View style={styles.container} />;
 }

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -445,6 +445,10 @@ declare module 'react-native-reanimated' {
       fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
+    export function createWorklet<A extends any[], R>(
+      fn: (...args: A) => R,
+      deps?: DependencyList
+    ): (...args: Parameters<typeof fn>) => R;
 
     type DependencyList = ReadonlyArray<any>;
 
@@ -480,6 +484,10 @@ declare module 'react-native-reanimated' {
       handlers: ScrollHandlers<TContext>,
       deps?: DependencyList
     ): OnScroll;
+    export function useWorkletCallback<A extends any[], R>(
+      fn: (...args: A) => R,
+      deps?: DependencyList
+    ): (...args: Parameters<typeof fn>) => R;
 
     export function useAnimatedRef<T extends Component>(): RefObject<T>;
     export function measure<T extends Component>(


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

This PR adds TS typings for the introduced in #1310 API

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- Added TypeScript definitions for useWorkletCallback and createCallback
- Added TS tests for useWorkletCallback and createCallback

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
