### PR TITLE
Override libfbjni.so

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -97,7 +97,9 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-
+    configurations {
+        all*.exclude module: 'fbjni-java-only'
+    }
     defaultConfig {
         applicationId "com.swmansion.reanimated.example"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/Example/src/AnimatedStyleUpdateExample.tsx
+++ b/Example/src/AnimatedStyleUpdateExample.tsx
@@ -14,19 +14,8 @@ function AnimatedStyleUpdateExample(): React.ReactElement {
     duration: 500,
     easing: Easing.bezier(0.5, 0.01, 0, 1),
   };
-  const a = () => {
-    'worklet'
-    throw 'mleko';
-  }
+
   const style = useAnimatedStyle(() => {
-    if(_WORKLET) {
-      try {
-        a();
-      }
-      catch(e) {
-        console.log("ok", e);
-      }
-    }
     return {
       width: withTiming(randomWidth.value, config),
     };

--- a/Example/src/AnimatedStyleUpdateExample.tsx
+++ b/Example/src/AnimatedStyleUpdateExample.tsx
@@ -14,8 +14,19 @@ function AnimatedStyleUpdateExample(): React.ReactElement {
     duration: 500,
     easing: Easing.bezier(0.5, 0.01, 0, 1),
   };
-
+  const a = () => {
+    'worklet'
+    throw 'mleko';
+  }
   const style = useAnimatedStyle(() => {
+    if(_WORKLET) {
+      try {
+        a();
+      }
+      catch(e) {
+        console.log("ok", e);
+      }
+    }
     return {
       width: withTiming(randomWidth.value, config),
     };

--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -8,6 +8,15 @@ def (major, minor, patch) = reactNativeVersion.tokenize('.')
 
 def engine = "jsc"
 rootProject.getSubprojects().forEach({project ->
+    if(project.getProperties().get("android")) {
+        def projectProperties = project.getProperties()
+        if(!projectProperties.get("reanimated")
+          || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
+        ) {
+            project.getProperties().android.packagingOptions.pickFirst("lib/**/libfbjni.so")
+        }
+    }
+
     if (project.plugins.hasPlugin("com.android.application")) {
         if(project.ext.react.enableHermes) {
             engine = "hermes"

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -88,12 +88,6 @@ find_library(
         log
 )
 find_library(
-        FBJNI_LIB
-        fbjni
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
         HERMES_LIB
         hermes
         PATHS ${HERMES_DIR}
@@ -118,16 +112,12 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
-        FBJNI_LIBRARY fbjni
-        PATHS ${libfbjni_link_DIRS}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
         GLOG_LIB 
         glog
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
 )
+find_package(fbjni REQUIRED CONFIG)
 # build shared lib
 
 set_target_properties(${PACKAGE_NAME} PROPERTIES LINKER_LANGUAGE CXX)
@@ -140,7 +130,7 @@ if(${FOR_HERMES})
             ${LOG_LIB}
             ${HERMES_LIB}
             ${GLOG_LIB}
-            ${FBJNI_LIB}
+            fbjni::fbjni
             ${FOLLY_JSON_LIB}
             ${REACT_NATIVE_JNI_LIB}
             android
@@ -151,7 +141,7 @@ else()
             ${LOG_LIB}
             ${JSEXECUTOR_LIB}
             ${GLOG_LIB}
-            ${FBJNI_LIB}
+            fbjni::fbjni
             ${FOLLY_JSON_LIB}
             ${REACT_NATIVE_JNI_LIB}
             android

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,6 +94,9 @@ if(!System.getenv('IS_TRAVIS')) {
 }
 
 android {
+    buildFeatures {
+        prefab true
+    }
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
     buildToolsVersion safeExtGet('buildToolsVersion', '29.0.2')
     defaultConfig {
@@ -438,6 +441,9 @@ task extractSOFiles {
 task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
+    if(REACT_VERSION == 64) {
+        include("**/fbjni.so")
+    }
     if(REACT_VERSION < 64) {
         include("**/libturbomodulejsijni.so")
     }
@@ -460,10 +466,11 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation 'com.facebook.fbjni:fbjni:0.2.2'
+    implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-    extractHeaders("com.facebook.fbjni:fbjni:0.0.2:headers")
-    extractSO("com.facebook.fbjni:fbjni:0.0.2")
+    extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
+    extractSO("com.facebook.fbjni:fbjni:0.2.2")
 
     def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,7 +134,7 @@ android {
     packagingOptions {
         println "Native libs debug enabled: ${debugNativeLibraries}"
         doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
-        excludes = ["**/libc++_shared.so"]
+        excludes = REACT_VERSION < 65 ? ["**/libc++_shared.so"] : ["**/libfbjni.so"]
     }
 
     tasks.withType(JavaCompile) {
@@ -441,9 +441,6 @@ task extractSOFiles {
 task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
-    if(REACT_VERSION == 64) {
-        include("**/libfbjni.so")
-    }
     if(REACT_VERSION < 64) {
         include("**/libturbomodulejsijni.so")
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,7 +134,7 @@ android {
     packagingOptions {
         println "Native libs debug enabled: ${debugNativeLibraries}"
         doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
-        excludes = REACT_VERSION < 65 ? ["**/libc++_shared.so"] : ["**/libfbjni.so"]
+        excludes = REACT_VERSION < 65 ? ["**/libc++_shared.so"] : ["**/libc++_shared.so", "**/libfbjni.so"]
     }
 
     tasks.withType(JavaCompile) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -442,7 +442,7 @@ task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
     if(REACT_VERSION == 64) {
-        include("**/fbjni.so")
+        include("**/libfbjni.so")
     }
     if(REACT_VERSION < 64) {
         include("**/libturbomodulejsijni.so")

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -43,4 +43,6 @@ npm pack
 mv android android-npm
 mv android-temp android
 
+rm -rf ./lib
+
 echo "Done!"


### PR DESCRIPTION
## Description

I added `libfbjni.so` (in version 0.2.2 with dynamic loading of libc++.so) to reanimated aar package. Reanimated will automatically change application configuration and add Gradle option:
```
android {
  ...
  packagingOptions {
    pickFirst 'lib/**/libfbjni.so'
  }
  ...
}
```
To disable this behavior user just need to add to `app/gradle.build` the following config:
```
project.ext.reanimated = [
    enablePackagingOptions: false,
]
```