### PR TITLE
feat: disable layout animations in other navigators

### DIFF
--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -12,7 +12,6 @@
 
 #if __has_include(<RNScreens/RNSScreen.h>)
 #import <RNScreens/RNSScreen.h>
-#import <RNScreens/RNSScreenStack.h>
 #endif
 
 @interface RCTUIManager (REA)
@@ -110,8 +109,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       }
       if ([toRemoveChild isKindOfClass:[RCTModalHostView class]]
 #if __has_include(<RNScreens/RNSScreen.h>)
-          ||
-          ([toRemoveChild isKindOfClass:[RNSScreenView class]] && [container isKindOfClass:[RNSScreenStackView class]])
+          || ([toRemoveChild isKindOfClass:[RNSScreenView class]])
 #endif
       ) {
         // we don't want layout animations when removing modals or Screens of native-stack since it brings buggy


### PR DESCRIPTION
## Description

Added all navigators using `screens` to list of disabled views for applying `layoutAnimations`. Should fix https://github.com/software-mansion/react-native-reanimated/issues/2639.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
