### PR TITLE
Auto-workletize React Native Gesture Handler callback functions

### DIFF
--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -100,7 +100,9 @@ function Box() {
 `;
 
 exports[`babel plugin workletizes gesture object callbacks 1`] = `
-"var singleTap = Gesture.Tap().onEnd(function () {
+"var _reactNativeGestureHandler = require(\\"react-native-gesture-handler\\");
+
+var singleTap = _reactNativeGestureHandler.Gesture.Tap().onEnd(function () {
   var _f = function _f(_event, success) {
     if (success) {
       console.log('single tap!');
@@ -110,7 +112,7 @@ exports[`babel plugin workletizes gesture object callbacks 1`] = `
   _f._closure = {};
   _f.asString = \\"function _f(_event,success){if(success){console.log('single tap!');}}\\";
   _f.__workletHash = 11668513436405;
-  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:44)\\";
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (4:44)\\";
 
   global.__reanimatedWorkletInit(_f);
 

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -61,28 +61,28 @@ exports[`babel plugin doesn't transform functions without 'worklet' directive 1`
 exports[`babel plugin implicitly workletizes possibly chained gesture object callback functions 1`] = `
 "var _reactNativeGestureHandler = require(\\"react-native-gesture-handler\\");
 
-var foo = _reactNativeGestureHandler.Gesture.Tap().onStart(function () {
+var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegan(function () {
   var _f = function _f() {
-    console.log('onStart');
+    console.log('onBegan');
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(){console.log('onStart');}\\";
-  _f.__workletHash = 16775988405661;
-  _f.__location = \\"${ process.cwd() }/jest tests fixture (5:17)\\";
+  _f.asString = \\"function _f(){console.log('onBegan');}\\";
+  _f.__workletHash = 10358176266034;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
 
   global.__reanimatedWorkletInit(_f);
 
   return _f;
-}()).onUpdate(function () {
+}()).onStart(function () {
   var _f = function _f(_event) {
-    console.log('onUpdate');
+    console.log('onStart');
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(_event){console.log('onUpdate');}\\";
-  _f.__workletHash = 9674014014239;
-  _f.__location = \\"${ process.cwd() }/jest tests fixture (8:18)\\";
+  _f.asString = \\"function _f(_event){console.log('onStart');}\\";
+  _f.__workletHash = 16334902412526;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (9:17)\\";
 
   global.__reanimatedWorkletInit(_f);
 
@@ -95,7 +95,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().onStart(function () {
   _f._closure = {};
   _f.asString = \\"function _f(_event,_success){console.log('onEnd');}\\";
   _f.__workletHash = 4053780716017;
-  _f.__location = \\"${ process.cwd() }/jest tests fixture (11:15)\\";
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (12:15)\\";
 
   global.__reanimatedWorkletInit(_f);
 

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -52,6 +52,14 @@ exports[`babel plugin doesn't transform functions without 'worklet' directive 1`
 }"
 `;
 
+exports[`babel plugin doesn't workletize standard callbacks 1`] = `
+"var foo = something.onEnd(function (_event, success) {
+  if (success) {
+    console.log('success!');
+  }
+});"
+`;
+
 exports[`babel plugin transforms  1`] = `
 "var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
 
@@ -89,4 +97,23 @@ function Box() {
     title: \\"Move\\"
   }));
 }"
