### PR TITLE
[v1] Name exported animation functions

### DIFF
--- a/src/reanimated1/animations/decay.js
+++ b/src/reanimated1/animations/decay.js
@@ -45,8 +45,10 @@ const procDecay = proc(
     decay(clock, { time, velocity, position, finished }, { deceleration })
 );
 
-export default (
+export default function decayAnimation(
   clock,
   { time, velocity, position, finished },
   { deceleration }
-) => procDecay(clock, time, velocity, position, finished, deceleration);
+) {
+  return procDecay(clock, time, velocity, position, finished, deceleration);
+}

--- a/src/reanimated1/animations/spring.js
+++ b/src/reanimated1/animations/spring.js
@@ -167,7 +167,7 @@ const procSpring = proc(
     )
 );
 
-export default (
+export default function springAnimation(
   clock,
   { finished, velocity, position, time, prevPosition },
   {
@@ -179,8 +179,8 @@ export default (
     restDisplacementThreshold,
     restSpeedThreshold,
   }
-) =>
-  procSpring(
+) {
+  return procSpring(
     finished,
     velocity,
     position,
@@ -195,3 +195,4 @@ export default (
     restDisplacementThreshold,
     clock
   );
+}

--- a/src/reanimated1/animations/timing.js
+++ b/src/reanimated1/animations/timing.js
@@ -50,7 +50,7 @@ const internalTiming = proc(function (
   ]);
 });
 
-export default function (clock, state, config) {
+export default function timing(clock, state, config) {
   if (config.duration === 0) {
     // when duration is zero we end the timing immediately
     return block([set(state.position, config.toValue), set(state.finished, 1)]);


### PR DESCRIPTION
## Description

When used with NextJS, this library produces this warning on compile

```
warn  - ./node_modules/react-native-reanimated/lib/reanimated1/animations/timing.js
Anonymous function declarations cause Fast Refresh to not preserve local component state.
Please add a name to your function, for example:

Before
export default function () { /* ... */ }

After
export default function Named() { /* ... */ }

A codemod is available to fix the most common cases: https://nextjs.link/codemod-ndc


```
## Changes

Named the default exported function

## Screenshots / GIFs

### Before

### After


## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
