### PR TITLE
Add runOnJS type export

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -443,6 +443,9 @@ declare module 'react-native-reanimated' {
     export function runOnUI<A extends any[], R>(
       fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => void;
+    export function runOnJS<A extends any[], R>(
+      fn: (...args: A) => R
+    ): (...args: Parameters<typeof fn>) => void;
     export function processColor(color: number | string): number;
     export function createWorklet<A extends any[], R>(
       fn: (...args: A) => R
@@ -713,6 +716,7 @@ declare module 'react-native-reanimated' {
   export const spring: typeof Animated.spring;
   export const SpringUtils: typeof Animated.SpringUtils;
   export const runOnUI: typeof Animated.runOnUI;
+  export const runOnJS: typeof Animated.runOnJS;
   export const processColor: typeof Animated.processColor;
   export const useValue: typeof Animated.useValue;
   export const useSharedValue: typeof Animated.useSharedValue;


### PR DESCRIPTION
## Description

`runOnJS` is required to dispatch functions from a worklet, but it isn't exported from the type module.

![Simulator Screen Shot - iPhone 11 - 2020-10-30 at 13 19 02](https://user-images.githubusercontent.com/15199031/97704621-104ecd00-1ab3-11eb-8aa2-580f568e4522.png)


## Changes

- Exported `runOnJS` using same type signature as `runOnUI`


