### PR TITLE
Added support for `@quilted/react-testing`

### DIFF
--- a/__tests__/Animation.test.js
+++ b/__tests__/Animation.test.js
@@ -96,8 +96,8 @@ describe('Tests of animations', () => {
       expect(view).toHaveAnimatedStyle(style);
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      style.width = 46.08; // value of component width after 260ms of animation
+      advanceAnimationByTime(250);
+      style.width = 78.22; // value of component width after 250ms of animation
       expect(view).toHaveAnimatedStyle(style);
     });
   });
@@ -109,9 +109,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByFrame(10);
-      // value of component width after 10 frames of animation
-      expect(view).toHaveAnimatedStyle({ width: 16.588799999999996 });
+      advanceAnimationByFrame(20);
+      // value of component width after 20 frames of animation
+      expect(view).toHaveAnimatedStyle({ width: 99.68 });
     });
   });
 
@@ -124,8 +124,8 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      style.width = 46.08; // value of component width after 260ms of animation
+      advanceAnimationByTime(250);
+      style.width = 78.22; // value of component width after 250ms of animation
       expect(view).toHaveAnimatedStyle(style, true);
     });
   });
@@ -143,9 +143,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      // value of component width after 260ms of animation
-      expect(view).toHaveAnimatedStyle({ width: 46.08 });
+      advanceAnimationByTime(250);
+      // value of component width after 250ms of animation
+      expect(view).toHaveAnimatedStyle({ width: 78.22 });
     });
   });
 

--- a/__tests__/Animation.test.js
+++ b/__tests__/Animation.test.js
@@ -96,8 +96,8 @@ describe('Tests of animations', () => {
       expect(view).toHaveAnimatedStyle(style);
 
       fireEvent.press(button);
-      advanceAnimationByTime(250);
-      style.width = 78.22; // value of component width after 250ms of animation
+      advanceAnimationByTime(260);
+      style.width = 56.5688; // value of component width after 260ms of animation
       expect(view).toHaveAnimatedStyle(style);
     });
   });
@@ -109,9 +109,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByFrame(20);
-      // value of component width after 20 frames of animation
-      expect(view).toHaveAnimatedStyle({ width: 99.68 });
+      advanceAnimationByFrame(5);
+      // value of component width after 5 frames of animation
+      expect(view).toHaveAnimatedStyle({ width: 5.6448 });
     });
   });
 
@@ -124,8 +124,8 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(250);
-      style.width = 78.22; // value of component width after 250ms of animation
+      advanceAnimationByTime(260);
+      style.width = 56.5688; // value of component width after 260ms of animation
       expect(view).toHaveAnimatedStyle(style, true);
     });
   });
@@ -143,9 +143,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(250);
-      // value of component width after 250ms of animation
-      expect(view).toHaveAnimatedStyle({ width: 78.22 });
+      advanceAnimationByTime(260);
+      // value of component width after 260ms of animation
+      expect(view).toHaveAnimatedStyle({ width: 56.5688 });
     });
   });
 

--- a/__tests__/Animation.test.js
+++ b/__tests__/Animation.test.js
@@ -96,8 +96,8 @@ describe('Tests of animations', () => {
       expect(view).toHaveAnimatedStyle(style);
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      style.width = 56.5688; // value of component width after 260ms of animation
+      advanceAnimationByTime(150);
+      style.width = 18.7272; // value of component width after 150ms of animation
       expect(view).toHaveAnimatedStyle(style);
     });
   });
@@ -109,9 +109,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByFrame(5);
-      // value of component width after 5 frames of animation
-      expect(view).toHaveAnimatedStyle({ width: 5.6448 });
+      advanceAnimationByFrame(13);
+      // value of component width after 13 frames of animation
+      expect(view).toHaveAnimatedStyle({ width: 39.0728 });
     });
   });
 
@@ -124,8 +124,8 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      style.width = 56.5688; // value of component width after 260ms of animation
+      advanceAnimationByTime(150);
+      style.width = 18.7272; // value of component width after 150ms of animation
       expect(view).toHaveAnimatedStyle(style, true);
     });
   });
