### PR TITLE
Typescript: createAnimatedComponent() add missing style prop type

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -121,6 +121,64 @@ function CreateAnimatedFlatList() {
   )
 }
 
+function CreateAnimatedComponentAddsStylePropTest() {
+  const animatedStyle = useAnimatedStyle(() => ({ width: 100 }));
+  const nonAnimatedStyle = { width: 100 };
+  return (
+    <>
+      <AnimatedPath style={animatedStyle} />
+      <AnimatedPath style={nonAnimatedStyle} />
+    </>
+  )
+}
+
+function CreateAnimatedComponentExistingStylePropTest() {
+  const animatedStyle = useAnimatedStyle(() => ({ resizeMode: 'cover' }));
+  const nonAnimatedStyle = { resizeMode: 'cover' } as const;
+  return (
+    <>
+      <AnimatedImage style={animatedStyle} source={{ uri: "" }} />
+      <AnimatedImage style={nonAnimatedStyle} source={{ uri: "" }} />
+    </>
+  )
+}
+
+function CreateAnimatedComponentExistingMismatchingStylePropTest() {
+  const animatedStyle = useAnimatedStyle(() => ({ fontSize: 100 }));
+  const nonAnimatedStyle = { fontSize: 100 }
+  return (
+    <>
+      <AnimatedImage
+        // @ts-expect-error
+        style={animatedStyle}
+        source={{ uri: "" }}
+      />
+      <AnimatedImage
+        // @ts-expect-error
+        style={nonAnimatedStyle}
+        source={{ uri: "" }}
+      />
+    </>
+  )
+}
+
+function CreateAnimatedComponentAddsViewStylePropTest() {
+  const animatedStyle = useAnimatedStyle(() => ({ fontSize: 100 }));
+  const nonAnimatedStyle = { fontSize: 100 }
+  return (
+    <>
+      <AnimatedPath
+        // @ts-expect-error
+        style={animatedStyle}
+      />
+      <AnimatedPath
+        // @ts-expect-error
+        style={nonAnimatedStyle}
+      />
+    </>
+  )
+}
+
 function TestClassComponentRef() {
   const animatedRef = useAnimatedRef<React.Component<ImageProps>>();
   return (

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -244,10 +244,28 @@ declare module 'react-native-reanimated' {
 
     export function createAnimatedComponent<P extends object>(
       component: ComponentClass<P>
-    ): ComponentClass<AnimateProps<P>>;
+    ): ComponentClass<
+      AnimateProps<
+        P &
+          ('style' extends keyof P
+            ? {}
+            : {
+                style?: StyleProp<ViewStyle>
+              })
+      >
+    >;
     export function createAnimatedComponent<P extends object>(
       component: FunctionComponent<P>
-    ): FunctionComponent<AnimateProps<P>>;
+    ): FunctionComponent<
+      AnimateProps<
+        P &
+          ('style' extends keyof P
+            ? {}
+            : {
+                style?: StyleProp<ViewStyle>
+              })
+      >
+    >;
 
     // classes
     export {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

Fixes #1717 

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

Updates Typescript type declaration for `createAnimatedComponent()` to reflect the fact that the returned wrapper component always exposes a `style` prop even if the wrapped component doesn't have a `style` prop

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

Added test cases

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
