### PR TITLE
fix: ssr support (#1890)

### DIFF
--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -13,9 +13,10 @@ export default class JSReanimated {
   timeProvider = null;
 
   constructor() {
-    this.timeProvider = process.env.JEST_WORKER_ID
-      ? { now: () => Date.now() }
-      : window.performance;
+    this.timeProvider = {
+      now: () =>
+        process.env.JEST_WORKER_ID ? Date.now() : window.performance.now(),
+    };
   }
 
   pushFrame(frame) {

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -10,13 +10,15 @@ export default class JSReanimated {
   _renderRequested = false;
   _mapperRegistry = new MapperRegistry(this);
   _frames = [];
-  timeProvider = null;
+  timeProvider = {};
 
   constructor() {
-    this.timeProvider = {
-      now: () =>
-        process.env.JEST_WORKER_ID ? Date.now() : window.performance.now(),
-    };
+    if(process.env.JEST_WORKER_ID) {
+      this.timeProvider.now = () => Date.now();
+    }
+    else {
+      this.timeProvider.now = () => window.performance.now();
+    }
   }
 
   pushFrame(frame) {


### PR DESCRIPTION
## Description

Fix #1890

## Changes

Don't call `window` in the constructor of JS Reanimated, since this isn't available on the server. 

## Test code and steps to reproduce

One-line change, which reverts back to what was already there in `2.0.0-rc.0`. Let me know if this is needed, but given that it's simply a regression patch, I figure it isn't.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
