### PR TITLE
Support for Android build flavors with uppercase letters

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -31,19 +31,13 @@ abstract class replaceSoTask extends DefaultTask {
 def getCurrentFlavor() {
     Gradle gradle = getGradle()
     String taskRequestName = gradle.getStartParameter().getTaskRequests().toString()
-    Pattern pattern
-
-    if(taskRequestName.contains("assemble")) {
-        pattern = Pattern.compile("assemble(\\w+)(Release|Debug)")
-    }
-    else {
-        pattern = Pattern.compile("generate(\\w+)(Release|Debug)")
-    }
+    Pattern pattern = Pattern.compile("(assemble|install|generate)(\\w+)(Release|Debug)")
     Matcher matcher = pattern.matcher(taskRequestName)
 
     if(matcher.find()) {
-        return matcher.group(1).toLowerCase()
+        return matcher.group(2)
     }
+
     return ""
 }
 


### PR DESCRIPTION
## Changes
- Remove `toLowerCase()` call because build flavors can have uppercase letters.
- Add support for task starts with `install*`.

## Fixes
- https://github.com/software-mansion/react-native-reanimated/issues/2447
- https://github.com/software-mansion/react-native-reanimated/issues/2444