### PR TITLE
Shared value rerender behavior

### DIFF
--- a/docs/docs/api/useSharedValue.md
+++ b/docs/docs/api/useSharedValue.md
@@ -22,18 +22,6 @@ Shared Values are just javascript objects, so you can pass them to children comp
 The first argument takes the initial value, which could be any of the primitive JavaScript types, and assigns it as the initial value of the created Shared Value.
 The value then can be read from the Shared Value reference using `.value` attribute.
 
-#### `shouldRebuild` [bool = true]
-
-This is optional and specifies whether the value of share value should be updated on rerender. This matters when a value passed to the hooks changes when components is rendered - for example when it is dependent on the state:
-
-```js {3}
-const App = () => {
-  const [state, setState] = useState(0)
-  const sv = useSharedValue(state)
-  //...
-}
-```
-
 ### Returns
 
 The hook returns a reference to shared value initialized with the provided data.

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -70,8 +70,8 @@ function MakeMutableTest() {
 // useSharedValue
 function SharedValueTest() {
   const translate = useSharedValue(0);
-  const translate2 = useSharedValue(0, true);
-  const translate3 = useSharedValue(0, false);
+  const translate2 = useSharedValue(0);
+  const translate3 = useSharedValue(0);
 
   const sharedBool = useSharedValue<boolean>(false);
   if (sharedBool.value) {

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -2,7 +2,13 @@
 // TypeScript Version: 2.8
 
 declare module 'react-native-reanimated' {
-  import { ComponentClass, ReactNode, Component, RefObject, ComponentType } from 'react';
+  import {
+    ComponentClass,
+    ReactNode,
+    Component,
+    RefObject,
+    ComponentType,
+  } from 'react';
   import {
     ViewProps,
     TextProps,
@@ -21,7 +27,7 @@ declare module 'react-native-reanimated' {
     NativeScrollEvent,
     NativeSyntheticEvent,
     ColorValue,
-    OpaqueColorValue
+    OpaqueColorValue,
   } from 'react-native';
   import {
     GestureHandlerGestureEvent,
@@ -54,7 +60,9 @@ declare module 'react-native-reanimated' {
       IDENTITY = 'identity',
     }
 
-    type ExtrapolateParameter = Extrapolate | { extrapolateLeft?: Extrapolate, extrapolateRight?: Extrapolate }
+    type ExtrapolateParameter =
+      | Extrapolate
+      | { extrapolateLeft?: Extrapolate; extrapolateRight?: Extrapolate };
 
     interface InterpolationConfig {
       inputRange: ReadonlyArray<Adaptable<number>>;
@@ -242,7 +250,10 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
-    export function createAnimatedComponent<S extends object, P extends { style?: StyleProp<S>; }>(component: ComponentType<P>): ComponentType<AnimateProps<S, P>>;
+    export function createAnimatedComponent<
+      S extends object,
+      P extends { style?: StyleProp<S> }
+    >(component: ComponentType<P>): ComponentType<AnimateProps<S, P>>;
 
     // classes
     export {
@@ -405,7 +416,7 @@ declare module 'react-native-reanimated' {
       easing?: EasingFunction;
     }
     export function withTiming(
-      toValue: number | Exclude<ColorValue, OpaqueColorValue>,  // string as a color value like `"rgba(20,20,20,0)"`
+      toValue: number | Exclude<ColorValue, OpaqueColorValue>, // string as a color value like `"rgba(20,20,20,0)"`
       userConfig?: WithTimingConfig,
       callback?: (isFinished: boolean) => void
     ): number;
@@ -418,10 +429,11 @@ declare module 'react-native-reanimated' {
       userConfig: WithDecayConfig,
       callback?: (isFinished: boolean) => void
     ): number;
-    export function cancelAnimation<T>(
-      sharedValue: SharedValue<T>
-    ): void;
-    export function withDelay(delayMS: number, delayedAnimation: number): number;
+    export function cancelAnimation<T>(sharedValue: SharedValue<T>): void;
+    export function withDelay(
+      delayMS: number,
+      delayedAnimation: number
+    ): number;
     export function withRepeat(
       animation: number,
       numberOfReps?: number,
@@ -448,7 +460,7 @@ declare module 'react-native-reanimated' {
     export function runOnJS<A extends any[], R>(
       fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => void;
-    
+
     type PropsAdapterFunction = (props: Record<string, unknown>) => void;
     export function createAnimatedPropAdapter(
       adapter: PropsAdapterFunction,
@@ -467,17 +479,12 @@ declare module 'react-native-reanimated' {
       colorSpace?: 'RGB' | 'HSV'
     ): string | number;
 
-    export function makeMutable<T>(
-      initialValue: T
-    ): SharedValue<T>;
+    export function makeMutable<T>(initialValue: T): SharedValue<T>;
 
     type DependencyList = ReadonlyArray<any>;
 
     // reanimated2 hooks
-    export function useSharedValue<T>(
-      initialValue: T,
-      shouldRebuild?: boolean
-    ): SharedValue<T>;
+    export function useSharedValue<T>(initialValue: T): SharedValue<T>;
 
     export function useDerivedValue<T>(
       processor: () => T,
@@ -489,8 +496,10 @@ declare module 'react-native-reanimated' {
       react: (prepareResult: D, preparePreviousResult: D | null) => void,
       deps?: DependencyList
     ): void;
-                        
-    export type AnimatedStyleProp<T extends object> = AnimateStyle<T> | RegisteredStyle<AnimateStyle<T>>;
+
+    export type AnimatedStyleProp<T extends object> =
+      | AnimateStyle<T>
+      | RegisteredStyle<AnimateStyle<T>>;
     export function useAnimatedStyle<
       T extends AnimatedStyleProp<ViewStyle | ImageStyle | TextStyle>
     >(updater: () => T, deps?: DependencyList | null): T;

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -19,19 +19,16 @@ import { Platform } from 'react-native';
 export function useSharedValue(init) {
   const ref = useRef(null);
   if (ref.current === null) {
-    ref.current = {
-      mutable: makeMutable(init),
-      last: init,
-    };
+    ref.current = makeMutable(init);
   }
 
   useEffect(() => {
     return () => {
-      cancelAnimation(ref.current.mutable);
+      cancelAnimation(ref.current);
     };
   }, []);
 
-  return ref.current.mutable;
+  return ref.current;
 }
 
 export function useEvent(handler, eventNames = [], rebuild = false) {

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -16,16 +16,13 @@ import { getTag } from './NativeMethods';
 import NativeReanimated from './NativeReanimated';
 import { Platform } from 'react-native';
 
-export function useSharedValue(init, shouldRebuild = true) {
+export function useSharedValue(init) {
   const ref = useRef(null);
   if (ref.current === null) {
     ref.current = {
       mutable: makeMutable(init),
       last: init,
     };
-  } else if (init !== ref.current.last && shouldRebuild) {
-    ref.current.last = init;
-    ref.current.mutable.value = init;
   }
 
   useEffect(() => {

--- a/src/reanimated2/hooks.useSharedValue.test.js
+++ b/src/reanimated2/hooks.useSharedValue.test.js
@@ -7,38 +7,13 @@ jest.mock('../ReanimatedModule');
 jest.mock('./NativeReanimated');
 
 describe('useSharedValue', () => {
-  it('update value when shouldRebuild = true', () => {
+  it('retains value on rerender', () => {
     // Given
-    const shouldRebuild = true;
     const initialValue = 0;
     const updatedValue = 1;
 
     function TestComponent(props) {
-      const opacity = useSharedValue(props.value, shouldRebuild);
-      return <Animated.View style={{ opacity: opacity.value }} />;
-    }
-
-    // When rendering with initial value
-    const wrapper = renderer.create(
-      <TestComponent key="box" value={initialValue} />
-    );
-
-    expect(wrapper.root.children[0].props.style.opacity).toBe(initialValue);
-
-    // When rendering with updated value
-    wrapper.update(<TestComponent key="box" value={updatedValue} />);
-
-    expect(wrapper.root.children[0].props.style.opacity).toBe(updatedValue);
-  });
-
-  it('retains value when shouldRebuild = false', () => {
-    // Given
-    const shouldRebuild = false;
-    const initialValue = 0;
-    const updatedValue = 1;
-
-    function TestComponent(props) {
-      const opacity = useSharedValue(props.value, shouldRebuild);
+      const opacity = useSharedValue(props.value);
       return <Animated.View style={{ opacity: opacity.value }} />;
     }
 


### PR DESCRIPTION
## Description

This is yet one more change to the logic of the `useSharedValue` hook and it comes as a modification of #1042. We decided to bring the rerender behavior of the `useSharedValue` closer to React's `useState` - every time a rerender happens(a state is changed), a shared value is not being rebuilt and it keeps the same value.
 
Fixes #1655 


#### Note

With that change, when having something like this `useSharedValue(x)` and changing the code that the hook receives a different value `useSharedValue(y)` it's not going to work with a fast refresh. This shared value will not have an updated value. Still, we decided to implement it that way as it's more important how it acts in the release mode than in the debug mode.

## Example code

```
import { useSharedValue } from 'react-native-reanimated';
import { View, Button } from 'react-native';
import React, { useState } from 'react';

export default function AnimatedStyleUpdateExample(props) {
  const [state, setState] = useState(10);
  const [stateCopy, setStateCopy] = useState(state);
  const sv = useSharedValue(state);

  setImmediate(() => {
    console.log(
      'render',
      state,
      sv.value,
      stateCopy
    );
  })

  return (
    <View>
      <Button
        title="set state"
        onPress={() => {
          setState(state + 1);
        }}
      />
    </View>
  );
}
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [x] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
