### PR TITLE
chore: improve parameter naming in TS typings

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -416,8 +416,8 @@ declare module 'react-native-reanimated' {
     // reanimated2 derived operations
     export function interpolate(
       x: number,
-      input: Array<number>,
-      output: Array<number>,
+      inputRange: Array<number>,
+      outputRange: Array<number>,
       type?: ExtrapolateParameter
     ): number;
 


### PR DESCRIPTION
## Description

`outputRange` is a little better name than `output` :), plus this unifies the naming of params to `interpolation` so that it's the same as in `interpolateColor` and others. 

## Screenshots / GIFs

### Before

<img width="556" alt="Screen Shot 2021-06-11 at 11 07 32" src="https://user-images.githubusercontent.com/1566403/121662470-ac0ed580-caa5-11eb-98d3-f2f3a15cfbb2.png">


### After

<img width="570" alt="Screen Shot 2021-06-11 at 11 08 07" src="https://user-images.githubusercontent.com/1566403/121662498-b335e380-caa5-11eb-8ef7-3fe4a27ad25f.png">


## Test code and steps to reproduce

tested in IDE locally

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
