### PR TITLE
feat: Add `performance.now()` to Worklets

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -83,6 +83,22 @@ void RuntimeDecorator::decorateRuntime(
           jsi::PropNameID::forAscii(rt, "_setGlobalConsole"),
           1,
           setGlobalConsole));
+
+  rt.global().setProperty(
+      rt,
+      "_chronoNow",
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, "_chronoNow"),
+          0,
+          [](jsi::Runtime &rt,
+             const jsi::Value &thisValue,
+             const jsi::Value *args,
+             size_t count) -> jsi::Value {
+            double now = std::chrono::system_clock::now().time_since_epoch() /
+                std::chrono::milliseconds(1);
+            return jsi::Value(now);
+          }));
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -1,4 +1,5 @@
 #include "RuntimeDecorator.h"
+#include <chrono>
 #include <memory>
 #include <unordered_map>
 #include "LayoutAnimationsProxy.h"

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -383,6 +383,9 @@ if (!NativeReanimatedModule.useOnlyV1) {
         info: runOnJS(capturableConsole.info),
       };
       _setGlobalConsole(console);
+      global.performance = {
+        now: global._chronoNow,
+      };
     })();
 }
 


### PR DESCRIPTION

## Description

Adds support for measuring performance/elapsed time in millisecond precision using Chrono with `performance.now()` in Worklets.

## Changes

- Inject `_chronoNow` func in global runtime object

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

```ts
runOnUI(() => {
  'worklet'
  const start = performance.now()
  for (let i = 0; i < 1000000; i++) {}
  const end = performance.now()
  console.log(`Loop took ${end - start} ms!`)
})()
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes

## Related Issues

* https://github.com/facebook/react-native/pull/32695