### PR TITLE
Do not mock `performance.now` for web

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,7 +1,7 @@
 /* global _WORKLET _getCurrentTime _frameTimestamp _eventTimestamp, _setGlobalConsole */
 import NativeReanimatedModule from './NativeReanimated';
 import { Platform } from 'react-native';
-import { nativeShouldBeMock, shouldBeUseWeb } from './PlatformChecker';
+import { nativeShouldBeMock, shouldBeUseWeb, isWeb } from './PlatformChecker';
 import {
   BasicWorkletFunction,
   WorkletFunction,
@@ -371,8 +371,8 @@ if (!NativeReanimatedModule.useOnlyV1) {
       : (workletValueSetterJS as <T>(value: T) => void)
   );
 
-  const capturableConsole = console;
-  isConfigured() &&
+  if (!isWeb() && isConfigured()) {
+    const capturableConsole = console;
     runOnUI(() => {
       'worklet';
       const console = {
@@ -387,6 +387,7 @@ if (!NativeReanimatedModule.useOnlyV1) {
         now: global._chronoNow,
       };
     })();
+  }
 }
 
 type FeaturesConfig = {


### PR DESCRIPTION
## Description

For web implementation we shouldn't mock `performance.now()` function. I added a check to disable mocking for the web.

Fixes #2714

Based on https://github.com/software-mansion/react-native-reanimated/pull/2715 
Thanks, @yusufyildirim I really appreciate that you report an issue and fixed it! Awesome! ❤️