### PR TITLE
Don't process event with null native map

### DIFF
--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -36,6 +36,10 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
   auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
   auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
 
+  if (eventJSON.compare(std::string("null")) == 0) {
+    return;
+  }
+
   auto eventObject = jsi::Value::createFromJsonUtf8(rt, (uint8_t*)(&eventJSON[0]), eventJSON.size());
 
   eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));


### PR DESCRIPTION
## Description

We don't want to process events with the `NativeMap` field set to `null`. Even though we use the `Nullable` annotation it still causes crashes on Android in some cases.

### Reproducing code

<details>
<summary>Tested with the following code</summary>

```
import React from 'react';
import { SafeAreaView, View, Text, StatusBar, Modal } from 'react-native';

const App = () => {
  return (
    <>
      <StatusBar barStyle="dark-content" />
      <SafeAreaView>
        <Modal animationType="slide" transparent={true} visible={true}>
          <View style={{ flex: 1 }}>
            <Text>Content modal</Text>
          </View>
        </Modal>
      </SafeAreaView>
    </>
  );
};

export default App;

```

</details>

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1444
Fixes https://github.com/software-mansion/react-native-reanimated/issues/1447


## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
