### PR TITLE
Add console.debug to worklets

### DIFF
--- a/src/reanimated2/core.js
+++ b/src/reanimated2/core.js
@@ -262,6 +262,7 @@ const capturableConsole = console;
 runOnUI(() => {
   'worklet';
   const console = {
+    debug: runOnJS(capturableConsole.debug),
     log: runOnJS(capturableConsole.log),
     warn: runOnJS(capturableConsole.warn),
     error: runOnJS(capturableConsole.error),


### PR DESCRIPTION
## Description

Until now, the console object in worklets only allowed pseudo-sync calls with `log`, `info`, `warn` and `error`. I was using `debug` a lot, so that was always a bit weird to encapsulate it in `runOnJS`

## Changes

- Adds `console.debug` to worklet console
<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```jsx
const x = useAnimatedStyle(() => {
  console.debug('works')
  return { opacity: opacity.value };
}, []);
```
