### PR TITLE
chore: add '-fstack-protector-all' flag to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ def reactNativeThirdParty = new File("$reactNative/ReactAndroid/src/main/jni/thi
 
 def HOME = System.getProperty("user.home")
 
+def _stackProtectorFlag = true;
 def FOR_HERMES = "";
 if(findProject(':app')) {
     FOR_HERMES = project(':app').ext.react.enableHermes;
@@ -108,7 +109,7 @@ android {
                              "-DBOOST_VERSION=${BOOST_VERSION}",
                              "-DFOR_HERMES=${FOR_HERMES}"
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
-                cppFlags "-fstack-protector-all"
+                _stackProtectorFlag ? (cppFlags("-fstack-protector-all")) : null
             }
         }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -108,6 +108,7 @@ android {
                              "-DBOOST_VERSION=${BOOST_VERSION}",
                              "-DFOR_HERMES=${FOR_HERMES}"
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+                cppFlags "-fstack-protector-all"
             }
         }
 


### PR DESCRIPTION
## Description

Add stack protector flag to build.gradle to add a stack canary value to the compiled libraries.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
