### PR TITLE
Fixed layout transition animation was started multiple times on android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -311,7 +311,6 @@ public class AnimationsManager {
                 parent.addView(view);
             }
         }
-
         for (View view : allViews) {
             Integer tag = view.getId();
             String type = "entering";
@@ -332,7 +331,7 @@ public class AnimationsManager {
 
             // If startValues are equal to targetValues it means that there was no UI Operation changing
             // layout of the View. So dirtiness of that View is false positive
-            if (state == ViewState.Appearing) {
+            if (state != ViewState.Inactive && startValues != null && targetValues != null) {
                 boolean doNotStartLayout = true;
                 for (String key : LAYOUT_KEYS) {
                     double startV = ((Number) startValues.get(key)).doubleValue();

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -311,7 +311,7 @@ public class AnimationsManager {
                 parent.addView(view);
             }
         }
-        
+
         for (View view : allViews) {
             Integer tag = view.getId();
             String type = "entering";

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -311,6 +311,7 @@ public class AnimationsManager {
                 parent.addView(view);
             }
         }
+        
         for (View view : allViews) {
             Integer tag = view.getId();
             String type = "entering";


### PR DESCRIPTION
## Description
On android sometimes layout transition animation was started multiple times with start and target values equal which resets the very first animation. I've added checking if the start and target values are equal for layout transition animation and if they are I'm not starting that animation.
Fixes #2235 
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- added check if start and target values are equal for layout transitions
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

## Screenshots / GIFs

### Before

https://user-images.githubusercontent.com/48885911/127633922-1485d765-c129-4dc5-ab74-69d27a81c668.mov


### After

https://user-images.githubusercontent.com/48885911/127633942-b864759f-727b-4a00-9dd1-05ff0d72c383.mov


-->
<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->


