### PR TITLE
Fix web errors

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -12,12 +12,12 @@ import setAndForwardRef from './setAndForwardRef';
 import invariant from 'fbjs/lib/invariant';
 import { adaptViewConfig } from './ConfigHelper';
 import { RNRenderer } from './reanimated2/platform-specific/RNRenderer';
+import { makeMutable, runOnUI } from './reanimated2/core';
 import {
   DefaultEntering,
   DefaultExiting,
   DefaultLayout,
 } from './reanimated2/layoutReanimation/defaultAnimationsBuilder';
-import { makeMutable, runOnUI } from './reanimated2/core';
 
 const NODE_MAPPING = new Map();
 

--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -501,9 +501,10 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
       }
     } else {
       optimalization = 0;
+      const decoratedUpadterFn = upadterFn;
       upadterFn = () => {
         'worklet';
-        const style = upadterFn();
+        const style = decoratedUpadterFn();
         parseColors(style);
         return style;
       };

--- a/src/reanimated2/Hooks.ts
+++ b/src/reanimated2/Hooks.ts
@@ -490,7 +490,7 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
       };
     }
 
-    if (canApplyOptimalisation(upadterFn)) {
+    if (canApplyOptimalisation(upadterFn) && Platform.OS !== 'web') {
       if (hasColorProps(upadterFn())) {
         upadterFn = () => {
           'worklet';
@@ -499,17 +499,18 @@ export function useAnimatedStyle(updater, dependencies, adapters) {
           return style;
         };
       }
-    } else {
+    } else if (Platform.OS !== 'web') {
       optimalization = 0;
-      const decoratedUpadterFn = upadterFn;
       upadterFn = () => {
         'worklet';
-        const style = decoratedUpadterFn();
+        const style = upadterFn();
         parseColors(style);
         return style;
       };
     }
-    upadterFn.__optimalization = optimalization;
+    if (typeof updater.__optimalization !== undefined) {
+      upadterFn.__optimalization = optimalization;
+    }
 
     if (process.env.JEST_WORKER_ID) {
       fun = () => {

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -198,7 +198,6 @@ export const setUpTests = (userConfig = {}) => {
     }
     return module.default;
   });
-  require('./core');
 };
 
 export const getAnimatedStyle = (received) => {

--- a/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
+++ b/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
@@ -1,14 +1,20 @@
 /* global _stopObservingProgress, _startObservingProgress */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { requireNativeComponent } from 'react-native';
+import { Platform, requireNativeComponent } from 'react-native';
 import React from 'react';
 import { runOnUI } from '../core';
 import { withStyleAnimation } from '../animations';
 
-const REALayoutView = (requireNativeComponent(
-  'REALayoutView'
-) as any) as React.Component;
+let REALayoutView;
+if (Platform.OS === 'web' && !requireNativeComponent) {
+  REALayoutView = React.Component;
+} else {
+  REALayoutView = (requireNativeComponent(
+    'REALayoutView'
+  ) as any) as React.Component;
+}
+
 export class AnimatedLayout extends React.Component<
   Record<string, unknown>,
   Record<string, unknown>


### PR DESCRIPTION
## Description

Issues:
- for web, we shouldn't process color to integer representation - I removed color processing for the web implementations
- for web the `requireNativeComponent`method is not defined - I added check for the web platform
- default animation requires `global. __reanimatedWorkletInit` - I changed the order of imports