### PR TITLE
Fixed float with scientific notation to string conversion

### DIFF
--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -17,6 +17,7 @@ export function initialUpdaterRun(updater) {
 
 /*
   converts float to string and removes the scientific notation
+  https://stackoverflow.com/questions/1685680/how-to-avoid-scientific-notation-for-large-numbers-in-javascript/46545519#46545519
 */
 function parseString(num) {
   'worklet';

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -15,6 +15,32 @@ export function initialUpdaterRun(updater) {
   return result;
 }
 
+/*
+  converts float to string and removes the scientific notation
+*/
+function parseString(num) {
+  'worklet';
+  let numStr = num.toString();
+  if (Math.abs(num) < 1.0) {
+    const e = parseInt(num.toString().split('e-')[1]);
+    if (e) {
+      const negative = num < 0;
+      if (negative) num *= -1;
+      num *= Math.pow(10, e - 1);
+      numStr = '0.' + new Array(e).join('0') + num.toString().substring(2);
+      if (negative) numStr = '-' + numStr;
+    }
+  } else {
+    const e = parseInt(num.toString().split('+')[1]);
+    if (e > 20) {
+      e -= 20;
+      num /= Math.pow(10, e);
+      numStr = num.toString() + new Array(e + 1).join('0');
+    }
+  }
+  return numStr;
+}
+
 export function transform(value, handler) {
   'worklet';
   if (value === undefined) {
@@ -38,15 +64,7 @@ export function transform(value, handler) {
     return value;
   }
 
-  return (
-    handler.__prefix +
-    value.toLocaleString('fullwide', {
-      useGrouping: false,
-      maximumFractionDigits: 20,
-      maximumSignificantDigits: 20,
-    }) +
-    handler.__suffix
-  );
+  return handler.__prefix + parseString(value) + handler.__suffix;
 }
 
 export function transformAnimation(animation) {

--- a/src/reanimated2/animations.ts
+++ b/src/reanimated2/animations.ts
@@ -38,7 +38,15 @@ export function transform(value, handler) {
     return value;
   }
 
-  return handler.__prefix + value + handler.__suffix;
+  return (
+    handler.__prefix +
+    value.toLocaleString('fullwide', {
+      useGrouping: false,
+      maximumFractionDigits: 20,
+      maximumSignificantDigits: 20,
+    }) +
+    handler.__suffix
+  );
 }
 
 export function transformAnimation(animation) {


### PR DESCRIPTION
## Description

During animations, property value is often converted between string and float. When the animation value gets too small or too big, it converts to string with scientific notation. It is then interpreted as a value with suffix `e` and is converted back to float without scientific notation which results in the unexpected and rapid change of the animation value. 

![Screenshot 2021-07-22 at 13 01 24](https://user-images.githubusercontent.com/48885911/126641410-f14783fd-c25b-46ab-a9b3-0420c91b0625.png)

I've changed float to string conversion, so it is now converted without scientific notation.

Fixes #2170 

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- changed animation value float to string conversion
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
