### PR TITLE
[expo] fix duplicated BuildConfig error in release build

### DIFF
--- a/android-npm/expo/linking.gradle
+++ b/android-npm/expo/linking.gradle
@@ -21,6 +21,10 @@ if (isExpoLinked) {
             main.manifest.srcFile 'src/AndroidManifest.xml'
             main.java.srcDirs = [ 'expo/src/main/java' ]
         }
+
+        libraryVariants.all {
+            generateBuildConfigProvider?.get()?.enabled = false
+        }
     }
 
     dependencies {

--- a/android-npm/expo/linking.gradle
+++ b/android-npm/expo/linking.gradle
@@ -15,6 +15,14 @@ if (isExpoLinked) {
     apply plugin: 'com.android.library'
 
     android {
+        // Disable aar bundling to fix the error when running `gradle assembleRelease` over `gradle :app:assembleRelease`
+        // which will throw `Direct local .aar file dependencies are not supported when building an AAR.`
+        tasks.whenTaskAdded { task ->
+            if (['bundleDebugAar', 'bundleReleaseAar'].contains(task.name)) {
+                task.enabled = false
+            }
+        }
+
         compileSdkVersion safeExtGet('compileSdkVersion', 30)
 
         sourceSets {


### PR DESCRIPTION
## Description

- in expo auto setup integration, we create an android library project and implicitly generate a `BuildConfig` class. reanimated also has one `BuildConfig` in aar. in release build, R8 will throw error when there's duplicated class.
- fix the error `Direct local .aar file dependencies are not supported when building an AAR.`.
fixes #2711 

## Changes

- disable implicitly `BuildConfig` creation in the android library project. 
- disable `bundleDebugAar` and `bundleReleaseAar` tasks

## Test code and steps to reproduce

1. the [auto setup example repo](https://github.com/Kudo/ExpoAndroidWrapper)
```
expo run:android
expo run:android --variant release
cd android && ./gradlew assembleRelease
```

2. scratch from expo project
```
expo init reanimatedexpo # choose blank managed project
# patch `node_modules/react-native-reanimated/android/expo/linking.gradle`
# add reanimated plugin to `babel.config.js`
expo run:android
expo run:android --variant release
```


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
