### PR TITLE
chore(android): replaced jCenter with maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -451,14 +451,6 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    // FIXME jcenter is deprecated and will be removed soon, however some modules still doesn't migrate to maven central
-    jcenter() {
-        content {
-            includeModule("com.facebook.fbjni", "fbjni-java-only")
-            includeModule("com.facebook.yoga", "proguard-annotations")
-
-        }
-    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -455,6 +455,8 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
+    implementation 'com.facebook.yoga:proguard-annotations:1.19.0'
+    implementation 'com.facebook.fbjni:fbjni-java-only:0.3.0'
     implementation 'com.facebook.fbjni:fbjni:' + FBJNI_VERSION
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation "androidx.transition:transition:1.1.0"


### PR DESCRIPTION
## Description

Packages on jcenter has been moved to mavenCentral

## Changes

Removed jcenter from android sources.

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
