### PR TITLE
Add `text` to the prop whitelist (for react-native-animateable-text)

### DIFF
--- a/src/ConfigHelper.js
+++ b/src/ConfigHelper.js
@@ -101,6 +101,8 @@ let NATIVE_THREAD_PROPS_WHITELIST = {
   writingDirection: true,
   /* text color */
   color: true,
+  // For react-native-animateable-text
+  text: true,
   tintColor: true,
   shadowColor: true,
 };


### PR DESCRIPTION
Hey!

We've been making a library called https://www.npmjs.com/package/react-native-animateable-text specifically for tieing in with Reanimated to allow to pass text as an Animated Value.

Since Alpha 9, the library does not work anymore, since `text` is not a whitelisted prop.
I would like to continue the library and try out the newer Reanimated versions, so I was wondering if it's okay to add `text` to the whitelist?

Also I am wondering if there is some way to do this in my library itself so not everybody has to send PRs to Reanimated. Thanks for considering!