### PR TITLE
Propose Expo integration

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -107,3 +107,5 @@ while (!aar.exists()) {
 }
 
 artifacts.add("default", aar)
+
+apply from: './expo/linking.gradle'

--- a/android-npm/expo/linking.gradle
+++ b/android-npm/expo/linking.gradle
@@ -1,0 +1,34 @@
+def isExpoLinked = false
+rootProject.getSubprojects().forEach({ project ->
+    if (project.plugins.hasPlugin("com.android.application")) {
+        if (project.configurations.implementation.getDependencies().find { dep -> dep.name == "expo" }) {
+            isExpoLinked = true
+        }
+    }
+})
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+if (isExpoLinked) {
+    apply plugin: 'com.android.library'
+
+    android {
+        compileSdkVersion safeExtGet('compileSdkVersion', 30)
+
+        sourceSets {
+            main.manifest.srcFile 'src/AndroidManifest.xml'
+            main.java.srcDirs = [ 'expo/src/main/java' ]
+        }
+    }
+
+    dependencies {
+        implementation 'com.facebook.react:react-native:+'
+        implementation project(':expo-modules-core')
+
+        project.configurations.default.artifacts.each { artifact ->
+            api files(artifact.file)
+        }
+    }
+}

--- a/android-npm/expo/src/main/java/com/swmansion/reanimated/EXReanimatedAdapter.java
+++ b/android-npm/expo/src/main/java/com/swmansion/reanimated/EXReanimatedAdapter.java
@@ -1,0 +1,12 @@
+package com.swmansion.reanimated;
+
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.ReactApplicationContext;
+
+public class EXReanimatedAdapter {
+  public static void registerJSIModules(ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext) {
+    NodesManager nodesManager =
+      reactApplicationContext.getNativeModule(ReanimatedModule.class).getNodesManager();
+    nodesManager.initWithContext(reactApplicationContext);
+  }
+}

--- a/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
+++ b/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
@@ -1,0 +1,52 @@
+package expo.modules.adapters.reanimated;
+
+import android.content.Context;
+
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.swmansion.reanimated.EXReanimatedAdapter;
+
+import java.util.Collections;
+import java.util.List;
+
+import expo.modules.core.interfaces.Package;
+import expo.modules.core.interfaces.ReactNativeHostHandler;
+
+public class EXReanimatedPackage implements Package {
+  @Override
+  public List<? extends ReactNativeHostHandler> createReactNativeHostHandlers(Context context) {
+    final ReactNativeHostHandler handler = new ReactNativeHostHandler() {
+      @Override
+      public ReactInstanceManager createReactInstanceManager(boolean useDeveloperSupport) {
+        return null;
+      }
+
+      @Override
+      public String getJSBundleFile(boolean useDeveloperSupport) {
+        return null;
+      }
+
+      @Override
+      public String getBundleAssetName(boolean useDeveloperSupport) {
+        return null;
+      }
+
+      @Override
+      public void onRegisterJSIModules(ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext, boolean useDeveloperSupport) {
+        EXReanimatedAdapter.registerJSIModules(reactApplicationContext, jsContext);
+      }
+
+      @Override
+      public void onBeforeCreateReactInstanceManager(boolean useDeveloperSupport) {
+
+      }
+
+      @Override
+      public void onDidCreateReactInstanceManager(boolean useDeveloperSupport) {
+
+      }
+    };
+    return Collections.singletonList(handler);
+  }
+}

--- a/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
+++ b/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
@@ -43,7 +43,7 @@ public class EXReanimatedPackage implements Package {
       }
 
       @Override
-      public void onDidCreateReactInstanceManager(boolean useDeveloperSupport) {
+      public void onDidCreateReactInstanceManager(ReactInstanceManager reactInstanceManager, boolean useDeveloperSupport) {
 
       }
     };

--- a/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
+++ b/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
@@ -38,7 +38,7 @@ public class EXReanimatedPackage implements Package {
       }
 
       @Override
-      public void onBeforeCreateReactInstanceManager(boolean useDeveloperSupport) {
+      public void onWillCreateReactInstanceManager(boolean useDeveloperSupport) {
 
       }
 

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-native-reanimated",
+  "platforms": ["android"]
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-native-reanimated.d.ts",
     "mock.js",
     "plugin.js",
+    "expo-module.config.json",
     "!__snapshots__",
     "!*.test.js",
     "!*.test.js.map"


### PR DESCRIPTION
## Description

Previously, to support reanimated in Expo SDK, we had reanimated builtin in our template even user don't use it. In newer SDK, we plan to support native modules as opt-in without extra setup; we proposed https://github.com/expo/expo/pull/14883 and this pr is for reanimated integration.

## Changes

- Add `expo-module.config.json` for expo autolinking
- Add `android/expo` files dedicated for expo integration
- Just add single line to existing build.gradle for the integration.

We will check the gradle dependencies to see if there are `expo` project and only enable the integration then.
  
## Test plan

## Test Expo integration

[demo repo](https://github.com/Kudo/ExpoAndroidWrapper) which based on expo sdk43 bare template with additional changes:
1. adapts https://github.com/expo/expo/pull/14883 patch because it doesn't publish yet.
2. remove `ReanimatedJSIModulePackage` from MainApplication.java
3. add this pr's patch by patch-package.

## Test classic RN app without Expo
makes sure not to break existing functionalities

```sh
$ npx react-native init RN066 --version 0.66
$ yarn add react-native-reanimated
# patch this pr's change into node_modules/react-native-reanimated
$ ./gradlew :app:assembleDebug
```

## Checklist

- [x] Included code example that can be used to test this change
- n/a Updated TS types
- n/a Added TS types tests
- n/a Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
