### PR TITLE
Restructure code

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -63,12 +63,12 @@ NativeReanimatedModule::NativeReanimatedModule(std::shared_ptr<CallInvoker> jsIn
                                                std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
                                                PlatformDepMethodsHolder platformDepMethodsHolder) : NativeReanimatedModuleSpec(jsInvoker),
                                                   runtime(std::move(rt)),
-                                                  mapperRegistry(new MapperRegistry()),
-                                                  eventHandlerRegistry(new EventHandlerRegistry()),
+                                                  mapperRegistry(std::make_shared<MapperRegistry>()),
+                                                  eventHandlerRegistry(std::make_shared<EventHandlerRegistry>()),
                                                   requestRender(platformDepMethodsHolder.requestRender),
                                                   propObtainer(propObtainer),
                                                   errorHandler(errorHandler),
-                                                  workletsCache(new WorkletsCache()),
+                                                  workletsCache(std::make_shared<WorkletsCache>()),
                                                   scheduler(scheduler)
 {
   auto requestAnimationFrame = [=](FrameCallback callback) {

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -174,7 +174,7 @@ jsi::Value NativeReanimatedModule::getViewProp(jsi::Runtime &rt, const jsi::Valu
   const int viewTagInt = (int)viewTag.asNumber();
   std::string propNameStr = propName.asString(rt).utf8(rt);
   jsi::Function fun = callback.getObject(rt).asFunction(rt);
-  std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
+  std::shared_ptr<jsi::Function> funPtr = std::make_shared<jsi::Function>(std::move(fun));
 
   scheduler->scheduleOnUI([&rt, viewTagInt, funPtr, this, propNameStr]() {
     const jsi::String propNameValue = jsi::String::createFromUtf8(rt, propNameStr);

--- a/Common/cpp/Registries/WorkletsCache.cpp
+++ b/Common/cpp/Registries/WorkletsCache.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<jsi::Function> WorkletsCache::getFunction(jsi::Runtime &rt, std:
       rt,
       ValueWrapper::asString(frozenObj->map["asString"]->valueContainer)
     );
-    std::shared_ptr<jsi::Function> funPtr(new jsi::Function(std::move(fun)));
+    std::shared_ptr<jsi::Function> funPtr = std::make_shared<jsi::Function>(std::move(fun));
     worklets[workletHash] = funPtr;
   }
   return worklets[workletHash];

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -170,7 +170,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
 }
 
 std::shared_ptr<ShareableValue> ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType valueType) {
-  auto sv = std::make_shared<ShareableValue>(module, module->scheduler);
+  auto sv = std::shared_ptr<ShareableValue>(new ShareableValue(module, module->scheduler));
   sv->adapt(rt, value, valueType);
   return sv;
 }

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -17,7 +17,7 @@ std::string CALLBACK_ERROR_SUFFIX = R"(
 Possible solutions are:
 a) If you want to synchronously execute this method, mark it as a Worklet
 b) If you want to execute this method on the JS thread, wrap it using runOnJS )";
-  
+
 void addHiddenProperty(jsi::Runtime &rt,
                        jsi::Value &&value,
                        jsi::Object &obj,
@@ -72,7 +72,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
       }
     }
   }
