### PR TITLE
Handle removing exception

### DIFF
--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -347,7 +347,10 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   NSMutableDictionary<NSNumber *, id<RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
   [view.reactSuperview removeReactSubview:view];
   id<RCTComponent> parentView = viewRegistry[tag];
-  [parentView removeReactSubview:view];
+  @try {
+    [parentView removeReactSubview:view];
+  } @catch (id anException) {
+  }
 #if __has_include(<RNScreens/RNSScreen.h>)
   if ([view isKindOfClass:[RNSScreenView class]]) {
     [parentView didUpdateReactSubviews];


### PR DESCRIPTION
## Description

I am not convinced to fix it by reanimated side. IMO this assertion is not necessary and handling it this way looks like dirty hacks for edge cases. I ask them to remove this assertion. in spite of it, I prepared a fix.

Handle Assert exception during disappearing of a component. Caused by https://github.com/oblador/react-native-shimmer/blob/620a9e899df40e1bef38127d4ef61384e1a195c5/ios/RNShimmeringView.m#L26

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2554

Related: https://github.com/oblador/react-native-shimmer/pull/33