### PR TITLE
Adjust default spring thresholds

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -123,8 +123,8 @@ export function withSpring(toValue, userConfig, callback) {
       mass: 1,
       stiffness: 100,
       overshootClamping: false,
-      restDisplacementThreshold: 0.001,
-      restSpeedThreshold: 0.001,
+      restDisplacementThreshold: 0.01,
+      restSpeedThreshold: 2,
     };
     if (userConfig) {
       Object.keys(userConfig).forEach((key) => (config[key] = userConfig[key]));


### PR DESCRIPTION
This PR changes the default "end" thresholds used for spring animations. The thresholds are used to signal the end of animation when the spring is no longer in motion. 

This change will affect how soon completion callback is called when provided, or how soon the next animation starts when spring is used as a part of animation sequence.

The new defaults seem to make much more sense as typically the units that are being animated are pixels. When speed is 2px/sec the movement is hardly noticeable. The same applies for displacement, there was no need to use `0.001` when `0.01` continuous movement yields 0.16px/s which is an order of magnitude slower than the speed threshold. However, keeping this constant a bit more secures us from also quite typical cases when users animate within 0-1 range.
