### PR TITLE
Fixed crash on iOS when using AnimatedLayout and React Navigation Native

### DIFF
--- a/ios/LayoutReanimation/REASnapshooter.m
+++ b/ios/LayoutReanimation/REASnapshooter.m
@@ -28,10 +28,12 @@ int Id = 1e9;
   
   if ([view isKindOfClass:[REAAnimationRootView class]]) {
     NSMutableArray * pathToWindow = [NSMutableArray new];
-    UIView *current = view;
+    UIResponder *current = view;
     do {
-      [pathToWindow addObject:current];
-      current = current.superview;
+      if (![current isKindOfClass:[UIViewController class]]) {
+        [pathToWindow addObject:current];
+      }
+      current = current.nextResponder;
     } while (current != windowView);
     values[@"pathToWindow"] = pathToWindow;
   }


### PR DESCRIPTION
## Description

On iOS when using React Navigation Native and AnimatedLayout the app would crash with an 
`NSArrayM insertObject:atIndex:] object cannot be nil` Exception
This was caused by the Snapshoter being unable to build a complete hierarchy of views as it wouldn't be able to navigate past certain viewControllers.
This fix uses `responder` instead of `superview` for its ability to know about views connected to viewControllers (including navigation controllers etc). Note that we now have to filter out UIViewControllers from the returned hierarchy as they were not included when only using `superiew`

Fixes #2124 

## Changes

- Use nextResponder instead of superView to traverse past UIViewControllers.
- Filter out UIViewControllers and subclasses from pathToWindow array.