### PR TITLE
Fixed Typo in AnimatedLayout.md

### DIFF
--- a/docs/docs/api/LayoutAnimations/AnimatedLayout.md
+++ b/docs/docs/api/LayoutAnimations/AnimatedLayout.md
@@ -9,7 +9,7 @@ The `AnimatedLayout` component is responsible for observing changes in its subtr
 
 
 ## Example
-You can use `AnimatedLayout` as regural React component and his hildren can use by transitions and mounting/unmpunting animations.
+You can use `AnimatedLayout` as regural React component and his children can use by transitions and mounting/unmpunting animations.
 
 ```js
     import { AnimatedLayout } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.3.0-alpha.1/api/LayoutAnimations/AnimatedLayout.md
+++ b/docs/versioned_docs/version-2.3.0-alpha.1/api/LayoutAnimations/AnimatedLayout.md
@@ -9,7 +9,7 @@ The `AnimatedLayout` component is responsible for observing changes in its subtr
 
 
 ## Example
-You can use `AnimatedLayout` as regural React component and his hildren can use by transitions and mounting/unmpunting animations.
+You can use `AnimatedLayout` as regural React component and his children can use by transitions and mounting/unmpunting animations.
 
 ```js
     import { AnimatedLayout } from 'react-native-reanimated';


### PR DESCRIPTION
## Description
Fixed a typo in documentation of `<AnimatedLayout>`

## Changes
Fixed Typo in `AnimatedLayout.md` in two locations.
1. In docs/docs/api/LayoutAnimations/AnimatedLayout.md
2. in docs/versioned_docs/version-2.3.0-alpha.1/api/LayoutAnimations/AnimatedLayout.md

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
