### PR TITLE
Remove _bridge_renimated, fix #2555

### DIFF
--- a/ios/REAEventDispatcher.m
+++ b/ios/REAEventDispatcher.m
@@ -7,7 +7,7 @@
 
 - (void)sendEvent:(id<RCTEvent>)event
 {
-  [[_bridge_reanimated moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
+  [[[self bridge] moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
   [super sendEvent:event];
 }
 

--- a/ios/REAModule.h
+++ b/ios/REAModule.h
@@ -7,8 +7,6 @@
 
 #import "REAValueNode.h"
 
-extern RCTBridge *_bridge_reanimated;
-
 @interface REAModule : RCTEventEmitter <RCTBridgeModule, RCTEventDispatcherObserver, RCTUIManagerObserver>
 
 @property (nonatomic, readonly) REANodesManager *nodesManager;

--- a/ios/REAModule.m
+++ b/ios/REAModule.m
@@ -6,8 +6,6 @@
 
 typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
-RCTBridge *_bridge_reanimated = nil;
-
 @implementation REAModule {
   NSMutableArray<AnimatedOperation> *_operations;
   REATransitionManager *_transitionManager;
@@ -17,7 +15,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)invalidate
 {
-  _bridge_reanimated = nil;
   _transitionManager = nil;
   [_nodesManager invalidate];
   [self.bridge.uiManager.observerCoordinator removeObserver:self];

--- a/ios/native/NativeProxy.h
+++ b/ios/native/NativeProxy.h
@@ -7,6 +7,7 @@
 namespace reanimated {
 
 std::shared_ptr<reanimated::NativeReanimatedModule> createReanimatedModule(
+    RCTBridge *bridge,
     std::shared_ptr<facebook::react::CallInvoker> jsInvoker);
 
 }

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -86,9 +86,8 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
 }
 
-std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<CallInvoker> jsInvoker)
+std::shared_ptr<NativeReanimatedModule> createReanimatedModule(RCTBridge *bridge, std::shared_ptr<CallInvoker> jsInvoker)
 {
-  RCTBridge *bridge = _bridge_reanimated;
   REAModule *reanimatedModule = [bridge moduleForClass:[REAModule class]];
 
   auto propUpdater = [reanimatedModule](

--- a/ios/native/REAInitializer.mm
+++ b/ios/native/REAInitializer.mm
@@ -35,16 +35,15 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
   [eventDispatcher setBridge:bridge];
 #endif
   [bridge updateModuleWithInstance:eventDispatcher];
-  _bridge_reanimated = bridge;
   const auto runtimeInstaller = [bridge, runtimeInstallerToWrap](facebook::jsi::Runtime &runtime) {
     if (!bridge) {
       return;
     }
 #if RNVERSION >= 63
-    auto reanimatedModule = reanimated::createReanimatedModule(bridge.jsCallInvoker);
+    auto reanimatedModule = reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
 #else
     auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
-    auto reanimatedModule = reanimated::createReanimatedModule(callInvoker);
+    auto reanimatedModule = reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
     runtime.global().setProperty(
         runtime,


### PR DESCRIPTION
## Description

Fixes #2555. 

## Changes

Perhaps I'm missing something, but it seems to me that `_bridge_renimated` is a vestigial organ that no longer serves any practical purpose. Its use in REAEventDispatcher is unnecessary, since we already assign RCTEventDispatcher.bridge with the same value, and its only other use in createReanimatedModule is a single call where we can pass bridge as an argument.

Since bridge is now passed as an explicit dependency, a race condition is no longer possible.

I've realized that I can reproduce #2555 quite easily by repeatedly ⌘Ring in the simulator in quick succession. I've easily managed to get to the point where REAEventDispatcher has a null `_bridge_reanimated`, but `[self bridge]` is correct, confirming that the fix works.

## Screenshots / GIFs

n/a

## Test code and steps to reproduce

Reload the app in simulator repeatedly and see if gestures break as per #2555.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
