### PR TITLE
Adding legacy hint for useFakeTimers

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -42,7 +42,7 @@ If you have custom babel configuration for testing, make sure that Reanimated's 
 #### Timers
 You can use jest timers to control animation
 ```js
-jest.useFakeTimers();
+jest.useFakeTimers(); // jest.useFakeTimers('legacy') for jest >= 27
 // call animation
 jest.runAllTimers();
 ```


### PR DESCRIPTION
Updating documentation for jest >= 27 since the 'modern' useFakeTimers does not work (yet) with react-native: https://github.com/facebook/jest/issues/10221

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [X] Updated documentation
- [ ] Ensured that CI passes
