### PR TITLE
Memory leaks

### DIFF
--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -9,6 +9,9 @@ FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeRe
   for (size_t i = 0, count = propertyNames.size(rt); i < count; i++) {
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
     map[propertyName.utf8(rt)] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module);
+    if (map[propertyName.utf8(rt)]->type == ValueType::HostFunctionType) {
+      this->containsHostFunction = true;
+    }
   }
 }
 

--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -8,8 +8,9 @@ FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeRe
   auto propertyNames = object.getPropertyNames(rt);
   for (size_t i = 0, count = propertyNames.size(rt); i < count; i++) {
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
-    map[propertyName.utf8(rt)] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module);
-    if (map[propertyName.utf8(rt)]->type == ValueType::HostFunctionType) {
+    std::string nameStr = propertyName.utf8(rt);
+    map[nameStr] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module);
+    if (map[nameStr]->type == ValueType::HostFunctionType) {
       this->containsHostFunction = true;
     }
   }

--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -10,9 +10,7 @@ FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeRe
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
     std::string nameStr = propertyName.utf8(rt);
     map[nameStr] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module);
-    if (map[nameStr]->type == ValueType::HostFunctionType) {
-      this->containsHostFunction = true;
-    }
+    this->containsHostFunction |= map[nameStr]->containsHostFunction;
   }
 }
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -33,7 +33,7 @@ void addHiddenProperty(jsi::Runtime &rt,
 void freeze(jsi::Runtime &rt, jsi::Object &obj) {
   jsi::Object globalObject = rt.global().getPropertyAsObject(rt, "Object");
   jsi::Function freeze = globalObject.getPropertyAsFunction(rt, "freeze");
-  freeze.call(rt, obj);
+  // freeze.call(rt, obj);
 }
 
 void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
@@ -179,7 +179,7 @@ jsi::Value createFrozenWrapper(jsi::Runtime &rt, std::shared_ptr<FrozenObject> f
     addHiddenProperty(rt, std::move(__reanimatedHiddenHost), obj, HIDDEN_HOST_OBJECT_PROP);
     addHiddenProperty(rt, true, obj, ALREADY_CONVERTED);
   }
-  return freeze.call(rt, obj);
+  return obj; //freeze.call(rt, obj);
 }
 
 jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -146,7 +146,6 @@ void cleanupShareable(ShareableValue &sv) {
   }
   if (sv.frozenObject != nullptr) {
     for (auto it = sv.frozenObject->map.begin(); it != sv.frozenObject->map.end(); ++it) {
-      auto itt = *it;
       cleanupShareable(*it->second);
     }
   }
@@ -280,17 +279,17 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               args[i] = params[i]->getValue(*hostRuntime);
             }
              
-              jsi::Value returnedValue = jsi::Value::undefined();
-             
-              auto shared = hostFunction.lock();
-              if (shared != nullptr) {
-                  returnedValue = shared->get()->call(*hostRuntime,
-                                                    static_cast<const jsi::Value*>(args),
-                                                    (size_t)params.size());
-              }
+            jsi::Value returnedValue = jsi::Value::undefined();
+            
+            auto shared = hostFunction.lock();
+            if (shared != nullptr) {
+              returnedValue = shared->get()->call(*hostRuntime,
+                                                static_cast<const jsi::Value*>(args),
+                                                (size_t)params.size());
+            }
              
             delete [] args;
-             // ToDo use returned value to return promise
+            // ToDo use returned value to return promise
           };
           
           module->scheduler->scheduleOnJS(job);
@@ -302,6 +301,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         return wrapperFunction;
       }
     case ValueType::WorkletFunctionType:
+      auto module = this->module;
+      auto frozenObject = this->frozenObject;
       if (module->isUIRuntime(rt)) {
         // when running on UI thread we prep a function
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -279,8 +279,6 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         return wrapperFunction;
       }
     case ValueType::WorkletFunctionType:
