### PR TITLE
fix: web performance.now is undefined

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -383,9 +383,11 @@ if (!NativeReanimatedModule.useOnlyV1) {
         info: runOnJS(capturableConsole.info),
       };
       _setGlobalConsole(console);
-      global.performance = {
-        now: global._chronoNow,
-      };
+      if (!runOnJS(shouldBeUseWeb)) {
+        global.performance = {
+          now: global._chronoNow,
+        };
+      }
     })();
 }
 


### PR DESCRIPTION
## Description
The web was broken in 2.3.0 due to a small change that was introduced in [a previous PR](https://github.com/software-mansion/react-native-reanimated/pull/2679).

Basically, we were setting the global.performance.now to global._chronoNow but it's not available for the web and it makes window.performance.now undefined. This PR fixes that by making that change native only.

Fixes: #2714 

# Error Screenshot
<img width="418" alt="Screen Shot 2021-12-08 at 23 49 37" src="https://user-images.githubusercontent.com/22980987/145294047-13e69db3-ea19-4e7b-9ec4-82da3d1ddb5f.png">


## Test code and steps to reproduce
You don't need anything special to reproduce it. Opening a web app using reanimated 2.3.0 should be enough to see the error message
