### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/docs/api/useAnimatedGestureHandler.md
+++ b/docs/docs/api/useAnimatedGestureHandler.md
@@ -6,7 +6,7 @@ sidebar_label: useAnimatedGestureHandler
 
 This hook allows for defining worklet handlers that can serve in a process of handling gestures.
 
-Before you can use the hook, make sure that you have `react-native-gesture-handler` [installed and configured](https://docs.swmansion.com/react-native-gesture-handler/docs/getting-started.html#installation) with your project.
+Before you can use the hook, make sure that you have `react-native-gesture-handler` [installed and configured](https://docs.swmansion.com/react-native-gesture-handler/docs/#installation) with your project.
 
 ### Arguments
 
@@ -15,16 +15,16 @@ Before you can use the hook, make sure that you have `react-native-gesture-handl
 The first argument to this hook is an object that can carry one or more worklet handlers.
 The handlers can be set under the following keys: `onStart`, `onActive`, `onEnd`, `onFail`, `onCancel`, `onFinish`.
 
-Read more about gesture handling states in the [Gesture Handler library documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/state.html).
+Read more about gesture handling states in the [Gesture Handler library documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/state).
 Each of the specified handlers will be triggered depending on the current state of the attached Gesture Handler.
 The handler worklet will receive the following arguments:
 
 - `event` [object] - event object carrying the event payload.
-The payload will be different depending on the type of the Gesture Handler to which the worklet is attached (`PanGestureHandler`, `RotationGestureHandler`, etc.).
-Please check the documentation section on the [selected handler type](https://docs.swmansion.com/react-native-gesture-handler/docs/getting-started.html) to learn about the event structure.
+  The payload will be different depending on the type of the Gesture Handler to which the worklet is attached (`PanGestureHandler`, `RotationGestureHandler`, etc.).
+  Please check the documentation section on the [selected handler type](https://docs.swmansion.com/react-native-gesture-handler/docs/) to learn about the event structure.
 
 - `context` [object] - plain JS object that can be used to store some state.
-This object will persist in between events and across worklet handlers for all the selected states and you can read and write any data to it.
+  This object will persist in between events and across worklet handlers for all the selected states and you can read and write any data to it.
 
 #### `dependencies` [Array]
 
@@ -46,8 +46,8 @@ const App = () => {
     dependencies
   );
   //...
-  return <></>
-}
+  return <></>;
+};
 ```
 
 `dependencies` here may be:
@@ -63,7 +63,7 @@ The handler should be passed under `onGestureEvent` parameter regardless of what
 
 ## Example
 
-In the below example we use [`PanGestureHandler`](https://docs.swmansion.com/react-native-gesture-handler/docs/handler-pan.html) to register for pan gesture events performed on the rendered View.
+In the below example we use [`PanGestureHandler`](https://docs.swmansion.com/react-native-gesture-handler/docs/api/gesture-handlers/pan-gh) to register for pan gesture events performed on the rendered View.
 We attach three handler worklets that are going to be triggered when the gesture starts, when it is active and the user is panning, and when the gesture is over.
 We create a shared value `x` that will correspond to the x-translation of the box.
 In `onStart` handler worklet we use `context` to save the current value of `x` and therefore remember the place at which the gesture started.
@@ -92,7 +92,7 @@ function App() {
     onActive: (event, ctx) => {
       x.value = ctx.startX + event.translationX;
     },
-    onEnd: _ => {
+    onEnd: (_) => {
       x.value = withSpring(0);
     },
   });

--- a/docs/versioned_docs/version-2.0.0-rc.2/api/useAnimatedGestureHandler.md
+++ b/docs/versioned_docs/version-2.0.0-rc.2/api/useAnimatedGestureHandler.md
@@ -6,7 +6,7 @@ sidebar_label: useAnimatedGestureHandler
 
 This hook allows for defining worklet handlers that can serve in a process of handling gestures.
 
-Before you can use the hook, make sure that you have `react-native-gesture-handler` [installed and configured](https://docs.swmansion.com/react-native-gesture-handler/docs/getting-started.html#installation) with your project.
+Before you can use the hook, make sure that you have `react-native-gesture-handler` [installed and configured](https://docs.swmansion.com/react-native-gesture-handler/docs/#installation) with your project.
 
 ### Arguments
 
@@ -15,16 +15,16 @@ Before you can use the hook, make sure that you have `react-native-gesture-handl
 The first argument to this hook is an object that can carry one or more worklet handlers.
 The handlers can be set under the following keys: `onStart`, `onActive`, `onEnd`, `onFail`, `onCancel`, `onFinish`.
 
-Read more about gesture handling states in the [Gesture Handler library documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/state.html).
+Read more about gesture handling states in the [Gesture Handler library documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/state).
 Each of the specified handlers will be triggered depending on the current state of the attached Gesture Handler.
 The handler worklet will receive the following arguments:
 
 - `event` [object] - event object carrying the event payload.
-The payload will be different depending on the type of the Gesture Handler to which the worklet is attached (`PanGestureHandler`, `RotationGestureHandler`, etc.).
-Please check the documentation section on the [selected handler type](https://docs.swmansion.com/react-native-gesture-handler/docs/getting-started.html) to learn about the event structure.
+  The payload will be different depending on the type of the Gesture Handler to which the worklet is attached (`PanGestureHandler`, `RotationGestureHandler`, etc.).
+  Please check the documentation section on the [selected handler type](https://docs.swmansion.com/react-native-gesture-handler/docs/) to learn about the event structure.
 
 - `context` [object] - plain JS object that can be used to store some state.
-This object will persist in between events and across worklet handlers for all the selected states and you can read and write any data to it.
+  This object will persist in between events and across worklet handlers for all the selected states and you can read and write any data to it.
 
 #### `dependencies` [Array]
 
@@ -46,8 +46,8 @@ const App = () => {
     dependencies
   );
   //...
-  return <></>
-}
+  return <></>;
+};
 ```
 
 `dependencies` here may be:
@@ -63,7 +63,7 @@ The handler should be passed under `onGestureEvent` parameter regardless of what
 
 ## Example
 
-In the below example we use [`PanGestureHandler`](https://docs.swmansion.com/react-native-gesture-handler/docs/handler-pan.html) to register for pan gesture events performed on the rendered View.
+In the below example we use [`PanGestureHandler`](https://docs.swmansion.com/react-native-gesture-handler/docs/api/gesture-handlers/pan-gh) to register for pan gesture events performed on the rendered View.
 We attach three handler worklets that are going to be triggered when the gesture starts, when it is active and the user is panning, and when the gesture is over.
 We create a shared value `x` that will correspond to the x-translation of the box.
 In `onStart` handler worklet we use `context` to save the current value of `x` and therefore remember the place at which the gesture started.
@@ -92,7 +92,7 @@ function App() {
     onActive: (event, ctx) => {
       x.value = ctx.startX + event.translationX;
     },
-    onEnd: _ => {
+    onEnd: (_) => {
       x.value = withSpring(0);
     },
   });


### PR DESCRIPTION
## Description

On documentation page of [Api/Hooks/useAnimatedGestureHandler](https://docs.swmansion.com/react-native-reanimated/docs/api/useAnimatedGestureHandler), links to the documentation page of react-native-gesture-handler is broken. They all end up in page not found.

## Changes

- updated `docs/docs/api/useAnimatedGestureHandler.md`
- updated `docs/versioned_docs/version-2.0.0-rc.2/api/useAnimatedGestureHandler.md`


## Test code and steps to reproduce

Just change of links. I don't think so this needs that much testing.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [X] Updated documentation
- [ ] Ensured that CI passes
