### PR TITLE
Fix animations with initial value

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -72,15 +72,17 @@ function prepareAnimation(animatedProp, lastAnimation, lastValue) {
           if (lastValue.value !== undefined) {
             // previously it was a shared value
             value = lastValue.value;
-          } else if (
-            lastValue.onFrame !== undefined &&
-            lastAnimation?.current
-          ) {
-            // it was an animation before, copy its state
-            value = lastAnimation.current;
+          } else if (lastValue.onFrame !== undefined) {
+            if (lastAnimation?.current) {
+              // it was an animation before, copy its state
+              value = lastAnimation.current;
+            } else if (lastValue?.current) {
+              // it was initialized
+              value = lastValue.current;
+            }
           }
         } else {
-          // previously it was a plan value, just set it as starting point
+          // previously it was a plain value, just set it as starting point
           value = lastValue;
         }
       }


### PR DESCRIPTION
## Description

When calling an animation inside the worklet passed to `useAnimatedStyle` hook, the initial value for the animation is set by calling `initialUpdaterRun` on the JS side and `lastAnimation` is not set yet. Until now we've been missing a case for that.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1477

## Changes

In `Hooks.js` add a case for setting a starting value for an animation to the one from initialization(`initialUpdaterRun` in `useAnimatedStyle`)

## Test code and steps to reproduce

<details>
<summary>code</summary>

```
import React, { useCallback, useMemo } from 'react';
import { GestureResponderEvent, Pressable, PressableProps, StyleSheet } from 'react-native';
import Reanimated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';

export interface PressableScaleProps extends PressableProps {
  children: React.ReactNode;
  /**
   * The value to scale to when the Pressable is being pressed.
   * @default 0.95
   */
  activeScale?: number;

  /**
   * The weight physics of this button
   * @default 'heavy'
   */
  weight?: 'light' | 'medium' | 'heavy';

  /**
   * Delay for the press-in animation
   */
  delayPressIn?: number;
}

const ReanimatedPressable = Reanimated.createAnimatedComponent(Pressable);

/**
 * A Pressable that scales down when pressed. Uses the JS Pressability API.
 */
export default function PressableScale(props: PressableScaleProps): React.ReactElement {
  const {
    activeScale = 0.5,
    weight = 'heavy',
    onPressIn: _onPressIn,
    onPressOut: _onPressOut,
    delayPressIn = 0,
    children,
    ...passThroughProps
  } = props;

  const mass = useMemo(() => {
    switch (weight) {
      case 'light':
        return 0.15;
      case 'medium':
        return 0.175;
      case 'heavy':
      default:
        return 0.2;
    }
  }, [weight]);

  const isPressedIn = useSharedValue(false);

  const springConfig = useMemo<Reanimated.WithSpringConfig>(
    () => ({
      mass: mass,
      damping: 15,
      stiffness: 150,
      overshootClamping: true,
      restDisplacementThreshold: 0.0001,
      restSpeedThreshold: 0.0001,
    }),
    [mass],
  );
  const touchableStyle = useAnimatedStyle(() => ({ transform: [{ scale: withSpring(isPressedIn.value ? activeScale : 1, springConfig) }] }), [
    activeScale,
    isPressedIn,
    springConfig,
  ]);

  const onPressIn = useCallback(
    (event: GestureResponderEvent) => {
      isPressedIn.value = true;
      _onPressIn?.(event);
    },
    [_onPressIn, isPressedIn],
  );
  const onPressOut = useCallback(
    (event: GestureResponderEvent) => {
      isPressedIn.value = false;
      _onPressOut?.(event);
    },
    [_onPressOut, isPressedIn],
  );

  return (
    <ReanimatedPressable
      unstable_pressDelay={delayPressIn}
      onPressIn={onPressIn}
      onPressOut={onPressOut}
      style={[styles.style, touchableStyle]}
      {...passThroughProps}>
      {children}
    </ReanimatedPressable>
  );
}


const styles = StyleSheet.create({
  style: {
    width: 100, height: 100, backgroundColor: 'red', margin: 100
  }
})
```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
