### PR TITLE
fix(android): avoid using null mPendingDeletionsForTag / mReaLayoutAnimator

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -172,7 +172,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
         ViewManager parentViewManager = this.resolveViewManager(parentTag);
         String parentViewManagerName = parentViewManager.getName();
         View container = resolveView(parentTag);
-        if (container != null && parentViewManagerName.equals("RNSScreenContainer")) {
+        if (container != null && parentViewManagerName.equals("RNSScreenContainer") && this.mReaLayoutAnimator != null) {
             this.mReaLayoutAnimator.applyLayoutUpdate(viewToUpdate, 0, 0, container.getWidth(), container.getHeight());
         }
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -215,9 +215,11 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
         }
 
         // mPendingDeletionsForTag is modify by React
-        Set<Integer> pendingTags = mPendingDeletionsForTag.get(tag);
-        if (pendingTags != null) {
-            pendingTags.clear();
+        if (mPendingDeletionsForTag != null) {
+            Set<Integer> pendingTags = mPendingDeletionsForTag.get(tag);
+            if (pendingTags != null) {
+                pendingTags.clear();
+            }
         }
 
         super.manageChildren(tag, indicesToRemove, viewsToAdd, null);


### PR DESCRIPTION
## Description

mPendingDeletionsForTag is only initialized in some constructor paths, in others it might be null,
so we cannot always blindly dereference it

Fixes #2477

## Test code and steps to reproduce

For me, I'm able to reproduce a crash here anytime minifyEnabled is true in my build (you can set it in debug, to check it), and it crashes on startup for me.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
