### PR TITLE
Add reanimated to proguard rules.

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -127,6 +127,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
 
 ```
+-keep class com.swmansion.reanimated.** { *; }
 -keep class com.facebook.react.turbomodule.** { *; }
 ```
 


### PR DESCRIPTION
After upgrading to 2.3.0 i was getting instant crashes on release variants. 

```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.swmansion.reanimated.layoutReanimation.f.j()' on a null object reference
```

Adding reanimated to proguard rules fixes the issue.

## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [X] Updated documentation
- [ ] Ensured that CI passes
