### PR TITLE
Fix crash in scheduler.

### DIFF
--- a/ios/native/REAIOSScheduler.mm
+++ b/ios/native/REAIOSScheduler.mm
@@ -10,6 +10,10 @@ REAIOSScheduler::REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker) {
 }
 
 void REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
+  if (module.lock() == nullptr) {
+    return;
+  }
+  
   if([NSThread isMainThread]) {
     if (module.lock()) job();
     return;
@@ -20,8 +24,11 @@ void REAIOSScheduler::scheduleOnUI(std::function<void()> job) {
     if (module.lock()) triggerUI();
     return;
   }
+  
+  __block std::weak_ptr<NativeReanimatedModule> blockModule = module;
+  
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (module.lock()) triggerUI();
+    if (blockModule.lock()) triggerUI();
   });
 }
 


### PR DESCRIPTION
## Description

Currently, we use scheduler's instance variable `module` in order to recognize if scheduling still makes sense ().  However, if the scheduler has been cleaned we are actually accessing the field of the freed object. In order to get rid of the problem, I've changed the code so we capture module variable instead of the pointer to scheduler instance.

fixes: https://github.com/software-mansion/react-native-reanimated/issues/1459

## Changes

Capture a local copy of weak module ref. (REAIOSScheduler.mm)

## Test code and steps to reproduce

Rapidly change sth in worklets. (hard to reproduce)

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [x] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
