### PR TITLE
Fix full reload on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -73,10 +73,13 @@ public class NativeProxy {
   private final HybridData mHybridData;
   private NodesManager mNodesManager;
   private final WeakReference<ReactApplicationContext> mContext;
+  private Scheduler mScheduler = null;
 
   public NativeProxy(ReactApplicationContext context) {
     CallInvokerHolderImpl holder = (CallInvokerHolderImpl)context.getCatalystInstance().getJSCallInvokerHolder();
-    mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), holder, new Scheduler(context));
+
+    mScheduler = new Scheduler(context);
+    mHybridData = initHybrid(context.getJavaScriptContextHolder().get(), holder, mScheduler);
     mContext = new WeakReference<>(context);
     prepare();
   }
@@ -123,6 +126,7 @@ public class NativeProxy {
   }
 
   public void onCatalystInstanceDestroy() {
+    mScheduler.deactivate();
     mHybridData.resetNative();
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/Scheduler.java
+++ b/android/src/main/java/com/swmansion/reanimated/Scheduler.java
@@ -4,17 +4,22 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class Scheduler {
 
   @DoNotStrip
   @SuppressWarnings("unused")
   private final HybridData mHybridData;
   private final ReactApplicationContext mContext;
+  private final AtomicBoolean mActive = new AtomicBoolean(true);
 
   private final Runnable mUIThreadRunnable = new Runnable() {
     @Override
     public void run() {
-      triggerUI();
+      if (mActive.get()) {
+        triggerUI();
+      }
     }
   };
 
@@ -32,4 +37,7 @@ public class Scheduler {
     mContext.runOnUiQueueThread(mUIThreadRunnable);
   }
 
+  public void deactivate() {
+      mActive.set(false);
+  }
 }


### PR DESCRIPTION
## Description
fixes: https://github.com/software-mansion/react-native-reanimated/issues/1815
There can be a situation when reanimated has been destroyed but there is still a runnable on UI queue that wants to trigger our render method. In order to avoid the scenario, I've added a condition in scheduler.schedulerOnUI that checks if react native instance has been destroyed.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
