### PR TITLE
chore: use createElement instead of JSX transform

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -86,7 +86,7 @@ function createTransitioningComponent(Component) {
     }
 
     render() {
-      return <Component {...this.props} />;
+      return React.createElement(Component, this.props);
     }
   };
 }


### PR DESCRIPTION
## Description

this avoids the ` Jest encountered an unexpected token` error when running tests,  because the mock uses JSX syntax.

So instead of transforming the code, I figured it's easier to use React.createElement()

## Changes

- use React.createElement() instead of JSX transform in the mock setup file



## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

Details:

```
    /Users/vojta/_dev/abc/node_modules/react-native-reanimated/mock.js:83
          return <Component {...this.props} />;
                 ^

    SyntaxError: Unexpected token '<'
```

### After

error is gone



## Test code and steps to reproduce



## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
