### PR TITLE
Fix timings for overriding spring animations

### DIFF
--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -131,7 +131,7 @@ export function withSpring(
           animation.velocity = 0;
           animation.current = toValue;
         }
-        // clear lastTimestamp to avoid next spring animation from using stale value
+        // clear lastTimestamp to avoid using stale value by the next spring animation that starts after this one
         animation.lastTimestamp = 0;
         return true;
       }


### PR DESCRIPTION
## Description

This change fixes an issue with invalid delta time in the first frame for spring animations. The issue was that in spring implementation we use `lastTimestamp` property to keep track of the duration of each frame. In `onStart` method (here: https://github.com/software-mansion/react-native-reanimated/blob/726c774f024645a667fa1e6b0f8712affbaf751a/src/reanimated2/animation/spring.ts#L149) we copy `lastTimestamp` from previous animation if the animation value that we assign spring animation to was previously running one. The reason for copying that value was that when we override spring animation while one is already running, we want a smooth transition to the next spring animation with potentcially different attributes (different toValue, or spring configuration). However, when the previous animation has finished a while ago, we'd still copy that `lastTimestamp` which would result in time delta being very long for the first frame of the new animation. This is undesirable as it'd result in the first frame "jumping" a couple of frames ahead. In order to avoid it we reset `lastTimestamp` attribute for spring animations that are finished.

## Changes

 - add a single line that resets `lastTimestamp` attribute when the spring animation reaches the final frame.
