### PR TITLE
Use targetTimestamp instead of timestamp

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -9,6 +9,7 @@
 #import <folly/json.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTUIManager.h>
+#import <iostream>
 
 namespace reanimated {
 
@@ -113,7 +114,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   auto requestRender = [reanimatedModule, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
     [reanimatedModule.nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
-      double frameTimestamp = displayLink.timestamp * 1000.0;
+      double frameTimestamp = displayLink.targetTimestamp * 1000;
       rt.global().setProperty(rt, "_frameTimestamp", frameTimestamp);
       onRender(frameTimestamp);
       rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -9,7 +9,6 @@
 #import <folly/json.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTUIManager.h>
-#import <iostream>
 
 namespace reanimated {
 
@@ -157,4 +156,3 @@ module = std::make_shared<NativeReanimatedModule>(jsInvoker,
 }
 
 }
-


### PR DESCRIPTION
## Description

Related issue: https://github.com/software-mansion/react-native-reanimated/issues/1610

As it turned out CADisplayLink.timestamp is the time of the last frame, not the upcoming one. 

**Context from the [docs](https://developer.apple.com/documentation/quartzcore/cadisplaylink?language=objc):** ```The target can read the display link’s timestamp property to retrieve the time that the previous frame was displayed. ... To calculate the actual frame duration, use targetTimestamp - timestamp. You can use actual frame duration in your application to calculate the frame rate of the display, the approximate time that the next frame will be displayed, and to adjust the drawing behavior so that the next frame is prepared in time to be displayed.```

**Why it is a problem?**
We use ```CACurrentMediaTime()``` to compute timestamp for events what may create a situation when animation started during the event uses timestamp later than used in onFrame. The reason for that is that we use CADisplayLink.timestamp as a timestamp during the render events.


## Changes

In NativeProxy: timestamp -> targetTimestamp

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```JS
import Animated, {
  useSharedValue,
  withTiming,
  useAnimatedStyle,
  useAnimatedReaction,
  cancelAnimation,
  useWorkletCallback,
  Easing,
  useAnimatedGestureHandler,
} from 'react-native-reanimated';
import { View, StyleSheet, Platform } from 'react-native';
import React from 'react';
import { PanGestureHandler } from 'react-native-gesture-handler';

export default function AnimatedStyleUpdateExample(props) {
  const animatedPosition = useSharedValue(0);
  const animatedLinePosition = useSharedValue(0);

  const config = {
    duration: 1000,
    easing: Easing.out(Easing.exp),
  };

  const animateToPoint = useWorkletCallback((destinationPoint) => {
    animatedPosition.value = withTiming(destinationPoint, config);
  }, []);

  const gestureHandler = useAnimatedGestureHandler(
    {
      onStart: (_ , context) => {
        context.currentPosition = animatedPosition.value;
        cancelAnimation(animatedPosition);
      },
      onActive: ({ translationY }, context) => {
        animatedLinePosition.value = context.currentPosition + translationY;
        animatedPosition.value = context.currentPosition + translationY;
      },
      onEnd: ({ state }) => {
        animateToPoint(0);
      },
    },
    [animateToPoint]
  );

  const boxAnimatedStyle = useAnimatedStyle(() => {
    return {
      backgroundColor: animatedPosition.value - animatedLinePosition.value > 0 ? 'red' : 'black',
      transform: [
        {
          translateY: animatedPosition.value,
        },
      ],
    };
  });

  const lineAnimatedStyle = useAnimatedStyle(() => {
    return {
      transform: [
        {
          translateY: animatedLinePosition.value,
        },
      ],
    };
  });

  useAnimatedReaction(
    () => animatedPosition.value - animatedLinePosition.value,
    (value) => {
      if(value > 0){
        console.log(Platform.OS, 'Offset', value)
      }
    },
    []
  );

  return (
    <View
      style={styles.container}>
      <PanGestureHandler onGestureEvent={gestureHandler}>
        <Animated.View style={[styles.box, boxAnimatedStyle]} />
      </PanGestureHandler>
      <Animated.View style={[styles.line, lineAnimatedStyle]} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#444'
  },
  box: {
    position: 'absolute',
    bottom: 0,
    left: 0,
    right: 0,
    height: 400,
    backgroundColor: 'black',
  },
  line: {
    position: 'absolute',
    bottom: 400,
    left: 0,
    right: 0,
    height: 1,
    backgroundColor: 'white',
  },
});
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
