### PR TITLE
Fix negative transform

### DIFF
--- a/Example/src/LightboxExample.js
+++ b/Example/src/LightboxExample.js
@@ -9,6 +9,7 @@ import Animated, {
   Easing,
   useAnimatedRef,
   measure,
+  runOnJS,
 } from 'react-native-reanimated';
 import {
   Dimensions,
@@ -102,7 +103,7 @@ function ListItem({ item, index, onPress }) {
       x.value = measurements.pageX;
       y.value = measurements.pageY - HEADER_HEIGHT;
 
-      handlePress();
+      runOnJS(handlePress)();
     },
   });
 
@@ -177,7 +178,9 @@ function ImageTransition({ activeImage, onClose }) {
             {
               duration: 16,
             },
-            onClose
+            () => {
+              runOnJS(onClose)();
+            }
           );
         });
 

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -21,7 +21,7 @@ export function transform(value, handler) {
   if (typeof value === 'string') {
     // toInt
     // TODO handle color
-    const match = value.match(/(\D*)([\d.]*)(\D*)/);
+    const match = value.match(/([A-Za-z]*)([-\d.]*)([A-Za-z]*)/);
     const prefix = match[1];
     const suffix = match[3];
     const number = match[2];
@@ -33,9 +33,6 @@ export function transform(value, handler) {
   // toString if __prefix is available and number otherwise
   if (handler.__prefix === undefined) {
     return value;
-  }
-  if (handler.__prefix === '-' && value < 0) {
-    value *= -1;
   }
 
   return handler.__prefix + value + handler.__suffix;

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -34,6 +34,9 @@ export function transform(value, handler) {
   if (handler.__prefix === undefined) {
     return value;
   }
+  if (handler.__prefix === '-' && value < 0) {
+    value *= -1;
+  }
 
   return handler.__prefix + value + handler.__suffix;
 }

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -98,7 +98,7 @@ function workletValueSetterJS(value) {
   }
   if (
     typeof value === 'function' ||
-    (value !== null && typeof value === 'object' && value.animation)
+    (value !== null && typeof value === 'object' && value.onFrame)
   ) {
     // animated set
     const animation = typeof value === 'function' ? value() : value;


### PR DESCRIPTION
## Description

This PR fixes lightbox example(there was a problem with `runOnJS`). 

It also introduces a fix to a bug which occurred on Android(may also appear on ios but such situation hasn't been encountered). The problem was when animation transform received negative numbers, the regex didn't work properly(putting `-` sign as a prefix instead of treating it as a part of the number).

In the meantime I found a bug in animations on the web which will be fixed in this PR as well.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [x] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
