### PR TITLE
fix: Add `RNScreens` to podspec dependency

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -94,5 +94,7 @@ Pod::Spec.new do |s|
 
   s.dependency "#{folly_prefix}Folly"
 
+  s.dependency "RNScreens"
+
 end
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "*"
+    "react-native-gesture-handler": "*",
+    "react-native-screens": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",


### PR DESCRIPTION
## Description

Instead of disabling `RNScreens` support, we can force the `RNScreens` native dependency by adding it to the REA podspec.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
