### PR TITLE
Prevent RGBA decimals

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -671,9 +671,9 @@ const interpolateColorsRGB = (
   colors: InterpolateCacheRGBA
 ) => {
   'worklet';
-  const r = interpolate(value, inputRange, colors.r, Extrapolate.CLAMP);
-  const g = interpolate(value, inputRange, colors.g, Extrapolate.CLAMP);
-  const b = interpolate(value, inputRange, colors.b, Extrapolate.CLAMP);
+  const r = Math.round(interpolate(value, inputRange, colors.r, Extrapolate.CLAMP));
+  const g = Math.round(interpolate(value, inputRange, colors.g, Extrapolate.CLAMP));
+  const b = Math.round(interpolate(value, inputRange, colors.b, Extrapolate.CLAMP));
   const a = interpolate(value, inputRange, colors.a, Extrapolate.CLAMP);
   return rgbaColor(r, g, b, a);
 };


### PR DESCRIPTION
## Description

Having decimals on [RGBA](https://www.w3.org/wiki/CSS3/Color/RGBA) values when using **`interpolateColor`** makes things problematic, especially while working with SVGs. react-native-svg throws [`console.warn(`"${color}" is not a valid color or brush`);`](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/src/lib/extract/extractBrush.ts#L43) whenever the RGBA value cannot be converted to int32.

The error was partially seen on #2290, #2246, #2009, #1909 

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
