### PR TITLE
Fix synchronous layout.

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -254,8 +254,8 @@
       
       if (canUpdateSynchronously) {
         [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
-        [strongSelf.uiManager setNeedsLayout];
         dispatch_semaphore_signal(semaphore);
+        [strongSelf.uiManager setNeedsLayout];
       } else {
         [strongSelf.uiManager setNeedsLayout];
       }

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -255,10 +255,8 @@
       if (canUpdateSynchronously) {
         [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
         dispatch_semaphore_signal(semaphore);
-        [strongSelf.uiManager setNeedsLayout];
-      } else {
-        [strongSelf.uiManager setNeedsLayout];
       }
+      [strongSelf.uiManager setNeedsLayout];
     });
     if (trySynchronously) {
       dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -256,6 +256,8 @@
         [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
         dispatch_semaphore_signal(semaphore);
       }
+      //In case canUpdateSynchronously=true we still have to send uiManagerWillPerformMounting event 
+      //to observers because some components (e.g. TextInput) update their UIViews only on that event.
       [strongSelf.uiManager setNeedsLayout];
     });
     if (trySynchronously) {

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -254,6 +254,7 @@
       
       if (canUpdateSynchronously) {
         [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
+        [strongSelf.uiManager setNeedsLayout];
         dispatch_semaphore_signal(semaphore);
       } else {
         [strongSelf.uiManager setNeedsLayout];
@@ -264,6 +265,7 @@
     }
     
     if (_mounting) {
+      
       _mounting();
       _mounting = nil;
     }
@@ -278,8 +280,7 @@
   if (trySync) {
     _tryRunBatchUpdatesSynchronously = YES;
   }
-  [_operationsInBatch addObject:^(RCTUIManager *uiManager) {
-    [uiManager updateView:reactTag viewName:viewName props:nativeProps];
+  [_operationsInBatch addObject:^(RCTUIManager *uiManager) {    [uiManager updateView:reactTag viewName:viewName props:nativeProps];
   }];
 }
 

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -265,7 +265,6 @@
     }
     
     if (_mounting) {
-      
       _mounting();
       _mounting = nil;
     }
@@ -280,7 +279,8 @@
   if (trySync) {
     _tryRunBatchUpdatesSynchronously = YES;
   }
-  [_operationsInBatch addObject:^(RCTUIManager *uiManager) {    [uiManager updateView:reactTag viewName:viewName props:nativeProps];
+  [_operationsInBatch addObject:^(RCTUIManager *uiManager) {
+    [uiManager updateView:reactTag viewName:viewName props:nativeProps];
   }];
 }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1576
Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1579
In https://github.com/software-mansion/react-native-reanimated/pull/1501 we forgot that sometimes we have to notify mounting listeners about a mounting. The problem we had with operation running out of order won't happen when we notify listeners after the mounting block is prepared. That's what I want to do in the pr.

It's also important to understand that we won't capture a new mounting block by calling `setNeedsLayout`because we add NodesManager as an observer only for the time of syncLayout.

## Changes

Add setNeedsLayout after sync layout.

## Test code and steps to reproduce

```JS
import React, { useEffect } from "react";
import { StyleSheet, View } from "react-native";
import { ReText } from 'react-native-redash';
import Animated, {
  useAnimatedStyle,
  useDerivedValue,
  useSharedValue,
  withSpring,
  withTiming,
} from "react-native-reanimated";

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  card: {
    position: "absolute",
    top: 0,
    left: 0,
    width: 100,
    height: 50,
  },
});

const DynamicSpring = () => {
  const x = useSharedValue('0deg');
  useEffect(() => {
    x.value = withTiming('300deg', { duration: 5000 });
  });
  
  return (
    <View style={styles.container}>
      <ReText
        text={x}
        style={{ color: "black", fontVariant: ["tabular-nums"] }}
      />
    </View>
  );
};

export default DynamicSpring;
```
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
