### PR TITLE
do not mock global.performance when connected to chrome debugger

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,7 +1,7 @@
 /* global _WORKLET _getCurrentTime _frameTimestamp _eventTimestamp, _setGlobalConsole */
 import NativeReanimatedModule from './NativeReanimated';
 import { Platform } from 'react-native';
-import { nativeShouldBeMock, shouldBeUseWeb, isWeb } from './PlatformChecker';
+import { nativeShouldBeMock, shouldBeUseWeb, isWeb, isChromeDebugger } from './PlatformChecker';
 import {
   BasicWorkletFunction,
   WorkletFunction,
@@ -371,7 +371,7 @@ if (!NativeReanimatedModule.useOnlyV1) {
       : (workletValueSetterJS as <T>(value: T) => void)
   );
 
-  if (!isWeb() && isConfigured()) {
+  if (!isWeb() && !isChromeDebugger() && isConfigured()) {
     const capturableConsole = console;
     runOnUI(() => {
       'worklet';

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,7 +1,12 @@
 /* global _WORKLET _getCurrentTime _frameTimestamp _eventTimestamp, _setGlobalConsole */
 import NativeReanimatedModule from './NativeReanimated';
 import { Platform } from 'react-native';
-import { nativeShouldBeMock, shouldBeUseWeb, isWeb, isChromeDebugger } from './PlatformChecker';
+import {
+  nativeShouldBeMock,
+  shouldBeUseWeb,
+  isWeb,
+  isChromeDebugger,
+} from './PlatformChecker';
 import {
   BasicWorkletFunction,
   WorkletFunction,


### PR DESCRIPTION
## Description

Description and motivation for this PR.
`global._chronoNow` doesn't seem to be defined when connected to chrome debugger but `global.performance` is defined already. So I think there is no need to mock in that case.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2760

## Changes
do not mock `global.performance` when connected to chrome debugger (same behaviour as for web)

<!--

## Screenshots / GIFs


<img width="495" alt="Screenshot 2021-12-17 at 12 48 34" src="https://user-images.githubusercontent.com/5617793/146547028-4f6e6b73-154c-4f31-8b59-5ddae9c1e024.png">

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->


## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
