### PR TITLE
Make worklets, runOnUI and runOnJS awaitable

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -344,29 +344,14 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
            rt.global().setProperty(rt, "jsThis", *jsThis); //set jsThis
 
            jsi::Value res = jsi::Value::undefined();
-           try {
-             if (thisValue.isObject()) {
-               res = funPtr->callWithThis(rt, thisValue.asObject(rt), args, count);
-             } else {
-               res = funPtr->call(rt, args, count);
-             }
-           } catch(jsi::JSError &e) {
-              throw e;
-           } catch(...) {
-              // TODO find out a way to get the error's message on hermes
-              jsi::Value location = jsThis->getProperty(rt, "__location");
-              std::string str = "Javascript worklet error";
-              if (location.isString()) {
-                str += "\nIn file: " + location.asString(rt).utf8(rt);
-              }
-              runtimeManager->errorHandler->setError(str);
-              runtimeManager->errorHandler->raise();
-            }
-
+           if (thisValue.isObject()) {
+             res = funPtr->callWithThis(rt, thisValue.asObject(rt), args, count);
+           } else {
+             res = funPtr->call(rt, args, count);
+           }
+          
            rt.global().setProperty(rt, "jsThis", oldJSThis); //clean jsThis
-           auto promise = rt.global().getPropertyAsObject(rt, "Promise");
-           auto resolver = promise.getPropertyAsFunction(rt, "resolve");
-           return resolver.call(rt, res);
+           return res;
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name.c_str()), 0, clb);
       } else {

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -298,22 +298,50 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           for (int i = 0; i < count; ++i) {
             params.push_back(ShareableValue::adapt(rt, args[i], runtimeManager));
           }
-
-          std::function<void()> job = [hostFunction, hostRuntime, params] {
-            jsi::Value * args = new jsi::Value[params.size()];
-            for (int i = 0; i < params.size(); ++i) {
-              args[i] = params[i]->getValue(*hostRuntime);
-            }
-            jsi::Value returnedValue = hostFunction->getPureFunction().get()->call(*hostRuntime,
-                                                static_cast<const jsi::Value*>(args),
-                                                (size_t)params.size());
-
-            delete [] args;
-            // ToDo use returned value to return promise
-          };
-
-          runtimeManager->scheduler->scheduleOnJS(job);
-          return jsi::Value::undefined();
+          
+          auto dispatchToJSCallback = jsi::Function::createFromHostFunction(rt,
+                                                                            jsi::PropNameID::forAscii(rt, "dispatchToJSCallback"),
+                                                                            2,
+                                                                            [runtimeManager, hostFunction, hostRuntime, params](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
+            auto resolverValue = std::make_shared<jsi::Value>((arguments[0].asObject(runtime)));
+            auto rejecterValue = std::make_shared<jsi::Value>((arguments[1].asObject(runtime)));
+            
+            auto resolver = [runtimeManager, &runtime, resolverValue](std::shared_ptr<reanimated::ShareableValue> shareableValue) {
+              runtimeManager->scheduler->scheduleOnJS([&runtime, resolverValue, shareableValue] () {
+                resolverValue->asObject(runtime).asFunction(runtime).call(runtime, shareableValue->getValue(runtime));
+              });
+            };
+            auto rejecter = [runtimeManager, &runtime, rejecterValue](std::string message) {
+              runtimeManager->scheduler->scheduleOnJS([&runtime, rejecterValue, message] () {
+                rejecterValue->asObject(runtime).asFunction(runtime).call(runtime, jsi::JSError(runtime, message).value());
+              });
+            };
+            
+            runtimeManager->scheduler->scheduleOnJS([hostFunction, hostRuntime, params, &runtime, runtimeManager, resolver, rejecter] {
+              jsi::Value * args = new jsi::Value[params.size()];
+              for (int i = 0; i < params.size(); ++i) {
+                args[i] = params[i]->getValue(*hostRuntime);
+              }
+              
+              try {
+                jsi::Value result = hostFunction->getPureFunction().get()->call(*hostRuntime,
+                                                                                static_cast<const jsi::Value*>(args),
+                                                                                (size_t)params.size());
+                auto shareableResult = reanimated::ShareableValue::adapt(runtime, result, runtimeManager);
+                resolver(shareableResult);
+              } catch (std::exception e) {
+                rejecter(e.what());
+              }
+              
+              delete [] args;
+            });
+            
+            return jsi::Value::undefined();
+          });
+          
+          auto promiseCtor = rt.global().getPropertyAsFunction(rt, "Promise");
+          auto promise = promiseCtor.callAsConstructor(rt, dispatchToJSCallback);
+          return promise;
         };
         jsi::Function wrapperFunction = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, warnFunction);
         jsi::Function res = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "hostFunction"), 0, clb);

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -454,7 +454,7 @@ declare module 'react-native-reanimated' {
     // reanimated2 functions
     export function runOnUI<A extends any[], R>(
       fn: (...args: A) => R
-    ): (...args: Parameters<typeof fn>) => void;
+    ): (...args: Parameters<typeof fn>) => Promise<R>;
     export function runOnJS<A extends any[], R>(
       fn: (...args: A) => R
     ): (...args: Parameters<typeof fn>) => void;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -457,7 +457,7 @@ declare module 'react-native-reanimated' {
     ): (...args: Parameters<typeof fn>) => Promise<R>;
     export function runOnJS<A extends any[], R>(
       fn: (...args: A) => R
-    ): (...args: Parameters<typeof fn>) => void;
+    ): (...args: Parameters<typeof fn>) => Promise<R>;
 
     type PropsAdapterFunction = (props: Record<string, unknown>) => void;
     export function createAnimatedPropAdapter(


### PR DESCRIPTION
## Description

Makes worklets (`runOnUI`) and `runOnJS` return a Promise so it can be awaited and can now return values.

```js
const result = await runOnUI(() => {
  return 'Test!'
})();
console.log(result);
```

## Changes

- Makes worklets (`runOnUI`) return a Promise
- Makes hostFunction (`runOnJS`) return a Promise

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Test await:

```js
  const run = async () => {
    console.log('in run')
    const x = await runOnUI(() => {
      'worklet';
      return 'result from worklet'
    })()
    console.log(`runOnUI result: ${x}`);
  };
  run();
```

Test errors thrown being Promise.rejected:

```js
      try {
        const result = await runOnUI(() => {
          'worklet';
          throw new Error("Failed!")
        })();
      } catch (e) {
        console.error(`Error: ${e.message}`)
      }
```

Test awaiting runOnJS in a worklet:

```js
const run = async () => {
  console.log('in run')
  const x = await runOnUI(async () => {
    'worklet';
    console.log('in runOnUI')
    const res = await runOnJS(doSomethingOnJS)();
    console.log(`runOnJS result: ${res}`)
    return 'yooo'
  })()
  console.log(`runOnUI result: ${x}`);
};
run();
```

> ⚠️ warning: the above snippet still crashes because the babel plugin requires additional transformation steps so it can successfully transform async/await code. Right now it just submits the above code with the `await` statement as is, and that crashes the `WorkletsCache` eval code because you cannot use top-level await there. I'm waiting on @piaskowyk / @Szymon20000 's feedback here.

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes


## Missing

When calling from JS -> UI it successfully returns a Promise which now can be awaited. When calling from UI -> UI, it does not return a Promise, but rather returns the return value of the worklet as is:
https://github.com/software-mansion/react-native-reanimated/blob/afa2791ed3c95de7c0c2d869104994a5362f0928/Common/cpp/SharedItems/ShareableValue.cpp#L354

I tried to use `Promise.resolve(res)` here, but this always gave me crashes because apparently some code depends on this behaviour, so I just left it as it is right now. This will likely never affect the user, as he never calls `runOnUI(() => runOnUI...)()`.