### PR TITLE
Prevent executing mappers for the same value

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -295,8 +295,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              }
            } catch(std::exception &e) {
              std::string str = e.what();
-             module->errorHandler->setError(str);
-             module->errorHandler->raise();
+             this->module->errorHandler->setError(str);
+             this->module->errorHandler->raise();
            }
 
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -295,8 +295,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
              }
            } catch(std::exception &e) {
              std::string str = e.what();
-             this->module->errorHandler->setError(str);
-             this->module->errorHandler->raise();
+             module->errorHandler->setError(str);
+             module->errorHandler->raise();
            }
 
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -111,8 +111,18 @@ function workletValueSetter(value) {
     typeof value === 'function' ||
     (value !== null && typeof value === 'object' && value.onFrame)
   ) {
-    // animated set
     const animation = typeof value === 'function' ? value() : value;
+    // prevent setting again to the same value
+    // and triggering the mappers that treat this value as an input
+    // note that this will work for most animations
+    // this assumes that toValue === current DOES MEAN that the animation's done
+    if (
+      this._value === animation.toValue &&
+      animation.toValue === animation.current
+    ) {
+      return;
+    }
+    // animated set
     const initializeAnimation = (timestamp) => {
       animation.onStart(animation, this.value, timestamp, previousAnimation);
     };
@@ -141,6 +151,11 @@ function workletValueSetter(value) {
       requestAnimationFrame(step);
     }
   } else {
+    // prevent setting again to the same value
+    // and triggering the mappers that treat this value as an input
+    if (this._value === value) {
+      return;
+    }
     this._value = value;
   }
 }

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -114,7 +114,7 @@ function workletValueSetter(value) {
     const animation = typeof value === 'function' ? value() : value;
     // prevent setting again to the same value
     // and triggering the mappers that treat this value as an input
-    // this happens when the animation's target value is set to the same value as a current one
+    // this happens when the animation's target value(stored in animation.current until animation.onStart is called) is set to the same value as a current one(this._value)
     if (this._value === animation.current) {
       return;
     }

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -114,12 +114,8 @@ function workletValueSetter(value) {
     const animation = typeof value === 'function' ? value() : value;
     // prevent setting again to the same value
     // and triggering the mappers that treat this value as an input
-    // note that this will work for most animations
-    // this assumes that toValue === current DOES MEAN that the animation's done
-    if (
-      this._value === animation.toValue &&
-      animation.toValue === animation.current
-    ) {
+    // this happens when the animation's target value is set to the same value as a current one
+    if (this._value === animation.current) {
       return;
     }
     // animated set


### PR DESCRIPTION
## Description

For now, if we attempt to set a shared value's value to the same value multiple times it'll go through the entire process of updating the value and also will trigger all the mappers that treat this shared value as an input.

Short pseudo code:

```
const sv = useSharedValue(50)
const uas = useAnimatedStyle(() => {
	return { width: sv.value }
})
for (let i = 0; i < 1000; ++i) {
	sv.value = 100;
}
```

The worklet in `useAnimatedStyle` is going to be triggered 1000 extra times even though the input(and the output) is going to be the same.

Closes #1499 

## Changes

Added checks for the same values in `workletValueSetter` and only conditionally update the shared value's value.

## Test code and steps to reproduce

<details>
<summary>code</summary>

```
import React from 'react';
import { View, Button } from 'react-native';
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  useDerivedValue,
  withTiming,
} from 'react-native-reanimated';

const useAnimation = true;

function App() {
  const sv = useSharedValue(100);

  const udv = useDerivedValue(()=>{
    console.log('worklet run: execute UDV', sv.value);
    return sv.value;
  });

  const uas = useAnimatedStyle(() => {
    console.log('worklet run: execute UAS', udv.value);
    return {
      width: udv.value
    }
  });

  return (
    <View style={{ flex: 1, margin: 50 }}>
      <Button
        title="change SV"
        onPress={() => {
          const target = sv.value === 100 ? 200 : 100
          sv.value = useAnimation ? withTiming(target) : target;
        }}
      />
      <Button
        title="set SV to 100"
        onPress={() => {
          sv.value = useAnimation ? withTiming(100) : 100;
        }}
      />
      <Button
        title="set SV to 200"
        onPress={() => {
          sv.value = useAnimation ? withTiming(200) : 200;
        }}
      />
      <Animated.View
        style={[
          {
            width: 100,
            height: 100,
            backgroundColor: 'purple',
          },
          uas,
        ]}
      />
    </View>
  );
}

export default App;

```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
