### PR TITLE
Interpolation: replace spread operator with Object.assign

### DIFF
--- a/src/reanimated2/interpolation.js
+++ b/src/reanimated2/interpolation.js
@@ -96,9 +96,9 @@ function internalInterpolate(x, l, r, ll, rr, type) {
 
   if (typeof type === 'object') {
     if (coef * val < coef * ll) {
-      return getVal({ ...config, type: type.extrapolateLeft });
+      return getVal(Object.assign(config, { type: type.extrapolateLeft }));
     } else if (coef * val > coef * ll) {
-      return getVal({ ...config, type: type.extrapolateRight });
+      return getVal(Object.assign(config, { type: type.extrapolateRight }));
     }
   }
 


### PR DESCRIPTION
## Description

In interpolation code, we want to use `Object.assign` instead of a spread operator in worklets in order to avoid errors.
