### PR TITLE
fix: fixed NullPointerException on Android 5.1

### DIFF
--- a/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -151,10 +151,10 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
       field.set(this, mReaLayoutAnimator);
 
+      setLayoutAnimationEnabled(true);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       e.printStackTrace();
     }
-    setLayoutAnimationEnabled(true);
   }
 
   public ReanimatedNativeHierarchyManager(

--- a/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -296,14 +296,15 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     }
   }
 
-  @Override
+  // @Override
   public synchronized void manageChildren(
       int tag,
       @Nullable int[] indicesToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
+    int[] mock = new int[] {};
     if (isLayoutAnimationDisabled()) {
-      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete, mock);
       return;
     }
     ViewGroup viewGroup;
@@ -314,13 +315,13 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     } catch (IllegalViewOperationException e) {
       // (IllegalViewOperationException) == (vm == null)
       e.printStackTrace();
-      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete, mock);
       return;
     }
 
     // we don't want layout animations in native-stack since it is currently buggy there
     if (viewGroupManager.getName().equals("RNSScreenStack")) {
-      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete, mock);
       return;
     }
 
@@ -375,7 +376,6 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       }
     }
 
-    int[] mock = new int[] {};
     super.manageChildren(tag, indicesToRemove, viewsToAdd, mock, mock);
     if (toBeRemoved.containsKey(tag)) {
       ArrayList<View> childrenToBeRemoved = toBeRemoved.get(tag);

--- a/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/rnVersionPatch/62/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -1,10 +1,13 @@
 package com.swmansion.reanimated.layoutReanimation;
 
+import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.RootViewManager;
 import com.facebook.react.uimanager.ViewAtIndex;
@@ -20,6 +23,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 
 class ReaLayoutAnimator extends LayoutAnimationController {
   private AnimationsManager mAnimationsManager = null;
@@ -45,6 +49,9 @@ class ReaLayoutAnimator extends LayoutAnimationController {
   }
 
   public boolean shouldAnimateLayout(View viewToAnimate) {
+    if (!isLayoutAnimationEnabled()) {
+      return super.shouldAnimateLayout(viewToAnimate);
+    }
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.
     // If there's a layout handling animation going on, it should be animated nonetheless since the
@@ -67,6 +74,10 @@ class ReaLayoutAnimator extends LayoutAnimationController {
    * @param height the new height value for the view
    */
   public void applyLayoutUpdate(View view, int x, int y, int width, int height) {
+    if (!isLayoutAnimationEnabled()) {
+      super.applyLayoutUpdate(view, x, y, width, height);
+      return;
+    }
     UiThreadUtil.assertOnUiThread();
     maybeInit();
     // Determine which animation to use : if view is initially invisible, use create animation,
@@ -74,10 +85,12 @@ class ReaLayoutAnimator extends LayoutAnimationController {
     // for recently created views.
     if (view.getWidth() == 0 || view.getHeight() == 0) {
       view.layout(x, y, x + width, y + height);
-      mAnimationsManager.onViewCreate(
-          view,
-          (ViewGroup) view.getParent(),
-          new Snapshot(view, mWeakNativeViewHierarchyManage.get()));
+      if (view.getId() != -1) {
+        mAnimationsManager.onViewCreate(
+            view,
+            (ViewGroup) view.getParent(),
+            new Snapshot(view, mWeakNativeViewHierarchyManage.get()));
+      }
     } else {
       Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManage.get());
       view.layout(x, y, x + width, y + height);
@@ -95,15 +108,50 @@ class ReaLayoutAnimator extends LayoutAnimationController {
    *     view.
    */
   public void deleteView(final View view, final LayoutAnimationListener listener) {
+    if (!isLayoutAnimationEnabled()) {
+      super.deleteView(view, listener);
+      return;
+    }
     UiThreadUtil.assertOnUiThread();
+    NativeViewHierarchyManager nativeViewHierarchyManager = mWeakNativeViewHierarchyManage.get();
+    ViewManager viewManager;
+    try {
+      viewManager = nativeViewHierarchyManager.resolveViewManager(view.getId());
+    } catch (IllegalViewOperationException e) {
+      // (IllegalViewOperationException) == (vm == null)
+      e.printStackTrace();
+      super.deleteView(view, listener);
+      return;
+    }
+    // we don't want layout animations in native-stack since it is currently buggy there
+    // so we check if it is a (grand)child of ScreenStack
+    if (viewManager.getName().equals("RNSScreen")
+        && view.getParent() != null
+        && view.getParent().getParent() instanceof View) {
+      // we check grandparent of Screen since the parent is a ScreenStackFragment
+      View screenParentView = (View) view.getParent().getParent();
+      ViewManager screenParentViewManager;
+      try {
+        screenParentViewManager =
+            nativeViewHierarchyManager.resolveViewManager(screenParentView.getId());
+      } catch (IllegalViewOperationException e) {
+        // (IllegalViewOperationException) == (vm == null)
+        e.printStackTrace();
+        super.deleteView(view, listener);
+        return;
+      }
+      String parentName = screenParentViewManager.getName();
+      if (parentName.equals("RNSScreenStack")) {
+        super.deleteView(view, listener);
+        return;
+      }
+    }
     maybeInit();
     Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManage.get());
     mAnimationsManager.onViewRemoval(
         view, (ViewGroup) view.getParent(), before, () -> listener.onAnimationEnd());
-    NativeViewHierarchyManager nativeViewHierarchyManager = mWeakNativeViewHierarchyManage.get();
-    ViewManager vm = nativeViewHierarchyManager.resolveViewManager(view.getId());
-    if (vm instanceof ViewGroupManager) {
-      ViewGroupManager vgm = (ViewGroupManager) vm;
+    if (viewManager instanceof ViewGroupManager) {
+      ViewGroupManager vgm = (ViewGroupManager) viewManager;
       for (int i = 0; i < vgm.getChildCount((ViewGroup) view); ++i) {
         dfs(vgm.getChildAt((ViewGroup) view, i), nativeViewHierarchyManager);
       }
@@ -111,8 +159,13 @@ class ReaLayoutAnimator extends LayoutAnimationController {
   }
 
   private void dfs(View view, NativeViewHierarchyManager nativeViewHierarchyManager) {
-    ViewManager vm = nativeViewHierarchyManager.resolveViewManager(view.getId());
-    if (vm != null) {
+    int tag = view.getId();
+    if (tag == -1) {
+      return;
+    }
+    ViewManager vm = null;
+    try {
+      vm = nativeViewHierarchyManager.resolveViewManager(tag);
       Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManage.get());
       mAnimationsManager.onViewRemoval(
           view,
@@ -123,6 +176,9 @@ class ReaLayoutAnimator extends LayoutAnimationController {
                 (ReanimatedNativeHierarchyManager) nativeViewHierarchyManager;
             reanimatedNativeHierarchyManager.publicDropView(view);
           });
+    } catch (IllegalViewOperationException e) {
+      // (IllegalViewOperationException) == (vm == null)
+      e.printStackTrace();
     }
     if (vm instanceof ViewGroupManager) {
       ViewGroupManager vgm = (ViewGroupManager) vm;
@@ -131,29 +187,76 @@ class ReaLayoutAnimator extends LayoutAnimationController {
       }
     }
   }
+
+  public boolean isLayoutAnimationEnabled() {
+    maybeInit();
+    return mAnimationsManager.isLayoutAnimationEnabled();
+  }
 }
 
 public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager {
-  private HashMap<Integer, ArrayList<View>> toBeRemoved = new HashMap();
-  private HashMap<Integer, Runnable> cleanerCallback = new HashMap();
+  private final HashMap<Integer, ArrayList<View>> toBeRemoved = new HashMap<>();
+  private final HashMap<Integer, Runnable> cleanerCallback = new HashMap<>();
   private LayoutAnimationController mReaLayoutAnimator = null;
+  private HashMap<Integer, Set<Integer>> mPendingDeletionsForTag = new HashMap<>();
+  private boolean initOk = true;
 
   public ReanimatedNativeHierarchyManager(
       ViewManagerRegistry viewManagers, ReactApplicationContext reactContext) {
     super(viewManagers);
-    Class clazz = this.getClass().getSuperclass();
-    try {
-      Field field = clazz.getDeclaredField("mLayoutAnimator");
-      field.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("accessFlags");
-      modifiersField.setAccessible(true);
-      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-      mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
-      field.set(this, mReaLayoutAnimator);
 
-      setLayoutAnimationEnabled(true);
+    mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
+
+    Class clazz = this.getClass().getSuperclass();
+    if (clazz == null) {
+      Log.e("reanimated", "unable to resolve super class of ReanimatedNativeHierarchyManager");
+      return;
+    }
+
+    try {
+      Field layoutAnimatorField = clazz.getDeclaredField("mLayoutAnimator");
+      layoutAnimatorField.setAccessible(true);
+
+      if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        try {
+          // accessFlags is supported only by API >=23
+          Field modifiersField = Field.class.getDeclaredField("accessFlags");
+          modifiersField.setAccessible(true);
+          modifiersField.setInt(
+              layoutAnimatorField, layoutAnimatorField.getModifiers() & ~Modifier.FINAL);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+      layoutAnimatorField.set(this, mReaLayoutAnimator);
     } catch (NoSuchFieldException | IllegalAccessException e) {
+      initOk = false;
       e.printStackTrace();
+    }
+
+    try {
+      Field pendingTagsField = clazz.getDeclaredField("mPendingDeletionsForTag");
+      pendingTagsField.setAccessible(true);
+
+      if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        try {
+          // accessFlags is supported only by API >=23
+          Field pendingTagsFieldModifiers = Field.class.getDeclaredField("accessFlags");
+          pendingTagsFieldModifiers.setAccessible(true);
+          pendingTagsFieldModifiers.setInt(
+              pendingTagsField, pendingTagsField.getModifiers() & ~Modifier.FINAL);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+      pendingTagsField.set(this, mPendingDeletionsForTag);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      initOk = false;
+      e.printStackTrace();
+    }
+
+    if (initOk) {
+      setLayoutAnimationEnabled(true);
     }
   }
 
@@ -162,27 +265,65 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     super(viewManagers, manager);
   }
 
+  private boolean isLayoutAnimationDisabled() {
+    return !initOk || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled();
+  }
+
   public synchronized void updateLayout(
       int parentTag, int tag, int x, int y, int width, int height) {
     super.updateLayout(parentTag, tag, x, y, width, height);
-    View viewToUpdate = this.resolveView(tag);
-    ViewManager parentViewManager = this.resolveViewManager(parentTag);
-    String parentViewManagerName = parentViewManager.getName();
-    View container = resolveView(parentTag);
-    if (container != null && parentViewManagerName.equals("RNSScreenContainer")) {
-      this.mReaLayoutAnimator.applyLayoutUpdate(
-          viewToUpdate, 0, 0, container.getWidth(), container.getHeight());
+    if (isLayoutAnimationDisabled()) {
+      return;
+    }
+    try {
+      View viewToUpdate = this.resolveView(tag);
+      ViewManager viewManager = this.resolveViewManager(tag);
+      String viewManagerName = viewManager.getName();
+      View container = resolveView(parentTag);
+      if (container != null
+          && viewManagerName.equals("RNSScreen")
+          && this.mReaLayoutAnimator != null) {
+        this.mReaLayoutAnimator.applyLayoutUpdate(
+            viewToUpdate,
+            (int) container.getX(),
+            (int) container.getY(),
+            container.getWidth(),
+            container.getHeight());
+      }
+    } catch (IllegalViewOperationException e) {
+      // (IllegalViewOperationException) == (vm == null)
+      e.printStackTrace();
     }
   }
 
-  // @Override
+  @Override
   public synchronized void manageChildren(
       int tag,
       @Nullable int[] indicesToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
-    ViewGroup viewGroup = (ViewGroup) resolveView(tag);
-    ViewGroupManager viewGroupManager = (ViewGroupManager) resolveViewManager(tag);
+    if (isLayoutAnimationDisabled()) {
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      return;
+    }
+    ViewGroup viewGroup;
+    ViewGroupManager viewGroupManager;
+    try {
+      viewGroup = (ViewGroup) resolveView(tag);
+      viewGroupManager = (ViewGroupManager) resolveViewManager(tag);
+    } catch (IllegalViewOperationException e) {
+      // (IllegalViewOperationException) == (vm == null)
+      e.printStackTrace();
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      return;
+    }
+
+    // we don't want layout animations in native-stack since it is currently buggy there
+    if (viewGroupManager.getName().equals("RNSScreenStack")) {
+      super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
+      return;
+    }
+
     if (toBeRemoved.containsKey(tag)) {
       ArrayList<View> childrenToBeRemoved = toBeRemoved.get(tag);
       HashSet<Integer> tagsToRemove = new HashSet<Integer>();
@@ -205,7 +346,14 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       }
       ArrayList<View> toBeRemovedChildren = toBeRemoved.get(tag);
       for (Integer childtag : tagsToDelete) {
-        View view = resolveView(childtag);
+        View view;
+        try {
+          view = resolveView(childtag);
+        } catch (IllegalViewOperationException e) {
+          // (IllegalViewOperationException) == (vm == null)
+          e.printStackTrace();
+          continue;
+        }
         toBeRemovedChildren.add(view);
         cleanerCallback.put(
             view.getId(),
@@ -213,10 +361,20 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
               @Override
               public void run() {
                 toBeRemovedChildren.remove(view);
+                viewGroupManager.removeView(viewGroup, view);
               } // It's far from optimal but let's leave it as it is for now
             });
       }
     }
+
+    // mPendingDeletionsForTag is modify by React
+    if (mPendingDeletionsForTag != null) {
+      Set<Integer> pendingTags = mPendingDeletionsForTag.get(tag);
+      if (pendingTags != null) {
+        pendingTags.clear();
+      }
+    }
+
     int[] mock = new int[] {};
     super.manageChildren(tag, indicesToRemove, viewsToAdd, mock, mock);
     if (toBeRemoved.containsKey(tag)) {
@@ -235,6 +393,10 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
 
   @Override
   protected synchronized void dropView(View view) {
+    if (isLayoutAnimationDisabled()) {
+      super.dropView(view);
+      return;
+    }
     if (toBeRemoved.containsKey(view.getId())) {
       toBeRemoved.remove(view.getId());
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -1,5 +1,7 @@
 package com.swmansion.reanimated.layoutReanimation;
 
+import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.Nullable;
@@ -193,35 +195,68 @@ class ReaLayoutAnimator extends LayoutAnimationController {
 }
 
 public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager {
-  private HashMap<Integer, ArrayList<View>> toBeRemoved = new HashMap();
-  private HashMap<Integer, Runnable> cleanerCallback = new HashMap();
+  private final HashMap<Integer, ArrayList<View>> toBeRemoved = new HashMap<>();
+  private final HashMap<Integer, Runnable> cleanerCallback = new HashMap<>();
   private LayoutAnimationController mReaLayoutAnimator = null;
-  private HashMap<Integer, Set<Integer>> mPendingDeletionsForTag = null;
+  private HashMap<Integer, Set<Integer>> mPendingDeletionsForTag = new HashMap<>();
+  private boolean initOk = true;
 
   public ReanimatedNativeHierarchyManager(
       ViewManagerRegistry viewManagers, ReactApplicationContext reactContext) {
     super(viewManagers);
-    Class clazz = this.getClass().getSuperclass();
-    try {
-      Field field = clazz.getDeclaredField("mLayoutAnimator");
-      field.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("accessFlags");
-      modifiersField.setAccessible(true);
-      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-      mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
-      field.set(this, mReaLayoutAnimator);
 
+    mReaLayoutAnimator = new ReaLayoutAnimator(reactContext, this);
+
+    Class clazz = this.getClass().getSuperclass();
+    if (clazz == null) {
+      Log.e("reanimated", "unable to resolve super class of ReanimatedNativeHierarchyManager");
+      return;
+    }
+
+    try {
+      Field layoutAnimatorField = clazz.getDeclaredField("mLayoutAnimator");
+      layoutAnimatorField.setAccessible(true);
+
+      if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        try {
+          // accessFlags is supported only by API >=23
+          Field modifiersField = Field.class.getDeclaredField("accessFlags");
+          modifiersField.setAccessible(true);
+          modifiersField.setInt(
+              layoutAnimatorField, layoutAnimatorField.getModifiers() & ~Modifier.FINAL);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+      layoutAnimatorField.set(this, mReaLayoutAnimator);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      initOk = false;
+      e.printStackTrace();
+    }
+
+    try {
       Field pendingTagsField = clazz.getDeclaredField("mPendingDeletionsForTag");
       pendingTagsField.setAccessible(true);
-      Field pendingTagsFieldModifiers = Field.class.getDeclaredField("accessFlags");
-      pendingTagsFieldModifiers.setAccessible(true);
-      pendingTagsFieldModifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-      mPendingDeletionsForTag = new HashMap<Integer, Set<Integer>>();
-      pendingTagsField.set(this, mPendingDeletionsForTag);
 
-      setLayoutAnimationEnabled(true);
+      if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        try {
+          // accessFlags is supported only by API >=23
+          Field pendingTagsFieldModifiers = Field.class.getDeclaredField("accessFlags");
+          pendingTagsFieldModifiers.setAccessible(true);
+          pendingTagsFieldModifiers.setInt(
+              pendingTagsField, pendingTagsField.getModifiers() & ~Modifier.FINAL);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+      pendingTagsField.set(this, mPendingDeletionsForTag);
     } catch (NoSuchFieldException | IllegalAccessException e) {
+      initOk = false;
       e.printStackTrace();
+    }
+
+    if (initOk) {
+      setLayoutAnimationEnabled(true);
     }
   }
 
@@ -230,11 +265,14 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     super(viewManagers, manager);
   }
 
+  private boolean isLayoutAnimationDisabled() {
+    return !initOk || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled();
+  }
+
   public synchronized void updateLayout(
       int parentTag, int tag, int x, int y, int width, int height) {
     super.updateLayout(parentTag, tag, x, y, width, height);
-    if (mReaLayoutAnimator == null
-        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (isLayoutAnimationDisabled()) {
       return;
     }
     try {
@@ -264,8 +302,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       @Nullable int[] indicesToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
-    if (mReaLayoutAnimator == null
-        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (isLayoutAnimationDisabled()) {
       super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
       return;
     }
@@ -354,8 +391,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
 
   @Override
   protected synchronized void dropView(View view) {
-    if (mReaLayoutAnimator == null
-        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (isLayoutAnimationDisabled()) {
       super.dropView(view);
       return;
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -219,10 +219,10 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       mPendingDeletionsForTag = new HashMap<Integer, Set<Integer>>();
       pendingTagsField.set(this, mPendingDeletionsForTag);
 
+      setLayoutAnimationEnabled(true);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       e.printStackTrace();
     }
-    setLayoutAnimationEnabled(true);
   }
 
   public ReanimatedNativeHierarchyManager(

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -233,7 +233,8 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
   public synchronized void updateLayout(
       int parentTag, int tag, int x, int y, int width, int height) {
     super.updateLayout(parentTag, tag, x, y, width, height);
-    if (!((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (mReaLayoutAnimator == null
+        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
       return;
     }
     try {
@@ -263,7 +264,8 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       @Nullable int[] indicesToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
-    if (!((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (mReaLayoutAnimator == null
+        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
       super.manageChildren(tag, indicesToRemove, viewsToAdd, tagsToDelete);
       return;
     }
@@ -352,7 +354,8 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
 
   @Override
   protected synchronized void dropView(View view) {
-    if (!((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
+    if (mReaLayoutAnimator == null
+        || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled()) {
       super.dropView(view);
       return;
     }

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -59,6 +59,10 @@ export interface BasicWorkletFunction<T> extends WorkletFunction {
   (): T;
 }
 
+export interface BasicWorkletFunctionOptional<T> extends WorkletFunction {
+  (): Partial<T>;
+}
+
 export interface NativeEvent<T> {
   nativeEvent: T;
 }

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -473,7 +473,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
           const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
           parseColors(diff);
-          return diff;
+          return diff as T;
         };
       } else {
         updaterFn = () => {
@@ -482,7 +482,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
           const oldValues = remoteState.last;
           const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
-          return diff;
+          return diff as T;
         };
       }
     } else if (!shouldBeUseWeb()) {

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -36,6 +36,7 @@ import {
   AdapterWorkletFunction,
   AnimatedStyle,
   BasicWorkletFunction,
+  BasicWorkletFunctionOptional,
   NestedObjectValues,
   SharedValue,
 } from '../commonTypes';
@@ -451,7 +452,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
 
   useEffect(() => {
     let fun;
-    let updaterFn = updater;
+    let updaterFn = updater as BasicWorkletFunctionOptional<T>;
     let optimalization = updater.__optimalization;
     if (adapters) {
       updaterFn = () => {
@@ -473,7 +474,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
           const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
           parseColors(diff);
-          return diff as T;
+          return diff;
         };
       } else {
         updaterFn = () => {
@@ -482,7 +483,7 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
           const oldValues = remoteState.last;
           const diff = styleDiff<T>(oldValues, newValues);
           remoteState.last = Object.assign({}, oldValues, newValues);
-          return diff as T;
+          return diff;
         };
       }
     } else if (!shouldBeUseWeb()) {

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -211,7 +211,7 @@ export function styleDiff<T extends AnimatedStyle>(
   newStyle: AnimatedStyle
 ): Partial<T> {
   'worklet';
-  const diff = {};
+  const diff: any = {};
   for (const key in oldStyle) {
     if (newStyle[key] === undefined) {
       diff[key] = null;


### PR DESCRIPTION
## Description

Close https://github.com/software-mansion/react-native-reanimated/issues/2773

ADB log crash
```
W/System.err( 5236): java.lang.NoSuchFieldException: accessFlags
W/System.err( 5236): 	at java.lang.Class.getDeclaredField(Class.java:890)
W/System.err( 5236): 	at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.<init>(ReanimatedNativeHierarchyManager.java:208)
W/System.err( 5236): 	at com.facebook.react.uimanager.ReanimatedUIImplementation.<init>(ReanimatedUIImplementation.java:40)
W/System.err( 5236): 	at com.facebook.react.uimanager.ReaUiImplementationProvider.createUIImplementation(ReanimatedUIManager.java:23)
W/System.err( 5236): 	at com.facebook.react.uimanager.UIManagerModule.<init>(UIManagerModule.java:189)
W/System.err( 5236): 	at com.facebook.react.uimanager.ReanimatedUIManager.<init>(ReanimatedUIManager.java:38)
W/System.err( 5236): 	at com.swmansion.reanimated.ReanimatedPackage.createUIManager(ReanimatedPackage.java:77)
W/System.err( 5236): 	at com.swmansion.reanimated.ReanimatedPackage.getModule(ReanimatedPackage.java:30)
W/System.err( 5236): 	at com.facebook.react.TurboReactPackage$ModuleHolderProvider.get(TurboReactPackage.java:159)
W/System.err( 5236): 	at com.facebook.react.TurboReactPackage$ModuleHolderProvider.get(TurboReactPackage.java:147)
W/System.err( 5236): 	at com.facebook.react.bridge.ModuleHolder.create(ModuleHolder.java:191)
W/System.err( 5236): 	at com.facebook.react.bridge.ModuleHolder.getModule(ModuleHolder.java:156)
W/System.err( 5236): 	at com.facebook.react.bridge.NativeModuleRegistry.getModule(NativeModuleRegistry.java:149)
W/System.err( 5236): 	at com.facebook.react.bridge.CatalystInstanceImpl.getNativeModule(CatalystInstanceImpl.java:488)
W/System.err( 5236): 	at com.facebook.react.bridge.CatalystInstanceImpl.getNativeModule(CatalystInstanceImpl.java:464)
W/System.err( 5236): 	at com.facebook.react.bridge.ReactContext.getNativeModule(ReactContext.java:165)
W/System.err( 5236): 	at com.swmansion.reanimated.NodesManager.<init>(NodesManager.java:157)
W/System.err( 5236): 	at com.swmansion.reanimated.ReanimatedModule.getNodesManager(ReanimatedModule.java:99)
W/System.err( 5236): 	at com.swmansion.reanimated.EXReanimatedAdapter.registerJSIModules(EXReanimatedAdapter.java:9)
W/System.err( 5236): 	at expo.modules.adapters.reanimated.EXReanimatedPackage$1.onRegisterJSIModules(EXReanimatedPackage.java:21)
W/System.err( 5236): 	at expo.modules.ReactNativeHostWrapper$JSIModuleContainerPackage.getJSIModules(ReactNativeHostWrapper.kt:95)
W/System.err( 5236): 	at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1265)
W/System.err( 5236): 	at com.facebook.react.ReactInstanceManager.access$1100(ReactInstanceManager.java:131)
W/System.err( 5236): 	at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:1023)
W/System.err( 5236): 	at java.lang.Thread.run(Thread.java:818)
```
## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

## Screenshots / GIFs

<img width="858" alt="Screen Shot 2022-01-16 at 13 31 28" src="https://user-images.githubusercontent.com/12751435/149649914-8c8d2bf7-42b6-47c3-80e2-a30b6fa4ac8f.png">


## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
