### PR TITLE
fix(mock): add Reanimated2 mock named exports

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -230,15 +230,17 @@ const Reanimated = {
   addWhitelistedNativeProps: NOOP,
 };
 
+const mergedReanimated = {
+  ...Reanimated,
+  ...ReanimatedV2,
+}
+
 module.exports = {
   __esModule: true,
 
-  ...Reanimated,
+  ...mergedReanimated,
 
-  default: {
-    ...Reanimated,
-    ...ReanimatedV2,
-  },
+  default: mergedReanimated,
 
   Transitioning: {
     View: createTransitioningComponent(View),


### PR DESCRIPTION
## Description

when using named import:
```tsx
import Animated, { useSharedValue } from 'react-native-reanimated'
``` 
instead of 
 ```tsx
import Animated, { useSharedValue } from 'react-native-reanimated'
const { useSharedValue } = Animated
``` 
jest throws an error
![image](https://user-images.githubusercontent.com/38642628/115433987-8ae4e380-a1de-11eb-8d87-9464c6b01c32.png)
the PR #1230 solved issue but only when using destructuring on `Animated`
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- Added Reanimated2 mock named exports on `mock.js`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
