### PR TITLE
build(android): post a warning message if fallback used

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -91,6 +91,18 @@ while (!aar.exists()) {
     if (minorCopy < 63) {
       throw new GradleException('No aar for react-native-reanimated found.')
     }
+    if (aar.exists()) {
+      println "\n\n\n"
+      println "****************************************************************************************"
+      println "\n\n\n"
+      println "WARNING reanimated - no version-specific reanimated AAR for react-native version " . minor . " found."
+      println "Falling back to AAR for react-native version " . minorCopy
+      println "The react-native JSI interface is not ABI-safe yet, this may result in crashes."
+      println "Please post a pull request to implement support for react-native version " . minor . " to the reanimated repo."
+      println "Thanks!"
+      println "\n\n\n"
+      println "****************************************************************************************"
+    }    
 }
 
 artifacts.add("default", aar)


### PR DESCRIPTION

## Description

As the JSI interface is not ABI_safe this should give users a warning in case there are problems.

Related #2553 / @WoLewicki 

## Changes

commit message and PR title are conventional-commit standard and encapsulate the change

I patterned this off a build warning/error I use in another project with good success for devs:

https://github.com/ankidroid/Anki-Android/blob/71d966c4f7e49166784919837c6cfc611bfeaeee/build.gradle#L37-L48

## Test code and steps to reproduce

Build with react-native 0.66.0-rc.0 once a new reanimated 2.3.0-beta is released

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
