### PR TITLE
Fix UTF-8 encoding on Android

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -212,7 +212,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       return jsi::Value(ValueWrapper::asNumber(valueContainer));
     case ValueType::StringType: {
       auto& stringValue = ValueWrapper::asString(valueContainer);
-      return jsi::Value(rt, jsi::String::createFromAscii(rt, stringValue));
+      return jsi::Value(rt, jsi::String::createFromUtf8(rt, stringValue));
     }
     case ValueType::FrozenObjectType: {
       auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1782

In `adapt()` function we use conversion to utf8 during `set`, but during `get` we used `jsi::String::createFromAscii` instead of `jsi::String::createFromUtf8`.

### Before
![Screenshot 2021-03-04 at 10 57 40](https://user-images.githubusercontent.com/36106620/109947656-db10f080-7cd9-11eb-9e5d-02f13a4e37be.png)

### After
![Screenshot 2021-03-04 at 10 59 50](https://user-images.githubusercontent.com/36106620/109947679-e06e3b00-7cd9-11eb-9045-afbea7aa32bd.png)

## Test code and steps to reproduce

<details>
<summary>code</summary>

```js
import React from 'react';
import {TextInput, Button} from 'react-native';
import Animated, {
  useAnimatedProps,
  useSharedValue,
} from 'react-native-reanimated';

const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);

const value = 'ööö';
export const Repro = () => {
  const sharedValue = useSharedValue(value);
  const animatedProps = useAnimatedProps(() => {
    return {value: `${value} ${sharedValue.value}`};
  }, []);
  return <Animated.View>
    <AnimatedTextInput animatedProps={animatedProps} />
    <Button title="click" onPress={() => {
      'worklet'
      sharedValue.value = 'ööö'
    }} />
  </Animated.View>;
};

export default Repro;
```

</summary>