### PR TITLE
Remove `@next` from docs

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -33,10 +33,10 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 
 :::
 
-First step is to install `react-native-reanimated` alpha as a dependency in your project:
+First step is to install `react-native-reanimated` as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+> yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo


### PR DESCRIPTION
Now that Reanimated 2 is stable, the `@next` suffix can be removed 🎉 