### PR TITLE
Remove > from bash commands

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.0.0/installation.md
+++ b/docs/versioned_docs/version-2.0.0/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.1.0/installation.md
+++ b/docs/versioned_docs/version-2.1.0/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.2.0/installation.md
+++ b/docs/versioned_docs/version-2.2.0/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.3.0-alpha.1/installation.md
+++ b/docs/versioned_docs/version-2.3.0-alpha.1/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.3.0-alpha.2/installation.md
+++ b/docs/versioned_docs/version-2.3.0-alpha.2/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.3.0-alpha.3/installation.md
+++ b/docs/versioned_docs/version-2.3.0-alpha.3/installation.md
@@ -20,7 +20,7 @@ If you just want to play with Reanimated 2, we made a clean repo that has all th
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```bash
-> git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
+git clone git@github.com:software-mansion-labs/reanimated-2-playground.git
 ```
 
 Continue with the instruction below if you'd like to install Reanimated v2 on an existing or new React Native project.
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-> yarn add react-native-reanimated@next
+yarn add react-native-reanimated@next
 ```
 
 ### Reanimated 2 in Expo


### PR DESCRIPTION
## Description

The bash commands on the installation page are currently prefixed with `> `. If you hover over any of the code fields, you’ll see a “copy” button, but clicking it will copy the code sample including the > meaning you can’t actually paste it in your terminal.

This PR removes the `>`, meaning the code snippets can be pasted directly to the terminal when copying them using the "copy" button.

## Changes

Removes `>` from the bash commands on the installation change.

## Screenshots / GIFs

### Before

![Screenshot 2021-09-06 at 12 22 26](https://user-images.githubusercontent.com/6534400/132209990-5b48ca07-00d5-4268-a192-b29fc496a142.png)

### After

![Screenshot 2021-09-06 at 12 22 03](https://user-images.githubusercontent.com/6534400/132209993-6000957c-4186-443a-8dc1-c55f82fe5b8d.png)