### PR TITLE
fix: remove unnecessary slash in docs

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -16,7 +16,7 @@ const boxes = [
     description: (
       <>
         Complexity reduced from tens to just a few methods. Try it out today:
-        Check out our <a href="/docs/">Documentation</a>.
+        Check out our <a href="docs/">Documentation</a>.
       </>
     ),
   },


### PR DESCRIPTION
## Description
One of the links on the main page of the docs had an additional slash character resulting in navigating to 404 page.

https://user-images.githubusercontent.com/39658211/115391540-de0b6600-a1df-11eb-8ffb-178a9aebfaed.mov

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

 - Fixed href in `<a>` tag in `docs/src/pages/index.js`
 
