### PR TITLE
Get rid of optional chaining in plugin

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -352,16 +352,11 @@ function processWorkletFunction(t, fun, fileName) {
   const funString = buildWorkletString(t, fun, variables, functionName);
   const workletHash = hash(funString);
 
-  try {
-    // try to append location in file
-    const loc = fun.node.loc.start;
-    if (loc) {
-      const { line, column } = loc;
+  const loc = fun && fun.node && fun.node.loc && fun.node.loc.start;
+  if (loc) {
+    const { line, column } = loc;
+    if (typeof line === 'number' && typeof column === 'number') {
       fileName = `${fileName} (${line}:${column})`;
-    }
-  } catch (e) {
-    if (!(e instanceof TypeError)) {
-      throw e;
     }
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -352,10 +352,17 @@ function processWorkletFunction(t, fun, fileName) {
   const funString = buildWorkletString(t, fun, variables, functionName);
   const workletHash = hash(funString);
 
-  const loc = fun?.node?.loc?.start;
-  if (loc) {
-    const { line, column } = loc;
-    fileName = `${fileName} (${line}:${column})`;
+  try {
+    // try to append location in file
+    const loc = fun.node.loc.start;
+    if (loc) {
+      const { line, column } = loc;
+      fileName = `${fileName} (${line}:${column})`;
+    }
+  } catch (e) {
+    if (!(e instanceof TypeError)) {
+      throw e;
+    }
   }
 
   const newFun = t.functionExpression(


### PR DESCRIPTION
## Description

It turned out that using [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) doesn't work for older node versions(confirmed for 12.x.x) but does work for newer ones(14.14.0). As we want to make it compatible with those versions we had to get rid of that feature and replace it with an equivalent solution.

## Changes

Instead of using conditional chaining just watch out for a `TypeError` when reading from the object.

## Checklist

- [x] Ensured that CI passes
