### PR TITLE
feat: added withInitialValues modifier

### DIFF
--- a/docs/docs/api/LayoutAnimations/EntryAnimations.md
+++ b/docs/docs/api/LayoutAnimations/EntryAnimations.md
@@ -55,6 +55,7 @@ Simple animation based on changing of opacity.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -75,6 +76,7 @@ Animation based on smoothly shaking of component.
 * `duration` (in ms) default: 250
 * `delay` (in ms) default: 0
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -104,6 +106,7 @@ Animation based on smoothly shaking of component.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -129,6 +132,7 @@ Animation based on changing width or height of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -160,6 +164,7 @@ Animation based on changing scale of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -187,6 +192,7 @@ Animation based on horizontal or vertical moving of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 #### Example
 <video src="https://user-images.githubusercontent.com/36106620/120317587-1a51dc00-c2df-11eb-937a-c53a237afca2.mov" controls="controls" muted="muted"></video>
@@ -211,6 +217,7 @@ Animation based on horizontal moving of object with changing of opacity and skew
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -235,6 +242,7 @@ Animation based on rotation with scale and opacity change.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -260,6 +268,7 @@ Animation based on horizontal moving of object with rotation.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -287,6 +296,7 @@ Animation based on rotation of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the entry animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example

--- a/docs/docs/api/LayoutAnimations/ExitAnimations.md
+++ b/docs/docs/api/LayoutAnimations/ExitAnimations.md
@@ -55,6 +55,7 @@ Simple animation based on changing of opacity.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -75,6 +76,7 @@ Animation based on smoothly shaking of component.
 * `duration` (in ms) default: 250
 * `delay` (in ms) default: 0
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -104,6 +106,7 @@ Animation based on smoothly shaking of component.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -129,6 +132,7 @@ Animation based on changing width or height of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -160,6 +164,7 @@ Animation based on changing scale of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 #### Example
 <video src="https://user-images.githubusercontent.com/36106620/120317554-0efeb080-c2df-11eb-88cf-6ec47778dccb.mov" controls="controls" muted="muted"></video>
@@ -186,6 +191,7 @@ Animation based on horizontal or vertical moving of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -211,6 +217,7 @@ Animation based on horizontal moving of object with changing of opacity and skew
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -235,6 +242,7 @@ Animation based on rotation with scale and opacity change.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -260,6 +268,7 @@ Animation based on horizontal moving of object with rotation.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example
@@ -287,6 +296,7 @@ Animation based on rotation of object.
 * `restDisplacementThreshold` default: 0.001
 * `restSpeedThreshold` default: 0.001
 * `withCallback` callback that will fire after the exit animation ends
+* `withInitialValues` sets the initial values
 * `randomDelay` randomize delay of the animation between 0 and provided delay ( or 1000ms if delay not provided )
 
 #### Example

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -830,6 +830,9 @@ declare module 'react-native-reanimated' {
       callback: (finished: boolean) => void
     ): ComplexAnimationBuilder;
 
+    static withInitialValues(values: StyleProps): BaseAnimationBuilder;
+    withInitialValues(values: StyleProps): BaseAnimationBuilder;
+
     static easing(easingFunction: EasingFunction): ComplexAnimationBuilder;
     easing(easingFunction: EasingFunction): ComplexAnimationBuilder;
     static springify(): ComplexAnimationBuilder;

--- a/src/reanimated2/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -6,6 +6,8 @@ import {
 } from './commonTypes';
 import { EasingFn } from '../../Easing';
 import { BaseAnimationBuilder } from './BaseAnimationBuilder';
