### PR TITLE
Perf/faster runtime checks

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -64,7 +64,7 @@ NativeReanimatedModule::NativeReanimatedModule(std::shared_ptr<CallInvoker> jsIn
                                                std::function<jsi::Value(jsi::Runtime &, const int, const jsi::String &)> propObtainer,
                                                PlatformDepMethodsHolder platformDepMethodsHolder) :
                                                   NativeReanimatedModuleSpec(jsInvoker),
-                                                  RuntimeManager(std::move(rt), errorHandler, scheduler),
+                                                  RuntimeManager(std::move(rt), errorHandler, scheduler, RuntimeType::UI),
                                                   mapperRegistry(std::make_shared<MapperRegistry>()),
                                                   eventHandlerRegistry(std::make_shared<EventHandlerRegistry>()),
                                                   requestRender(platformDepMethodsHolder.requestRender),
@@ -80,8 +80,7 @@ NativeReanimatedModule::NativeReanimatedModule(std::shared_ptr<CallInvoker> jsIn
                                       requestAnimationFrame,
                                       platformDepMethodsHolder.scrollToFunction,
                                       platformDepMethodsHolder.measuringFunction,
-                                      platformDepMethodsHolder.getCurrentTime,
-                                      true);
+                                      platformDepMethodsHolder.getCurrentTime);
    onRenderCallback = [this](double timestampMs) {
     this->renderRequested = false;
     this->onRender(timestampMs);

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -5,6 +5,10 @@
 
 namespace reanimated {
 
+void RuntimeDecorator::registerRuntime(jsi::Runtime *runtime, RuntimeType runtimeType) {
+  runtimeRegistry.insert({ runtime, runtimeType });
+}
+
 void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, const std::string &label) {
   // This property will be used to find out if a runtime is a custom worklet runtime (e.g. UI, VisionCamera frame processor, ...)
   rt.global().setProperty(rt, "_WORKLET", jsi::Value(true));
@@ -58,8 +62,6 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, const std::string &labe
     return jsi::Value::undefined();
   };
   rt.global().setProperty(rt, "_setGlobalConsole", jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_setGlobalConsole"), 1, setGlobalConsole));
-  
-  runtimeRegistry.insert({ &rt, RuntimeType::Worklet });
 }
 
 void RuntimeDecorator::decorateUIRuntime(jsi::Runtime& rt,
@@ -148,8 +150,6 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime& rt,
 
   rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
   rt.global().setProperty(rt, "_eventTimestamp", jsi::Value::undefined());
-  
-  runtimeRegistry.insert({ &rt, RuntimeType::UI });
 }
 
 }

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -5,8 +5,6 @@
 
 namespace reanimated {
 
-std::unique_ptr<RuntimeDetectorStrategy> RuntimeDecorator::runtimeDetectorStrategy = std::make_unique<DefaultRuntimeDetectorStrategy>();
-
 void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, const std::string &label) {
   // This property will be used to find out if a runtime is a custom worklet runtime (e.g. UI, VisionCamera frame processor, ...)
   rt.global().setProperty(rt, "_WORKLET", jsi::Value(true));
@@ -60,6 +58,8 @@ void RuntimeDecorator::decorateRuntime(jsi::Runtime &rt, const std::string &labe
     return jsi::Value::undefined();
   };
   rt.global().setProperty(rt, "_setGlobalConsole", jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "_setGlobalConsole"), 1, setGlobalConsole));
+  
+  runtimeRegistry.insert({ &rt, RuntimeType::Worklet });
 }
 
 void RuntimeDecorator::decorateUIRuntime(jsi::Runtime& rt,
@@ -67,11 +67,7 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime& rt,
                                          const RequestFrameFunction& requestFrame,
                                          const ScrollToFunction& scrollTo,
                                          const MeasuringFunction& measure,
-                                         const TimeProviderFunction& getCurrentTime,
-                                         const bool comparePointers) {
-  if(comparePointers) {
-    runtimeDetectorStrategy = std::make_unique<UIRuntimeDetectorStrategy>(rt);
-  }
+                                         const TimeProviderFunction& getCurrentTime) {
   RuntimeDecorator::decorateRuntime(rt, "UI");
   rt.global().setProperty(rt, "_UI", jsi::Value(true));
 
@@ -152,6 +148,8 @@ void RuntimeDecorator::decorateUIRuntime(jsi::Runtime& rt,
 
   rt.global().setProperty(rt, "_frameTimestamp", jsi::Value::undefined());
   rt.global().setProperty(rt, "_eventTimestamp", jsi::Value::undefined());
+  
+  runtimeRegistry.insert({ &rt, RuntimeType::UI });
 }
 
 }

--- a/Common/cpp/headers/SharedItems/RuntimeManager.h
+++ b/Common/cpp/headers/SharedItems/RuntimeManager.h
@@ -4,6 +4,7 @@
 #include "ErrorHandler.h"
 #include "Scheduler.h"
 #include "WorkletsCache.h"
+#include "RuntimeDecorator.h"
 #include <jsi/jsi.h>
 #include <memory>
 
@@ -18,7 +19,10 @@ class RuntimeManager {
 public:
   RuntimeManager(std::unique_ptr<jsi::Runtime>&& runtime,
                  std::shared_ptr<ErrorHandler> errorHandler,
-                 std::shared_ptr<Scheduler> scheduler): runtime(std::move(runtime)), errorHandler(errorHandler), scheduler(scheduler), workletsCache(std::make_unique<WorkletsCache>()) { }
+                 std::shared_ptr<Scheduler> scheduler,
+                 RuntimeType runtimeType = RuntimeType::Worklet): runtime(std::move(runtime)), errorHandler(errorHandler), scheduler(scheduler), workletsCache(std::make_unique<WorkletsCache>()) {
+    RuntimeDecorator::registerRuntime(this->runtime.get(), runtimeType);
+  }
 public:
   /**
    Holds the jsi::Function worklet that is responsible for updating values in JS.

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -45,6 +45,11 @@ public:
    Returns true if the given Runtime is the default React-JS Runtime.
    */
   inline static bool isReactRuntime(jsi::Runtime &rt);
+  
+  /**
+   Register the given Runtime. This function is required for every RuntimeManager, otherwise future runtime checks will fail.
+   */
+  static void registerRuntime(jsi::Runtime* runtime, RuntimeType runtimeType);
 
 private:
   static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;


### PR DESCRIPTION
Uses `unordered_map` registration for faster runtime checks (worklet, UI).

Everything is managed by the `RuntimeDecorator`, it's faster because it only compares pointers using an `unordered_map`, and it also works for every worklet runtime (VisionCamera, Multithreading). Also it's less code and the backwards compatible 🤗 