### PR TITLE
Unset `CI` env var when building npm package

### DIFF
--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -4,6 +4,9 @@ set -x
 
 ROOT=$(pwd)
 
+# unset CI so all archs are built
+unset CI
+
 # PART I - I (install RN)
 yarn add react-native --dev
 


### PR DESCRIPTION
## Description

Fixes #1321.

This ensures that we build every arch variant. Right now if `CI` is set we skip everything but x86 (test inside Application.mk). This was used to make CI builds faster.

