### PR TITLE
Fix tsc generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "lint-check": "eslint --ext '.js,.ts,.tsx' src/ && yarn prettier --check src/",
     "release": "npm login && release-it",
     "type:check": "yarn tsc --noEmit",
-    "type:generate": "rm -rf lib/ && mkdir lib/ && cp -RL src/ lib/ && find ./lib -type f -name \"*.ts\" -and -not -name \"*.d.ts\" -delete && yarn tsc"
+    "type:generate": "yarn type:generate:clean && yarn type:generate:cp-js-src && yarn type:generate:tsc-and-mv",
+    "type:generate:clean": "rm -rf lib/ && mkdir lib/",
+    "type:generate:cp-js-src": "cp -RL src/ lib/ && find ./lib -type f -name \"*.ts\" -and -not -name \"*.d.ts\" -delete",
+    "type:generate:tsc-and-mv": "yarn tsc && mv lib/reanimated2/src/reanimated2/* lib/reanimated2 && rm -r lib/reanimated2/src/"
   },
   "main": "lib/Animated.js",
   "module": "lib/Animated",


### PR DESCRIPTION
## Description

`tsc` generated directory structure reflects source structure, starting from `rootDir` specified in ts-config. We can't set it to `src/reanimated2` because it has to contain _all_ sources (including d.ts files we have in repo root). To workaround that we move generated directory two levels upper.

This PR also splits `type:generate` task to make it more maintainable.
