### PR TITLE
Install global bindings for executor factory

### DIFF
--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -6,6 +6,7 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <RNReanimated/REAEventDispatcher.h>
+#import <React/RCTJSIExecutorRuntimeInstaller.h>
 
 #if RNVERSION < 63
 #import <ReactCommon/BridgeJSCallInvoker.h>
@@ -37,7 +38,7 @@ typedef JSCExecutorFactory ExecutorFactory;
    _bridge_reanimated = bridge;
   __weak __typeof(self) weakSelf = self;
 
-  return std::make_unique<ExecutorFactory>([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
+  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
     if (!bridge) {
       return;
     }
@@ -54,7 +55,7 @@ typedef JSCExecutorFactory ExecutorFactory;
                                    jsi::Object::createFromHostObject(runtime, reanimatedModule)
       );
     }
-  });
+  }));
 }
 
 @end

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -6,7 +6,10 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <RNReanimated/REAEventDispatcher.h>
+
+#if RNVERSION >= 64
 #import <React/RCTJSIExecutorRuntimeInstaller.h>
+#endif
 
 #if RNVERSION < 63
 #import <ReactCommon/BridgeJSCallInvoker.h>
@@ -38,24 +41,30 @@ typedef JSCExecutorFactory ExecutorFactory;
    _bridge_reanimated = bridge;
   __weak __typeof(self) weakSelf = self;
 
-  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
+  const auto executor = [weakSelf, bridge](facebook::jsi::Runtime &runtime) {
     if (!bridge) {
       return;
     }
     __typeof(self) strongSelf = weakSelf;
     if (strongSelf) {
-      #if RNVERSION < 63
-        auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
-        auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
-      #else
-        auto reanimatedModule = reanimated::createReanimatedModule(bridge.jsCallInvoker);
-      #endif
+#if RNVERSION >= 63
+      auto reanimatedModule = reanimated::createReanimatedModule(bridge.jsCallInvoker);
+#else
+      auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
+      auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
+#endif
       runtime.global().setProperty(runtime,
                                    jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
-                                   jsi::Object::createFromHostObject(runtime, reanimatedModule)
-      );
+                                   jsi::Object::createFromHostObject(runtime, reanimatedModule));
     }
-  }));
+  };
+
+#if RNVERSION >= 64
+  // installs globals such as console, nativePerformanceNow, etc.
+  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(executor));
+#else
+  return std::make_unique<ExecutorFactory>(executor);
+#endif
 }
 
 @end


### PR DESCRIPTION
## Description

After upgrading to RN 0.64 and enabling Hermes, I noticed that my console.logs were gone.

That's the only thing I saw in metro:

![](https://user-images.githubusercontent.com/15199031/107367690-e52b3f00-6adf-11eb-8259-f60ea490e7e1.png)

After a long journey of debugging (see https://github.com/facebook/metro/issues/635#issuecomment-775939213) I finally found the weird side-effect our custom executor factory creation was having.

This is our `jsExecutorFactoryForBridge` func's return:

```objc
  return std::make_unique<ExecutorFactory>([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
    if (!bridge) {
      return;
    }
    __typeof(self) strongSelf = weakSelf;
    if (strongSelf) {
      #if RNVERSION < 63
        auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
        auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
      #else
        auto reanimatedModule = reanimated::createReanimatedModule(bridge.jsCallInvoker);
      #endif
      runtime.global().setProperty(runtime,
                                   jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
                                   jsi::Object::createFromHostObject(runtime, reanimatedModule)
      );
    }
  });
```

This is from rn-tester:

```objc
  __weak __typeof(self) weakSelf = self;
#if RCT_USE_HERMES
  return std::make_unique<facebook::react::HermesExecutorFactory>(
#else
  return std::make_unique<facebook::react::JSCExecutorFactory>(
#endif
      facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
        if (!bridge) {
          return;
        }
        __typeof(self) strongSelf = weakSelf;
        if (strongSelf) {
          facebook::react::RuntimeExecutor syncRuntimeExecutor =
              [&](std::function<void(facebook::jsi::Runtime & runtime_)> &&callback) { callback(runtime); };
          [strongSelf->_turboModuleManager installJSBindingWithRuntimeExecutor:syncRuntimeExecutor];
        }
      }));
```

As you can see, we're missing `RCTJSIExecutorRuntimeInstaller` which is responsible for binding nativePerformanceNow, console, etc.

## Changes

* Correctly install bindings using `RCTJSIExecutorRuntimeInstaller` for the JSI Executor.

### Before

no logs in console (no `global.console`, no `global.nativePerformanceNow`)

### After

logs in console 🎉 

### Related

fixes #1542 (probably)