### PR TITLE
fix: animated react native svg web

### DIFF
--- a/src/reanimated2/js-reanimated/index.web.ts
+++ b/src/reanimated2/js-reanimated/index.web.ts
@@ -18,7 +18,22 @@ export const _updatePropsJS = (_viewTag, _viewName, updates, viewRef) => {
       [{}, {}]
     );
 
-    viewRef.current._component.setNativeProps({ style: rawStyles });
+    if (typeof viewRef.current._component.setNativeProps === 'function') {
+      viewRef.current._component.setNativeProps({ style: rawStyles });
+    } else if (Object.keys(viewRef.current._component.props).length > 0) {
+      Object.keys(viewRef.current._component.props).forEach((key) => {
+        if (!rawStyles[key]) {
+          return;
+        }
+        const dashedKey = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+        viewRef.current._component._touchableNode.setAttribute(
+          dashedKey,
+          rawStyles[key]
+        );
+      });
+    } else {
+      console.warn('It is not possible to manipulate component');
+    }
   }
 };
 


### PR DESCRIPTION
## Description

Add the ability to animate svg components with `createAnimatedComponent` on the web.
Cf : https://github.com/software-mansion/react-native-reanimated/issues/1951

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [X] Ensured that CI passes
