### PR TITLE
Use shared value instead of copy

### DIFF
--- a/Common/cpp/headers/Tools/Mapper.h
+++ b/Common/cpp/headers/Tools/Mapper.h
@@ -27,8 +27,8 @@ private:
   bool dirty = true;
   std::shared_ptr<jsi::Function> userUpdater;
   UpdaterFunction* updateProps;
-  std::vector<ViewDescriptor> viewDescriptors;
   int optimalizationLvl = 0;
+  std::shared_ptr<ShareableValue> viewDescriptors;
 
 public:
   Mapper(NativeReanimatedModule *module,


### PR DESCRIPTION
## Description

I can't copy the viewDescriptors set because it can be empty during starting of the mapper.
