### PR TITLE
Handling JSError on iOS

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -39,12 +39,6 @@ void freeze(jsi::Runtime &rt, jsi::Object &obj) {
   freeze.call(rt, obj);
 }
 
-void on_sigabrt (int signum)
-{
-//    signal (signum, SIG_DFL);
-//    longjmp (env, 1);
-}
-
 void ShareableValue::adaptCache(jsi::Runtime &rt, const jsi::Value &value) {
   // when adapting from host object we can assign cached value immediately such that we avoid
   // running `toJSValue` in the future when given object is accessed

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -443,8 +443,9 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
 std::string ShareableValue::demangleExceptionName(std::string toDemangle) {
   int status = 0;
   char * buff = __cxxabiv1::__cxa_demangle(toDemangle.c_str(), nullptr, nullptr, &status);
-  if (!buff)
+  if (!buff) {
     return toDemangle;
+  }
   std::string demangled = buff;
   std::free(buff);
   return demangled;

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -38,6 +38,7 @@ private:
   jsi::Object createHost(jsi::Runtime &rt, std::shared_ptr<jsi::HostObject> host);
   void adapt(jsi::Runtime &rt, const jsi::Value &value, ValueType objectType);
   void adaptCache(jsi::Runtime &rt, const jsi::Value &value);
+  std::string demangleExceptionName(std::string toDemangle);
 
 public:
   ValueType type = ValueType::UndefinedType;


### PR DESCRIPTION
## Description

Now on iOS is possible to catch JSError thrown from the worklet.

## Example
```js
const a = () => {
  'worklet';
  throw new Error('exception_message')
}

const style = useAnimatedStyle(() => {
  'worklet'
  if(_WORKLET) {
    try {
      a();
    } 
    catch(e) {
      console.log("SUCCESS!", e.message)
    }
  }

  return {
    width: withTiming(sv.value),
  };
});
```