### PR TITLE
Fix bundle reload on iOS, Event handler null check.

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -481,6 +481,9 @@
       if (strongSelf == nil) {
         return;
       }
+      if (eventHandler == nil) {
+        return;
+      }
       eventHandler(eventHash, event);
       if ([strongSelf isDirectEvent:event]) {
         [strongSelf performOperations];


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2031

## Changes

Added null check in dispatchEvent method after RCTExecuteOnMainQueue.

See issue for further details.

