### PR TITLE
shared values are either not cancellable or only interruptible once

### DIFF
--- a/docs/docs/fundamentals/shared-values.md
+++ b/docs/docs/fundamentals/shared-values.md
@@ -147,11 +147,12 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+
 Below is a complete code example which is the modified version of the example from the previous section.
 Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Note that `withSpring` has to be called within the worklet created with `useAnimatedStyle`. Hence, launching an animation this way must be done from the UI thread.
 
-```js {17}
+```js {8}
 import Animated, { withSpring } from 'react-native-reanimated';
 
 function Box() {
@@ -159,7 +160,7 @@ function Box() {
 
   const animatedStyles = useAnimatedStyle(() => {
     return {
-      transform: [{ translateX: offset.value * 255 }],
+      transform: [{ translateX: withSpring(offset.value * 255) }],
     };
   });
 
@@ -168,7 +169,7 @@ function Box() {
       <Animated.View style={[styles.box, animatedStyles]} />
       <Button
         onPress={() => {
-          offset.value = withSpring(Math.random());
+          offset.value = Math.random();
         }}
         title="Move"
       />
@@ -177,7 +178,7 @@ function Box() {
 }
 ```
 
-The only change we made in the above code compared to the example from the previous section, is that we wrapped `Math.random()` call that updates the `offset` with `withSpring` call.
+The only change we made in the above code compared to the example from the previous section, is that we wrapped `offset.value * 255` call that updates the `offset` with `withSpring` call.
 As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)


### PR DESCRIPTION
Fix docs which claims that "launching animation this way can be done both from the UI and from the React-Native JS thread".

**Attention**: This solution has the side-effect that the animation now is not cancellable via `cancelAnimation` anymore. So I think this is a bug in `react-native-reanimated` (see #2733 ) which should be addressed before updating the docs. When it's fixed I can update this PR accordingly.

## Description

[Shared Value Docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/shared-values/) falsely claim that 

>launching animation this way can be done both from the UI and from the React-Native JS thread

This PR fixes the example code and the comment.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

This PR addresses bug report #2733 

## Changes

Updated `shared-values.md ` docs

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Use example from the shared values docs:

```js
import Animated, { withSpring } from 'react-native-reanimated';

function Box() {
  const offset = useSharedValue(0);

  const animatedStyles = useAnimatedStyle(() => {
    return {
      transform: [{ translateX: offset.value * 255 }],
    };
  });

  return (
    <>
      <Animated.View style={[styles.box, animatedStyles]} />
      <Button
        onPress={() => {
          offset.value = withSpring(Math.random());
        }}
        title="Move"
      />
    </>
  );
}
```

With reanimated `2.3.0` the transition won't be interruptible.

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
