### PR TITLE
Fix stop condition for scroll animation in Example

### DIFF
--- a/Example/src/ScrollableViewExample.js
+++ b/Example/src/ScrollableViewExample.js
@@ -58,7 +58,9 @@ function ScrollableView({ children }) {
 
   const handler = useAnimatedGestureHandler({
     onStart: (evt, ctx) => {
-      ctx.startY = translateY.value;
+      const currentY = translateY.value;
+      ctx.startY = currentY;
+      translateY.value = currentY; // for stop animation
     },
 
     onActive: (evt, ctx) => {


### PR DESCRIPTION
## Description

The list in scroll Example app is inertness, and when list is moved and someone taps on screen and doesn't move by finger it calls only onStart() event from GestureHandler, and this sets the actual position but the list is still moving. If in the next step someone moves their finger then the list jumps to this position and starts animation of scroll from this position like in issue:

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1597

## Changes
I just set the actual position of the animation to stop inertness of list.
