### PR TITLE
Fix initialization of animation value

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -71,10 +71,10 @@ function prepareAnimation(animatedProp, lastAnimation, lastValue) {
             // previously it was a shared value
             value = lastValue.value;
           } else if (lastValue.onFrame !== undefined) {
-            if (lastAnimation?.current) {
+            if (lastAnimation?.current !== undefined) {
               // it was an animation before, copy its state
               value = lastAnimation.current;
-            } else if (lastValue?.current) {
+            } else if (lastValue?.current !== undefined) {
               // it was initialized
               value = lastValue.current;
             }


### PR DESCRIPTION
## Description

Fix initialization of animation value. In some case It wasn't possible to initiate animation with 0 value because `if` condition deal with 0 value and `undefined` in the same way.
Fixes: #1547

## Changes

I replace `if` condition from comparing 0 to boolean to comparing with `undefined`

### Before
![Screen Recording 2021-01-07 at 10 48 38](https://user-images.githubusercontent.com/36106620/103879545-4ecabe80-50d8-11eb-833e-48eb017c8505.gif)

### After
![Screen Recording 2021-01-07 at 10 49 02](https://user-images.githubusercontent.com/36106620/103879598-59855380-50d8-11eb-8c35-d9e4ca16455f.gif)


## Example code
<details>
<summary>code</summary>

```js
import React from 'react'
import { Button, View } from 'react-native'
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  withSpring,
} from 'react-native-reanimated'

const AnimatedStyle = () => {
  const offset = useSharedValue(0)
  const defaultSpringStyles = useAnimatedStyle(() => {
    return {
      transform: [{ translateX: withSpring(offset.value) }],
    }
  })

  return (
    <View>
      <Animated.View style={[{width: 50, height: 50, backgroundColor: '#001A72'}, defaultSpringStyles]} />
      <Button
        onPress={() => {
          offset.value = 200
        }}
        title="Move"
      />
    </View>
  )
}

export default AnimatedStyle
```

</details>