### PR TITLE
Fixed android crashing when useAnimatedStyles returns an object with nested properties.

### DIFF
--- a/android/src/main/cpp/JNIHelper.cpp
+++ b/android/src/main/cpp/JNIHelper.cpp
@@ -52,7 +52,7 @@ jni::local_ref<JNIHelper::PropsMap> JNIHelper::ConvertToPropsMap(jsi::Runtime &r
       }
       else
       {
-        map->put(key, ReadableNativeMap::newObjectCxxArgs(jsi::dynamicFromValue(rt, value)));
+        map->put(key, WritableNativeMap::newObjectCxxArgs(jsi::dynamicFromValue(rt, value)));
       }
     }
   }


### PR DESCRIPTION
## Description
During converting props to map, nested props are converted to `ReadableNativeMap`. When they are later added to the props `WritableNativeMap` by Nodes Manager error occurs, as WritableNativeMap implementation requires map to be WritableNativeMap.
```java
  @Override
  public void putMap(@NonNull String key, @Nullable ReadableMap value) {
    Assertions.assertCondition(
        value == null || value instanceof WritableNativeMap, "Illegal type provided");
    putNativeMap(key, (WritableNativeMap) value);
  }
```
The result was that the app crashed whenever there were nested props provided in `useAnimatedStyle` or `useAnimatedProps`.
Fixes #2040.
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- Changed `ReadableNativeMap` to `WritableNativeMap` during props converting
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->
