### PR TITLE
Update validator bot configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-v2.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.md
@@ -19,9 +19,7 @@ Tell us what's happening here.
 
 ### Expected behavior
 
-### Actual behavior 
-
-## Steps to reproduce
+### Actual behavior & steps to reproduce 
 
 ## Snack or minimal code example
 

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.md
@@ -19,7 +19,7 @@ Tell us what's happening here.
 
 ### Expected behavior
 
-### Actual behavior & steps to reproduce 
+### Actual behavior & steps to reproduce
 
 ## Snack or minimal code example
 

--- a/.github/ISSUE_TEMPLATE/bug-report-v2.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-v2.md
@@ -19,7 +19,9 @@ Tell us what's happening here.
 
 ### Expected behavior
 
-### Actual behavior & steps to reproduce
+### Actual behavior 
+
+## Steps to reproduce
 
 ## Snack or minimal code example
 

--- a/.github/workflows/issue-validator.yml
+++ b/.github/workflows/issue-validator.yml
@@ -13,4 +13,4 @@ jobs:
       uses: karol-bisztyga/issue-validator@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        required-sections: 🐞 Bug,Description,Steps To Reproduce,Expected behavior,Actual behavior,Package versions;💡 Feature request,Description,Motivation;❓Question,Description
+        required-sections: 🐞 Bug,Description,Expected behavior,Actual behavior & steps to reproduce,Package versions;💡 Feature request,Description,Motivation;❓Question,Description


### PR DESCRIPTION
## Description

Just a minor change on a Github issues template. 

## Changes

Title 'steps to reproduce' separated from 'Actual behavior & steps to reproduce'. It makes the github-bot validator fail if you don't put it separately.

## Test code and steps to reproduce

1. Create a new Github issue.
2. When sending it, the validator will not fail on steps to reproduce item.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
