### PR TITLE
Remove ref loop from ShareableValue

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -325,8 +325,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name.c_str()), 0, clb);
       } else {
         // when run outside of UI thread we enqueue a call on the UI thread
-        auto retain_this = shared_from_this();
-        auto clb = [retain_this = std::move(retain_this)](
+        auto module_ptr = module;
+        auto clb = [module_ptr, frozenObject](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
             const jsi::Value *args,
@@ -337,15 +337,15 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
 
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
-            params.push_back(ShareableValue::adapt(rt, args[i], retain_this->module));
+            params.push_back(ShareableValue::adapt(rt, args[i], module_ptr));
           }
           
-          retain_this->module->scheduler->scheduleOnUI([retain_this, params] {
-            NativeReanimatedModule *module = retain_this->module;
+          module_ptr->scheduler->scheduleOnUI([module_ptr, frozenObject, params] {
+            NativeReanimatedModule *module = module_ptr;
             jsi::Runtime &rt = *module->runtime.get();
-            auto jsThis = createFrozenWrapper(rt, retain_this->frozenObject).getObject(rt);
+            auto jsThis = createFrozenWrapper(rt, frozenObject).getObject(rt);
             auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
-            std::shared_ptr<jsi::Function> funPtr(retain_this->module->workletsCache->getFunction(rt, retain_this->frozenObject));
+            std::shared_ptr<jsi::Function> funPtr(module_ptr->workletsCache->getFunction(rt, frozenObject));
             
             jsi::Value * args = new jsi::Value[params.size()];
             for (int i = 0; i < params.size(); ++i) {

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -279,6 +279,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         return wrapperFunction;
       }
     case ValueType::WorkletFunctionType:
+      auto module = this->module;
+      auto frozenObject = this->frozenObject;
       if (module->isUIRuntime(rt)) {
         // when running on UI thread we prep a function
 


### PR DESCRIPTION
## Description

ShareableValue keeps a reference to its JS representation. Unfortunately, worklet retains `this` in lambda function what creates a reference loop.

## Changes

Capture in the lambda function only necessary values.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```JS
makeShareable(
   () =>{
      'worklet'
      //nothing
   }
);
```
ShareableValue destructor is never called.

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
