### PR TITLE
Handle null deps in hooks

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -393,7 +393,7 @@ function buildWorkletsHash(handlers) {
 
 // builds dependencies array for gesture handlers
 function buildDependencies(dependencies, handlers) {
-  if (dependencies === undefined) {
+  if (!dependencies) {
     dependencies = Object.keys(handlers).map((handlerKey) => {
       const handler = handlers[handlerKey];
       return {
@@ -417,7 +417,8 @@ function areDependenciesEqual(nextDeps, prevDeps) {
   var objectIs = typeof Object.is === 'function' ? Object.is : is;
 
   function areHookInputsEqual(nextDeps, prevDeps) {
-    if (!nextDeps || !prevDeps || (prevDeps.length !== nextDeps.length)) return !1;
+    if (!nextDeps || !prevDeps || prevDeps.length !== nextDeps.length)
+      return !1;
     for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++)
       if (!objectIs(nextDeps[i], prevDeps[i])) return !1;
     return !0;

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -420,7 +420,7 @@ function areDependenciesEqual(nextDeps, prevDeps) {
     if (!nextDeps || !prevDeps || prevDeps.length !== nextDeps.length) {
       return false;
     }
-    for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+    for (let i = 0; i < prevDeps.length; ++i) {
       if (!objectIs(nextDeps[i], prevDeps[i])) {
         return false;
       }

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -417,11 +417,15 @@ function areDependenciesEqual(nextDeps, prevDeps) {
   var objectIs = typeof Object.is === 'function' ? Object.is : is;
 
   function areHookInputsEqual(nextDeps, prevDeps) {
-    if (!nextDeps || !prevDeps || prevDeps.length !== nextDeps.length)
-      return !1;
-    for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++)
-      if (!objectIs(nextDeps[i], prevDeps[i])) return !1;
-    return !0;
+    if (!nextDeps || !prevDeps || prevDeps.length !== nextDeps.length) {
+      return false;
+    }
+    for (var i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+      if (!objectIs(nextDeps[i], prevDeps[i])) {
+        return false;
+      }
+    }
+    return true;
   }
 
   return areHookInputsEqual(nextDeps, prevDeps);


### PR DESCRIPTION
## Description

We don't handle the case when `null` is passed as dependencies in either `useAnimatedGestureHandler` or `useAnimatedScrollHandler`. Although in types it's not an option we have to consider that not all of the users use TypeScript.

Automatic casting to boolean works fine here as `!![] === true`.

<details>
<summary>example code</summary>

```
const gestureHandler = useAnimatedGestureHandler({
    onActive: (event, ctx) => {
        // ...
    },
  }, null);
```

</details>

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
