### PR TITLE
Fix animations initial calculations

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -7,7 +7,6 @@ import {
   makeMutable,
   makeRemote,
   requestFrame,
-  FRAME_LENGTH,
 } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
@@ -112,7 +111,8 @@ function runAnimations(animation, timestamp, key, result) {
       return allFinished;
     } else if (typeof animation === 'object' && animation.animation) {
       if (animation.callStart) {
-        animation.callStart(timestamp - FRAME_LENGTH);
+        // we subtract one frame so the initial delta will not be 0
+        animation.callStart(timestamp - 1000 / 60);
         animation.callStart = null;
       }
       const finished = animation.animation(animation, timestamp);

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -7,6 +7,7 @@ import {
   makeMutable,
   makeRemote,
   requestFrame,
+  FRAME_LENGTH,
 } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
@@ -111,7 +112,7 @@ function runAnimations(animation, timestamp, key, result) {
       return allFinished;
     } else if (typeof animation === 'object' && animation.animation) {
       if (animation.callStart) {
-        animation.callStart(timestamp);
+        animation.callStart(timestamp - FRAME_LENGTH);
         animation.callStart = null;
       }
       const finished = animation.animation(animation, timestamp);

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -132,6 +132,7 @@ export function withSpring(toValue, userConfig, callback) {
 
     function spring(animation, now) {
       const { toValue, lastTimestamp, current, velocity } = animation;
+
       const deltaTime = Math.min(now - lastTimestamp, 64);
       animation.lastTimestamp = now;
 

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -3,6 +3,7 @@ import { Easing } from './Easing';
 import NativeReanimated from './NativeReanimated';
 
 let IN_STYLE_UPDATER = false;
+const FRAME_LENGTH = 1000 / 60;
 
 const assertNumber = (value, callerName) => {
   'worklet';
@@ -133,7 +134,10 @@ export function withSpring(toValue, userConfig, callback) {
     function spring(animation, now) {
       const { toValue, lastTimestamp, current, velocity } = animation;
 
-      const deltaTime = Math.min(now - lastTimestamp, 64);
+      const deltaTime =
+        lastTimestamp === now
+          ? FRAME_LENGTH
+          : Math.min(now - lastTimestamp, 64);
       animation.lastTimestamp = now;
 
       const c = config.damping;

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -3,7 +3,6 @@ import { Easing } from './Easing';
 import NativeReanimated from './NativeReanimated';
 
 let IN_STYLE_UPDATER = false;
-const FRAME_LENGTH = 1000 / 60;
 
 const assertNumber = (value, callerName) => {
   'worklet';
@@ -133,11 +132,7 @@ export function withSpring(toValue, userConfig, callback) {
 
     function spring(animation, now) {
       const { toValue, lastTimestamp, current, velocity } = animation;
-
-      const deltaTime =
-        lastTimestamp === now
-          ? FRAME_LENGTH
-          : Math.min(now - lastTimestamp, 64);
+      const deltaTime = Math.min(now - lastTimestamp, 64);
       animation.lastTimestamp = now;
 
       const c = config.damping;

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -112,7 +112,8 @@ function workletValueSetterJS(value) {
         return;
       }
       if (callStart) {
-        callStart(timestamp);
+        // we subtract one frame so the initial delta will not be 0
+        callStart(timestamp - 1000 / 60);
         callStart = null; // prevent closure from keeping ref to previous animation
       }
       const finished = animation.animation(animation, timestamp);

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -1,8 +1,6 @@
 /* global _WORKLET */
 import NativeReanimated from './NativeReanimated';
 
-export const FRAME_LENGTH = 1000 / 60;
-
 global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;
 };
@@ -69,7 +67,8 @@ function workletValueSetter(value) {
         return;
       }
       if (callStart) {
-        callStart(timestamp - FRAME_LENGTH);
+        // we subtract one frame so the initial delta will not be 0
+        callStart(timestamp - 1000 / 60);
         callStart = null; // prevent closure from keeping ref to previous animation
       }
       const finished = animation.animation(animation, timestamp);

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -1,4 +1,7 @@
+/* global _WORKLET */
 import NativeReanimated from './NativeReanimated';
+
+const FRAME_LENGTH = 1000 / 60;
 
 global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;
@@ -66,7 +69,7 @@ function workletValueSetter(value) {
         return;
       }
       if (callStart) {
-        callStart(timestamp);
+        callStart(timestamp - FRAME_LENGTH);
         callStart = null; // prevent closure from keeping ref to previous animation
       }
       const finished = animation.animation(animation, timestamp);

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -1,7 +1,7 @@
 /* global _WORKLET */
 import NativeReanimated from './NativeReanimated';
 
-const FRAME_LENGTH = 1000 / 60;
+export const FRAME_LENGTH = 1000 / 60;
 
 global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;


### PR DESCRIPTION
## Description

As we can see here
https://github.com/software-mansion/react-native-reanimated/blob/master/src/reanimated2/core.js#L72
first animation invocation happens directly after calling `animation.start`. As it is wrapped in the same `step` call it uses the same `timestamp`. In the same time, we set `animation.lastTimestamp` or `animation.startTime` inside `animation.start`, which is then used for calculating current progress(and other things) of the animations. All of the following values come from `step` called on the following frames(with according `timestamp`), which results in time delta being equal to or greater than a frame length(for 60FPS that's 1000/60=16.66). That causes a frame delay in animations.

Solution is to call `animation.start` with `timestamp - FRAME_LENGTH` and call `animation.animation` with `timestamp`(so it's like `animation.start` is called in the frame before `animation.animation`).


Thanks @terrysahaidak for investigation


Fixes https://github.com/software-mansion/react-native-reanimated/issues/1313


