### PR TITLE
Decorate callbacks

### DIFF
--- a/Example/test/SimpleTest.js
+++ b/Example/test/SimpleTest.js
@@ -1,3 +1,4 @@
+/* global _WORKLET */
 import React from 'react';
 import { TextInput, Button, View } from 'react-native';
 import Animated, {
@@ -13,7 +14,8 @@ import Animated, {
   useAnimatedScrollHandler,
   withDecay,
   withDelay,
-  loop,
+  withRepeat,
+  withSequence,
 } from 'react-native-reanimated';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 
@@ -107,33 +109,90 @@ const SimpleTest = () => {
       <Button
         title="change size(with timing)"
         onPress={() => {
-          sv.value = withTiming(updateSV());
+          sv.value = withTiming(updateSV(), null, (finished) => {
+            // callback may run on UI or on JS
+            // 'worklet'
+            console.log('timing clb', _WORKLET, finished);
+          });
         }}
       />
       <Button
         title="change size(with spring)"
         onPress={() => {
-          sv.value = withSpring(updateSV());
+          sv.value = withSpring(updateSV(), null, (finished) => {
+            // callback may run on UI or on JS
+            // 'worklet'
+            console.log('spring clb', _WORKLET, finished);
+          });
         }}
       />
       <Button
         title="change size(with decay)"
         onPress={() => {
-          sv.value = withDecay({
-            velocity: Math.floor(Math.random() * 100 - 50),
-          });
+          sv.value = withDecay(
+            {
+              velocity: Math.floor(Math.random() * 100 - 50),
+            },
+            (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('decay clb', _WORKLET, finished);
+            }
+          );
         }}
       />
       <Button
         title="change size(with delay)"
         onPress={() => {
-          sv.value = withDelay(1000, withTiming(updateSV(), { duration: 0 }));
+          sv.value = withDelay(
+            1000,
+            withTiming(updateSV(), { duration: 0 }, (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('delayed timing clb', _WORKLET, finished);
+            })
+          );
         }}
       />
       <Button
-        title="change size(loop)"
+        title="change size(with sequence)"
         onPress={() => {
-          sv.value = loop(withTiming(updateSV(), { duration: 500 }));
+          sv.value = withSequence(
+            withTiming(updateSV(), { duration: 500 }, (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('sequenced timing clb 1', _WORKLET, finished);
+            }),
+            withTiming(updateSV(), { duration: 500 }, (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('sequenced timing clb 2', _WORKLET, finished);
+            }),
+            withTiming(updateSV(), { duration: 500 }, (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('sequenced timing clb 3', _WORKLET, finished);
+            })
+          );
+        }}
+      />
+      <Button
+        title="change size(with repeat)"
+        onPress={() => {
+          sv.value = withRepeat(
+            withTiming(updateSV(), { duration: 500 }, (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('repeated timing clb', _WORKLET, finished);
+            }),
+            4,
+            true,
+            (finished) => {
+              // callback may run on UI or on JS
+              // 'worklet'
+              console.log('repeat clb final', _WORKLET, finished);
+            }
+          );
         }}
       />
       <PanGestureHandler onGestureEvent={gestureHandler}>

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -165,6 +165,7 @@ export function cancelAnimation(sharedValue) {
 }
 
 function callbackDecorator(callback) {
+  'worklet';
   if (!callback || callback.__worklet) {
     return callback;
   }

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -2,6 +2,7 @@
 import { Easing } from './Easing';
 import { isColor, convertToHSVA, toRGBA } from './Colors';
 import NativeReanimated from './NativeReanimated';
+import { runOnJS } from './core';
 
 let IN_STYLE_UPDATER = false;
 
@@ -163,8 +164,20 @@ export function cancelAnimation(sharedValue) {
   sharedValue.value = sharedValue.value; // eslint-disable-line no-self-assign
 }
 
+function callbackDecorator(callback) {
+  if (callback.__worklet) {
+    return callback;
+  }
+  return (isFinished) => {
+    'worklet';
+    runOnJS(callback)(isFinished);
+  };
+}
+
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
+  // check toValue
+  callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {
     'worklet';
@@ -230,6 +243,8 @@ export function withTiming(toValue, userConfig, callback) {
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
+  // check toValue
+  callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {
     'worklet';
@@ -349,6 +364,8 @@ export function withSpring(toValue, userConfig, callback) {
 
 export function withDecay(userConfig, callback) {
   'worklet';
+  callback = callbackDecorator(callback);
+
   return defineAnimation(0, () => {
     'worklet';
     const config = {
@@ -539,6 +556,8 @@ export function withRepeat(
   callback
 ) {
   'worklet';
+  callback = callbackDecorator(callback);
+
   return defineAnimation(_nextAnimation, () => {
     'worklet';
 

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -177,7 +177,6 @@ function callbackDecorator(callback) {
 
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
-  // check toValue
   callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {
@@ -244,7 +243,6 @@ export function withTiming(toValue, userConfig, callback) {
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
-  // check toValue
   callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -165,7 +165,7 @@ export function cancelAnimation(sharedValue) {
 }
 
 function callbackDecorator(callback) {
-  if (callback.__worklet) {
+  if (!callback || callback.__worklet) {
     return callback;
   }
   return (isFinished) => {


### PR DESCRIPTION
## Description

`runOnJS` change made it harder to create animation callback which runs on JS thread. Previously it worked with code like this:

```
import React, { useEffect } from 'react';
import { View } from 'react-native';
import {
  useSharedValue,
  withTiming,
} from 'react-native-reanimated';

const App = function({ componentId }) {
  const progress = useSharedValue(-1);
  useEffect(() => {
    progress.value = withTiming(
      10,
      null,
      (isFinished) => {
        console.log('clb', _WORKLET, isFinished);
      }
    );
  }, []);
  return <View style={{ backgroundColor: 'red', width: 100, height: 100 }} />;
};

export default App;
```

This would just print `'clb', false, true` which meant that it runs on JS thread and the argument `isFinished` is passed correctly.

Now such code throws an error

```
Tried to synchronously call function from a diffrent thread.
Solution is:
a) if you want to synchronously execute this method, mark it as a worklet
b) if you want to execute this method on the JS thread, wrap it using runOnJS
```

Wrapping the callback with `runOnJS` like this

```
runOnJS((isFinished) => {
  console.log('clb', _WORKLET, isFinished);
})
```

does not make any change(also when lambda is defined outside and just passed as a variable).
To make it work we may convert the callback into a worklet and call `runOnJS` inside like this:

```
(isFinished) => {
  'worklet'
  runOnJS(() => {
    console.log('clb', _WORKLET, isFinished);
  })(isFinished)
}
```

or like this:

```
const fun = (isFinished) => {
    console.log('clb', _WORKLET, isFinished);
  };

  useEffect(() => {
    progress.value = withTiming(
      10,
      {duration: 2000},
      createWorklet((isFinished) => {
        runOnJS(fun)(isFinished)
      }
    ));
  }, []);
```

In order to avoid such code boilerplate I decided to decorate callbacks. Those which are worklets stay as they are and those which are not are wrapped into similar call like above: they are invoked in `runOnJS` inside of the worklet.
I also improved animations test.

## Changes

`animations.js` - decorate callbacks
`SimpleTest.js` - improve animations test
