### PR TITLE
feat: remove old animation builder type

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -158,12 +158,12 @@ declare module 'react-native-reanimated' {
       entering?:
         | BaseAnimationBuilder
         | typeof BaseAnimationBuilder
-        | EntryExitAnimationFunction
+        | AnimationConfigFunction<EntryAnimationsValues>
         | Keyframe;
       exiting?:
         | BaseAnimationBuilder
         | typeof BaseAnimationBuilder
-        | EntryExitAnimationFunction
+        | AnimationConfigFunction<ExitAnimationsValues>
         | Keyframe;
     };
 
@@ -474,9 +474,7 @@ declare module 'react-native-reanimated' {
     currentGlobalOriginY: number;
   }
 
-  export type EntryExitAnimationFunction =
-    | ((targetValues: EntryAnimationsValues) => LayoutAnimation)
-    | ((targetValues: ExitAnimationsValues) => LayoutAnimation);
+  export type AnimationConfigFunction<T> = (targetValues: T) => LayoutAnimation;
 
   export type LayoutAnimationsValues = {
     currentOriginX: number;
@@ -503,8 +501,12 @@ declare module 'react-native-reanimated' {
     build: () => LayoutAnimationFunction;
   }
 
-  export interface IEntryExitAnimationBuilder {
-    build: () => EntryExitAnimationFunction;
+  export interface IEntryAnimationBuilder {
+    build: () => AnimationConfigFunction<EntryAnimationsValues>;
+  }
+
+  export interface IExitAnimationBuilder {
+    build: () => AnimationConfigFunction<ExitAnimationsValues>;
   }
 
   export type AnimatableValue = number | string | Array<number>;
@@ -761,7 +763,10 @@ declare module 'react-native-reanimated' {
     withCallback(callback: (finished: boolean) => void): BaseAnimationBuilder;
     static randomDelay(): BaseAnimationBuilder;
     randomDelay(): BaseAnimationBuilder;
-    build: () => LayoutAnimationFunction | EntryExitAnimationFunction;
+    build: () =>
+      | LayoutAnimationFunction
+      | AnimationConfigFunction<EntryAnimationsValues>
+      | AnimationConfigFunction<ExitAnimationsValues>;
   }
 
   export class ComplexAnimationBuilder extends BaseAnimationBuilder {

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -35,7 +35,9 @@ import {
 import { initialUpdaterRun } from './reanimated2/animation';
 import {
   BaseAnimationBuilder,
-  EntryExitAnimationFunction,
+  AnimationConfigFunction,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
   ILayoutAnimationBuilder,
 } from './reanimated2/layoutReanimation';
 import { SharedValue, StyleProps } from './reanimated2/commonTypes';
@@ -143,12 +145,12 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
   entering?:
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
-    | EntryExitAnimationFunction
+    | AnimationConfigFunction<EntryAnimationsValues>
     | Keyframe;
   exiting?:
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
-    | EntryExitAnimationFunction
+    | AnimationConfigFunction<ExitAnimationsValues>
     | Keyframe;
 };
 
@@ -552,11 +554,11 @@ export default function createAnimatedComponent(
           }
 
           if (has('build', entering)) {
-            entering = entering.build() as EntryExitAnimationFunction;
+            entering = entering.build() as AnimationConfigFunction<EntryAnimationsValues>;
           }
 
           if (has('build', exiting)) {
-            exiting = exiting.build() as EntryExitAnimationFunction;
+            exiting = exiting.build() as AnimationConfigFunction<ExitAnimationsValues>;
           }
 
           const config = {

--- a/src/reanimated2/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
@@ -1,7 +1,9 @@
 import { withDelay } from '../../animation';
 import {
-  EntryExitAnimationFunction,
+  AnimationConfigFunction,
   AnimationFunction,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
   LayoutAnimationFunction,
 } from './commonTypes';
 
@@ -12,7 +14,10 @@ export class BaseAnimationBuilder {
   callbackV?: (finished: boolean) => void;
 
   static createInstance: () => BaseAnimationBuilder;
-  build = (): EntryExitAnimationFunction | LayoutAnimationFunction => {
+  build = ():
+    | AnimationConfigFunction<EntryAnimationsValues>
+    | AnimationConfigFunction<ExitAnimationsValues>
+    | LayoutAnimationFunction => {
     throw Error('Unimplemented method in child class.');
   };
 
@@ -84,7 +89,10 @@ export class BaseAnimationBuilder {
         };
   }
 
-  static build(): EntryExitAnimationFunction | LayoutAnimationFunction {
+  static build():
+    | AnimationConfigFunction<EntryAnimationsValues>
+    | AnimationConfigFunction<ExitAnimationsValues>
+    | LayoutAnimationFunction {
     const instance = this.createInstance();
     return instance.build();
   }

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -2,7 +2,9 @@ import { Easing, EasingFn } from '../../Easing';
 import { withDelay, withSequence, withTiming } from '../../animation';
 import {
   AnimationFunction,
-  EntryExitAnimationFunction,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
   IEntryExitAnimationBuilder,
   KeyframeProps,
 } from './commonTypes';
@@ -16,7 +18,10 @@ export interface ParsedKeyframesDefinition {
   initialValues: StyleProps;
   keyframes: Record<string, KeyframePoint[]>;
 }
-export class Keyframe implements IEntryExitAnimationBuilder {
+
+export class Keyframe
+  implements
+    IEntryExitAnimationBuilder<EntryAnimationsValues | ExitAnimationsValues> {
   durationV?: number;
   delayV?: number;
   callbackV?: (finished: boolean) => void;
@@ -188,7 +193,9 @@ export class Keyframe implements IEntryExitAnimationBuilder {
         };
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<
+    EntryAnimationsValues | ExitAnimationsValues
+  > => {
     const delay = this.delayV;
     const delayFunction = this.getDelayFunction();
     const { keyframes, initialValues } = this.parseDefinitions();

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -32,10 +32,6 @@ export interface ExitAnimationsValues {
   currentGlobalOriginY: number;
 }
 
-export type EntryExitAnimationFunction = (
-  targetValues: EntryAnimationsValues | ExitAnimationsValues
-) => LayoutAnimation;
-
 export type AnimationConfigFunction<T> = (targetValues: T) => LayoutAnimation;
 
 export interface LayoutAnimationsValues {
@@ -84,14 +80,10 @@ export type LayoutAnimationAndConfig = [
   BaseBuilderAnimationConfig
 ];
 
-export interface IEntryExitAnimationBuilder {
-  build: () => EntryExitAnimationFunction;
+export interface IEntryExitAnimationBuilder<T> {
+  build: () => AnimationConfigFunction<T>;
 }
 
-export interface IEntryAnimationBuilder {
-  build: () => AnimationConfigFunction<EntryAnimationsValues>;
-}
+export type IEntryAnimationBuilder = IEntryExitAnimationBuilder<EntryAnimationsValues>;
 
-export interface IExitAnimationBuilder {
-  build: () => AnimationConfigFunction<ExitAnimationsValues>;
-}
+export type IExitAnimationBuilder = IEntryExitAnimationBuilder<ExitAnimationsValues>;

--- a/src/reanimated2/layoutReanimation/animationBuilder/index.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/index.ts
@@ -6,7 +6,6 @@ export {
   AnimationFunction,
   EntryAnimationsValues,
   ExitAnimationsValues,
-  EntryExitAnimationFunction,
   AnimationConfigFunction,
   IEntryAnimationBuilder,
   IExitAnimationBuilder,
@@ -16,5 +15,4 @@ export {
   BaseLayoutAnimationConfig,
   BaseBuilderAnimationConfig,
   LayoutAnimationAndConfig,
-  IEntryExitAnimationBuilder,
 } from './commonTypes';

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
@@ -1,6 +1,9 @@
 import {
-  EntryExitAnimationFunction,
-  IEntryExitAnimationBuilder,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 import { withSequence, withTiming } from '../../animation';
 import { Dimensions } from 'react-native';
@@ -10,7 +13,7 @@ const { width, height } = Dimensions.get('window');
 
 export class BounceIn
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): BounceIn {
     return new BounceIn();
   }
@@ -23,7 +26,7 @@ export class BounceIn
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -58,7 +61,7 @@ export class BounceIn
 
 export class BounceInDown
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): BounceInDown {
     return new BounceInDown();
   }
@@ -71,7 +74,7 @@ export class BounceInDown
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -110,7 +113,7 @@ export class BounceInDown
 
 export class BounceInUp
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): BounceInUp {
     return new BounceInUp();
   }
@@ -123,7 +126,7 @@ export class BounceInUp
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -158,7 +161,7 @@ export class BounceInUp
 
 export class BounceInLeft
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): BounceInLeft {
     return new BounceInLeft();
   }
@@ -171,7 +174,7 @@ export class BounceInLeft
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -206,7 +209,7 @@ export class BounceInLeft
 
 export class BounceInRight
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): BounceInRight {
     return new BounceInRight();
   }
@@ -219,7 +222,7 @@ export class BounceInRight
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -254,7 +257,7 @@ export class BounceInRight
 
 export class BounceOut
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): BounceOut {
     return new BounceOut();
   }
@@ -267,7 +270,7 @@ export class BounceOut
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -302,7 +305,7 @@ export class BounceOut
 
 export class BounceOutDown
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): BounceOutDown {
     return new BounceOutDown();
   }
@@ -315,7 +318,7 @@ export class BounceOutDown
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -352,7 +355,7 @@ export class BounceOutDown
 
 export class BounceOutUp
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): BounceOutUp {
     return new BounceOutUp();
   }
@@ -365,7 +368,7 @@ export class BounceOutUp
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -402,7 +405,7 @@ export class BounceOutUp
 
 export class BounceOutLeft
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): BounceOutRight {
     return new BounceOutLeft();
   }
@@ -415,7 +418,7 @@ export class BounceOutLeft
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();
@@ -452,7 +455,7 @@ export class BounceOutLeft
 
 export class BounceOutRight
   extends BaseAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): BounceOutRight {
     return new BounceOutRight();
   }
@@ -465,7 +468,7 @@ export class BounceOutRight
     return this.durationV ?? 600;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const delay = this.getDelay();
     const duration = this.getDuration();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
@@ -1,17 +1,20 @@
 import {
-  IEntryExitAnimationBuilder,
-  EntryExitAnimationFunction,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 
 export class FadeIn
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FadeIn {
     return new FadeIn();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -34,12 +37,12 @@ export class FadeIn
 
 export class FadeInRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FadeInRight {
     return new FadeInRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -66,12 +69,12 @@ export class FadeInRight
 
 export class FadeInLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FadeInLeft {
     return new FadeInLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -98,12 +101,12 @@ export class FadeInLeft
 
 export class FadeInUp
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FadeInUp {
     return new FadeInUp();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -130,12 +133,12 @@ export class FadeInUp
 
 export class FadeInDown
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FadeInDown {
     return new FadeInDown();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -162,12 +165,12 @@ export class FadeInDown
 
 export class FadeOut
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FadeOut {
     return new FadeOut();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -190,12 +193,12 @@ export class FadeOut
 
 export class FadeOutRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FadeOutRight {
     return new FadeOutRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -222,12 +225,12 @@ export class FadeOutRight
 
 export class FadeOutLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FadeOutLeft {
     return new FadeOutLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -254,12 +257,12 @@ export class FadeOutLeft
 
 export class FadeOutUp
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FadeOutUp {
     return new FadeOutUp();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
@@ -286,12 +289,12 @@ export class FadeOutUp
 
 export class FadeOutDown
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FadeOutDown {
     return new FadeOutDown();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -1,6 +1,4 @@
 import {
-  IEntryExitAnimationBuilder,
-  EntryExitAnimationFunction,
   EntryAnimationsValues,
   ExitAnimationsValues,
   AnimationConfigFunction,
@@ -155,12 +153,12 @@ export class FlipInYRight
 
 export class FlipInEasyX
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FlipInEasyX {
     return new FlipInEasyX();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -186,12 +184,12 @@ export class FlipInEasyX
 
 export class FlipInEasyY
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FlipInEasyY {
     return new FlipInEasyY();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -381,12 +379,12 @@ export class FlipOutYRight
 
 export class FlipOutEasyX
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): FlipOutEasyX {
     return new FlipOutEasyX();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -412,12 +410,12 @@ export class FlipOutEasyX
 
 export class FlipOutEasyY
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): FlipOutEasyY {
     return new FlipOutEasyY();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -2,20 +2,23 @@ import { Dimensions } from 'react-native';
 import { withSequence, withTiming } from '../../animation';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import {
-  EntryExitAnimationFunction,
-  IEntryExitAnimationBuilder,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 
 const { width } = Dimensions.get('window');
 
 export class LightSpeedInRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): LightSpeedInRight {
     return new LightSpeedInRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -58,12 +61,12 @@ export class LightSpeedInRight
 
 export class LightSpeedInLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): LightSpeedInLeft {
     return new LightSpeedInLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -106,12 +109,12 @@ export class LightSpeedInLeft
 
 export class LightSpeedOutRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): LightSpeedOutRight {
     return new LightSpeedOutRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -143,12 +146,12 @@ export class LightSpeedOutRight
 
 export class LightSpeedOutLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): LightSpeedOutLeft {
     return new LightSpeedOutLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -1,17 +1,20 @@
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import {
-  EntryExitAnimationFunction,
-  IEntryExitAnimationBuilder,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 
 export class PinwheelIn
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): PinwheelIn {
     return new PinwheelIn();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -50,12 +53,12 @@ export class PinwheelIn
 
 export class PinwheelOut
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): PinwheelOut {
     return new PinwheelOut();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -1,20 +1,23 @@
 import { Dimensions } from 'react-native';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import {
-  EntryExitAnimationFunction,
-  IEntryExitAnimationBuilder,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 
 const { width } = Dimensions.get('window');
 
 export class RollInLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): RollInLeft {
     return new RollInLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -40,12 +43,12 @@ export class RollInLeft
 
 export class RollInRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): RollInRight {
     return new RollInRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -71,12 +74,12 @@ export class RollInRight
 
 export class RollOutLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): RollOutLeft {
     return new RollOutLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -102,12 +105,12 @@ export class RollOutLeft
 
 export class RollOutRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): RollOutRight {
     return new RollOutRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
@@ -1,17 +1,20 @@
 import {
-  IEntryExitAnimationBuilder,
-  EntryExitAnimationFunction,
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+  AnimationConfigFunction,
+  IEntryAnimationBuilder,
+  IExitAnimationBuilder,
 } from '../animationBuilder/commonTypes';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 
 export class StretchInX
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): StretchInX {
     return new StretchInX();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -34,12 +37,12 @@ export class StretchInX
 
 export class StretchInY
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): StretchInY {
     return new StretchInY();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -62,12 +65,12 @@ export class StretchInY
 
 export class StretchOutX
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): StretchOutX {
     return new StretchOutX();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -90,12 +93,12 @@ export class StretchOutX
 
 export class StretchOutY
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): StretchOutY {
     return new StretchOutY();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
@@ -1,6 +1,4 @@
 import {
-  IEntryExitAnimationBuilder,
-  EntryExitAnimationFunction,
   EntryAnimationsValues,
   ExitAnimationsValues,
   AnimationConfigFunction,
@@ -14,12 +12,12 @@ const { width, height } = Dimensions.get('window');
 
 export class ZoomIn
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomIn {
     return new ZoomIn();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -42,12 +40,12 @@ export class ZoomIn
 
 export class ZoomInRotate
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomInRotate {
     return new ZoomInRotate();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -74,12 +72,12 @@ export class ZoomInRotate
 
 export class ZoomInLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomInLeft {
     return new ZoomInLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -105,12 +103,12 @@ export class ZoomInLeft
 
 export class ZoomInRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomInRight {
     return new ZoomInRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -136,12 +134,12 @@ export class ZoomInRight
 
 export class ZoomInUp
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomInUp {
     return new ZoomInUp();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -167,12 +165,12 @@ export class ZoomInUp
 
 export class ZoomInDown
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IEntryAnimationBuilder {
   static createInstance(): ZoomInDown {
     return new ZoomInDown();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -260,12 +258,12 @@ export class ZoomInEasyDown
 
 export class ZoomOut
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOut {
     return new ZoomOut();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -288,12 +286,12 @@ export class ZoomOut
 
 export class ZoomOutRotate
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOutRotate {
     return new ZoomOutRotate();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -320,12 +318,12 @@ export class ZoomOutRotate
 
 export class ZoomOutLeft
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOutLeft {
     return new ZoomOutLeft();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -351,12 +349,12 @@ export class ZoomOutLeft
 
 export class ZoomOutRight
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOutRight {
     return new ZoomOutRight();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -382,12 +380,12 @@ export class ZoomOutRight
 
 export class ZoomOutUp
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOutUp {
     return new ZoomOutUp();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();
@@ -413,12 +411,12 @@ export class ZoomOutUp
 
 export class ZoomOutDown
   extends ComplexAnimationBuilder
-  implements IEntryExitAnimationBuilder {
+  implements IExitAnimationBuilder {
   static createInstance(): ZoomOutDown {
     return new ZoomOutDown();
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const delay = this.getDelay();


### PR DESCRIPTION
## Description

PR removing `EntryExitAnimationFunction` and `IEntryExitAnimationBuilder` and replacing it with `Entry` or `Exit` options for better consistency.

## Checklist

- [x] Updated TS types
- [ ] Ensured that CI passes