@@ -143,9 +143,9 @@ describe('Tests of animations', () => {
       const button = getByTestId('button');
 
       fireEvent.press(button);
-      advanceAnimationByTime(260);
-      // value of component width after 260ms of animation
-      expect(view).toHaveAnimatedStyle({ width: 56.5688 });
+      advanceAnimationByTime(150);
+      // value of component width after 150ms of animation
+      expect(view).toHaveAnimatedStyle({ width: 18.7272 });
     });
   });
 

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -144,10 +144,8 @@ const afterTest = () => {
 };
 
 const tickTravel = (frameIndex) => {
-  MockDate.set(
-    new Date(Date.now() + frameTime + frameTimeFraction * (frameIndex + 1))
-  );
-  jest.advanceTimersByTime(frameTime);
+  MockDate.set(new Date(frameTime * (frameIndex + 1)));
+  jest.advanceTimersByTime(Math.ceil(frameTime));
 };
 
 export const withReanimatedTimer = (animatonTest) => {
@@ -171,7 +169,6 @@ export const advanceAnimationByFrame = (count) => {
 export const setUpTests = (userConfig = {}) => {
   const expect = require('expect');
   frameTime = 1000 / config.fps;
-  frameTimeFraction = frameTime - Math.trunc(frameTime);
 
   config = {
     ...config,

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -147,9 +147,9 @@ const afterTest = () => {
   global.requestAnimationFrame = requestAnimationFrameCopy;
 };
 
-const tickTravel = (frameIndex) => {
-  MockDate.set(new Date(frameTime * (frameIndex + 1)));
-  jest.advanceTimersByTime(Math.ceil(frameTime));
+const tickTravel = () => {
+  MockDate.set(new Date(Date.now() + frameTime));
+  jest.advanceTimersByTime(frameTime);
 };
 
 export const withReanimatedTimer = (animatonTest) => {
@@ -160,19 +160,21 @@ export const withReanimatedTimer = (animatonTest) => {
 
 export const advanceAnimationByTime = (time = frameTime) => {
   for (let i = 0; i <= Math.ceil(time / frameTime); i++) {
-    tickTravel(i);
+    tickTravel();
   }
+  jest.advanceTimersByTime(frameTime);
 };
 
 export const advanceAnimationByFrame = (count) => {
   for (let i = 0; i <= count; i++) {
-    tickTravel(i);
+    tickTravel();
   }
+  jest.advanceTimersByTime(frameTime);
 };
 
 export const setUpTests = (userConfig = {}) => {
   const expect = require('expect');
-  frameTime = 1000 / config.fps;
+  frameTime = Math.round(1000 / config.fps);
 
   config = {
     ...config,

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -112,7 +112,9 @@ const compareStyle = (received, expectedStyle, config) => {
   const differences = diffs
     .map(
       (diff) =>
-        `- '${diff.property}' should be ${diff.expect}, but is ${diff.current}`
+        `- '${diff.property}' should be ${JSON.stringify(
+          diff.expect
+        )}, but is ${JSON.stringify(diff.current)}`
     )
     .join('\n');
 

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -51,8 +51,8 @@ const checkEqual = (currentStyle, expectStyle) => {
       }
     }
   } else if (typeof currentStyle === 'object') {
-    for (const propertyName in expectStyle) {
-      if (!checkEqual(currentStyle[propertyName], expectStyle[propertyName])) {
+    for (const property in expectStyle) {
+      if (!checkEqual(currentStyle[property], expectStyle[property])) {
         return false;
       }
     }

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -20,13 +20,15 @@ const getCurrentStyle = (received) => {
   if (Array.isArray(styleObject)) {
     received.props.style.forEach((style) => {
       if (isAnimatedStyle(style)) {
-        currentStyle = Object.assign(
-          {},
-          currentStyle,
-          getAnimatedStyleFromObject(style)
-        );
+        currentStyle = {
+          ...currentStyle,
+          ...getAnimatedStyleFromObject(style),
+        };
       } else {
-        currentStyle = Object.assign({}, currentStyle, style);
+        currentStyle = {
+          ...currentStyle,
+          ...style,
+        };
       }
     });
   } else {
@@ -50,7 +52,7 @@ const checkEqual = (currentStyle, expectStyle) => {
         return false;
       }
     }
-  } else if (typeof currentStyle === 'object') {
+  } else if (typeof currentStyle === 'object' && currentStyle) {
     for (const property in expectStyle) {
       if (!checkEqual(currentStyle[property], expectStyle[property])) {
         return false;


### PR DESCRIPTION
## Description

Added support for `@quilted/react-testing` - used by Shopify.
`@testing-library/react-hooks` uses `render()`
`@quilted/react-testing` uses `mount()`
Both methods `render()` and `mount()` returns objects with different structure.

## Example code

```js
import React, { useEffect } from 'react';
import Animated, { useSharedValue, useAnimatedStyle, withTiming, } from '../src/';
import { withReanimatedTimer, advanceAnimationByTime, } from '../src/reanimated2/jestUtils';
import { mount } from '@quilted/react-testing';

const PinCircle = ({filled = false}) => {
  const animatedValue = useSharedValue(0);
  useEffect(() => {
    animatedValue.value = withTiming(filled ? 0 : 1, {duration: 250});
  }, [animatedValue, filled]);

  const animatedStyle = useAnimatedStyle(() => {
    const scale = animatedValue.value;
    return { transform: [{scale}] };
  });

  return (
    <Animated.View
      testID="PinCircle/InnerCircle"
      style={animatedStyle}
    />
  );
}

it('filled prop is true', () => {
  withReanimatedTimer(() => {
    const wrapper = mount(<PinCircle filled={true} />);
    advanceAnimationByTime(250);
    const InnerView = wrapper.find(Animated.View, {testID: 'PinCircle/InnerCircle'});
    expect(InnerView).toHaveAnimatedStyle({transform: [{scale: 0}]});
  });
});

it('filled prop is false', () => {
  withReanimatedTimer(() => {
    const wrapper = mount(<PinCircle filled={false} />);
    advanceAnimationByTime(250);
    const InnerViewAfter = wrapper.find(Animated.View, {testID: 'PinCircle/InnerCircle'});
    expect(InnerViewAfter).toHaveAnimatedStyle({transform: [{scale: 1}]});
  });
});

```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that CI passes
