### PR TITLE
Clear `mPendingDeletionsForTag`

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -18,6 +18,7 @@ import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.RootView;
 import com.facebook.react.uimanager.UIImplementation;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.lang.ref.WeakReference;
@@ -289,16 +290,18 @@ public class AnimationsManager implements ViewHierarchyObserver {
             return true;
         }
         boolean cannotStripe = false;
-        if (view instanceof ViewGroup) {
+        if (view instanceof ViewGroup && mViewManager.get(view.getId()) instanceof ViewGroupManager) {
             ViewGroup vg = (ViewGroup) view;
+            ViewGroupManager vgm = (ViewGroupManager) mViewManager.get(vg.getId());
             ArrayList<View> children = new ArrayList<>();
-            for (int i = 0; i < vg.getChildCount(); ++i) {
-                children.add(vg.getChildAt(i));
+            for (int i = 0; i < vgm.getChildCount(vg); ++i) {
+                children.add(vgm.getChildAt(vg, i));
             }
             for (View child : children) {
                 cannotStripe = cannotStripe || dfs(root, child, cands);
             }
         }
+
         if (!cannotStripe) {
             View parentView = (View)view.getParent();
             if (mCallbacks.containsKey(view.getId())) {
@@ -308,7 +311,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
             }
             if (mParent.containsKey(view.getId())) {
                 ViewGroup parent = (ViewGroup) mParent.get(view.getId());
-                if(parent != null) {
+                if(parent != null ) {
                     parent.removeView(view);
                 }
             }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -208,6 +208,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
                     @Override
                     public void run() {
                         toBeRemovedChildren.remove(view);
+                        viewGroupManager.removeView(viewGroup, view);
                     } // It's far from optimal but let's leave it as it is for now
                 });
             }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 class ReaLayoutAnimator extends LayoutAnimationController {
     private AnimationsManager mAnimationsManager = null;
@@ -133,6 +134,8 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     private HashMap<Integer, ArrayList<View>> toBeRemoved = new HashMap();
     private HashMap<Integer, Runnable> cleanerCallback = new HashMap();
     private LayoutAnimationController mReaLayoutAnimator = null;
+    private HashMap<Integer, Set<Integer>> mPendingDeletionsForTag = null;
+
     public ReanimatedNativeHierarchyManager(ViewManagerRegistry viewManagers, ReactApplicationContext reactContext) {
         super(viewManagers);
         Class clazz = this.getClass().getSuperclass();
@@ -144,6 +147,14 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
             mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
             field.set(this, mReaLayoutAnimator);
+
+            Field pendingTagsField = clazz.getDeclaredField("mPendingDeletionsForTag");
+            pendingTagsField.setAccessible(true);
+            Field pendingTagsFieldModifiers = Field.class.getDeclaredField("accessFlags");
+            pendingTagsFieldModifiers.setAccessible(true);
+            pendingTagsFieldModifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            mPendingDeletionsForTag = new HashMap<Integer, Set<Integer>>();
+            pendingTagsField.set(this, mPendingDeletionsForTag);
 
         } catch (NoSuchFieldException | IllegalAccessException e) {
             e.printStackTrace();
@@ -201,6 +212,13 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
                 });
             }
         }
+
+        // mPendingDeletionsForTag is modify by React
+        Set<Integer> pendingTags = mPendingDeletionsForTag.get(tag);
+        if (pendingTags != null) {
+            pendingTags.clear();
+        }
+
         super.manageChildren(tag, indicesToRemove, viewsToAdd, null);
         if (toBeRemoved.containsKey(tag)) {
             ArrayList<View> childrenToBeRemoved = toBeRemoved.get(tag);


### PR DESCRIPTION
## Description

React native stores some tags as pending to delete in a separate array. To keep a consistency of states we clear `mPendingDeletionsForTag` before we call `manageChildren`.
We also resolve an issue with the unknown view manager for the tag. React `dropView` method removes only children of views, we added removing parent view also.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2393, https://github.com/software-mansion/react-native-reanimated/issues/2394

Authors: @Szymon20000 @piaskowyk 