### PR TITLE
Remove Reanimated 2 from default exports

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -234,10 +234,10 @@ module.exports = {
   __esModule: true,
 
   ...Reanimated,
+  ...ReanimatedV2,
 
   default: {
     ...Reanimated,
-    ...ReanimatedV2,
   },
 
   Transitioning: {

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -4,7 +4,6 @@ import {
   addWhitelistedNativeProps,
   addWhitelistedUIProps,
 } from './ConfigHelper';
-import * as reanimated2 from './reanimated2';
 import * as reanimated1 from './reanimated1';
 
 const Animated = {
@@ -19,8 +18,6 @@ const Animated = {
   addWhitelistedUIProps,
   // reanimated 1
   ...reanimated1,
-  // reanimated 2
-  ...reanimated2,
 };
 
 export * from './reanimated2';


### PR DESCRIPTION
## Description

After an internal discussion with @Szymon20000 we concluded that reanimated 2 should be exported only via named exports.

Default exports are antipattern in es6 (they prevent tree-shaking for example).

This PR is a breaking change so we may wait with merging it.
