### PR TITLE
Added support for shareable jsi host objects and host functions

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -313,9 +313,11 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
     case ValueType::DirectHostFunctionType: {
       auto directFunctionWrapper =
           ValueWrapper::asDirectHostFunctionWrapper(valueContainer);
-      jsi::HostFunctionType func = *directFunctionWrapper->value;
       return jsi::Function::createFromHostFunction(
-          rt, jsi::PropNameID::forAscii(rt, "directHostFunction"), 0, func);
+          rt,
+          jsi::PropNameID::forAscii(rt, "directHostFunction"),
+          0,
+          *directFunctionWrapper->value);
     }
     case ValueType::HostFunctionType: {
       auto hostFunctionWrapper =

--- a/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -49,12 +49,15 @@ class ShareableValue : public std::enable_shared_from_this<ShareableValue>,
 
  public:
   ValueType type = ValueType::UndefinedType;
+  static void markAsHostShareable(jsi::Runtime &rt, jsi::Object &object);
   static std::shared_ptr<ShareableValue> adapt(
       jsi::Runtime &rt,
       const jsi::Value &value,
       RuntimeManager *runtimeManager,
       ValueType objectType = ValueType::UndefinedType);
   jsi::Value getValue(jsi::Runtime &rt);
+
+  static const char *HOST_SHAREABLE;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/SharedItems/SharedParent.h
+++ b/Common/cpp/headers/SharedItems/SharedParent.h
@@ -17,6 +17,10 @@ enum class ValueType {
   WorkletFunctionType, // function that gets run on the UI thread
   FrozenObjectType, // frozen object, can only be set and never modified
   FrozenArrayType, // frozen array, can only be set and never modified
+  DirectHostObjectType, /* Shared jsi host object stored as underlying cpp
+                           object */
+  DirectHostFunctionType, /* Shared jsi host function stored as underlying cpp
+                             object */
 };
 
 class ShareableValue;

--- a/Common/cpp/headers/SharedItems/SharedParent.h
+++ b/Common/cpp/headers/SharedItems/SharedParent.h
@@ -17,10 +17,10 @@ enum class ValueType {
   WorkletFunctionType, // function that gets run on the UI thread
   FrozenObjectType, // frozen object, can only be set and never modified
   FrozenArrayType, // frozen array, can only be set and never modified
-  DirectHostObjectType, /* Shared jsi host object stored as underlying cpp
-                           object */
-  DirectHostFunctionType, /* Shared jsi host function stored as underlying cpp
-                             object */
+  DirectHostObjectType, // Shared jsi host object stored as underlying cpp
+                        // object
+  DirectHostFunctionType, // Shared jsi host function stored as underlying cpp
+                          // object
 };
 
 class ShareableValue;

--- a/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -12,6 +12,8 @@
 namespace reanimated {
 
 class HostFunctionWrapper;
+class DirectHostFunctionWrapper;
+class DirectHostObjectWrapper;
 
 class ValueWrapper {
  public:
@@ -41,6 +43,12 @@ class ValueWrapper {
       const std::unique_ptr<ValueWrapper> &valueContainer);
 
   static const HostFunctionWrapper *asHostFunctionWrapper(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+
+  static const DirectHostFunctionWrapper *asDirectHostFunctionWrapper(
+      const std::unique_ptr<ValueWrapper> &valueContainer);
+
+  static const DirectHostObjectWrapper *asDirectHostObjectWrapper(
       const std::unique_ptr<ValueWrapper> &valueContainer);
 
  protected:
@@ -106,6 +114,21 @@ class MutableValueWrapper : public ValueWrapper {
   std::shared_ptr<MutableValue> value;
 };
 
+class DirectHostFunctionWrapper : public ValueWrapper {
+ public:
+  DirectHostFunctionWrapper(
+      const std::shared_ptr<jsi::HostFunctionType> &_value)
+      : ValueWrapper(ValueType::DirectHostFunctionType), value(_value){};
+  std::shared_ptr<jsi::HostFunctionType> value;
+};
+
+class DirectHostObjectWrapper : public ValueWrapper {
+ public:
+  DirectHostObjectWrapper(const std::shared_ptr<jsi::HostObject> &_value)
+      : ValueWrapper(ValueType::DirectHostObjectType), value(_value){};
+  std::shared_ptr<jsi::HostObject> value;
+};
+
 inline bool ValueWrapper::asBoolean(
     const std::unique_ptr<ValueWrapper> &valueContainer) {
   return static_cast<BooleanValueWrapper *>(valueContainer.get())->value;
@@ -151,5 +174,16 @@ inline const HostFunctionWrapper *ValueWrapper::asHostFunctionWrapper(
     const std::unique_ptr<ValueWrapper> &valueContainer) {
   return static_cast<HostFunctionWrapper *>(valueContainer.get());
 }
+
+inline const DirectHostFunctionWrapper *
+ValueWrapper::asDirectHostFunctionWrapper(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<DirectHostFunctionWrapper *>(valueContainer.get());
+};
+
+inline const DirectHostObjectWrapper *ValueWrapper::asDirectHostObjectWrapper(
+    const std::unique_ptr<ValueWrapper> &valueContainer) {
+  return static_cast<DirectHostObjectWrapper *>(valueContainer.get());
+};
 
 } // namespace reanimated

--- a/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -116,16 +116,17 @@ class MutableValueWrapper : public ValueWrapper {
 
 class DirectHostFunctionWrapper : public ValueWrapper {
  public:
-  DirectHostFunctionWrapper(
+  explicit DirectHostFunctionWrapper(
       const std::shared_ptr<jsi::HostFunctionType> &_value)
-      : ValueWrapper(ValueType::DirectHostFunctionType), value(_value){};
+      : ValueWrapper(ValueType::DirectHostFunctionType), value(_value) {}
   std::shared_ptr<jsi::HostFunctionType> value;
 };
 
 class DirectHostObjectWrapper : public ValueWrapper {
  public:
-  DirectHostObjectWrapper(const std::shared_ptr<jsi::HostObject> &_value)
-      : ValueWrapper(ValueType::DirectHostObjectType), value(_value){};
+  explicit DirectHostObjectWrapper(
+      const std::shared_ptr<jsi::HostObject> &_value)
+      : ValueWrapper(ValueType::DirectHostObjectType), value(_value) {}
   std::shared_ptr<jsi::HostObject> value;
 };
 
@@ -179,11 +180,11 @@ inline const DirectHostFunctionWrapper *
 ValueWrapper::asDirectHostFunctionWrapper(
     const std::unique_ptr<ValueWrapper> &valueContainer) {
   return static_cast<DirectHostFunctionWrapper *>(valueContainer.get());
-};
+}
 
 inline const DirectHostObjectWrapper *ValueWrapper::asDirectHostObjectWrapper(
     const std::unique_ptr<ValueWrapper> &valueContainer) {
   return static_cast<DirectHostObjectWrapper *>(valueContainer.get());
-};
+}
 
 } // namespace reanimated


### PR DESCRIPTION
## Description

When implementing jsi host objects or host functions that wraps native objects/funcs it would be nice to be able to share these between javascript runtimes.

This commit adds support for marking jsi host objects/host functions as shareable and handle them in a controlled manner.

It will always be the implementer's responsibility to ensure thread safety when using objects/funcs in different runtimes.

To mark a host object or host function as shareable, either call the ShareableValue::markHostAsShareable on the object/func, or make sure the host object returns true when the `get` method is called for the property ShareableValue::HOST_SHAREABLE.

An example of such a use case can be seen here:

![image](https://user-images.githubusercontent.com/875252/137136312-3800df4a-35c7-47ab-ac90-bc3743bef7c6.png)

The `paint` object is constructed by calling a jsi-based host function and returns a host object that points to the underlying cpp object representing the paint object in the native world. The object can be accessed across threads so Reanimated can just copy the underlying cpp pointer and return it as a new host object when the worklet runtime asks for the object.

In the host object implementation we can look for access to the shareable host property and return true to indicate to Reanimated that this object can be freely copied between the two runtimes:

<img width="839" alt="image" src="https://user-images.githubusercontent.com/875252/137137010-ac7c74db-fbbe-449d-bf81-197694e44068.png">

If we want to share a host function we can mark it with the shareable host property to accomplish the same thing for the function:

<img width="957" alt="image" src="https://user-images.githubusercontent.com/875252/137137327-2ba2b000-b994-444c-8a79-78ca06e0deca.png">


## Changes

- Added two new ValueTypes to support shareable host objects/functions.
- Added value wrappers for the new ValueTypes
- Added conversion from jsi::Value to the two new value wrappers
- Added conversion to jsi:Value from value wrappers.
- Added methods for making a hostobject/hostfunction shareable 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