-      auto module = this->module;
-      auto frozenObject = this->frozenObject;
       if (module->isUIRuntime(rt)) {
         // when running on UI thread we prep a function
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -225,14 +225,14 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         
         auto module = this->module;
         auto hostFunction = this->hostFunction;
-
+        
         auto warnFunction = [module, hostFunction](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
             const jsi::Value *args,
             size_t count
             ) -> jsi::Value {
-
+            
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
           std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -100,10 +100,8 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         type = ValueType::WorkletFunctionType;
         frozenObject = std::make_shared<FrozenObject>(rt, object, module);
         containsHostFunction |= frozenObject->containsHostFunction;
-        if (isRNRuntime) {
-          if (!containsHostFunction) {
-            addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
-          }
+        if (isRNRuntime && !containsHostFunction) {
+          addHiddenProperty(rt, createHost(rt, frozenObject), object, HIDDEN_HOST_OBJECT_PROP);
         }
       }
     } else if (object.isArray(rt)) {

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -219,24 +219,22 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         // call on an appropriate thread
         
         auto module = this->module;
-        std::weak_ptr<HostFunctionHandler> hostFunction = this->hostFunction;
-        
+        auto hostFunction = this->hostFunction;
+
         auto warnFunction = [module, hostFunction](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
             const jsi::Value *args,
             size_t count
             ) -> jsi::Value {
-          auto shared = hostFunction.lock();
-          std::string name = (shared != nullptr) ? shared->functionName : "unknown";
 
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
           std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
-          if(name.empty()) {
+          if(hostFunction->functionName.empty()) {
             exceptionMessage += "anonymous function";
           } else {
-            exceptionMessage += "function {" + name + "}";
+            exceptionMessage += "function {" + hostFunction->functionName + "}";
           }
           exceptionMessage += " from a different thread.\n\nOccurred in worklet location: ";
           exceptionMessage += workletLocation;
@@ -268,14 +266,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               args[i] = params[i]->getValue(*hostRuntime);
             }
              
-            jsi::Value returnedValue = jsi::Value::undefined();
-            
-            auto shared = hostFunction.lock();
-            if (shared != nullptr) {
-              returnedValue = shared->get()->call(*hostRuntime,
+            jsi::Value returnedValue = hostFunction->get()->call(*hostRuntime,
                                                 static_cast<const jsi::Value*>(args),
                                                 (size_t)params.size());
-            }
              
             delete [] args;
             // ToDo use returned value to return promise

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -140,17 +140,6 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
   }
 }
 
-void cleanupShareable(ShareableValue &sv) {
-  if (sv.hostFunction != nullptr) {
-    sv.hostFunction = nullptr;
-  }
-  if (sv.frozenObject != nullptr) {
-    for (auto it = sv.frozenObject->map.begin(); it != sv.frozenObject->map.end(); ++it) {
-      cleanupShareable(*it->second);
-    }
-  }
-}
-
 std::shared_ptr<ShareableValue> ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType valueType) {
   auto sv = std::shared_ptr<ShareableValue>(new ShareableValue(module, module->scheduler));
   sv->adapt(rt, value, valueType);

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -14,10 +14,8 @@ class FrozenObject : public jsi::HostObject {
   friend void extractMutables(jsi::Runtime &rt,
                               std::shared_ptr<ShareableValue> sv,
                               std::vector<std::shared_ptr<MutableValue>> &res);
-  friend jsi::Value createFrozenWrapper(ShareableValue *sv,
-                                        jsi::Runtime &rt,
-                                        std::shared_ptr<FrozenObject> frozenObject); // ?? what for ??
-  
+  friend void cleanupShareable(ShareableValue &sv);
+
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
 
@@ -25,7 +23,7 @@ class FrozenObject : public jsi::HostObject {
 
   FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module);
   jsi::Object shallowClone(jsi::Runtime &rt);
-  bool containsHostFunction = true;
+  bool containsHostFunction = false;
 };
 
 }

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -2,7 +2,6 @@
 
 #include "WorkletsCache.h"
 #include "SharedParent.h"
-#include "Logger.h"
 #include <jsi/jsi.h>
 
 using namespace facebook;

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -15,7 +15,7 @@ class FrozenObject : public jsi::HostObject {
                               std::vector<std::shared_ptr<MutableValue>> &res);
   friend jsi::Value createFrozenWrapper(ShareableValue *sv,
                                         jsi::Runtime &rt,
-                                        std::shared_ptr<FrozenObject> frozenObject);
+                                        std::shared_ptr<FrozenObject> frozenObject); // ?? what for ??
   
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
@@ -24,6 +24,7 @@ class FrozenObject : public jsi::HostObject {
 
   FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module);
   jsi::Object shallowClone(jsi::Runtime &rt);
