### PR TITLE
Add types for `makeMutable()`

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -26,6 +26,7 @@ import Animated, {
   runOnUI,
   useAnimatedReaction,
   interpolateColor,
+  makeMutable
 } from 'react-native-reanimated';
 
 const styles = StyleSheet.create({
@@ -43,6 +44,18 @@ const styles = StyleSheet.create({
  */
 
 // @TODO: add reanimated 1 tests here
+
+/**
+ * Reanimated 2 Function
+ */
+
+// makeMutable
+function SharedValueTest() {
+  const mut = makeMutable(0);
+  const mut2 = makeMutable(true);
+
+  return <Animated.View style={styles.container} />;
+}
 
 /**
  * Reanimated 2 Hooks

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
 // @TODO: add reanimated 1 tests here
 
 /**
- * Reanimated 2 Function
+ * Reanimated 2 Functions
  */
 
 // makeMutable

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
  */
 
 // makeMutable
-function SharedValueTest() {
+function MakeMutableTest() {
   const mut = makeMutable(0);
   const mut2 = makeMutable(true);
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -458,7 +458,7 @@ declare module 'react-native-reanimated' {
       colorSpace?: 'RGB' | 'HSV'
     ): string | number;
 
-    export function makeMutable<T>(
+    export function makeMutable<T extends SharedValueType>(
       initialValue: T
     ): SharedValue<T>;
 
@@ -729,6 +729,7 @@ declare module 'react-native-reanimated' {
   export const runOnUI: typeof Animated.runOnUI;
   export const runOnJS: typeof Animated.runOnJS;
   export const processColor: typeof Animated.processColor;
+  export const makeMutable: typeof Animated.makeMutable;
   export const useValue: typeof Animated.useValue;
   export const useSharedValue: typeof Animated.useSharedValue;
   export const useAnimatedStyle: typeof Animated.useAnimatedStyle;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -458,6 +458,10 @@ declare module 'react-native-reanimated' {
       colorSpace?: 'RGB' | 'HSV'
     ): string | number;
 
+    export function makeMutable<T>(
+      initialValue: T
+    ): SharedValue<T>;
+
     type DependencyList = ReadonlyArray<any>;
 
     // reanimated2 hooks


### PR DESCRIPTION
## Description

Added missing types for `makeMutable` function as the function is safe to use (see https://github.com/software-mansion/react-native-reanimated/issues/1404)

## Changes

In `./react-native-reanimated.d.ts`

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
