### PR TITLE
Wrap in animation if needed && export Layout [Layout Animations]

### DIFF
--- a/Example/src/LayoutReanimation/Carousel.tsx
+++ b/Example/src/LayoutReanimation/Carousel.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, Button, StyleSheet, Image } from 'react-native';
 import Animated, { 
     Layout,
-    SlideInRight,
+    SlideInLeft,
     SlideOutRight,
     AnimatedLayout,
 } from 'react-native-reanimated';
@@ -33,9 +33,9 @@ const DATA = [
 function AnimatedView({pokemon}) {
 
     return (
-        <Animated.View entering={SlideInRight} exiting={SlideOutRight} style={[styles.animatedView]} >
-            <AnimatedImage entering={SlideInRight.delay(300).springify()} source={pokemon.img} />
-            <Animated.View entering={SlideInRight.delay(500).springify()} exiting={SlideOutRight}>
+        <Animated.View entering={SlideInLeft} exiting={SlideOutRight} style={[styles.animatedView]} >
+            <AnimatedImage entering={SlideInLeft.delay(300).springify()} source={pokemon.img} />
+            <Animated.View entering={SlideInLeft.delay(500).springify()} exiting={SlideOutRight}>
                 <Text> { pokemon.firstType } </Text>
                 <Text> { pokemon.secondType }</Text>
             </Animated.View>

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -166,6 +166,84 @@ export function cancelAnimation(sharedValue) {
   sharedValue.value = sharedValue.value; // eslint-disable-line no-self-assign
 }
 
+// TODO it should work only if there was no animation before.
+export function withStartValue(startValue, animation) {
+  'worklet';
+  return defineAnimation(startValue, () => {
+    'worklet';
+    if (!_WORKLET && typeof animation === 'function') {
+      animation = animation();
+    }
+    animation.current = startValue;
+    return animation;
+  });
+}
+
+export function withTiming(toValue, userConfig, callback) {
+  'worklet';
+
+  return defineAnimation(toValue, () => {
+    'worklet';
+    const config = {
+      duration: 300,
+      easing: Easing.inOut(Easing.quad),
+    };
+    if (userConfig) {
+      Object.keys(userConfig).forEach((key) => (config[key] = userConfig[key]));
+    }
+
+    function timing(animation, now) {
+      const { toValue, progress, startTime, current } = animation;
+
+      const runtime = now - startTime;
+
+      if (runtime >= config.duration) {
+        // reset startTime to avoid reusing finished animation config in `start` method
+        animation.startTime = 0;
+        animation.current = toValue;
+        return true;
+      }
+
+      const newProgress = config.easing(runtime / config.duration);
+
+      const dist =
+        ((toValue - current) * (newProgress - progress)) / (1 - progress);
+      animation.current += dist;
+      animation.progress = newProgress;
+      return false;
+    }
+
+    function onStart(animation, value, now, previousAnimation) {
+      if (
+        previousAnimation &&
+        previousAnimation.type === 'timing' &&
+        previousAnimation.toValue === toValue &&
+        previousAnimation.startTime
+      ) {
+        // to maintain continuity of timing animations we check if we are starting
+        // new timing over the old one with the same parameters. If so, we want
+        // to copy animation timeline properties
+        animation.startTime = previousAnimation.startTime;
+        animation.progress = previousAnimation.progress;
+      } else {
+        animation.startTime = now;
+        animation.progress = 0;
+      }
+      animation.current = value;
+    }
+
+    return {
+      type: 'timing',
+      onFrame: timing,
+      onStart,
+      progress: 0,
+      toValue,
+      current: toValue,
+      callback,
+    };
+  });
+}
+
 export function withStyleAnimation(styleAnimations) {
   'worklet';
   return defineAnimation({}, () => {
@@ -253,7 +331,11 @@ export function withStyleAnimation(styleAnimations) {
             const obj = {};
             obj[type] = prevVal;
             animation.current.transform[i] = obj;
-            const currentAnimation = transform[i][type];
+            let currentAnimation = transform[i][type];
+            if (typeof currentAnimation != 'object' && !Array.isArray(currentAnimation)) {
+              currentAnimation = withTiming(currentAnimation);
+              transform[i][type] = currentAnimation
+            }
             currentAnimation.onStart(
               currentAnimation,
               prevVal,
@@ -278,7 +360,11 @@ export function withStyleAnimation(styleAnimations) {
             prevVal = value[key];
           }
           animation.current[key] = prevVal;
-          const currentAnimation = animation.styleAnimations[key];
+          let currentAnimation = animation.styleAnimations[key];
+          if (typeof currentAnimation != 'object' && !Array.isArray(currentAnimation)) {
+            currentAnimation = withTiming(currentAnimation);
+            animation.styleAnimations[key] = currentAnimation;
+          }
           currentAnimation.onStart(
             currentAnimation,
             prevVal,
@@ -327,83 +413,6 @@ export function withStyleAnimation(styleAnimations) {
   });
 }
 
-// TODO it should work only if there was no animation before.
-export function withStartValue(startValue, animation) {
-  'worklet';
-  return defineAnimation(startValue, () => {
-    'worklet';
-    if (!_WORKLET && typeof animation === 'function') {
-      animation = animation();
-    }
-    animation.current = startValue;
-    return animation;
-  });
-}
-
-export function withTiming(toValue, userConfig, callback) {
-  'worklet';
-
-  return defineAnimation(toValue, () => {
-    'worklet';
-    const config = {
-      duration: 300,
-      easing: Easing.inOut(Easing.quad),
-    };
-    if (userConfig) {
-      Object.keys(userConfig).forEach((key) => (config[key] = userConfig[key]));
-    }
-
-    function timing(animation, now) {
-      const { toValue, progress, startTime, current } = animation;
-
-      const runtime = now - startTime;
-
-      if (runtime >= config.duration) {
-        // reset startTime to avoid reusing finished animation config in `start` method
-        animation.startTime = 0;
-        animation.current = toValue;
-        return true;
-      }
-
-      const newProgress = config.easing(runtime / config.duration);
-
-      const dist =
-        ((toValue - current) * (newProgress - progress)) / (1 - progress);
-      animation.current += dist;
-      animation.progress = newProgress;
-      return false;
-    }
-
-    function onStart(animation, value, now, previousAnimation) {
-      if (
-        previousAnimation &&
-        previousAnimation.type === 'timing' &&
-        previousAnimation.toValue === toValue &&
-        previousAnimation.startTime
-      ) {
-        // to maintain continuity of timing animations we check if we are starting
-        // new timing over the old one with the same parameters. If so, we want
-        // to copy animation timeline properties
-        animation.startTime = previousAnimation.startTime;
-        animation.progress = previousAnimation.progress;
-      } else {
-        animation.startTime = now;
-        animation.progress = 0;
-      }
-      animation.current = value;
-    }
-
-    return {
-      type: 'timing',
-      onFrame: timing,
-      onStart,
-      progress: 0,
-      toValue,
-      current: toValue,
-      callback,
-    };
-  });
-}
 
 export function withSpring(toValue, userConfig, callback) {
   'worklet';

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -333,7 +333,7 @@ export function withStyleAnimation(styleAnimations) {
             animation.current.transform[i] = obj;
             let currentAnimation = transform[i][type];
             if (typeof currentAnimation != 'object' && !Array.isArray(currentAnimation)) {
-              currentAnimation = withTiming(currentAnimation);
+              currentAnimation = withTiming(currentAnimation, { duration: 0 });
               transform[i][type] = currentAnimation
             }
             currentAnimation.onStart(
@@ -362,7 +362,7 @@ export function withStyleAnimation(styleAnimations) {
           animation.current[key] = prevVal;
           let currentAnimation = animation.styleAnimations[key];
           if (typeof currentAnimation != 'object' && !Array.isArray(currentAnimation)) {
-            currentAnimation = withTiming(currentAnimation);
+            currentAnimation = withTiming(currentAnimation, { duration: 0 });
             animation.styleAnimations[key] = currentAnimation;
           }
           currentAnimation.onStart(

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -22,7 +22,7 @@ export class FlipInXUp extends BaseAnimationBuilder {
         },
         animations: {
           transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
+            { perspective: 500 },
             { rotateX: delayFunction(delay, animation('0deg', config)) },
             { translateY: delayFunction(delay, animation(0, config)) },
           ],

--- a/src/reanimated2/layoutReanimation/index.js
+++ b/src/reanimated2/layoutReanimation/index.js
@@ -1,2 +1,3 @@
 export * from './AnimatedRoot';
+export * from './defaultAnimationsBuilder';
 export * from './defaultAnimations';


### PR DESCRIPTION
## Description

Before this pr all properties in animations object returned by animation builder had to be wrapped in animation manually. The pr makes it automatic. 

```js
return (targetValues) => {
      'worklet';
      return {
        initialValues:{
          transform: [
            { perspective: 500 },
            { rotateX: '90deg'},
            { translateY: -targetValues.height },
          ],
        },
        animations: {
          transform: [
            { perspective: 500 },
            { rotateX: delayFunction(delay, animation('0deg', config)) },
            { translateY: delayFunction(delay, animation(0, config)) },
          ],
        }
      }
    };
```

+ some Example's fixes and exporting Layout

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