-  
+
   if (objectType == ValueType::MutableValueType) {
     type = ValueType::MutableValueType;
     valueContainer = std::make_unique<MutableValueWrapper>(
@@ -98,7 +98,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
         // not a worklet, we treat this as a host function
         type = ValueType::HostFunctionType;
         containsHostFunction = true;
-          
+
         //Check if it's a hostFunction wrapper
         jsi::Value primalFunction = object.getProperty(rt, PRIMAL_FUNCTION);
         if (!primalFunction.isUndefined()) {
@@ -109,11 +109,11 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
             valueContainer = std::make_unique<HostFunctionWrapper>(
               std::make_shared<HostFunctionHandler>(std::make_shared<jsi::Function>(object.asFunction(rt)), rt));
         }
-        
+
       } else {
         // a worklet
         type = ValueType::WorkletFunctionType;
-        
+
         valueContainer = std::make_unique<FrozenObjectWrapper>(std::make_shared<FrozenObject>(rt, object, module));
         auto& frozenObject = ValueWrapper::asFrozenObject(valueContainer);
         containsHostFunction |= frozenObject->containsHostFunction;
@@ -170,7 +170,7 @@ void ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType 
 }
 
 std::shared_ptr<ShareableValue> ShareableValue::adapt(jsi::Runtime &rt, const jsi::Value &value, NativeReanimatedModule *module, ValueType valueType) {
-  auto sv = std::shared_ptr<ShareableValue>(new ShareableValue(module, module->scheduler));
+  auto sv = std::make_shared<ShareableValue>(module, module->scheduler);
   sv->adapt(rt, value, valueType);
   return sv;
 }
@@ -182,7 +182,7 @@ jsi::Value ShareableValue::getValue(jsi::Runtime &rt) {
       auto ref = getWeakRef(rt);
       remoteValue = ref;
     }
-    
+
     if (remoteValue.lock()->isUndefined()) {
       (*remoteValue.lock()) = jsi::Value(rt, toJSValue(rt));
     }
@@ -253,22 +253,22 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       auto& hostRuntime = hostFunctionWrapper->value->hostRuntime;
       if (hostRuntime == &rt) {
         // function is accessed from the same runtime it was crated, we just return same function obj
-        
+
         return jsi::Value(rt, *hostFunctionWrapper->value->getPureFunction().get());
       } else {
         // function is accessed from a different runtime, we wrap function in host func that'd enqueue
         // call on an appropriate thread
-        
+
         auto module = this->module;
         auto hostFunction = hostFunctionWrapper->value;
-        
+
         auto warnFunction = [module, hostFunction](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
             const jsi::Value *args,
             size_t count
             ) -> jsi::Value {
-            
+
           jsi::Value jsThis = rt.global().getProperty(rt, "jsThis");
           std::string workletLocation = jsThis.asObject(rt).getProperty(rt, "__location").toString(rt).utf8(rt);
           std::string exceptionMessage = "Tried to synchronously call ";
@@ -282,10 +282,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           exceptionMessage += CALLBACK_ERROR_SUFFIX;
           module->errorHandler->setError(exceptionMessage);
           module->errorHandler->raise();
-          
+
           return jsi::Value::undefined();
         };
-        
+
         auto clb = [module, hostFunction, hostRuntime](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
@@ -294,26 +294,26 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
             ) -> jsi::Value {
           // TODO: we should find thread based on runtime such that we could also call UI methods
           // from RN and not only RN methods from UI
-          
+
           std::vector<std::shared_ptr<ShareableValue>> params;
           for (int i = 0; i < count; ++i) {
             params.push_back(ShareableValue::adapt(rt, args[i], module));
           }
-          
+
           std::function<void()> job = [hostFunction, hostRuntime, params] {
             jsi::Value * args = new jsi::Value[params.size()];
             for (int i = 0; i < params.size(); ++i) {
               args[i] = params[i]->getValue(*hostRuntime);
             }
-             
+
             jsi::Value returnedValue = hostFunction->getPureFunction().get()->call(*hostRuntime,
                                                 static_cast<const jsi::Value*>(args),
                                                 (size_t)params.size());
-             
+
             delete [] args;
             // ToDo use returned value to return promise
           };
-          
+
           module->scheduler->scheduleOnJS(job);
           return jsi::Value::undefined();
         };
@@ -383,27 +383,27 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           for (int i = 0; i < count; ++i) {
             params.push_back(ShareableValue::adapt(rt, args[i], module));
           }
-          
+
           module->scheduler->scheduleOnUI([=] {
             jsi::Runtime &rt = *module->runtime.get();
             auto jsThis = createFrozenWrapper(rt, frozenObject).getObject(rt);
             auto code = jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
             std::shared_ptr<jsi::Function> funPtr(module->workletsCache->getFunction(rt, frozenObject));
-            
+
             jsi::Value * args = new jsi::Value[params.size()];
             for (int i = 0; i < params.size(); ++i) {
               args[i] = params[i]->getValue(rt);
             }
-            
+
             jsi::Value returnedValue;
-            
+
             jsi::Value oldJSThis = rt.global().getProperty(rt, "jsThis");
             rt.global().setProperty(rt, "jsThis", jsThis); //set jsThis
             try {
               returnedValue = funPtr->call(rt,
                                              static_cast<const jsi::Value*>(args),
                                              (size_t)params.size());
-            
+
             } catch(std::exception &e) {
               std::string str = e.what();
               module->errorHandler->setError(str);
@@ -419,7 +419,7 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
               module->errorHandler->raise();
             }
             rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
-            
+
             delete [] args;
             // ToDo use returned value to return promise
           });

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -25,49 +25,49 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec
   friend ShareableValue;
   friend MutableValue;
   
-  public:
-    NativeReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker,
-                           std::shared_ptr<Scheduler> scheduler,
-                           std::unique_ptr<jsi::Runtime> rt,
-                           std::shared_ptr<ErrorHandler> errorHandler,
-                           std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
-                           PlatformDepMethodsHolder platformDepMethodsHolder);
-
-    virtual ~NativeReanimatedModule();
-
-    void installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter) override;
-
-    jsi::Value makeShareable(jsi::Runtime &rt, const jsi::Value &value) override;
-    jsi::Value makeMutable(jsi::Runtime &rt, const jsi::Value &value) override;
-    jsi::Value makeRemote(jsi::Runtime &rt, const jsi::Value &value) override;
-
-    jsi::Value startMapper(jsi::Runtime &rt, const jsi::Value &worklet, const jsi::Value &inputs, const jsi::Value &outputs) override;
-    void stopMapper(jsi::Runtime &rt, const jsi::Value &mapperId) override;
-
-    jsi::Value registerEventHandler(jsi::Runtime &rt, const jsi::Value &eventHash, const jsi::Value &worklet) override;
-    void unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId) override;
-
-    jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) override;
-    
-    void onRender(double timestampMs);
-    void onEvent(std::string eventName, std::string eventAsString);
-    bool isAnyHandlerWaitingForEvent(std::string eventName);
-
-    void maybeRequestRender();
-
-    bool isUIRuntime(jsi::Runtime &rt);
-    bool isHostRuntime(jsi::Runtime &rt);
-  public:
-    std::unique_ptr<jsi::Runtime> runtime;
-  private:
-    std::shared_ptr<MapperRegistry> mapperRegistry;
-    std::shared_ptr<EventHandlerRegistry> eventHandlerRegistry;
-    std::function<void(FrameCallback, jsi::Runtime&)> requestRender;
-    std::shared_ptr<jsi::Value> dummyEvent;
-    std::vector<FrameCallback> frameCallbacks;
-    bool renderRequested = false;
-    std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer;
-  public:
+public:
+  NativeReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker,
+                         std::shared_ptr<Scheduler> scheduler,
+                         std::unique_ptr<jsi::Runtime> rt,
+                         std::shared_ptr<ErrorHandler> errorHandler,
+                         std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
+                         PlatformDepMethodsHolder platformDepMethodsHolder);
+  
+  virtual ~NativeReanimatedModule();
+  
+  void installCoreFunctions(jsi::Runtime &rt, const jsi::Value &valueSetter) override;
+  
+  jsi::Value makeShareable(jsi::Runtime &rt, const jsi::Value &value) override;
+  jsi::Value makeMutable(jsi::Runtime &rt, const jsi::Value &value) override;
+  jsi::Value makeRemote(jsi::Runtime &rt, const jsi::Value &value) override;
+  
+  jsi::Value startMapper(jsi::Runtime &rt, const jsi::Value &worklet, const jsi::Value &inputs, const jsi::Value &outputs) override;
+  void stopMapper(jsi::Runtime &rt, const jsi::Value &mapperId) override;
+  
+  jsi::Value registerEventHandler(jsi::Runtime &rt, const jsi::Value &eventHash, const jsi::Value &worklet) override;
+  void unregisterEventHandler(jsi::Runtime &rt, const jsi::Value &registrationId) override;
+  
+  jsi::Value getViewProp(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &propName, const jsi::Value &callback) override;
+  
+  void onRender(double timestampMs);
+  void onEvent(std::string eventName, std::string eventAsString);
+  bool isAnyHandlerWaitingForEvent(std::string eventName);
+  
+  void maybeRequestRender();
+  
+  bool isUIRuntime(jsi::Runtime &rt);
+  bool isHostRuntime(jsi::Runtime &rt);
+public:
+  std::unique_ptr<jsi::Runtime> runtime;
+private:
+  std::shared_ptr<MapperRegistry> mapperRegistry;
+  std::shared_ptr<EventHandlerRegistry> eventHandlerRegistry;
+  std::function<void(FrameCallback, jsi::Runtime&)> requestRender;
+  std::shared_ptr<jsi::Value> dummyEvent;
+  std::vector<FrameCallback> frameCallbacks;
+  bool renderRequested = false;
+  std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer;
+public:
   std::shared_ptr<ErrorHandler> errorHandler;
   std::shared_ptr<WorkletsCache> workletsCache;
   std::shared_ptr<ShareableValue> valueSetter;

