### PR TITLE
Fix ios crash

### DIFF
--- a/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -7,7 +7,7 @@ std::shared_ptr<StaticStoreUser> StoreUser::staticStoreUserData = std::make_shar
 std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
   const std::lock_guard<std::recursive_mutex> lock(storeUserData->storeMutex);
   if (storeUserData->store.count(identifier) == 0) {
-      storeUserData->store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
+    storeUserData->store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
   }
   std::shared_ptr<jsi::Value> sv = std::make_shared<jsi::Value>(rt, jsi::Value::undefined());
   storeUserData->store[identifier].push_back(sv);

--- a/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -2,33 +2,32 @@
 
 namespace reanimated {
 
-std::atomic<int> StoreUser::ctr;
-std::recursive_mutex StoreUser::storeMutex;
-std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> StoreUser::store;
+std::shared_ptr<StaticStoreUser> StoreUser::staticStoreUserData = std::make_shared<StaticStoreUser>();
 
 std::weak_ptr<jsi::Value> StoreUser::getWeakRef(jsi::Runtime &rt) {
-  const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-  if (StoreUser::store.count(identifier) == 0) {
-    StoreUser::store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
+  const std::lock_guard<std::recursive_mutex> lock(storeUserData->storeMutex);
+  if (storeUserData->store.count(identifier) == 0) {
+      storeUserData->store[identifier] = std::vector<std::shared_ptr<jsi::Value>>();
   }
   std::shared_ptr<jsi::Value> sv = std::make_shared<jsi::Value>(rt, jsi::Value::undefined());
-  StoreUser::store[identifier].push_back(sv);
+  storeUserData->store[identifier].push_back(sv);
   
   return sv;
 }
 
 StoreUser::StoreUser(std::shared_ptr<Scheduler> s): scheduler(s) {
-  identifier = StoreUser::ctr++;
+  storeUserData = StoreUser::staticStoreUserData;
+  identifier = storeUserData->ctr++;
 }
 
 StoreUser::~StoreUser() {
   int id = identifier;
   std::shared_ptr<Scheduler> strongScheduler = scheduler.lock();
   if (strongScheduler != nullptr) {
-    strongScheduler->scheduleOnUI([id]() {
-      const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-      if (StoreUser::store.count(id) > 0) {
-        StoreUser::store.erase(id);
+    strongScheduler->scheduleOnUI([id, this]() {
+      const std::lock_guard<std::recursive_mutex> lock(storeUserData->storeMutex);
+      if (storeUserData->store.count(id) > 0) {
+        storeUserData->store.erase(id);
       }
     });
   }
@@ -36,8 +35,8 @@ StoreUser::~StoreUser() {
 
 
 void StoreUser::clearStore() {
-  const std::lock_guard<std::recursive_mutex> lock(storeMutex);
-  StoreUser::store.clear();
+  const std::lock_guard<std::recursive_mutex> lock(StoreUser::staticStoreUserData->storeMutex);
+  StoreUser::staticStoreUserData->store.clear();
 }
 
 }

--- a/Common/cpp/headers/Tools/JSIStoreValueUser.h
+++ b/Common/cpp/headers/Tools/JSIStoreValueUser.h
@@ -13,11 +13,15 @@ using namespace facebook;
 
 namespace reanimated {
 
+struct StaticStoreUser {
+    std::atomic<int> ctr;
+    std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
+    std::recursive_mutex storeMutex;
+};
+
 class StoreUser {
   int identifier = 0;
-  static std::atomic<int> ctr;
-  static std::unordered_map<int, std::vector<std::shared_ptr<jsi::Value>>> store;
-  static std::recursive_mutex storeMutex;
+  std::shared_ptr<StaticStoreUser> staticStoreUserData;
   std::weak_ptr<Scheduler> scheduler;
   
 public:

--- a/Common/cpp/headers/Tools/JSIStoreValueUser.h
+++ b/Common/cpp/headers/Tools/JSIStoreValueUser.h
@@ -21,7 +21,8 @@ struct StaticStoreUser {
 
 class StoreUser {
   int identifier = 0;
-  std::shared_ptr<StaticStoreUser> staticStoreUserData;
+  static std::shared_ptr<StaticStoreUser> staticStoreUserData;
+  std::shared_ptr<StaticStoreUser> storeUserData;
   std::weak_ptr<Scheduler> scheduler;
   
 public:

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -312,8 +312,9 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (2.17.1):
+  - RNScreens (3.4.0):
     - React-Core
+    - React-RCTImage
   - RNSVG (12.1.0):
     - React
   - Yoga (1.14.0)
@@ -464,7 +465,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 5e58135436aacc1c5d29b75547d3d2b9430d052c
   RNReanimated: 833ebd229b31e18a8933ebd0cd744a0f47d88c42
-  RNScreens: b6c9607e6fe47c1b6e2f1910d2acd46dd7ecea3a
+  RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 


### PR DESCRIPTION
## Description

fixes: https://github.com/software-mansion/react-native-reanimated/issues/2092
As you can see in the stack trace from the issue static object are deallocated before StoreUser destructor is called. 
It seems like the problem only occurs when a user closes an app. However, it's still a serious problem as crashing apps are treated differently on iOS. In order to get rid of the problem, I store old static members as one object which is kept as shared_ptr instance field. 

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
