### PR TITLE
Building script for RN65

### DIFF
--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -6,10 +6,10 @@ ROOT=$(pwd)
 
 unset CI
 
-versions=("0.64.1" "0.63.3" "0.62.2 --dev")
-version_name=("64" "63" "62")
+versions=("0.65.0-rc.2" "0.64.1" "0.63.3" "0.62.2 --dev")
+version_name=("65" "64" "63" "62")
 
-for index in {0..2}
+for index in {0..3}
 do
   yarn add react-native@"${versions[$index]}"
   for for_hermes in "True" "False"


### PR DESCRIPTION
## Description

Currently, I added once again aar to the building script but I think that we need to consider how to limit the number of aars in the reanimated package.
I tested `rea.65.aar` on RN64 app but unfortunately, it doesn't work.
