### PR TITLE
Fix JNI null refference in destructor

### DIFF
--- a/Common/cpp/Tools/JSIStoreValueUser.cpp
+++ b/Common/cpp/Tools/JSIStoreValueUser.cpp
@@ -1,3 +1,4 @@
+#include <AndroidScheduler.h>
 #include "JSIStoreValueUser.h"
 #include "RuntimeManager.h"
 
@@ -29,11 +30,13 @@ StoreUser::~StoreUser() {
   std::shared_ptr<Scheduler> strongScheduler = scheduler.lock();
   if (strongScheduler != nullptr) {
     std::shared_ptr<StaticStoreUser> sud = storeUserData;
-    strongScheduler->scheduleOnUI([id, sud]() {
-      const std::lock_guard<std::recursive_mutex> lock(sud->storeMutex);
-      if (sud->store.count(id) > 0) {
-        sud->store.erase(id);
-      }
+    jni::ThreadScope::WithClassLoader([&] {
+      strongScheduler->scheduleOnUI([id, sud]() {
+        const std::lock_guard<std::recursive_mutex> lock(sud->storeMutex);
+        if (sud->store.count(id) > 0) {
+          sud->store.erase(id);
+        }
+      });
     });
   }
 }


### PR DESCRIPTION
## Description

After changes in Hermes's garbage collector - the host object destructor can be called from another thread than JNI is assigned. We need to change the way of calling JNI in destructors to avoid calling a function on a null object.
We should make it like Hermes: https://github.com/facebook/hermes/blob/6e5868763b08eb80f4164a926abb92fa5c71117f/lib/Platform/Intl/PlatformIntlAndroid.cpp#L319

Related issue: https://github.com/facebook/hermes/issues/590

Fixes #2256

Authors: @Szymon20000 @piaskowyk 