### PR TITLE
Display only warn if measure is called on RN side

### DIFF
--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -28,12 +28,12 @@ export function measure(
   if (!_WORKLET || isChromeDebugger()) {
     console.warn('[reanimated.measure] method cannot be used on RN side!');
     return {
-      x: -1,
-      y: -1,
-      width: -1,
-      height: -1,
-      pageX: -1,
-      pageY: -1,
+      x: NaN,
+      y: NaN,
+      width: NaN,
+      height: NaN,
+      pageX: NaN,
+      pageY: NaN,
     };
   }
   const viewTag = animatedRef();

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -25,7 +25,7 @@ export function measure(
   animatedRef: RefObjectFunction<Component>
 ): MeasuredDimensions {
   'worklet';
-  if (!_WORKLET && !isChromeDebugger()) {
+  if (!_WORKLET || isChromeDebugger()) {
     console.warn('[reanimated.measure] method cannot be used on RN side!');
     return {
       x: -1,

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -26,7 +26,15 @@ export function measure(
 ): MeasuredDimensions {
   'worklet';
   if (!_WORKLET && !isChromeDebugger()) {
-    throw new Error('(measure) method cannot be used on RN side!');
+    console.warn('[reanimated.measure] method cannot be used on RN side!');
+    return {
+      x: -1,
+      y: -1,
+      width: -1,
+      height: -1,
+      pageX: -1,
+      pageY: -1,
+    };
   }
   const viewTag = animatedRef();
   const result = _measure(viewTag);


### PR DESCRIPTION
## Description

I replaced the exception with a warning message in the `measure` function because if someone uses `measure` inside `useDerivedValue` the initial call is called on react native side.

Fixes #2779
