### PR TITLE
Babel plugin update

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,10 +1,8 @@
 'use strict';
 const generate = require('@babel/generator').default;
 const hash = require('string-hash-64');
-const { visitors } = require('@babel/traverse');
 const traverse = require('@babel/traverse').default;
-const parse = require('@babel/parser').parse;
-const { transformSync } = require("@babel/core");
+const { transformSync } = require('@babel/core');
 /**
  * holds a map of function names as keys and array of argument indexes as values which should be automatically workletized(they have to be functions)(starting from 0)
  */
@@ -268,7 +266,10 @@ function buildWorkletString(t, fun, closureVariables, name) {
   const workletFunction = t.functionExpression(
     t.identifier(name),
     fun.program.body[0].expression.params,
-    prependClosureVariablesIfNecessary(closureVariables, fun.program.body[0].expression.body)
+    prependClosureVariablesIfNecessary(
+      closureVariables,
+      fun.program.body[0].expression.body
+    )
   );
 
   return generate(workletFunction, { compact: true }).code;
@@ -289,13 +290,13 @@ function processWorkletFunction(t, fun, fileName, options = {}) {
   const code = '\n(' + fun.toString() + '\n)';
   const transformed = transformSync(code, {
     filename: fileName,
-    "presets": ["@babel/preset-typescript"],
-    "plugins": [
-      "@babel/plugin-transform-shorthand-properties",
-      "@babel/plugin-transform-arrow-functions", 
-      "@babel/plugin-proposal-optional-chaining",
-      "@babel/plugin-proposal-nullish-coalescing-operator",
-      ["@babel/plugin-transform-template-literals", { "loose": true }],
+    presets: ['@babel/preset-typescript'],
+    plugins: [
+      '@babel/plugin-transform-shorthand-properties',
+      '@babel/plugin-transform-arrow-functions',
+      '@babel/plugin-proposal-optional-chaining',
+      '@babel/plugin-proposal-nullish-coalescing-operator',
+      ['@babel/plugin-transform-template-literals', { loose: true }],
     ],
     ast: true,
     babelrc: false,
@@ -362,8 +363,18 @@ function processWorkletFunction(t, fun, fileName, options = {}) {
 
   const privateFunctionId = t.identifier('_f');
   const clone = t.cloneNode(fun.node);
-  const funExpression = t.functionExpression(null, clone.params, clone.body);
-  const funString = buildWorkletString(t, transformed.ast, variables, functionName).replace("'worklet';", '');
+  let funExpression;
+  if (clone.body.type === 'BlockStatement') {
+    funExpression = t.functionExpression(null, clone.params, clone.body);
+  } else {
+    funExpression = clone;
+  }
+  const funString = buildWorkletString(
+    t,
+    transformed.ast,
+    variables,
+    functionName
+  ).replace("'worklet';", '');
   const workletHash = hash(funString);
 
   const loc = fun && fun.node && fun.node.loc && fun.node.loc.start;
@@ -530,8 +541,8 @@ function processWorklets(t, path, fileName) {
   }
 }
 
-const FUNCTIONLESS_FLAG =   0b00000001;
-const STATEMENTLESS_FLAG =  0b00000010;
+const FUNCTIONLESS_FLAG = 0b00000001;
+const STATEMENTLESS_FLAG = 0b00000010;
 
 function isPossibleOptimization(fun) {
   let isFunctionCall = false;
@@ -562,8 +573,8 @@ module.exports = function ({ types: t }) {
       // allows adding custom globals such as host-functions
       if (this.opts != null && Array.isArray(this.opts.globals)) {
         this.opts.globals.forEach((name) => {
-          globals.add(name)
-        })
+          globals.add(name);
+        });
       }
     },
     visitor: {


### PR DESCRIPTION
## Description

AST body of expression: `() => ({})` isn't `BlockStatement` but `ObjectExpression`, so I added check for this. The problem occurred in ExtrapolationExample.