### PR TITLE
Accept generic type in Animated.FlatList

### DIFF
--- a/react-native-reanimated-tests.tsx
+++ b/react-native-reanimated-tests.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState, useCallback, forwardRef } from 'react';
 import {
+  Text,
   StyleSheet,
   Button,
   View,
@@ -102,7 +103,7 @@ function CreateAnimatedComponentTest3() {
   );
 }
 
-function CreateAnimatedFlatList() {
+function CreateAnimatedFlatListTest1() {
   const renderItem = useCallback(
     ({ item, index }: { item: Item[]; index: number }) => {
       if (Math.random()) {
@@ -126,6 +127,23 @@ function CreateAnimatedFlatList() {
         renderItem={() => null}
       />
       <AnimatedImage style={{ flex: 1 }} source={{ uri: '' }} />
+    </>
+  );
+}
+
+function CreateAnimatedFlatListTest2() {
+  return (
+    <>
+      <Animated.FlatList<Item>
+        // @ts-expect-error
+        data={[{ foo: 1 }]}
+        // @ts-expect-error
+        renderItem={({ item, index }) => <View key={item.foo} />}
+      />
+      <Animated.FlatList<Item>
+        data={[{ id: 1 }]}
+        renderItem={({ item, index }) => <View key={item.id} />}
+      />
     </>
   );
 }

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -16,6 +16,7 @@ declare module 'react-native-reanimated' {
     TextProps,
     ImageProps,
     ScrollViewProps,
+    FlatListProps,
     StyleProp,
     RegisteredStyle,
     ViewStyle,
@@ -257,7 +258,7 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeScrollView;
     }
     export class Code extends Component<CodeProps> {}
-    export class FlatList extends Component<AnimateProps<FlatList>> {
+    export class FlatList<T> extends Component<AnimateProps<FlatListProps<T>>> {
       itemLayoutAnimation: ILayoutAnimationBuilder;
       getNode(): ReactNativeFlatList;
     }
@@ -977,12 +978,6 @@ declare module 'react-native-reanimated' {
     back(s?: number): Animated.EasingFunction;
     bounce: Animated.EasingFunction;
     bezier(
-      x1: number,
-      y1: number,
-      x2: number,
-      y2: number
-    ): { factory: () => Animated.EasingFunction };
-    bezierFn(
       x1: number,
       y1: number,
       x2: number,

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -982,6 +982,12 @@ declare module 'react-native-reanimated' {
       y1: number,
       x2: number,
       y2: number
+    ): { factory: () => Animated.EasingFunction };
+    bezierFn(
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number
     ): Animated.EasingFunction;
     in(easing: Animated.EasingFunction): Animated.EasingFunction;
     out(easing: Animated.EasingFunction): Animated.EasingFunction;


### PR DESCRIPTION
## Description

Reanimated exposes animated `FlatList` component under `Animated` namespace, but using it in a real world scenario is a bit cumbersome, since it doesn't accept a type parameter that is used to describe list items. 

Fixes #2858

## Changes

- Updated type for `Animated.FlatList`
- Added additional type test for `Animated.FlatList`

## Screenshots / GIFs

### Before
<img width="823" alt="image" src="https://user-images.githubusercontent.com/6288237/150246605-620b768b-eefa-44b5-8ff5-8e9a1fd5dd27.png">

### After
<img width="573" alt="image" src="https://user-images.githubusercontent.com/6288237/150246662-d196bf29-2089-4f4d-887a-58416e624f88.png">

## Checklist

- [ ] Included code example that can be used to test this change
- [X] Updated TS types
- [X] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
