### PR TITLE
Fix naming collision

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -6,7 +6,7 @@
 #include "Mapper.h"
 #include "RuntimeDecorator.h"
 #include "EventHandlerRegistry.h"
-#include "EventHandler.h"
+#include "WorkletEventHandler.h"
 #include "FrozenObject.h"
 #include <functional>
 #include <thread>
@@ -153,7 +153,7 @@ jsi::Value NativeReanimatedModule::registerEventHandler(jsi::Runtime &rt, const 
 
   scheduler->scheduleOnUI([=] {
     auto handlerFunction = handlerShareable->getValue(*runtime).asObject(*runtime).asFunction(*runtime);
-    auto handler = std::make_shared<EventHandler>(newRegistrationId, eventName, std::move(handlerFunction));
+    auto handler = std::make_shared<WorkletEventHandler>(newRegistrationId, eventName, std::move(handlerFunction));
     eventHandlerRegistry->registerEventHandler(handler);
   });
 

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -1,9 +1,9 @@
 #include "EventHandlerRegistry.h"
-#include "EventHandler.h"
+#include "WorkletEventHandler.h"
 
 namespace reanimated {
 
-void EventHandlerRegistry::registerEventHandler(std::shared_ptr<EventHandler> eventHandler) {
+void EventHandlerRegistry::registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
   eventMappings[eventHandler->eventName][eventHandler->id] = eventHandler;
   eventHandlers[eventHandler->id] = eventHandler;
@@ -22,7 +22,7 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 }
 
 void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload) {
-  std::vector<std::shared_ptr<EventHandler>> handlersForEvent;
+  std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
     const std::lock_guard<std::mutex> lock(instanceMutex);
     auto handlersIt = eventMappings.find(eventName);

--- a/Common/cpp/Tools/EventHandler.cpp
+++ b/Common/cpp/Tools/EventHandler.cpp
@@ -1,9 +1,0 @@
-#include "EventHandler.h"
-
-namespace reanimated {
-
-void EventHandler::process(jsi::Runtime &rt, jsi::Value &eventValue) {
-  handler.callWithThis(rt, handler, eventValue);
-}
-
-}

--- a/Common/cpp/Tools/WorkletEventHandler.cpp
+++ b/Common/cpp/Tools/WorkletEventHandler.cpp
@@ -1,0 +1,9 @@
+#include "WorkletEventHandler.h"
+
+namespace reanimated {
+
+void WorkletEventHandler::process(jsi::Runtime &rt, jsi::Value &eventValue) {
+  handler.callWithThis(rt, handler, eventValue);
+}
+
+}

--- a/Common/cpp/headers/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/headers/Registries/EventHandlerRegistry.h
@@ -12,15 +12,15 @@ using namespace facebook;
 
 namespace reanimated {
 
-class EventHandler;
+class WorkletEventHandler;
 
 class EventHandlerRegistry {
-  std::map<std::string, std::unordered_map<unsigned long, std::shared_ptr<EventHandler>>> eventMappings;
-  std::map<unsigned long, std::shared_ptr<EventHandler>> eventHandlers;
+  std::map<std::string, std::unordered_map<unsigned long, std::shared_ptr<WorkletEventHandler>>> eventMappings;
+  std::map<unsigned long, std::shared_ptr<WorkletEventHandler>> eventHandlers;
   std::mutex instanceMutex;
 
 public:
-  void registerEventHandler(std::shared_ptr<EventHandler> eventHandler);
+  void registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler);
   void unregisterEventHandler(unsigned long id);
 
   void processEvent(jsi::Runtime &rt, std::string eventName, std::string eventPayload);

--- a/Common/cpp/headers/Tools/WorkletEventHandler.h
+++ b/Common/cpp/headers/Tools/WorkletEventHandler.h
@@ -9,7 +9,7 @@ namespace reanimated {
 
 class EventHandlerRegistry;
 
-class EventHandler {
+class WorkletEventHandler {
   friend EventHandlerRegistry;
 
 private:
@@ -18,7 +18,7 @@ private:
   jsi::Function handler;
 
 public:
-  EventHandler(unsigned long id,
+  WorkletEventHandler(unsigned long id,
                std::string eventName,
                jsi::Function &&handler): id(id), eventName(eventName), handler(std::move(handler)) {}
   void process(jsi::Runtime &rt, jsi::Value &eventValue);


### PR DESCRIPTION
## Description

Remove naming collision that led to crashes.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
