### PR TITLE
Reactivate animations on mount

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -351,6 +351,7 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
   }, dependencies);
 
   useEffect(() => {
+    animationsActive.value = true;
     return () => {
       initRef.current = null;
       viewRef.current = null;


### PR DESCRIPTION
## Description

This is a fix to the changes from #1619(problem 2). This change was good, but we forgot to check the fast refresh. When the fast refresh occurs, the components are being unmounted and mounted again. That's why there's a need to manually activate (again) the animations on the component mount. 

# How to reproduce

Run [this example](https://github.com/software-mansion/react-native-reanimated/blob/416b1759c9e3b498a9835130f59f132da1fc15e5/Example/src/AnimatedStyleUpdateExample.js), change a js file to trigger the hot reload, and see that the animation does not work.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
