### PR TITLE
A better way to handle exceptional situations

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -253,6 +253,11 @@ export default function createAnimatedComponent(Component) {
       } else {
         // hostInstance can be null for a component that doesn't render anything (render function returns null). Example: svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
         const hostInstance = RNRenderer.findHostInstance_DEPRECATED(this);
+        if (!hostInstance) {
+          throw new Error(
+            'Cannot find host instance for this component. Maybe it renders nothing?'
+          );
+        }
         // we can access view tag in the same way it's accessed here https://github.com/facebook/react/blob/e3f4eb7272d4ca0ee49f27577156b57eeb07cf73/packages/react-native-renderer/src/ReactFabric.js#L146
         viewTag = hostInstance?._nativeTag;
         /**

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -237,7 +237,6 @@ function styleUpdater(
   'worklet';
   const animations = state.animations || {};
   const newValues = updater() || {};
-  validateAnimatedStyles(newValues);
   const oldValues = state.last;
 
   // extract animated props

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -213,6 +213,19 @@ function styleDiff(oldStyle, newStyle) {
   return diff;
 }
 
+const validateAnimatedStyles = (styles) => {
+  'worklet';
+  if (typeof styles !== 'object') {
+    throw new Error(
+      `useAnimatedStyle has to return an object, found ${typeof styles} instead`
+    );
+  } else if (Array.isArray(styles)) {
+    throw new Error(
+      'useAnimatedStyle has to return an object and cannot return static styles combined with dynamic ones. Please do merging where a component receives props.'
+    );
+  }
+};
+
 function styleUpdater(
   viewDescriptor,
   updater,
@@ -224,6 +237,7 @@ function styleUpdater(
   'worklet';
   const animations = state.animations || {};
   const newValues = updater() || {};
+  validateAnimatedStyles(newValues);
   const oldValues = state.last;
 
   // extract animated props
@@ -323,6 +337,7 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
 
   if (initRef.current === null) {
     const initial = initialUpdaterRun(updater);
+    validateAnimatedStyles(initial);
     initRef.current = {
       initial,
       remoteState: makeRemote({ last: initial }),


### PR DESCRIPTION
## Part 1

### Description

If we wanted to update animated props of a component that renders nothing, an error has to be thrown. Until now, the error message has looked like this: `Exception in HostFunction: Value is undefined, expected a number`. This PR makes it more clear and tells what went wrong.

Fixes #1638 

### Test code and steps to reproduce

```Js
import Animated, {
  useSharedValue,
  useAnimatedProps,
} from 'react-native-reanimated';
import { View, Button } from 'react-native';
import React from 'react';

class MyComp1 extends React.Component {
  constructor (props) {
    super(props);
    console.log('x passed 1', props.x);
  }

  render () {
    return null;
  }
};

class MyComp2 extends React.Component {
  constructor (props) {
    super(props);
    console.log('x passed 2', props.x);
  }

  render () {
    return <View></View>;
  }
};

const Animated1 = Animated.createAnimatedComponent(MyComp1);
const Animated2 = Animated.createAnimatedComponent(MyComp2);

export default function AnimatedStyleUpdateExample(props) {
  const sv = useSharedValue(0);

  const props1 = useAnimatedProps(() => ({ x: sv.value }));
  const props2 = useAnimatedProps(() => ({ x: sv.value*2 }));

  return (
    <View>
      <Button
        title="toggle"
        onPress={() => {
          sv.value = Math.random() * 350;
        }}
      />
      {/* this will break */}
      <Animated1 animatedProps={props1} />
      {/* this will do alright */}
      <Animated2 animatedProps={props2} />
    </View>
  );
}

```

## Part 2

### Description

We don't want to allow returning combined styles from `useAnimatedStyle`. Here a value returned by an updater is being checked on both - initial updater run and UI thread. We only want `useAnimatedStyle` to return an object(array excluded). This PR makes error messages more clear.

Fixes #1253 

### Test code and steps to reproduce

```Js
import Animated, {
  withTiming,
  useAnimatedStyle,
  useSharedValue,
} from 'react-native-reanimated';
import { View, Button, StyleSheet } from 'react-native';
import React from 'react';

export default function AnimatedStyleUpdateExample() {
  const sv = useSharedValue(0);

  const style = useAnimatedStyle(() => {
    // if (_WORKLET) return 55;
    return [
      {
        width: withTiming(sv.value),
      },
      styles.test,
    ];
  });

  return (
    <View>
      <Animated.View
        style={[
          { width: 100, height: 80, backgroundColor: 'black', margin: 30 },
          style,
        ]}
      />
      <Button
        title="toggle"
        onPress={() => {
          sv.value = Math.random() * 350;
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  test: {
    backgroundColor: 'red',
  },
});

```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
