### PR TITLE
Fixed callback doesn't run when animating to the same value

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -164,6 +164,7 @@ function workletValueSetter(value) {
     // this happens when the animation's target value(stored in animation.current until animation.onStart is called) is set to the same value as a current one(this._value)
     // built in animations that are not higher order(withTiming, withSpring) hold target value in .current
     if (this._value === animation.current && !animation.isHigherOrder) {
+      animation.callback && animation.callback(true);
       return;
     }
     // animated set

--- a/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
+++ b/src/reanimated2/layoutReanimation/AnimatedRoot.tsx
@@ -54,9 +54,7 @@ runOnUI(() => {
         if (finished) {
           _stopObservingProgress(tag, finished);
         }
-        if (style.callback) {
-          style.callback(finished);
-        }
+        style.callback && style.callback(finished);
       };
       configs[tag].sv.value = animation;
       _startObservingProgress(tag, sv);


### PR DESCRIPTION
## Description

Currently, when the user wants to animate property to the same value as property has, animation doesn't run and so the animation callback. It might be not intuitive so I changed it, and now callback runs even if the new value is the same as the old one.

Fixes #1959 
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- added callback triggering when new value is the same as the old one

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->
