### PR TITLE
[LayoutAnimations] Order in initialValues.transform

### DIFF
--- a/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
+++ b/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
@@ -30,7 +30,7 @@ runOnUI(() => {
     withStyleAnimation requires the same order of object in `animation.transform` as in `initialValues.transform`
   */
   const sortInitialValues = (style) => {
-    if (!style.animations.transform) {
+    if (!style.animations.transform || style.animations.transform.length <= 1) {
       return;
     }
 

--- a/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
+++ b/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
@@ -26,6 +26,33 @@ runOnUI(() => {
 
   const configs: Record<string, any> = {};
 
+  /* 
+    withStyleAnimation requires the same order of object in `animation.transform` as in `initialValues.transform`
+  */
+  const sortInitialValues = (style) => {
+    if (!style.animations.transform) {
+      return;
+    }
+
+    const transformKeysOrder = [];
+    for (const transformObject of style.animations.transform) {
+      transformKeysOrder.push(Object.keys(transformObject)[0]);
+    }
+
+    const transformValues = {};
+    for (const transformObject of style.initialValues.transform) {
+      const key = Object.keys(transformObject)[0];
+      transformValues[key] = transformObject;
+    }
+
+    const transformInitialValues = [];
+    for (const key of transformKeysOrder) {
+      transformInitialValues.push(transformValues[key]);
+    }
+
+    style.initialValues.transform = transformInitialValues;
+  };
+
   global.LayoutAnimationRepository = {
     configs,
     registerConfig(tag, config) {
@@ -44,6 +71,7 @@ runOnUI(() => {
       }
 
       const style = configs[tag][type](yogaValues);
+      sortInitialValues(style);
       const sv: { value: boolean; _value: boolean } = configs[tag].sv;
       _stopObservingProgress(tag, false);
       _startObservingProgress(tag, sv);

--- a/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
+++ b/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
@@ -39,15 +39,15 @@ runOnUI(() => {
       transformKeysOrder.push(Object.keys(transformObject)[0]);
     }
 
-    const transformValues = {};
+    const transformByKey = {};
     for (const transformObject of style.initialValues.transform) {
       const key = Object.keys(transformObject)[0];
-      transformValues[key] = transformObject;
+      transformByKey[key] = transformObject;
     }
 
     const transformInitialValues = [];
     for (const key of transformKeysOrder) {
-      transformInitialValues.push(transformValues[key]);
+      transformInitialValues.push(transformByKey[key]);
     }
 
     style.initialValues.transform = transformInitialValues;


### PR DESCRIPTION
## Description

`withStyleAnimation` requires the same order of objects in `animation.transform` as in `initialValues.transform`
https://github.com/software-mansion/react-native-reanimated/blob/master/src/reanimated2/animations.ts#L328
Without this animation doesn't receive the correct start values, and acting strange. I think it can be really confusing and I decided to add a transformer to keep the same order of objects for arrays.
