### PR TITLE
fix: intellisense for Example directory

### DIFF
--- a/Example/tsconfig.json
+++ b/Example/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "react-native-reanimated": ["./react-native-reanimated.d.ts"]
+      "react-native-reanimated": ["../react-native-reanimated.d.ts"]
     }
   },
   "include": ["index.js", "src/**/*", "reanimated1/**/*", "test/**/*"]


### PR DESCRIPTION
## Description
I just cloned this repo and installed node_module at root and in Example then i saw 
```
Cannot find module 'react-native-reanimated' or its corresponding type declarations.ts(2307)
```

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
i fixed IntelliSense by edit `Example/tsconfig.json` and set the correct path of `react-native-reanimated.d.ts`

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

just clone this repo and installed node_module at root and in Example then when you will hover mouse on `Animated` then you will see this error 

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
