### PR TITLE
Use web implementation for gesture handlers in Jest

### DIFF
--- a/__tests__/GestureHandler.test.js
+++ b/__tests__/GestureHandler.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { View, Text } from 'react-native';
+import { useAnimatedGestureHandler } from '../src';
+import {
+  GestureHandlerRootView,
+  TapGestureHandler,
+} from 'react-native-gesture-handler';
+import { fireGestureHandlerClick } from 'react-native-gesture-handler/src/jestUtils';
+
+const App = (props) => {
+  const eventHandler = useAnimatedGestureHandler({
+    onStart: () => {
+      props.begin();
+    },
+    onEnd: () => {
+      props.press();
+    },
+  });
+
+  return (
+    <GestureHandlerRootView>
+      <TapGestureHandler onHandlerStateChange={eventHandler}>
+        <View>
+          <Text>Text</Text>
+        </View>
+      </TapGestureHandler>
+    </GestureHandlerRootView>
+  );
+};
+
+test('test', () => {
+  const begin = jest.fn();
+  const press = jest.fn();
+
+  const { getByText } = render(<App begin={begin} press={press} />);
+
+  fireGestureHandlerClick(getByText('Text'));
+  fireGestureHandlerClick(getByText('Text'));
+
+  expect(begin).toHaveBeenCalledTimes(2);
+  expect(press).toHaveBeenCalledTimes(2);
+});

--- a/__tests__/GestureHandler.test.js
+++ b/__tests__/GestureHandler.test.js
@@ -1,43 +1,145 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { View, Text } from 'react-native';
-import { useAnimatedGestureHandler } from '../src';
+import { Text } from 'react-native';
 import {
   GestureHandlerRootView,
   TapGestureHandler,
+  PanGestureHandler,
+  LongPressGestureHandler,
+  FlingGestureHandler,
+  RotationGestureHandler,
+  PinchGestureHandler,
 } from 'react-native-gesture-handler';
-import { fireGestureHandlerClick } from 'react-native-gesture-handler/src/jestUtils';
+import {
+  fireGestureHandlerTap,
+  fireGestureHandlerPan,
+  fireGestureHandlerLongPress,
+  fireGestureHandlerRotation,
+  fireGestureHandlerFling,
+  fireGestureHandlerPinch,
+  ghTagEventMacro,
+} from 'react-native-gesture-handler/src/jestUtils';
+import { useAnimatedGestureHandler } from '../src';
+
+const mockEventFunctions = () => {
+  return {
+    begin: jest.fn(),
+    progress: jest.fn(),
+    end: jest.fn(),
+  };
+};
+
+const assertEventCalls = (eventFunctions, progressCount = 1) => {
+  expect(eventFunctions.begin).toHaveBeenCalledTimes(1);
+  expect(eventFunctions.progress).toHaveBeenCalledTimes(progressCount);
+  expect(eventFunctions.end).toHaveBeenCalledTimes(1);
+};
 
 const App = (props) => {
   const eventHandler = useAnimatedGestureHandler({
-    onStart: () => {
-      props.begin();
-    },
-    onEnd: () => {
-      props.press();
-    },
+    onStart: () => props.eventFunctions.begin(),
+    onActive: () => props.eventFunctions.progress(),
+    onEnd: () => props.eventFunctions.end(),
   });
 
   return (
     <GestureHandlerRootView>
       <TapGestureHandler onHandlerStateChange={eventHandler}>
-        <View>
-          <Text>Text</Text>
-        </View>
+        <Text {...ghTagEventMacro()}>TapGestureHandlerTest</Text>
       </TapGestureHandler>
+
+      <PanGestureHandler onHandlerStateChange={eventHandler}>
+        <Text {...ghTagEventMacro()}>PanGestureHandlerTest</Text>
+      </PanGestureHandler>
+
+      <LongPressGestureHandler onHandlerStateChange={eventHandler}>
+        <Text {...ghTagEventMacro()}>LongPressGestureHandlerTest</Text>
+      </LongPressGestureHandler>
+
+      <RotationGestureHandler onHandlerStateChange={eventHandler}>
+        <Text {...ghTagEventMacro()}>RotationGestureHandlerTest</Text>
+      </RotationGestureHandler>
+
+      <FlingGestureHandler onHandlerStateChange={eventHandler}>
+        <Text {...ghTagEventMacro()}>FlingGestureHandlerTest</Text>
+      </FlingGestureHandler>
+
+      <PinchGestureHandler onHandlerStateChange={eventHandler}>
+        <Text {...ghTagEventMacro()}>PinchGestureHandlerTest</Text>
+      </PinchGestureHandler>
     </GestureHandlerRootView>
   );
 };
 
