### PR TITLE
Multithreading with worklets

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -79,7 +79,7 @@ NativeReanimatedModule::NativeReanimatedModule(std::shared_ptr<CallInvoker> jsIn
     maybeRequestRender();
   };
 
-  RuntimeDecorator::addNativeObjects(*runtime,
+  RuntimeDecorator::decorateUI(*runtime,
                                      platformDepMethodsHolder.updaterFunction,
                                      requestAnimationFrame,
                                      platformDepMethodsHolder.scrollToFunction,
@@ -213,10 +213,10 @@ jsi::Value NativeReanimatedModule::spawnThread(jsi::Runtime &rt, const jsi::Valu
     std::unique_ptr<jsi::Runtime> customRuntime = runtimeObtainer();
     std::shared_ptr<Th> th = this->threads.at(threadId);
     th->rt = std::move(customRuntime);
-    RuntimeDecorator::addLog(*th->rt);
+    RuntimeDecorator::decorateCustomThread(*th->rt);
     jsi::Value result = jsi::Value::undefined();
 
-    jsi::Function func = workletShareable->getValue(*th->rt).asObject(*th->rt).asFunction(*th->rt);
+    jsi::Function func = workletShareable->getValue(*th->rt, threadId).asObject(*th->rt).asFunction(*th->rt);
     std::shared_ptr<jsi::Function> funcPtr = std::make_shared<jsi::Function>(std::move(func));
     try {
       result = funcPtr->callWithThis(*th->rt, *funcPtr);

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -89,6 +89,16 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
     return jsi::Value::undefined();
 }
 
+static jsi::Value __hostFunction_NativeReanimatedModuleSpec_spawnThread(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+        ->spawnThread(rt, std::move(args[0]));
+    return jsi::Value::undefined();
+}
+
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
   methodMap_["installCoreFunctions"] = MethodMetadata{
@@ -115,6 +125,9 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(std::shared_ptr<CallInvok
 
   methodMap_["getViewProp"] = MethodMetadata{
     3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
+
+  methodMap_["spawnThread"] = MethodMetadata{
+      3, __hostFunction_NativeReanimatedModuleSpec_spawnThread};
 }
 
 }

--- a/Common/cpp/Registries/WorkletsCache.cpp
+++ b/Common/cpp/Registries/WorkletsCache.cpp
@@ -7,18 +7,15 @@ using namespace facebook;
 namespace reanimated
 {
 
-jsi::Value eval(jsi::Runtime &rt, const char *code) {
-  return rt.global().getPropertyAsFunction(rt, "eval").call(rt, code);
-}
-
-jsi::Function function(jsi::Runtime &rt, const std::string& code) {
-  return eval(rt, ("(" + code + ")").c_str()).getObject(rt).getFunction(rt);
+jsi::Function WorkletsCache::functionFromString(jsi::Runtime &rt, const std::string &code)
+{
+  return rt.global().getPropertyAsFunction(rt, "eval").call(rt, ("(" + code + ")").c_str()).getObject(rt).getFunction(rt);
 }
 
 std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObj) {
   long long workletHash = frozenObj->map["__workletHash"]->numberValue;
   if (worklets.count(workletHash) == 0) {
-    jsi::Function fun = function(rt, frozenObj->map["asString"]->stringValue);
+    jsi::Function fun = functionFromString(rt, frozenObj->map["asString"]->stringValue);
     std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
     worklets[workletHash] = funPtr;
   }

--- a/Common/cpp/Registries/WorkletsCache.cpp
+++ b/Common/cpp/Registries/WorkletsCache.cpp
@@ -7,17 +7,24 @@ using namespace facebook;
 namespace reanimated
 {
 
-jsi::Function WorkletsCache::functionFromString(jsi::Runtime &rt, const std::string &code)
-{
+jsi::Function WorkletsCache::functionFromString(jsi::Runtime &rt, const std::string &code) {
   return rt.global().getPropertyAsFunction(rt, "eval").call(rt, ("(" + code + ")").c_str()).getObject(rt).getFunction(rt);
 }
 
-std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObj) {
+std::shared_ptr<jsi::Function> WorkletsCache::obtainFunction(jsi::Runtime &rt, const std::string &code) {
+  jsi::Function fun = functionFromString(rt, code);
+  std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
+  return std::move(funPtr);
+}
+
+std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std::shared_ptr<FrozenObject> frozenObj, const int customThreadId) {
+  if (customThreadId != -1) {
+    // worklets cache wouldn't work for custom threads as every time we have a different RT
+    return obtainFunction(rt, frozenObj->map["asString"]->stringValue);
+  }
   long long workletHash = frozenObj->map["__workletHash"]->numberValue;
   if (worklets.count(workletHash) == 0) {
-    jsi::Function fun = functionFromString(rt, frozenObj->map["asString"]->stringValue);
-    std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
-    worklets[workletHash] = funPtr;
+    worklets[workletHash] = obtainFunction(rt, frozenObj->map["asString"]->stringValue);
   }
   return worklets[workletHash];
 }

--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -12,10 +12,11 @@ FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeRe
   }
 }
 
-jsi::Object FrozenObject::shallowClone(jsi::Runtime &rt) {
+jsi::Object FrozenObject::shallowClone(jsi::Runtime &rt, const int customThreadId) {
+  this->customThreadId = (this->customThreadId == -1 && this->customThreadId != customThreadId) ? customThreadId : this->customThreadId;
   jsi::Object object(rt);
   for (auto prop : map) {
-    object.setProperty(rt, jsi::String::createFromUtf8(rt, prop.first), prop.second->getValue(rt));
+    object.setProperty(rt, jsi::String::createFromUtf8(rt, prop.first), prop.second->getValue(rt, customThreadId));
   }
   return object;
 }

--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -4,11 +4,11 @@
 
 namespace reanimated {
 
-FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module) {
+FrozenObject::FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module, const int customThreadId) : customThreadId(customThreadId) {
   auto propertyNames = object.getPropertyNames(rt);
   for (size_t i = 0, count = propertyNames.size(rt); i < count; i++) {
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
-    map[propertyName.utf8(rt)] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module);
+    map[propertyName.utf8(rt)] = ShareableValue::adapt(rt, object.getProperty(rt, propertyName), module, ValueType::UndefinedType, customThreadId);
   }
 }
 

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -5,6 +5,29 @@
 
 namespace reanimated {
 
+void RuntimeDecorator::addLog(jsi::Runtime &rt) {
+  auto callback = [](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+      ) -> jsi::Value {
+    const jsi::Value *value = &args[0];
+    if (value->isString()) {
+      Logger::log(value->getString(rt).utf8(rt).c_str());
+    } else if (value->isNumber()) {
+      Logger::log(value->getNumber());
+    } else if (value->isUndefined()) {
+      Logger::log("undefined");
+    } else {
+      Logger::log("unsupported value type");
+    }
+    return jsi::Value::undefined();
+    };
+  jsi::Value log = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
+	rt.global().setProperty(rt, "_log", log);
+}
+
 void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
                                         UpdaterFunction updater,
                                         RequestFrameFunction requestFrame,
@@ -29,28 +52,6 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
   
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());
 
-  auto callback = [](
-      jsi::Runtime &rt,
-      const jsi::Value &thisValue,
-      const jsi::Value *args,
-      size_t count
-      ) -> jsi::Value {
-    const jsi::Value *value = &args[0];
-    if (value->isString()) {
-      Logger::log(value->getString(rt).utf8(rt).c_str());
-    } else if (value->isNumber()) {
-      Logger::log(value->getNumber());
-    } else if (value->isUndefined()) {
-      Logger::log("undefined");
-    } else {
-      Logger::log("unsupported value type");
-    }
-    return jsi::Value::undefined();
-    };
-  jsi::Value log = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
-	rt.global().setProperty(rt, "_log", log);
-
-
   auto clb = [updater](
       jsi::Runtime &rt,
       const jsi::Value &thisValue,
@@ -66,6 +67,7 @@ void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,
   jsi::Value updateProps = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_updateProps"), 2, clb);
   rt.global().setProperty(rt, "_updateProps", updateProps);
 
+  addLog(rt);
 
   auto clb2 = [requestFrame](
       jsi::Runtime &rt,

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -25,7 +25,8 @@ void RuntimeDecorator::addLog(jsi::Runtime &rt) {
     return jsi::Value::undefined();
     };
   jsi::Value log = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
-	rt.global().setProperty(rt, "_log", log);
+  rt.global().setProperty(rt, "_log", log);
+  rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());
 }
 
 void RuntimeDecorator::addNativeObjects(jsi::Runtime &rt,

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -31,7 +31,8 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
                            std::unique_ptr<jsi::Runtime> rt,
                            std::shared_ptr<ErrorHandler> errorHandler,
                            std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
-                           PlatformDepMethodsHolder platformDepMethodsHolder);
+                           PlatformDepMethodsHolder platformDepMethodsHolder,
+                           std::function<std::unique_ptr<jsi::Runtime>()> runtimeObtainer);
 
     virtual ~NativeReanimatedModule();
 
@@ -48,7 +49,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
     void unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId) override;
 
     jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) override;
-    
+
+    jsi::Value spawnThread(jsi::Runtime &rt, const jsi::Value &operations) override;
+
     void onRender(double timestampMs);
     void onEvent(std::string eventName, std::string eventAsString);
     bool isAnyHandlerWaitingForEvent(std::string eventName);
@@ -67,6 +70,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
     std::vector<FrameCallback> frameCallbacks;
     bool renderRequested = false;
     std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer;
+    std::function<std::unique_ptr<jsi::Runtime>()> runtimeObtainer;
   public:
   std::shared_ptr<ErrorHandler> errorHandler;
   std::shared_ptr<WorkletsCache> workletsCache;

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -9,6 +9,8 @@
 #include <unistd.h>
 #include <memory>
 #include <vector>
+#include <thread>
+#include <unordered_map>
 
 namespace reanimated
 {
@@ -76,6 +78,13 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
   std::shared_ptr<WorkletsCache> workletsCache;
   std::shared_ptr<ShareableValue> valueSetter;
   std::shared_ptr<Scheduler> scheduler;
+  
+  struct Th {
+    std::string str;
+    std::shared_ptr<std::thread> thread;
+  };
+  int currentThreadId = 0;
+  std::unordered_map<int, Th> threads;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -82,7 +82,6 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
   struct Th {
     std::unique_ptr<jsi::Runtime> rt;
     std::shared_ptr<std::thread> thread;
-    std::shared_ptr<ShareableValue> worklet;
   };
   int currentThreadId = 0;
   std::unordered_map<int, std::shared_ptr<Th>> threads;

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -80,11 +80,12 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
   std::shared_ptr<Scheduler> scheduler;
   
   struct Th {
-    std::string str;
+    std::unique_ptr<jsi::Runtime> rt;
     std::shared_ptr<std::thread> thread;
+    std::shared_ptr<ShareableValue> worklet;
   };
   int currentThreadId = 0;
-  std::unordered_map<int, Th> threads;
+  std::unordered_map<int, std::shared_ptr<Th>> threads;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -40,6 +40,8 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
 
   // views
   virtual jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) = 0;
+
+  virtual jsi::Value spawnThread(jsi::Runtime &rt, const jsi::Value &operations) = 0;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/Registries/WorkletsCache.h
+++ b/Common/cpp/headers/Registries/WorkletsCache.h
@@ -15,6 +15,7 @@ class FrozenObject;
 class WorkletsCache {
   std::unordered_map<long long, std::shared_ptr<jsi::Function>> worklets;
 public:
+  jsi::Function functionFromString(jsi::Runtime &rt, const std::string &code);
   std::shared_ptr<jsi::Function> getFunction(jsi::Runtime & rt, std::shared_ptr<reanimated::FrozenObject> frozenObj);
 };
 

--- a/Common/cpp/headers/Registries/WorkletsCache.h
+++ b/Common/cpp/headers/Registries/WorkletsCache.h
@@ -14,9 +14,10 @@ class FrozenObject;
 
 class WorkletsCache {
   std::unordered_map<long long, std::shared_ptr<jsi::Function>> worklets;
+  std::shared_ptr<jsi::Function> obtainFunction(jsi::Runtime &rt, const std::string &code);
 public:
   jsi::Function functionFromString(jsi::Runtime &rt, const std::string &code);
-  std::shared_ptr<jsi::Function> getFunction(jsi::Runtime & rt, std::shared_ptr<reanimated::FrozenObject> frozenObj);
+  std::shared_ptr<jsi::Function> getFunction(jsi::Runtime & rt, std::shared_ptr<reanimated::FrozenObject> frozenObj, const int customThreadId = -1);
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -19,12 +19,12 @@ class FrozenObject : public jsi::HostObject {
   
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
-  const int customThreadId;
+  int customThreadId;
 
   public:
 
   FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module, const int customThreadId = -1);
-  jsi::Object shallowClone(jsi::Runtime &rt);
+  jsi::Object shallowClone(jsi::Runtime &rt, const int customThreadId = -1);
 };
 
 }

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -19,10 +19,11 @@ class FrozenObject : public jsi::HostObject {
   
   private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
+  const int customThreadId;
 
   public:
 
-  FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module);
+  FrozenObject(jsi::Runtime &rt, const jsi::Object &object, NativeReanimatedModule *module, const int customThreadId = -1);
   jsi::Object shallowClone(jsi::Runtime &rt);
 };
 

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -59,8 +59,7 @@ public:
   ValueType type = ValueType::UndefinedType;
   std::shared_ptr<MutableValue> mutableValue;
   static std::shared_ptr<ShareableValue> adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType valueType = ValueType::UndefinedType, const int customThreadId = -1);
