### PR TITLE
Make jest test pass

### DIFF
--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -367,14 +367,14 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
 exports[`babel plugin workletizes possibly chained gesture object callback functions automatically 1`] = `
 "var _reactNativeGestureHandler = require(\\"react-native-gesture-handler\\");
 
-var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegan(function () {
+var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(function () {
   var _f = function _f() {
-    console.log('onBegan');
+    console.log('onBegin');
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(){console.log('onBegan');}\\";
-  _f.__workletHash = 10358176266034;
+  _f.asString = \\"function _f(){console.log('onBegin');}\\";
+  _f.__workletHash = 13662490049850;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
 
   global.__reanimatedWorkletInit(_f);

--- a/__tests__/hooks.useSharedValue.test.js
+++ b/__tests__/hooks.useSharedValue.test.js
@@ -4,7 +4,7 @@ import Animated, { useSharedValue } from '../src/Animated';
 
 jest.mock('../src/ReanimatedEventEmitter');
 jest.mock('../src/ReanimatedModule');
-jest.mock('../src/reanimated2/NativeReanimated');
+jest.mock('../src/reanimated2/NativeReanimated/NativeReanimated');
 
 describe('useSharedValue', () => {
   it('retains value on rerender', () => {

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -409,8 +409,8 @@ describe('babel plugin', () => {
 
       const foo = Gesture.Tap()
         .numberOfTaps(2)
-        .onBegan(() => {
-          console.log('onBegan');
+        .onBegin(() => {
+          console.log('onBegin');
         })
         .onStart((_event) => {
           console.log('onStart');

--- a/src/reanimated1/core/Core.test.js
+++ b/src/reanimated1/core/Core.test.js
@@ -5,7 +5,7 @@ import renderer from 'react-test-renderer';
 
 jest.mock('../../ReanimatedEventEmitter');
 jest.mock('../../ReanimatedModule');
-jest.mock('../../reanimated2/NativeReanimated');
+jest.mock('../../reanimated2/NativeReanimated/NativeReanimated');
 
 describe('Core Animated components', () => {
   xit('fails if something other then a node or function that returns a node is passed to Animated.Code exec prop', () => {


### PR DESCRIPTION
## Description

Fix typos, update jest snapshots to make jest tests pass.

* Replace onBegan with onBegin in one of tests located in plugin.test.js (method name changed in [this commit](https://github.com/software-mansion/react-native-reanimated/pull/2519/commits/5696bfa742d86f6e0817a887b997ed0e8158ebd5))
* Update jest snapshot for the test
* Fix path to `NativeReanimated` (location of this file changed [here](https://github.com/software-mansion/react-native-reanimated/pull/2401))


## Test code and steps to reproduce

run `yarn test:unit` and see it passes

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
