### PR TITLE
Remove rn-screens from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "invariant": "^2.2.4",
     "lodash.isequal": "^4.5.0",
     "mockdate": "^3.0.2",
-    "react-native-screens": "^3.4.0",
     "string-hash-64": "^1.0.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9045,13 +9045,6 @@ react-native-gesture-handler@^1.6.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-screens@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.6.0.tgz#054af728e50c06bff6b3b4fa7b4b656b70f247cd"
-  integrity sha512-emQmSu+B6cOIjJH2OIgpuxd9zCD6xz7/oo5GCetyjsM5qR3sMnVgOxqtK99xPu9XJH/8k7MplXbtJgtk/PHXwA==
-  dependencies:
-    warn-once "^0.1.0"
-
 react-native@0.67.0-rc.4:
   version "0.67.0-rc.4"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.67.0-rc.4.tgz#3a4d3bd4543f5fc01a6a969cd22161231cf9c474"
@@ -10480,11 +10473,6 @@ walker@^1.0.7, walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
-
-warn-once@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.0.tgz#4f58d89b84f968d0389176aa99e0cf0f14ffd4c8"
-  integrity sha512-recZTSvuaH/On5ZU5ywq66y99lImWqzP93+AiUo9LUwG8gXHW+LJjhOd6REJHm7qb0niYqrEQJvbHSQfuJtTqA==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

I noticed that in our project yarn is downloading react-native-screens in two different versions. The culprit turned out to be this library

## Changes

I removed react-native-screens from package.json.

According to a quick diff, Android RNScreens was used here:
https://github.com/software-mansion/react-native-reanimated/pull/2340/files
And then removed here:
https://github.com/software-mansion/react-native-reanimated/commit/2938606b58568139e0e3af6890c824fc129e6a9d

In iOS rn-screens is used here:
https://github.com/software-mansion/react-native-reanimated/blob/df873f0090acb14bbd993577a4bfb096f5ff8a49/ios/LayoutReanimation/REAUIManager.mm
But thanks to @mrousavy here is also an optional import:
https://github.com/software-mansion/react-native-reanimated/pull/2377

So currently rn-screens is only used in Example, which has its own package.json

rn-screens library takes up over 8MB, so node_modules will be lighter with this change.

## Screenshots / GIFs

<img width="244" alt="Zrzut ekranu 2021-12-17 o 19 46 54" src="https://user-images.githubusercontent.com/16975059/146593382-dde8cc4f-7bb9-43ec-bcb8-9c23b19a67a4.png">

https://giant.gfycat.com/RawScaryCowbird.webm

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
