### PR TITLE
Use nttld/setup-ndk@v1 to setup ndk

### DIFF
--- a/.github/workflows/build-npm-package.yml
+++ b/.github/workflows/build-npm-package.yml
@@ -16,16 +16,15 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Cache (NDK)
-        uses: actions/cache@v2
-        with:
-          path: ${ANDROID_HOME}/ndk/21.0.6113669
-          key: ndk-cache
-
       - name: Install NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install 'ndk;21.0.6113669'
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21d
 
       - name: Build package
+        env:
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: >-
           ./createNPMPackage.sh
 


### PR DESCRIPTION
## Description

I noticed that upgrading gradle version from 3.5.2 to 4.1.2 might break workflow `build-npm-package` (the build.gradle throws at https://github.com/software-mansion/react-native-reanimated/blob/master/android/build.gradle#L285). 

I then noticed https://github.com/nttld/setup-ndk which can easily handle the installation of ndk and provide the installation path.

I tried it out and [it seems to be working fine](https://github.com/UNIDY2002/react-native-reanimated/runs/1827930983?check_suite_focus=true).

Hope that this will help.

## Changes

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
