### PR TITLE
Add Gesture Handler touch events setters to babel plugin

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -157,6 +157,10 @@ const gestureHandlerBuilderMethods = new Set([
   'onStart',
   'onEnd',
   'onUpdate',
+  'onTouchesDown',
+  'onTouchesMove',
+  'onTouchesUp',
+  'onTouchesCancelled',
 ]);
 
 class ClosureGenerator {


### PR DESCRIPTION
## Description

Added `onTouchesDown`, `onTouchesMove`, `onTouchesUp` and `onTouchesCancelled` to the list of gesture handler builder methods in the babel plugin.
