### PR TITLE
Fix interpolate of alpha channel

### DIFF
--- a/src/reanimated2/Colors.js
+++ b/src/reanimated2/Colors.js
@@ -424,7 +424,7 @@ export const rgbaColor = (r, g, b, alpha = 1) => {
   if (Platform.OS === 'web' || !_WORKLET) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
-  const a = alpha * 255;
+  const a = Math.round(alpha * 255);
   const c =
     a * (1 << 24) +
     Math.round(r) * (1 << 16) +


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1488
Fix interpolate of alpha channel. Alpha value is normalized to [0-1] float value by parser and in the next step this value is mapped to [0-255] value but mapping was without usage of round() and alpha value was still float instead of integer.

## Example code
<details>
<summary>Example code</summary>

```js
import React from 'react';
import { View, Button } from 'react-native';
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  withTiming,
  Easing,
  interpolateColor,
} from 'react-native-reanimated';

export default function AnimatedStyleUpdateExample() {
  const color = useSharedValue(0)
  const animatedStyles = useAnimatedStyle(() => {
    return {
      backgroundColor: interpolateColor(
        color.value,
        [0, 1],
        ['rgba(255,0,0,0.1)', 'rgba(0,255,0,0.9)'],
      ),
    };
  });

  return (
    <View>
      <Animated.View style={[{ height: 100, width: 100 }, animatedStyles]} />
      <Button onPress={() => {
        color.value = withTiming((color.value + 1) % 2, {duration: 300, easing: Easing.linear})
      }} title="click" />
    </View>
  );
}
```

</details>

## Changes

Call Math.round() on aplha channel value.

### Before
![Screen Recording 2021-01-05 at 16 18 29](https://user-images.githubusercontent.com/36106620/103665030-38efb900-4f73-11eb-8c3d-e87efca3c7fb.gif)

### After
![Screen Recording 2021-01-05 at 16 18 49](https://user-images.githubusercontent.com/36106620/103665049-3f7e3080-4f73-11eb-9461-0a839fd81985.gif)
