### PR TITLE
Fix for uninitialized map

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -7,12 +7,10 @@
 
 namespace reanimated {
 
-std::unordered_map<RuntimePointer, RuntimeType>
-    RuntimeDecorator::runtimeRegistry;
 void RuntimeDecorator::registerRuntime(
     jsi::Runtime *runtime,
     RuntimeType runtimeType) {
-  runtimeRegistry.insert({runtime, runtimeType});
+  runtimeRegistry().insert({runtime, runtimeType});
 }
 
 void RuntimeDecorator::decorateRuntime(

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -7,6 +7,12 @@
 
 namespace reanimated {
 
+std::unordered_map<RuntimePointer, RuntimeType>
+    &RuntimeDecorator::runtimeRegistry() {
+  static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;
+  return runtimeRegistry;
+}
+
 void RuntimeDecorator::registerRuntime(
     jsi::Runtime *runtime,
     RuntimeType runtimeType) {

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -59,27 +59,30 @@ class RuntimeDecorator {
   static void registerRuntime(jsi::Runtime *runtime, RuntimeType runtimeType);
 
  private:
-  static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;
+  static std::unordered_map<RuntimePointer, RuntimeType> &runtimeRegistry() {
+    static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;
+    return runtimeRegistry;
+  }
 };
 
 inline bool RuntimeDecorator::isUIRuntime(jsi::Runtime &rt) {
-  auto iterator = runtimeRegistry.find(&rt);
-  if (iterator == runtimeRegistry.end())
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
     return false;
   return iterator->second == RuntimeType::UI;
 }
 
 inline bool RuntimeDecorator::isWorkletRuntime(jsi::Runtime &rt) {
-  auto iterator = runtimeRegistry.find(&rt);
-  if (iterator == runtimeRegistry.end())
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
     return false;
   auto type = iterator->second;
   return type == RuntimeType::UI || type == RuntimeType::Worklet;
 }
 
 inline bool RuntimeDecorator::isReactRuntime(jsi::Runtime &rt) {
-  auto iterator = runtimeRegistry.find(&rt);
-  if (iterator == runtimeRegistry.end())
+  auto iterator = runtimeRegistry().find(&rt);
+  if (iterator == runtimeRegistry().end())
     return true;
   return false;
 }

--- a/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -59,10 +59,7 @@ class RuntimeDecorator {
   static void registerRuntime(jsi::Runtime *runtime, RuntimeType runtimeType);
 
  private:
-  static std::unordered_map<RuntimePointer, RuntimeType> &runtimeRegistry() {
-    static std::unordered_map<RuntimePointer, RuntimeType> runtimeRegistry;
-    return runtimeRegistry;
-  }
+  static std::unordered_map<RuntimePointer, RuntimeType> &runtimeRegistry();
 };
 
 inline bool RuntimeDecorator::isUIRuntime(jsi::Runtime &rt) {


### PR DESCRIPTION
## Description

Possibly fix for crash during access to `RuntimeDecoratorRegistry`
Stack trace:
```
0 std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<facebook::jsi::Runtime*, reanimated::RuntimeType>, void*>*> std::__1::__hash_table<std::__1::__hash_value_type<facebook::... + 124 (__hash_table:2394)
1 std::__1::unordered_map<facebook::jsi::Runtime*, reanimated::RuntimeType, std::__1::hash<facebook::jsi::Runtime*>, std::__1::equal_to<facebook::jsi::Runtime*>, std::__1::allocator<std::__1::pair<fa... + 16 (unordered_map:1352)
2 reanimated::RuntimeDecorator::isReactRuntime(facebook::jsi::Runtime&) + 20 (RuntimeDecorator.h:73)
```

The solution described here: https://stackoverflow.com/a/13893502/7276742
