### PR TITLE
Initial style for component with shared style

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -20,6 +20,7 @@ import {
   DefaultLayout,
 } from './reanimated2/layoutReanimation/defaultAnimations/Default';
 import { isJest, isChromeDebugger } from './reanimated2/PlatformChecker';
+import { initialUpdaterRun } from './reanimated2/animation';
 
 const NODE_MAPPING = new Map();
 
@@ -456,7 +457,10 @@ export default function createAnimatedComponent(Component, options = {}) {
             if (style && style.viewDescriptors) {
               // this is how we recognize styles returned by useAnimatedStyle
               style.viewsRef.add(this);
-              return style.initial.value;
+              return {
+                ...style.initial.value,
+                ...initialUpdaterRun(style.initial.updater),
+              };
             } else {
               return style;
             }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -78,6 +78,7 @@ export default function createAnimatedComponent(Component, options = {}) {
     _invokeAnimatedPropsCallbackOnMount = false;
     _styles = null;
     _viewTag = -1;
+    _isFirstRender = true;
 
     constructor(props) {
       super(props);
@@ -457,10 +458,14 @@ export default function createAnimatedComponent(Component, options = {}) {
             if (style && style.viewDescriptors) {
               // this is how we recognize styles returned by useAnimatedStyle
               style.viewsRef.add(this);
-              return {
-                ...style.initial.value,
-                ...initialUpdaterRun(style.initial.updater),
-              };
+              if (this._isFirstRender) {
+                return {
+                  ...style.initial.value,
+                  ...initialUpdaterRun(style.initial.updater),
+                };
+              } else {
+                return style.initial.value;
+              }
             } else {
               return style;
             }
@@ -509,6 +514,10 @@ export default function createAnimatedComponent(Component, options = {}) {
       const props = this._filterNonAnimatedProps(this.props);
       if (isJest()) {
         props.animatedStyle = this.animatedStyle;
+      }
+
+      if (this._isFirstRender) {
+        this._isFirstRender = false;
       }
 
       const platformProps = Platform.select({

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -57,6 +57,7 @@ interface AnimatedState {
 interface AnimationRef {
   initial: {
     value: AnimatedStyle;
+    updater: () => AnimatedStyle;
   };
   remoteState: AnimatedState;
   sharableViewDescriptors: SharedValue<Descriptor[]>;
@@ -428,6 +429,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
     initRef.current = {
       initial: {
         value: initialStyle,
+        updater: updater,
       },
       remoteState: makeRemote({ last: initialStyle }),
       sharableViewDescriptors: makeMutable([]),
@@ -443,7 +445,6 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
   const { initial, remoteState, sharableViewDescriptors } = initRef.current!;
   const maybeViewRef = NativeReanimated.native ? undefined : viewsRef;
 
-  initial.value = initialUpdaterRun(updater);
   useEffect(() => {
     let fun;
     let upadterFn = updater;


### PR DESCRIPTION
## Description

In the previous approach, initialUpdaterRun was called inside createAnimatedComponent(), and if `createAnimatedComponent` was called during an animation, it can cause an inconsistent state of style because on UI thread was scheduled to update and on JS thread was computed current style. But on the UI thread, this update can be executed before action on the JS thread or after them.
I moved `initialUpdaterRun` to createAnimatedComponent and compute initial style in the component's constructor.

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/2406