### PR TITLE
[expo] remove unnecessary integration code

### DIFF
--- a/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
+++ b/android-npm/expo/src/main/java/expo/modules/adapters/reanimated/EXReanimatedPackage.java
@@ -2,7 +2,6 @@ package expo.modules.adapters.reanimated;
 
 import android.content.Context;
 
-import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.swmansion.reanimated.EXReanimatedAdapter;
@@ -18,33 +17,8 @@ public class EXReanimatedPackage implements Package {
   public List<? extends ReactNativeHostHandler> createReactNativeHostHandlers(Context context) {
     final ReactNativeHostHandler handler = new ReactNativeHostHandler() {
       @Override
-      public ReactInstanceManager createReactInstanceManager(boolean useDeveloperSupport) {
-        return null;
-      }
-
-      @Override
-      public String getJSBundleFile(boolean useDeveloperSupport) {
-        return null;
-      }
-
-      @Override
-      public String getBundleAssetName(boolean useDeveloperSupport) {
-        return null;
-      }
-
-      @Override
       public void onRegisterJSIModules(ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext, boolean useDeveloperSupport) {
         EXReanimatedAdapter.registerJSIModules(reactApplicationContext, jsContext);
-      }
-
-      @Override
-      public void onWillCreateReactInstanceManager(boolean useDeveloperSupport) {
-
-      }
-
-      @Override
-      public void onDidCreateReactInstanceManager(ReactInstanceManager reactInstanceManager, boolean useDeveloperSupport) {
-
       }
     };
     return Collections.singletonList(handler);

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,4 +1,3 @@
 {
-  "name": "react-native-reanimated",
   "platforms": ["android"]
 }


### PR DESCRIPTION
## Description

remove unnecessary expo integration code and reduce maintain cost from future interfaces change.

## Changes

- remove unused autolink `name` from [the review comment](https://github.com/software-mansion/react-native-reanimated/pull/2595#discussion_r760030289)
- remove unused override methods where we will change expo-modules-core to support java 8 interface default method https://github.com/expo/expo/pull/15421

## Test code and steps to reproduce

to verify it works, i also update the [demo repo](https://github.com/Kudo/ExpoAndroidWrapper) and the same patch [here](https://github.com/Kudo/ExpoAndroidWrapper/commit/3f95bdd35cc2e0f465e66c22b51deb71db82176e#diff-42ef841dc27fe0b5aa2d06bd31308bb63a59cdcddcbcddd917248349d22020a3) 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
