### PR TITLE
Concretize createAnimatedComponent

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import React, { useState, useCallback } from 'react';
-import { StyleSheet, Button, View, Image, FlatListProps } from 'react-native';
+import React, { useState, useCallback, forwardRef } from 'react';
+import { StyleSheet, Button, View, Image, FlatListProps, ViewProps, ImageProps } from 'react-native';
 import {
   PanGestureHandler,
   PinchGestureHandlerGestureEvent,
@@ -34,6 +34,7 @@ import Animated, {
   interpolateColors,
   createAnimatedPropAdapter,
   useAnimatedProps,
+  useAnimatedRef,
 } from 'react-native-reanimated';
 
 class Path extends React.Component<{ fill?: string }> {
@@ -46,10 +47,23 @@ type Item = {
   id: number;
 };
 
+const SomeFC = (props: ViewProps) => {
+  return <View {...props} />;
+}
+
+const SomeFCWithRef = forwardRef((props: ViewProps) => {
+  return <View {...props} />;
+});
+
+// Class Component -> Animated Class Component
 const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 const AnimatedTypedFlatList = Animated.createAnimatedComponent<FlatListProps<Item[]>>(FlatList);
+
+// Function Component -> Animated Function Component
+const AnimatedFC = Animated.createAnimatedComponent(SomeFC);
+const AnimatedFCWithRef = Animated.createAnimatedComponent(SomeFCWithRef);
 
 function CreateAnimatedComponentTest1() {
   const animatedProps = useAnimatedProps(() => ({ fill: 'blue' }));
@@ -104,6 +118,35 @@ function CreateAnimatedFlatList() {
       />
       <AnimatedImage style={{ flex: 1 }} source={{ uri: "" }} />
     </>
+  )
+}
+
+function TestClassComponentRef() {
+  const animatedRef = useAnimatedRef<React.Component<ImageProps>>();
+  return (
+    <AnimatedImage
+      ref={animatedRef}
+      source={{ }}
+    />
+  )
+}
+
+function TestFunctionComponentRef() {
+  const animatedRef = useAnimatedRef<React.Component<ViewProps>>();
+  return (
+    <AnimatedFC
+      // @ts-expect-error ref is not available on plain function-components
+      ref={animatedRef}
+    />
+  )
+}
+
+function TestFunctionComponentForwardRef() {
+  const animatedRef = useAnimatedRef<React.Component<ViewProps>>();
+  return (
+    <AnimatedFCWithRef
+      ref={animatedRef}
+    />
   )
 }
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -241,9 +241,13 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
-    export function createAnimatedComponent<P>(
+
+    export function createAnimatedComponent<P extends object>(
       component: ComponentClass<P>
-    ): ComponentType<AnimateProps<P>>;
+    ): ComponentClass<AnimateProps<P>>;
+    export function createAnimatedComponent<P extends object>(
+      component: FunctionComponent<P>
+    ): FunctionComponent<AnimateProps<P>>;
   
     // classes
     export {

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -2,7 +2,7 @@
 // TypeScript Version: 2.8
 
 declare module 'react-native-reanimated' {
-  import { ComponentClass, ReactNode, Component, RefObject, ComponentType, ComponentProps } from 'react';
+  import { ComponentClass, ReactNode, Component, RefObject, ComponentType, ComponentProps, FunctionComponent } from 'react';
   import {
     ViewProps,
     TextProps,
@@ -248,7 +248,7 @@ declare module 'react-native-reanimated' {
     export function createAnimatedComponent<P extends object>(
       component: FunctionComponent<P>
     ): FunctionComponent<AnimateProps<P>>;
-  
+
     // classes
     export {
       AnimatedClock as Clock,


### PR DESCRIPTION
## Description

Until now `createAnimatedComponent` took the `ComponentType<P>` parameter, and returned a `ComponentType<AnimateProps<P>>` animated component as a result.

This added a few problems, such as the loss of information on whether a component is a class or a function component.

This PR concretizizes the function to return `ComponentClass<AnimateProps<P>>` if a class component was passed, and `FunctionComponent<AnimateProps<P>>` if a function component was passed.

## Test code and steps to reproduce

```tsx

const ReanimatedCircle = Reanimated.createAnimatedComponent(Circle);

function App() {
  const svgCircleRef = useRef<React.Component<CircleProps>>();

  return <ReanimatedCircle ref={svgCircleRef} />;
}
```

The above code now doesn't raise an error.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
