### PR TITLE
fix(android): react-native 0.65 event emitter stubs

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -230,6 +230,16 @@ public class ReanimatedModule extends ReactContextBaseJavaModule implements
     });
   }
 
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
   @Override
   public void onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy();


### PR DESCRIPTION


## Description

Fixes #2297 by adding stub implementations of newly-required
methods from react-native 0.65

See e.g. 

- https://github.com/react-native-device-info/react-native-device-info/commit/3917f339207a5a2b05e3922f7489a0568dfde666
- https://github.com/invertase/react-native-firebase/pull/5616

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
