### PR TITLE
Changed default ViewState

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -61,10 +61,10 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public enum ViewState {
+    Inactive,
     Appearing,
     Disappearing,
     Layout,
-    Inactive,
     ToRemove;
   }
 
@@ -107,11 +107,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
     HashMap<String, Object> currentValues = before.toCurrentMap();
     ViewState state = mStates.get(view.getId());
 
-    if (state == null || state == ViewState.Disappearing || state == ViewState.ToRemove) {
+    if (state == ViewState.Disappearing || state == ViewState.ToRemove) {
       return;
     }
     mCallbacks.put(tag, callback);
-    if (state == ViewState.Inactive) {
+    if (state == ViewState.Inactive || state == null) {
       if (currentValues != null) {
         mStates.put(view.getId(), ViewState.ToRemove);
         mToRemove.add(view.getId());
@@ -232,6 +232,10 @@ public class AnimationsManager implements ViewHierarchyObserver {
     // go through ready to remove from bottom to top
     for (int tag : mToRemove) {
       View view = mViewForTag.get(tag);
+      if (view == null) {
+        view = mUIManager.resolveView(tag);
+        mViewForTag.put(tag, view);
+      }
       findRoot(view, roots);
     }
     for (int tag : roots) {

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -5,10 +5,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, ViewState) {
+  Inactive,
   Appearing,
   Disappearing,
   Layout,
-  Inactive,
   ToRemove,
 };
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -150,6 +150,10 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   NSMutableSet<NSNumber *> *roots = [NSMutableSet new];
   for (NSNumber *viewTag in _toRemove) {
     UIView *view = _viewForTag[viewTag];
+    if (view == nil) {
+      view = [_reaUiManager viewForReactTag:viewTag];
+      _viewForTag[viewTag] = view;
+    }
     [self findRoot:view roots:roots];
   }
   for (NSNumber *viewTag in roots) {


### PR DESCRIPTION
## Description

The problem occurs since #2651
Why?
Layout animations are disabled by default until someone call layout animation. Then layout animation is enabled. The problem is when someone uses layout animation in components that don't appear in the first render. It breaks the previous assumption of layout animation - "every component is sent to `onViewCreate` function". In effect, we tried to remove the view that wasn't registered in `_viewForTag` register.

There was also another problem because uses this:
```c++
ViewState state = [_states[tag] intValue];
```
without checking if `_states[tag]` is `nil`. Then `nil` was converted to `0` and then to the first value from `ViewState` (`Appearing`), but this is wrong because the default state should be `Inactive` because not every component has animation.

I added similar changes for Android also.

## Reproduction
```js
import React from 'react';
import { useEffect, useState } from 'react';
import { ActivityIndicator, StyleSheet, Text, View, findNodeHandle } from 'react-native';
import Animated, { FadeOutDown } from 'react-native-reanimated';

export default function App() {
  const [isLoading, setIsLoading] = useState<boolean>(true);
  useEffect(() => {
    const timeout = setTimeout(() => setIsLoading(false), 500);
    return () => {
      clearTimeout(timeout);
    };
  }, []);

  return (
    <View style={styles.container}>
      { isLoading ? 
          <ActivityIndicator size='large' color='red' />
        : 
          <Animated.View exiting={FadeOutDown} style={styles.scrollContainer}>
            {[...Array(10).keys()].map((value) => (
              <View style={styles.row} key={value}>
                <Text>row n°{value}</Text>
              </View>
            ))}
          </Animated.View>
      }
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
  scrollContainer: {
    flex: 1,
    width: '100%',
  },
  row: {
    flexDirection: 'row',
    backgroundColor: 'transparent',
    height: 50,
  },
});
```

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2758