### PR TITLE
fix: libreanimated.so mergeDebugNativeLibs issue for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -123,6 +123,7 @@ android {
         println "Native libs debug enabled: ${debugNativeLibraries}"
         doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
         excludes = ["**/libc++_shared.so", "**/libfbjni.so"]
+        pickFirst "lib/**/libreanimated.so"
     }
 
     tasks.withType(JavaCompile) {


### PR DESCRIPTION
## Description
fixed #2412
I just cloned this repo and run `./createNPMPackage.sh` command and get this error
```
* What went wrong:
A problem occurred evaluating project ':react-native-reanimated'.
> Task with path ':app:mergeDebugNativeLibs' not found in project ':app'
 > More than one file was found 'libreanimated.so'
```

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

i used `pickFirst "lib/**/libreanimated.so"` for all `abiFilters`

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

after `pickFirst`, run `./createNPMPackage.sh` command worrking properly

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
