### PR TITLE
do not execute finished animation

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -117,15 +117,20 @@ function runAnimations(animation, timestamp, key, result) {
       });
       return allFinished;
     } else if (typeof animation === 'object' && animation.onFrame) {
-      if (animation.callStart) {
-        animation.callStart(timestamp);
-        animation.callStart = null;
-      }
-      const finished = animation.onFrame(animation, timestamp);
-      animation.timestamp = timestamp;
-      if (finished) {
-        animation.finished = true;
-        animation.callback && animation.callback(true /* finished */);
+      let finished = false;
+      if (animation.finished) {
+        finished = true;
+      } else {
+        if (animation.callStart) {
+          animation.callStart(timestamp);
+          animation.callStart = null;
+        }
+        finished = animation.onFrame(animation, timestamp);
+        animation.timestamp = timestamp;
+        if (finished) {
+          animation.finished = true;
+          animation.callback && animation.callback(true /* finished */);
+        }
       }
       result[key] = animation.current;
       return finished;


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1588

There is a case In `runAnimations` function (used by `useAnimatedStyle`) in which we have an array of animations.
Of course, we have to wait until the last animation from the array is done but we cannot execute finished animations. 
To prevent that I've added an additional check.

## Changes

Added check if the animation has already finished.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```JS
import React from 'react'
import {
  StyleSheet
} from 'react-native'
import Animated, {
  useAnimatedStyle,
  withSequence,
  withSpring
  // withTiming
} from 'react-native-reanimated'

// const withSpring = withTiming;

export default function SequenceBug() {
  const animatedStyle = useAnimatedStyle(() => ({
    // if you change every instance of withSpring to withTiming, it works.
    transform: [ {
         scale: withSequence(withSpring(0), withSpring(0.5), withSpring(1), withSpring(1.5))
     },
      {
        translateY: withSequence(withSpring(0), withSpring(5), withSpring(10), withSpring(15))
      } 
    ]
  }))
  return <Animated.View style = {
    [style.item, animatedStyle]
  }
  />
}

const style = StyleSheet.create({
  item: {
    margin: 100,
    width: 300,
    height: 300,
    backgroundColor: 'blue',
    alignSelf: 'center',
    borderRadius: 999
  }
})
```
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
