### PR TITLE
Disable sample profiler for UI hermes JS runtime

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -122,8 +122,10 @@ void NativeProxy::installJSIBindings() {
   };
 
 #if FOR_HERMES
+  auto config = ::hermes::vm::RuntimeConfig::Builder()
+          .withEnableSampleProfiling(false);
   std::shared_ptr<jsi::Runtime> animatedRuntime =
-      facebook::hermes::makeHermesRuntime();
+      facebook::hermes::makeHermesRuntime(config);
 #else
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -125,7 +125,7 @@ void NativeProxy::installJSIBindings() {
   auto config = ::hermes::vm::RuntimeConfig::Builder()
           .withEnableSampleProfiling(false);
   std::shared_ptr<jsi::Runtime> animatedRuntime =
-      facebook::hermes::makeHermesRuntime(config);
+      facebook::hermes::makeHermesRuntime(config.build());
 #else
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();


### PR DESCRIPTION
## Description

The hermes profiler expects the runtime to be running on the same thread as it was created on. Since the UI JS runtime is created from the JS thread it seems to be the cause of the issue. As a workaround it is possible to disable the profiler for the UI runtime.

Fixes #2143

## Changes

Disable profiler for Hermes JS runtime on Android.

## Screenshots / GIFs

N/A

## Test code and steps to reproduce

On android open the dev menu and select "Enable Sampling Profiler". This will cause the app to crash before this fix, after it will properly record a sample trace.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
