### PR TITLE
Fix access to 'viewDescriptor' property in `createAnimatedComponent`

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -269,7 +269,7 @@ export default function createAnimatedComponent(Component) {
       }
       if (this.props.style) {
         for (const style of flattenStyles) {
-          if (typeof style === 'object' && 'viewDescriptor' in style) {
+          if (style?.hasOwnProperty('viewDescriptor')) {
             return true;
           }
         }


### PR DESCRIPTION
## Description

Fixes #1443.

Used `hasOwnProperty` instead of `in` operator which should work pretty much the same here.

## Checklist

- [x] Ensured that CI passes
