### PR TITLE
fix for using hermes on iOS 0.65 after the headers update

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags
   s.xcconfig               = {
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\"",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
                                "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags  }
 
   s.requires_arc = true

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -11,7 +11,9 @@
 #import "REAAnimationsManager.h"
 #import "REAReactBatchObserver.h"
 
-#if __has_include(<hermes/hermes.h>)
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#import <reacthermes/HermesExecutorFactory.h>
+#elif __has_include(<hermes/hermes.h>)
 #import <hermes/hermes.h>
 #else
 #import <jsi/JSCRuntime.h>
@@ -113,8 +115,9 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
       return val;
   };
 
-
-#if __has_include(<hermes/hermes.h>)
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+  std::shared_ptr<jsi::Runtime> animatedRuntime = facebook::hermes::makeHermesRuntime();
+#elif __has_include(<hermes/hermes.h>)
   std::shared_ptr<jsi::Runtime> animatedRuntime = facebook::hermes::makeHermesRuntime();
 #else
   std::shared_ptr<jsi::Runtime> animatedRuntime = facebook::jsc::makeJSCRuntime();

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -15,7 +15,10 @@
 #import <ReactCommon/BridgeJSCallInvoker.h>
 #endif
 
-#if __has_include(<React/HermesExecutorFactory.h>)
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#import <reacthermes/HermesExecutorFactory.h>
+typedef HermesExecutorFactory ExecutorFactory;
+#elif __has_include(<React/HermesExecutorFactory.h>)
 #import <React/HermesExecutorFactory.h>
 typedef HermesExecutorFactory ExecutorFactory;
 #else


### PR DESCRIPTION
## Description

RN 0.65 has updated the way hermes header are being imported
Context: See https://github.com/facebook/react-native/commit/59abb5f378e116288cdea2f619de0c128bb0b0eb 

## Changes

added a third statement for backward compat
