### PR TITLE
Set default text color to black in Example app

### DIFF
--- a/Example/android/app/src/main/res/values/styles.xml
+++ b/Example/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:textColor">#000000</item>
     </style>
 
 </resources>


### PR DESCRIPTION
The text on the Example project is very hard to read with white text
on the gray background. This PR changes the default text color to
black so it is readable.

## Description

The text in the Example project when run on Android is white on a gray background making it very hard to read. I actually thought there was no text at first.

## Changes

Changes the default text color to black on Android for the Example project.

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

![Screenshot_20210424-204351](https://user-images.githubusercontent.com/121034/115976645-feb82080-a53d-11eb-91c6-11d9b82ddf25.png)

### After

![Screenshot_20210424-204116](https://user-images.githubusercontent.com/121034/115976648-04ae0180-a53e-11eb-8475-e2c2c301c809.png)

## Test code and steps to reproduce

Build the project on Android. May require launching to a physical device to see the bug.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
