### PR TITLE
Check falsy style item in AnimatedComponent._detachStyles

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -150,7 +150,7 @@ export default function createAnimatedComponent(Component, options = {}) {
     _detachStyles() {
       if (Platform.OS === 'web') {
         for (const style of this._styles) {
-          if (style.viewsRef) {
+          if (style?.viewsRef) {
             style.viewsRef.remove(this);
           }
         }


### PR DESCRIPTION
## Description

If any of the style in a style prop array is falsy (which is allowed by React Native), an error will throw upon component unmount.

This case is already handled for mobile but in not in the web, resulting to a `of undefined` error.

Fixed #2413

## Changes

Check if style is not falsy in AnimatedComponent._detachStyles for the case of `Platform.OS = 'web'`

## Screenshots / GIFs

(Please use the CodeSandBox below)

### Before

It throws the error:

```
createAnimatedComponent.js:153 Uncaught TypeError: Cannot read properties of undefined (reading 'viewsRef')
    at AnimatedComponent._detachStyles (createAnimatedComponent.js:153)
    at AnimatedComponent.componentWillUnmount (createAnimatedComponent.js:94)
    at callComponentWillUnmountWithTimer (react-dom.development.js:20413)
```

if any of the style in style prop is falsy.

### After

Does not throw anymore.

## Test code and steps to reproduce

https://github.com/hoangvvo/react-native-reanimated-web-unmount-reproduction

The above stop throwing after the change.

I looked into the test cases in `__tests__` but did not see a setup for web, so I could not add one. But if there is a pointer, I can try to add the case.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