+`;
+
+exports[`babel plugin workletizes gesture object callbacks 1`] = `
+"var singleTap = Gesture.Tap().onEnd(function () {
+  var _f = function _f(_event, success) {
+    if (success) {
+      console.log('single tap!');
+    }
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function _f(_event,success){if(success){console.log('single tap!');}}\\";
+  _f.__workletHash = 11668513436405;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:44)\\";
+
+  global.__reanimatedWorkletInit(_f);
+
+  return _f;
+}());"
 `;

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -46,18 +46,61 @@ exports[`babel plugin doesn't capture globals 1`] = `
 }();"
 `;
 
+exports[`babel plugin doesn't implicitly workletize standard callback functions 1`] = `
+"var foo = Something.Tap().onEnd(function (_event, _success) {
+  console.log('onEnd');
+});"
+`;
+
 exports[`babel plugin doesn't transform functions without 'worklet' directive 1`] = `
 "function f(x) {
   return x + 2;
 }"
 `;
 
-exports[`babel plugin doesn't workletize standard callbacks 1`] = `
-"var foo = something.onEnd(function (_event, success) {
-  if (success) {
-    console.log('success!');
-  }
-});"
+exports[`babel plugin implicitly workletizes possibly chained gesture object callback functions 1`] = `
+"var _reactNativeGestureHandler = require(\\"react-native-gesture-handler\\");
+
+var foo = _reactNativeGestureHandler.Gesture.Tap().onStart(function () {
+  var _f = function _f() {
+    console.log('onStart');
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function _f(){console.log('onStart');}\\";
+  _f.__workletHash = 16775988405661;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (5:17)\\";
+
+  global.__reanimatedWorkletInit(_f);
+
+  return _f;
+}()).onUpdate(function () {
+  var _f = function _f(_event) {
+    console.log('onUpdate');
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function _f(_event){console.log('onUpdate');}\\";
+  _f.__workletHash = 9674014014239;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (8:18)\\";
+
+  global.__reanimatedWorkletInit(_f);
+
+  return _f;
+}()).onEnd(function () {
+  var _f = function _f(_event, _success) {
+    console.log('onEnd');
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function _f(_event,_success){console.log('onEnd');}\\";
+  _f.__workletHash = 4053780716017;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (11:15)\\";
+
+  global.__reanimatedWorkletInit(_f);
+
+  return _f;
+}());"
 `;
 
 exports[`babel plugin transforms  1`] = `
@@ -97,25 +140,4 @@ function Box() {
     title: \\"Move\\"
   }));
 }"
-`;
-
-exports[`babel plugin workletizes gesture object callbacks 1`] = `
-"var _reactNativeGestureHandler = require(\\"react-native-gesture-handler\\");
-
-var singleTap = _reactNativeGestureHandler.Gesture.Tap().onEnd(function () {
-  var _f = function _f(_event, success) {
-    if (success) {
-      console.log('single tap!');
-    }
-  };
-
-  _f._closure = {};
-  _f.asString = \\"function _f(_event,success){if(success){console.log('single tap!');}}\\";
-  _f.__workletHash = 11668513436405;
-  _f.__location = \\"${ process.cwd() }/jest tests fixture (4:44)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
-  return _f;
-}());"
 `;

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -144,6 +144,8 @@ describe('babel plugin', () => {
 
   it('workletizes gesture object callbacks', () => {
     const input = `
+      import { Gesture } from 'react-native-gesture-handler';
+
       const singleTap = Gesture.Tap().onEnd((_event, success) => {
         if (success) {
           console.log('single tap!');

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -142,26 +142,29 @@ describe('babel plugin', () => {
     expect(code).toMatchSnapshot();
   });
 
-  it('workletizes gesture object callbacks', () => {
+  it('implicitly workletizes possibly chained gesture object callback functions', () => {
     const input = `
       import { Gesture } from 'react-native-gesture-handler';
 
-      const singleTap = Gesture.Tap().onEnd((_event, success) => {
-        if (success) {
-          console.log('single tap!');
-        }
-      });
+      const foo = Gesture.Tap()
+        .onStart(() => {
+          console.log('onStart');
+        })
+        .onUpdate((_event) => {
+          console.log('onUpdate');
+        })
+        .onEnd((_event, _success) => {
+          console.log('onEnd');
+        });
     `;
     const { code } = runPlugin(input);
     expect(code).toMatchSnapshot();
   });
 
-  it("doesn't workletize standard callbacks", () => {
+  it("doesn't implicitly workletize standard callback functions", () => {
     const input = `
-      const foo = something.onEnd((_event, success) => {
-        if (success) {
-          console.log('success!');
-        }
+      const foo = Something.Tap().onEnd((_event, _success) => {
+        console.log('onEnd');
       });
     `;
     const { code } = runPlugin(input);

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -141,4 +141,28 @@ describe('babel plugin', () => {
     expect(closureBindings).toEqual([]);
     expect(code).toMatchSnapshot();
   });
+
+  it('workletizes gesture object callbacks', () => {
+    const input = `
+      const singleTap = Gesture.Tap().onEnd((_event, success) => {
+        if (success) {
+          console.log('single tap!');
+        }
+      });
+    `;
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
+
+  it("doesn't workletize standard callbacks", () => {
+    const input = `
+      const foo = something.onEnd((_event, success) => {
+        if (success) {
+          console.log('success!');
+        }
+      });
+    `;
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
 });

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -147,11 +147,12 @@ describe('babel plugin', () => {
       import { Gesture } from 'react-native-gesture-handler';
 
       const foo = Gesture.Tap()
-        .onStart(() => {
-          console.log('onStart');
+        .numberOfTaps(2)
+        .onBegan(() => {
+          console.log('onBegan');
         })
-        .onUpdate((_event) => {
-          console.log('onUpdate');
+        .onStart((_event) => {
+          console.log('onStart');
         })
         .onEnd((_event, _success) => {
           console.log('onEnd');

--- a/plugin.js
+++ b/plugin.js
@@ -136,7 +136,7 @@ const blacklistedFunctions = new Set([
 const possibleOptFunction = new Set(['interpolate']);
 
 const gestureHandlerGestureObjects = new Set([
-  // from https://github.com/software-mansion/react-native-gesture-handler/blob/new-api/src/handlers/gestures/gestureObjects.ts#L15
+  // from https://github.com/software-mansion/react-native-gesture-handler/blob/new-api/src/handlers/gestures/gestureObjects.ts
   'Tap',
   'Pan',
   'Pinch',
@@ -144,17 +144,62 @@ const gestureHandlerGestureObjects = new Set([
   'Fling',
   'LongPress',
   'ForceTouch',
+  'Native',
   'Race',
   'Simultaneous',
   'Exclusive',
 ]);
 
-const gestureHandlerCallbacks = new Set([
-  // from https://github.com/software-mansion/react-native-gesture-handler/blob/new-api/src/handlers/gestures/gesture.ts#L35
+const gestureHandlerBuilderMethods = new Set([
+  // BaseGesture
+  'withRef',
   'onBegan',
   'onStart',
-  'onUpdate',
   'onEnd',
+  'enabled',
+  'shouldCancelWhenOutside',
+  'hitSlop',
+  'simultaneousWithExternalGesture',
+  'requireExternalGestureToFail',
+
+  // ContinousBaseGesture
+  'onUpdate',
+
+  // TapGesture
+  'minPointers',
+  'numberOfTaps',
+  'maxDistance',
+  'maxDuration',
+  'maxDelay',
+  'maxDeltaX',
+  'maxDeltaY',
+
+  // PanGesture
+  'activeOffsetY',
+  'activeOffsetX',
+  'failOffsetY',
+  'failOffsetX',
+  'minPointers',
+  'minDistance',
+  'averageTouches',
+  'enableTrackpadTwoFingerGesture',
+
+  // FlingGesture
+  'numberOfPointers',
+  'direction',
+
+  // LongPress
+  'minDuration',
+  'maxDistance',
+
+  // ForceTouchGesture:
+  'minForce',
+  'maxForce',
+  'feedbackOnActivation',
+
+  // NativeGesture
+  'shouldActivateOnStart',
+  'disallowInterruption',
 ]);
 
 class ClosureGenerator {
@@ -544,7 +589,7 @@ function processIfWorkletNode(t, fun, fileName) {
   });
 }
 
-function processIfGestureHandlerCallbackFunctionNode(t, fun, fileName) {
+function processIfGestureHandlerEventCallbackFunctionNode(t, fun, fileName) {
   // Auto-workletizes React Native Gesture Handler callback functions.
   // Detects `Gesture.Tap().onEnd(<fun>)` or similar, but skips `something.onEnd(<fun>)`.
   // Supports method chaining as well, e.g. `Gesture.Tap().onStart(<fun1>).onUpdate(<fun2>).onEnd(<fun3>)`.
@@ -618,7 +663,7 @@ function isGestureObjectEventCallbackMethod(t, node) {
   if (
     t.isMemberExpression(node) &&
     t.isIdentifier(node.property) &&
-    gestureHandlerCallbacks.has(node.property.name)
+    gestureHandlerBuilderMethods.has(node.property.name)
   ) {
     // direct call
     if (isGestureObject(t, node.object)) {
@@ -733,7 +778,7 @@ module.exports = function ({ types: t }) {
         enter(path, state) {
           const fileName = state.file.opts.filename;
           processIfWorkletNode(t, path, fileName);
-          processIfGestureHandlerCallbackFunctionNode(t, path, fileName);
+          processIfGestureHandlerEventCallbackFunctionNode(t, path, fileName);
         },
       },
     },

--- a/plugin.js
+++ b/plugin.js
@@ -542,7 +542,9 @@ function processIfWorkletNode(t, fun, fileName) {
       }
     },
   });
+}
 
+function processIfGestureHandlerCallbackFunctionNode(t, fun, fileName) {
   // React Native Gesture Handler auto-workletization
   // detects `Gesture.Tap().onEnd(fun)` etc. but skips `something.onEnd(fun)`.
 
@@ -653,7 +655,9 @@ module.exports = function ({ types: t }) {
       },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
         enter(path, state) {
-          processIfWorkletNode(t, path, state.file.opts.filename);
+          const fileName = state.file.opts.filename;
+          processIfWorkletNode(t, path, fileName);
+          processIfGestureHandlerCallbackFunctionNode(t, path, fileName);
         },
       },
     },


### PR DESCRIPTION
## Description

This PR adds support for detecting patterns in JavaScript code which are specific to [React Native Gesture Handler](https://github.com/software-mansion/react-native-gesture-handler), like `Gesture.Tap().onEnd(...)`, so that they can be automatically converted into worklets even if they are not marked with `'worklet';` directive.

The general pattern is `Gesture.Foo()[*].bar(fun)`, where:
* `Foo` is a gesture object, like `Tap`, `Pan`, `Pinch`, etc.
* `[*]` is any number of chained builder method calls (e.g. `numberOfTaps(2)` or `onStart(...)`)
* `bar` is any builder method name, e.g. `onEnd`
* `fun` is a function declaration, function expression or arrow function expression

The following callback functions will be auto-workletized:

```ts
import { Gesture } from 'react-native-gesture-handler';

const foo = Gesture.Tap()
  .numberOfTaps(2)
  .onBegan(() => {
    // from now on, you may skip the 'worklet'; directive here...
    console.log('onBegan');
  })
  .onStart((_event) => {
    // ...and here...
    console.log('onStart');
  })
  .onEnd((_event, _success) => {
    // ...and here too!
    console.log('onEnd');
  });
```

Please note that the following callback functions will not be auto-workletized:

```ts
somethingNotRelatedToGestures.onEnd(( /* ... */ ) => { /* ... */ });
```

```ts
const tap = Gesture.Tap();
tap.onEnd((_event, success) => { /* ... */ });
```

```ts
const fun = (_event, success) => { /* ... */ };
Gesture.Tap().onEnd(fun);
```

```ts
import { Gesture as RNGHGesture } from 'react-native-gesture-handler';
RNGHGesture.Tap().onEnd((_event, success) => { /* ... */ });
```

In all the above cases, you still need to specify the `'worklet';` directive explicitly.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

- Added `processIfGestureHandlerEventCallbackFunctionNode` function in `babel.config.js`
- Added snapshot tests for functions that should and should not be workletized

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```sh
yarn jest
```

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [x] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
