### PR TITLE
Fix animationsActive + default interpolation type

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -120,7 +120,9 @@ function runAnimations(animation, timestamp, key, result, animationsActive) {
       result[key] = [];
       let allFinished = true;
       animation.forEach((entry, index) => {
-        if (!runAnimations(entry, timestamp, index, result[key])) {
+        if (
+          !runAnimations(entry, timestamp, index, result[key], animationsActive)
+        ) {
           allFinished = false;
         }
       });
@@ -145,7 +147,15 @@ function runAnimations(animation, timestamp, key, result, animationsActive) {
       result[key] = {};
       let allFinished = true;
       Object.keys(animation).forEach((k) => {
-        if (!runAnimations(animation[k], timestamp, k, result[key])) {
+        if (
+          !runAnimations(
+            animation[k],
+            timestamp,
+            k,
+            result[key],
+            animationsActive
+          )
+        ) {
           allFinished = false;
         }
       });

--- a/src/reanimated2/interpolation.js
+++ b/src/reanimated2/interpolation.js
@@ -45,11 +45,7 @@ function validateType(type) {
       ${extrapolate}: 'clamp',
   })`;
 
-  if (!type) {
-    throw new Error(
-      `${EXTRAPOLATE_ERROR_MSG} or interpolate(value, [inputRange], [outputRange], 'clamp')`
-    );
-  }
+  type = type ?? 'extend';
 
   // eslint-disable-next-line no-prototype-builtins
   const hasExtrapolateLeft = type.hasOwnProperty('extrapolateLeft');


### PR DESCRIPTION
## Description

- problem 1
	`animationsActive` wasn't propagated to recursive calls causing errors all around.
- problem 2
	There was no default value for the interpolation type. Added one for backward compatibility(that would be `extend` like [here](https://github.com/software-mansion/react-native-reanimated/pull/1549/files?file-filters%5B%5D=.js#diff-6e3ba842c35e8c6f6f93c508caf29f134d9b457f836daf7850ef592afbdda9f5L12))
