### PR TITLE
Fix animating colors direclty from useAnimatedStyle

### DIFF
--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -163,7 +163,12 @@ export function parseColors(updates: AnimatedStyle): void {
   'worklet';
   for (const key in updates) {
     if (colorProps.indexOf(key) !== -1) {
-      updates[key] = processColor(updates[key]);
+      // value could be an animation in which case processColor will recognize it and will return undefined
+      // -> in such a case we don't want to override style of that key
+      const processedColor = processColor(updates[key]);
+      if (processedColor !== undefined) {
+        updates[key] = processedColor;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes the ability to use color animations directly in useAnimatedStyle. 

## Changes

This diff changes the way `parseColors` method works. Before this change we'd run all the updates for color properties (e.g. `backgroundColor`) via that method and expect it to update color to a normalized form. This way we'd get normalized values to send to the native side. However, if you'd specify `withTiming(someColor)` as a value, the parser would return `undefined` and override that animated value. As a result removing that animation object from styles would result in disabling that animation completely (the code fragment responsible for running animation would never see it). What we should be doing instead is to allow animated color values to be passed as animation objects and be parsed only when they are turned into actual values when the animation is running.

### Before

To test it add a code that has style like this:
```
const style = useAnimatedStyle(() => { backgroundColor: withTiming(toggle ? 'red' : 'green') });
```

Before this change the color would not change after we switch the toggle

### After

After this change the color propertly animated when toggle variable is flipped.

## Test code and steps to reproduce

```
const style = useAnimatedStyle(() => { backgroundColor: withTiming(toggle ? 'red' : 'green') });
```