+  bool containsHostFunction = false;
 };
 
 }

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -2,6 +2,7 @@
 
 #include "WorkletsCache.h"
 #include "SharedParent.h"
+#include "Logger.h"
 #include <jsi/jsi.h>
 
 using namespace facebook;
@@ -24,7 +25,7 @@ class FrozenObject : public jsi::HostObject {
 
   FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module);
   jsi::Object shallowClone(jsi::Runtime &rt);
-  bool containsHostFunction = false;
+  bool containsHostFunction = true;
 };
 
 }

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -13,7 +13,6 @@ class FrozenObject : public jsi::HostObject {
   friend void extractMutables(jsi::Runtime &rt,
                               std::shared_ptr<ShareableValue> sv,
                               std::vector<std::shared_ptr<MutableValue>> &res);
-  friend void cleanupShareable(ShareableValue &sv);
 
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -31,6 +31,8 @@ friend WorkletsCache;
 friend void extractMutables(jsi::Runtime &rt,
                             std::shared_ptr<ShareableValue> sv,
                             std::vector<std::shared_ptr<MutableValue>> &res);
+friend void cleanupShareable(ShareableValue &sv);
+
 private:
   NativeReanimatedModule *module;
   bool boolValue;
@@ -55,6 +57,9 @@ private:
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
 
 public:
+  virtual ~ShareableValue() {
+    cleanupShareable(*this);
+  }
   ValueType type = ValueType::UndefinedType;
   std::shared_ptr<MutableValue> mutableValue;
   static std::shared_ptr<ShareableValue> adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType objectType = ValueType::UndefinedType);

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -32,7 +32,6 @@ friend FrozenObject;
 friend void extractMutables(jsi::Runtime &rt,
                             std::shared_ptr<ShareableValue> sv,
                             std::vector<std::shared_ptr<MutableValue>> &res);
-friend void cleanupShareable(ShareableValue &sv);
 
 private:
   NativeReanimatedModule *module;

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -57,9 +57,6 @@ private:
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
 
 public:
