### PR TITLE
Fix hardcrash caused by #1826

### DIFF
--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -306,7 +306,7 @@ function styleUpdater(
 
   // calculate diff
   const diff = styleDiff(oldValues, newValues);
-  state.last = Object.assign({}, oldValues, newValues);
+  state.last = { ...oldValues, ...newValues };
 
   if (Object.keys(diff).length !== 0) {
     updateProps(viewDescriptor, diff, maybeViewRef, adapters);

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -57,7 +57,7 @@ export function decorateAnimation(animation) {
   }
   const baseOnStart = animation.onStart;
   const baseOnFrame = animation.onFrame;
-  const animationCopy = Object.assign({}, animation);
+  const animationCopy = { ...animation };
   delete animationCopy.callback;
 
   const prefNumberSuffOnStart = (
@@ -98,7 +98,7 @@ export function decorateAnimation(animation) {
       }
     }
     tab.forEach((i, index) => {
-      animation[i] = Object.assign({}, animationCopy);
+      animation[i] = { ...animationCopy };
       animation[i].current = HSVACurrent[index];
       animation[i].toValue = HSVAToValue ? HSVAToValue[index] : undefined;
       animation[i].onStart(


### PR DESCRIPTION
## Description
This is a fix for issue https://github.com/software-mansion/react-native-reanimated/issues/1826 and  https://github.com/GetStream/stream-chat-react-native/issues/640 

Issue 1826 described the solution for this problem and the symptoms I was seeing are described in issue 640.

## Changes
Make copy of objects with spread operator as per the description in issue 1826
### Before
Before I would get a hard crash of my App.
### After
After the fix my app works again

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
