### PR TITLE
Removed @next

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-yarn add react-native-reanimated@next
+yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.0.0/installation.md
+++ b/docs/versioned_docs/version-2.0.0/installation.md
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-yarn add react-native-reanimated@next
+yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.1.0/installation.md
+++ b/docs/versioned_docs/version-2.1.0/installation.md
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-yarn add react-native-reanimated@next
+yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.2.0/installation.md
+++ b/docs/versioned_docs/version-2.2.0/installation.md
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-yarn add react-native-reanimated@next
+yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo

--- a/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
@@ -36,7 +36,7 @@ Please note that Reanimated 2 doesn't support remote debugging, only Flipper can
 First step is to install `react-native-reanimated` alpha as a dependency in your project:
 
 ```bash
-yarn add react-native-reanimated@next
+yarn add react-native-reanimated
 ```
 
 ### Reanimated 2 in Expo


### PR DESCRIPTION
## Description

After the stable release, we no longer need to use `@next` during the installation

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2633