### PR TITLE
Use implementation of useSharedValue in mock

### DIFF
--- a/src/reanimated2/__mocks__/MutableValue.js
+++ b/src/reanimated2/__mocks__/MutableValue.js
@@ -1,0 +1,13 @@
+export default class MutableValue {
+  constructor(value) {
+    this._value = value;
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(nextValue) {
+    this._value = nextValue;
+  }
+}

--- a/src/reanimated2/__mocks__/NativeReanimated.js
+++ b/src/reanimated2/__mocks__/NativeReanimated.js
@@ -1,9 +1,11 @@
+import MutableValue from './MutableValue';
+
 global._setGlobalConsole = (val) => {};
 
 export default {
   installCoreFunctions: () => {},
   makeShareable: (worklet) => worklet,
-  makeMutable: () => {},
+  makeMutable: (init) => new MutableValue(init),
   makeRemote: () => {},
   startMapper: () => {},
   stopMapper: () => {},

--- a/src/reanimated2/hooks.useSharedValue.test.js
+++ b/src/reanimated2/hooks.useSharedValue.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Animated, { useSharedValue } from '../Animated';
+
+jest.mock('../ReanimatedEventEmitter');
+jest.mock('../ReanimatedModule');
+jest.mock('./NativeReanimated');
+
+describe('useSharedValue', () => {
+  it('update value when shouldRebuild = true', () => {
+    // Given
+    const shouldRebuild = true;
+    const initialValue = 0;
+    const updatedValue = 1;
+
+    function TestComponent(props) {
+      const opacity = useSharedValue(props.value, shouldRebuild);
+      return <Animated.View style={{ opacity: opacity.value }} />;
+    }
+
+    // When rendering with initial value
+    const wrapper = renderer.create(
+      <TestComponent key="box" value={initialValue} />
+    );
+
+    expect(wrapper.root.children[0].props.style.opacity).toBe(initialValue);
+
+    // When rendering with updated value
+    wrapper.update(<TestComponent key="box" value={updatedValue} />);
+
+    expect(wrapper.root.children[0].props.style.opacity).toBe(updatedValue);
+  });
+
+  it('retains value when shouldRebuild = false', () => {
+    // Given
+    const shouldRebuild = false;
+    const initialValue = 0;
+    const updatedValue = 1;
+
+    function TestComponent(props) {
+      const opacity = useSharedValue(props.value, shouldRebuild);
+      return <Animated.View style={{ opacity: opacity.value }} />;
+    }
+
+    // When rendering with initial value
+    const wrapper = renderer.create(
+      <TestComponent key="box" value={initialValue} />
+    );
+
+    expect(wrapper.root.children[0].props.style.opacity).toBe(initialValue);
+
+    // When rendering with updated value
+    wrapper.update(<TestComponent key="box" value={updatedValue} />);
+
+    expect(wrapper.root.children[0].props.style.opacity).toBe(initialValue);
+  });
+});

--- a/src/reanimated2/mock.js
+++ b/src/reanimated2/mock.js
@@ -1,9 +1,11 @@
+const hooks = require('./Hooks');
+
 /* eslint-disable standard/no-callback-literal */
 const NOOP = () => {};
 const ID = (t) => t;
 
 const ReanimatedV2 = {
-  useSharedValue: (value) => ({ value }),
+  useSharedValue: hooks.useSharedValue,
   useDerivedValue: (a) => ({ value: a() }),
   useAnimatedScrollHandler: () => NOOP,
   useAnimatedGestureHandler: () => NOOP,


### PR DESCRIPTION
Previous implementation did lack "memoize" feature, essentially yielding incorrect return in certain cases.
I added mocks of `useSharedValue`'s hook in order to "unmock" this hook and use its implementation in global mock.

PR contains hook test.