### PR TITLE
Set order for keys in object inside a worklet

### DIFF
--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -10,8 +10,11 @@ FrozenObject::FrozenObject(
     const jsi::Object &object,
     RuntimeManager *runtimeManager) {
   auto propertyNames = object.getPropertyNames(rt);
-  for (size_t i = 0, count = propertyNames.size(rt); i < count; i++) {
+  const size_t count = propertyNames.size(rt);
+  namesOrder.reserve(count);
+  for (size_t i = 0; i < count; i++) {
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
+    namesOrder.push_back(propertyName.utf8(rt));
     std::string nameStr = propertyName.utf8(rt);
     map[nameStr] = ShareableValue::adapt(
         rt, object.getProperty(rt, propertyName), runtimeManager);
@@ -21,11 +24,12 @@ FrozenObject::FrozenObject(
 
 jsi::Object FrozenObject::shallowClone(jsi::Runtime &rt) {
   jsi::Object object(rt);
-  for (auto prop : map) {
+  for (auto propName : namesOrder) {
+    auto value = map[propName];
     object.setProperty(
         rt,
-        jsi::String::createFromUtf8(rt, prop.first),
-        prop.second->getValue(rt));
+        jsi::String::createFromUtf8(rt, propName),
+        value->getValue(rt));
   }
   return object;
 }

--- a/Common/cpp/headers/SharedItems/FrozenObject.h
+++ b/Common/cpp/headers/SharedItems/FrozenObject.h
@@ -18,6 +18,7 @@ class FrozenObject : public jsi::HostObject {
 
  private:
   std::unordered_map<std::string, std::shared_ptr<ShareableValue>> map;
+  std::vector<std::string> namesOrder;
 
  public:
   FrozenObject(


### PR DESCRIPTION
## Description

We used `unordered_map` to store object keys. It may cause different results of `Object.keys()` called on JS or UI thread. I added `vector` of keys to store the right order of keys and keep constant complexity. Instead of this solution I also can use just `std::map` to store objects in the right order but `map` logarithmic complexity.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2352

## Reproduce
```js
import * as React from 'react';
import { View } from 'react-native';
import { useAnimatedStyle } from 'react-native-reanimated';

export default function App() {
  const obj = {
    a: 0,
    b: 1,
  };
  const style = useAnimatedStyle(() => {
    console.log("is worklet:", _WORKLET + ",", "keys:", Object.keys(obj));
    return {};
  });
  return <View></View>;
}
```

### Before
```
is worklet: false, keys: ["a", "b"]
is worklet: true, keys: ["b", "a"]
```

### After
```
is worklet: false, keys: ["a", "b"]
is worklet: true, keys: ["a", "b"]
```
