### PR TITLE
Fix broken v2 mocks on RC.2

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -234,6 +234,7 @@ module.exports = {
   __esModule: true,
 
   ...Reanimated,
+  ...ReanimatedV2,
 
   default: {
     ...Reanimated,

--- a/src/reanimated2/mock.js
+++ b/src/reanimated2/mock.js
@@ -1,11 +1,18 @@
-const hooks = require('./Hooks');
+const useRef = require('react').useRef
 
 /* eslint-disable standard/no-callback-literal */
 const NOOP = () => {};
 const ID = (t) => t;
 
 const ReanimatedV2 = {
-  useSharedValue: hooks.useSharedValue,
+  useSharedValue: (init) => {
+    const ref = useRef(null);
+    if (ref.current === null) {
+      ref.current = { value: init };
+    }
+  
+    return ref.current
+  },
   useDerivedValue: (a) => ({ value: a() }),
   useAnimatedScrollHandler: () => NOOP,
   useAnimatedGestureHandler: () => NOOP,


### PR DESCRIPTION
## Description

Fixes #1642. The useSharedValue was using the real implementation causing Jest to try importing/calling native methods from RN.

## Changes

- Add missing V2 exports.
- Fixes useSharedValue mock implementation.