### PR TITLE
[Web] Fix 2589: `null` in `useDerivedValue` 

### DIFF
--- a/src/reanimated2/js-reanimated/Mapper.ts
+++ b/src/reanimated2/js-reanimated/Mapper.ts
@@ -43,7 +43,9 @@ export default class Mapper<T> {
     const res: MutableValue<T>[] = [];
 
     function extractMutables(value: NestedObjectValues<MutableValue<T>>) {
-      if (value instanceof MutableValue) {
+      if (value == null) {
+        // do nothing
+      } else if (value instanceof MutableValue) {
         res.push(value);
       } else if (Array.isArray(value)) {
         value.forEach((v) => extractMutables(v));

--- a/src/reanimated2/js-reanimated/Mapper.ts
+++ b/src/reanimated2/js-reanimated/Mapper.ts
@@ -44,7 +44,7 @@ export default class Mapper<T> {
 
     function extractMutables(value: NestedObjectValues<MutableValue<T>>) {
       if (value == null) {
-        // do nothing
+        return;
       } else if (value instanceof MutableValue) {
         res.push(value);
       } else if (Array.isArray(value)) {


### PR DESCRIPTION
## Description

Fixes #2589

* https://github.com/software-mansion/react-native-reanimated/issues/2589

## Changes

[`extractMutableFromArray` function](https://github.com/software-mansion/react-native-reanimated/blob/12093cbe04d978b2ef619531755ef7d472242cd9/src/reanimated2/js-reanimated/Mapper.ts#L40) now returns empty array when `array` is `null | undefined`

## Test code and steps to reproduce

Use this code to see that it now works on web:

```tsx
import React from 'react'
import { useDerivedValue } from 'react-native-reanimated'
 
export default function HelloWorld() {
  const broken = null
  useDerivedValue(() => {
    const d = broken
  })
  return (<Text>Test</Text>)
}
```

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
