### PR TITLE
Update animations.md with `.map` and `useAnimatedStyle` example

### DIFF
--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -299,7 +299,7 @@ Below we present the end result:
 
 **A note about `useAnimatedStyle` and `map` components**
 
-When using a map that returns an `Animated.View` with a `useAnimatedStyle` style, the elements cannot share the same returned style. This would cause only the last element to have the value. Because hooks cannot be used in callbacks, you're best to split out the returned `View` into its own functional component.
+When using a map that returns an `Animated.View` with a `useAnimatedStyle` style, the animated style will only be applied to the last item in the map. Furether, because hooks cannot be used in callbacks, you can't nest the `useAnimatedStyle` directly in the map either. You're best to split out the returned `Animated.View` into its own functional component.
 
 For example, this would only apply styles to the last element:
 

--- a/docs/docs/animations.md
+++ b/docs/docs/animations.md
@@ -297,6 +297,73 @@ Below we present the end result:
 
 ![](/react-native-reanimated/docs/animations/wobble.gif)
 
+**A note about `useAnimatedStyle` and `map` components**
+
+When using a map that returns an `Animated.View` with a `useAnimatedStyle` style, the elements cannot share the same returned style. This would cause only the last element to have the value. Because hooks cannot be used in callbacks, you're best to split out the returned `View` into its own functional component.
+
+For example, this would only apply styles to the last element:
+
+```js
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function WobbleExample(props) {
+  const rotation = useSharedValue(0);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ rotateZ: `${rotation.value}deg` }],
+    };
+  });
+
+  return (
+    <>
+      {[0, 1, 2].map(i => (
+        <Animated.View key={`${i}nth-element`} style={[styles.box, animatedStyle]} />
+      ))}
+      <Button
+        title="wobble"
+        onPress={() => {
+          // Your animation logic
+        }}
+      />
+    </>
+  );
+}
+```
+
+But this would apply them to each element:
+
+```js
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+
+function WobbleView = (rotation: Animated.SharedValue) {
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ rotateZ: `${rotation.value}deg` }],
+    };
+  });
+  
+  return <Animated.View key={`${i}nth-element`} style={[styles.box, animatedStyle]} />
+}
+    
+
+function WobbleExample(props) {
+  const rotation = useSharedValue(0);
+
+  return (
+    <>
+      {[0, 1, 2].map(i => (<WobbleView rotation={rotation}/>))}
+      <Button
+        title="wobble"
+        onPress={() => {
+          // Your animation logic
+        }}
+      />
+    </>
+  );
+}
+```
+
 ## Animating Layout Properties
 
 Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.


### PR DESCRIPTION
## Description

Adds a basic example for adding animated styles to mapped elements, after I encountered this issue and couldn't immediately see the reason from the docs.

## Changes

- Updates `animations.md` with an example of incorrect and correct usages of `useAnimatedStyle` inside of a `map` function.

## Screenshots / GIFs

Viewable in diff - no other change