### PR TITLE
Remove dependency on `fbjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   "homepage": "https://github.com/software-mansion/react-native-reanimated#readme",
   "dependencies": {
     "@babel/plugin-transform-object-assign": "^7.10.4",
-    "fbjs": "^3.0.0",
+    "invariant": "^2.2.4",
+    "lodash.isequal": "^4.5.0",
     "mockdate": "^3.0.2",
     "string-hash-64": "^1.0.3"
   },

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -9,7 +9,7 @@ import { createOrReusePropsNode } from './reanimated1/core/AnimatedProps';
 import WorkletEventHandler from './reanimated2/WorkletEventHandler';
 import setAndForwardRef from './setAndForwardRef';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { adaptViewConfig } from './ConfigHelper';
 import { RNRenderer } from './reanimated2/platform-specific/RNRenderer';
 import { makeMutable, runOnUI } from './reanimated2/core';

--- a/src/reanimated1/core/AnimatedAlways.js
+++ b/src/reanimated1/core/AnimatedAlways.js
@@ -1,5 +1,5 @@
 import AnimatedNode from './AnimatedNode';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { val } from '../val';
 
 class AnimatedAlways extends AnimatedNode {

--- a/src/reanimated1/core/AnimatedBezier.js
+++ b/src/reanimated1/core/AnimatedBezier.js
@@ -1,6 +1,6 @@
 import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 // These values are established by empiricism with tests (tradeoff: performance VS precision)
 var NEWTON_ITERATIONS = 4;

--- a/src/reanimated1/core/AnimatedBlock.js
+++ b/src/reanimated1/core/AnimatedBlock.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
 import InternalAnimatedValue from './InternalAnimatedValue';

--- a/src/reanimated1/core/AnimatedCall.js
+++ b/src/reanimated1/core/AnimatedCall.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import ReanimatedEventEmitter from '../../ReanimatedEventEmitter';
 import { val } from '../val';
 import AnimatedNode from './AnimatedNode';

--- a/src/reanimated1/core/AnimatedCallFunc.js
+++ b/src/reanimated1/core/AnimatedCallFunc.js
@@ -1,7 +1,7 @@
 import AnimatedNode, { getCallID, setCallID } from './AnimatedNode';
 import { adapt } from './AnimatedBlock';
 import { val } from '../val';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 class AnimatedCallFunc extends AnimatedNode {
   _previousCallID;

--- a/src/reanimated1/core/AnimatedConcat.js
+++ b/src/reanimated1/core/AnimatedConcat.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { adapt } from '../core/AnimatedBlock';
 import AnimatedNode from './AnimatedNode';
 import { val } from '../val';

--- a/src/reanimated1/core/AnimatedCond.js
+++ b/src/reanimated1/core/AnimatedCond.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { adapt } from '../core/AnimatedBlock';
 import { val } from '../val';
 import AnimatedNode from './AnimatedNode';

--- a/src/reanimated1/core/AnimatedDebug.js
+++ b/src/reanimated1/core/AnimatedDebug.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { NativeModules } from 'react-native';
 import { val } from '../val';
 import { adapt, createAnimatedBlock as block } from './AnimatedBlock';

--- a/src/reanimated1/core/AnimatedEvent.js
+++ b/src/reanimated1/core/AnimatedEvent.js
@@ -5,7 +5,7 @@ import AnimatedNode from './AnimatedNode';
 import InternalAnimatedValue from './AnimatedValue';
 import { createAnimatedAlways } from './AnimatedAlways';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import createEventObjectProxyPolyfill from './createEventObjectProxyPolyfill';
 
 function sanitizeArgMapping(argMapping) {

--- a/src/reanimated1/core/AnimatedFunction.js
+++ b/src/reanimated1/core/AnimatedFunction.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import { createAnimatedCallFunc } from './AnimatedCallFunc';
 import { createAnimatedParam } from './AnimatedParam';
 import { val } from '../val';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 class AnimatedFunction extends AnimatedNode {
   _what;

--- a/src/reanimated1/core/AnimatedOperator.js
+++ b/src/reanimated1/core/AnimatedOperator.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { adapt } from '../core/AnimatedBlock';
 
 function reduce(fn) {

--- a/src/reanimated1/core/AnimatedParam.js
+++ b/src/reanimated1/core/AnimatedParam.js
@@ -1,4 +1,4 @@
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import AnimatedNode, { getCallID, setCallID } from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import { val } from '../val';

--- a/src/reanimated1/core/AnimatedProps.js
+++ b/src/reanimated1/core/AnimatedProps.js
@@ -4,8 +4,8 @@ import AnimatedNode from './AnimatedNode';
 import AnimatedEvent from './AnimatedEvent';
 import { createOrReuseStyleNode } from './AnimatedStyle';
 
-import invariant from 'fbjs/lib/invariant';
-import deepEqual from 'fbjs/lib/areEqual';
+import invariant from 'invariant';
+import deepEqual from 'lodash.isequal';
 import { val } from '../val';
 
 function sanitizeProps(inputProps) {

--- a/src/reanimated1/core/AnimatedSet.js
+++ b/src/reanimated1/core/AnimatedSet.js
@@ -1,5 +1,5 @@
 import AnimatedNode from './AnimatedNode';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 import { val } from '../val';
 import { adapt } from '../core/AnimatedBlock';
 

--- a/src/reanimated1/core/AnimatedStartClock.js
+++ b/src/reanimated1/core/AnimatedStartClock.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import { AnimatedParam } from './AnimatedParam';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 class AnimatedStartClock extends AnimatedNode {
   _clockNode;

--- a/src/reanimated1/core/AnimatedStopClock.js
+++ b/src/reanimated1/core/AnimatedStopClock.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import { AnimatedParam } from './AnimatedParam';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 class AnimatedStopClock extends AnimatedNode {
   _clockNode;

--- a/src/reanimated1/core/AnimatedStyle.js
+++ b/src/reanimated1/core/AnimatedStyle.js
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import AnimatedNode from './AnimatedNode';
 import { createOrReuseTransformNode } from './AnimatedTransform';
 
-import deepEqual from 'fbjs/lib/areEqual';
+import deepEqual from 'lodash.isequal';
 
 function sanitizeStyle(inputStyle) {
   let style;

--- a/src/reanimated1/core/AnimatedTransform.js
+++ b/src/reanimated1/core/AnimatedTransform.js
@@ -1,6 +1,6 @@
 import AnimatedNode from './AnimatedNode';
 
-import deepEqual from 'fbjs/lib/areEqual';
+import deepEqual from 'lodash.isequal';
 
 function sanitizeTransform(inputTransform) {
   const outputTransform = [];

--- a/src/reanimated1/core/InternalAnimatedValue.js
+++ b/src/reanimated1/core/InternalAnimatedValue.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 import ReanimatedModule from '../../ReanimatedModule';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 function sanitizeValue(value) {
   return value === null || value === undefined || typeof value === 'string'

--- a/src/reanimated1/core/__mocks__/AnimatedProps.js
+++ b/src/reanimated1/core/__mocks__/AnimatedProps.js
@@ -2,7 +2,7 @@ import AnimatedNode from '../AnimatedNode';
 import AnimatedEvent from '../AnimatedEvent';
 import AnimatedStyle, { createOrReuseStyleNode } from '../AnimatedStyle';
 
-import deepEqual from 'fbjs/lib/areEqual';
+import deepEqual from 'lodash.isequal';
 
 // This file has been mocked as react-native's `findNodeHandle` is returning undefined value;
 // and I became easier to mock whole this file instead of mocking RN

--- a/src/reanimated1/derived/interpolate.js
+++ b/src/reanimated1/derived/interpolate.js
@@ -8,7 +8,7 @@ import {
   lessOrEq,
   eq,
 } from '../operators';
-import invariant from 'fbjs/lib/invariant';
+import invariant from 'invariant';
 
 import AnimatedNode from '../core/AnimatedNode';
 import { createAnimatedCond as cond } from '../core/AnimatedCond';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,7 +3813,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -4533,13 +4533,6 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-cross-fetch@^3.0.4:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
-  dependencies:
-    node-fetch "2.6.1"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -5412,23 +5405,6 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
-
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-
-fbjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.0.tgz#0907067fb3f57a78f45d95f1eacffcacd623c165"
-  integrity sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==
-  dependencies:
-    cross-fetch "^3.0.4"
-    fbjs-css-vars "^1.0.0"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -7176,6 +7152,11 @@ lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
@@ -7742,7 +7723,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0:
+node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -7839,7 +7820,7 @@ ob1@0.64.0:
   resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.64.0.tgz#f254a55a53ca395c4f9090e28a85483eac5eba19"
   integrity sha512-CO1N+5dhvy+MoAwxz8+fymEUcwsT4a+wHhrHFb02LppcJdHxgcBWviwEhUwKOD2kLMQ7ijrrzybOqpGcqEtvpQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -8296,12 +8277,6 @@ process-nextick-args@~2.0.0:
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  dependencies:
-    asap "~2.0.3"
 
 promise@^8.0.3:
   version "8.1.0"
@@ -9039,10 +9014,6 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -9632,11 +9603,6 @@ typescript@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-
-ua-parser-js@^0.7.18:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
## Description

React Native has removed the dependency on `fbjs` for several releases. The library is for sharing JS code between Facebook projects, and is not intended to be used by the broader open-source community.

React Native replaced the implementation for `invariant` a couple years ago, so I used the same replacement:
https://github.com/facebook/react-native/commit/4148976a83ab96029de1b26b515ff95d3cb58c10

## Changes

- Use `invariant` instead of `fbjs/lib/invariant`
- Use `lodash.isequal` instead of `fbjs/lib/areEqual`

## Test code and steps to reproduce

All tests pass

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
