### PR TITLE
Fix import of gesture handler headers on iOS

### DIFF
--- a/ios/native/NativeMethods.h
+++ b/ios/native/NativeMethods.h
@@ -1,11 +1,11 @@
 #import <Foundation/Foundation.h>
+#import <RNGestureHandlerStateManager.h>
 #import <React/RCTUIManager.h>
 #include <string>
 #import <string>
 #include <utility>
 #include <vector>
 #import <vector>
-#import "RNGestureHandlerStateManager.h"
 
 namespace reanimated {
 

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -3,6 +3,7 @@
 #import <React/RCTUIManager.h>
 #import <folly/json.h>
 
+#import <RNGestureHandlerStateManager.h>
 #import "LayoutAnimationsProxy.h"
 #import "NativeMethods.h"
 #import "NativeProxy.h"
@@ -12,7 +13,6 @@
 #import "REAModule.h"
 #import "REANodesManager.h"
 #import "REAUIManager.h"
-#import "RNGestureHandlerStateManager.h"
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>


### PR DESCRIPTION
## Description

I just changed the way of importing gesture handler headers because in some configurations these were unknown.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2740