### PR TITLE
Rename `useWorkletCallback` to `useWorklet`

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -15,7 +15,7 @@ const functionHooks = new Map([
   ['useDerivedValue', [0]],
   ['useAnimatedScrollHandler', [0]],
   ['useAnimatedReaction', [0, 1]],
-  ['useWorkletCallback', [0]],
+  ['useWorklet', [0]],
   ['createWorklet', [0]],
 ]);
 

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import React from 'react';
 import { StyleSheet, Button, View } from 'react-native';
-import { 
+import {
   PanGestureHandler,
   PinchGestureHandlerGestureEvent,
   PinchGestureHandler,
@@ -22,7 +22,7 @@ import Animated, {
   repeat,
   sequence,
   withDecay,
-  useWorkletCallback,
+  useWorklet,
   createWorklet,
   runOnUI,
 } from 'react-native-reanimated';
@@ -364,9 +364,9 @@ function WithDecayTest() {
   );
 }
 
-// useWorkletCallback
-function UseWorkletCallbackTest() {
-  const callback = useWorkletCallback((a: number, b: number) => {
+// useWorklet
+function UseWorkletTest() {
+  const callback = useWorklet((a: number, b: number) => {
     return a + b;
   }, []);
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -483,7 +483,7 @@ declare module 'react-native-reanimated' {
       handlers: ScrollHandlers<TContext>,
       deps?: DependencyList
     ): OnScroll;
-    export function useWorkletCallback<A extends any[], R>(
+    export function useWorklet<A extends any[], R>(
       fn: (...args: A) => R,
       deps?: DependencyList
     ): (...args: Parameters<typeof fn>) => R;
@@ -713,7 +713,7 @@ declare module 'react-native-reanimated' {
   export const useAnimatedStyle: typeof Animated.useAnimatedStyle;
   export const useAnimatedProps: typeof Animated.useAnimatedProps;
   export const useDerivedValue: typeof Animated.useDerivedValue;
-  export const useWorkletCallback: typeof Animated.useWorkletCallback;
+  export const useWorklet: typeof Animated.useWorklet;
   export const createWorklet: typeof Animated.createWorklet;
   export const useAnimatedGestureHandler: typeof Animated.useAnimatedGestureHandler;
   export const useAnimatedScrollHandler: typeof Animated.useAnimatedScrollHandler;

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -595,7 +595,7 @@ export function useAnimatedReaction(prepare, react) {
   }, inputs);
 }
 
-export function useWorkletCallback(fun, deps) {
+export function useWorklet(fun, deps) {
   return useCallback(fun, deps);
 }
 


### PR DESCRIPTION
## Description

While I'm a big fan of the hook syntax for worklets, I think it would be a better name to shorten `useWorkletCallback` to `useWorklet`. A 'worklet' if per definition something like a callback anyways, no?

## Changes

- Renamed `useWorkletCallback` to `useWorklet`

## Reference

https://github.com/software-mansion/react-native-reanimated/pull/1310#issuecomment-704898870
