### PR TITLE
Fix collision name

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -254,7 +254,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       if (hostRuntime == &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
         
-        return jsi::Value(rt, *hostFunctionWrapper->value->get());
+        return jsi::Value(rt, *hostFunctionWrapper->value->getPureFunction().get());
       } else {
         // function is accessed from a different runtime, we wrap function in host func that'd enqueue
         // call on an appropriate thread
@@ -306,7 +306,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               args[i] = params[i]->getValue(*hostRuntime);
             }
              
-            jsi::Value returnedValue = hostFunction->get()->call(*hostRuntime,
+            jsi::Value returnedValue = hostFunction->getPureFunction().get()->call(*hostRuntime,
                                                 static_cast<const jsi::Value*>(args),
                                                 (size_t)params.size());
              

--- a/Common/cpp/headers/SharedItems/HostFunctionHandler.h
+++ b/Common/cpp/headers/SharedItems/HostFunctionHandler.h
@@ -8,6 +8,7 @@ struct HostFunctionHandler : jsi::HostObject {
   std::shared_ptr<jsi::Function> pureFunction;
   std::string functionName;
   jsi::Runtime *hostRuntime;
+    jsi::HostObject a;
     
   HostFunctionHandler(std::shared_ptr<jsi::Function> f, jsi::Runtime &rt) {
     pureFunction = f;
@@ -15,7 +16,7 @@ struct HostFunctionHandler : jsi::HostObject {
     hostRuntime = &rt;
   }
   
-  std::shared_ptr<jsi::Function> get() {
+  std::shared_ptr<jsi::Function> getPureFunction() {
     return pureFunction;
   }
 };


### PR DESCRIPTION
## Description

Method `std::shared_ptr<jsi::Function> get()` from `struct HostFunctionHandler : jsi::HostObject` had name conflict wtih `virtual Value get(Runtime&, const PropNameID& name)` from `jsi::HostObject` and this crashed CI and compilation for android.
Related with: https://github.com/software-mansion/react-native-reanimated/pull/1844

## Checklist

- [x] Ensured that CI passes
