### PR TITLE
Improve error handling

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -211,7 +211,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
         return jsi::Value(rt, *hostFunction->get());
       } else {
-        // function is accessed from a different runtme, we wrap function in host func that'd enqueue
+        // function is accessed from a different runtime, we wrap function in host func that'd enqueue
         // call on an appropriate thread
         
         auto module = this->module;
@@ -294,7 +294,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
                res = funPtr->call(rt, args, count);
              }
            } catch(std::exception &e) {
-               std::string str = e.what();
+             std::string str = e.what();
              this->module->errorHandler->setError(str);
              this->module->errorHandler->raise();
            }
@@ -344,8 +344,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             
             } catch(std::exception &e) {
               std::string str = e.what();
-              module->errorHandler->setError(str);
-              module->errorHandler->raise();
+              retain_this->module->errorHandler->setError(str);
+              retain_this->module->errorHandler->raise();
             }
             rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
             

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -314,15 +314,13 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
           // TODO: we should find thread based on runtime such that we could also call UI methods
           // from RN and not only RN methods from UI
-          
-          auto module = retain_this->module;
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], module));
+            params.push_back(ShareableValue::adapt(rt, args[i], retain_this->module));
           }
           
-          module->scheduler->scheduleOnUI([retain_this, params] {
+          retain_this->module->scheduler->scheduleOnUI([retain_this, params] {
             NativeReanimatedModule *module = retain_this->module;
             jsi::Runtime &rt = *module->runtime.get();
             auto jsThis = createFrozenWrapper(rt, retain_this->frozenObject).getObject(rt);

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -322,8 +322,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             params.push_back(ShareableValue::adapt(rt, args[i], module));
           }
           
-          module->scheduler->scheduleOnUI([retain_this, params, &module] {
-            jsi::Runtime &rt = *retain_this->module->runtime.get();
+          module->scheduler->scheduleOnUI([retain_this, params] {
+            NativeReanimatedModule *module = retain_this->module;
+            jsi::Runtime &rt = *module->runtime.get();
             auto jsThis = createFrozenWrapper(rt, retain_this->frozenObject).getObject(rt);
             auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
             std::shared_ptr<jsi::Function> funPtr(retain_this->module->workletsCache->getFunction(rt, retain_this->frozenObject));
@@ -344,8 +345,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             
             } catch(std::exception &e) {
               std::string str = e.what();
-              retain_this->module->errorHandler->setError(str);
-              retain_this->module->errorHandler->raise();
+              module->errorHandler->setError(str);
+              module->errorHandler->raise();
             }
             rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
             


### PR DESCRIPTION
## Description

Improve error handling.

By using a proper `module` we omit the crash which used to occur on error catching before - the module is caught by copy instead of by reference in lambda thus there are no crashes when the `module` is no longer accessible but is used in the inner scope.

## Test code and steps to reproduce

<details>
<summary>code</summary>

```
import { runOnUI } from 'react-native-reanimated';
import { View } from 'react-native';
import React from 'react';

export default function AnimatedStyleUpdateExample() {
  const val = {};
  const wrklt = (x) => {
    'worklet';
    x.f();
  };

  runOnUI(() => {
    'worklet'
    val.f(4); // will call https://github.com/software-mansion/react-native-reanimated/blob/master/Common/cpp/SharedItems/ShareableValue.cpp#L347
    wrklt(9); // will call https://github.com/software-mansion/react-native-reanimated/blob/master/Common/cpp/SharedItems/ShareableValue.cpp#L298
  })();

  return <></>;
}
```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
