### PR TITLE
fix: Fix `RNScreens/RNSScreen.h` import if react-native-screens is not installed

### DIFF
--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -8,7 +8,10 @@
 #import "RCTLayoutAnimationGroup.h"
 #import "REAIOSScheduler.h"
 #include "Scheduler.h"
+
+#if __has_include(<RNScreens/RNSScreen.h>)
 #import <RNScreens/RNSScreen.h>
+#endif
 
 @interface RCTUIManager(REA)
 - (void)_manageChildren:(NSNumber *)containerTag
@@ -40,7 +43,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
 {
   if(!_blockSetter) {
     _blockSetter = true;
-    
+
     self.bridge = bridge;
     [self setValue:[bridge.uiManager valueForKey:@"_shadowViewRegistry"] forKey:@"_shadowViewRegistry"];
     [self setValue:[bridge.uiManager valueForKey:@"_viewRegistry"] forKey:@"_viewRegistry"];
@@ -51,7 +54,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
     [self setValue:[bridge.uiManager valueForKey:@"_rootViewTags"] forKey:@"_rootViewTags"];
     [self setValue:[bridge.uiManager valueForKey:@"_observerCoordinator"] forKey:@"_observerCoordinator"];
     [self setValue:[bridge.uiManager valueForKey:@"_componentDataByName"] forKey:@"_componentDataByName"];
-    
+
     _blockSetter = false;
   }
 }
@@ -67,12 +70,12 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   BOOL isUIViewRegistry = ((id)registry == (id)[self valueForKey:@"_viewRegistry"]);
   id<RCTComponent> container;
   NSArray<id<RCTComponent>> *permanentlyRemovedChildren;
-  if(isUIViewRegistry) {    
-    container = registry[containerTag];    
+  if(isUIViewRegistry) {
+    container = registry[containerTag];
     for(id<RCTComponent> toRemoveChild in _toBeRemovedRegister[containerTag]) {
       [container removeReactSubview:toRemoveChild];
     }
-    
+
     permanentlyRemovedChildren = [super _childrenToRemoveFromContainer:container atIndices:removeAtIndices];
     if(permanentlyRemovedChildren != nil) {
       for(id<RCTComponent> permanentlyRemovedChild in permanentlyRemovedChildren) {
@@ -83,7 +86,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       }
     }
   }
-  
+
   [super _manageChildren:containerTag
          moveFromIndices:moveFromIndices
            moveToIndices:moveToIndices
@@ -91,7 +94,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
             addAtIndices:addAtIndices
          removeAtIndices:removeAtIndices
                 registry:registry];
-  
+
   if(isUIViewRegistry) {
     NSMutableDictionary<NSNumber *, id<RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
     for(id<RCTComponent> toRemoveChild in _toBeRemovedRegister[containerTag]) {
@@ -102,7 +105,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       [container insertReactSubview:toRemoveChild atIndex:lastIndex];
       viewRegistry[toRemoveChild.reactTag] = toRemoveChild;
     }
-    
+
     for (UIView *removedChild in permanentlyRemovedChildren) {
       [self callAnimationForTree: removedChild parentTag:containerTag];
     }
@@ -114,7 +117,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   REASnapshot* snapshot = [[REASnapshot alloc] init:view];
   _parentMapper[view.reactTag] = parentTag;
   [_animationsManager onViewRemoval:view before:snapshot];
-  
+
   for(UIView* subView in view.reactSubviews) {
     [self callAnimationForTree:subView parentTag:view.reactTag];
   }
@@ -122,7 +125,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
 
 // Overrided https://github.com/facebook/react-native/blob/v0.65.0/React/Modules/RCTUIManager.m#L530
 - (RCTViewManagerUIBlock)uiBlockWithLayoutUpdateForRootView:(RCTRootShadowView *)rootShadowView
-{  
+{
   NSHashTable<RCTShadowView *> *affectedShadowViews = [NSHashTable weakObjectsHashTable];
   [rootShadowView layoutWithAffectedShadowViews:affectedShadowViews];
 
@@ -231,7 +234,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       if (view.isHidden != isHidden) {
         view.hidden = isHidden;
       }
-      
+
       REASnapshot* snapshotBefore = [[REASnapshot alloc] init:view];
       if (creatingLayoutAnimation) {
         // Animate view creation
@@ -277,7 +280,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         [view reactSetFrame:frame];
         completion(YES);
       }
-      
+
       if(isNew) {
         REASnapshot* snapshot = [[REASnapshot alloc] init:view];
         [_animationsManager onViewCreate:view after:snapshot];
@@ -286,7 +289,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         REASnapshot* snapshotAfter = [[REASnapshot alloc] init:view];
         [_animationsManager onViewUpdate:view before:snapshotBefore after:snapshotAfter];
       }
-      
+
     }
 
     // Clean up
@@ -317,7 +320,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   if(tag == nil) {
     return;
   }
-  
+
   [_toBeRemovedRegister[tag] removeObject:view];
   if(_toBeRemovedRegister[tag].count == 0) {
     [_toBeRemovedRegister removeObjectForKey:tag];
@@ -326,9 +329,11 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   [view.reactSuperview removeReactSubview:view];
   id<RCTComponent> parentView = viewRegistry[tag];
   [parentView removeReactSubview:view];
+#if __has_include(<RNScreens/RNSScreen.h>)
   if ([view isKindOfClass:[RNSScreenView class]]) {
     [parentView didUpdateReactSubviews];
   }
+#endif
   [viewRegistry removeObjectForKey:view.reactTag];
 }
 


### PR DESCRIPTION


## Description

When not having react-native-screens installed, react-native-reanimated does not build in alpha.3 (or current master).

There is an import: 

```objc
#import <RNScreens/RNSScreen.h>
```

which does not work since RNScreens does not exist. This PR fixes this issue by conditionally importing RNScreens.

## Changes

- Conditionally import RNScreens depending on whether it's installed or not
- Conditionally use RNSScreen class depending on whether it's available or not

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
