### PR TITLE
Inject frameTimestamp to our context for time of frame

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -60,7 +60,10 @@ void NativeProxy::installJSIBindings()
   };
 
   auto requestRender = [this, getCurrentTime](std::function<void(double)> onRender, jsi::Runtime &rt) {
-    auto wrappedOnRender = [getCurrentTime, &rt, onRender](double doNotUse) {
+    //doNoUse -> NodesManager passes here a timestamp from choreographer which is useless for us 
+    //as we use diffrent timer to better handle events. The lambda is translated to NodeManager.OnAnimationFrame
+    //and treated just like reanimated 1 frame callbacks which make use of the timestamp.
+    auto wrappedOnRender = [getCurrentTime, &rt, onRender](double doNotUse) { 
        double frameTimestamp = getCurrentTime();
        rt.global().setProperty(rt, "_frameTimestamp", frameTimestamp);
        onRender(frameTimestamp);


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1610

By accident, somebody wrapped a different part of the code in frameTimestamp injection logic. They were supposed to wrap frameCallback but instead wrapped a part that registers frame callbacks.

## Changes

NativeProxy.cpp - wrap callback before passing it to NodesManager.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```JS
import Animated, {
  useSharedValue,
  withTiming,
  useAnimatedStyle,
  useAnimatedReaction,
  cancelAnimation,
  useWorkletCallback,
  Easing,
  useAnimatedGestureHandler,
} from 'react-native-reanimated';
import { View, StyleSheet, Platform } from 'react-native';
import React from 'react';
import { PanGestureHandler } from 'react-native-gesture-handler';

export default function AnimatedStyleUpdateExample(props) {
  const animatedPosition = useSharedValue(0);
  const animatedLinePosition = useSharedValue(0);

  const config = {
    duration: 1000,
    easing: Easing.out(Easing.exp),
  };

  const animateToPoint = useWorkletCallback((destinationPoint) => {
    animatedPosition.value = withTiming(destinationPoint, config);
  }, []);

  const gestureHandler = useAnimatedGestureHandler(
    {
      onStart: (_ , context) => {
        context.currentPosition = animatedPosition.value;
        cancelAnimation(animatedPosition);
      },
      onActive: ({ translationY }, context) => {
        animatedLinePosition.value = context.currentPosition + translationY;
        animatedPosition.value = context.currentPosition + translationY;
      },
      onEnd: ({ state }) => {
        animateToPoint(0);
      },
    },
    [animateToPoint]
  );

  const boxAnimatedStyle = useAnimatedStyle(() => {
    return {
      backgroundColor: animatedPosition.value - animatedLinePosition.value > 0 ? 'red' : 'black',
      transform: [
        {
          translateY: animatedPosition.value,
        },
      ],
    };
  });

  const lineAnimatedStyle = useAnimatedStyle(() => {
    return {
      transform: [
        {
          translateY: animatedLinePosition.value,
        },
      ],
    };
  });

  useAnimatedReaction(
    () => animatedPosition.value - animatedLinePosition.value,
    (value) => {
      if(value > 0){
        console.log(Platform.OS, 'Offset', value)
      }
    },
    []
  );

  return (
    <View
      style={styles.container}>
      <PanGestureHandler onGestureEvent={gestureHandler}>
        <Animated.View style={[styles.box, boxAnimatedStyle]} />
      </PanGestureHandler>
      <Animated.View style={[styles.line, lineAnimatedStyle]} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#444'
  },
  box: {
    position: 'absolute',
    bottom: 0,
    left: 0,
    right: 0,
    height: 400,
    backgroundColor: 'black',
  },
  line: {
    position: 'absolute',
    bottom: 400,
    left: 0,
    right: 0,
    height: 1,
    backgroundColor: 'white',
  },
});
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
