### PR TITLE
[v1] Replace global.Expo.Constants with NativeModules check

### DIFF
--- a/src/core/AnimatedDebug.js
+++ b/src/core/AnimatedDebug.js
@@ -1,4 +1,5 @@
 import invariant from 'fbjs/lib/invariant';
+import { NativeModules } from 'react-native';
 import { val } from '../val';
 import { adapt, createAnimatedBlock as block } from './AnimatedBlock';
 import { createAnimatedCall as call } from './AnimatedCall';
@@ -35,12 +36,15 @@ class AnimatedDebug extends AnimatedNode {
 
 export function createAnimatedDebug(message, value) {
   if (__DEV__) {
-    const runningInRemoteDebugger = typeof atob !== 'undefined';
     // hack to detect if app is running in remote debugger
     // https://stackoverflow.com/questions/39022216
+    const runningInRemoteDebugger = typeof atob !== 'undefined';
 
+    // read the executionEnvironment off of expo-constants without explicitly
+    // depending on the package
     const runningInExpoShell =
-      global.Expo && global.Expo.Constants.appOwnership !== 'standalone';
+      NativeModules.NativeUnimoduleProxy?.modulesConstants?.ExponentConstants
+        ?.executionEnvironment === 'storeClient';
 
     if (runningInRemoteDebugger || runningInExpoShell) {
       // When running in expo or remote debugger we use JS console.log to output variables


### PR DESCRIPTION
## Description

In Expo SDK 40 we deprecated the global Expo object. In SDK 41, we are deleting it, so we need to change this.

Fixes #1612

## Changes

Instead of using the global Expo object, we check for the `executionEnvironment` on the `ExponentConstants` native module, if it is available. This is the same thing we do in @react-native-async-storage/async-storage. In the future, we could potentially move to try/catch around requiring expo-constants, but this feature is only available on react-native@>=63 so I don't think we should start depending on it in libraries yet.

This is a bit tricky for react-native-reanimated authors to test in the Expo Go context. Outside of Expo Go, you can use AnimatedDebug to ensure that this does not cause any new problems outside of Expo Go (although I think this is easy to determine from reading the code).

## Checklist

- [ ] Included code example that can be used to test this change
- [n/a] Updated TS types
- [n/a] Added TS types tests
- [ ] Added unit / integration tests
- [n/a] Updated documentation
- [ ] Ensured that CI passes
