### PR TITLE
Fixed ios build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - 'android/**'
+      - 'common/**'
   push:
     branches:
       - master

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,7 +5,7 @@ on:
       - master
     paths:
       - 'android/**'
-      - 'common/**'
+      - 'Common/**'
   push:
     branches:
       - master

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,7 +5,7 @@ on:
       - master
     paths:
       - 'ios/**'
-      - 'common/**'
+      - 'Common/**'
   push:
     branches:
       - master

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - 'ios/**'
+      - 'common/**'
   push:
     branches:
       - master


### PR DESCRIPTION
## Description
On ios build didn't work because of `<AndroidScheduler.h>` include. I made this include conditional, so it will be included only on android.
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes
* Added conditional include
* Added triggering build check when files inside common directory are edited
<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

