### PR TITLE
Enhanced jest mocks

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -5,15 +5,17 @@ const NOOP = () => {
   // noop
 };
 const ID = (t) => t;
+const IMMEDIATE_CB_INVOCATION = (cb: () => unknown) => cb();
 
 const ReanimatedV2 = {
   useSharedValue: (v) => ({ value: v }),
   useDerivedValue: (a) => ({ value: a() }),
   useAnimatedScrollHandler: () => NOOP,
   useAnimatedGestureHandler: () => NOOP,
-  useAnimatedStyle: (style) => style,
+  useAnimatedStyle: IMMEDIATE_CB_INVOCATION,
   useAnimatedRef: () => ({ current: null }),
   useAnimatedReaction: NOOP,
+  useAnimatedProps: IMMEDIATE_CB_INVOCATION,
 
   withTiming: (toValue, _, cb) => {
     cb && cb(true);


### PR DESCRIPTION
## Description

Added missing mock for `useAnimatedProps` which make it impossible to cover the component by unit-tests (because you will see `TypeError: (0 , _reactNativeReanimated.useAnimatedProps) is not a function` error).

Also changed the mock implementation for `useAnimatedStyle`, because current implementation returns a callback, that is passed to this hook. As a result in snapshot you will see `style={[Function]}` and the code inside of the callback will never be executed (and as a result you can not achieve 100% test coverage).

The mock implementation for these functions is identical, so I added generic `IMMEDIATE_CB_INVOCATION` function, which accepts `cb` function as a param and invoke it afterwards (I added type for it as `() => unknown`, because I know, that the usage of `Function` type is [forbidden](https://github.com/typescript-eslint/typescript-eslint/blob/v4.32.0/packages/eslint-plugin/docs/rules/ban-types.md) - I don't know, maybe you already have predefined TS type for such functions, I'm not familiar with your codebase, so if you think it can be improved - let me know 🙂)

## Changes

- Added mock for `useAnimatedProps` hook;
- Updated mock for `useAnimatedStyle` hook;
- Added generic `IMMEDIATE_CB_INVOCATION` mock;

## Screenshots

### useAnimatedStyle

|Before|After|
|-------|-----|
|![image](https://user-images.githubusercontent.com/22820318/136379596-c1776ad6-cdf5-4cbb-b1ec-cd928c8435e0.png)|![image](https://user-images.githubusercontent.com/22820318/136379443-f9b8c4ea-b5e0-42ce-bc4c-ac750fc5d1e0.png)|

<!--

## Test code and steps to reproduce

### useAnimatedStyle

### useAnimatedProps

-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
