### PR TITLE
Make mockdate a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@babel/plugin-transform-object-assign": "^7.10.4",
     "fbjs": "^3.0.0",
-    "mockdate": "^3.0.2",
     "string-hash-64": "^1.0.3"
   },
   "peerDependencies": {
@@ -97,6 +96,7 @@
     "husky": "^4.2.5",
     "jest": "^24.9.0",
     "lint-staged": "^10.2.11",
+    "mockdate": "^3.0.2",
     "prettier": "^2.2.1",
     "react": "17.0.1",
     "react-native": "0.64.0",


### PR DESCRIPTION
`mockdate` is really a dev dependency, no reason to install it in host project.