### PR TITLE
Remove ref from useAnimatedReaction hook

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -573,14 +573,6 @@ export function useAnimatedRef() {
  * the second one can modify any shared values but those which are mentioned in the first worklet. Beware of that, because this may result in endless loop and high cpu usage.
  */
 export function useAnimatedReaction(prepare, react, dependencies) {
-  const inputsRef = useRef(null);
-  if (inputsRef.current === null) {
-    inputsRef.current = {
-      inputs: Object.values(prepare._closure),
-    };
-  }
-  const { inputs } = inputsRef.current;
-
   if (dependencies === undefined) {
     dependencies = [
       Object.values(prepare._closure),
@@ -598,7 +590,7 @@ export function useAnimatedReaction(prepare, react, dependencies) {
       const input = prepare();
       react(input);
     };
-    const mapperId = startMapper(fun, inputs, []);
+    const mapperId = startMapper(fun, Object.values(prepare._closure), []);
     return () => {
       stopMapper(mapperId);
     };


### PR DESCRIPTION
## Description

This PR is a response for the problem with `useAnimatedReaction` hook. The problem is with using reference inside of that hook, because it persists the mapper's input values between rerenders. This may even work if we don't change the type of the input but the problem occurred when the input changed from `undefined` to `number`.

Reproducing code is in the issue.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1399

