### PR TITLE
Use hook's web implementation in Jest tests

### DIFF
--- a/src/reanimated2/hook/useAnimatedGestureHandler.ts
+++ b/src/reanimated2/hook/useAnimatedGestureHandler.ts
@@ -1,6 +1,5 @@
 import { MutableRefObject } from 'react';
 import { WorkletFunction } from '../commonTypes';
-import { isWeb } from '../PlatformChecker';
 import WorkletEventHandler from '../WorkletEventHandler';
 import { Context, DependencyList } from './commonTypes';
 import { useEvent, useHandler } from './Hooks';
@@ -98,7 +97,7 @@ export function useAnimatedGestureHandler<
     }
   };
 
-  if (isWeb()) {
+  if (useWeb) {
     return handler;
   }
 

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -9,7 +9,7 @@ import {
   WorkletFunction,
 } from '../commonTypes';
 import { makeRemote } from '../core';
-import { isWeb } from '../PlatformChecker';
+import { isWeb, isJest } from '../PlatformChecker';
 import { colorProps } from '../UpdateProps';
 import WorkletEventHandler from '../WorkletEventHandler';
 import {
@@ -80,7 +80,7 @@ export function useHandler<T, TContext extends Context>(
     savedDependencies
   );
   initRef.current.savedDependencies = dependencies;
-  const useWeb = isWeb();
+  const useWeb = isWeb() || isJest();
 
   return { context, doDependenciesDiffer, useWeb };
 }


### PR DESCRIPTION
## Description

RNGH needs to use useAnimatedGestureHandler in Jest environment so we want to use web implementation there.

## Checklist

- [x] Ensured that CI passes
