### PR TITLE
Show proper error for transform in UAS

### DIFF
--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -493,11 +493,26 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
 
   // check for invalid usage of shared values in returned object
   let wrongKey;
-  const isError = Object.keys(initial).some((key) => {
-    const element = initial[key];
+  const isObjectInvalid = (element, key) => {
     const result = typeof element === 'object' && element.value !== undefined;
     if (result) {
       wrongKey = key;
+    }
+    return result;
+  };
+  const isError = Object.keys(initial).some((key) => {
+    const element = initial[key];
+    let result = false;
+    if (key === 'transform') {
+      for (const transformItem of element) {
+        const item = Object.values(transformItem)[0];
+        result = isObjectInvalid(item, key);
+        if (result) {
+          break;
+        }
+      }
+    } else {
+      result = isObjectInvalid(element, key);
     }
     return result;
   });

--- a/src/reanimated2/Hooks.js
+++ b/src/reanimated2/Hooks.js
@@ -493,28 +493,33 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
 
   // check for invalid usage of shared values in returned object
   let wrongKey;
-  const isObjectInvalid = (element, key) => {
+  const isObjectValid = (element, key) => {
     const result = typeof element === 'object' && element.value !== undefined;
     if (result) {
       wrongKey = key;
     }
-    return result;
+    return !result;
   };
   const isError = Object.keys(initial).some((key) => {
     const element = initial[key];
     let result = false;
-    if (key === 'transform') {
-      for (const transformItem of element) {
-        const item = Object.values(transformItem)[0];
-        result = isObjectInvalid(item, key);
-        if (result) {
+    // a case for transform that has a format of an array of objects
+    if (Array.isArray(element)) {
+      for (const elementArrayItem of element) {
+        // this means unhandled format and it doesn't match the transform format
+        if (typeof elementArrayItem !== 'object') {
+          break;
+        }
+        const objectValue = Object.values(elementArrayItem)[0];
+        result = isObjectValid(objectValue, key);
+        if (!result) {
           break;
         }
       }
     } else {
-      result = isObjectInvalid(element, key);
+      result = isObjectValid(element, key);
     }
-    return result;
+    return !result;
   });
   if (isError && wrongKey !== undefined) {
     throw new Error(


### PR DESCRIPTION
## Description

We want to handle a situation when a user forgets `.value` using `transform` in `useAnimatedStyle`:

```
const sv = useSharedValue(0);
const style = useAnimatedStyle(() => {
  return {
    transform: [{translateX: sv}],// should be sv.value
    width: sv,// should be sv.value
  };
});
```

For now, in such a case an uninformative error is being thrown.