### PR TITLE
Fix: Invariant Violation - Unable to locate attached view in the nati…

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -75,7 +75,7 @@ export default function createAnimatedComponent(Component) {
 
     componentWillUnmount() {
       this._detachPropUpdater();
-      this._propsAnimated && this._propsAnimated.__detach();
+      this._propsAnimated && this.__nodeID && this._propsAnimated.__detach();
       this._detachNativeEvents();
     }
 


### PR DESCRIPTION
## Description
I've run into some errors in logs in my project and was able to fix it by patching the lib. It would be great if I could move these changes here and get rid of my patch

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce
Not sure about the steps to reproduce but here's the trace stack

```
Invariant Violation: Unable to locate attached view in the native tree
  at __detach(node_modules/react-native-reanimated/src/core/AnimatedProps.js:64:5)
  at componentWillUnmount(node_modules/react-native-reanimated/src/createAnimatedComponent.js:36:50)
  at safelyCallComponentWillUnmount(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:4782:16)
  at commitUnmount(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:4886:9)
  at unmountHostComponents(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:5108:12)
  at Ll(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:6559:15)
  at Ll(app:///[native code])
  at runWithPriority(node_modules/scheduler/cjs/scheduler.production.min.js:18:438)
  at commitRoot(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:6463:3)
  at performSyncWorkOnRoot(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:5813:7)
  at Rl(app:///[native code])
  at b(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:1889:25)
  at runWithPriority(node_modules/scheduler/cjs/scheduler.production.min.js:18:438)
  at flushSyncCallbackQueueImpl(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:1886:7)
  at flushSyncCallbackQueue(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:1878:3)
  at flushPassiveEffectsImpl(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:6769:3)
  at flushPassiveEffects(node_modules/scheduler/cjs/scheduler.production.min.js:18:438)
  at d(node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js:6725:9)
  at Y(node_modules/scheduler/cjs/scheduler.production.min.js:17:184)
  at t(node_modules/scheduler/cjs/scheduler.production.min.js:11:145)
  at _callTimer(node_modules/react-native/Libraries/Core/Timers/JSTimers.js:135:7)
  at apply(node_modules/react-native/Libraries/Core/Timers/JSTimers.js:387:7)
  at __callFunction(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:425:42)
  at fn(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:112:12)
  at __guard(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:373:9)
  at value(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:111:10)
  at value(app:///[native code])
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
