### PR TITLE
Handle worklet errors on hermes

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -299,10 +299,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              this->module->errorHandler->raise();
            } catch(...) {
                // TODO find out a way to get the error's message on hermes
-               jsi::Value fileName = jsThis->getProperty(rt, "__fileName");
+               jsi::Value location = jsThis->getProperty(rt, "__location");
                std::string str = "Javascript worklet error";
-               if (fileName.isString()) {
-                 str += "\nIn file: " + fileName.asString(rt).utf8(rt);
+               if (location.isString()) {
+                 str += "\nIn file: " + location.asString(rt).utf8(rt);
                }
                module->errorHandler->setError(str);
                module->errorHandler->raise();
@@ -356,10 +356,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               module->errorHandler->raise();
             } catch(...) {
               // TODO find out a way to get the error's message on hermes
-              jsi::Value fileName = jsThis.getProperty(rt, "__fileName");
+              jsi::Value location = jsThis.getProperty(rt, "__location");
               std::string str = "Javascript worklet error";
-              if (fileName.isString()) {
-                str += "\nIn file: " + fileName.asString(rt).utf8(rt);
+              if (location.isString()) {
+                str += "\nIn file: " + location.asString(rt).utf8(rt);
               }
               module->errorHandler->setError(str);
               module->errorHandler->raise();

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -295,8 +295,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              }
            } catch(std::exception &e) {
              std::string str = e.what();
-             this->module->errorHandler->setError(str);
-             this->module->errorHandler->raise();
+             module->errorHandler->setError(str);
+             module->errorHandler->raise();
            } catch(...) {
                // TODO find out a way to get the error's message on hermes
                jsi::Value location = jsThis->getProperty(rt, "__location");

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -299,7 +299,11 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              this->module->errorHandler->raise();
            } catch(...) {
              // TODO find out a way to get the error's message on hermes
+             jsi::Value workletHash = jsThis->getProperty(rt, "__workletHash");
              std::string str = "Javascript worklet error";
+             if (workletHash.isNumber()) {
+               str += ", in worklet with __workletHash=" + std::to_string((int)workletHash.getNumber());
+             }
              module->errorHandler->setError(str);
              module->errorHandler->raise();
            }
@@ -352,7 +356,11 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               module->errorHandler->raise();
             } catch(...) {
               // TODO find out a way to get the error's message on hermes
+              jsi::Value workletHash = jsThis.getProperty(rt, "__workletHash");
               std::string str = "Javascript worklet error";
+              if (workletHash.isNumber()) {
+                str += ", in worklet with __workletHash=" + std::to_string((int)workletHash.getNumber());
+              }
               module->errorHandler->setError(str);
               module->errorHandler->raise();
             }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -297,6 +297,11 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              std::string str = e.what();
              this->module->errorHandler->setError(str);
              this->module->errorHandler->raise();
+           } catch(...) {
+             // TODO find out a way to get the error's message on hermes
+             std::string str = "Javascript worklet error";
+             module->errorHandler->setError(str);
+             module->errorHandler->raise();
            }
 
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
@@ -343,6 +348,11 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             
             } catch(std::exception &e) {
               std::string str = e.what();
+              module->errorHandler->setError(str);
+              module->errorHandler->raise();
+            } catch(...) {
+              // TODO find out a way to get the error's message on hermes
+              std::string str = "Javascript worklet error";
               module->errorHandler->setError(str);
               module->errorHandler->raise();
             }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -298,15 +298,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              this->module->errorHandler->setError(str);
              this->module->errorHandler->raise();
            } catch(...) {
-             // TODO find out a way to get the error's message on hermes
-             jsi::Value workletHash = jsThis->getProperty(rt, "__workletHash");
-             std::string str = "Javascript worklet error";
-             if (workletHash.isNumber()) {
-               str += ", in worklet with __workletHash=" + std::to_string((int)workletHash.getNumber());
+               // TODO find out a way to get the error's message on hermes
+               jsi::Value fileName = jsThis->getProperty(rt, "__fileName");
+               std::string str = "Javascript worklet error";
+               if (fileName.isString()) {
+                 str += "\nIn file: " + fileName.asString(rt).utf8(rt);
+               }
+               module->errorHandler->setError(str);
+               module->errorHandler->raise();
              }
-             module->errorHandler->setError(str);
-             module->errorHandler->raise();
-           }
 
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
            return res;
