### PR TITLE
Add info about proguard to docs

### DIFF
--- a/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
@@ -127,6 +127,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
 
 ```
+-keep class com.swmansion.reanimated.** { *; }
 -keep class com.facebook.react.turbomodule.** { *; }
 ```
 


### PR DESCRIPTION
## Description

We had updated information about Proguard only in the newest version of the documentation: https://github.com/software-mansion/react-native-reanimated/blob/main/docs/docs/fundamentals/installation.md#proguard

I added this info also documentation in version 2.3.0

Related PR: https://github.com/software-mansion/react-native-reanimated/pull/2725
