### PR TITLE
Fixed transparent colors in interpolateColors

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -707,7 +707,7 @@ const getInterpolateCacheRGBA = (
   for (let i = 0; i < colors.length; ++i) {
     const color = colors[i];
     const proocessedColor = processColor(color);
-    // in case if processedColor is 0, it's not added to cache
+    // explicit check in case if processedColor is 0
     if (proocessedColor !== null && proocessedColor !== undefined) {
       r.push(red(proocessedColor));
       g.push(green(proocessedColor));

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -707,7 +707,8 @@ const getInterpolateCacheRGBA = (
   for (let i = 0; i < colors.length; ++i) {
     const color = colors[i];
     const proocessedColor = processColor(color);
-    if (proocessedColor) {
+    // in case if processedColor is 0, it's not added to cache
+    if (proocessedColor !== null && proocessedColor !== undefined) {
       r.push(red(proocessedColor));
       g.push(green(proocessedColor));
       b.push(blue(proocessedColor));


### PR DESCRIPTION
## Description
When one of the colors in the output range was transparent, interpolateColors doesn't work, due to a wrong undefined check.

Fixes #2328 

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
- Changed to explicit check if color is undefined, to prevent issue when color value is 0
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


