### PR TITLE
Add sideEffects: false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "lib/Animated.js",
   "module": "lib/Animated",
   "react-native": "src/Animated",
+  "sideEffects": false,
   "source": "src/Animated",
   "types": "react-native-reanimated.d.ts",
   "files": [


### PR DESCRIPTION
## Changes

Add sideEffects: false to package.json

## Description

When used with react-native-web this library struggles with Webpack tree-shaking

For example, this code adds 61kB to the bundle

```
import { useSharedValue } from 'react-native-reanimated';

function SomeComponent() {
  const sharedVal = useSharedValue(0);
  return (
    <Button
      onPress={() => (sharedVal.value = Math.random())}
      title="Randomize"
    />
  );
}
```

By adding `sideEffects: false` to the package.json it provides webpack an optimisation hint that it can tree-shake at the module level. You can read more about this here https://webpack.js.org/guides/tree-shaking/

This reduces the react-native-reanimated's bundle size to 35kB 



 **Before adding sideEffects**

![_home_mark_Hundredpoints_core_packages_ui-framework-example_ next_analyze_client html](https://user-images.githubusercontent.com/3946701/116841741-6e549c80-ac1d-11eb-97e5-7578d9fb8cce.png)

**After adding sideEffects**

![_home_mark_Hundredpoints_core_packages_ui-framework-example_ next_analyze_client html (1)](https://user-images.githubusercontent.com/3946701/116841730-6563cb00-ac1d-11eb-9437-32d8f3f900cc.png)


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