-  virtual ~ShareableValue() {
-    cleanupShareable(*this);
-  }
   ValueType type = ValueType::UndefinedType;
   std::shared_ptr<MutableValue> mutableValue;
   static std::shared_ptr<ShareableValue> adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType objectType = ValueType::UndefinedType);

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -28,6 +28,7 @@ struct HostFunctionHandler {
 
 class ShareableValue: public std::enable_shared_from_this<ShareableValue>, public StoreUser {
 friend WorkletsCache;
+friend FrozenObject;
 friend void extractMutables(jsi::Runtime &rt,
                             std::shared_ptr<ShareableValue> sv,
                             std::vector<std::shared_ptr<MutableValue>> &res);
@@ -55,6 +56,7 @@ private:
   ShareableValue(NativeReanimatedModule *module, std::shared_ptr<Scheduler> s): StoreUser(s), module(module) {}
   void adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType);
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
+  bool containsHostFunction = false;
 
 public:
   ValueType type = ValueType::UndefinedType;

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -270,7 +270,7 @@ PODS:
     - React
   - RNGestureHandler (1.9.0):
     - React-Core
-  - RNReanimated (2.0.0-rc.0):
+  - RNReanimated (2.0.0-rc.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -446,7 +446,7 @@ SPEC CHECKSUMS:
   ReactCommon: f63556ee9e41e9802257228237e5e660451a03cf
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
-  RNReanimated: b9c929bfff7dedc9c89ab1875f1c6151023358d9
+  RNReanimated: b2d6785c8fc1f61e1c81179c64c9b6b1a00e6ab5
   RNScreens: 13f23e5498fb4aa749d19a5eda7f8792fbb9d01f
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 7d2edc5b410474191962e6dee88ee67f9b328b6b

--- a/Example/src/AnimatedStyleUpdateExample.js
+++ b/Example/src/AnimatedStyleUpdateExample.js
@@ -1,165 +1,44 @@
-import {
-  useAnimatedStyle,
-  runOnJS,
-  makeShareable,
+import Animated, {
   useSharedValue,
-  UASMinimal,
+  withTiming,
+  useAnimatedStyle,
+  Easing,
 } from 'react-native-reanimated';
-import { View, Text, Button } from 'react-native';
-import React, { useState, useEffect, useRef } from 'react';
+import { View, Button } from 'react-native';
+import React from 'react';
 
-function Zerooo() {
-  makeShareable(0);
+export default function AnimatedStyleUpdateExample(props) {
+  const randomWidth = useSharedValue(10);
 
-  return <Text>Zerooo</Text>;
-}
-
-export function OneMakeShareable() {
-  function sth() {}
-
-  class Temp1 {
-    constructor(fun) {
-      this.fun = fun;
-    }
-  }
-
-  const ctx = useRef(null);
-  if (ctx.current === null) {
-    const temp = new Temp1(sth);
-    ctx.current = {
-      t: makeShareable(temp),
-    };
-  }
-
-  useEffect(() => {
-    return () => {
-      ctx.current = undefined;
-    };
-  }, []);
-
-  return <Text>ONE</Text>;
-}
-
-function TwoUAS() {
-  function sth() {}
-
-  class Temp2 {
-    constructor(fun) {
-      this.fun = fun;
-    }
-  }
-
-  const temp = new Temp2(sth);
-
-  UASMinimal(() => {
-    'worklet';
-    const x = temp;
-  });
-  /** /
-  useAnimatedStyle(() => {
-    runOnJS(temp.fun)();
-    return {
-      width: 100,
-    };
-  });
-  /**/
-  return <Text>Two</Text>;
-}
-
-// leak
-const ThreeTest = () => {
-  function sth() {}
-  class Temp31 {
-    constructor(fun) {
-      this.fun = fun;
-    }
-  }
-  class Temp32 {
-    constructor(fun) {
-      this.fun = fun;
-    }
-  }
-  const tempc = new Temp31(sth);
-  useEffect(() => {
-    return () => {
-      // tempc.fun = null;
-      // tempc = null;
-    };
-  }, []);
-  const wrk = () => {
-    'worklet';
-    const t = tempc; // leak
-    // const o = new Temp32(sth); // no leak
+  const config = {
+    duration: 500,
+    easing: Easing.bezier(0.5, 0.01, 0, 1),
   };
 
-  /**
-   * z wyczyszczeniem tego RN czeka na zwolnienie referencji w c++
-   * a referencja w c++ jest zwalniana w destruktorze(ktory czeka na wyczyszczenie po stronie js)
-   */
-  makeShareable(wrk);
-  // let x = makeShareable(wrk);
-  // x = null;
-  return <Text>Three</Text>;
-};
-
-// no leak
-const FourTest = () => {
-  function sth() {}
-
-  class Temp4 {
-    constructor(fun) {
-      this.fun = fun;
-    }
-  }
-
-  let shrb = makeShareable(() => {
-    'worklet';
-    const temp = new Temp4(sth);
+  const style = useAnimatedStyle(() => {
+    return {
+      width: withTiming(randomWidth.value, config),
+    };
   });
 
-  shrb = null;
-
-  return <Text>Four</Text>;
-};
-
-export default function App() {
-  const [state, setState] = useState(0);
-
-  const states = [0, 2];
-  console.log('running example', state);
-
   return (
-    <View>
+    <View
+      style={{
+        flex: 1,
+        flexDirection: 'column',
+      }}>
+      <Animated.View
+        style={[
+          { width: 100, height: 80, backgroundColor: 'black', margin: 30 },
+          style,
+        ]}
+      />
       <Button
-        title="change example"
+        title="toggle"
         onPress={() => {
-          const currentIndex = states.indexOf(state);
-          const newIndex = (currentIndex + 1) % states.length;
-          setState(states[newIndex]);
+          randomWidth.value = Math.random() * 350;
         }}
       />
-      {states.map((item, index) => {
-        return (
-          <Button
-            key={index}
-            title={`set example to ${item}`}
-            onPress={() => {
-              setState(item);
-            }}
-          />
-        );
-      })}
-      {state === 0 ? (
-        <>
-          <Text>EMPTY</Text>
-        </>
-      ) : (
-        <></>
-      )}
-      {state === 1 ? <OneMakeShareable /> : <></>}
-      {state === 2 ? <TwoUAS /> : <></>}
-      {state === 3 ? <ThreeTest /> : <></>}
-      {state === 4 ? <FourTest /> : <></>}
     </View>
   );
 }

--- a/Example/src/AnimatedStyleUpdateExample.js
+++ b/Example/src/AnimatedStyleUpdateExample.js
@@ -11,7 +11,7 @@ import React, { useState, useEffect, useRef } from 'react';
 function Zerooo() {
   makeShareable(0);
 
-  return (<Text>Zerooo</Text>)
+  return <Text>Zerooo</Text>;
 }
 
 export function OneMakeShareable() {
@@ -42,14 +42,14 @@ export function OneMakeShareable() {
 
 function TwoUAS() {
   function sth() {}
-  
+
   class Temp2 {
     constructor(fun) {
       this.fun = fun;
     }
   }
 
-  const temp = new Temp2(sth)
+  const temp = new Temp2(sth);
 
   UASMinimal(() => {
     'worklet';
@@ -69,37 +69,36 @@ function TwoUAS() {
 // leak
 const ThreeTest = () => {
   function sth() {}
-
   class Temp31 {
     constructor(fun) {
       this.fun = fun;
     }
   }
-
   class Temp32 {
     constructor(fun) {
       this.fun = fun;
     }
   }
-
   const tempc = new Temp31(sth);
-
   useEffect(() => {
     return () => {
       // tempc.fun = null;
       // tempc = null;
-    }
+    };
   }, []);
-
   const wrk = () => {
     'worklet';
     const t = tempc; // leak
     // const o = new Temp32(sth); // no leak
   };
 
-  let shrb = makeShareable(wrk);
-  shrb = null;
-
+  /**
+   * z wyczyszczeniem tego RN czeka na zwolnienie referencji w c++
+   * a referencja w c++ jest zwalniana w destruktorze(ktory czeka na wyczyszczenie po stronie js)
+   */
+  makeShareable(wrk);
+  // let x = makeShareable(wrk);
+  // x = null;
   return <Text>Three</Text>;
 };
 
@@ -126,7 +125,7 @@ const FourTest = () => {
 export default function App() {
   const [state, setState] = useState(0);
 
-  const states = [0, 3];
+  const states = [0, 2];
   console.log('running example', state);
 
   return (

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -104,14 +104,14 @@ export default function createAnimatedComponent(Component) {
       const viewTag = findNodeHandle(node);
 
       for (const key in this.props) {
-        let prop = this.props[key];
-        if (prop?.current && prop.current instanceof WorkletEventHandler) {
-          prop = prop.current;
-        }
+        const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
           prop.attachEvent(node, key);
-        } else if (prop instanceof WorkletEventHandler) {
-          prop.registerForEvents(viewTag, key);
+        } else if (
+          prop?.current &&
+          prop.current instanceof WorkletEventHandler
+        ) {
+          prop.current.registerForEvents(viewTag, key);
         }
       }
     }
@@ -120,14 +120,14 @@ export default function createAnimatedComponent(Component) {
       const node = this._getEventViewRef();
 
       for (const key in this.props) {
-        let prop = this.props[key];
-        if (prop?.current && prop.current instanceof WorkletEventHandler) {
-          prop = prop.current;
-        }
+        const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
           prop.detachEvent(node, key);
-        } else if (prop instanceof WorkletEventHandler) {
-          prop.unregisterFromEvents();
+        } else if (
+          prop?.current &&
+          prop.current instanceof WorkletEventHandler
+        ) {
+          prop.current.unregisterFromEvents();
         }
       }
     }
@@ -139,24 +139,20 @@ export default function createAnimatedComponent(Component) {
       let viewTag;
 
       for (const key in this.props) {
-        let prop = this.props[key];
-        if (prop?.current && prop.current instanceof WorkletEventHandler) {
-          prop = prop.current;
-        }
+        const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
           nextEvts.add(prop.__nodeID);
         } else if (
-          prop instanceof WorkletEventHandler &&
-          viewTag === undefined
+          prop?.current &&
+          prop.current instanceof WorkletEventHandler
         ) {
-          viewTag = prop.viewTag;
+          if (viewTag === undefined) {
+            viewTag = prop.current.viewTag;
+          }
         }
       }
       for (const key in prevProps) {
-        let prop = this.props[key];
-        if (prop?.current && prop.current instanceof WorkletEventHandler) {
-          prop = prop.current;
-        }
+        const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
           if (!nextEvts.has(prop.__nodeID)) {
             // event was in prev props but not in current props, we detach
@@ -165,22 +161,27 @@ export default function createAnimatedComponent(Component) {
             // event was in prev and is still in current props
             attached.add(prop.__nodeID);
           }
-        } else if (prop instanceof WorkletEventHandler && prop.reattachNeeded) {
-          prop.unregisterFromEvents();
+        } else if (
+          prop?.current &&
+          prop.current instanceof WorkletEventHandler &&
+          prop.current.reattachNeeded
+        ) {
+          prop.current.unregisterFromEvents();
         }
       }
 
       for (const key in this.props) {
-        let prop = this.props[key];
-        if (prop?.current && prop.current instanceof WorkletEventHandler) {
-          prop = prop.current;
-        }
+        const prop = this.props[key];
         if (prop instanceof AnimatedEvent && !attached.has(prop.__nodeID)) {
           // not yet attached
           prop.attachEvent(node, key);
-        } else if (prop instanceof WorkletEventHandler && prop.reattachNeeded) {
-          prop.registerForEvents(viewTag, key);
-          prop.reattachNeeded = false;
+        } else if (
+          prop?.current &&
+          prop.current instanceof WorkletEventHandler &&
+          prop.current.reattachNeeded
+        ) {
+          prop.current.registerForEvents(viewTag, key);
+          prop.current.reattachNeeded = false;
         }
       }
     }

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -9,7 +9,6 @@ import {
   makeRemote,
   requestFrame,
   getTimestamp,
-  makeShareable,
 } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
@@ -278,7 +277,11 @@ function styleUpdater(viewDescriptor, updater, state, maybeViewRef) {
 
 export function UASMinimal(updater) {
   const mapperId = startMapper(updater, [], []);
-  stopMapper(mapperId);
+  useEffect(() => {
+    return () => {
+      stopMapper(mapperId);
+    };
+  }, []);
 }
 
 export function useAnimatedStyle(updater, dependencies) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -9,6 +9,7 @@ import {
   makeRemote,
   requestFrame,
   getTimestamp,
+  makeShareable,
 } from './core';
 import updateProps from './UpdateProps';
 import { initialUpdaterRun } from './animations';
@@ -273,6 +274,11 @@ function styleUpdater(viewDescriptor, updater, state, maybeViewRef) {
   if (Object.keys(diff).length !== 0) {
     updateProps(viewDescriptor, diff, maybeViewRef);
   }
+}
+
+export function UASMinimal(updater) {
+  const mapperId = startMapper(updater, [], []);
+  stopMapper(mapperId);
 }
 
 export function useAnimatedStyle(updater, dependencies) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -275,15 +275,6 @@ function styleUpdater(viewDescriptor, updater, state, maybeViewRef) {
   }
 }
 
-export function UASMinimal(updater) {
-  const mapperId = startMapper(updater, [], []);
-  useEffect(() => {
-    return () => {
-      stopMapper(mapperId);
-    };
-  }, []);
-}
-
 export function useAnimatedStyle(updater, dependencies) {
   const viewDescriptor = useSharedValue({ tag: -1, name: null }, false);
   const initRef = useRef(null);

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -41,7 +41,6 @@ export function useEvent(handler, eventNames = [], rebuild = false) {
 
   useEffect(() => {
     return () => {
-      initRef.current.unregisterFromEvents();
       initRef.current = null;
     };
   }, []);


### PR DESCRIPTION
## Description

Here we will solve/discuss/work on issues related to memory leaks and also code changes in #1543.

Every case will be taken care of separately in terms of both the code and the description.

# Cases

### Memory leak with `makeShareable`, inner class, and a method(that has to be inside of the component) passed to its constructor.


- solution
	  - prevent applying cache for objects containing host functions(be1cb52)
	  - remove ref loop from ShareableValue(#1580)

<details>
<summary>graph</summary>

![diagram](https://user-images.githubusercontent.com/59833830/103015936-861a6680-4541-11eb-898b-63ee7be1f033.png)

</details>

<details>
<summary>code</summary>

```
import {
  makeShareable,
} from 'react-native-reanimated';
import { Text } from 'react-native';
import React, { useEffect, useRef } from 'react';

export default function OneMakeShareable() {
  function sth() {}

  class Temp1 {
    constructor(fun) {
      this.fun = fun;
    }
  }

  const ctx = useRef(null);
  if (ctx.current === null) {
    const temp = new Temp1(sth);
    ctx.current = {
      t: makeShareable(temp),
    };
  }

  useEffect(() => {
    return () => {
      ctx.current = undefined;
    };
  }, []);

  return <Text>ONE</Text>;
}

```

</details>

### The same as in the first case but a worklet with a reference to the `temp` object is passed to `makeShareable` instead of a `temp` object directly.


<details>
<summary>graph</summary>

![graph](https://user-images.githubusercontent.com/59833830/103353589-88cd0c80-4aa9-11eb-95e4-a37c566fa24a.png)

</details>

<details>
<summary>code</summary>

```
const ThreeTest = () => {
  function sth() {}
  class Temp31 {
    constructor(fun) {
      this.fun = fun;
    }
  }

  const tempc = new Temp31(sth);

  const wrk = () => {
    'worklet';
    const t = tempc;
  };

  makeShareable(wrk);
  let x = makeShareable(wrk);
  x = null;
  return <Text>Three</Text>;
};
```

</details>


### Similar pattern as above but this time `useAnimatedStyle` is used instead of `makeShareable`

❗ this turned out not to be a problem. It just depends on the UI garbage collector. If it is triggered manually there are no dangling objects(it was observed that it cleans after some time).

<details>
<summary>graph</summary>

![depgraph2](https://user-images.githubusercontent.com/59833830/103352655-14916980-4aa7-11eb-870d-28f9bcf6edfc.png)

</details>



<details>
<summary>code</summary>

```
import { runOnJS, useAnimatedStyle } from 'react-native-reanimated';
import { Text } from 'react-native';
import React from 'react';

export default function OneMakeShareable() {
  function sth() {}

  class Temp2 {
    constructor(fun) {
      this.fun = fun;
    }
  }

  const temp = new Temp2(sth);

  useAnimatedStyle(() => {
    const x = temp;
    return {
      width: 100,
    };
  });

  return <Text>Two</Text>;
}

```

</details>

also tested with `useState`

<details>
<summary>code</summary>

```
export function FourState() {
 const [state, setState] = useState(0);
 
 class Temp4 {
   constructor(f) {
     this.f = f;
   }
 }
 const temp = new Temp4(setState);
 
 useAnimatedStyle(() => {
    runOnJS(temp.f)(state + 1);
   return {};
 });
 
 
 return (
   <View>
     <Text>Four</Text>
   </View>
 );
}
```

</details>

# Other

- forwarded: https://github.com/software-mansion/react-native-reanimated/pull/1543/files#r546597171
	- This seems to be unnecessary as unregistering from events happen anyway on `componentWillUnmount` in `createAnimatedComponent`
- forwarded: https://github.com/software-mansion/react-native-reanimated/pull/1543/files#r546594788
	- This prevents the loop: c++ -> ref -> fiberNode(@Szymon20000) where in ref we hold for instance `setState`


