### PR TITLE
fix: Package build failing - RNScreens not found

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -462,7 +462,6 @@ dependencies {
     implementation 'com.facebook.fbjni:fbjni:0.2.2'
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-    implementation project(path: ':react-native-screens')
     extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
     extractSO("com.facebook.fbjni:fbjni:0.2.2")
 


### PR DESCRIPTION
## Description

Currently, package build is failing due to react-native-screens not being found. Looks like it was added by accident, because package.json doesn't include it.

## Changes

- I've removed react-native-screens from module's `build.gradle` as it fixes the build stage.

## Test code and steps to reproduce

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
