### PR TITLE
Disable by default layout animation

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <thread>
 #include "EventHandlerRegistry.h"
+#include "FeaturesConfig.h"
 #include "FrozenObject.h"
 #include "JSIStoreValueUser.h"
 #include "Mapper.h"
@@ -231,6 +232,13 @@ jsi::Value NativeReanimatedModule::getViewProp(
     });
   });
 
+  return jsi::Value::undefined();
+}
+
+jsi::Value NativeReanimatedModule::setEnableFeatures(
+    jsi::Runtime &rt,
+    const jsi::Value &config) {
+  FeaturesConfig::setLayoutAnimationEnabled(true);
   return jsi::Value::undefined();
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -235,19 +235,10 @@ jsi::Value NativeReanimatedModule::getViewProp(
   return jsi::Value::undefined();
 }
 
-jsi::Value NativeReanimatedModule::setEnableFeatures(
+jsi::Value NativeReanimatedModule::enableLayoutAnimations(
     jsi::Runtime &rt,
     const jsi::Value &config) {
-  auto propertyNames = config.asObject(rt).getPropertyNames(rt).asArray(rt);
-  for (int i = 0; i < propertyNames.size(rt); ++i) {
-    std::string propertyName =
-        propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    if (propertyName == "layoutAnimation") {
-      bool flag =
-          config.asObject(rt).getProperty(rt, "layoutAnimation").getBool();
-      FeaturesConfig::setLayoutAnimationEnabled(flag);
-    }
-  }
+  FeaturesConfig::setLayoutAnimationEnabled(config.getBool());
   return jsi::Value::undefined();
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -238,7 +238,16 @@ jsi::Value NativeReanimatedModule::getViewProp(
 jsi::Value NativeReanimatedModule::setEnableFeatures(
     jsi::Runtime &rt,
     const jsi::Value &config) {
-  FeaturesConfig::setLayoutAnimationEnabled(true);
+  auto propertyNames = config.asObject(rt).getPropertyNames(rt).asArray(rt);
+  for (int i = 0; i < propertyNames.size(rt); ++i) {
+    std::string propertyName =
+        propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
+    if (propertyName == "layoutAnimation") {
+      bool flag =
+          config.asObject(rt).getProperty(rt, "layoutAnimation").getBool();
+      FeaturesConfig::setLayoutAnimationEnabled(flag);
+    }
+  }
   return jsi::Value::undefined();
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -99,6 +99,16 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
   return jsi::Value::undefined();
 }
 
+static jsi::Value __hostFunction_NativeReanimatedModuleSpec_setEnableFeatures(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->setEnableFeatures(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
@@ -124,6 +134,8 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
 
   methodMap_["getViewProp"] =
       MethodMetadata{3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
+  methodMap_["setEnableFeatures"] = MethodMetadata{
+      2, __hostFunction_NativeReanimatedModuleSpec_setEnableFeatures};
 }
 
 } // namespace reanimated

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -99,13 +99,14 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
   return jsi::Value::undefined();
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_setEnableFeatures(
+static jsi::Value
+__hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t count) {
   static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->setEnableFeatures(rt, std::move(args[0]));
+      ->enableLayoutAnimations(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
 
@@ -134,8 +135,8 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
 
   methodMap_["getViewProp"] =
       MethodMetadata{3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
-  methodMap_["setEnableFeatures"] = MethodMetadata{
-      2, __hostFunction_NativeReanimatedModuleSpec_setEnableFeatures};
+  methodMap_["enableLayoutAnimations"] = MethodMetadata{
+      2, __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations};
 }
 
 } // namespace reanimated

--- a/Common/cpp/Tools/FeaturesConfig.cpp
+++ b/Common/cpp/Tools/FeaturesConfig.cpp
@@ -1,0 +1,3 @@
+#include "FeaturesConfig.h"
+
+bool FeaturesConfig::_isLayoutAnimationEnabled = false;

--- a/Common/cpp/Tools/FeaturesConfig.cpp
+++ b/Common/cpp/Tools/FeaturesConfig.cpp
@@ -1,3 +1,5 @@
 #include "FeaturesConfig.h"
 
+namespace reanimated {
 bool FeaturesConfig::_isLayoutAnimationEnabled = false;
+}

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -68,6 +68,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       const jsi::Value &propName,
       const jsi::Value &callback) override;
 
+  jsi::Value setEnableFeatures(jsi::Runtime &rt, const jsi::Value &config)
+      override;
+
   void onRender(double timestampMs);
   void onEvent(std::string eventName, std::string eventAsString);
   bool isAnyHandlerWaitingForEvent(std::string eventName);

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -68,7 +68,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       const jsi::Value &propName,
       const jsi::Value &callback) override;
 
-  jsi::Value setEnableFeatures(jsi::Runtime &rt, const jsi::Value &config)
+  jsi::Value enableLayoutAnimations(jsi::Runtime &rt, const jsi::Value &config)
       override;
 
   void onRender(double timestampMs);

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -60,7 +60,7 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       const jsi::Value &callback) = 0;
 
   // other
-  virtual jsi::Value setEnableFeatures(
+  virtual jsi::Value enableLayoutAnimations(
       jsi::Runtime &rt,
       const jsi::Value &config) = 0;
 };

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -58,6 +58,11 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       const jsi::Value &viewTag,
       const jsi::Value &propName,
       const jsi::Value &callback) = 0;
+
+  // other
+  virtual jsi::Value setEnableFeatures(
+      jsi::Runtime &rt,
+      const jsi::Value &config) = 0;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/Tools/FeaturesConfig.h
+++ b/Common/cpp/headers/Tools/FeaturesConfig.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+
+class FeaturesConfig {
+ public:
+  static bool isLayoutAnimationEnabled() {
+    return _isLayoutAnimationEnabled;
+  }
+  static void setLayoutAnimationEnabled(bool isLayoutAnimationEnabled) {
+    _isLayoutAnimationEnabled = isLayoutAnimationEnabled;
+  }
+  static void setByKey(std::string propName) {}
+
+ private:
+  static bool _isLayoutAnimationEnabled;
+};

--- a/Common/cpp/headers/Tools/FeaturesConfig.h
+++ b/Common/cpp/headers/Tools/FeaturesConfig.h
@@ -9,7 +9,6 @@ class FeaturesConfig {
   static void setLayoutAnimationEnabled(bool isLayoutAnimationEnabled) {
     _isLayoutAnimationEnabled = isLayoutAnimationEnabled;
   }
-  static void setByKey(std::string propName) {}
 
  private:
   static bool _isLayoutAnimationEnabled;

--- a/Common/cpp/headers/Tools/FeaturesConfig.h
+++ b/Common/cpp/headers/Tools/FeaturesConfig.h
@@ -1,15 +1,19 @@
 #pragma once
 #include <string>
 
+namespace reanimated {
+
 class FeaturesConfig {
  public:
-  static bool isLayoutAnimationEnabled() {
+  static inline bool isLayoutAnimationEnabled() {
     return _isLayoutAnimationEnabled;
   }
-  static void setLayoutAnimationEnabled(bool isLayoutAnimationEnabled) {
+  static inline void setLayoutAnimationEnabled(bool isLayoutAnimationEnabled) {
     _isLayoutAnimationEnabled = isLayoutAnimationEnabled;
   }
 
  private:
   static bool _isLayoutAnimationEnabled;
 };
+
+} // namespace reanimated

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
         "./src/main/Common/cpp/Tools/RuntimeDecorator.cpp"
         "./src/main/Common/cpp/Tools/Scheduler.cpp"
         "./src/main/Common/cpp/Tools/WorkletEventHandler.cpp"
+        "./src/main/Common/cpp/Tools/FeaturesConfig.cpp"
         "./src/main/Common/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp"
 )
 

--- a/android/src/main/cpp/LayoutAnimations.cpp
+++ b/android/src/main/cpp/LayoutAnimations.cpp
@@ -1,4 +1,5 @@
 #include "LayoutAnimations.h"
+#include "FeaturesConfig.h"
 #include "Logger.h"
 
 namespace reanimated {
@@ -82,6 +83,10 @@ void LayoutAnimations::notifyAboutEnd(int tag, int cancelled) {
   method(javaPart_.get(), tag, cancelled);
 }
 
+bool LayoutAnimations::isLayoutAnimationEnabled() {
+  return FeaturesConfig::isLayoutAnimationEnabled();
+}
+
 void LayoutAnimations::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", LayoutAnimations::initHybrid),
@@ -89,6 +94,9 @@ void LayoutAnimations::registerNatives() {
           "startAnimationForTag", LayoutAnimations::startAnimationForTag),
       makeNativeMethod(
           "removeConfigForTag", LayoutAnimations::removeConfigForTag),
+      makeNativeMethod(
+          "isLayoutAnimationEnabled",
+          LayoutAnimations::isLayoutAnimationEnabled),
   });
 }
 

--- a/android/src/main/cpp/headers/LayoutAnimations.h
+++ b/android/src/main/cpp/headers/LayoutAnimations.h
@@ -23,6 +23,7 @@ class LayoutAnimations : public jni::HybridClass<LayoutAnimations> {
       alias_ref<JString> type,
       alias_ref<JMap<jstring, jstring>> values);
   void removeConfigForTag(int tag);
+  bool isLayoutAnimationEnabled();
 
   void setWeakUIRuntime(std::weak_ptr<jsi::Runtime> wrt);
 

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -170,6 +170,11 @@ public class NativeProxy {
               LayoutAnimations.removeConfigForTag(tag);
             }
           }
+
+          @Override
+          public boolean isLayoutAnimationEnabled() {
+            return LayoutAnimations.isLayoutAnimationEnabled();
+          }
         });
   }
 }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -508,4 +508,8 @@ public class AnimationsManager implements ViewHierarchyObserver {
       viewToUpdate.layout(x, y, x + width, y + height);
     }
   }