-test('test', () => {
-  const begin = jest.fn();
-  const press = jest.fn();
+test('test fireGestureHandlerTap', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerTap(getByText('TapGestureHandlerTest'));
+  assertEventCalls(eventFunctions);
+});
 
-  const { getByText } = render(<App begin={begin} press={press} />);
+test('test fireGestureHandlerPan', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerPan(
+    getByText('PanGestureHandlerTest'),
+    { x: 1, y: 1 },
+    [
+      { x: 2, y: 2 },
+      { x: 3, y: 3 },
+    ],
+    { x: 4, y: 4 }
+  );
+  assertEventCalls(eventFunctions, 2);
+});
 
-  fireGestureHandlerClick(getByText('Text'));
-  fireGestureHandlerClick(getByText('Text'));
+test('test fireGestureHandlerLongPress', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerLongPress(getByText('LongPressGestureHandlerTest'), {
+    x: 1,
+    y: 1,
+  });
+  assertEventCalls(eventFunctions);
+});
 
-  expect(begin).toHaveBeenCalledTimes(2);
-  expect(press).toHaveBeenCalledTimes(2);
+test('test fireGestureHandlerRotation', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerRotation(
+    getByText('RotationGestureHandlerTest'),
+    {
+      rotation: 0,
+      velocity: 0,
+      anchorX: 0,
+      anchorY: 0,
+    },
+    {
+      rotation: 5,
+      velocity: 5,
+      anchorX: 5,
+      anchorY: 5,
+    },
+    {
+      rotation: 0,
+      velocity: 0,
+      anchorX: 0,
+      anchorY: 0,
+    }
+  );
+  assertEventCalls(eventFunctions);
+});
+
+test('test fireGestureHandlerFling', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerFling(getByText('FlingGestureHandlerTest'), { x: 1, y: 1 });
+  assertEventCalls(eventFunctions);
+});
+
+test('test fireGestureHandlerPinch', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  fireGestureHandlerPinch(getByText('PinchGestureHandlerTest'), { x: 1, y: 1 });
+  assertEventCalls(eventFunctions);
 });

--- a/__tests__/GestureHandler.test.js
+++ b/__tests__/GestureHandler.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import {
   GestureHandlerRootView,
   TapGestureHandler,
@@ -11,12 +11,12 @@ import {
   PinchGestureHandler,
 } from 'react-native-gesture-handler';
 import {
-  fireGestureHandlerTap,
-  fireGestureHandlerPan,
-  fireGestureHandlerLongPress,
-  fireGestureHandlerRotation,
-  fireGestureHandlerFling,
-  fireGestureHandlerPinch,
+  fireTapGestureHandler,
+  firePanGestureHandler,
+  fireLongPressGestureHandler,
+  fireRotationGestureHandler,
+  fireFlingGestureHandler,
+  firePinchGestureHandler,
   ghTagEventMacro,
 } from 'react-native-gesture-handler/src/jestUtils';
 import { useAnimatedGestureHandler } from '../src';
@@ -29,10 +29,16 @@ const mockEventFunctions = () => {
   };
 };
 
