### PR TITLE
Workletize animations' callbacks

### DIFF
--- a/Example/test/SimpleTest.js
+++ b/Example/test/SimpleTest.js
@@ -5,21 +5,105 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   useDerivedValue,
-  withSpring,
   useMapper,
   useEvent,
   useAnimatedProps,
-  withTiming,
   useAnimatedGestureHandler,
   useAnimatedScrollHandler,
+  withTiming,
+  withSpring,
   withDecay,
   withDelay,
   withRepeat,
   withSequence,
+  useAnimatedReaction,
 } from 'react-native-reanimated';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 
 const SimpleTest = () => {
+  const shv = useSharedValue(0);
+  /* CHECK CALLBACKS CREATED ON JS SIDE */
+  shv.value = withTiming(1, null, (finished) => {
+    console.log('timing clb', _WORKLET, finished);
+  });
+  shv.value = withSpring(2, null, (finished) => {
+    console.log('spring clb', _WORKLET, finished);
+  });
+  shv.value = withDecay(null, (finished) => {
+    console.log('decay clb', _WORKLET, finished);
+  });
+  shv.value = withDelay(
+    1000,
+    withTiming(3, null, (finished) => {
+      console.log('delayed timing clb', _WORKLET, finished);
+    })
+  );
+  shv.value = withRepeat(
+    withTiming(4, { duration: 500 }, (finished) => {
+      console.log('repeated timing clb', _WORKLET, finished);
+    }),
+    4,
+    true,
+    (finished) => {
+      console.log('repeat clb final', _WORKLET, finished);
+    }
+  );
+  shv.value = withSequence(
+    withTiming(7, { duration: 500 }, (finished) => {
+      console.log('sequenced timing clb 1', _WORKLET, finished);
+    }),
+    withTiming(8, { duration: 500 }, (finished) => {
+      console.log('sequenced timing clb 2', _WORKLET, finished);
+    }),
+    withTiming(9, { duration: 500 }, (finished) => {
+      console.log('sequenced timing clb 3', _WORKLET, finished);
+    })
+  );
+  /* CHECK CALLBACKS ON UI */
+  useAnimatedReaction(
+    () => {
+      return Math.floor(Math.random() * 20);
+    },
+    (res) => {
+      shv.value = withTiming(1, null, (finished) => {
+        console.log('timing clb', _WORKLET, finished);
+      });
+      shv.value = withSpring(2, null, (finished) => {
+        console.log('spring clb', _WORKLET, finished);
+      });
+      shv.value = withDecay(null, (finished) => {
+        console.log('decay clb', _WORKLET, finished);
+      });
+      shv.value = withDelay(
+        1000,
+        withTiming(3, null, (finished) => {
+          console.log('delayed timing clb', _WORKLET, finished);
+        })
+      );
+      shv.value = withRepeat(
+        withTiming(4, { duration: 500 }, (finished) => {
+          console.log('repeated timing clb', _WORKLET, finished);
+        }),
+        4,
+        true,
+        (finished) => {
+          console.log('repeat clb final', _WORKLET, finished);
+        }
+      );
+      shv.value = withSequence(
+        withTiming(7, { duration: 500 }, (finished) => {
+          console.log('sequenced timing clb 1', _WORKLET, finished);
+        }),
+        withTiming(8, { duration: 500 }, (finished) => {
+          console.log('sequenced timing clb 2', _WORKLET, finished);
+        }),
+        withTiming(9, { duration: 500 }, (finished) => {
+          console.log('sequenced timing clb 3', _WORKLET, finished);
+        })
+      );
+    }
+  );
+  /* */
   // check if certain hooks work
   const sv = useSharedValue(50);
 
@@ -110,8 +194,6 @@ const SimpleTest = () => {
         title="change size(with timing)"
         onPress={() => {
           sv.value = withTiming(updateSV(), null, (finished) => {
-            // callback may run on UI or on JS
-            // 'worklet'
             console.log('timing clb', _WORKLET, finished);
           });
         }}
@@ -120,8 +202,6 @@ const SimpleTest = () => {
         title="change size(with spring)"
         onPress={() => {
           sv.value = withSpring(updateSV(), null, (finished) => {
-            // callback may run on UI or on JS
-            // 'worklet'
             console.log('spring clb', _WORKLET, finished);
           });
         }}
@@ -134,8 +214,6 @@ const SimpleTest = () => {
               velocity: Math.floor(Math.random() * 100 - 50),
             },
             (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('decay clb', _WORKLET, finished);
             }
           );
@@ -147,8 +225,6 @@ const SimpleTest = () => {
           sv.value = withDelay(
             1000,
             withTiming(updateSV(), { duration: 0 }, (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('delayed timing clb', _WORKLET, finished);
             })
           );
@@ -159,18 +235,12 @@ const SimpleTest = () => {
         onPress={() => {
           sv.value = withSequence(
             withTiming(updateSV(), { duration: 500 }, (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('sequenced timing clb 1', _WORKLET, finished);
             }),
             withTiming(updateSV(), { duration: 500 }, (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('sequenced timing clb 2', _WORKLET, finished);
             }),
             withTiming(updateSV(), { duration: 500 }, (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('sequenced timing clb 3', _WORKLET, finished);
             })
           );
@@ -181,15 +251,11 @@ const SimpleTest = () => {
         onPress={() => {
           sv.value = withRepeat(
             withTiming(updateSV(), { duration: 500 }, (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('repeated timing clb', _WORKLET, finished);
             }),
             4,
             true,
             (finished) => {
-              // callback may run on UI or on JS
-              // 'worklet'
               console.log('repeat clb final', _WORKLET, finished);
             }
           );

--- a/plugin.js
+++ b/plugin.js
@@ -17,6 +17,11 @@ const functionHooks = new Map([
   ['useAnimatedReaction', [0, 1]],
   ['useWorkletCallback', [0]],
   ['createWorklet', [0]],
+  // animations' callbacks
+  ['withTiming', [2]],
+  ['withSpring', [2]],
+  ['withDecay', [1]],
+  ['withRepeat', [3]],
 ]);
 
 const objectHooks = new Set([

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -2,7 +2,6 @@
 import { Easing } from './Easing';
 import { isColor, convertToHSVA, toRGBA } from './Colors';
 import NativeReanimated from './NativeReanimated';
-import { runOnJS } from './core';
 
 let IN_STYLE_UPDATER = false;
 
@@ -164,20 +163,8 @@ export function cancelAnimation(sharedValue) {
   sharedValue.value = sharedValue.value; // eslint-disable-line no-self-assign
 }
 
-function callbackDecorator(callback) {
-  'worklet';
-  if (!callback || callback.__worklet) {
-    return callback;
-  }
-  return (isFinished) => {
-    'worklet';
-    runOnJS(callback)(isFinished);
-  };
-}
-
 export function withTiming(toValue, userConfig, callback) {
   'worklet';
-  callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {
     'worklet';
@@ -243,7 +230,6 @@ export function withTiming(toValue, userConfig, callback) {
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';
-  callback = callbackDecorator(callback);
 
   return defineAnimation(toValue, () => {
     'worklet';
@@ -363,7 +349,6 @@ export function withSpring(toValue, userConfig, callback) {
 
 export function withDecay(userConfig, callback) {
   'worklet';
-  callback = callbackDecorator(callback);
 
   return defineAnimation(0, () => {
     'worklet';
@@ -555,7 +540,6 @@ export function withRepeat(
   callback
 ) {
   'worklet';
-  callback = callbackDecorator(callback);
 
   return defineAnimation(_nextAnimation, () => {
     'worklet';


### PR DESCRIPTION
## Description

After `runOnJS`, `callbackDecorator` has been introduced but due to inconsistencies and misleading sources of invoking animations' callbacks I decided the best thing to do is automatically workletizing all of them so they'd be launched on UI side.

This PR reverts `callbackDecorator` changes and updates `functionHooks` array(used for automatic workletization) in babel plugin.