### PR TITLE
[v1] Fix animation of placeholderTextColor

### DIFF
--- a/src/ConfigHelper.js
+++ b/src/ConfigHelper.js
@@ -103,6 +103,7 @@ let NATIVE_THREAD_PROPS_WHITELIST = {
   color: true,
   tintColor: true,
   shadowColor: true,
+  placeholderTextColor: true,
 };
 
 function configureProps() {


### PR DESCRIPTION
## Description

This PR fixes #2273.

## Changes
- Added `placeholderTextColor` to `NATIVE_THREAD_PROPS_WHITELIST`