### PR TITLE
Information about worklet localization to exception message

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -6,18 +6,17 @@
 #include "MutableValueSetterProxy.h"
 #include "RemoteObject.h"
 #include "FrozenObject.h"
+#include <jsi/jsi.h>
 
 namespace reanimated {
 
 const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";
 const char *ALREADY_CONVERTED= "__alreadyConverted";
-std::string CALLBACK_ERROR_PREFIX = R"(
-Tried to synchronously call function {)";
-std::string CALLBACK_ERROR_SUFFIX = R"(} from a different thread.
+std::string CALLBACK_ERROR_SUFFIX = R"(
+
 Solution is:
 a) If you want to synchronously execute this method, mark it as a Worklet
-b) If you want to execute this method on the JS thread, wrap it using runOnJS
-)";
+b) If you want to execute this method on the JS thread, wrap it using runOnJS )";
   
 void addHiddenProperty(jsi::Runtime &rt,
                        jsi::Value &&value,
@@ -223,8 +222,22 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             const jsi::Value *args,
             size_t count
             ) -> jsi::Value {
-          module->errorHandler->setError(CALLBACK_ERROR_PREFIX + hostFunction->functionName + CALLBACK_ERROR_SUFFIX);
+            
+          jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
+          std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
+          std::string exceptionMessage = "Tried to synchronously call ";
+          if(hostFunction->functionName == "") {
+            exceptionMessage += "anonymous function";
+          }
+          else {
+            exceptionMessage += "function {" + hostFunction->functionName + "}";
+          }
+          exceptionMessage += " from a different thread.\n\nOccurred in worklet location: ";
+          exceptionMessage += workletLocation;
+          exceptionMessage += CALLBACK_ERROR_SUFFIX;
+          module->errorHandler->setError(exceptionMessage);
           module->errorHandler->raise();
+          
           return jsi::Value::undefined();
         };
         

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -6,7 +6,6 @@
 #include "MutableValueSetterProxy.h"
 #include "RemoteObject.h"
 #include "FrozenObject.h"
-#include <jsi/jsi.h>
 
 namespace reanimated {
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -13,7 +13,7 @@ const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";
 const char *ALREADY_CONVERTED= "__alreadyConverted";
 std::string CALLBACK_ERROR_SUFFIX = R"(
 
-Solution is:
+Possible solutions are:
 a) If you want to synchronously execute this method, mark it as a Worklet
 b) If you want to execute this method on the JS thread, wrap it using runOnJS )";
   
@@ -225,10 +225,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
           std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
-          if(hostFunction->functionName == "") {
+          if(hostFunction->functionName.empty()) {
             exceptionMessage += "anonymous function";
-          }
-          else {
+          } else {
             exceptionMessage += "function {" + hostFunction->functionName + "}";
           }
           exceptionMessage += " from a different thread.\n\nOccurred in worklet location: ";


### PR DESCRIPTION
## Description

When an anonymous function is called `fn(() => {})` we can't get the name of this function. In this case the exception message isn't really helpful. I changed the exception message and also added information about worklet localization. It isn't exactly localization of this lambda/function called, but localization of the worklet where lambda/function is called.

Imrovement for PR: [#1361](https://github.com/software-mansion/react-native-reanimated/pull/1361)
Fixes #1503

## Changes

### Before
![Screenshot 2020-12-29 at 12 34 23](https://user-images.githubusercontent.com/36106620/103281160-6e742f80-49d2-11eb-8fef-e9a27cf61721.png)

### After
![Screenshot 2020-12-29 at 12 21 55](https://user-images.githubusercontent.com/36106620/103281183-79c75b00-49d2-11eb-8448-071b9b4e8a58.png)

## Test code
<details>
<summary>Example of code</summary>

```js
import { useAnimatedStyle } from 'react-native-reanimated';
import React, { useCallback } from 'react';

export default function AnimatedStyleUpdateExample(props) {
  
  const testfunc = useCallback(() => {
    console.log('test');
  }, []);

  useAnimatedStyle(() => {
    testfunc();
    return {};
  });

  return (<></>);
}
```
</details>
