### PR TITLE
Fix Use of undeclared identifier 'JSIExecutor'

### DIFF
--- a/ios/native/REAInitializer.h
+++ b/ios/native/REAInitializer.h
@@ -13,6 +13,7 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <RNReanimated/REAEventDispatcher.h>
+#import <jsireact/JSIExecutor.h>
 
 #if RNVERSION >= 64
 #import <React/RCTJSIExecutorRuntimeInstaller.h>

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -17,13 +17,13 @@ typedef JSCExecutorFactory ExecutorFactory;
 @implementation UIResponder (Reanimated)
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-  const auto executor = reanimated::REAJSIExecutorRuntimeInstaller(bridge, NULL);
+  const auto installer = reanimated::REAJSIExecutorRuntimeInstaller(bridge, NULL);
 
 #if RNVERSION >= 64
   // installs globals such as console, nativePerformanceNow, etc.
-  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(executor));
+  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(installer));
 #else
-  return std::make_unique<ExecutorFactory>(executor);
+  return std::make_unique<ExecutorFactory>(installer);
 #endif
 }
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

This pull request fixes the following compilation error when using Reanimated 2 with React Native 0.63.4 or earlier:

```
react-native-reanimated/ios/native/REAInitializer.h:32:1: Use of undeclared identifier 'JSIExecutor'
```

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