--- a/Common/cpp/headers/Registries/WorkletsCache.h
+++ b/Common/cpp/headers/Registries/WorkletsCache.h
@@ -13,6 +13,7 @@ using namespace facebook;
 class FrozenObject;
 
 class WorkletsCache {
+private:
   std::unordered_map<long long, std::shared_ptr<jsi::Function>> worklets;
 public:
   std::shared_ptr<jsi::Function> getFunction(jsi::Runtime & rt, std::shared_ptr<reanimated::FrozenObject> frozenObj);

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -9,6 +9,10 @@ PODS:
     - React-Core (= 0.64.0-rc.2)
     - React-jsi (= 0.64.0-rc.2)
     - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
+  - Folly (2016.09.26.00):
+    - boost-for-react-native
+    - DoubleConversion
+    - glog
   - glog (0.3.5)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -283,12 +287,12 @@ PODS:
     - React
   - RNGestureHandler (1.10.1):
     - React-Core
-  - RNReanimated (2.0.0-rc.3):
+  - RNReanimated (2.0.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
+    - Folly
     - glog
-    - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
@@ -360,6 +364,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
+    - Folly
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -435,7 +440,8 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: b21700af840f633338ac968a36da9aa3a8268887
-  FBReactNativeSpec: ac5ae8902727ea99deddd51bc998500c64a27275
+  FBReactNativeSpec: 042442754c4377344b9c14ef2186aa2c1e6f7208
+  Folly: 211775e49d8da0ca658aebc8eab89d642935755c
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: fa44b153ba69cb9dd6cec5084b86719e3be7c90b
@@ -463,7 +469,7 @@ SPEC CHECKSUMS:
   ReactCommon: c8ae344df0376e043f2899a5badb60709d24821e
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
-  RNReanimated: 2111076cba59d4ea29d8a10b4310d20bab2d3b7f
+  RNReanimated: 9dce67e20b65f1813ab5eaae17e4fc1adf932e2f
   RNScreens: b6c9607e6fe47c1b6e2f1910d2acd46dd7ecea3a
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 17d4f4db4e2efbaa7c3bc316ce4f762d02c4023d

--- a/android/src/main/cpp/AndroidLogger.cpp
+++ b/android/src/main/cpp/AndroidLogger.cpp
@@ -6,7 +6,7 @@
 namespace reanimated
 {
 
-std::unique_ptr<LoggerInterface> Logger::instance = std::unique_ptr<AndroidLogger>(new AndroidLogger());
+std::unique_ptr<LoggerInterface> Logger::instance = std::make_unique<AndroidLogger>();
 
 void AndroidLogger::log(const char* str) {
     __android_log_print(ANDROID_LOG_VERBOSE, APPNAME, "%s", str);

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -60,10 +60,10 @@ void NativeProxy::installJSIBindings()
   };
 
   auto requestRender = [this, getCurrentTime](std::function<void(double)> onRender, jsi::Runtime &rt) {
-    //doNoUse -> NodesManager passes here a timestamp from choreographer which is useless for us 
+    //doNoUse -> NodesManager passes here a timestamp from choreographer which is useless for us
     //as we use diffrent timer to better handle events. The lambda is translated to NodeManager.OnAnimationFrame
     //and treated just like reanimated 1 frame callbacks which make use of the timestamp.
-    auto wrappedOnRender = [getCurrentTime, &rt, onRender](double doNotUse) { 
+    auto wrappedOnRender = [getCurrentTime, &rt, onRender](double doNotUse) {
        double frameTimestamp = getCurrentTime();
        rt.global().setProperty(rt, "_frameTimestamp", frameTimestamp);
        onRender(frameTimestamp);
@@ -92,7 +92,7 @@ void NativeProxy::installJSIBindings()
 
   std::unique_ptr<jsi::Runtime> animatedRuntime = facebook::hermes::makeHermesRuntime();
 
-  std::shared_ptr<ErrorHandler> errorHandler = std::shared_ptr<AndroidErrorHandler>(new AndroidErrorHandler(scheduler_));
+  std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<AndroidErrorHandler>(scheduler_);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
     requestRender,

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -143,13 +143,13 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
     getCurrentTime,
   };
 
-module = std::make_shared<NativeReanimatedModule>(jsInvoker,
-                                                  scheduler,
-                                                  std::move(animatedRuntime),
-                                                  errorHandler,
-                                                  propObtainer,
-                                                  platformDepMethodsHolder
-                                                  );
+  module = std::make_shared<NativeReanimatedModule>(jsInvoker,
+                                                    scheduler,
+                                                    std::move(animatedRuntime),
+                                                    errorHandler,
+                                                    propObtainer,
+                                                    platformDepMethodsHolder
+                                                    );
 
   scheduler->setModule(module);
 

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -111,13 +111,14 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
       return val;
   };
 
-  std::shared_ptr<Scheduler> scheduler(new REAIOSScheduler(jsInvoker));
 
 #if __has_include(<hermes/hermes.h>)
   std::unique_ptr<jsi::Runtime> animatedRuntime = facebook::hermes::makeHermesRuntime();
 #else
   std::unique_ptr<jsi::Runtime> animatedRuntime = facebook::jsc::makeJSCRuntime();
 #endif
+  
+  std::shared_ptr<Scheduler> scheduler = std::make_shared<REAIOSScheduler>(jsInvoker);
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<REAIOSErrorHandler>(scheduler);
   std::shared_ptr<NativeReanimatedModule> module;
 

--- a/ios/native/REAIOSLogger.mm
+++ b/ios/native/REAIOSLogger.mm
@@ -3,7 +3,7 @@
 
 namespace reanimated {
 
-std::unique_ptr<LoggerInterface> Logger::instance = std::unique_ptr<REAIOSLogger>(new REAIOSLogger());
+std::unique_ptr<LoggerInterface> Logger::instance = std::make_unique<REAIOSLogger>();
 
 void REAIOSLogger::log(const char* str) {
   NSLog(@"%@", [NSString stringWithCString:str encoding:[NSString defaultCStringEncoding]]);

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -7,12 +7,19 @@
 #import <React/RCTCxxBridgeDelegate.h>
 #import <RNReanimated/REAEventDispatcher.h>
 
-#if RNVERSION >= 64
+#if __has_include(<React/RCTJSIExecutorRuntimeInstaller.h>)
 #import <React/RCTJSIExecutorRuntimeInstaller.h>
+#else
+#define RCTJSIExecutorRuntimeInstaller(x) x
 #endif
 
-#if RNVERSION < 63
+#if __has_include(<ReactCommon/CallInvoker.h>)
+#import <ReactCommon/CallInvoker.h>
+#define NEW_CALL_INVOKER
+#elif __has_include(<ReactCommon/BridgeJSCallInvoker.h>)
 #import <ReactCommon/BridgeJSCallInvoker.h>
+#else
+#error JS-CallInvoker import could not be found!
 #endif
 
 #if __has_include(<React/HermesExecutorFactory.h>)
@@ -38,33 +45,29 @@ typedef JSCExecutorFactory ExecutorFactory;
   RCTEventDispatcher *eventDispatcher = [REAEventDispatcher new];
   [eventDispatcher setBridge:bridge];
   [bridge updateModuleWithInstance:eventDispatcher];
-   _bridge_reanimated = bridge;
+  _bridge_reanimated = bridge;
   __weak __typeof(self) weakSelf = self;
-
+  
   const auto executor = [weakSelf, bridge](facebook::jsi::Runtime &runtime) {
     if (!bridge) {
       return;
     }
     __typeof(self) strongSelf = weakSelf;
     if (strongSelf) {
-#if RNVERSION >= 63
-      auto reanimatedModule = reanimated::createReanimatedModule(bridge.jsCallInvoker);
+#ifdef NEW_CALL_INVOKER
+      auto callInvoker = bridge.jsCallInvoker;
 #else
       auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
-      auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
 #endif
+      auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
       runtime.global().setProperty(runtime,
                                    jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
                                    jsi::Object::createFromHostObject(runtime, reanimatedModule));
     }
   };
-
-#if RNVERSION >= 64
+  
   // installs globals such as console, nativePerformanceNow, etc.
   return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(executor));
-#else
-  return std::make_unique<ExecutorFactory>(executor);
-#endif
 }
 
 @end


### PR DESCRIPTION
Part 1 of 3

* Re-indents a few wrongly indented code-pieces
* Uses `std::make_shared`/`std::make_unique` instead of `new` (it's a bit faster, and cleaner to read imo)
* Restructures `UIResponder+Reanimated.mm` to be a bit more future proof and easier to read (dummy macro, include checking, ...)