### PR TITLE
[v1] Support radians in interpolateNode()

### DIFF
--- a/Example/reanimated1/src/interpolate/Basic.js
+++ b/Example/reanimated1/src/interpolate/Basic.js
@@ -61,11 +61,23 @@ export default class Basic extends Component {
       inputRange: [-1, 1],
       outputRange: [-100, 100],
     });
+    this._rotateZ = interpolateNode(base, {
+      inputRange: [-1, 1],
+      outputRange: ['0rad', `${Math.PI}rad`],
+    });
   }
+
   render() {
     return (
       <Row>
-        <Box style={{ transform: [{ translateX: this._transX }] }} />
+        <Box
+          style={{
+            transform: [
+              { translateX: this._transX },
+              { rotateZ: this._rotateZ },
+            ],
+          }}
+        />
       </Row>
     );
   }

--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -699,6 +699,10 @@ function interpolateNodeTest() {
     inputRange: [0, 1],
     outputRange: ['0deg', '100deg'],
   });
+  interpolateNode(value, {
+    inputRange: [0, 1],
+    outputRange: ['0rad', `${Math.PI}rad`],
+  });
 }
 
 function colorTest() {

--- a/src/reanimated1/derived/interpolate.js
+++ b/src/reanimated1/derived/interpolate.js
@@ -98,6 +98,8 @@ function convertToRadians(outputRange) {
   for (const [i, value] of outputRange.entries()) {
     if (typeof value === 'string' && value.endsWith('deg')) {
       outputRange[i] = parseFloat(value) * (Math.PI / 180);
+    } else if (typeof value === 'string' && value.endsWith('rad')) {
+      outputRange[i] = parseFloat(value);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR will add support for strings with radians in interpolate's outputRange.
Currently code like this works on iOS but crashes on Android.

ref.
https://github.com/software-mansion/react-native-reanimated/issues/1436#issuecomment-726779954

```typescript
Animated.interpolate(animatedValue, {
  inputRange: [0, 1],
  outputRange: ['0rad', `${Math.PI}rad`]
})
```


## Changes
- Added code to convert strings with radians to number
- Added a test in `interpolateNodeTest()` function

## Test code and steps to reproduce

Added test case

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [x] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
