### PR TITLE
Add link to iOS "previous instruction" in installation docs

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -138,7 +138,7 @@ Run `pod install` in the `ios/` directory.
 
 In previous releases, the installation process was manual and required turning turbo modules on. Some libraries break when turbo modules are enabled so we decided to change our approach and we no longer
 use the standard way for registering a turbo module. It let us simplify the installation process and as a result, you can safely
-undo all installation steps from the previous instruction.
+undo all installation steps from the [previous instruction](https://github.com/software-mansion/react-native-reanimated/blob/2.0.0-alpha.4/docs/docs/installation.md#ios).
 
 :::
 

--- a/docs/versioned_docs/version-2.0.0/installation.md
+++ b/docs/versioned_docs/version-2.0.0/installation.md
@@ -138,7 +138,7 @@ Run `pod install` in the `ios/` directory.
 
 In previous releases, the installation process was manual and required turning turbo modules on. Some libraries break when turbo modules are enabled so we decided to change our approach and we no longer
 use the standard way for registering a turbo module. It let us simplify the installation process and as a result, you can safely
-undo all installation steps from the previous instruction.
+undo all installation steps from the [previous instruction](https://github.com/software-mansion/react-native-reanimated/blob/2.0.0-alpha.4/docs/docs/installation.md#ios).
 
 :::
 


### PR DESCRIPTION
## Description

Added a link in the iOS installed documentation to the old native code previously needed to enable Turbo Modules. This will help people like me who installed v2 alphas and are trying to install 2.0.0

## Changes

Added hyperlinks to doc markdown

## Test code and steps to reproduce

It's just docs

## Checklist

~- [ ] Included code example that can be used to test this change~
~- [ ] Updated TS types~
~- [ ] Added TS types tests~
~- [ ] Added unit / integration tests~
- [x] Updated documentation
- [x] Ensured that CI passes
