### PR TITLE
Remove pickFirst from gradle

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -13,21 +13,15 @@ def engine = "jsc"
 abstract class replaceSoTask extends DefaultTask {
     public static String appName = ":app"
     public static String buildDir = "../../../android/app/build"
-    public static String engine = "jsc"
-    public static String reactVersion = "64"
 
     @TaskAction
     def run() {
-        ant.unzip(
-            src: "./react-native-reanimated-${reactVersion}-${engine}.aar",
-            dest: "./tmp"
-        )
         for(def abiVersion in ["x86", "x86_64", "armeabi-v7a", "arm64-v8a"]) {
             ant.sequential {
                 copy(
-                    tofile: "${buildDir}/intermediates/merged_native_libs/debug/out/lib/${abiVersion}/libfbjni.so",
-                    file: "./tmp/jni/${abiVersion}/libfbjni.so",
-                    overwrite: true
+                        tofile: "${buildDir}/intermediates/merged_native_libs/debug/out/lib/${abiVersion}/libfbjni.so",
+                        file: "../libSo/fbjni/jni/${abiVersion}/libfbjni.so",
+                        overwrite: true
                 )
             }
         }
@@ -71,25 +65,22 @@ rootProject.getSubprojects().forEach({project ->
         if(project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
             def projectProperties = project.getProperties()
             if(!projectProperties.get("reanimated")
-                || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
+                    || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
             ) {
                 def flavorString = getCurrentFlavor()
                 replaceSoTask.appName = project.getProperties().path
                 replaceSoTask.buildDir = project.getProperties().buildDir
-                replaceSoTask.engine = engine
-                replaceSoTask.reactVersion = minor
                 def appName = project.getProperties().path
-                project.getProperties().android.packagingOptions.pickFirst("lib/**/libfbjni.so")
 
                 replaceSoTaskDebug.dependsOn(
-                    project.getTasks().getByPath("${appName}:merge${flavorString}DebugNativeLibs"),
-                    project.getTasks().getByPath("${appName}:strip${flavorString}DebugDebugSymbols")
+                        project.getTasks().getByPath("${appName}:merge${flavorString}DebugNativeLibs"),
+                        project.getTasks().getByPath("${appName}:strip${flavorString}DebugDebugSymbols")
                 )
                 project.getTasks().getByPath("${appName}:package${flavorString}Debug").dependsOn(replaceSoTaskDebug)
 
                 replaceSoTaskRelease.dependsOn(
-                    project.getTasks().getByPath("${appName}:merge${flavorString}ReleaseNativeLibs"),
-                    project.getTasks().getByPath("${appName}:strip${flavorString}ReleaseDebugSymbols")
+                        project.getTasks().getByPath("${appName}:merge${flavorString}ReleaseNativeLibs"),
+                        project.getTasks().getByPath("${appName}:strip${flavorString}ReleaseDebugSymbols")
                 )
                 project.getTasks().getByPath("${appName}:package${flavorString}Release").dependsOn(replaceSoTaskRelease)
             }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,6 @@ def debugNativeLibraries = localProps.getProperty('NATIVE_DEBUG_ON', 'FALSE').to
 
 import java.nio.file.Paths
 
-import de.undercouch.gradle.tasks.download.Download
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.filters.ReplaceTokens
 
@@ -19,6 +18,7 @@ def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_V
 def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
 def GLOG_VERSION = reactProperties.getProperty("GLOG_VERSION")
 def REACT_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\.")[1].toInteger()
+def FBJNI_VERSION = '0.2.2'
 
 // We download various C++ open-source dependencies into downloads.
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
@@ -58,12 +58,6 @@ def follyReplaceContent = '''
   } while (r == -1 && errno == EINTR);
   return r;
 '''
-
-def boost_file = new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz")
-def double_conversion_file = new File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz")
-def folly_file = new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz")
-def glog_file = new File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz")
-
 
 buildscript {
     repositories {
@@ -128,7 +122,7 @@ android {
     packagingOptions {
         println "Native libs debug enabled: ${debugNativeLibraries}"
         doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
-        excludes = REACT_VERSION < 65 ? ["**/libc++_shared.so"] : ["**/libc++_shared.so", "**/libfbjni.so"]
+        excludes = ["**/libc++_shared.so", "**/libfbjni.so"]
     }
 
     tasks.withType(JavaCompile) {
@@ -462,11 +456,11 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.fbjni:fbjni:0.2.2'
+    implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-    extractHeaders("com.facebook.fbjni:fbjni:0.2.2:headers")
-    extractSO("com.facebook.fbjni:fbjni:0.2.2")
+    extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
+    extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
     def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -65,6 +65,16 @@ do
   done
 done
 
+rm -rf libSo
+mkdir libSo
+cd libSo
+mkdir fbjni
+cd fbjni
+wget https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/0.2.2/fbjni-0.2.2.aar
+unzip fbjni-0.2.2.aar 
+rm -r $(find . ! -name '.' ! -name 'jni' -maxdepth 1)
+cd ../..
+
 yarn add react-native@0.65.1 --dev
 
 mv android android-temp
@@ -77,8 +87,9 @@ npm pack
 mv android android-npm
 mv android-temp android
 
+rm -rf ./libSo
 rm -rf ./lib
-rm -rf ./rnVersionPatch/backup/*
-touch ./rnVersionPatch/backup/.gitkeep
+rm -rf ./android/rnVersionPatch/backup/*
+touch ./android/rnVersionPatch/backup/.gitkeep
 
 echo "Done!"

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -73,6 +73,7 @@ cd fbjni
 wget https://repo1.maven.org/maven2/com/facebook/fbjni/fbjni/0.2.2/fbjni-0.2.2.aar
 unzip fbjni-0.2.2.aar 
 rm -r $(find . ! -name '.' ! -name 'jni' -maxdepth 1)
+rm $(find . -name '*libc++_shared.so')
 cd ../..
 
 yarn add react-native@0.65.1 --dev

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "Common/",
     "src/",
     "lib/",
+    "libSo/",
     "android/src/main/AndroidManifest.xml",
     "android/src/main/java/",
     "android/build.gradle",


### PR DESCRIPTION
## Description
I removed `packagingOptions.pickFirst("lib/**/libfbjni.so")` from `build.gradle` script because this was a cause of some `.so` conflicts in expo projects.