### PR TITLE
Fix animations

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -126,10 +126,8 @@ function runAnimations(animation, timestamp, key, result, animationsActive) {
       });
       return allFinished;
     } else if (typeof animation === 'object' && animation.onFrame) {
-      let finished = false;
-      if (animation.finished) {
-        finished = true;
-      } else {
+      let finished = true;
+      if (!animation.finished) {
         if (animation.callStart) {
           animation.callStart(timestamp);
           animation.callStart = null;
@@ -205,7 +203,14 @@ function styleDiff(oldStyle, newStyle) {
   return diff;
 }
 
-function styleUpdater(viewDescriptor, updater, state, maybeViewRef, adapters, animationsActive) {
+function styleUpdater(
+  viewDescriptor,
+  updater,
+  state,
+  maybeViewRef,
+  adapters,
+  animationsActive
+) {
   'worklet';
   const animations = state.animations || {};
   const newValues = updater() || {};
@@ -326,7 +331,7 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
         remoteState,
         maybeViewRef,
         adapters,
-        animationsActive,
+        animationsActive
       );
     };
     const mapperId = startMapper(fun, inputs, []);

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -116,7 +116,7 @@ function workletValueSetter(value) {
     // prevent setting again to the same value
     // and triggering the mappers that treat this value as an input
     // this happens when the animation's target value(stored in animation.current until animation.onStart is called) is set to the same value as a current one(this._value)
-    if (this._value === animation.current) {
+    if (this._value === animation.current && !animation.isHigherOrder) {
       return;
     }
     // animated set

--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -116,6 +116,7 @@ function workletValueSetter(value) {
     // prevent setting again to the same value
     // and triggering the mappers that treat this value as an input
     // this happens when the animation's target value(stored in animation.current until animation.onStart is called) is set to the same value as a current one(this._value)
+    // built in animations that are not higher order(withTiming, withSpring) hold target value in .current
     if (this._value === animation.current && !animation.isHigherOrder) {
       return;
     }


### PR DESCRIPTION
## Description

#### Problem 1

Until now we used to break the execution of setting a new value of a mutable with animation in order to prevent going through the setting process for the same value. But we cannot do this for higher-order animations(they have the same current value as the ones they include).

The problem occurs when we have a shared value and, let's say, a couple of animations placed together in some higher-order animation like `withSequence`, and the first one has the same target value as the shared value current value. The flow stops but it should go on and execute the rest of the animations.

#### Problem 2

Another thing is we didn't support breaking animations on component unmount until now. The worst scenario(not that rare though) would be when a user would run infinite animation using `withRepeat` with repeats value set to `0`(goes infinitely). They would have to stop the animation manually, like this:
```
const sv = useSharedValue(10);
sv.value = withRepeat(withTiming(Math.random() * 400 + 100), 0);
useEffect(() => {
  return () => {
    cancelAnimation(sv);
  };
}, []);
```
But that could easily be skipped and cause efficiency problems after some rerenders(the unstopped animations would be proceeding in the background).

## Test code and steps to reproduce

<details>
<summary>problem 1</summary>

```
import Animated, {
  useSharedValue,
  withTiming,
  useAnimatedStyle,
  withSequence,
  withRepeat,
} from 'react-native-reanimated';
import { View } from 'react-native';
import React from 'react';

export default function AnimatedStyleUpdateExample() {
  const randomWidth = useSharedValue(10);

  randomWidth.value = withRepeat(
    withSequence(
      withTiming(10, { duration: 500 }),
      withTiming(100, { duration: 500 })
    ),
    0,
    true,
    () => {
      console.log('clb');
    }
  );

  const style = useAnimatedStyle(() => {
    return {
      width: randomWidth.value,
    };
  });

  return (
    <View
      style={{
        flex: 1,
        flexDirection: 'column',
      }}>
      <Animated.View
        style={[
          { width: 100, height: 80, backgroundColor: 'black', margin: 30 },
          style,
        ]}
      />
    </View>
  );
}

```

</details>

<details>
<summary>problem 2</summary>

```
import Animated, {
  useSharedValue,
  withTiming,
  useAnimatedStyle,
  withRepeat,
} from 'react-native-reanimated';
import { View, StyleSheet } from 'react-native';
import React, { useEffect } from 'react';

export default function Test() {
  const sv = useSharedValue(10);
  useEffect(() => {
    sv.value = withRepeat(
      withTiming(Math.random() * 400 + 100, null, () => {
        console.log('clb #1');
      }),
      0
    );
  }, []);

  const style1 = useAnimatedStyle(() => {
    return {
      width: sv.value,
    };
  });

  const style2 = useAnimatedStyle(() => {
    return {
      width: withRepeat(
        withTiming(Math.random() * 200 + 100, null, () => {
          console.log('clb #2');
        }),
        0
      ),
    };
  });

  return (
    <View>
      <Animated.View style={[styles.box, style1]} />
      <Animated.View style={[styles.box, style2]} />
    </View>
  );
}

const styles = StyleSheet.create({
  box: {
    width: 100,
    height: 50,
    backgroundColor: 'orange',
    margin: 20,
  },
});
```

</details>


## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
