### PR TITLE
Fix chrome debugger for android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -1,6 +1,7 @@
 package com.swmansion.reanimated;
 
 import android.os.SystemClock;
+import android.util.Log;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
@@ -161,6 +162,10 @@ public class NativeProxy {
   }
 
   public void prepare(LayoutAnimations LayoutAnimations) {
+    if (Utils.isChromeDebugger) {
+      Log.w("[REANIMATED]", "You can not use LayoutAnimation with enabled Chrome Debugger");
+      return;
+    }
     mNodesManager = mContext.get().getNativeModule(ReanimatedModule.class).getNodesManager();
     installJSIBindings();
     AnimationsManager animationsManager =

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedJSIModulePackage.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedJSIModulePackage.java
@@ -1,5 +1,7 @@
 package com.swmansion.reanimated;
 
+import android.util.Log;
+
 import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JSIModuleSpec;
 import com.facebook.react.bridge.JavaScriptContextHolder;
@@ -13,9 +15,18 @@ public class ReanimatedJSIModulePackage implements JSIModulePackage {
   public List<JSIModuleSpec> getJSIModules(
       ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext) {
 
-    NodesManager nodesManager =
-        reactApplicationContext.getNativeModule(ReanimatedModule.class).getNodesManager();
-    nodesManager.initWithContext(reactApplicationContext);
+    // When debugging in chrome the JS context is not available.
+    // https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25
+    Utils.isChromeDebugger = jsContext.get() == 0;
+
+    if (!Utils.isChromeDebugger) {
+      NodesManager nodesManager =
+          reactApplicationContext.getNativeModule(ReanimatedModule.class).getNodesManager();
+      nodesManager.initWithContext(reactApplicationContext);
+    }
+    else {
+      Log.w("[REANIMATED]", "Unable to create Reanimated Native Module. You can ignore this message if you are using Chrome Debugger now.");
+    }
     return Arrays.<JSIModuleSpec>asList();
   }
 }

--- a/android/src/main/java/com/swmansion/reanimated/Utils.java
+++ b/android/src/main/java/com/swmansion/reanimated/Utils.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 public class Utils {
 
+  protected static boolean isChromeDebugger = false;
+
   public static Map<String, Integer> processMapping(ReadableMap style) {
     ReadableMapKeySetIterator iter = style.keySetIterator();
     HashMap<String, Integer> mapping = new HashMap<>();

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -504,6 +504,6 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public boolean isLayoutAnimationEnabled() {
-    return mNativeMethodsHolder.isLayoutAnimationEnabled();
+    return mNativeMethodsHolder != null && mNativeMethodsHolder.isLayoutAnimationEnabled(); 
   }
 }


### PR DESCRIPTION
## Description

Layout animated provided many changes, one of the effects is that Reanimated always tries to load the native module, but this breaks the chrome debugger on Android, unfortunately. I detected when chrome debugger is enabled based on React Native code: [source](https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25-L26)
```js
// When debugging in chrome the JS context is not available.
if (jsContext.get() != 0) {
```
ant then I don't load the native reanimated module.

Crash:
```
E/AndroidRuntime: FATAL EXCEPTION: mqt_js
    Process: com.swmansion.reanimated.example, PID: 3681
    java.lang.AssertionError: No source URL loaded, have you initialised the instance?
        at com.facebook.infer.annotation.Assertions.assertNotNull(Assertions.java:19)
        at com.facebook.react.modules.debug.SourceCodeModule.getTypedExportedConstants(SourceCodeModule.java:39)
        at com.facebook.fbreact.specs.NativeSourceCodeSpec.getConstants(NativeSourceCodeSpec.java:38)
        at com.facebook.react.bridge.JavaModuleWrapper.getConstants(JavaModuleWrapper.java:142)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:223)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:923)
I/Process: Sending signal. PID: 3681 SIG: 9
```

Fixes #2671 

Related threads:
- https://github.com/expo/expo/issues/10284
- https://github.com/expo/expo/pull/10383
- https://github.com/facebook/react-native/issues/28844