### PR TITLE
Don't run observer callbacks during sync uimanager batch update

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -202,6 +202,9 @@ public class NodesManager implements EventDispatcherListener {
                 @Override
                 public void runGuarded() {
                   boolean shouldDispatchUpdates = UIManagerReanimatedHelper.isOperationQueueEmpty(mUIImplementation);
+                  if (!shouldDispatchUpdates) {
+                    semaphore.release();
+                  }
                   while (!copiedOperationsQueue.isEmpty()) {
                     NativeUpdateOperation op = copiedOperationsQueue.remove();
                     ReactShadowNode shadowNode = mUIImplementation.resolveShadowNode(op.mViewTag);
@@ -211,8 +214,8 @@ public class NodesManager implements EventDispatcherListener {
                   }
                   if (shouldDispatchUpdates) {
                     mUIImplementation.dispatchViewUpdates(-1); // no associated batchId
+                    semaphore.release();
                   }
-                  semaphore.release();
                 }
               });
       while (true) {

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -136,6 +136,7 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
   private Queue<NativeUpdateOperation> mOperationsInBatch = new LinkedList<>();
+  private boolean mTryRunBatchUpdatesSynchronously = false;
 
   public NodesManager(ReactContext context) {
     mContext = context;
@@ -195,13 +196,15 @@ public class NodesManager implements EventDispatcherListener {
     if (!mOperationsInBatch.isEmpty()) {
       final Queue<NativeUpdateOperation> copiedOperationsQueue = mOperationsInBatch;
       mOperationsInBatch = new LinkedList<>();
+      final boolean trySynchronously = mTryRunBatchUpdatesSynchronously;
+      mTryRunBatchUpdatesSynchronously = false;
       final Semaphore semaphore = new Semaphore(0);
       mContext.runOnNativeModulesQueueThread(
               // FIXME replace `mContext` with `mContext.getExceptionHandler()` after RN 0.59 support is dropped
               new GuardedRunnable(mContext) {
                 @Override
                 public void runGuarded() {
-                  boolean shouldDispatchUpdates = UIManagerReanimatedHelper.isOperationQueueEmpty(mUIImplementation);
+                  boolean shouldDispatchUpdates = trySynchronously && UIManagerReanimatedHelper.isOperationQueueEmpty(mUIImplementation);
                   if (!shouldDispatchUpdates) {
                     semaphore.release();
                   }
@@ -218,12 +221,14 @@ public class NodesManager implements EventDispatcherListener {
                   }
                 }
               });
-      while (true) {
-        try {
-          semaphore.acquire();
-          break;
-        } catch (InterruptedException e) {
-          //noop
+      if (trySynchronously) {
+        while (true) {
+          try {
+            semaphore.acquire();
+            break;
+          } catch (InterruptedException e) {
+            //noop
+          }
         }
       }
     }
@@ -401,7 +406,10 @@ public class NodesManager implements EventDispatcherListener {
     ((PropsNode) node).disconnectFromView(viewTag);
   }
 
-  public void enqueueUpdateViewOnNativeThread(int viewTag, WritableMap nativeProps) {
+  public void enqueueUpdateViewOnNativeThread(int viewTag, WritableMap nativeProps, boolean trySynchronously) {
+    if (trySynchronously) {
+      mTryRunBatchUpdatesSynchronously = true;
+    }
     mOperationsInBatch.add(new NativeUpdateOperation(viewTag, nativeProps));
   }
 
@@ -547,7 +555,7 @@ public class NodesManager implements EventDispatcherListener {
                 viewTag, new ReactStylesDiffMap(newUIProps));
       }
       if (hasNativeProps) {
-        enqueueUpdateViewOnNativeThread(viewTag, newNativeProps);
+        enqueueUpdateViewOnNativeThread(viewTag, newNativeProps, true);
       }
       if (hasJSProps) {
         WritableMap evt = Arguments.createMap();

--- a/android/src/main/java/com/swmansion/reanimated/nodes/PropsNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/PropsNode.java
@@ -129,7 +129,7 @@ public class PropsNode extends Node implements FinalNode {
                 mDiffMap);
       }
       if (hasNativeProps) {
-        mNodesManager.enqueueUpdateViewOnNativeThread(mConnectedViewTag, nativeProps);
+        mNodesManager.enqueueUpdateViewOnNativeThread(mConnectedViewTag, nativeProps, false);
       }
       if (hasJSProps) {
         WritableMap evt = Arguments.createMap();

--- a/ios/Nodes/REAPropsNode.m
+++ b/ios/Nodes/REAPropsNode.m
@@ -72,7 +72,7 @@
        props:uiProps];
     }
     if (nativeProps.count > 0) {
-      [self.nodesManager enqueueUpdateViewOnNativeThread:_connectedViewTag viewName:_connectedViewName nativeProps:nativeProps];
+      [self.nodesManager enqueueUpdateViewOnNativeThread:_connectedViewTag viewName:_connectedViewName nativeProps:nativeProps trySynchronously:NO];
     }
     if (jsProps.count > 0) {
       [self.nodesManager.reanimatedModule

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -35,7 +35,8 @@ typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
 - (void)registerEventHandler:(REAEventHandler)eventHandler;
 - (void)enqueueUpdateViewOnNativeThread:(nonnull NSNumber *)reactTag
                                viewName:(NSString *) viewName
-                            nativeProps:(NSMutableDictionary *)nativeProps;
+                            nativeProps:(NSMutableDictionary *)nativeProps
+                       trySynchronously:(BOOL)trySync;
 - (void)getValue:(REANodeID)nodeID
         callback:(RCTResponseSenderBlock)callback;
 


### PR DESCRIPTION
## Description

This PR fixes the way we perform sync updates on iOS by avoiding UIManager observers from firing. This in turn fixes the problem of ui manager commands that may be executed out of order as reported in #1498. The reason behind that issue was that due to the fact we'd trigger ui manager observers, those may enqueue some commands in the ui-manager block and we'd run them along the sync ui updates that we were expecting to get after layout phase. In the sync layout call we only expect the ui commands to come from the layout calculations and not from other sources (e.g. native animated or reanimated which uses ui manager observers to enqueue additional commands).

## Changes

1) This PR wraps uimanager batchDidComplete call with additional code that temporarily removes registered ui observers and only puts a single observer instead that is then used to capture mounting block.
2) Some additional cleanup in NodesManager on iOS to extract code that deals with RCTUIManager implementation details to a category on RCTUIManager.
3) As a part of this we also make an update to Android where we trigger semaphore release earlier when sync layout is not possible to match the implementation on iOS.
4) Opt-out of synchronous updates when no reanimated 2 code is being used by adding a flag `trySynchronousBatch` which is only set for reanimated 2 code paths. Then use this flag in the update procedure and skip semaphor wait on iOS and Android when it isn't set

### Before

Under certain condition (difficult to reproduce on a small app) reanimated 1 commands would sometimes run out of order (e.g. first "connect node" and only then "create node")

### After

We no longer allow for reanimated or native animated modules to enqueue commands that are goign to be executed in the sync layout phase.

## Test code and steps to reproduce

Apparently, we don't have a good repro steps for this, will test this internally on an app where we could reproduce the issue, and also reach out for help with testing to people who reported this in #1318
