### PR TITLE
Plugin: Allow adding custom globals for Worklets (e.g. HostFunctions)

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -554,6 +554,14 @@ function removePluginsFromBlacklist(plugins) {
 
 module.exports = function({ types: t }) {
   return {
+    pre() {
+      // allows adding custom globals such as host-functions
+      if (this.opts != null && Array.isArray(this.opts.globals)) {
+        this.opts.globals.forEach((name) => {
+          globals.add(name)
+        })
+      }
+    },
     visitor: {
       CallExpression: {
         exit(path, state) {


### PR DESCRIPTION
## Description

This PR adds an option to the react-native-reanimated plugin: `globals`. It is of type Array and specifies any additional globals the Babel Plugin allows. 

The main motivation behind this change was that I am developing a Camera library which allows native host-functions to be called inside worklets in a custom runtime. So for instance, a custom `scanQRCodes(...)` function that is registered to the `jsi::Runtime::global` property was not callable before because the REA plugin whitelists all available globals here: https://github.com/software-mansion/react-native-reanimated/blob/462e21ee18e732cabc4381816486a5808ce7e961/plugin.js#L33-L70

With this PR you can now add additional globals, without breaking any behaviour. To add the `_scanQRCodes` host-function to the globals simply edit your `babel.config.js` file and add plugin options:

```js
module.exports = {
  presets: ['module:metro-react-native-babel-preset'],
  plugins: [
    [
      'react-native-reanimated/plugin',
      {
        globals: ['_scanQRCodes'],
      },
    ],
  ]
}
```

> Note: The default behaviour remains untouched and you can omit the options as expected.

## Changes

- Add options to the REA babel plugin to allow adding custom global variables

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [x] Ensured that nothing breaks
- [x] Ensured that CI passes