+
+  public boolean isLayoutAnimationEnabled() {
+    return mNativeMethodsHolder.isLayoutAnimationEnabled();
+  }
 }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
@@ -30,6 +30,8 @@ public class LayoutAnimations {
 
   public native void removeConfigForTag(int tag);
 
+  public native boolean isLayoutAnimationEnabled();
+
   private void notifyAboutEnd(int tag, int cancelledInt) {
     ReactApplicationContext context = mContext.get();
     if (context != null) {

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/NativeMethodsHolder.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/NativeMethodsHolder.java
@@ -6,4 +6,6 @@ public interface NativeMethodsHolder {
   public void startAnimationForTag(int tag, String type, HashMap<String, Float> values);
 
   public void removeConfigForTag(int tag);
+
+  public boolean isLayoutAnimationEnabled();
 }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -47,6 +47,9 @@ class ReaLayoutAnimator extends LayoutAnimationController {
   }
 
   public boolean shouldAnimateLayout(View viewToAnimate) {
+    if(!isLayoutAnimationEnabled()) {
+      return super.shouldAnimateLayout(viewToAnimate);
+    }
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.
     // If there's a layout handling animation going on, it should be animated nonetheless since the
@@ -69,6 +72,10 @@ class ReaLayoutAnimator extends LayoutAnimationController {
    * @param height the new height value for the view
    */
   public void applyLayoutUpdate(View view, int x, int y, int width, int height) {
+    if(!isLayoutAnimationEnabled()) {
+      super.applyLayoutUpdate(view, x, y, width, height);
+      return;
+    }
     UiThreadUtil.assertOnUiThread();
     maybeInit();
     // Determine which animation to use : if view is initially invisible, use create animation,
@@ -99,6 +106,10 @@ class ReaLayoutAnimator extends LayoutAnimationController {
    *     view.
    */
   public void deleteView(final View view, final LayoutAnimationListener listener) {
+    if(!isLayoutAnimationEnabled()) {
+      super.deleteView(view, listener);
+      return;
+    }
     UiThreadUtil.assertOnUiThread();
     maybeInit();
     Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManage.get());
@@ -143,6 +154,11 @@ class ReaLayoutAnimator extends LayoutAnimationController {
       }
     }
   }
+
+  public boolean isLayoutAnimationEnabled() {
+    maybeInit();
+    return mAnimationsManager.isLayoutAnimationEnabled();
+  }
 }
 
 public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager {
@@ -186,6 +202,9 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
   public synchronized void updateLayout(
       int parentTag, int tag, int x, int y, int width, int height) {
     super.updateLayout(parentTag, tag, x, y, width, height);
+    if(!((ReaLayoutAnimator)mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+      return;
+    }
     View viewToUpdate = this.resolveView(tag);
     ViewManager parentViewManager = this.resolveViewManager(parentTag);
     String parentViewManagerName = parentViewManager.getName();
@@ -204,6 +223,10 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       @Nullable int[] indicesToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
+    if(!((ReaLayoutAnimator)mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      return;
+    }
     ViewGroup viewGroup = (ViewGroup) resolveView(tag);
     ViewGroupManager viewGroupManager = (ViewGroupManager) resolveViewManager(tag);
     if (toBeRemoved.containsKey(tag)) {
@@ -266,6 +289,10 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
 
   @Override
   protected synchronized void dropView(View view) {
+    if(!((ReaLayoutAnimator)mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+      super.dropView(view);
+      return;
+    }
     if (toBeRemoved.containsKey(view.getId())) {
       toBeRemoved.remove(view.getId());
     }

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -73,7 +73,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         removeAtIndices:(NSArray<NSNumber *> *)removeAtIndices
                registry:(NSMutableDictionary<NSNumber *, id<RCTComponent>> *)registry
 {
-  if (!FeaturesConfig::isLayoutAnimationEnabled()) {
+  if (!reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
     [super _manageChildren:containerTag
            moveFromIndices:moveFromIndices
              moveToIndices:moveToIndices
@@ -268,7 +268,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       }
 
       REASnapshot *snapshotBefore;
-      if (FeaturesConfig::isLayoutAnimationEnabled()) {
+      if (reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
         snapshotBefore = [[REASnapshot alloc] init:view];
       }
 
@@ -317,7 +317,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         completion(YES);
       }
 
-      if (FeaturesConfig::isLayoutAnimationEnabled()) {
+      if (reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
         if (isNew) {
           REASnapshot *snapshot = [[REASnapshot alloc] init:view];
           [_animationsManager onViewCreate:view after:snapshot];

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -84,6 +84,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
     return;
   }
 
+  // Reanimated changes /start
   BOOL isUIViewRegistry = ((id)registry == (id)[self valueForKey:@"_viewRegistry"]);
   id<RCTComponent> container;
   NSMutableArray<id<RCTComponent>> *permanentlyRemovedChildren;
@@ -104,6 +105,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       }
     }
   }
+  // Reanimated changes /end
 
   [super _manageChildren:containerTag
          moveFromIndices:moveFromIndices
@@ -113,6 +115,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
          removeAtIndices:removeAtIndices
                 registry:registry];
 
+  // Reanimated changes /start
   if (isUIViewRegistry) {
     NSMutableDictionary<NSNumber *, id<RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
     for (id<RCTComponent> toRemoveChild in _toBeRemovedRegister[containerTag]) {
@@ -141,6 +144,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       [self callAnimationForTree:removedChild parentTag:containerTag];
     }
   }
+  // Reanimated changes /end
 }
 
 - (void)callAnimationForTree:(UIView *)view parentTag:(NSNumber *)parentTag
@@ -267,10 +271,12 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         view.hidden = isHidden;
       }
 
+      // Reanimated changes /start
       REASnapshot *snapshotBefore;
       if (reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
         snapshotBefore = [[REASnapshot alloc] init:view];
       }
+      // Reanimated changes /end
 
       if (creatingLayoutAnimation) {
         // Animate view creation
@@ -317,6 +323,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         completion(YES);
       }
 
+      // Reanimated changes /start
       if (reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
         if (isNew) {
           REASnapshot *snapshot = [[REASnapshot alloc] init:view];
@@ -330,7 +337,9 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
 
     [_animationsManager removeLeftovers];
     // Clean up
+    // uiManager->_layoutAnimationGroup = nil;
     [uiManager setValue:nil forKey:@"_layoutAnimationGroup"];
+    // Reanimated changes /end
   };
 }
 

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -86,7 +86,9 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
 }
 
-std::shared_ptr<NativeReanimatedModule> createReanimatedModule(RCTBridge *bridge, std::shared_ptr<CallInvoker> jsInvoker)
+std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
+    RCTBridge *bridge,
+    std::shared_ptr<CallInvoker> jsInvoker)
 {
   REAModule *reanimatedModule = [bridge moduleForClass:[REAModule class]];
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -1071,9 +1071,5 @@ declare module 'react-native-reanimated' {
   export const SpringUtils: typeof Animated.SpringUtils;
   export const useValue: typeof Animated.useValue;
   export const ReverseAnimation: typeof Animated.ReverseAnimation;
-
-  export type OptionalReanimatedFeatures = {
-    layoutAnimation?: boolean;
-  };
-  export function setEnableFeatures(option: OptionalReanimatedFeatures): void;
+  export function enableLayoutAnimations(flag: boolean): void;
 }

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -1071,4 +1071,9 @@ declare module 'react-native-reanimated' {
   export const SpringUtils: typeof Animated.SpringUtils;
   export const useValue: typeof Animated.useValue;
   export const ReverseAnimation: typeof Animated.ReverseAnimation;
+
+  export type OptionalReanimatedFeatures = {
+    layoutAnimation?: boolean;
+  };
+  export function setEnableFeatures(option: OptionalReanimatedFeatures): void;
 }

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -17,13 +17,21 @@ import './reanimated2/layoutReanimation/LayoutAnimationRepository';
 import invariant from 'invariant';
 import { adaptViewConfig } from './ConfigHelper';
 import { RNRenderer } from './reanimated2/platform-specific/RNRenderer';
-import { makeMutable, runOnUI, setEnableFeatures } from './reanimated2/core';
+import {
+  makeMutable,
+  runOnUI,
+  enableLayoutAnimations,
+} from './reanimated2/core';
 import {
   DefaultEntering,
   DefaultExiting,
   DefaultLayout,
 } from './reanimated2/layoutReanimation/defaultAnimations/Default';
-import { isJest, isChromeDebugger } from './reanimated2/PlatformChecker';
+import {
+  isJest,
+  isChromeDebugger,
+  shouldBeUseWeb,
+} from './reanimated2/PlatformChecker';
 import { initialUpdaterRun } from './reanimated2/animation';
 import {
   BaseAnimationBuilder,
@@ -496,7 +504,9 @@ export default function createAnimatedComponent(
           (this.props.layout || this.props.entering || this.props.exiting) &&
           tag != null
         ) {
-          setEnableFeatures({ layoutAnimation: true }, false);
+          if (!shouldBeUseWeb()) {
+            enableLayoutAnimations(true, false);
+          }
           let layout = this.props.layout ? this.props.layout : DefaultLayout;
           let entering = this.props.entering
             ? this.props.entering

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -17,7 +17,7 @@ import './reanimated2/layoutReanimation/LayoutAnimationRepository';
 import invariant from 'invariant';
 import { adaptViewConfig } from './ConfigHelper';
 import { RNRenderer } from './reanimated2/platform-specific/RNRenderer';
-import { makeMutable, runOnUI } from './reanimated2/core';
+import { makeMutable, runOnUI, setEnableFeatures } from './reanimated2/core';
 import {
   DefaultEntering,
   DefaultExiting,
@@ -496,6 +496,7 @@ export default function createAnimatedComponent(
           (this.props.layout || this.props.entering || this.props.exiting) &&
           tag != null
         ) {
+          setEnableFeatures({ layoutAnimation: true }, false);
           let layout = this.props.layout ? this.props.layout : DefaultLayout;
           let entering = this.props.entering
             ? this.props.entering

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -1,5 +1,6 @@
 import { SharedValue } from '../commonTypes';
 import { Descriptor } from '../hook/commonTypes';
+import { OptionalReanimatedFeatures } from '../core';
 
 const InnerNativeModule = global.__reanimatedModuleProxy;
 export class NativeReanimated {
@@ -64,5 +65,9 @@ export class NativeReanimated {
     callback?: (result: T) => void
   ): Promise<T> {
     return InnerNativeModule.getViewProp(viewTag, propName, callback);
+  }
+
+  setEnableFeatures(option: OptionalReanimatedFeatures): void {
+    InnerNativeModule.setEnableFeatures(option);
   }
 }

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -1,6 +1,5 @@
 import { SharedValue } from '../commonTypes';
 import { Descriptor } from '../hook/commonTypes';
-import { OptionalReanimatedFeatures } from '../core';
 
 const InnerNativeModule = global.__reanimatedModuleProxy;
 export class NativeReanimated {
@@ -67,7 +66,7 @@ export class NativeReanimated {
     return InnerNativeModule.getViewProp(viewTag, propName, callback);
   }
 
-  setEnableFeatures(option: OptionalReanimatedFeatures): void {
-    InnerNativeModule.setEnableFeatures(option);
+  enableLayoutAnimations(flag: boolean): void {
+    InnerNativeModule.enableLayoutAnimations(flag);
   }
 }

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -386,35 +386,31 @@ if (!NativeReanimatedModule.useOnlyV1) {
     })();
 }
 
-export type OptionalReanimatedFeatures = {
-  layoutAnimation?: boolean;
+type FeaturesConfig = {
+  enableLayoutAnimations: boolean;
+  setByUser: boolean;
 };
 
-let userFeaturesConfig: OptionalReanimatedFeatures = {
-  layoutAnimation: null,
+let featuresConfig: FeaturesConfig = {
+  enableLayoutAnimations: false,
+  setByUser: false,
 };
 
-export function setEnableFeatures(
-  option: OptionalReanimatedFeatures,
+export function enableLayoutAnimations(
+  flag: boolean,
   isCallByUser = true
 ): void {
-  let filteredOptions = {};
   if (isCallByUser) {
-    userFeaturesConfig = {
-      ...userFeaturesConfig,
-      ...option,
+    featuresConfig = {
+      enableLayoutAnimations: flag,
+      setByUser: true,
     };
-    filteredOptions = option;
-  } else {
-    for (const key in option) {
-      const userFlag = userFeaturesConfig[key];
-      if (userFlag !== false) {
-        filteredOptions[key] = option[key];
-      }
-    }
+    NativeReanimatedModule.enableLayoutAnimations(flag);
+  } else if (
+    !featuresConfig.setByUser &&
+    featuresConfig.enableLayoutAnimations !== flag
+  ) {
+    featuresConfig.enableLayoutAnimations = flag;
+    NativeReanimatedModule.enableLayoutAnimations(flag);
   }
-  if (!filteredOptions) {
-    return;
-  }
-  NativeReanimatedModule.setEnableFeatures(filteredOptions);
 }

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -385,3 +385,36 @@ if (!NativeReanimatedModule.useOnlyV1) {
       _setGlobalConsole(console);
     })();
 }
+
+export type OptionalReanimatedFeatures = {
+  layoutAnimation?: boolean;
+};
+
+let userFeaturesConfig: OptionalReanimatedFeatures = {
+  layoutAnimation: null,
+};
+
+export function setEnableFeatures(
+  option: OptionalReanimatedFeatures,
+  isCallByUser = true
+): void {
+  let filteredOptions = {};
+  if (isCallByUser) {
+    userFeaturesConfig = {
+      ...userFeaturesConfig,
+      ...option,
+    };
+    filteredOptions = option;
+  } else {
+    for (const key in option) {
+      const userFlag = userFeaturesConfig[key];
+      if (userFlag !== false) {
+        filteredOptions[key] = option[key];
+      }
+    }
+  }
+  if (!filteredOptions) {
+    return;
+  }
+  NativeReanimatedModule.setEnableFeatures(filteredOptions);
+}

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -98,4 +98,8 @@ export default class JSReanimated extends NativeReanimated {
   unregisterEventHandler(_: string): void {
     // noop
   }
+
+  setEnableFeatures() {
+    console.warn('[Reanimated] setEnableFeatures is not available for WEB yet');
+  }
 }

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -99,7 +99,9 @@ export default class JSReanimated extends NativeReanimated {
     // noop
   }
 
-  setEnableFeatures() {
-    console.warn('[Reanimated] setEnableFeatures is not available for WEB yet');
+  enableLayoutAnimations() {
+    console.warn(
+      '[Reanimated] enableLayoutAnimations is not available for WEB yet'
+    );
   }
 }


### PR DESCRIPTION
## Description

I added the possibility to disable layout animations. By default layout animations are disabled, but you don't need to turn it on manually, because these will be enabled if you will use the `entering`/`exiting`/`layout` prop in an animated component. You also have the possibility to disable/enable it manually.

## Example
```js
import { enableLayoutAnimations } from 'react-native-reanimated';

enableLayoutAnimations(false);
```