### PR TITLE
Add `onChange` to set of Gesture Handler builder methods in the Babel plugin

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -158,6 +158,7 @@ const gestureHandlerBuilderMethods = new Set([
   'onEnd',
   'onFinalize',
   'onUpdate',
+  'onChange',
   'onTouchesDown',
   'onTouchesMove',
   'onTouchesUp',


### PR DESCRIPTION
## Description

Add `onChange` to set of Gesture Handler builder methods in the Babel plugin.
Related PR: https://github.com/software-mansion/react-native-gesture-handler/pull/1802