-  jsi::Value getValue(jsi::Runtime &rt);
-
+  jsi::Value getValue(jsi::Runtime &rt, const int customThreadId = -1);
 };
 
 }

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -42,6 +42,7 @@ private:
   std::shared_ptr<RemoteObjectInitializer> remoteObjectInitializer;
   std::shared_ptr<RemoteObject> remoteObject;
   std::vector<std::shared_ptr<ShareableValue>> frozenArray;
+  const int customThreadId;
 
   std::unique_ptr<jsi::Value> hostValue;
   std::weak_ptr<jsi::Value> remoteValue;
@@ -50,14 +51,14 @@ private:
 
   jsi::Object createHost(jsi::Runtime &rt, std::shared_ptr<jsi::HostObject> host);
 
-  ShareableValue(NativeReanimatedModule *module, std::shared_ptr<Scheduler> s): StoreUser(s), module(module) {}
+  ShareableValue(NativeReanimatedModule *module, std::shared_ptr<Scheduler> s, const int customThreadId = -1) : StoreUser(s), module(module), customThreadId(customThreadId) {}
   void adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType);
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
 
 public:
   ValueType type = ValueType::UndefinedType;
   std::shared_ptr<MutableValue> mutableValue;
-  static std::shared_ptr<ShareableValue> adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType objectType = ValueType::UndefinedType);
+  static std::shared_ptr<ShareableValue> adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType valueType = ValueType::UndefinedType, const int customThreadId = -1);
   jsi::Value getValue(jsi::Runtime &rt);
 
 };

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -18,6 +18,7 @@ public:
                                ScrollToFunction scrollTo,
                                MeasuringFunction measure,
                                TimeProviderFunction getCurrentTime);
