### PR TITLE
Allow string as toValue type in withTiming and withSpring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,5 +90,5 @@ jobs:
           - node_modules
       script:
         - yarn
-        - yarn tsc react-native-reanimated.d.ts react-native-reanimated-tests.tsx --noEmit --lib 'es6' --jsx 'react-native' --esModuleInterop
+        - yarn run type:check
         - yarn test

--- a/docs/docs/api/withSpring.md
+++ b/docs/docs/api/withSpring.md
@@ -8,9 +8,21 @@ Starts a spring-based animation.
 
 ### Arguments
 
-#### `toValue` [number]
+#### `toValue` [number | string]
 
 The target value at which the spring should settle.
+It can be specified as a color value by providing string like: `rgba(255, 105, 180, 0)`.
+
+Currently supported formats are:
+
+- `"rgb(r, g, b)"`
+- `"rgba(r, g, b, a)"`
+- `"hsl(h, s, l)"`
+- `"hsla(h, s, l, a)"`
+- `"#rgb"`
+- `"#rgba"`
+- `"#rrggbb"`
+- `"#rrggbbaa"`
 
 #### `options` [object]
 

--- a/docs/docs/api/withTiming.md
+++ b/docs/docs/api/withTiming.md
@@ -8,9 +8,21 @@ Starts a time based animation.
 
 ### Arguments
 
-#### `toValue` [number]
+#### `toValue` [number | string]
 
 The target value at which the animation should conclude.
+It can be specified as a color value by providing string like: `rgba(255, 105, 180, 0)`.
+
+Currently supported formats are:
+
+- `"rgb(r, g, b)"`
+- `"rgba(r, g, b, a)"`
+- `"hsl(h, s, l)"`
+- `"hsla(h, s, l, a)"`
+- `"#rgb"`
+- `"#rgba"`
+- `"#rrggbb"`
+- `"#rrggbbaa"`
 
 #### `options` [object]
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write --list-different './src/**/*.js'",
     "lint": "eslint './src/**/*.js'",
     "release": "npm login && release-it",
-    "type:check": "tsc"
+    "type:check": "yarn tsc"
   },
   "main": "src/Animated.js",
   "module": "lib/module/Animated",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/babel__generator": "^7.6.2",
     "@types/babel__traverse": "^7.0.15",
     "@types/jest": "^26.0.15",
-    "@types/react-native": "^0.62.13",
+    "@types/react-native": "^0.63.43",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "eslint": "^6.5.1",

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -235,6 +235,26 @@ function WithTimingTest() {
   );
 }
 
+function WithTimingToValueAsColorTest() {
+  const style = useAnimatedStyle(() => {
+    return {
+      width: withTiming(
+        'rgba(255,105,180,0)',
+        {
+          duration: 500,
+          easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+        },
+        (_finished) => {}
+      ),
+    };
+  });
+  return (
+    <View>
+      <Animated.View style={[styles.box, style]} />
+    </View>
+  );
+}
+
 // withSpring
 function WithSpringTest() {
   const x = useSharedValue(0);
@@ -262,6 +282,19 @@ function WithSpringTest() {
     <PanGestureHandler onGestureEvent={gestureHandler}>
       <Animated.View style={[styles.box, animatedStyle]} />
     </PanGestureHandler>
+  );
+}
+
+function WithSpringToValueAsColorTest() {
+  const style = useAnimatedStyle(() => {
+    return {
+      width: withSpring('rgba(255,105,180,0)', {}, (_finished) => {}),
+    };
+  });
+  return (
+    <View>
+      <Animated.View style={[styles.box, style]} />
+    </View>
   );
 }
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -401,17 +401,19 @@ declare module 'react-native-reanimated' {
     ): BackwardCompatibleWrapper;
 
     // reanimated2 animations
+
+    export type StringColor = string; // string as a color value like `"rgba(20,20,20,0)"`
     export interface WithTimingConfig {
       duration?: number;
       easing?: EasingFunction;
     }
     export function withTiming(
-      toValue: number | string, // string as a color value like `"rgba(20,20,20,0)"`
+      toValue: number | StringColor, 
       userConfig?: WithTimingConfig,
       callback?: (isFinished: boolean) => void
     ): number;
     export function withSpring(
-      toValue: number | string, // string as a color value like `"rgba(20,20,20,0)"`,
+      toValue: number | StringColor,
       userConfig?: WithSpringConfig,
       callback?: (isFinished: boolean) => void
     ): number;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -406,12 +406,12 @@ declare module 'react-native-reanimated' {
       easing?: EasingFunction;
     }
     export function withTiming(
-      toValue: number,
+      toValue: number | string, // string as a color value like `"rgba(20,20,20,0)"`
       userConfig?: WithTimingConfig,
       callback?: (isFinished: boolean) => void
     ): number;
     export function withSpring(
-      toValue: number,
+      toValue: number | string, // string as a color value like `"rgba(20,20,20,0)"`,
       userConfig?: WithSpringConfig,
       callback?: (isFinished: boolean) => void
     ): number;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -20,6 +20,8 @@ declare module 'react-native-reanimated' {
     ScrollView as ReactNativeScrollView,
     NativeScrollEvent,
     NativeSyntheticEvent,
+    ColorValue,
+    OpaqueColorValue
   } from 'react-native';
   import {
     GestureHandlerGestureEvent,
@@ -401,19 +403,17 @@ declare module 'react-native-reanimated' {
     ): BackwardCompatibleWrapper;
 
     // reanimated2 animations
-
-    export type StringColor = string; // string as a color value like `"rgba(20,20,20,0)"`
     export interface WithTimingConfig {
       duration?: number;
       easing?: EasingFunction;
     }
     export function withTiming(
-      toValue: number | StringColor, 
+      toValue: number | Exclude<ColorValue, OpaqueColorValue>,  // string as a color value like `"rgba(20,20,20,0)"`
       userConfig?: WithTimingConfig,
       callback?: (isFinished: boolean) => void
     ): number;
     export function withSpring(
-      toValue: number | StringColor,
+      toValue: number | Exclude<ColorValue, OpaqueColorValue>, // string as a color value like `"rgba(20,20,20,0)"`
       userConfig?: WithSpringConfig,
       callback?: (isFinished: boolean) => void
     ): number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "lib": ["es2015"]
+    "lib": ["es6"],
+    "esModuleInterop": true
   },
   "files": ["react-native-reanimated-tests.tsx", "react-native-reanimated.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,9 +2776,10 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
 
-"@types/react-native@^0.62.13":
-  version "0.62.18"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.18.tgz#ad63691e7c44edef2beeb6af52b2eb942c3ed8a1"
+"@types/react-native@^0.63.43":
+  version "0.63.43"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.43.tgz#0278dd540f8479b35ae5d6ef373dd9b3be4cffb1"
+  integrity sha512-zFD+rFf7xmk3ZL5laaGdWB8NLNoN36TjHc2M5PcT5gXcDk7ZJBPsiabNcPDQPSIU/om8YPwBpaFdd1IiyuIM+g==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
## Description

Fixes #845.

Now we can use strings in `withTiming()` and `withSpring()` to animate color value like `"rgba(20,20,20,0)"`

## Checklist

- [x] Updated TS types
- [x] Added TS types tests
- [x] Updated documentation
- [ ] Ensured that CI passes
