### PR TITLE
Attach pointer to worklet runtime in main runtime on iOS

### DIFF
--- a/ios/native/REAInitializer.mm
+++ b/ios/native/REAInitializer.mm
@@ -46,6 +46,12 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     auto reanimatedModule = reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
     runtime.global().setProperty(
+      runtime,
+      "_WORKLET_RUNTIME",
+      static_cast<double>(
+          reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+
+    runtime.global().setProperty(
         runtime,
         jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
         jsi::Object::createFromHostObject(runtime, reanimatedModule));


### PR DESCRIPTION
## Description

When I was adding https://github.com/software-mansion/react-native-reanimated/pull/2253 I forgot about iOS part, this PR injects the same value as on android

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

- console.log value in the bare expo project
- run code that is using that pointer

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