+import { StyleProps } from '../../commonTypes';
+
 export class ComplexAnimationBuilder extends BaseAnimationBuilder {
   easingV?: EasingFn;
   rotateV?: string;
@@ -16,6 +18,7 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
   overshootClampingV?: number;
   restDisplacementThresholdV?: number;
   restSpeedThresholdV?: number;
+  initialValues?: StyleProps;
 
   static createInstance: () => ComplexAnimationBuilder;
 
@@ -112,6 +115,16 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
 
   restSpeedThreshold(restSpeedThreshold: number): ComplexAnimationBuilder {
     this.restSpeedThresholdV = restSpeedThreshold;
+    return this;
+  }
+
+  static withInitialValues(values: StyleProps): BaseAnimationBuilder {
+    const instance = this.createInstance();
+    return instance.withInitialValues(values);
+  }
+
+  withInitialValues(values: StyleProps): BaseAnimationBuilder {
+    this.initialValues = values;
     return this;
   }
 

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
@@ -4,12 +4,12 @@ import {
 } from '../animationBuilder/commonTypes';
 import { withSequence, withTiming } from '../../animation';
 import { Dimensions } from 'react-native';
-import { BaseAnimationBuilder } from '../animationBuilder/BaseAnimationBuilder';
+import { ComplexAnimationBuilder } from '../animationBuilder/ComplexAnimationBuilder';
 
 const { width, height } = Dimensions.get('window');
 
 export class BounceIn
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceIn {
     return new BounceIn();
@@ -28,6 +28,7 @@ export class BounceIn
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -49,6 +50,7 @@ export class BounceIn
         },
         initialValues: {
           transform: [{ scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -57,7 +59,7 @@ export class BounceIn
 }
 
 export class BounceInDown
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceInDown {
     return new BounceInDown();
@@ -76,6 +78,7 @@ export class BounceInDown
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -101,6 +104,7 @@ export class BounceInDown
               translateY: height,
             },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -109,7 +113,7 @@ export class BounceInDown
 }
 
 export class BounceInUp
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceInUp {
     return new BounceInUp();
@@ -128,6 +132,7 @@ export class BounceInUp
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -149,6 +154,7 @@ export class BounceInUp
         },
         initialValues: {
           transform: [{ translateY: -height }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -157,7 +163,7 @@ export class BounceInUp
 }
 
 export class BounceInLeft
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceInLeft {
     return new BounceInLeft();
@@ -176,6 +182,7 @@ export class BounceInLeft
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -197,6 +204,7 @@ export class BounceInLeft
         },
         initialValues: {
           transform: [{ translateX: -width }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -205,7 +213,7 @@ export class BounceInLeft
 }
 
 export class BounceInRight
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceInRight {
     return new BounceInRight();
@@ -224,6 +232,7 @@ export class BounceInRight
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -245,6 +254,7 @@ export class BounceInRight
         },
         initialValues: {
           transform: [{ translateX: width }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -253,7 +263,7 @@ export class BounceInRight
 }
 
 export class BounceOut
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceOut {
     return new BounceOut();
@@ -272,6 +282,7 @@ export class BounceOut
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -293,6 +304,7 @@ export class BounceOut
         },
         initialValues: {
           transform: [{ scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -301,7 +313,7 @@ export class BounceOut
 }
 
 export class BounceOutDown
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceOutDown {
     return new BounceOutDown();
@@ -320,6 +332,7 @@ export class BounceOutDown
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -343,6 +356,7 @@ export class BounceOutDown
         },
         initialValues: {
           transform: [{ translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -351,7 +365,7 @@ export class BounceOutDown
 }
 
 export class BounceOutUp
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceOutUp {
     return new BounceOutUp();
@@ -370,6 +384,7 @@ export class BounceOutUp
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -393,6 +408,7 @@ export class BounceOutUp
         },
         initialValues: {
           transform: [{ translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -401,7 +417,7 @@ export class BounceOutUp
 }
 
 export class BounceOutLeft
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceOutRight {
     return new BounceOutLeft();
@@ -420,6 +436,7 @@ export class BounceOutLeft
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -443,6 +460,7 @@ export class BounceOutLeft
         },
         initialValues: {
           transform: [{ translateX: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -451,7 +469,7 @@ export class BounceOutLeft
 }
 
 export class BounceOutRight
-  extends BaseAnimationBuilder
+  extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder {
   static createInstance(): BounceOutRight {
     return new BounceOutRight();
@@ -470,6 +488,7 @@ export class BounceOutRight
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -493,6 +512,7 @@ export class BounceOutRight
         },
         initialValues: {
           transform: [{ translateX: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
@@ -15,6 +15,7 @@ export class FadeIn
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return (_) => {
@@ -25,6 +26,7 @@ export class FadeIn
         },
         initialValues: {
           opacity: 0,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -43,6 +45,7 @@ export class FadeInRight
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -57,6 +60,7 @@ export class FadeInRight
         initialValues: {
           opacity: 0,
           transform: [{ translateX: 25 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -75,6 +79,7 @@ export class FadeInLeft
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -89,6 +94,7 @@ export class FadeInLeft
         initialValues: {
           opacity: 0,
           transform: [{ translateX: -25 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -107,6 +113,7 @@ export class FadeInUp
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -121,6 +128,7 @@ export class FadeInUp
         initialValues: {
           opacity: 0,
           transform: [{ translateY: -25 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -139,6 +147,7 @@ export class FadeInDown
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -153,6 +162,7 @@ export class FadeInDown
         initialValues: {
           opacity: 0,
           transform: [{ translateY: 25 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -171,6 +181,7 @@ export class FadeOut
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return (_) => {
@@ -181,6 +192,7 @@ export class FadeOut
         },
         initialValues: {
           opacity: 1,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -199,6 +211,7 @@ export class FadeOutRight
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -213,6 +226,7 @@ export class FadeOutRight
         initialValues: {
           opacity: 1,
           transform: [{ translateX: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -231,6 +245,7 @@ export class FadeOutLeft
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -245,6 +260,7 @@ export class FadeOutLeft
         initialValues: {
           opacity: 1,
           transform: [{ translateX: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -263,6 +279,7 @@ export class FadeOutUp
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -277,6 +294,7 @@ export class FadeOutUp
         initialValues: {
           opacity: 1,
           transform: [{ translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -295,6 +313,7 @@ export class FadeOutDown
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
     const delay = this.getDelay();
 
     return () => {
@@ -309,6 +328,7 @@ export class FadeOutDown
         initialValues: {
           opacity: 1,
           transform: [{ translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -21,6 +21,7 @@ export class FlipInXUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -31,6 +32,7 @@ export class FlipInXUp
             { rotateX: '90deg' },
             { translateY: -targetValues.targetHeight },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -57,6 +59,7 @@ export class FlipInYLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -67,6 +70,7 @@ export class FlipInYLeft
             { rotateY: '-90deg' },
             { translateX: -targetValues.targetWidth },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -93,6 +97,7 @@ export class FlipInXDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -103,6 +108,7 @@ export class FlipInXDown
             { rotateX: '-90deg' },
             { translateY: targetValues.targetHeight },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -129,6 +135,7 @@ export class FlipInYRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -139,6 +146,7 @@ export class FlipInYRight
             { rotateY: '90deg' },
             { translateX: targetValues.targetWidth },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -165,12 +173,14 @@ export class FlipInEasyX
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
       return {
         initialValues: {
           transform: [{ perspective: 500 }, { rotateX: '90deg' }],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -196,12 +206,14 @@ export class FlipInEasyY
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
       return {
         initialValues: {
           transform: [{ perspective: 500 }, { rotateY: '90deg' }],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -227,6 +239,7 @@ export class FlipOutXUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -237,6 +250,7 @@ export class FlipOutXUp
             { rotateX: '0deg' },
             { translateY: 0 },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -268,6 +282,7 @@ export class FlipOutYLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -278,6 +293,7 @@ export class FlipOutYLeft
             { rotateY: '0deg' },
             { translateX: 0 },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -309,6 +325,7 @@ export class FlipOutXDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -319,6 +336,7 @@ export class FlipOutXDown
             { rotateX: '0deg' },
             { translateY: 0 },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -350,6 +368,7 @@ export class FlipOutYRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (targetValues) => {
       'worklet';
@@ -360,6 +379,7 @@ export class FlipOutYRight
             { rotateY: '0deg' },
             { translateX: 0 },
           ],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -391,12 +411,14 @@ export class FlipOutEasyX
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
       return {
         initialValues: {
           transform: [{ perspective: 500 }, { rotateX: '0deg' }],
+          ...initialValues,
         },
         animations: {
           transform: [
@@ -422,12 +444,14 @@ export class FlipOutEasyY
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
       return {
         initialValues: {
           transform: [{ perspective: 500 }, { rotateY: '0deg' }],
+          ...initialValues,
         },
         animations: {
           transform: [

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -21,6 +21,7 @@ export class LightSpeedInRight
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -49,6 +50,7 @@ export class LightSpeedInRight
         initialValues: {
           opacity: 0,
           transform: [{ translateX: width }, { skewX: '-45deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -69,6 +71,7 @@ export class LightSpeedInLeft
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -97,6 +100,7 @@ export class LightSpeedInLeft
         initialValues: {
           opacity: 0,
           transform: [{ translateX: -width }, { skewX: '45deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -116,6 +120,7 @@ export class LightSpeedOutRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -134,6 +139,7 @@ export class LightSpeedOutRight
         initialValues: {
           opacity: 1,
           transform: [{ translateX: 0 }, { skewX: '0deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -153,6 +159,7 @@ export class LightSpeedOutLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -171,6 +178,7 @@ export class LightSpeedOutLeft
         initialValues: {
           opacity: 1,
           transform: [{ translateX: 0 }, { skewX: '0deg' }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -16,6 +16,7 @@ export class PinwheelIn
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (_values) => {
       'worklet';
@@ -41,6 +42,7 @@ export class PinwheelIn
               rotate: '5',
             },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -60,6 +62,7 @@ export class PinwheelOut
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (_values) => {
       'worklet';
@@ -85,6 +88,7 @@ export class PinwheelOut
               rotate: '0',
             },
           ],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -19,6 +19,7 @@ export class RollInLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -31,6 +32,7 @@ export class RollInLeft
         },
         initialValues: {
           transform: [{ translateX: -width }, { rotate: '-180deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -50,6 +52,7 @@ export class RollInRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -62,6 +65,7 @@ export class RollInRight
         },
         initialValues: {
           transform: [{ translateX: width }, { rotate: '180deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -81,6 +85,7 @@ export class RollOutLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -93,6 +98,7 @@ export class RollOutLeft
         },
         initialValues: {
           transform: [{ translateX: 0 }, { rotate: '0deg' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -112,6 +118,7 @@ export class RollOutRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -124,6 +131,7 @@ export class RollOutRight
         },
         initialValues: {
           transform: [{ translateX: 0 }, { rotate: '0deg' }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
@@ -19,6 +19,7 @@ export class RotateInDownLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -38,6 +39,7 @@ export class RotateInDownLeft
             { translateX: values.targetWidth / 2 - values.targetHeight / 2 },
             { translateY: -(values.targetWidth / 2 - values.targetHeight / 2) },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -57,6 +59,7 @@ export class RotateInDownRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -76,6 +79,7 @@ export class RotateInDownRight
             { translateX: -(values.targetWidth / 2 - values.targetHeight / 2) },
             { translateY: -(values.targetWidth / 2 - values.targetHeight / 2) },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -95,6 +99,7 @@ export class RotateInUpLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -114,6 +119,7 @@ export class RotateInUpLeft
             { translateX: values.targetWidth / 2 - values.targetHeight / 2 },
             { translateY: values.targetWidth / 2 - values.targetHeight / 2 },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -133,6 +139,7 @@ export class RotateInUpRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -152,6 +159,7 @@ export class RotateInUpRight
             { translateX: -(values.targetWidth / 2 - values.targetHeight / 2) },
             { translateY: values.targetWidth / 2 - values.targetHeight / 2 },
           ],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -171,6 +179,7 @@ export class RotateOutDownLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -202,6 +211,7 @@ export class RotateOutDownLeft
         initialValues: {
           opacity: 1,
           transform: [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -221,6 +231,7 @@ export class RotateOutDownRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -252,6 +263,7 @@ export class RotateOutDownRight
         initialValues: {
           opacity: 1,
           transform: [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -271,6 +283,7 @@ export class RotateOutUpLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -302,6 +315,7 @@ export class RotateOutUpLeft
         initialValues: {
           opacity: 1,
           transform: [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -321,6 +335,7 @@ export class RotateOutUpRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -352,6 +367,7 @@ export class RotateOutUpRight
         initialValues: {
           opacity: 1,
           transform: [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
@@ -22,6 +22,7 @@ export class SlideInRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -34,6 +35,7 @@ export class SlideInRight
         },
         initialValues: {
           originX: values.targetOriginX + width,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -53,6 +55,7 @@ export class SlideInLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -65,6 +68,7 @@ export class SlideInLeft
         },
         initialValues: {
           originX: values.targetOriginX - width,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -84,6 +88,7 @@ export class SlideOutRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -96,6 +101,7 @@ export class SlideOutRight
         },
         initialValues: {
           originX: values.currentOriginX,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -115,6 +121,7 @@ export class SlideOutLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -127,6 +134,7 @@ export class SlideOutLeft
         },
         initialValues: {
           originX: values.currentOriginX,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -146,6 +154,7 @@ export class SlideInUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -158,6 +167,7 @@ export class SlideInUp
         },
         initialValues: {
           originY: -height,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -177,6 +187,7 @@ export class SlideInDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -189,6 +200,7 @@ export class SlideInDown
         },
         initialValues: {
           originY: values.targetOriginY + height,
+          ...initialValues,
         },
         callback: callback,
       };
@@ -208,6 +220,7 @@ export class SlideOutUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -218,7 +231,7 @@ export class SlideOutUp
             animation(Math.min(values.currentOriginY - height, -height), config)
           ),
         },
-        initialValues: { originY: values.currentOriginY },
+        initialValues: { originY: values.currentOriginY, ...initialValues },
         callback: callback,
       };
     };
@@ -237,6 +250,7 @@ export class SlideOutDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -247,7 +261,7 @@ export class SlideOutDown
             animation(Math.max(values.currentOriginY + height, height), config)
           ),
         },
-        initialValues: { originY: values.currentOriginY },
+        initialValues: { originY: values.currentOriginY, ...initialValues },
         callback: callback,
       };
     };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
@@ -16,6 +16,7 @@ export class StretchInX
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -25,6 +26,7 @@ export class StretchInX
         },
         initialValues: {
           transform: [{ scaleX: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -44,6 +46,7 @@ export class StretchInY
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -53,6 +56,7 @@ export class StretchInY
         },
         initialValues: {
           transform: [{ scaleY: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -72,6 +76,7 @@ export class StretchOutX
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -81,6 +86,7 @@ export class StretchOutX
         },
         initialValues: {
           transform: [{ scaleX: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -100,6 +106,7 @@ export class StretchOutY
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -109,6 +116,7 @@ export class StretchOutY
         },
         initialValues: {
           transform: [{ scaleY: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
@@ -24,6 +24,7 @@ export class ZoomIn
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -33,6 +34,7 @@ export class ZoomIn
         },
         initialValues: {
           transform: [{ scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -53,6 +55,7 @@ export class ZoomInRotate
     const delay = this.getDelay();
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -65,6 +68,7 @@ export class ZoomInRotate
         },
         initialValues: {
           transform: [{ scale: 0 }, { rotate: rotate }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -84,6 +88,7 @@ export class ZoomInLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -96,6 +101,7 @@ export class ZoomInLeft
         },
         initialValues: {
           transform: [{ translateX: -width }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -115,6 +121,7 @@ export class ZoomInRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -127,6 +134,7 @@ export class ZoomInRight
         },
         initialValues: {
           transform: [{ translateX: width }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -146,6 +154,7 @@ export class ZoomInUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -158,6 +167,7 @@ export class ZoomInUp
         },
         initialValues: {
           transform: [{ translateY: -height }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -177,6 +187,7 @@ export class ZoomInDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -189,6 +200,7 @@ export class ZoomInDown
         },
         initialValues: {
           transform: [{ translateY: height }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -208,6 +220,7 @@ export class ZoomInEasyUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -220,6 +233,7 @@ export class ZoomInEasyUp
         },
         initialValues: {
           transform: [{ translateY: -values.targetHeight }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -239,6 +253,7 @@ export class ZoomInEasyDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -251,6 +266,7 @@ export class ZoomInEasyDown
         },
         initialValues: {
           transform: [{ translateY: values.targetHeight }, { scale: 0 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -270,6 +286,7 @@ export class ZoomOut
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -279,6 +296,7 @@ export class ZoomOut
         },
         initialValues: {
           transform: [{ scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -299,6 +317,7 @@ export class ZoomOutRotate
     const delay = this.getDelay();
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -311,6 +330,7 @@ export class ZoomOutRotate
         },
         initialValues: {
           transform: [{ scale: 1 }, { rotate: '0' }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -330,6 +350,7 @@ export class ZoomOutLeft
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -342,6 +363,7 @@ export class ZoomOutLeft
         },
         initialValues: {
           transform: [{ translateX: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -361,6 +383,7 @@ export class ZoomOutRight
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -373,6 +396,7 @@ export class ZoomOutRight
         },
         initialValues: {
           transform: [{ translateX: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -392,6 +416,7 @@ export class ZoomOutUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -404,6 +429,7 @@ export class ZoomOutUp
         },
         initialValues: {
           transform: [{ translateY: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -423,6 +449,7 @@ export class ZoomOutDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return () => {
       'worklet';
@@ -435,6 +462,7 @@ export class ZoomOutDown
         },
         initialValues: {
           transform: [{ translateY: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -454,6 +482,7 @@ export class ZoomOutEasyUp
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -471,6 +500,7 @@ export class ZoomOutEasyUp
         },
         initialValues: {
           transform: [{ translateY: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };
@@ -490,6 +520,7 @@ export class ZoomOutEasyDown
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
+    const initialValues = this.initialValues;
 
     return (values) => {
       'worklet';
@@ -507,6 +538,7 @@ export class ZoomOutEasyDown
         },
         initialValues: {
           transform: [{ translateY: 0 }, { scale: 1 }],
+          ...initialValues,
         },
         callback: callback,
       };


### PR DESCRIPTION
## Description

This pr introduce a new layout animation modifier `withInitialValues` to sets initial values for pre-defined animations.

This is needed for third-party libraries to override animation props and add initial values - like `originX` & `originY`.

## Changes

- feat: added `withInitialValues` modifier to `ComplexAnimationBuilder`.
- docs: added the mention for the `withInitialValues` modifier.

## Test code and steps to reproduce

Tested the example `DefaultAnimations.tsx >> FadeIn`, where i added a background color as an initial value, and it works

```tsx
FadeIn.withInitialValues({ backgroundColor: 'red' })
``` 

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
