### PR TITLE
Shared value rerender upgrade

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -50,6 +50,9 @@ const styles = StyleSheet.create({
 // useSharedValue
 function SharedValueTest() {
   const translate = useSharedValue(0);
+  const translate2 = useSharedValue(0, true);
+  const translate3 = useSharedValue(0, false);
+
   return <Animated.View style={styles.container} />;
 }
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -453,7 +453,8 @@ declare module 'react-native-reanimated' {
 
     // reanimated2 hooks
     export function useSharedValue<T>(
-      initialValue: T
+      initialValue: T,
+      shouldRebuild?: boolean
     ): T extends SharedValueType ? SharedValue<T> : never;
 
     export function useDerivedValue<T extends SharedValueType>(

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -14,14 +14,14 @@ import { getTag } from './NativeMethods';
 import NativeReanimated from './NativeReanimated';
 import { Platform } from 'react-native';
 
-export function useSharedValue(init) {
+export function useSharedValue(init, shouldRebuild = true) {
   const ref = useRef(null);
   if (ref.current === null) {
     ref.current = {
       mutable: makeMutable(init),
       last: init,
     };
-  } else if (init !== ref.current.last) {
+  } else if (init !== ref.current.last && shouldRebuild) {
     ref.current.last = init;
     ref.current.mutable.value = init;
   }


### PR DESCRIPTION
## Description

This PR makes `useSharedValue` more consistent with other hooks when needed. Now it would change on every rerender when the value passed to the hook changes.
So in the following scenario
```
const [state, setState] = useState(0);
const sv = useSharedValue(state);
```
every time `state` changes(and component rerenders) `sv`'s value is updated to what's in `state`.

This is inconsistent with for instance `useState`, for which the state has to be set explicitly to get modified. However the default behavior persisted for backward compatibility.


Fixes https://github.com/software-mansion/react-native-reanimated/issues/1293

