### PR TITLE
fix(mock): add interpolate to mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -209,6 +209,7 @@ const Reanimated = {
   },
   diff: NOOP,
   diffClamp: NOOP,
+  interpolate: NOOP,
   interpolateNode: NOOP,
   interpolateColors: NOOP,
   max: (a, b) => Math.max(getValue(a), getValue(b)),


### PR DESCRIPTION
## Description

`interpolate is not a function` was encountered during test when `reanimated` is mocked, it was, in fact, missing from `mock.js`

## Changes

add `interpolate` to `mock.js`

## Test code and steps to reproduce

```js
// jest.setup.js
jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
```

Test render a component that has interpolation.

## Checklist

- [?] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
