### PR TITLE
[V1] Use maven-publish to support React Native 0.67.1 (gradle 7)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,8 +17,10 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
+plugins {
+    id('com.android.library')
+    id('maven-publish')
+}
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -97,7 +99,7 @@ afterEvaluate { project ->
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }
@@ -121,13 +123,11 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-
-            configureReactNativePom pom
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,34 +56,6 @@ dependencies {
     implementation "androidx.transition:transition:1.1.0"
 }
 
-def configureReactNativePom(def pom) {
-    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
-
-    pom.project {
-        name packageJson.title
-        artifactId packageJson.name
-        version = packageJson.version
-        group = "com.swmansion.reanimated"
-        description packageJson.description
-        url packageJson.repository.baseUrl
-
-        licenses {
-            license {
-                name packageJson.license
-                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
-                distribution 'repo'
-            }
-        }
-
-        developers {
-            developer {
-                id packageJson.author.username
-                name packageJson.author.name
-            }
-        }
-    }
-}
-
 afterEvaluate { project ->
 
     task androidJavadoc(type: Javadoc) {
@@ -94,7 +66,7 @@ afterEvaluate { project ->
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from androidJavadoc.destinationDir
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "1.14.0",
+  "version": "1.13.4",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

The `maven` plugin has been deprecated since gradle 6.0 and was removed in gradle 7.0.

React Native 0.67.1 uses gradle 7.2

This PR updates the library to use `maven-publish` so it works with gradle 7.2 and React Native 0.67.1

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

If you run use `"react-native-reanimated": "1.13.3"` with `"react-native": "0.67.1"` and gradle `7.2` the app fails with:

```
node_modules/react-native-reanimated/android/build.gradle' line: 21

* What went wrong:
A problem occurred evaluating project ':react-native-reanimated'.
> Plugin with id 'maven' not found.
```

With the changes in this PR or the following `patch-patch` changes, the app builds:

```
diff --git a/node_modules/react-native-reanimated/android/build.gradle b/node_modules/react-native-reanimated/android/build.gradle
index 21c386c..627334a 100644
--- a/node_modules/react-native-reanimated/android/build.gradle
+++ b/node_modules/react-native-reanimated/android/build.gradle
@@ -17,8 +17,10 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
+plugins {
+    id('com.android.library')
+    id('maven-publish')
+}
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
@@ -97,7 +99,7 @@ afterEvaluate { project ->
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }
@@ -121,13 +123,11 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-
-            configureReactNativePom pom
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
         }
     }
 }
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [x] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
