### PR TITLE
Feature: enable native code debugging via LLDB

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -73,8 +73,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js",
-    enableHermes:true,
+        entryFile   : "index.js",
+        enableHermes: true,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -115,6 +115,11 @@ android {
     signingConfigs {
     }
     buildTypes {
+        debug {
+            packagingOptions {
+                doNotStrip "**/**/*.so"
+            }
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
@@ -125,7 +130,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2]
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
@@ -140,16 +145,10 @@ android {
     }
 
     packagingOptions {
-        pickFirst 'lib/x86/libc++_shared.so'
-        pickFirst 'lib/x86_64/libjsc.so'
+        pickFirst 'lib/**/libc++_shared.so'
+        pickFirst 'lib/**/libreanimated.so'
         pickFirst 'lib/arm64-v8a/libjsc.so'
-        pickFirst 'lib/arm64-v8a/libc++_shared.so'
-        pickFirst 'lib/x86_64/libc++_shared.so'
-        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
-        pickFirst 'lib/armeabi-v7a/libreanimated.so'
-        pickFirst 'lib/x86_64/libreanimated.so'
-        pickFirst 'lib/x86/libreanimated.so'
-        pickFirst 'lib/arm64-v8a/libreanimated.so'
+        pickFirst 'lib/x86_64/libjsc.so'
     }
 }
 
@@ -166,16 +165,16 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.fbjni'
+        exclude group: 'com.facebook.fbjni'
     }
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.flipper'
+        exclude group: 'com.facebook.flipper'
     }
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
-        exclude group:'com.facebook.flipper'
+        exclude group: 'com.facebook.flipper'
     }
 
-    def hermesPath = "../../node_modules/hermes-engine/android/";
+    def hermesPath = "../../node_modules/hermes-engine/android/"
     debugImplementation files(hermesPath + "hermes-debug.aar")
     releaseImplementation files(hermesPath + "hermes-release.aar")
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,8 @@
 def localProps = new Properties()
-localProps.load(new InputStreamReader(new FileInputStream(file("local.properties")), "UTF-8"))
+def localPropertiesFile = file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProps.load(new InputStreamReader(new FileInputStream(localPropertiesFile), "UTF-8"))
+}
 def debugNativeLibraries = localProps.getProperty('NATIVE_DEBUG_ON', 'FALSE').toBoolean()
 
 buildscript {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,7 @@
+def localProps = new Properties()
+localProps.load(new InputStreamReader(new FileInputStream(file("local.properties")), "UTF-8"))
+def debugNativeLibraries = localProps.getProperty('NATIVE_DEBUG_ON', 'FALSE').toBoolean()
+
 buildscript {
     repositories {
         jcenter()
@@ -37,6 +41,11 @@ android {
     }
     lintOptions {
         abortOnError false
+    }
+
+    packagingOptions {
+        println "Native libs debug enabled: ${debugNativeLibraries}"
+        doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
     }
 
     tasks.withType(JavaCompile) {
@@ -231,7 +240,7 @@ task downloadNdkBuildDependencies {
  * The search begins at the given base directory (a File object). The returned
  * path is a string.
  */
-def findNodeModulePath(baseDir, packageName) {
+static def findNodeModulePath(baseDir, packageName) {
     def basePath = baseDir.toPath().normalize()
     // Node's module resolution algorithm searches up to the root directory,
     // after which the base path will be null
@@ -245,7 +254,7 @@ def findNodeModulePath(baseDir, packageName) {
     return null
 }
 
-def getNdkBuildName() {
+static def getNdkBuildName() {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         return "ndk-build.cmd"
     } else {
@@ -395,6 +404,7 @@ task buildReanimated(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversi
             "REACT_NATIVE_REACT=$reactNative/ReactAndroid/src/main/jni/react",
             "HERMES_ENGINE=$projectDir/../node_modules/hermes-engine",
             "VM=HERMES",
+            "NATIVE_DEBUG=${debugNativeLibraries}",
             "-C", file("src/main/JNI").absolutePath,
             "--jobs", project.findProperty("jobs") ?: Runtime.runtime.availableProcessors()
     )
@@ -409,7 +419,7 @@ task cleanNdkLibs(type: Exec) {
             "-C", file("src/main/JNI").absolutePath,
             "clean")
     doLast {
-        def aar_path = "$buildDir/outputs/aar";
+        def aar_path = "$buildDir/outputs/aar"
         file(aar_path).delete()
         println("Deleted aar output dir at ${file(aar_path)}")
     }

--- a/android/src/main/JNI/Android.mk
+++ b/android/src/main/JNI/Android.mk
@@ -32,6 +32,11 @@ include $(BUILD_SHARED_LIBRARY)
 # start | build empty library which is needed by CallInvokerHolderImpl.java
 include $(CLEAR_VARS)
 
+# Don't strip debug builds
+ifeq ($(NATIVE_DEBUG), true)
+    cmd-strip :=
+endif
+
 LOCAL_MODULE := turbomodulejsijni
 include $(BUILD_SHARED_LIBRARY)
 # end


### PR DESCRIPTION
## Wix Goodness Squad Event

## Description

To enable debug native (C/C++) code was added required changes to `Android.mk` file and `build.gradle`s.

## Changes

- Added required to build.gradle and Android.mk config to enable native debugging with LLDB;
- Fixed some warnings;

## Screenshots / GIFs

Live demo of native code debug setup

[![Live demo of native code debug setup](
https://user-images.githubusercontent.com/6543359/102722766-06f01d00-430c-11eb-9771-de8ac66b3785.gif
)](https://user-images.githubusercontent.com/6543359/102721791-ad84ef80-4305-11eb-9eb5-7a9b5a72c9cb.mp4)


Live debugging demo session
[![Live debugging demo session](
https://user-images.githubusercontent.com/6543359/102722876-d197ff00-430c-11eb-880f-b5aa9b5898c6.gif
)](https://user-images.githubusercontent.com/6543359/102721798-b37ad080-4305-11eb-9a14-d6da393e36d1.mp4)


## Test code

To enable native code debugging please put `NATIVE_DEBUG_ON=TRUE` line to the end of `android/local.properties` file:
```
NATIVE_DEBUG_ON=TRUE
``` 
