### PR TITLE
Replace inner timing function

### DIFF
--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -193,7 +193,7 @@ export function withTiming(toValue, userConfig, callback) {
     }
 
     function timing(animation, now) {
-      const { toValue, progress, startTime, current } = animation;
+      const { toValue, progress, startTime, startValue } = animation;
       const runtime = now - startTime;
 
       if (runtime >= config.duration) {
@@ -202,10 +202,8 @@ export function withTiming(toValue, userConfig, callback) {
         animation.current = toValue;
         return true;
       }
-
       const newProgress = animation.easing(runtime / config.duration);
-      animation.current +=
-        ((toValue - current) * (newProgress - progress)) / (1 - progress);
+      animation.current = startValue + (toValue - startValue) * progress;
       animation.progress = newProgress;
       return false;
     }
@@ -222,9 +220,11 @@ export function withTiming(toValue, userConfig, callback) {
         // to copy animation timeline properties
         animation.startTime = previousAnimation.startTime;
         animation.progress = previousAnimation.progress;
+        animation.startValue = previousAnimation.startValue;
       } else {
         animation.startTime = now;
         animation.progress = 0;
+        animation.startValue = value;
       }
       animation.current = value;
       if (typeof config.easing === 'object') {

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -193,7 +193,7 @@ export function withTiming(toValue, userConfig, callback) {
     }
 
     function timing(animation, now) {
-      const { toValue, progress, startTime, startValue } = animation;
+      const { toValue, startTime, startValue } = animation;
       const runtime = now - startTime;
 
       if (runtime >= config.duration) {
@@ -202,9 +202,8 @@ export function withTiming(toValue, userConfig, callback) {
         animation.current = toValue;
         return true;
       }
-      const newProgress = animation.easing(runtime / config.duration);
+      const progress = animation.easing(runtime / config.duration);
       animation.current = startValue + (toValue - startValue) * progress;
-      animation.progress = newProgress;
       return false;
     }
 
@@ -219,11 +218,9 @@ export function withTiming(toValue, userConfig, callback) {
         // new timing over the old one with the same parameters. If so, we want
         // to copy animation timeline properties
         animation.startTime = previousAnimation.startTime;
-        animation.progress = previousAnimation.progress;
         animation.startValue = previousAnimation.startValue;
       } else {
         animation.startTime = now;
-        animation.progress = 0;
         animation.startValue = value;
       }
       animation.current = value;


### PR DESCRIPTION
## Description

In timing animation, we use the following function to compute the value for the current frame of animation:
```js
animation.current += ((toValue - current) * (newProgress - progress)) / (1 - progress);
```
But these function has asymptote in `progress = 1` and value 1 is inside function's domain. In summary, if progress was equal to 1 we had division by 0 in consequence `animation.current` was `NaN`. Android can't handle style with `NaN` value and this was a cause of blinking.

I decided to change this function to a complementary form without asymptote:
```js
animation.current = startValue + (toValue - startValue) * progress;
```

another possible solution (but imo worst):
```js
const a = ((toValue - current) * (newProgress - progress)) / (1 - (progress == 1 ? 1 + Number.EPSILON : progress))
```

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2079

