### PR TITLE
Add runOnJS, withDelay mock

### DIFF
--- a/src/reanimated2/mock.js
+++ b/src/reanimated2/mock.js
@@ -25,8 +25,8 @@ const ReanimatedV2 = {
     cb && setTimeout(() => cb(true), 0);
     return 0;
   },
-  withDelay: () => {
-    return 0;
+  withDelay: (_, animationValue) => {
+    return animationValue;
   },
   cancelAnimation: NOOP,
   delay: (_, b) => b,

--- a/src/reanimated2/mock.js
+++ b/src/reanimated2/mock.js
@@ -25,6 +25,9 @@ const ReanimatedV2 = {
     cb && setTimeout(() => cb(true), 0);
     return 0;
   },
+  withDelay: () => {
+    return 0;
+  },
   cancelAnimation: NOOP,
   delay: (_, b) => b,
   sequence: () => 0,

--- a/src/reanimated2/mock.js
+++ b/src/reanimated2/mock.js
@@ -54,6 +54,8 @@ const ReanimatedV2 = {
     out: ID,
     inOut: ID,
   },
+
+  runOnJS: (fn) => fn,
 };
 
 module.exports = {


### PR DESCRIPTION
## Description

### runOnJS

I added `runOnJS` mock for V2.
The usage of `runOnJS` function is switching the running context of a JS function. 
```js
runOnJS(externalLibraryFunction)(args);
```
So, we can just return the function directly. 

### withDelay

I added empty mock function.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
