### PR TITLE
Fix "cannot access `repeat()` before initialisation" error on the web

### DIFF
--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -601,19 +601,6 @@ export function withRepeat(
   });
 }
 
-/* Deprecated section, kept for backward compatibility. Will be removed soon */
-export function loop(nextAnimation, numberOfLoops = 1) {
-  'worklet';
-  console.warn('Method `loop` is deprecated. Please use `withRepeat` instead');
-  return repeat(nextAnimation, Math.round(numberOfLoops * 2), true);
-}
-
-export function delay(delayMs, _nextAnimation) {
-  'worklet';
-  console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
-  return withDelay(delayMs, _nextAnimation);
-}
-
 export function repeat(
   _nextAnimation,
   numberOfReps = 2,
@@ -625,6 +612,19 @@ export function repeat(
     'Method `repeat` is deprecated. Please use `withRepeat` instead'
   );
   return withRepeat(_nextAnimation, numberOfReps, reverse, callback);
+}
+
+/* Deprecated section, kept for backward compatibility. Will be removed soon */
+export function loop(nextAnimation, numberOfLoops = 1) {
+  'worklet';
+  console.warn('Method `loop` is deprecated. Please use `withRepeat` instead');
+  return repeat(nextAnimation, Math.round(numberOfLoops * 2), true);
+}
+
+export function delay(delayMs, _nextAnimation) {
+  'worklet';
+  console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
+  return withDelay(delayMs, _nextAnimation);
 }
 
 export function sequence(..._animations) {

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -601,6 +601,12 @@ export function withRepeat(
   });
 }
 
+export function delay(delayMs, _nextAnimation) {
+  'worklet';
+  console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
+  return withDelay(delayMs, _nextAnimation);
+}
+
 export function repeat(
   _nextAnimation,
   numberOfReps = 2,
@@ -619,12 +625,6 @@ export function loop(nextAnimation, numberOfLoops = 1) {
   'worklet';
   console.warn('Method `loop` is deprecated. Please use `withRepeat` instead');
   return repeat(nextAnimation, Math.round(numberOfLoops * 2), true);
-}
-
-export function delay(delayMs, _nextAnimation) {
-  'worklet';
-  console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
-  return withDelay(delayMs, _nextAnimation);
 }
 
 export function sequence(..._animations) {

--- a/src/reanimated2/animations.js
+++ b/src/reanimated2/animations.js
@@ -601,6 +601,7 @@ export function withRepeat(
   });
 }
 
+/* Deprecated section, kept for backward compatibility. Will be removed soon */
 export function delay(delayMs, _nextAnimation) {
   'worklet';
   console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
@@ -620,7 +621,6 @@ export function repeat(
   return withRepeat(_nextAnimation, numberOfReps, reverse, callback);
 }
 
-/* Deprecated section, kept for backward compatibility. Will be removed soon */
 export function loop(nextAnimation, numberOfLoops = 1) {
   'worklet';
   console.warn('Method `loop` is deprecated. Please use `withRepeat` instead');


### PR DESCRIPTION
## Description
related(https://github.com/software-mansion/react-native-reanimated/issues/1400)
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
