### PR TITLE
NodesManager.onEventDispatch(): ignore mNativeProxy when null

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -464,7 +464,7 @@ public class NodesManager implements EventDispatcherListener {
       int viewTag = event.getViewTag();
       String key = viewTag + eventName;
 
-      shouldSaveEvent |= (mCustomEventHandler != null && mNativeProxy.isAnyHandlerWaitingForEvent(key));
+      shouldSaveEvent |= (mCustomEventHandler != null && mNativeProxy != null && mNativeProxy.isAnyHandlerWaitingForEvent(key));
       if (shouldSaveEvent) {
         mEventQueue.offer(new CopiedEvent(event));
       }


### PR DESCRIPTION
## Description

Fixes #1614 (maybe?)

Sorry, I have no idea if this is the right fix, or just a band-aid that hides problems elsewhere.

## Changes

Just skip calling .isAnyHandlerWaitingForEvent() when mNativeProxy is null
