### PR TITLE
Make runOnJS more descriptive.

### DIFF
--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -13,6 +13,19 @@ using namespace facebook;
 
 namespace reanimated {
 
+struct HostFunctionHandler {
+  std::shared_ptr<jsi::Function> pureFunction;
+  std::string functionName;
+  HostFunctionHandler(std::shared_ptr<jsi::Function> f, jsi::Runtime &rt) {
+    pureFunction = f;
+    functionName = f->getProperty(rt, "name").asString(rt).utf8(rt);
+  }
+  
+  std::shared_ptr<jsi::Function> get() {
+    return pureFunction;
+  }
+};
+
 class ShareableValue: public std::enable_shared_from_this<ShareableValue>, public StoreUser {
 friend WorkletsCache;
 friend void extractMutables(jsi::Runtime &rt,
@@ -23,7 +36,7 @@ private:
   bool boolValue;
   double numberValue;
   std::string stringValue;
-  std::shared_ptr<jsi::Function> hostFunction;
+  std::shared_ptr<HostFunctionHandler> hostFunction;
   jsi::Runtime *hostRuntime;
   std::shared_ptr<FrozenObject> frozenObject;
   std::shared_ptr<RemoteObjectInitializer> remoteObjectInitializer;


### PR DESCRIPTION
It's only a temporary solution. In the future, we will display a full JS stack trace.
