### PR TITLE
Fix measure in iOS Modal

### DIFF
--- a/ios/native/NativeMethods.mm
+++ b/ios/native/NativeMethods.mm
@@ -18,7 +18,7 @@ std::vector<std::pair<std::string, double>> measure(int viewTag, RCTUIManager *u
     rootView = rootView.superview;
   }
 
-  if (rootView == nil || (![rootView isReactRootView])) {
+  if (rootView == nil) {
     return std::vector<std::pair<std::string, double>>(1, std::make_pair("x", -1234567.0));
   }
 


### PR DESCRIPTION
## Description

#### Before
```c++
if (rootView == nil || (![rootView isReactRootView])) {
  return <error>;
}
```

#### After
```c++
if (rootView == nil) {
  return <error>;
}
```

#### Why?

Native Modal on iOS is not attached to ReactRootView.

#### Why I can do it?
Because React does it the same!  - [react-native measure method](https://github.com/facebook/react-native/blob/1465c8f3874cdee8c325ab4a4916fda0b3e43bdb/React/Modules/RCTUIManager.m#L1315-L1324)

#### Repro
https://github.com/emilioschepis/reanimated-2-in-modal
https://snack.expo.dev/@piaskowyk/github.com-emilioschepis-reanimated-2-in-modal

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1973