### PR TITLE
Enable build from source on client side

### DIFF
--- a/android-npm/build.gradle
+++ b/android-npm/build.gradle
@@ -34,7 +34,7 @@ def getCurrentFlavor() {
     Pattern pattern = Pattern.compile("(assemble|bundle|install|generate)(\\w*)(Release|Debug)")
     Matcher matcher = pattern.matcher(taskRequestName)
 
-    if(matcher.find()) {
+    if (matcher.find()) {
         return matcher.group(2)
     }
 
@@ -43,7 +43,7 @@ def getCurrentFlavor() {
 
 def replaceSoTaskDebug
 def replaceSoTaskRelease
-if(Integer.parseInt(minor) < 65) {
+if (Integer.parseInt(minor) < 65) {
     tasks.register("replaceSoTaskDebug", replaceSoTask)
     tasks.register("replaceSoTaskRelease", replaceSoTask)
     replaceSoTaskDebug = project.getTasks().getByPath(":react-native-reanimated:replaceSoTaskDebug")
@@ -52,14 +52,14 @@ if(Integer.parseInt(minor) < 65) {
 
 rootProject.getSubprojects().forEach({project ->
     if (project.plugins.hasPlugin("com.android.application")) {
-        if(project.ext.react.enableHermes) {
+        if (project.ext.react.enableHermes) {
             engine = "hermes"
         }
 
-        if(project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
+        if (project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
             def projectProperties = project.getProperties()
             final NOTFOUND = "NOT-FOUND"
-            if(!NOTFOUND.equals(getCurrentFlavor()) && (!projectProperties.get("reanimated")
+            if (!NOTFOUND.equals(getCurrentFlavor()) && (!projectProperties.get("reanimated")
                     || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions")))
             ) {
                 def flavorString = getCurrentFlavor()

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -9,40 +9,31 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 
 set (PACKAGE_NAME "reanimated")
 set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
+set (SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 
-#set (NODE_MODULES_DIR "../node_modules")
-#set (RN_SO_DIR ${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/first-party/react/jni)
-#set (FBJNI_HEADERS_DIR ${RN_SO_DIR}/../../fbjni/headers)
-#
-## reanimated shared
-#
-#file(GLOB sources_tools  "./src/main/Common/cpp/Tools/*.cpp")
-#file(GLOB sources_native_modules  "./src/main/Common/cpp/NativeModules/*.cpp")
-#file(GLOB sources_shared_items  "./src/main/Common/cpp/SharedItems/*.cpp")
-#file(GLOB sources_registries  "./src/main/Common/cpp/Registries/*.cpp")
-#file(GLOB sources_android  "./src/main/cpp/*.cpp")
-
-message(DEBUG "CMakeLists.txt CLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}")
-message(DEBUG "CMakeLists.txt CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
+message(WARNING "CMakeLists.txt CLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}")
+message(WARNING "CMakeLists.txt CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
 
 if(${CLIENT_SIDE_BUILD})
-    set (NODE_MODULES_DIR  "../../node_modules")
-    message(DEBUG "CMakeLists.txt NODE_MODULES_DIR=${NODE_MODULES_DIR}")
+    set (NODE_MODULES_DIR  "${CMAKE_SOURCE_DIR}/../../")
+    set (COMMON_SRC_DIR "${CMAKE_SOURCE_DIR}/../Common")
 else()
     set (NODE_MODULES_DIR "../node_modules")
-    message(DEBUG "CMakeLists.txt NODE_MODULES_DIR=${NODE_MODULES_DIR}")
+    set (COMMON_SRC_DIR "${SRC_DIR}/main/Common")
 endif()
+
+message(WARNING  "CMakeLists.txt NODE_MODULES_DIR=${NODE_MODULES_DIR}")
 
 set (RN_SO_DIR ${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/first-party/react/jni)
 set (FBJNI_HEADERS_DIR ${RN_SO_DIR}/../../fbjni/headers)
 
 # reanimated shared
 
-file(GLOB sources_tools  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/Tools/*.cpp")
-file(GLOB sources_native_modules  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/NativeModules/*.cpp")
-file(GLOB sources_shared_items  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/SharedItems/*.cpp")
-file(GLOB sources_registries  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/Registries/*.cpp")
-file(GLOB sources_android  "${CMAKE_SOURCE_DIR}/src/main/cpp/*.cpp")
+file(GLOB sources_tools  "${COMMON_SRC_DIR}/cpp/Tools/*.cpp")
+file(GLOB sources_native_modules  "${COMMON_SRC_DIR}/cpp/NativeModules/*.cpp")
+file(GLOB sources_shared_items  "${COMMON_SRC_DIR}/cpp/SharedItems/*.cpp")
+file(GLOB sources_registries  "${COMMON_SRC_DIR}/cpp/Registries/*.cpp")
+file(GLOB sources_android  "${SRC_DIR}/main/cpp/*.cpp")
 
 
 if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
@@ -66,13 +57,12 @@ add_library(
         ${source_tools}
         ${INCLUDE_JSI_CPP}
         ${INCLUDE_JSIDYNAMIC_CPP}
-        "./src/main/Common/cpp/Tools/JSIStoreValueUser.cpp"
-        "./src/main/Common/cpp/Tools/Mapper.cpp"
-        "./src/main/Common/cpp/Tools/RuntimeDecorator.cpp"
-        "./src/main/Common/cpp/Tools/Scheduler.cpp"
-        "./src/main/Common/cpp/Tools/WorkletEventHandler.cpp"
-        "./src/main/Common/cpp/Tools/FeaturesConfig.cpp"
-        "./src/main/Common/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/JSIStoreValueUser.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/Mapper.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/RuntimeDecorator.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/Scheduler.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/WorkletEventHandler.cpp"
+        "${COMMON_SRC_DIR}/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp"
 )
 
 # includes
@@ -97,14 +87,14 @@ target_include_directories(
         "${NODE_MODULES_DIR}/react-native/ReactCommon/turbomodule/core"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/turbomodule"
         "${NODE_MODULES_DIR}/hermes-engine/android/include/"
-        "./src/main/Common/cpp/headers/Tools"
-        "./src/main/Common/cpp/headers/SpecTools"
-        "./src/main/Common/cpp/headers/NativeModules"
-        "./src/main/Common/cpp/headers/SharedItems"
-        "./src/main/Common/cpp/headers/Registries"
-        "./src/main/Common/cpp/headers/LayoutAnimations"
-        "./src/main/Common/cpp/hidden_headers"
-        "./src/main/cpp/headers"
+        "${COMMON_SRC_DIR}/cpp/headers/Tools"
+        "${COMMON_SRC_DIR}/cpp/headers/SpecTools"
+        "${COMMON_SRC_DIR}/cpp/headers/NativeModules"
+        "${COMMON_SRC_DIR}/cpp/headers/SharedItems"
+        "${COMMON_SRC_DIR}/cpp/headers/Registries"
+        "${COMMON_SRC_DIR}/cpp/headers/LayoutAnimations"
+        "${COMMON_SRC_DIR}/cpp/hidden_headers"
+        "${SRC_DIR}/main/cpp/headers"
 )
 
 # find libraries

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -9,17 +9,41 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 
 set (PACKAGE_NAME "reanimated")
 set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
-set (NODE_MODULES_DIR "../node_modules")
+
+#set (NODE_MODULES_DIR "../node_modules")
+#set (RN_SO_DIR ${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/first-party/react/jni)
+#set (FBJNI_HEADERS_DIR ${RN_SO_DIR}/../../fbjni/headers)
+#
+## reanimated shared
+#
+#file(GLOB sources_tools  "./src/main/Common/cpp/Tools/*.cpp")
+#file(GLOB sources_native_modules  "./src/main/Common/cpp/NativeModules/*.cpp")
+#file(GLOB sources_shared_items  "./src/main/Common/cpp/SharedItems/*.cpp")
+#file(GLOB sources_registries  "./src/main/Common/cpp/Registries/*.cpp")
+#file(GLOB sources_android  "./src/main/cpp/*.cpp")
+
+message(DEBUG "CMakeLists.txt CLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}")
+message(DEBUG "CMakeLists.txt CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
+
+if(${CLIENT_SIDE_BUILD})
+    set (NODE_MODULES_DIR  "../../node_modules")
+    message(DEBUG "CMakeLists.txt NODE_MODULES_DIR=${NODE_MODULES_DIR}")
+else()
+    set (NODE_MODULES_DIR "../node_modules")
+    message(DEBUG "CMakeLists.txt NODE_MODULES_DIR=${NODE_MODULES_DIR}")
+endif()
+
 set (RN_SO_DIR ${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/jni/first-party/react/jni)
 set (FBJNI_HEADERS_DIR ${RN_SO_DIR}/../../fbjni/headers)
 
 # reanimated shared
 
-file(GLOB sources_tools  "./src/main/Common/cpp/Tools/*.cpp")
-file(GLOB sources_native_modules  "./src/main/Common/cpp/NativeModules/*.cpp")
-file(GLOB sources_shared_items  "./src/main/Common/cpp/SharedItems/*.cpp")
-file(GLOB sources_registries  "./src/main/Common/cpp/Registries/*.cpp")
-file(GLOB sources_android  "./src/main/cpp/*.cpp")
+file(GLOB sources_tools  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/Tools/*.cpp")
+file(GLOB sources_native_modules  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/NativeModules/*.cpp")
+file(GLOB sources_shared_items  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/SharedItems/*.cpp")
+file(GLOB sources_registries  "${CMAKE_SOURCE_DIR}/src/main/Common/cpp/Registries/*.cpp")
+file(GLOB sources_android  "${CMAKE_SOURCE_DIR}/src/main/cpp/*.cpp")
+
 
 if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
         set (

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(
         "${COMMON_SRC_DIR}/cpp/Tools/RuntimeDecorator.cpp"
         "${COMMON_SRC_DIR}/cpp/Tools/Scheduler.cpp"
         "${COMMON_SRC_DIR}/cpp/Tools/WorkletEventHandler.cpp"
+        "${COMMON_SRC_DIR}/cpp/Tools/FeaturesConfig.cpp"
         "${COMMON_SRC_DIR}/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp"
 )
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -213,20 +213,23 @@ if (CLIENT_SIDE_BUILD) {
         }
     })
 
-    def minorCopy = Integer.parseInt(minor)
-    aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
+    def rnMinorVersionCopy = Integer.parseInt(minor)
+    aar = file("react-native-reanimated-${rnMinorVersionCopy}-${engine}.aar")
 
-    while (!aar.exists()) {
-        minorCopy -= 1
-        if (minorCopy < 63) {
-            println "No AAR for react-native-reanimated found. Attempting to build from source."
-            buildFromSource = true
-            break
+    if (aar.exists()) {
+        println "AAR for react-native-renimated has been found\n$aar"
+        buildFromSource = false
+        artifacts.add("default", aar)
+    } else {
+        while (!aar.exists() && rnMinorVersionCopy >= 63) {
+            rnMinorVersionCopy -= 1
+            aar = file("react-native-reanimated-${rnMinorVersionCopy}-${engine}.aar")
         }
 
-        aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
-
-        if (aar.exists()) {
+        if (rnMinorVersionCopy < 63) {
+            println "No AAR for react-native-reanimated found. Attempting to build from source."
+            buildFromSource = true
+        } else { // aar exists, but was built for lower react-native version
             println "\n\n\n"
             println "****************************************************************************************"
             println "\n\n\n"
@@ -599,11 +602,11 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-//    implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
+//   implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-//    extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
-//    extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
+//   extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
+//   extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
     def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -139,7 +139,7 @@ def HOME = System.getProperty("user.home")
 
 def _stackProtectorFlag = true
 def FOR_HERMES = ""
-if(findProject(':app')) {
+if (findProject(':app')) {
     FOR_HERMES = project(':app').ext.react.enableHermes
 }
 else {
@@ -424,7 +424,7 @@ def findNdkBuildFullPath() {
     if (rootProject.file("local.properties").exists()) {
         properties.load(project.rootProject.file("local.properties").newDataInputStream())
         def ndkDir=properties.getProperty("ndk.dir", null);
-        if(ndkDir)
+        if (ndkDir)
         {
             return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
         }
@@ -570,7 +570,7 @@ task extractSOFiles {
 task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
-    if(REACT_VERSION < 64) {
+    if (REACT_VERSION < 64) {
         include("**/libturbomodulejsijni.so")
     }
     into("$projectDir/src/main/jniLibs")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,133 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.apache.tools.ant.filters.ReplaceTokens
+import java.util.regex.Pattern
+import java.util.regex.Matcher
+import java.nio.file.Paths
+import groovy.json.JsonSlurper
+
+// TODO: kkafar: handle property passed via local.properties or gradle.properties
+def CLIENT_SIDE_BUILD = System.getenv("CLIENT_SIDE_BUILD") == "True" ?: false
+
+def buildFromSource = !CLIENT_SIDE_BUILD
+
+def reactNative
+if (CLIENT_SIDE_BUILD) {
+    reactNative = file("$projectDir/../../react-native")
+} else {
+    reactNative = file("$projectDir/../node_modules/react-native")
+}
+
+// start -----------------
+
+abstract class replaceSoTask extends DefaultTask {
+    public static String appName = ":app"
+    public static String buildDir = "../../../android/app/build"
+
+    @TaskAction
+    def run() {
+        for (def abiVersion in ["x86", "x86_64", "armeabi-v7a", "arm64-v8a"]) {
+            ant.sequential {
+                copy(
+                    tofile: "${buildDir}/intermediates/merged_native_libs/debug/out/lib/${abiVersion}/libfbjni.so",
+                    file: "../libSo/fbjni/jni/${abiVersion}/libfbjni.so",
+                    overwrite: true
+                )
+            }
+        }
+    }
+}
+
+def aar
+if (CLIENT_SIDE_BUILD) {
+    def reactNativeManifest = file("$reactNative/package.json")
+    def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.text)
+    def reactNativeVersion = reactNativeManifestAsJson.version as String
+    def (major, minor, patch) = reactNativeVersion.tokenize('.')
+    def engine = "jsc"
+
+    def replaceSoTaskDebug
+    def replaceSoTaskRelease
+    if (Integer.parseInt(minor) < 65) {
+        tasks.register("replaceSoTaskDebug", replaceSoTask)
+        tasks.register("replaceSoTaskRelease", replaceSoTask)
+        replaceSoTaskDebug = project.getTasks().getByPath(":react-native-reanimated:replaceSoTaskDebug")
+        replaceSoTaskRelease = project.getTasks().getByPath(":react-native-reanimated:replaceSoTaskRelease")
+    }
+
+    rootProject.getSubprojects().forEach({project ->
+        if (project.plugins.hasPlugin("com.android.application")) {
+            if(project.ext.react.enableHermes) {
+                engine = "hermes"
+            }
+
+            if(project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
+                def projectProperties = project.getProperties()
+                if(!projectProperties.get("reanimated")
+                        || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
+                ) {
+                    def flavorString = getCurrentFlavor()
+                    replaceSoTask.appName = project.getProperties().path
+                    replaceSoTask.buildDir = project.getProperties().buildDir
+                    def appName = project.getProperties().path
+
+                    replaceSoTaskDebug.dependsOn(
+                        project.getTasks().getByPath("${appName}:merge${flavorString}DebugNativeLibs"),
+                        project.getTasks().getByPath("${appName}:strip${flavorString}DebugDebugSymbols")
+                    )
+                    project.getTasks().getByPath("${appName}:package${flavorString}Debug").dependsOn(replaceSoTaskDebug)
+
+                    replaceSoTaskRelease.dependsOn(
+                        project.getTasks().getByPath("${appName}:merge${flavorString}ReleaseNativeLibs"),
+                        project.getTasks().getByPath("${appName}:strip${flavorString}ReleaseDebugSymbols")
+                    )
+                    project.getTasks().getByPath("${appName}:package${flavorString}Release").dependsOn(replaceSoTaskRelease)
+                }
+            }
+        }
+    })
+
+    def minorCopy = Integer.parseInt(minor)
+    aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
+
+    while (!aar.exists()) {
+        minorCopy -= 1
+        aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
+        if (minorCopy < 63) {
+            println "No aar for react-native-reanimated found. Attempting to build from source."
+            buildFromSource = true
+            break
+        }
+        if (aar.exists()) {
+            println "\n\n\n"
+            println "****************************************************************************************"
+            println "\n\n\n"
+            println "WARNING reanimated - no version-specific reanimated AAR for react-native version " . minor . " found."
+            println "Falling back to AAR for react-native version " . minorCopy
+            println "The react-native JSI interface is not ABI-safe yet, this may result in crashes."
+            println "Please post a pull request to implement support for react-native version " . minor . " to the reanimated repo."
+            println "Thanks!"
+            println "\n\n\n"
+            println "****************************************************************************************"
+
+            artifacts.add("default", aar)
+        }
+    }
+}
+
+// end --------------------
+
+if (!buidFromSource) return
+
 def localProps = new Properties()
+
 def localPropertiesFile = file("local.properties")
 if (localPropertiesFile.exists()) {
     localProps.load(new InputStreamReader(new FileInputStream(localPropertiesFile), "UTF-8"))
 }
+
 def debugNativeLibraries = localProps.getProperty('NATIVE_DEBUG_ON', 'FALSE').toBoolean()
-
-import java.nio.file.Paths
-
-import org.apache.tools.ant.taskdefs.condition.Os
-import org.apache.tools.ant.filters.ReplaceTokens
-
 def reactProperties = new Properties()
-file("$projectDir/../node_modules/react-native/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+file("$reactNative/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
 
 def BOOST_VERSION = reactProperties.getProperty("BOOST_VERSION")
 def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_VERSION")
@@ -27,15 +143,14 @@ def FBJNI_VERSION = '0.2.2'
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
-def reactNative = new File("$projectDir/../node_modules/react-native")
 def reactNativeThirdParty = new File("$reactNative/ReactAndroid/src/main/jni/third-party")
 
 def HOME = System.getProperty("user.home")
 
-def _stackProtectorFlag = true;
-def FOR_HERMES = "";
+def _stackProtectorFlag = true
+def FOR_HERMES = ""
 if(findProject(':app')) {
-    FOR_HERMES = project(':app').ext.react.enableHermes;
+    FOR_HERMES = project(':app').ext.react.enableHermes
 }
 else {
     FOR_HERMES = System.getenv("FOR_HERMES") == "True";
@@ -73,11 +188,6 @@ buildscript {
         classpath("de.undercouch:gradle-download-task:4.1.2")
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
-}
-
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 if (project == rootProject) {
@@ -332,6 +442,10 @@ def findNdkBuildFullPath() {
     return null
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 def getNdkBuildFullPath() {
     def ndkBuildFullPath = findNdkBuildFullPath()
     if (ndkBuildFullPath == null) {
@@ -349,6 +463,19 @@ def getNdkBuildFullPath() {
                 null)
     }
     return ndkBuildFullPath
+}
+
+def getCurrentFlavor() {
+    Gradle gradle = getGradle()
+    String taskRequestName = gradle.getStartParameter().getTaskRequests().toString()
+    Pattern pattern = Pattern.compile("(assemble|bundle|install|generate)(\\w*)(Release|Debug)")
+    Matcher matcher = pattern.matcher(taskRequestName)
+
+    if (matcher.find()) {
+        return matcher.group(2)
+    }
+
+    return "NOT-FOUND"
 }
 
 task prepareHermes() {
@@ -496,3 +623,10 @@ tasks.whenTaskAdded { task ->
     }
 }
 
+if (CLIENT_SIDE_BUILD) {
+    aar = file("$buildDir/outputs/mockFileName")
+    if (aar == null) {
+        throw GradleScriptException("TODO: EXCEPTION MESSAGE")
+    }
+    artifacts.add("default", aar)
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,19 +5,10 @@ import java.util.regex.Matcher
 import java.nio.file.Paths
 import groovy.json.JsonSlurper
 
-// TODO: kkafar: handle property passed via local.properties or gradle.properties
-def CLIENT_SIDE_BUILD = System.getenv("CLIENT_SIDE_BUILD") == "True" ?: false
-
+def CLIENT_SIDE_BUILD = detectBuildType()
 def buildFromSource = !CLIENT_SIDE_BUILD
 
-def reactNative
-if (CLIENT_SIDE_BUILD) {
-    reactNative = file("$projectDir/../../react-native")
-} else {
-    reactNative = file("$projectDir/../node_modules/react-native")
-}
-
-// start -----------------
+def reactNative = getReactNativeDir(CLIENT_SIDE_BUILD)
 
 abstract class replaceSoTask extends DefaultTask {
     public static String appName = ":app"
@@ -39,6 +30,7 @@ abstract class replaceSoTask extends DefaultTask {
 
 def aar
 if (CLIENT_SIDE_BUILD) {
+    configurations.maybeCreate("default")
     def reactNativeManifest = file("$reactNative/package.json")
     def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.text)
     def reactNativeVersion = reactNativeManifestAsJson.version as String
@@ -56,13 +48,13 @@ if (CLIENT_SIDE_BUILD) {
 
     rootProject.getSubprojects().forEach({project ->
         if (project.plugins.hasPlugin("com.android.application")) {
-            if(project.ext.react.enableHermes) {
+            if (project.ext.react.enableHermes) {
                 engine = "hermes"
             }
 
-            if(project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
+            if (project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
                 def projectProperties = project.getProperties()
-                if(!projectProperties.get("reanimated")
+                if (!projectProperties.get("reanimated")
                         || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
                 ) {
                     def flavorString = getCurrentFlavor()
@@ -114,9 +106,7 @@ if (CLIENT_SIDE_BUILD) {
     }
 }
 
-// end --------------------
-
-if (!buidFromSource) return
+if (!buildFromSource) return
 
 def localProps = new Properties()
 
@@ -184,8 +174,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:4.2.2')
-        classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "de.undercouch:gradle-download-task:4.1.2"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
     }
 }
@@ -478,6 +468,26 @@ def getCurrentFlavor() {
     return "NOT-FOUND"
 }
 
+def detectBuildType() {
+    if (hasProperty("clientSideBuild")) {
+        return property("clientSideBuild") == "true"
+    }
+    def buildType = System.getenv("CLIENT_SIDE_BUILD")
+    if (buildType == null) {
+        return "$rootDir" != "$projectDir"
+    } else {
+        return buildType == "True"
+    }
+}
+
+def getReactNativeDir(boolean clientSideBuild) {
+    if (clientSideBuild) {
+        return file("$projectDir/../../react-native")
+    } else {
+        return file("$projectDir/../node_modules/react-native")
+    }
+}
+
 task prepareHermes() {
     def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
     if (!hermesPackagePath) {
@@ -624,7 +634,7 @@ tasks.whenTaskAdded { task ->
 }
 
 if (CLIENT_SIDE_BUILD) {
-    aar = file("$buildDir/outputs/mockFileName")
+    aar = file("$buildDir/outputs/android-debug.aar")
     if (aar == null) {
         throw GradleScriptException("TODO: EXCEPTION MESSAGE")
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,7 +109,6 @@ if (CLIENT_SIDE_BUILD) {
 if (!buildFromSource) return
 
 def localProps = new Properties()
-
 def localPropertiesFile = file("local.properties")
 if (localPropertiesFile.exists()) {
     localProps.load(new InputStreamReader(new FileInputStream(localPropertiesFile), "UTF-8"))
@@ -207,7 +206,8 @@ android {
                              "-DREACT_NATIVE_TARGET_VERSION=${REACT_VERSION}",
                              "-DANDROID_TOOLCHAIN=clang",
                              "-DBOOST_VERSION=${BOOST_VERSION}",
-                             "-DFOR_HERMES=${FOR_HERMES}"
+                             "-DFOR_HERMES=${FOR_HERMES}",
+                             "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}"
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
                 _stackProtectorFlag ? (cppFlags("-fstack-protector-all")) : null
             }
@@ -469,11 +469,11 @@ def getCurrentFlavor() {
 }
 
 def detectBuildType() {
-    if (hasProperty("clientSideBuild")) {
-        return property("clientSideBuild") == "true"
-    }
     def buildType = System.getenv("CLIENT_SIDE_BUILD")
     if (buildType == null) {
+        if (hasProperty("clientSideBuild")) {
+            return property("clientSideBuild") == "true"
+        }
         return "$rootDir" != "$projectDir"
     } else {
         return buildType == "True"
@@ -566,7 +566,6 @@ task extractSOFiles {
     }
 }
 
-
 task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
@@ -600,11 +599,11 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
+//    implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-    extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
-    extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
+//    extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
+//    extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
     def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
@@ -631,6 +630,9 @@ tasks.whenTaskAdded { task ->
         task.dependsOn(extractAARHeaders)
         task.dependsOn(extractSOFiles)
     }
+//    if (task.name.contains('generateJsonModelDebug')) {
+//        task.dependsOn(tasks.getByName(':mergeDebugNativeLibs'))
+//    }
 }
 
 if (CLIENT_SIDE_BUILD) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -170,11 +170,12 @@ if (CLIENT_SIDE_BUILD) {
     def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.text)
     def reactNativeVersion = reactNativeManifestAsJson.version as String
     def (major, minor, patch) = reactNativeVersion.tokenize('.')
+    def rnMinorVersion = Integer.parseInt(minor)
     def engine = "jsc"
 
     def replaceSoTaskDebug
     def replaceSoTaskRelease
-    if (Integer.parseInt(minor) < 65) {
+    if (rnMinorVersion < 65) {
         tasks.register("replaceSoTaskDebug", replaceSoTask)
         tasks.register("replaceSoTaskRelease", replaceSoTask)
         replaceSoTaskDebug = project.getTasks().getByPath(":react-native-reanimated:replaceSoTaskDebug")
@@ -185,9 +186,11 @@ if (CLIENT_SIDE_BUILD) {
         if (project.plugins.hasPlugin("com.android.application")) {
             if (project.ext.react.enableHermes) {
                 engine = "hermes"
+                project.getProperties().android.packagingOptions.pickFirst("lib/**/*")
+                project.configurations.all*.exclude module: 'fbjni-java-only'
             }
 
-            if (project.getProperties().get("android") && Integer.parseInt(minor) < 65) {
+            if (project.getProperties().get("android") && rnMinorVersion < 65) {
                 def projectProperties = project.getProperties()
                 if (!projectProperties.get("reanimated")
                         || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
@@ -233,10 +236,10 @@ if (CLIENT_SIDE_BUILD) {
             println "\n\n\n"
             println "****************************************************************************************"
             println "\n\n\n"
-            println "WARNING reanimated - no version-specific reanimated AAR for react-native version " . minor . " found."
-            println "Falling back to AAR for react-native version " . minorCopy
+            println "WARNING reanimated - no version-specific reanimated AAR for react-native version $rnMinorVersion found."
+            println "Falling back to AAR for react-native version $rnMinorVersionCopy."
             println "The react-native JSI interface is not ABI-safe yet, this may result in crashes."
-            println "Please post a pull request to implement support for react-native version " . minor . " to the reanimated repo."
+            println "Please post a pull request to implement support for react-native version $rnMinorVersion to the reanimated repo."
             println "Thanks!"
             println "\n\n\n"
             println "****************************************************************************************"
@@ -602,11 +605,11 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-//   implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
+    implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"
-//   extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
-//   extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
+    extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
+    extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
     def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
     def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,141 @@ import java.util.regex.Matcher
 import java.nio.file.Paths
 import groovy.json.JsonSlurper
 
+/**
+ * Finds the path of the installed npm package with the given name using Node's
+ * module resolution algorithm, which searches "node_modules" directories up to
+ * the file system root. This handles various cases, including:
+ *
+ *   - Working in the open-source RN repo:
+ *       Gradle: /path/to/react-native/ReactAndroid
+ *       Node module: /path/to/react-native/node_modules/[package]
+ *
+ *   - Installing RN as a dependency of an app and searching for hoisted
+ *     dependencies:
+ *       Gradle: /path/to/app/node_modules/react-native/ReactAndroid
+ *       Node module: /path/to/app/node_modules/[package]
+ *
+ *   - Working in a larger repo (e.g., Facebook) that contains RN:
+ *       Gradle: /path/to/repo/path/to/react-native/ReactAndroid
+ *       Node module: /path/to/repo/node_modules/[package]
+ *
+ * The search begins at the given base directory (a File object). The returned
+ * path is a string.
+ */
+static def findNodeModulePath(baseDir, packageName) {
+    def basePath = baseDir.toPath().normalize()
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null
+    while (basePath) {
+        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
+        if (candidatePath.toFile().exists()) {
+            return candidatePath.toString()
+        }
+        basePath = basePath.getParent()
+    }
+    return null
+}
+
+static def getNdkBuildName() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return "ndk-build.cmd"
+    } else {
+        return "ndk-build"
+    }
+}
+
+def findNdkBuildFullPath() {
+    // we allow to provide full path to ndk-build tool
+    if (hasProperty("ndk.command")) {
+        return property("ndk.command")
+    }
+    // or just a path to the containing directory
+    if (hasProperty("ndk.path")) {
+        def ndkDir = property("ndk.path")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
+    if (System.getenv("ANDROID_NDK") != null) {
+        def ndkDir = System.getenv("ANDROID_NDK")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
+    if (hasProperty("ndkDirectory")) {
+        def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+
+        if (ndkDir) {
+            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+        }
+    }
+
+    def Properties properties = new Properties()
+    if (rootProject.file("local.properties").exists()) {
+        properties.load(project.rootProject.file("local.properties").newDataInputStream())
+        def ndkDir=properties.getProperty("ndk.dir", null);
+        if (ndkDir)
+        {
+            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+        }
+    }
+    return null
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def getNdkBuildFullPath() {
+    def ndkBuildFullPath = findNdkBuildFullPath()
+    if (ndkBuildFullPath == null) {
+        throw new GradleScriptException(
+                "ndk-build binary cannot be found, check if you've set " +
+                        "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
+                        "setup in local.properties",
+                null)
+    }
+    if (!new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException(
+                "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
+                        "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.\n" +
+                        "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
+                null)
+    }
+    return ndkBuildFullPath
+}
+
+def getCurrentFlavor() {
+    Gradle gradle = getGradle()
+    String taskRequestName = gradle.getStartParameter().getTaskRequests().toString()
+    Pattern pattern = Pattern.compile("(assemble|bundle|install|generate)(\\w*)(Release|Debug)")
+    Matcher matcher = pattern.matcher(taskRequestName)
+
+    if (matcher.find()) {
+        return matcher.group(2)
+    }
+
+    return "NOT-FOUND"
+}
+
+def detectBuildType() {
+    def buildType = System.getenv("CLIENT_SIDE_BUILD")
+    if (buildType == null) {
+        if (hasProperty("clientSideBuild")) {
+            return property("clientSideBuild") == "true"
+        }
+        return "$rootDir" != "$projectDir"
+    } else {
+        return buildType == "True"
+    }
+}
+
+def getReactNativeDir(boolean clientSideBuild) {
+    if (clientSideBuild) {
+        return file("$projectDir/../../react-native")
+    } else {
+        return file("$projectDir/../node_modules/react-native")
+    }
+}
+
 def CLIENT_SIDE_BUILD = detectBuildType()
 def buildFromSource = !CLIENT_SIDE_BUILD
 
@@ -83,12 +218,14 @@ if (CLIENT_SIDE_BUILD) {
 
     while (!aar.exists()) {
         minorCopy -= 1
-        aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
         if (minorCopy < 63) {
-            println "No aar for react-native-reanimated found. Attempting to build from source."
+            println "No AAR for react-native-reanimated found. Attempting to build from source."
             buildFromSource = true
             break
         }
+
+        aar = file("react-native-reanimated-${minorCopy}-${engine}.aar")
+
         if (aar.exists()) {
             println "\n\n\n"
             println "****************************************************************************************"
@@ -351,143 +488,6 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
     }
 }
 
-
-
-/**
- * Finds the path of the installed npm package with the given name using Node's
- * module resolution algorithm, which searches "node_modules" directories up to
- * the file system root. This handles various cases, including:
- *
- *   - Working in the open-source RN repo:
- *       Gradle: /path/to/react-native/ReactAndroid
- *       Node module: /path/to/react-native/node_modules/[package]
- *
- *   - Installing RN as a dependency of an app and searching for hoisted
- *     dependencies:
- *       Gradle: /path/to/app/node_modules/react-native/ReactAndroid
- *       Node module: /path/to/app/node_modules/[package]
- *
- *   - Working in a larger repo (e.g., Facebook) that contains RN:
- *       Gradle: /path/to/repo/path/to/react-native/ReactAndroid
- *       Node module: /path/to/repo/node_modules/[package]
- *
- * The search begins at the given base directory (a File object). The returned
- * path is a string.
- */
-static def findNodeModulePath(baseDir, packageName) {
-    def basePath = baseDir.toPath().normalize()
-    // Node's module resolution algorithm searches up to the root directory,
-    // after which the base path will be null
-    while (basePath) {
-        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
-        if (candidatePath.toFile().exists()) {
-            return candidatePath.toString()
-        }
-        basePath = basePath.getParent()
-    }
-    return null
-}
-
-static def getNdkBuildName() {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        return "ndk-build.cmd"
-    } else {
-        return "ndk-build"
-    }
-}
-
-def findNdkBuildFullPath() {
-    // we allow to provide full path to ndk-build tool
-    if (hasProperty("ndk.command")) {
-        return property("ndk.command")
-    }
-    // or just a path to the containing directory
-    if (hasProperty("ndk.path")) {
-        def ndkDir = property("ndk.path")
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    if (System.getenv("ANDROID_NDK") != null) {
-        def ndkDir = System.getenv("ANDROID_NDK")
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    if (hasProperty("ndkDirectory")) {
-        def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
-
-        if (ndkDir) {
-            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-        }
-    }
-
-    def Properties properties = new Properties()
-    if (rootProject.file("local.properties").exists()) {
-        properties.load(project.rootProject.file("local.properties").newDataInputStream())
-        def ndkDir=properties.getProperty("ndk.dir", null);
-        if (ndkDir)
-        {
-            return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-        }
-    }
-    return null
-}
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def getNdkBuildFullPath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null) {
-        throw new GradleScriptException(
-                "ndk-build binary cannot be found, check if you've set " +
-                        "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
-                        "setup in local.properties",
-                null)
-    }
-    if (!new File(ndkBuildFullPath).canExecute()) {
-        throw new GradleScriptException(
-                "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
-                        "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.\n" +
-                        "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
-                null)
-    }
-    return ndkBuildFullPath
-}
-
-def getCurrentFlavor() {
-    Gradle gradle = getGradle()
-    String taskRequestName = gradle.getStartParameter().getTaskRequests().toString()
-    Pattern pattern = Pattern.compile("(assemble|bundle|install|generate)(\\w*)(Release|Debug)")
-    Matcher matcher = pattern.matcher(taskRequestName)
-
-    if (matcher.find()) {
-        return matcher.group(2)
-    }
-
-    return "NOT-FOUND"
-}
-
-def detectBuildType() {
-    def buildType = System.getenv("CLIENT_SIDE_BUILD")
-    if (buildType == null) {
-        if (hasProperty("clientSideBuild")) {
-            return property("clientSideBuild") == "true"
-        }
-        return "$rootDir" != "$projectDir"
-    } else {
-        return buildType == "True"
-    }
-}
-
-def getReactNativeDir(boolean clientSideBuild) {
-    if (clientSideBuild) {
-        return file("$projectDir/../../react-native")
-    } else {
-        return file("$projectDir/../node_modules/react-native")
-    }
-}
-
 task prepareHermes() {
     def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
     if (!hermesPackagePath) {
@@ -630,15 +630,14 @@ tasks.whenTaskAdded { task ->
         task.dependsOn(extractAARHeaders)
         task.dependsOn(extractSOFiles)
     }
-//    if (task.name.contains('generateJsonModelDebug')) {
-//        task.dependsOn(tasks.getByName(':mergeDebugNativeLibs'))
-//    }
 }
 
 if (CLIENT_SIDE_BUILD) {
-    aar = file("$buildDir/outputs/android-debug.aar")
+    def aarDir = "$buildDir/outputs"
+    aar = file("$aarDir/android-debug.aar")
+    // TODO: copy AAR file to projectDir with appropriate name
     if (aar == null) {
-        throw GradleScriptException("TODO: EXCEPTION MESSAGE")
+        throw GradleScriptException("Build failed. No AAR found in $aarDir.")
     }
     artifacts.add("default", aar)
 }

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -5,6 +5,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -19,7 +20,7 @@ import com.facebook.systrace.Systrace;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ReanimatedPackage extends TurboReactPackage {
+public class ReanimatedPackage extends TurboReactPackage implements ReactPackage {
 
   @Override
   public NativeModule getModule(String name, ReactApplicationContext reactContext) {

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -60,8 +60,8 @@ do
 
     cd $ROOT
 
-    rm -rf android-npm/react-native-reanimated-"${version_name[$index]}-${engine}".aar
-    cp android/build/outputs/aar/*.aar android-npm/react-native-reanimated-"${version_name[$index]}-${engine}".aar
+    rm -rf android/react-native-reanimated-"${version_name[$index]}-${engine}".aar
+    cp android/build/outputs/aar/*.aar android/react-native-reanimated-"${version_name[$index]}-${engine}".aar
   done
 done
 
@@ -78,15 +78,9 @@ cd ../..
 
 yarn add react-native@0.67.0-rc.4 --dev
 
-mv android android-temp
-mv android-npm android
-
 yarn run type:generate
 
 npm pack
-
-mv android android-npm
-mv android-temp android
 
 rm -rf ./libSo
 rm -rf ./lib

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -80,6 +80,8 @@ yarn add react-native@0.67.0-rc.4 --dev
 
 yarn run type:generate
 
+cd $ROOT/android && ./gradlew clean && cd $ROOT
+
 npm pack
 
 rm -rf ./libSo

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -6,7 +6,7 @@ ROOT=$(pwd)
 
 unset CI
 
-versions=("0.67.0-rc.2")
+versions=("0.67.0-rc.4")
 version_name=("67")
 
 for index in {0..0}

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -6,10 +6,10 @@ ROOT=$(pwd)
 
 unset CI
 
-versions=("0.67.0-rc.4" "0.66.3" "0.65.1" "0.64.3" "0.63.3")
-version_name=("67" "66" "65" "64" "63")
+versions=("0.67.0-rc.2")
+version_name=("67")
 
-for index in {0..4}
+for index in {0..0}
 do
   yarn add react-native@"${versions[$index]}"
   for for_hermes in "True" "False"
@@ -43,7 +43,7 @@ do
 
     ./gradlew clean
 
-    FOR_HERMES=${for_hermes} ./gradlew :assembleDebug
+    CLIENT_SIDE_BUILD="False" FOR_HERMES=${for_hermes} ./gradlew :assembleDebug
 
     cd ./rnVersionPatch/$versionNumber
     if [ $(find . | grep 'java') ];


### PR DESCRIPTION
## Description

This PR introduces mechanism to build aar for reanimated, from source on a client side, in case appropriate version is not provided initially with the package.

## Changes

* Merged `android-npm/build.gradle` with `android/build.gradle`
* Adjusted paths in `android/CMakeLists.txt`
* Updated `createNPMPackage` script

  Android source code is now provided with the package

## Before

For given react-native minor version, if aar built for equal of lower was not provided, the build would fail.

## After

If aar built for equal or lower react-native minor version is not provided, client attempts to build it from the provided source code. 

## Test code and steps to reproduce

Changes were tested on [reanimated react native version tester](https://github.com/piaskowyk/reanimated-rn-version-tester).

1. Build package for some react-native version
2. See that projects for different RN versions compile 



## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
