### PR TITLE
Use createFromJsonUtf8 in processEvent

### DIFF
--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -30,10 +30,8 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
     auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
     auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
 
-    std::vector<uint8_t> eventJSONVector(eventJSON.begin(), eventJSON.end());
+    auto eventObject = jsi::Value::createFromJsonUtf8(rt, (uint8_t*)(&eventJSON[0]), eventJSON.size());
 
-    auto eventObject = jsi::Value::createFromJsonUtf8(rt, &eventJSONVector[0], eventJSON.size());
-      
     eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
     for (auto handler : handlersIt->second) {
       handler.second->process(rt, eventObject);

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -22,9 +22,14 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload) {
   auto handlersIt = eventMappings.find(eventName);
   if (handlersIt != eventMappings.end()) {
+    // We receive here a JS Map with JSON as a value of NativeMap key
+    // { NativeMap: { "jsonProp": "json value" } }
+    // So we need to extract only JSON part
     std::string delimimter = "NativeMap:";
-    auto eventSplitted = eventPayload.substr(eventPayload.find(delimimter) + delimimter.size(), eventPayload.size());
-    auto eventJSON = eventSplitted.substr(0, eventSplitted.size() - 1);
+    auto positionToSplit = eventPayload.find(delimimter) + delimimter.size();
+    auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
+    auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
+
     std::vector<uint8_t> eventJSONVector(eventJSON.begin(), eventJSON.end());
 
     auto eventObject = jsi::Value::createFromJsonUtf8(rt, &eventJSONVector[0], eventJSON.size());

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -22,8 +22,13 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload) {
   auto handlersIt = eventMappings.find(eventName);
   if (handlersIt != eventMappings.end()) {
-    // TODO: use jsi::Value::createFromJsonUtf8
-    auto eventObject = eval(rt, ("(" + eventPayload + ")").c_str()).asObject(rt).getProperty(rt, "NativeMap");
+    std::string delimimter = "NativeMap:";
+    auto eventSplitted = eventPayload.substr(eventPayload.find(delimimter) + del.size(), eventPayload.size());
+    auto eventJSON = eventSplitted.substr(0, eventSplitted.size() - 1);
+    std::vector<uint8_t> eventJSONVector(eventJSON.begin(), eventJSON.end());
+
+    auto eventObject = jsi::Value::createFromJsonUtf8(rt, &eventJSONVector[0], eventJSON.size());
+      
     eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
     for (auto handler : handlersIt->second) {
       handler.second->process(rt, eventObject);

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -3,10 +3,6 @@
 
 namespace reanimated {
 
-static jsi::Value eval(jsi::Runtime &rt, const char *code) {
-  return rt.global().getPropertyAsFunction(rt, "eval").call(rt, code);
-}
-
 void EventHandlerRegistry::registerEventHandler(std::shared_ptr<EventHandler> eventHandler) {
   eventMappings[eventHandler->eventName][eventHandler->id] = eventHandler;
   eventHandlers[eventHandler->id] = eventHandler;

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -23,7 +23,7 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
   auto handlersIt = eventMappings.find(eventName);
   if (handlersIt != eventMappings.end()) {
     std::string delimimter = "NativeMap:";
-    auto eventSplitted = eventPayload.substr(eventPayload.find(delimimter) + del.size(), eventPayload.size());
+    auto eventSplitted = eventPayload.substr(eventPayload.find(delimimter) + delimimter.size(), eventPayload.size());
     auto eventJSON = eventSplitted.substr(0, eventSplitted.size() - 1);
     std::vector<uint8_t> eventJSONVector(eventJSON.begin(), eventJSON.end());
 


### PR DESCRIPTION
## Description

There was TODO to migrate from inline eval. 
I'm not sure it's faster/slower right now, but I guess it will be faster.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

— use createFromJsonUtf8 instead of inline eval in processEvent

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
