### PR TITLE
Add maintainer-issue label

### DIFF
--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -5,9 +5,10 @@ on:
 
 jobs:
   main:
+    if: ${{ !contains(github.event.issue.labels.*.name, 'maintainer-issue') }}
     runs-on: ubuntu-latest
     concurrency:
-      group: needs-more-info-${{ github.ref }}
+      group: needs-more-info-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout Actions

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   main:
+    if: ${{ !contains(github.event.issue.labels.*.name, 'maintainer-issue') }}
     runs-on: ubuntu-latest
     concurrency:
-      group: needs-repro-${{ github.ref }}
+      group: needs-repro-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout Actions

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -5,9 +5,10 @@ on:
 
 jobs:
   main:
+    if: ${{ !contains(github.event.issue.labels.*.name, 'maintainer-issue') }}
     runs-on: ubuntu-latest
     concurrency:
-      group: platforms-${{ github.ref }}
+      group: platforms-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
## Description

This PR adds a way to disable GitHub Actions bot replies by adding a `maintainer-issue` label. 

Also, this PR fixes the concurrency issue when two independent actions close one other.