### PR TITLE
Fix spread operator.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -43,6 +43,7 @@ const globals = new Set([
   'Number',
   'Object',
   'String',
+  'Symbol',
   'undefined',
   'null',
   'UIManager',

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -7,6 +7,42 @@ global.__reanimatedWorkletInit = function(worklet) {
   worklet.__worklet = true;
 };
 
+function _toArrayReanimated(object) {
+  'worklet';
+  if (Array.isArray(object)) {
+    return object;
+  }
+  if (
+    typeof Symbol !== 'undefined' &&
+    (typeof Symbol === 'function' ? Symbol.iterator : '@@iterator') in
+      Object(object)
+  )
+    return Array.from(object);
+  throw new 'Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.'();
+}
+
+function _mergeObjectsReanimated() {
+  'worklet';
+  return Object.assign.apply(null, arguments);
+}
+
+global.__reanimatedWorkletInit = function(worklet) {
+  worklet.__worklet = true;
+
+  if (worklet._closure) {
+    const closure = worklet._closure;
+    Object.keys(closure).forEach((key) => {
+      if (key === '_toConsumableArray') {
+        closure[key] = _toArrayReanimated;
+      }
+
+      if (key === '_objectSpread') {
+        closure[key] = _mergeObjectsReanimated;
+      }
+    });
+  }
+};
+
 function pushFrame(frame) {
   NativeReanimated.pushFrame(frame);
 }


### PR DESCRIPTION
## Description

Workletize polyfills for spread operator. Blacklisting plugins which polyfill spread operator would be a perfect solution. Unfortunately, It's not possible with our current blacklisting solutions as the plugin is added by other plugins that we cannot blacklist. For instance Typescript plugin. We still want to provide the spread operator inside our worklets. In order to do this, I replace spread polyfills with workletized versions of them in `global.__reanimatedWorkletInit` method.

## Changes

core.js

## Test code and steps to reproduce

```Js
import React, { useState, useEffect } from 'react';
import { View, Button } from 'react-native';
import { withTiming, withRepeat, useSharedValue, useDerivedValue, runOnUI } from 'react-native-reanimated'; 

export default function Animation() {
  
  runOnUI(worklet_worklet)();

  return (
    <View style={{padding: 30}}>
      <Button title="change Message" onPress={() => {}}/>
    </View>
  );
}

const worklet_worklet = () => {
  'worklet';
  const tab = ['a', 'b'];
  console.log("c", ...tab, "c");
  const cc = {
    pie: 'pie',
    apple: 'apple',
  }
  console.log({...cc, bb:'bb'});
}

```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [x] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
