### PR TITLE
Fix no host instance case

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -250,21 +250,18 @@ export default function createAnimatedComponent(Component) {
         viewTag = findNodeHandle(this);
         viewName = null;
       } else {
+        // hostInstance can be null for a component that doesn't render anything (render function returns null). Example: svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
         const hostInstance = RNRenderer.findHostInstance_DEPRECATED(this);
-        if (hostInstance === null) {
-          // in a case when there is no view tag for this component we want to cut further operations that use view tag and name. This happens when a component doesn't render anything (render function returns null). Example: svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
-          return;
-        }
         // we can access view tag in the same way it's accessed here https://github.com/facebook/react/blob/e3f4eb7272d4ca0ee49f27577156b57eeb07cf73/packages/react-native-renderer/src/ReactFabric.js#L146
-        viewTag = hostInstance._nativeTag;
+        viewTag = hostInstance?._nativeTag;
         /**
          * RN uses viewConfig for components for storing different properties of the component(example: https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollViewViewConfig.js#L16).
          * The name we're looking for is in the field named uiViewClassName.
          */
-        viewName = hostInstance.viewConfig?.uiViewClassName;
+        viewName = hostInstance?.viewConfig?.uiViewClassName;
         // update UI props whitelist for this view
         if (this._hasReanimated2Props(styles)) {
-          adaptViewConfig(hostInstance.viewConfig);
+          adaptViewConfig(hostInstance?.viewConfig);
         }
       }
 

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -260,8 +260,8 @@ export default function createAnimatedComponent(Component) {
          */
         viewName = hostInstance?.viewConfig?.uiViewClassName;
         // update UI props whitelist for this view
-        if (this._hasReanimated2Props(styles)) {
-          adaptViewConfig(hostInstance?.viewConfig);
+        if (hostInstance && this._hasReanimated2Props(styles)) {
+          adaptViewConfig(hostInstance.viewConfig);
         }
       }
 

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -251,6 +251,10 @@ export default function createAnimatedComponent(Component) {
         viewName = null;
       } else {
         const hostInstance = RNRenderer.findHostInstance_DEPRECATED(this);
+        if (hostInstance === null) {
+          // in a case when there is no view tag for this component we want to cut further operations that use view tag and name. This happens when a component doesn't render anything (render function returns null). Example: svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
+          return;
+        }
         // we can access view tag in the same way it's accessed here https://github.com/facebook/react/blob/e3f4eb7272d4ca0ee49f27577156b57eeb07cf73/packages/react-native-renderer/src/ReactFabric.js#L146
         viewTag = hostInstance._nativeTag;
         /**


### PR DESCRIPTION
## Description

This fixes the case when we create an animated component out of a component that does not render anything(render function returns `null`).

An example would be [svg Stop](https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx)

Fixes #1569 

<details>
<summary>code example</summary>

```
import Svg, { Defs, Stop, RadialGradient, ClipPath, G, Circle, Ellipse, Rect, Polygon } from 'react-native-svg';

import Animated from 'react-native-reanimated';
import React from 'react';
import { Text } from 'react-native';

const AnimatedStop = Animated.createAnimatedComponent(Stop);

const Test = () => (
  <Svg height="100" width="100">
    <Defs>
      <RadialGradient
        id="grad"
        cx="50%"
        cy="50%"
        rx="50%"
        ry="50%"
        fx="50%"
        fy="50%"
        gradientUnits="userSpaceOnUse">
        <AnimatedStop offset="0%" stopColor="#ff0" stopOpacity="1" />
        <AnimatedStop offset="100%" stopColor="#00f" stopOpacity="1" />
      </RadialGradient>
      <ClipPath id="clip">
        <G scale="0.9" x="10">
          <Circle cx="30" cy="30" r="20" />
          <Ellipse cx="60" cy="70" rx="20" ry="10" />
          <Rect x="65" y="15" width="30" height="30" />
          <Polygon points="20,60 20,80 50,70" />
          <Text
            x="50"
            y="30"
            fontSize="32"
            fonWeight="bold"
            textAnchor="middle"
            scale="1.2">
            Q
          </Text>
        </G>
      </ClipPath>
    </Defs>
    <Rect
      x="0"
      y="0"
      width="100"
      height="100"
      fill="url(#grad)"
      clipPath="url(#clip)"
    />
  </Svg>
);

export default Test;

```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
