### PR TITLE
feat: add fallback for not yet supported RN versions

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -88,6 +88,9 @@ def aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
 while (!aar.exists()) {
     minorCopy -= 1
     aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
+    if (minorCopy < 63) {
+      throw new GradleException('No aar for react-native-reanimated found.')
+    }
 }
 
 artifacts.add("default", aar)


### PR DESCRIPTION
## Description

PR checking if `aar` for `react-native` version exists, and if no, looking for `aar` for lower versions.

## Test code and steps to reproduce

Add RN 0.67 in your project and try build with and without this change.


After removing the aars from folder, such error is thrown:
![image](https://user-images.githubusercontent.com/32481228/138067517-df33f9e7-0e7f-4b58-89c2-640eb83c9460.png)


## Checklist

- [ ] Ensured that CI passes
