### PR TITLE
cachedMatchers initialization

### DIFF
--- a/src/reanimated2/Colors.js
+++ b/src/reanimated2/Colors.js
@@ -50,8 +50,8 @@ function getMatchers() {
   return cachedMatchers;
 }
 // cachedMatchers is lazy loaded and it is frozen when worklet is being created,
-// is possible to call getMatchers() when object is freezed then cachedMatchers
-// has no assigned regexs
+// it is possible to call getMatchers() when the object is frozen, then cachedMatchers
+// has no assigned regexes
 getMatchers();
 
 function hue2rgb(p, q, t) {

--- a/src/reanimated2/Colors.js
+++ b/src/reanimated2/Colors.js
@@ -49,6 +49,10 @@ function getMatchers() {
   }
   return cachedMatchers;
 }
+// cachedMatchers is lazy loaded and it is frozen when worklet is being created,
+// is possible to call getMatchers() when object is freezed then cachedMatchers
+// has no assigned regexs
+getMatchers();
 
 function hue2rgb(p, q, t) {
   'worklet';


### PR DESCRIPTION
## Description
cachedMatchers is lazy loaded and it is frozen when the worklet is being created - it means that is blocked to changes, is possible to call getMatchers() when object is freezed then cachedMatchers has no assigned regexs.

Fixes #1472
Fixes #1478

## Changes
- Added eager initialization of cachedMatchers

## Test code and steps to reproduce
<details>
<summary>Problematic code</summary>

```
import React, { Component, useEffect } from 'react';
import { StyleSheet, View, Button } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withTiming,
  isColor,
} from 'react-native-reanimated';
export default function Dwa() {
  const vv = useSharedValue(10);
  const stylez = useAnimatedStyle(() => {
    if (vv.value > 20) {
      isColor('123');
    }
    return { height: vv.value };
  });
  return (
    <View style={styles.container}>
      <Button
        title="One"
        onPress={() => {
          vv.value = 40;
        }}
      />
      <Button
        title="Two"
        onPress={() => {
          isColor('blue');
        }}
      />
      <Animated.View style={[styles.box, stylez]} />
    </View>
  );
}
const BOX_SIZE = 100;
const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
  box: {
    width: BOX_SIZE,
    height: BOX_SIZE,
    borderColor: '#F5FCFF',
    alignSelf: 'center',
    backgroundColor: 'plum',
    margin: BOX_SIZE / 2,
  },
});
```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
