### PR TITLE
Compute style changes before update

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -451,10 +451,10 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
 
   useEffect(() => {
     let fun;
-    let upadterFn = updater;
+    let updaterFn = updater;
     let optimalization = updater.__optimalization;
     if (adapters) {
-      upadterFn = () => {
+      updaterFn = () => {
         'worklet';
         const newValues = updater();
         adaptersArray.forEach((adapter) => {
@@ -464,38 +464,38 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
       };
     }
 
-    if (canApplyOptimalisation(upadterFn) && !shouldBeUseWeb()) {
-      if (hasColorProps(upadterFn())) {
-        upadterFn = () => {
+    if (canApplyOptimalisation(updaterFn) && !shouldBeUseWeb()) {
+      if (hasColorProps(updaterFn())) {
+        updaterFn = () => {
           'worklet';
-          const newValues = upadterFn();
+          const newValues = updaterFn();
           const oldValues = remoteState.last;
-          const diff = styleDiff(oldValues, newValues);
+          const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
           parseColors(diff);
-          return diff as T;
+          return diff;
         };
       } else {
-        upadterFn = () => {
+        updaterFn = () => {
           'worklet';
-          const newValues = upadterFn();
+          const newValues = updaterFn();
           const oldValues = remoteState.last;
-          const diff = styleDiff(oldValues, newValues);
+          const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
-          return diff as T;
+          return diff;
         };
       }
     } else if (!shouldBeUseWeb()) {
       optimalization = 0;
-      upadterFn = () => {
+      updaterFn = () => {
         'worklet';
-        const style = upadterFn();
+        const style = updaterFn();
         parseColors(style);
         return style;
       };
     }
     if (typeof updater.__optimalization !== undefined) {
-      upadterFn.__optimalization = optimalization;
+      updaterFn.__optimalization = optimalization;
     }
 
     if (isJest()) {
@@ -516,7 +516,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
         'worklet';
         styleUpdater(
           sharableViewDescriptors,
-          upadterFn,
+          updaterFn,
           remoteState,
           maybeViewRef,
           animationsActive
@@ -527,7 +527,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
       fun,
       inputs,
       [],
-      upadterFn,
+      updaterFn,
       // TODO fix this
       sharableViewDescriptors
     );

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -207,27 +207,23 @@ export function styleDiff(
 ): AnimatedStyle {
   'worklet';
   const diff: AnimatedStyle = {};
-  Object.keys(oldStyle).forEach((key) => {
+  for (const key in oldStyle) {
     if (newStyle[key] === undefined) {
       diff[key] = null;
     }
-  });
-  Object.keys(newStyle).forEach((key) => {
+  }
+  for (const key in newStyle) {
     const value = newStyle[key];
     const oldValue = oldStyle[key];
 
     if (isAnimated(value)) {
       // do nothing
-      return;
+      continue;
     }
-    if (
-      oldValue !== value &&
-      JSON.stringify(oldValue) !== JSON.stringify(value)
-    ) {
-      // I'd use deep equal here but that'd take additional work and this was easier
+    if (oldValue !== value) {
       diff[key] = value;
     }
-  });
+  }
   return diff;
 }
 

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -204,9 +204,9 @@ export function isAnimated(prop: NestedObjectValues<AnimationObject>): boolean {
 export function styleDiff<T extends AnimatedStyle>(
   oldStyle: AnimatedStyle,
   newStyle: AnimatedStyle
-): T {
+): Partial<T> {
   'worklet';
-  const diff: any = {};
+  const diff = {};
   for (const key in oldStyle) {
     if (newStyle[key] === undefined) {
       diff[key] = null;

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -201,12 +201,12 @@ export function isAnimated(prop: NestedObjectValues<AnimationObject>): boolean {
   return false;
 }
 
-export function styleDiff(
+export function styleDiff<T extends AnimatedStyle>(
   oldStyle: AnimatedStyle,
   newStyle: AnimatedStyle
-): AnimatedStyle {
+): T {
   'worklet';
-  const diff: AnimatedStyle = {};
+  const diff: any = {};
   for (const key in oldStyle) {
     if (newStyle[key] === undefined) {
       diff[key] = null;


### PR DESCRIPTION
## Description

When I was doing performance optimizations, I removed function `styleDiff`, this function computes differences between old style and new style and returns only differences. In effect, we updated only changed style properties. When I removed the call of styleDiff (because was expensive) there was possible to call `layout()` too many times, even if someone doesn't change the layout property (layout is also expensive) but there was another problem because we need an update synchronous and asynchronous updates in the same `updateProps` call. So we decided to restore `styleDiff` but with faster implementation. We get rid of comparison by `JSON.stringify()`, the shall computation should be enough in this way.

## Benchmark
<details>
<summary>code</summary>

```js
const objA = {
  a: 1,
  b: 2,
  c: {},
  d: [],
  e: { a: 1 },
  f: [1, 2, 3],
  g: [{a: 1}, {a: 2}, {a: 2}],
  h: 'abc',
  i: 'abc1',
  a1: 1,
  a2: 1,
  a3: 1,
  a4: 1,
}
const objB = {
  a: 1,
  b: 22,
  c: {},
  d: [],
  e: { a: 11 },
  f: [11, 22, 33],
  g: [{a: 11}, {a: 2}, {a: 2}],
  h: 'abc',
  i: 'abc2',
}
const iteration = 99999;

for(let i = 0; i < 100; i++) {
  let a = performance.now();
}

const t1_start = performance.now();
for(let i = 0; i < iteration; i++) {
  styleDiff_old(objA, objB);
}
const t1_end = performance.now();

const t2_start = performance.now();
for(let i = 0; i < iteration; i++) {
  styleDiff(objA, objB);
}
const t2_end = performance.now();

console.log(
  'old', Math.round(t1_end - t1_start), 'ms',
  '|',
  'new', Math.round(t2_end - t2_start), 'ms'
)
```
</details>

Results:
```
old 919 ms | new 282 ms
old 870 ms | new 283 ms
old 901 ms | new 273 ms
old 878 ms | new 306 ms
old 868 ms | new 274 ms
old 860 ms | new 266 ms
old 907 ms | new 309 ms
old 912 ms | new 334 ms
old 922 ms | new 291 ms
old 867 ms | new 261 ms
old 880 ms | new 261 ms
```

In addition, this
```js
state.last = Object.assign({}, oldValues, newValues);
```
fixes https://github.com/software-mansion/react-native-reanimated/issues/2752