### PR TITLE
Fix, replace for..of on for loop

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -704,7 +704,8 @@ const getInterpolateCacheRGBA = (
   const g = [];
   const b = [];
   const a = [];
-  for (const color of colors) {
+  for (let i = 0; i < colors.length; i += 1) {
+    const color = colors[i];
     const proocessedColor = processColor(color);
     if (proocessedColor) {
       r.push(red(proocessedColor));
@@ -747,7 +748,8 @@ const getInterpolateCacheHSV = (
   const h = [];
   const s = [];
   const v = [];
-  for (const color of colors) {
+  for (let i = 0; i < colors.length; i += 1) {
+    const color = colors[i];
     const proocessedColor = RGBtoHSV(processColor(color) as any);
     if (proocessedColor) {
       h.push(proocessedColor.h);

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -704,7 +704,7 @@ const getInterpolateCacheRGBA = (
   const g = [];
   const b = [];
   const a = [];
-  for (let i = 0; i < colors.length; i += 1) {
+  for (let i = 0; i < colors.length; ++i) {
     const color = colors[i];
     const proocessedColor = processColor(color);
     if (proocessedColor) {
@@ -748,7 +748,7 @@ const getInterpolateCacheHSV = (
   const h = [];
   const s = [];
   const v = [];
-  for (let i = 0; i < colors.length; i += 1) {
+  for (let i = 0; i < colors.length; ++i) {
     const color = colors[i];
     const proocessedColor = RGBtoHSV(processColor(color) as any);
     if (proocessedColor) {

--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -162,7 +162,7 @@ function runAnimations(animation, timestamp, key, result, animationsActive) {
 function isAnimated(prop) {
   'worklet';
   if (Array.isArray(prop)) {
-    for (let i = 0; i < prop.length; i += 1) {
+    for (let i = 0; i < prop.length; ++i) {
       const item = prop[i];
       for (const key in item) {
         if (item[key].onFrame !== undefined) {

--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -163,7 +163,7 @@ function isAnimated(prop) {
   'worklet';
   if (Array.isArray(prop)) {
     for (let i = 0; i < prop.length; i += 1) {
-      const item = prop[i]
+      const item = prop[i];
       for (const key in item) {
         if (item[key].onFrame !== undefined) {
           return true;

--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -162,7 +162,8 @@ function runAnimations(animation, timestamp, key, result, animationsActive) {
 function isAnimated(prop) {
   'worklet';
   if (Array.isArray(prop)) {
-    for (const item of prop) {
+    for (let i = 0; i < prop.length; i += 1) {
+      const item = prop[i]
       for (const key in item) {
         if (item[key].onFrame !== undefined) {
           return true;


### PR DESCRIPTION
## Description
Application crash when using transform or color properties on a style object. Replacing for..of loop on for loop solves it problem.

### Issue
- #2120
- #2125