### PR TITLE
fix: ios native stack and RN modals

### DIFF
--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -24,6 +24,7 @@ import {
   MountingUnmounting,
   SpringLayoutAnimation,
   SwipeableList,
+  NativeModals,
 } from './LayoutReanimation';
 
 import AnimatedStyleUpdateExample from './AnimatedStyleUpdateExample';
@@ -102,6 +103,10 @@ const SCREENS: Screens = {
   Modal: {
     title: '🆕 Modal',
     screen: Modal,
+  },
+  NativeModals: {
+    title: '🆕  Native modals (RN and Screens)',
+    screen: NativeModals,
   },
   Carousel: {
     title: '🆕 Carousel',

--- a/Example/src/LayoutReanimation/NativeModals.tsx
+++ b/Example/src/LayoutReanimation/NativeModals.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { Alert, Modal, StyleSheet, Text, Pressable, View } from 'react-native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from 'react-native-screens/native-stack';
+import { ParamListBase } from '@react-navigation/native';
+
+// import { createStackNavigator } from "@react-navigation/stack";
+
+const Stack = createNativeStackNavigator();
+// you can check if normal stack works ok too
+// const Stack = createStackNavigator();
+
+export function NativeModals() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={App} />
+      <Stack.Screen
+        name="Modal"
+        options={{
+          // comment below for native-stack to see if it works with normal screens
+          stackPresentation: 'modal',
+        }}
+        component={App}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const App = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<ParamListBase>;
+}) => {
+  const [modalVisible, setModalVisible] = useState(false);
+  return (
+    <View style={styles.centeredView}>
+      <Modal
+        animationType="slide"
+        transparent={true}
+        visible={modalVisible}
+        onRequestClose={() => {
+          Alert.alert('Modal has been closed.');
+          setModalVisible(!modalVisible);
+        }}>
+        <View style={styles.centeredView}>
+          <View style={styles.modalView}>
+            <Text style={styles.modalText}>Hello World!</Text>
+            <Pressable
+              style={[styles.button, styles.buttonClose]}
+              onPress={() => setModalVisible(!modalVisible)}>
+              <Text style={styles.textStyle}>Hide Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+      <Pressable
+        style={[styles.button, styles.buttonOpen]}
+        onPress={() => setModalVisible(true)}>
+        <Text style={styles.textStyle}>Show Modal</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, styles.buttonOpen]}
+        onPress={() => navigation.navigate('Modal')}>
+        <Text style={styles.textStyle}>Go to next Screen</Text>
+      </Pressable>
+      <Pressable
+        style={[styles.button, styles.buttonOpen]}
+        onPress={() => navigation.goBack()}>
+        <Text style={styles.textStyle}>Go back</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+// export default App;
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalView: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  button: {
+    borderRadius: 20,
+    padding: 10,
+    elevation: 2,
+  },
+  buttonOpen: {
+    backgroundColor: '#F194FF',
+  },
+  buttonClose: {
+    backgroundColor: '#2196F3',
+  },
+  textStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  modalText: {
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+});

--- a/Example/src/LayoutReanimation/index.ts
+++ b/Example/src/LayoutReanimation/index.ts
@@ -6,3 +6,4 @@ export * from './Carousel';
 export * from './ModalNewAPI';
 export * from './DefaultAnimations';
 export * from './CustomLayout';
+export * from './NativeModals';


### PR DESCRIPTION
## Description

PR fixing buggy behavior of RN modals and laggy animation of `RNScreens` `native-stack` JS going back animation. It does not apply layout animation logic in case one of those is removed.

## Test code and steps to reproduce

`NativeModals` in `Example` app.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Ensured that CI passes
