### PR TITLE
Fix crash when handling event containing `NaN` or `INF` values for iOS

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -250,7 +250,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     std::string eventAsString;
     try {
       eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
-    } catch (folly::json::parse_error) {
+    } catch (folly::json::parse_error &) {
       // Events from other libraries may contain NaN or INF values which cannot be represented in JSON.
       // See https://github.com/software-mansion/react-native-reanimated/issues/1776 for details.
       return;

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -246,7 +246,15 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventName, id<RCTEvent> event) {
     std::string eventNameString([eventName UTF8String]);
-    std::string eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
+
+    std::string eventAsString;
+    try {
+      eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
+    } catch (folly::json::parse_error) {
+      // Events from other libraries may contain NaN or INF values which cannot be represented in JSON.
+      // See https://github.com/software-mansion/react-native-reanimated/issues/1776 for details.
+      return;
+    }
 
     eventAsString = "{ NativeMap:" + eventAsString + "}";
     jsi::Object global = module->runtime->global();


### PR DESCRIPTION
## Description

Fixes:
- #1776
- #2757

See https://github.com/software-mansion/react-native-reanimated/issues/1776#issuecomment-1024215820 for details

## Changes

- Fix crash when handling event containing `NaN` or `INF` values

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

1. Set breakpoint in `NativeProxy.mm:259` to make sure that there is no regression in handling valid Reanimated events.
2. Send an event with `NaN` or `INF` value and set breakpoint in `catch` block to make sure the exception is caught.

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
