### PR TITLE
Find App module instead of hardcoding it

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -7,8 +7,12 @@ def reactNativeVersion = json.version as String
 def (major, minor, patch) = reactNativeVersion.tokenize('.')
 
 def engine = "jsc"
-if (project(':app').ext.react.enableHermes) {
-    engine = "hermes"
-}
+rootProject.getSubprojects().forEach({project ->
+    if (project.plugins.hasPlugin("com.android.application")) {
+        if(project.ext.react.enableHermes) {
+            engine = "hermes"
+        }
+    }
+})
 
 artifacts.add("default", file("react-native-reanimated-${minor}-${engine}.aar"))


### PR DESCRIPTION
## Description
Problem: An application module can have different name than `:App` and currently, we are only looking for enableHermes property in `:App` module.
Fixes: https://github.com/software-mansion/react-native-reanimated/issues/2129
To find App module I iterate over all modules and choose the one with `com.android.application` plugin applied as only application module can apply it.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
