### PR TITLE
Fix Error in `measure` not throwing

### DIFF
--- a/ios/native/NativeMethods.mm
+++ b/ios/native/NativeMethods.mm
@@ -10,7 +10,7 @@ std::vector<std::pair<std::string,double>> measure(int viewTag, RCTUIManager *ui
   UIView *rootView = view;
 
   if (view == nil) {
-    return std::vector<std::pair<std::string, double>>(0, std::make_pair("x", -1234567.0));
+    return std::vector<std::pair<std::string, double>>(std::make_pair("x", -1234567.0));
   }
 
   while (rootView.superview && ![rootView isReactRootView]) {
@@ -18,7 +18,7 @@ std::vector<std::pair<std::string,double>> measure(int viewTag, RCTUIManager *ui
   }
 
   if (rootView == nil || (![rootView isReactRootView])) {
-    return std::vector<std::pair<std::string, double>>(0, std::make_pair("x", -1234567.0));
+    return std::vector<std::pair<std::string, double>>(std::make_pair("x", -1234567.0));
   }
 
   CGRect frame = view.frame;


### PR DESCRIPTION
## Description

`measure` checks if the `x` values is exactly `-1234567.0` - if it is, it's an error. if it isn't, a result is available.

We returned an incorrect vector from the native `measure` function.

## Changes


- Updated native method `measure` to correctly return error-ish values

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