+  static void addLog(jsi::Runtime &rt);
 };
 
 }

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -12,13 +12,13 @@ using RequestFrameFunction = std::function<void(std::function<void(double)>)>;
 
 class RuntimeDecorator {
 public:
-  static void addNativeObjects(jsi::Runtime &rt,
+  static void decorateCustomThread(jsi::Runtime &rt);
+  static void decorateUI(jsi::Runtime &rt,
                                UpdaterFunction updater,
                                RequestFrameFunction requestFrame,
                                ScrollToFunction scrollTo,
                                MeasuringFunction measure,
                                TimeProviderFunction getCurrentTime);
-  static void addLog(jsi::Runtime &rt);
 };
 
 }

--- a/Example/src/AnimatedStyleUpdateExample.js
+++ b/Example/src/AnimatedStyleUpdateExample.js
@@ -3,6 +3,7 @@ import Animated, {
   withTiming,
   useAnimatedStyle,
   Easing,
+  spawnThread,
 } from 'react-native-reanimated';
 import { View, Button } from 'react-native';
 import React from 'react';
@@ -19,6 +20,11 @@ export default function AnimatedStyleUpdateExample(props) {
     return {
       width: withTiming(randomWidth.value, config),
     };
+  });
+
+  spawnThread(() => {
+    'worklet';
+    console.log('huge calculations in progress...');
   });
 
   return (

--- a/Example/src/AnimatedStyleUpdateExample.js
+++ b/Example/src/AnimatedStyleUpdateExample.js
@@ -19,7 +19,7 @@ export default function App() {
   /* * /
   useAnimatedStyle(() => {
     sv;
-    console.log('siema', _WORKLET)
+    console.log('here', _WORKLET)
     return {};
   })
 /*
@@ -40,10 +40,6 @@ export default function App() {
     'worklet';
     _log('> spawn thread #1 start ' + vvv);
     sv.value = 1;
-    // vvv;// nie ma krasha
-    // sv.value; // jest krasz
-    // po prostu shared value nie jest przystosowane do innych watkow niz js/ui najwyrazniej...
-    // vvv;
     for (let i = 0; i < 3000000000; ++i) {}
     sv.value = 2;
     _log('> spawn thread #1 end');

--- a/Example/src/AnimatedStyleUpdateExample.js
+++ b/Example/src/AnimatedStyleUpdateExample.js
@@ -4,45 +4,76 @@ import Animated, {
   useAnimatedStyle,
   Easing,
   spawnThread,
+  runOnUI,
+  runOnJS,
 } from 'react-native-reanimated';
 import { View, Button } from 'react-native';
 import React from 'react';
 
-export default function AnimatedStyleUpdateExample(props) {
-  const randomWidth = useSharedValue(10);
+export default function App() {
+  const sv = useSharedValue(0);
 
-  const config = {
-    duration: 500,
-    easing: Easing.bezier(0.5, 0.01, 0, 1),
-  };
+  console.log('here 1');
+  // for(let i=0;i<3000000000;++i) {}
+  console.log('here 2');
+  /* * /
+  useAnimatedStyle(() => {
+    sv;
+    console.log('siema', _WORKLET)
+    return {};
+  })
+/*
+  runOnUI(() => {
+    'worklet';
+    sv.value = 1;
+    console.log('> run on ui #1 begin', _WORKLET);
+    // for(let i=0;i<3000000000;++i) {}
+    console.log('> run on ui #1 end', _WORKLET);
+  })();
 
-  const style = useAnimatedStyle(() => {
-    return {
-      width: withTiming(randomWidth.value, config),
-    };
-  });
-
+  console.log('here 3');
+/* */
+/* */
+  // thread 1
+  const vvv = 99;
   spawnThread(() => {
     'worklet';
-    console.log('huge calculations in progress...');
+    _log('> spawn thread #1 start ' + vvv);
+    sv.value = 1;
+    // vvv;// nie ma krasha
+    // sv.value; // jest krasz
+    // po prostu shared value nie jest przystosowane do innych watkow niz js/ui najwyrazniej...
+    // vvv;
+    for (let i = 0; i < 3000000000; ++i) {}
+    sv.value = 2;
+    _log('> spawn thread #1 end');
+    return Math.random() * 100;
   });
+  // thread 2
+  /* * /
+  spawnThread(() => {
+    'worklet';
+    _log('> spawn thread #2 start');
+    // sv.value = 3;
+    for (let i = 0; i < 3000000000; ++i) {}
+    _log('> spawn thread #2 end');
+    return Math.random() * 100;
+  });
+  */
+  //
 
+  setTimeout(() => {
+    console.log('here timeout');
+  }, 100);
+
+  console.log('here 4');
+/* */
   return (
-    <View
-      style={{
-        flex: 1,
-        flexDirection: 'column',
-      }}>
-      <Animated.View
-        style={[
-          { width: 100, height: 80, backgroundColor: 'black', margin: 30 },
-          style,
-        ]}
-      />
+    <View>
       <Button
-        title="toggle"
+        title="read sv"
         onPress={() => {
-          randomWidth.value = Math.random() * 350;
+          console.log(sv.value)
         }}
       />
     </View>

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -108,6 +108,13 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   std::shared_ptr<Scheduler> scheduler(new REAIOSScheduler(jsInvoker));
   std::unique_ptr<jsi::Runtime> animatedRuntime = facebook::jsc::makeJSCRuntime();
+  std::string str = animatedRuntime->description();
+    /**/
+    auto runtimeObtainer = []() -> std::unique_ptr<jsi::Runtime> {
+        return facebook::jsc::makeJSCRuntime();
+    };
+    /**/
+    
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<REAIOSErrorHandler>(scheduler);
   std::shared_ptr<NativeReanimatedModule> module;
 
@@ -132,14 +139,14 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
     getCurrentTime,
   };
   
-module = std::make_shared<NativeReanimatedModule>(jsInvoker,
-                                                  scheduler,
-                                                  std::move(animatedRuntime),
-                                                  errorHandler,
-                                                  propObtainer,
-                                                  platformDepMethodsHolder
-                                                  );
-  
+  module = std::make_shared<NativeReanimatedModule>(jsInvoker,
+                                                                            scheduler,
+                                                                            std::move(animatedRuntime),
+                                                                            errorHandler,
+                                                                            propObtainer,
+                                                                            platformDepMethodsHolder,
+                                                                            runtimeObtainer
+                                                                            );
   scheduler->setModule(module);
 
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventName, id<RCTEvent> event) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -647,7 +647,3 @@ export function useWorkletCallback(fun, deps) {
 export function createWorklet(fun) {
   return fun;
 }
-
-export function spawnThread(operations) {
-  return NativeReanimated.spawnThread(operations);
-}

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -647,3 +647,7 @@ export function useWorkletCallback(fun, deps) {
 export function createWorklet(fun) {
   return fun;
 }
+
+export function spawnThread(operations) {
+  return NativeReanimated.spawnThread(operations);
+}

--- a/src/reanimated2/NativeReanimated.native.js
+++ b/src/reanimated2/NativeReanimated.native.js
@@ -42,6 +42,10 @@ const NativeReanimated = {
   getViewProp(viewTag, propName, callback) {
     return InnerNativeModule.getViewProp(viewTag, propName, callback);
   },
+
+  spawnThread(operations) {
+    return InnerNativeModule.spawnThread(operations);
+  },
 };
 
 export default NativeReanimated;

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -245,3 +245,20 @@ runOnUI(() => {
   };
   _setGlobalConsole(console);
 })();
+
+export function spawnThread(operations) {
+  const target = () => {
+    'worklet';
+    const console = {
+      log: runOnJS(capturableConsole.log),
+      warn: runOnJS(capturableConsole.warn),
+      error: runOnJS(capturableConsole.error),
+      info: runOnJS(capturableConsole.info),
+    };
+    _setGlobalConsole(console);
+
+    operations();
+  };
+
+  return NativeReanimated.spawnThread(target);
+}


### PR DESCRIPTION
## Description

This idea has been postponed due to low priority.
The solution here is dirty, it's more like a POC for the future if we decide to focus on this topic again.
The goal is to be able to run worklets on multiple threads different than JS and UI.

### Use cases

- downloading data from the Internet
- processing video/audio/images
- obtaining a contact list from the device
- in fact, processing any data in the background in order to avoid blocking UI or JS.

### Examples

<details>
<summary>example code</summary>

```
import React, { useState } from 'react';
import {
  View,
  Button,
  Text,
} from 'react-native';
import {
  useSharedValue,
  spawnThread,
} from 'react-native-reanimated';


const Child = () => {
  const sv = useSharedValue(0)

  spawnThread(() => {
    'worklet';
    sv.value = 1.1;
    console.log('here thread #1 begin', sv.value, _WORKLET);
    for (let i = 0; i < 3000000000; ++i) {}
    sv.value = 1.2;
    console.log('here thread #1 end', sv.value, _WORKLET);
  });

  spawnThread(() => {
    'worklet';
    sv.value = 2.1;
    console.log('here thread #2 begin', sv.value, _WORKLET);
    for (let i = 0; i < 3000000000; ++i) {}
    sv.value = 2.2;
    console.log('here thread #2 end', sv.value, _WORKLET);
  });

  return (
    <View>
      <Text>Child</Text>
      <Button title="check responsiveness" onPress={() => {
        console.log('UI responsive', sv.value, Math.random())
      }} />
    </View>
  );
}

export default function App() {
  const [s, setS] = useState(0);

  return (<View>
    <Button title="change state" onPress={()=>{ setS(s+1) }} />

    { s%2 === 1 ? <Child /> : <Text>EMPTY</Text>}
  </View>)
}
```

</details>
