### PR TITLE
Layout animation for FlatList

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -26,6 +26,7 @@ declare module 'react-native-reanimated' {
     Text as ReactNativeText,
     Image as ReactNativeImage,
     ScrollView as ReactNativeScrollView,
+    FlatList as ReactNativeFlatList,
     NativeScrollEvent,
     NativeSyntheticEvent,
     ColorValue,
@@ -258,6 +259,7 @@ declare module 'react-native-reanimated' {
     export class Code extends Component<CodeProps> {}
     export class FlatList extends Component<AnimateProps<FlatList>> {
       itemLayoutAnimation: ILayoutAnimationBuilder;
+      getNode(): ReactNativeFlatList;
     }
 
     type Options<P> = {

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -256,6 +256,9 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
+    export class FlatList extends Component<AnimateProps<FlatList>> {
+      itemLayoutAnimation: ILayoutAnimationBuilder;
+    }
 
     type Options<P> = {
       setNativeProps: (ref: any, props: P) => void;

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,17 +1,15 @@
-import { Image, ScrollView, Text, View, LogBox } from 'react-native';
+import { LogBox } from 'react-native';
 import createAnimatedComponent from './createAnimatedComponent';
 import {
   addWhitelistedNativeProps,
   addWhitelistedUIProps,
 } from './ConfigHelper';
 import * as reanimated1 from './reanimated1';
+import ReanimatedComponents from './reanimated2/component';
 
 const Animated = {
   // components
-  View: createAnimatedComponent(View),
-  Text: createAnimatedComponent(Text),
-  Image: createAnimatedComponent(Image),
-  ScrollView: createAnimatedComponent(ScrollView),
+  ...ReanimatedComponents,
   createAnimatedComponent,
   // configuration
   addWhitelistedNativeProps,

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -36,7 +36,7 @@ import { initialUpdaterRun } from './reanimated2/animation';
 import {
   BaseAnimationBuilder,
   EntryExitAnimationFunction,
-  LayoutAnimationFunction,
+  ILayoutAnimationBuilder,
 } from './reanimated2/layoutReanimation';
 import { SharedValue, StyleProps } from './reanimated2/commonTypes';
 import {
@@ -133,7 +133,7 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
   animatedStyle?: StyleProps;
   layout?:
     | BaseAnimationBuilder
-    | LayoutAnimationFunction
+    | ILayoutAnimationBuilder
     | typeof BaseAnimationBuilder;
   entering?:
     | BaseAnimationBuilder

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { FlatList, FlatListProps, LayoutChangeEvent } from 'react-native';
+import WrappedComponents from './WrappedComponents';
+import createAnimatedComponent from '../../createAnimatedComponent';
+import { ILayoutAnimationBuilder } from '../layoutReanimation/animationBuilder/commonTypes';
+
+const AnimatedFlatList = createAnimatedComponent(FlatList as any);
+
+const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
+  const cellRenderer: React.FC<{
+    onLayout: (event: LayoutChangeEvent) => void;
+  }> = (props) => {
+    return (
+      <WrappedComponents.View
+        layout={itemLayoutAnimation}
+        onLayout={props.onLayout}>
+        {props.children}
+      </WrappedComponents.View>
+    );
+  };
+
+  return cellRenderer;
+};
+
+interface ReanimatedFlatlistProps<ItemT> extends FlatListProps<ItemT> {
+  itemLayoutAnimation?: ILayoutAnimationBuilder;
+}
+
+type ReanimatedFlatListFC<T = any> = React.FC<ReanimatedFlatlistProps<T>>;
+
+const ReanimatedFlatlist: ReanimatedFlatListFC = ({
+  itemLayoutAnimation,
+  ...restProps
+}) => {
+  const cellRenderer = React.useMemo(
+    () => createCellRenderer(itemLayoutAnimation),
+    []
+  );
+  return (
+    <AnimatedFlatList
+      {...(restProps as any)}
+      CellRendererComponent={cellRenderer}
+    />
+  );
+};
+
+export default ReanimatedFlatlist;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -4,7 +4,7 @@ import WrappedComponents from './WrappedComponents';
 import createAnimatedComponent from '../../createAnimatedComponent';
 import { ILayoutAnimationBuilder } from '../layoutReanimation/animationBuilder/commonTypes';
 
-const AnimatedFlatList = createAnimatedComponent(FlatList as any);
+const AnimatedFlatList = createAnimatedComponent(FlatList as any) as any;
 
 const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
   const cellRenderer: React.FC<{
@@ -37,10 +37,7 @@ const ReanimatedFlatlist: ReanimatedFlatListFC = ({
     []
   );
   return (
-    <AnimatedFlatList
-      {...(restProps as any)}
-      CellRendererComponent={cellRenderer}
-    />
+    <AnimatedFlatList {...restProps} CellRendererComponent={cellRenderer} />
   );
 };
 

--- a/src/reanimated2/component/WrappedComponents.ts
+++ b/src/reanimated2/component/WrappedComponents.ts
@@ -1,0 +1,11 @@
+import { Image, ScrollView, Text, View } from 'react-native';
+import createAnimatedComponent from '../../createAnimatedComponent';
+
+const WrappedComponents = {
+  View: createAnimatedComponent(View),
+  Text: createAnimatedComponent(Text as any),
+  Image: createAnimatedComponent(Image as any),
+  ScrollView: createAnimatedComponent(ScrollView),
+};
+
+export default WrappedComponents;

--- a/src/reanimated2/component/index.ts
+++ b/src/reanimated2/component/index.ts
@@ -1,0 +1,9 @@
+import ReanimatedFlatlist from './FlatList';
+import WrappedComponents from './WrappedComponents';
+
+const ReanimatedComponents = {
+  ...WrappedComponents,
+  FlatList: ReanimatedFlatlist,
+};
+
+export default ReanimatedComponents;


### PR DESCRIPTION
## Description

The default implementation of `FlatList` wraps every item by custom component. This component hasn't got children's properties - in effect wrapping component hasn't the layout property with `layout` animation. It means the animation of the layout will not run because the "layout event" will be consumed by the wrapping component instead of his child.

## How to use it

```js
<Animated.FlatList // use Animated.FlatList instead of FlatList
  itemLayoutAnimation={Layout.springify()} // this animation will be apply as layout property for every list item
  data={itemsData} // as always
  renderItem={renderItem} // as always
/>
```

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/2664 https://github.com/software-mansion/react-native-reanimated/issues/2424

Inspired by: @nicholash747 's https://github.com/software-mansion/react-native-reanimated/issues/2424#issuecomment-962084108 - thanks! 🚀