### PR TITLE
Fix SSR regression in 2.3.0

### DIFF
--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -24,7 +24,8 @@ export interface ViewDescriptorsSet {
   ) => void;
 }
 
-const scheduleUpdates: Platform.OS === 'web' ? requestAnimationFrame : setImmediate;
+const scheduleUpdates =
+  Platform.OS === 'web' ? requestAnimationFrame : setImmediate;
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const ref = useRef<ViewDescriptorsSet | null>(null);

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { makeMutable } from './core';
 import { SharedValue } from './commonTypes';
 import { Descriptor } from './hook/commonTypes';
-import { Platform } from 'react-native'
+import { Platform } from 'react-native';
 
 export interface ViewRefSet<T> {
   items: Set<T>;

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { makeMutable } from './core';
 import { SharedValue } from './commonTypes';
 import { Descriptor } from './hook/commonTypes';
+import { Platform } from 'react-native'
 
 export interface ViewRefSet<T> {
   items: Set<T>;
@@ -22,6 +23,8 @@ export interface ViewDescriptorsSet {
     sharableViewDescriptor: SharedValue<Descriptor[]>
   ) => void;
 }
+
+const scheduleUpdates: Platform.OS === 'web' ? requestAnimationFrame : setImmediate;
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const ref = useRef<ViewDescriptorsSet | null>(null);
@@ -44,7 +47,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
         if (!data.waitForInsertSync) {
           data.waitForInsertSync = true;
 
-          setImmediate(() => {
+          scheduleUpdates(() => {
             data.sharableViewDescriptors.value = data.items;
             data.waitForInsertSync = false;
           });
@@ -57,7 +60,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
         if (!data.waitForRemoveSync) {
           data.waitForRemoveSync = true;
 
-          setImmediate(() => {
+          scheduleUpdates(() => {
             const items = [];
             for (const item of data.items) {
               if (data.batchToRemove.has(item.tag)) {


### PR DESCRIPTION
Use `requestAnimationFrame` on Web, instead of `setImmediate`.

See #2621 and https://github.com/software-mansion/react-native-reanimated/pull/1521 for reference.

## Description

Fix #2621
<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

`setImmediate` breaks SSR on Web. `requestAnimationFrame` is better. This was already discussed and merged previously at #1521.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

N/A.

### Before

Next.js wouldn't compile.

### After

It now does compile.

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