-const assertEventCalls = (eventFunctions, progressCount = 1) => {
-  expect(eventFunctions.begin).toHaveBeenCalledTimes(1);
-  expect(eventFunctions.progress).toHaveBeenCalledTimes(progressCount);
-  expect(eventFunctions.end).toHaveBeenCalledTimes(1);
+const assertEventCalls = (eventFunctions, counts) => {
+  expect(eventFunctions.begin).toHaveBeenCalledTimes(
+    counts?.begin ? counts.begin : 1
+  );
+  expect(eventFunctions.progress).toHaveBeenCalledTimes(
+    counts?.progress ? counts.progress : 1
+  );
+  expect(eventFunctions.end).toHaveBeenCalledTimes(
+    counts?.end ? counts.end : 1
+  );
 };
 
 const App = (props) => {
@@ -48,7 +54,9 @@ const App = (props) => {
         <Text {...ghTagEventMacro()}>TapGestureHandlerTest</Text>
       </TapGestureHandler>
 
-      <PanGestureHandler onHandlerStateChange={eventHandler}>
+      <PanGestureHandler
+        onHandlerStateChange={eventHandler}
+        onGestureEvent={eventHandler}>
         <Text {...ghTagEventMacro()}>PanGestureHandlerTest</Text>
       </PanGestureHandler>
 
@@ -67,79 +75,98 @@ const App = (props) => {
       <PinchGestureHandler onHandlerStateChange={eventHandler}>
         <Text {...ghTagEventMacro()}>PinchGestureHandlerTest</Text>
       </PinchGestureHandler>
+
+      <PanGestureHandler onHandlerStateChange={eventHandler}>
+        <View>
+          <Text {...ghTagEventMacro()}>NestedGestureHandlerTest1</Text>
+          <TapGestureHandler onHandlerStateChange={eventHandler}>
+            <Text {...ghTagEventMacro()}>NestedGestureHandlerTest2</Text>
+          </TapGestureHandler>
+        </View>
+      </PanGestureHandler>
     </GestureHandlerRootView>
   );
 };
 
-test('test fireGestureHandlerTap', () => {
+test('test fireTapGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerTap(getByText('TapGestureHandlerTest'));
+  fireTapGestureHandler(getByText('TapGestureHandlerTest'));
   assertEventCalls(eventFunctions);
 });
 
-test('test fireGestureHandlerPan', () => {
+test('test firePanGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerPan(
-    getByText('PanGestureHandlerTest'),
-    { x: 1, y: 1 },
-    [
+  firePanGestureHandler(getByText('PanGestureHandlerTest'), {
+    configBegin: { x: 1, y: 1 },
+    configProgress: [
       { x: 2, y: 2 },
       { x: 3, y: 3 },
     ],
-    { x: 4, y: 4 }
-  );
-  assertEventCalls(eventFunctions, 2);
+    configEnd: { x: 4, y: 4 },
+  });
+  assertEventCalls(eventFunctions, { progress: 2 });
 });
 
-test('test fireGestureHandlerLongPress', () => {
+test('test fireLongPressGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerLongPress(getByText('LongPressGestureHandlerTest'), {
-    x: 1,
-    y: 1,
+  fireLongPressGestureHandler(getByText('LongPressGestureHandlerTest'), {
+    configBegin: { x: 1, y: 1 },
   });
   assertEventCalls(eventFunctions);
 });
 
-test('test fireGestureHandlerRotation', () => {
+test('test fireRotationGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerRotation(
-    getByText('RotationGestureHandlerTest'),
-    {
+  fireRotationGestureHandler(getByText('RotationGestureHandlerTest'), {
+    configBegin: {
       rotation: 0,
       velocity: 0,
       anchorX: 0,
       anchorY: 0,
     },
-    {
+    configProgress: {
       rotation: 5,
       velocity: 5,
       anchorX: 5,
       anchorY: 5,
     },
-    {
+    configEnd: {
       rotation: 0,
       velocity: 0,
       anchorX: 0,
       anchorY: 0,
-    }
-  );
+    },
+  });
   assertEventCalls(eventFunctions);
 });
 
-test('test fireGestureHandlerFling', () => {
+test('test fireFlingGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerFling(getByText('FlingGestureHandlerTest'), { x: 1, y: 1 });
+  fireFlingGestureHandler(getByText('FlingGestureHandlerTest'), {
+    configBegin: { x: 1, y: 1 },
+  });
   assertEventCalls(eventFunctions);
 });
 
-test('test fireGestureHandlerPinch', () => {
+test('test firePinchGestureHandler', () => {
   const eventFunctions = mockEventFunctions();
   const { getByText } = render(<App eventFunctions={eventFunctions} />);
-  fireGestureHandlerPinch(getByText('PinchGestureHandlerTest'), { x: 1, y: 1 });
+  firePinchGestureHandler(getByText('PinchGestureHandlerTest'), {
+    configBegin: { x: 1, y: 1 },
+  });
   assertEventCalls(eventFunctions);
+});
+
+test('test nestedGestureHandler', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<App eventFunctions={eventFunctions} />);
+  firePanGestureHandler(getByText('NestedGestureHandlerTest1'));
+  firePanGestureHandler(getByText('NestedGestureHandlerTest2'));
+  fireTapGestureHandler(getByText('NestedGestureHandlerTest2'));
+  assertEventCalls(eventFunctions, { begin: 3, progress: 3, end: 3 });
 });

--- a/__tests__/GestureHandler.test.js
+++ b/__tests__/GestureHandler.test.js
@@ -9,6 +9,8 @@ import {
   FlingGestureHandler,
   RotationGestureHandler,
   PinchGestureHandler,
+  Gesture,
+  GestureDetector,
 } from 'react-native-gesture-handler';
 import {
   fireTapGestureHandler,
@@ -26,6 +28,9 @@ const mockEventFunctions = () => {
     begin: jest.fn(),
     progress: jest.fn(),
     end: jest.fn(),
+    fail: jest.fn(),
+    cancel: jest.fn(),
+    finish: jest.fn(),
   };
 };
 
@@ -169,4 +174,41 @@ test('test nestedGestureHandler', () => {
   firePanGestureHandler(getByText('NestedGestureHandlerTest2'));
   fireTapGestureHandler(getByText('NestedGestureHandlerTest2'));
   assertEventCalls(eventFunctions, { begin: 3, progress: 3, end: 3 });
+});
+
+const AppAPIv2 = (props) => {
+  const tap = Gesture.Tap()
+    .onBegin(() => {
+      props.eventFunctions.begin();
+    })
+    .onEnd(() => {
+      props.eventFunctions.progress();
+    });
+
+  const pan = Gesture.Pan()
+    .onBegin(() => {
+      props.eventFunctions.begin();
+    })
+    .onEnd(() => {
+      props.eventFunctions.progress();
+    });
+
+  return (
+    <GestureHandlerRootView>
+      <GestureDetector gesture={Gesture.Race(tap, pan)}>
+        <View>
+          <Text {...ghTagEventMacro()}>Text</Text>
+        </View>
+      </GestureDetector>
+    </GestureHandlerRootView>
+  );
+};
+
+test('test API v2', () => {
+  const eventFunctions = mockEventFunctions();
+  const { getByText } = render(<AppAPIv2 eventFunctions={eventFunctions} />);
+  fireTapGestureHandler(getByText('Text'));
+  firePanGestureHandler(getByText('Text'));
+  expect(eventFunctions.begin).toHaveBeenCalledTimes(2);
+  expect(eventFunctions.progress).toHaveBeenCalledTimes(2);
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   preset: 'react-native',
   modulePathIgnorePatterns: ['Example', 'docs', 'lib'],
-  setupFiles: ['./jest-setup.js'],
+  setupFiles: [
+    './jest-setup.js',
+    './node_modules/react-native-gesture-handler/jestSetup.js',
+  ],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transformIgnorePatterns: ['node_modules/?!(react-native-gesture-handler)'],
 };

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "fbjs": "^3.0.2",
     "husky": "^7.0.0",
     "jest": "^26.6.3",
     "lint-staged": "^11.2.0",
@@ -118,7 +119,7 @@
     "react": "17.0.2",
     "react-native": "0.67.0-rc.4",
     "react-native-codegen": "^0.0.7",
-    "react-native-gesture-handler": "^1.6.1",
+    "react-native-gesture-handler": "^2.1.0",
     "react-test-renderer": "17.0.2",
     "release-it": "^13.7.2",
     "typescript": "^4.1.3"

--- a/src/reanimated2/hook/useAnimatedGestureHandler.ts
+++ b/src/reanimated2/hook/useAnimatedGestureHandler.ts
@@ -1,6 +1,6 @@
 import { MutableRefObject } from 'react';
 import { WorkletFunction } from '../commonTypes';
-import { isWeb } from '../PlatformChecker';
+import { isJest, isWeb } from '../PlatformChecker';
 import WorkletEventHandler from '../WorkletEventHandler';
 import { Context, DependencyList } from './commonTypes';
 import { useEvent, useHandler } from './Hooks';
@@ -98,7 +98,7 @@ export function useAnimatedGestureHandler<
     }
   };
 
-  if (isWeb()) {
+  if (isWeb() || isJest()) {
     return handler;
   }
 

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -9,7 +9,7 @@ import {
   WorkletFunction,
 } from '../commonTypes';
 import { makeRemote } from '../core';
-import { isWeb } from '../PlatformChecker';
+import { isJest, isWeb } from '../PlatformChecker';
 import { colorProps } from '../UpdateProps';
 import WorkletEventHandler from '../WorkletEventHandler';
 import {
@@ -80,7 +80,7 @@ export function useHandler<T, TContext extends Context>(
     savedDependencies
   );
   initRef.current.savedDependencies = dependencies;
-  const useWeb = isWeb();
+  const useWeb = isWeb() || isJest();
 
   return { context, doDependenciesDiffer, useWeb };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,7 +4137,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-asap@~2.0.6:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -4965,6 +4965,13 @@ cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+cross-fetch@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -5900,6 +5907,24 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.2.tgz#dfae08a85c66a58372993ce2caf30863f569ff94"
+  integrity sha512-qv+boqYndjElAJHNN3NoM8XuwQZ1j2m3kEvTgdle8IDjr6oUbkEpvABWtj/rQl3vq4ew7dnElBxL4YJAwTVqQQ==
+  dependencies:
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.30"
+
 figures@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec"
@@ -6402,9 +6427,12 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -7721,7 +7749,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8286,7 +8314,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.2.0, node-fetch@^2.6.0:
+node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8395,7 +8423,7 @@ ob1@0.66.2:
   resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.66.2.tgz#8caf548202cf2688944bae47db405a08bca17a61"
   integrity sha512-RFewnL/RjE0qQBOuM+2bbY96zmJPIge/aDtsiDbLSb+MOiK8CReAhBHDgL+zrA3F1hQk00lMWpUwYcep750plA==
 
-object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -8899,6 +8927,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 promise@^8.0.3:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -9009,6 +9044,11 @@ react-error-boundary@^3.1.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
@@ -9036,13 +9076,15 @@ react-native-codegen@^0.0.8:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
-react-native-gesture-handler@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.7.0.tgz#0ef74a5ba836832e497dc49eb1ce58baa6c617e5"
+react-native-gesture-handler@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.1.0.tgz#be7a83a7bd340a2316551a4d30d7abf06b46c1da"
+  integrity sha512-vF4yEUrV5GMBioTkvf5Le1l3N/52dSLBnNMFC+kZ4hssnRoXB0hEQ0ReUkZckRB5L3nbHBhAyjySEtFPx4nyEA==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
-    hoist-non-react-statics "^2.3.1"
+    hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
+    lodash "^4.17.21"
     prop-types "^15.7.2"
 
 react-native-screens@^3.4.0:
@@ -9684,6 +9726,11 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -10286,6 +10333,11 @@ typescript@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
+ua-parser-js@^0.7.30:
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
+  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
## Description

I want to add support for gesture-handler events in Jest. I want to make it user-friendly, so I am adding changes to react-native-gesture-handler. During this, I noticed that reanimated sometimes tried to use native implementation instead of web implementation. So I changed it to prevent mocking `Platform.OS`.

Related PR: https://github.com/software-mansion/react-native-gesture-handler/pull/1762