### PR TITLE
Add cpplint to check C++ code

### DIFF
--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -1,0 +1,35 @@
+name: Validate C++
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/validate-cpp.yml'
+      - 'Common/cpp/**'
+      - 'ios/native/**'
+      - 'android/src/main/cpp/**'
+  pull_request:
+    paths:
+      - '.github/workflows/validate-cpp.yml'
+      - 'Common/cpp/**'
+      - 'ios/native/**'
+      - 'android/src/main/cpp/**'
+
+jobs:
+  lint:
+    name: cpplint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-cpplint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          flags: --linelength=230
+          targets: --recursive Common/cpp ios/native android/src/main/cpp
+          filter: "-legal/copyright\
+            ,-readability/todo\
+            ,-build/namespaces\
+            ,-whitespace/comments\
+            "

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:unit": "jest",
     "format": "prettier --write --list-different './src/**/*.js'",
     "lint-check": "eslint --ext '.js,.ts,.tsx' src/ && yarn prettier --check src/",
+    "lint-check-cpp": "./scripts/cpplint.sh",
     "release": "npm login && release-it",
     "type:check": "yarn tsc --noEmit",
     "type:generate": "yarn type:generate:clean && yarn type:generate:cp-js-src && yarn type:generate:tsc-and-mv",

--- a/scripts/cpplint.sh
+++ b/scripts/cpplint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if which cpplint >/dev/null; then
+  cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments --quiet --recursive Common/cpp ios/native android/src/main/cpp
+else
+  echo "warning: cpplint not installed, download from https://github.com/cpplint/cpplint"
+fi


### PR DESCRIPTION
## Description

This PR adds a script to run [cpplint](https://github.com/cpplint/cpplint), a C++ linter.

You can run the script with `npm run lint-check-cpp`, and any changes to C++ code will be linted automatically by the GitHub action workflow.

I just ran it once and noticed 503 errors, so either we tweak the config to ignore a few errors, or we fix them. Most of them are style guidelines, but there are some performance/efficiency tips in there as well.