### PR TITLE
Don't run needs-repro action on PRs

### DIFF
--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
     concurrency:
       group: needs-repro-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Description

It looks like GitHub [merged `pull_request_comment` and `issue_comment` triggers](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_comment-use-issue_comment) into the `issue_comments` trigger. It resulted in our GitHub actions bot replying to comments on pull requests.

Following [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only) this one-line check will prevent the unnecessary effect.

## Changes

- Added check to `needs-repro` action so it's not triggered on pull-request

## Screenshots

Change tested on a private repo:
![Screenshot 2022-01-17 at 14 38 11](https://user-images.githubusercontent.com/39658211/149779014-38c79e00-0ed4-4882-a876-3fc218d8f522.png)

