### PR TITLE
Fix Threading issues (SV access from different Thread)

### DIFF
--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -65,7 +65,6 @@ void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi:
           .callWithThis(rt, setterProxy, newValue);
       });
     }
-    return;
   }
 
 }

--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -16,7 +16,7 @@ void MutableValue::setValue(jsi::Runtime &rt, const jsi::Value &newValue) {
       listener.second();
     }
   };
-  if (RuntimeDecorator::isWorkletRuntime(rt)) {
+  if (RuntimeDecorator::isUIRuntime(rt)) {
     notifyListeners();
   } else {
     runtimeManager->scheduler->scheduleOnUI([notifyListeners] {
@@ -77,7 +77,7 @@ jsi::Value MutableValue::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     return getValue(rt);
   }
 
-  if (RuntimeDecorator::isWorkletRuntime(rt)) {
+  if (RuntimeDecorator::isUIRuntime(rt)) {
     // _value and _animation should be accessed from UI only
     if (propName == "_value") {
       return getValue(rt);

--- a/Common/cpp/SharedItems/MutableValue.cpp
+++ b/Common/cpp/SharedItems/MutableValue.cpp
@@ -32,8 +32,27 @@ jsi::Value MutableValue::getValue(jsi::Runtime &rt) {
 
 void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi::Value &newValue) {
   auto propName = name.utf8(rt);
+  if (!runtimeManager->valueSetter) {
+    throw jsi::JSError(rt, "Value-Setter is not yet configured! Make sure the core-functions are installed.");
+  }
 
-  if (RuntimeDecorator::isReactRuntime(rt)) {
+  if (RuntimeDecorator::isUIRuntime(rt)) {
+    // UI thread
+    if (propName == "value") {
+      auto setterProxy = jsi::Object::createFromHostObject(rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
+      runtimeManager->valueSetter->getValue(rt)
+      .asObject(rt)
+      .asFunction(rt)
+      .callWithThis(rt, setterProxy, newValue);
+    } else if (propName == "_animation") {
+      // TODO: assert to allow animation to be set from UI only
+      if (animation.expired()) {
+        animation = getWeakRef(rt);
+      }
+      *animation.lock() = jsi::Value(rt, newValue);
+    }
+  } else {
+    // React-JS Thread or another threaded Runtime.
     if (propName == "value") {
       auto shareable = ShareableValue::adapt(rt, newValue, runtimeManager);
       runtimeManager->scheduler->scheduleOnUI([this, shareable] {
@@ -49,20 +68,6 @@ void MutableValue::set(jsi::Runtime &rt, const jsi::PropNameID &name, const jsi:
     return;
   }
 
-  // UI thread
-  if (propName == "value") {
-    auto setterProxy = jsi::Object::createFromHostObject(rt, std::make_shared<MutableValueSetterProxy>(shared_from_this()));
-    runtimeManager->valueSetter->getValue(rt)
-      .asObject(rt)
-      .asFunction(rt)
-      .callWithThis(rt, setterProxy, newValue);
-  } else if (propName == "_animation") {
-    // TODO: assert to allow animation to be set from UI only
-    if (animation.expired()) {
-      animation = getWeakRef(rt);
-    }
-    *animation.lock() = jsi::Value(rt, newValue);
-  }
 }
 
 jsi::Value MutableValue::get(jsi::Runtime &rt, const jsi::PropNameID &name) {

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -324,9 +324,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       }
     }
     case ValueType::WorkletFunctionType: {
+      // runOnUI call
       auto runtimeManager = this->runtimeManager;
       auto& frozenObject = ValueWrapper::asFrozenObject(this->valueContainer);
-      if (RuntimeDecorator::isWorkletRuntime(rt)) {
+      if (RuntimeDecorator::isUIRuntime(rt)) {
         // when running on UI thread we prep a function
 
         auto jsThis = std::make_shared<jsi::Object>(frozenObject->shallowClone(*runtimeManager->runtime));

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -324,11 +324,10 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
       }
     }
     case ValueType::WorkletFunctionType: {
-      // runOnUI call
       auto runtimeManager = this->runtimeManager;
       auto& frozenObject = ValueWrapper::asFrozenObject(this->valueContainer);
-      if (RuntimeDecorator::isUIRuntime(rt)) {
-        // when running on UI thread we prep a function
+      if (RuntimeDecorator::isWorkletRuntime(rt)) {
+        // when running on worklet thread we prep a function
 
         auto jsThis = std::make_shared<jsi::Object>(frozenObject->shallowClone(*runtimeManager->runtime));
         std::shared_ptr<jsi::Function> funPtr(runtimeManager->workletsCache->getFunction(rt, frozenObject));

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -10,7 +10,7 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, std::string label) {
   rt.global().setProperty(rt, "_WORKLET", jsi::Value(true));
   // This property will be used for debugging
   rt.global().setProperty(rt, "_LABEL", jsi::String::createFromAscii(rt, label));
-  
+
   jsi::Object dummyGlobal(rt);
   auto dummyFunction = [](
                           jsi::Runtime &rt,
@@ -21,12 +21,12 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, std::string label) {
     return jsi::Value::undefined();
   };
   jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"), 1, dummyFunction);
-  
+
   dummyGlobal.setProperty(rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
-  
+
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());
-  
+
   auto callback = [](
                      jsi::Runtime &rt,
                      const jsi::Value &thisValue,
@@ -47,7 +47,7 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, std::string label) {
   };
   jsi::Value log = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
   rt.global().setProperty(rt, "_log", log);
-  
+
   auto setGlobalConsole = [](
                              jsi::Runtime &rt,
                              const jsi::Value &thisValue,
@@ -68,7 +68,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
                                          TimeProviderFunction getCurrentTime) {
   RuntimeDecorator::decorateRuntime(rt, "UI");
   rt.global().setProperty(rt, "_UI", jsi::Value(true));
-  
+
   auto clb = [updater](
                        jsi::Runtime &rt,
                        const jsi::Value &thisValue,
@@ -83,8 +83,8 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   };
   jsi::Value updateProps = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_updateProps"), 2, clb);
   rt.global().setProperty(rt, "_updateProps", updateProps);
-  
-  
+
+
   auto clb2 = [requestFrame](
                              jsi::Runtime &rt,
                              const jsi::Value &thisValue,
@@ -99,7 +99,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   };
   jsi::Value requestAnimationFrame = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "requestAnimationFrame"), 1, clb2);
   rt.global().setProperty(rt, "requestAnimationFrame", requestAnimationFrame);
-  
+
   auto clb3 = [scrollTo](
                          jsi::Runtime &rt,
                          const jsi::Value &thisValue,
@@ -115,7 +115,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   };
   jsi::Value scrollToFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_scrollTo"), 4, clb3);
   rt.global().setProperty(rt, "_scrollTo", scrollToFunction);
-  
+
   auto clb4 = [measure](
                         jsi::Runtime &rt,
                         const jsi::Value &thisValue,
@@ -132,7 +132,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   };
   jsi::Value measureFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_measure"), 1, clb4);
   rt.global().setProperty(rt, "_measure", measureFunction);
-  
+
   auto clb6 = [getCurrentTime](
                                jsi::Runtime &rt,
                                const jsi::Value &thisValue,
@@ -143,7 +143,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   };
   jsi::Value timeFun = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_getCurrentTime"), 0, clb6);
   rt.global().setProperty(rt, "_getCurrentTime", timeFun);
-  
+
   rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
   rt.global().setProperty(rt, "_eventTimestamp", jsi::Value::undefined());
 }
@@ -154,8 +154,8 @@ bool RuntimeDecorator::isUIRuntime(jsi::Runtime& rt) {
 }
 
 bool RuntimeDecorator::isWorkletRuntime(jsi::Runtime& rt) {
-  auto isUi = rt.global().getProperty(rt, "_WORKLET");
-  return isUi.isBool() && isUi.getBool();
+  auto isWorklet = rt.global().getProperty(rt, "_WORKLET");
+  return isWorklet.isBool() && isWorklet.getBool();
 }
 
 bool RuntimeDecorator::isReactRuntime(jsi::Runtime& rt) {

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -67,6 +67,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
                                          MeasuringFunction measure,
                                          TimeProviderFunction getCurrentTime) {
   RuntimeDecorator::decorateRuntime(rt, "UI");
+  rt.global().setProperty(rt, "_UI", jsi::Value(true));
   
   auto clb = [updater](
                        jsi::Runtime &rt,
@@ -145,6 +146,11 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime &rt,
   
   rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
   rt.global().setProperty(rt, "_eventTimestamp", jsi::Value::undefined());
+}
+
+bool RuntimeDecorator::isUIRuntime(jsi::Runtime& rt) {
+  auto isUi = rt.global().getProperty(rt, "_UI");
+  return isUi.isBool() && isUi.getBool();
 }
 
 bool RuntimeDecorator::isWorkletRuntime(jsi::Runtime& rt) {

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -20,8 +20,17 @@ public:
                                 MeasuringFunction measure,
                                 TimeProviderFunction getCurrentTime);
   
+  /**
+   Returns true if the given Runtime is the Reanimated UI-Thread Runtime.
+   */
   static bool isUIRuntime(jsi::Runtime &rt);
+  /**
+   Returns true if the given Runtime is a Runtime that supports Workletization. (REA, Vision, ...)
+   */
   static bool isWorkletRuntime(jsi::Runtime &rt);
+  /**
+   Returns true if the given Runtime is the default React-JS Runtime.
+   */
   static bool isReactRuntime(jsi::Runtime &rt);
 };
 

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -20,6 +20,7 @@ public:
                                 MeasuringFunction measure,
                                 TimeProviderFunction getCurrentTime);
   
+  static bool isUIRuntime(jsi::Runtime &rt);
   static bool isWorkletRuntime(jsi::Runtime &rt);
   static bool isReactRuntime(jsi::Runtime &rt);
 };


### PR DESCRIPTION
## Description

There are a few functions that check if you're currently on the REA UI Runtime by using `RuntimeDecorator::isWorkletRuntime`. This might actually lead to threading issues if you're calling those functions from another worklet runtime that is not from Reanimated (e.g. VisionCamera Frame Processors, Multithreading, ...) - so this PR fixes this. A few of those functions should actually check if they are specifically on the UI thread, Worklet thread is not enough.

## Changes

- Add `RuntimeDecorator::isUIRuntime` - a function that specifically checks if the given `jsi::Runtime` is the REA UI Runtime as opposed to any Worklet Runtime
- Replace a few `isWorkletRuntime` calls with `isUIRuntime`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Ensured that CI passes
