### PR TITLE
Make StoreUser concurrent.

### DIFF
--- a/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -2,11 +2,12 @@
 
 namespace reanimated {
 
-int identifier = 0;
 std::atomic<int> StoreUser::ctr;
+std::mutex StoreUser::storeMutex;
 std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> StoreUser::store;
 
 std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
+  const std::lock_guard<std::mutex> lock(storeMutex);
   if (StoreUser::store.count(identifier) == 0) {
     StoreUser::store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
   }
@@ -17,6 +18,7 @@ std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
 }
 
 void StoreUser::removeRefs() {
+  const std::lock_guard<std::mutex> lock(storeMutex);
   if (StoreUser::store.count(identifier) > 0) {
     StoreUser::store.erase(identifier);
   }
@@ -28,6 +30,7 @@ StoreUser::~StoreUser() {
 
 
 void StoreUser::clearStore() {
+  const std::lock_guard<std::mutex> lock(storeMutex);
   StoreUser::store.clear();
 }
 

--- a/Common/cpp/headers/Tools/JSIStoreValueUser.h
+++ b/Common/cpp/headers/Tools/JSIStoreValueUser.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <jsi/jsi.h>
+#include <mutex>
 
 using namespace facebook;
 
@@ -15,6 +16,7 @@ class StoreUser {
   int identifier = 0;
   static std::atomic<int> ctr;
   static std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
+  static std::mutex storeMutex;
   
 public:
   StoreUser() {


### PR DESCRIPTION
I believe the problems mentioned in https://github.com/software-mansion/react-native-reanimated/issues/1284 are caused by parallel read/writes operations made on hash map. We can create shared value on different threads so we should also take care of concurrent updates.