### PR TITLE
fix: Avoid duplicate C++ symbols by using `libjsi.so` shared library

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -29,8 +29,6 @@ add_library(
         ${sources_registries}
         ${sources_android}
         ${source_tools}
-        ${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp
-        ${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/JSIDynamic.cpp
         "./src/main/Common/cpp/Tools/JSIStoreValueUser.cpp"
         "./src/main/Common/cpp/Tools/Mapper.cpp"
         "./src/main/Common/cpp/Tools/RuntimeDecorator.cpp"
@@ -108,7 +106,13 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
-        GLOG_LIB 
+        JSI_LIB
+        jsi
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+find_library(
+        GLOG_LIB
         glog
         PATHS ${LIBRN_DIR}
         NO_CMAKE_FIND_ROOT_PATH
@@ -124,6 +128,7 @@ if(${FOR_HERMES})
     target_link_libraries(
             ${PACKAGE_NAME}
             ${LOG_LIB}
+            ${JSI_LIB}
             ${HERMES_LIB}
             ${GLOG_LIB}
             fbjni::fbjni
@@ -135,6 +140,7 @@ else()
     target_link_libraries(
             ${PACKAGE_NAME}
             ${LOG_LIB}
+            ${JSI_LIB}
             ${JSEXECUTOR_LIB}
             ${GLOG_LIB}
             fbjni::fbjni


### PR DESCRIPTION
## Description

By compiling `jsi.cpp`, we will have duplicate C++ symbols in the user's app because `jsi.cpp` is compiled multiple times. (once for RN, once for REA, and maybe also for other third party libs)

This PR fixes this by re-using the shared/dynamic C++ library `libjsi.so`.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