@@ -356,10 +356,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               module->errorHandler->raise();
             } catch(...) {
               // TODO find out a way to get the error's message on hermes
-              jsi::Value workletHash = jsThis.getProperty(rt, "__workletHash");
+              jsi::Value fileName = jsThis.getProperty(rt, "__fileName");
               std::string str = "Javascript worklet error";
-              if (workletHash.isNumber()) {
-                str += ", in worklet with __workletHash=" + std::to_string((int)workletHash.getNumber());
+              if (fileName.isString()) {
+                str += "\nIn file: " + fileName.asString(rt).utf8(rt);
               }
               module->errorHandler->setError(str);
               module->errorHandler->raise();

--- a/plugin.js
+++ b/plugin.js
@@ -352,6 +352,12 @@ function processWorkletFunction(t, fun, fileName) {
   const funString = buildWorkletString(t, fun, variables, functionName);
   const workletHash = hash(funString);
 
+  const loc = fun?.node?.loc?.start;
+  if (loc) {
+    const { line, column } = loc;
+    fileName = `${fileName} (${line}:${column})`;
+  }
+
   const newFun = t.functionExpression(
     fun.id,
     [],

--- a/plugin.js
+++ b/plugin.js
@@ -403,7 +403,7 @@ function processWorkletFunction(t, fun, fileName) {
           '=',
           t.memberExpression(
             privateFunctionId,
-            t.identifier('__fileName'),
+            t.identifier('__location'),
             false
           ),
           t.stringLiteral(fileName)

--- a/plugin.js
+++ b/plugin.js
@@ -459,7 +459,7 @@ function processIfWorkletNode(t, fun, fileName) {
   });
 }
 
-function processWorklets(t, path, processor, fileName) {
+function processWorklets(t, path, fileName) {
   const name =
     path.node.callee.type === 'MemberExpression'
       ? path.node.callee.property.name
@@ -474,13 +474,17 @@ function processWorklets(t, path, processor, fileName) {
       return;
     }
     for (let i = 0; i < objectPath.container.length; i++) {
-      processor(t, objectPath.getSibling(i).get('value'), fileName);
+      processWorkletFunction(
+        t,
+        objectPath.getSibling(i).get('value'),
+        fileName
+      );
     }
   } else {
     const indexes = functionHooks.get(name);
     if (Array.isArray(indexes)) {
       indexes.forEach((index) => {
-        processor(t, path.get(`arguments.${index}`), fileName);
+        processWorkletFunction(t, path.get(`arguments.${index}`), fileName);
       });
     }
   }
@@ -544,12 +548,7 @@ module.exports = function({ types: t }) {
     visitor: {
       CallExpression: {
         exit(path, state) {
-          processWorklets(
-            t,
-            path,
-            processWorkletFunction, // TODO move this inside this func instead of processor...
-            state.file.opts.filename
-          );
+          processWorklets(t, path, state.file.opts.filename);
         },
       },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {

--- a/plugin.js
+++ b/plugin.js
@@ -269,7 +269,7 @@ function buildWorkletString(t, fun, closureVariables, name) {
   return generate(workletFunction, { compact: true }).code;
 }
 
-function processWorkletFunction(t, fun) {
+function processWorkletFunction(t, fun, fileName) {
   if (!t.isFunctionParent(fun)) {
     return;
   }
@@ -393,6 +393,17 @@ function processWorkletFunction(t, fun) {
         )
       ),
       t.expressionStatement(
+        t.assignmentExpression(
+          '=',
+          t.memberExpression(
+            privateFunctionId,
+            t.identifier('__fileName'),
+            false
+          ),
+          t.stringLiteral(fileName)
+        )
+      ),
+      t.expressionStatement(
         t.callExpression(
           t.memberExpression(
             t.identifier('global'),
@@ -423,7 +434,7 @@ function processWorkletFunction(t, fun) {
   );
 }
 
-function processIfWorkletNode(t, fun) {
+function processIfWorkletNode(t, fun, fileName) {
   fun.traverse({
     DirectiveLiteral(path) {
       const value = path.node.value;
@@ -441,14 +452,14 @@ function processIfWorkletNode(t, fun) {
               directive.value.value === 'worklet'
           )
         ) {
-          processWorkletFunction(t, fun);
+          processWorkletFunction(t, fun, fileName);
         }
       }
     },
   });
 }
 
-function processWorklets(t, path, processor) {
+function processWorklets(t, path, processor, fileName) {
   const name =
     path.node.callee.type === 'MemberExpression'
       ? path.node.callee.property.name
@@ -463,13 +474,13 @@ function processWorklets(t, path, processor) {
       return;
     }
     for (let i = 0; i < objectPath.container.length; i++) {
-      processor(t, objectPath.getSibling(i).get('value'));
+      processor(t, objectPath.getSibling(i).get('value'), fileName);
     }
   } else {
     const indexes = functionHooks.get(name);
     if (Array.isArray(indexes)) {
       indexes.forEach((index) => {
-        processor(t, path.get(`arguments.${index}`));
+        processor(t, path.get(`arguments.${index}`), fileName);
       });
     }
   }
@@ -532,13 +543,18 @@ module.exports = function({ types: t }) {
   return {
     visitor: {
       CallExpression: {
-        exit(path) {
-          processWorklets(t, path, processWorkletFunction);
+        exit(path, state) {
+          processWorklets(
+            t,
+            path,
+            processWorkletFunction, // TODO move this inside this func instead of processor...
+            state.file.opts.filename
+          );
         },
       },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
-        exit(path) {
-          processIfWorkletNode(t, path);
+        exit(path, state) {
+          processIfWorkletNode(t, path, state.file.opts.filename);
         },
       },
     },

--- a/src/reanimated2/__snapshots__/plugin.test.js.snap
+++ b/src/reanimated2/__snapshots__/plugin.test.js.snap
@@ -21,7 +21,7 @@ var f = function () {
   };
   _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
   _f.__workletHash = 10184269015616;
-  _f.__fileName = \\"${ process.cwd() }/jest tests fixture (4:4)\\";
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (4:4)\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -38,7 +38,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   _f._closure = {};
   _f.asString = \\"function f(){console.log(\\\\\\"test\\\\\\");}\\";
   _f.__workletHash = 6265462104213;
-  _f.__fileName = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -73,7 +73,7 @@ function Box() {
     };
     _f.asString = \\"function _f(){const{offset}=jsThis._closure;{return{transform:[{translateX:offset.value*255}]};}}\\";
     _f.__workletHash = 7114514849439;
-    _f.__fileName = \\"${ process.cwd() }/jest tests fixture (7:48)\\";
+    _f.__location = \\"${ process.cwd() }/jest tests fixture (7:48)\\";
 
     global.__reanimatedWorkletInit(_f);
 

--- a/src/reanimated2/__snapshots__/plugin.test.js.snap
+++ b/src/reanimated2/__snapshots__/plugin.test.js.snap
@@ -21,6 +21,7 @@ var f = function () {
   };
   _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
   _f.__workletHash = 10184269015616;
+  _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -37,6 +38,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   _f._closure = {};
   _f.asString = \\"function f(){console.log(\\\\\\"test\\\\\\");}\\";
   _f.__workletHash = 6265462104213;
+  _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -71,6 +73,7 @@ function Box() {
     };
     _f.asString = \\"function _f(){const{offset}=jsThis._closure;{return{transform:[{translateX:offset.value*255}]};}}\\";
     _f.__workletHash = 7114514849439;
+    _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
 
     global.__reanimatedWorkletInit(_f);
 

--- a/src/reanimated2/__snapshots__/plugin.test.js.snap
+++ b/src/reanimated2/__snapshots__/plugin.test.js.snap
@@ -21,7 +21,7 @@ var f = function () {
   };
   _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
   _f.__workletHash = 10184269015616;
-  _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
+  _f.__fileName = \\"${ process.cwd() }/jest tests fixture (4:4)\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -38,7 +38,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   _f._closure = {};
   _f.asString = \\"function f(){console.log(\\\\\\"test\\\\\\");}\\";
   _f.__workletHash = 6265462104213;
-  _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
+  _f.__fileName = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -73,7 +73,7 @@ function Box() {
     };
     _f.asString = \\"function _f(){const{offset}=jsThis._closure;{return{transform:[{translateX:offset.value*255}]};}}\\";
     _f.__workletHash = 7114514849439;
-    _f.__fileName = \\"${ process.cwd() }/jest tests fixture\\";
+    _f.__fileName = \\"${ process.cwd() }/jest tests fixture (7:48)\\";
 
     global.__reanimatedWorkletInit(_f);
 


### PR DESCRIPTION
## Description

This PR refers to a situation in which there is a javascript error in a worklet that's being executed by jsi.
On iOS with JSC, it works as expected which means it throws a `std::exception` from jsi's `call` invocation.
Unfortunately on Android, it does not. This c++ code is being scheduled on the UI thread by the scheduler and the error that appears in `Scheduler.java` is: `com.facebook.JNI.UnknownCppException: Unknown`.
This comes with two problems:
1. Our example app crashes with `A/libc: Fatal signal 6 (SIGABRT), code -6`
This may be a problem with how we build the example app(As @tmikov suggested maybe e.g. linking problem)
2. When reanimated is installed in any other app it shows Redbox with an error message: `Unknown` - this gives almost no information on what went wrong.

The good news is that some error is thrown in c++ and can be caught. The bad news is that it's not a `std::exception` and we don't know its type so we cannot really get the proper message. Unless it changes we only can rethrow an error with a hardcoded message which indicates that something went wrong in a worklet. That's what is done in this PR.

Edit: Using the babel plugin I was able to fetch the path of the file containing the worklet in which the error occurred so it's now attached to the hardcoded error message.

## Changes

Just added catch clauses that catch anything for try blocks that include worklet execution.

I also repaired access to a module when using the `errorHandler`.

## Testing code

<details>
<summary>code</summary>

```
import { runOnUI } from 'react-native-reanimated';
import { View, Text, Button } from 'react-native';
import React, { useState } from 'react';

const Bug1 = () => {
  const val = {};

  runOnUI(() => {
    'worklet';
    val.f(4); // will call https://github.com/software-mansion/react-native-reanimated/blob/master/Common/cpp/SharedItems/ShareableValue.cpp#L347
  })();

  return <></>;
};

const Bug2 = () => {
  const wrklt = (x) => {
    'worklet';
    x.f();
  };

  runOnUI(() => {
    'worklet';
    wrklt(9); // will call https://github.com/software-mansion/react-native-reanimated/blob/master/Common/cpp/SharedItems/ShareableValue.cpp#L298
  })();

  return <></>;
};

export default function AnimatedStyleUpdateExample() {
  const [bug, setBug] = useState(0);

  const renderBug = () => {
    if (bug === 1) {
      return <Bug1 />;
    }
    if (bug === 2) {
      return <Bug2 />;
    }
  };

  return (
    <View>
      <Text>Pick a bug:</Text>
      <Button
        title="bug 1"
        onPress={() => {
          setBug(1);
        }}
      />
      <Button
        title="bug 2"
        onPress={() => {
          setBug(2);
        }}
      />
      {renderBug()}
    </View>
  );
}

```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
