### PR TITLE
Fix Host Function

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -104,12 +104,10 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         if (!primalFunction.isUndefined()) {
             jsi::Object handlerAsObject = primalFunction.asObject(rt);
             std::shared_ptr<HostFunctionHandler> handler = handlerAsObject.getHostObject<HostFunctionHandler>(rt);
-            valueContainer = std::make_unique<HostFunctionWrapper>(handler, &rt);
+            valueContainer = std::make_unique<HostFunctionWrapper>(handler);
         } else {
             valueContainer = std::make_unique<HostFunctionWrapper>(
-              std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt),
-              &rt
-            );
+              std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt));
         }
         
       } else {
@@ -272,7 +270,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
             
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
-            std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
+          std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
           if(hostFunction->functionName.empty()) {
             exceptionMessage += "anonymous function";

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -10,6 +10,8 @@ namespace reanimated {
 
 const char *HIDDEN_HOST_OBJECT_PROP = "__reanimatedHostObjectRef";
 const char *ALREADY_CONVERTED= "__alreadyConverted";
+const char *CALL_ASYNC = "__callAsync";
+const char *PRIMAL_FUNCTION = "__primalFunction";
 std::string CALLBACK_ERROR_SUFFIX = R"(
 
 Possible solutions are:
@@ -96,13 +98,24 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         // not a worklet, we treat this as a host function
         type = ValueType::HostFunctionType;
         containsHostFunction = true;
-        valueContainer = std::make_unique<HostFunctionWrapper>(
-          std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt),
-          &rt
-        );
+          
+        //Check if it's a hostFunction wrapper
+        jsi::Value primalFunction = object.getProperty(rt, PRIMAL_FUNCTION);
+        if (!primalFunction.isUndefined()) {
+            jsi::Object handlerAsObject = primalFunction.asObject(rt);
+            std::shared_ptr<HostFunctionHandler> handler = handlerAsObject.getHostObject<HostFunctionHandler>(rt);
+            valueContainer = std::make_unique<HostFunctionWrapper>(handler, &rt);
+        } else {
+            valueContainer = std::make_unique<HostFunctionWrapper>(
+              std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt),
+              &rt
+            );
+        }
+        
       } else {
         // a worklet
         type = ValueType::WorkletFunctionType;
+        
         valueContainer = std::make_unique<FrozenObjectWrapper>(std::make_shared<FrozenObject>(rt, object, module));
         auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);
         containsHostFunction |= frozenObject->containsHostFunction;
@@ -239,8 +252,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     }
     case ValueType::HostFunctionType: {
       auto hostFunctionWrapper = ValueWrapper::asHostFunctionWrapper(valueContainer);
-      if (hostFunctionWrapper->hostRuntime == &rt) {
+      auto hostRuntime = hostFunctionWrapper->value->hostRuntime;
+      if (hostRuntime == &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
+        
         return jsi::Value(rt, *hostFunctionWrapper->value->get());
       } else {
         // function is accessed from a different runtime, we wrap function in host func that'd enqueue
@@ -257,7 +272,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
             
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
-          std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
+            std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
           if(hostFunction->functionName.empty()) {
             exceptionMessage += "anonymous function";
@@ -273,7 +288,6 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           return jsi::Value::undefined();
         };
         
-        auto hostRuntime = hostFunctionWrapper->hostRuntime;
         auto clb = [module, hostFunction, hostRuntime](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
@@ -307,7 +321,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
         };
         jsi::Function wrapperFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, warnFunction);
         jsi::Function res = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, clb);
-        addHiddenProperty(rt, std::move(res), wrapperFunction, "__callAsync");
+        addHiddenProperty(rt, std::move(res), wrapperFunction, CALL_ASYNC);
+        jsi::Object functionHandler = createHost(rt, hostFunctionWrapper->value);
+        addHiddenProperty(rt, std::move(functionHandler), wrapperFunction, PRIMAL_FUNCTION);
         return wrapperFunction;
       }
     }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -250,7 +250,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     }
     case ValueType::HostFunctionType: {
       auto hostFunctionWrapper = ValueWrapper::asHostFunctionWrapper(valueContainer);
-      auto hostRuntime = hostFunctionWrapper->value->hostRuntime;
+      auto& hostRuntime = hostFunctionWrapper->value->hostRuntime;
       if (hostRuntime == &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
         

--- a/Common/cpp/headers/SharedItems/HostFunctionHandler.h
+++ b/Common/cpp/headers/SharedItems/HostFunctionHandler.h
@@ -1,13 +1,18 @@
 #pragma once
 
+#include <jsi/jsi.h>
+
 namespace reanimated {
 
-struct HostFunctionHandler {
+struct HostFunctionHandler : jsi::HostObject {
   std::shared_ptr<jsi::Function> pureFunction;
   std::string functionName;
+  jsi::Runtime *hostRuntime;
+    
   HostFunctionHandler(std::shared_ptr<jsi::Function> f, jsi::Runtime &rt) {
     pureFunction = f;
     functionName = f->getProperty(rt, "name").asString(rt).utf8(rt);
+    hostRuntime = &rt;
   }
   
   std::shared_ptr<jsi::Function> get() {

--- a/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -64,9 +64,8 @@ public:
   HostFunctionWrapper(
     const std::shared_ptr<HostFunctionHandler> & _value,
     jsi::Runtime *_hostRuntime
-  ) : ValueWrapper(ValueType::HostFunctionType), value(_value), hostRuntime(_hostRuntime) {};
+  ) : ValueWrapper(ValueType::HostFunctionType), value(_value){};
   std::shared_ptr<HostFunctionHandler> value;
-  jsi::Runtime *hostRuntime;
 };
 
 class FrozenObjectWrapper : public ValueWrapper {

--- a/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -61,10 +61,6 @@ class HostFunctionWrapper : public ValueWrapper {
 public:
   HostFunctionWrapper(const std::shared_ptr<HostFunctionHandler> & _value)
     : ValueWrapper(ValueType::HostFunctionType), value(_value) {};
-  HostFunctionWrapper(
-    const std::shared_ptr<HostFunctionHandler> & _value,
-    jsi::Runtime *_hostRuntime
-  ) : ValueWrapper(ValueType::HostFunctionType), value(_value){};
   std::shared_ptr<HostFunctionHandler> value;
 };
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/1758
Currently, when we send callback function to UI thread and then back to RN then we will get function wrapper that checks is somebody uses runOnJS. In order to solve the problem, I've added logic that attaches additional info to a function wrapper that allows to get original callback.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
