### PR TITLE
Fix Flatlist scroll with refresh

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
@@ -5,11 +5,13 @@ import android.graphics.RectF;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewParent;
+import android.view.animation.AnimationUtils;
 
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.RootViewUtil;
 import com.facebook.react.views.scroll.ReactHorizontalScrollView;
 import com.facebook.react.views.scroll.ReactScrollView;
+import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout;
 
 public class NativeMethodsHelper {
 
@@ -43,9 +45,15 @@ public class NativeMethodsHelper {
     
     if (view instanceof ReactHorizontalScrollView) {
       horizontal = true;
-    } else if (!(view instanceof ReactScrollView)) {
-      Log.w("REANIMATED", "NativeMethodsHelper: Unhandled scroll view type - allowed only {ReactScrollView, ReactHorizontalScrollView}");
-      return;
+    }
+    else {
+      if (view instanceof ReactSwipeRefreshLayout) {
+        view = findScrollView((ReactSwipeRefreshLayout)view);
+      }
+      if (!(view instanceof ReactScrollView)) {
+        Log.w("REANIMATED", "NativeMethodsHelper: Unhandled scroll view type - allowed only {ReactScrollView, ReactHorizontalScrollView}");
+        return;
+      }
     }
 
     if (animated) {
@@ -62,6 +70,15 @@ public class NativeMethodsHelper {
       }
     }
 
+  }
+
+  private static ReactScrollView findScrollView(ReactSwipeRefreshLayout view) {
+    for(int i = 0; i < view.getChildCount(); i++) {
+      if(view.getChildAt(i) instanceof ReactScrollView) {
+        return (ReactScrollView)view.getChildAt(i);
+      }
+    }
+    return null;
   }
 
   private static void computeBoundingBox(View view, int[] outputBuffer) {


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1703

If FlatList contains `onRefresh` property then `ReactScrollView` is wrapped by `ReactSwipeRefreshLayout` who doesn't have `smoothScrollTo()` method.

ReactSwipeRefreshLayout support only vertical scroll - "[The SwipeRefreshLayout should be used whenever the user can refresh the contents of a view via a vertical swipe gesture.](https://developer.android.com/reference/androidx/swiperefreshlayout/widget/SwipeRefreshLayout)"
