### PR TITLE
Add console.info on native, fix console on the web

### DIFF
--- a/src/reanimated2/__mocks__/NativeReanimated.js
+++ b/src/reanimated2/__mocks__/NativeReanimated.js
@@ -1,6 +1,4 @@
-global._setGlobalConsole = (val) => {
-  global.console = val;
-};
+global._setGlobalConsole = (val) => {};
 
 export default {
   installCoreFunctions: () => {},

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -241,6 +241,7 @@ runOnUI(() => {
     log: runOnJS(capturableConsole.log),
     warn: runOnJS(capturableConsole.warn),
     error: runOnJS(capturableConsole.error),
+    info: runOnJS(capturableConsole.info),
   };
   _setGlobalConsole(console);
 })();

--- a/src/reanimated2/js-reanimated/index.web.js
+++ b/src/reanimated2/js-reanimated/index.web.js
@@ -20,8 +20,6 @@ export const _updatePropsJS = (viewTag, viewName, updates, viewRef) => {
   }
 };
 
-global._setGlobalConsole = (val) => {
-  global.console = val;
-};
+global._setGlobalConsole = (val) => {};
 
 export default reanimatedJS;


### PR DESCRIPTION
## Description
I have a 'console.info is not a function' error on the web
This seems there is no needed to add a custom console to global.console on web

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Avoid adding a custom console to the global.console on the web
- add console.info to UI thread console.

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
