### PR TITLE
Fix crash when handling event containing NaN or INF values for android

### DIFF
--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -59,16 +59,16 @@ class EventHandler : public HybridClass<EventHandler> {
       jni::alias_ref<JString> eventKey,
       jni::alias_ref<react::WritableMap> event) {
     std::string eventAsString = "{NativeMap:null}";
-    try {
-      if (event != nullptr) {
+    if (event != nullptr) {
+      try {
         eventAsString = event->toString();
+      } catch (std::exception) {
+        // Events from other libraries may contain NaN or INF values which
+        // cannot be represented in JSON. See
+        // https://github.com/software-mansion/react-native-reanimated/issues/1776
+        // for details.
+        return;
       }
-    } catch (const std::exception &) {
-      // Events from other libraries may contain NaN or INF values which cannot
-      // be represented in JSON. See
-      // https://github.com/software-mansion/react-native-reanimated/issues/1776
-      // for details.
-      return;
     }
     handler_(eventKey->toString(), eventAsString);
   }

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -62,7 +62,7 @@ class EventHandler : public HybridClass<EventHandler> {
     if (event != nullptr) {
       try {
         eventAsString = event->toString();
-      } catch (std::exception) {
+      } catch (folly::json::parse_error &) {
         // Events from other libraries may contain NaN or INF values which
         // cannot be represented in JSON. See
         // https://github.com/software-mansion/react-native-reanimated/issues/1776

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -59,9 +59,18 @@ class EventHandler : public HybridClass<EventHandler> {
       jni::alias_ref<JString> eventKey,
       jni::alias_ref<react::WritableMap> event) {
     std::string eventAsString = "{NativeMap:null}";
-    if (event != nullptr) {
-      eventAsString = event->toString();
+    try {
+      if (event != nullptr) {
+        eventAsString = event->toString();
+      }
+    } catch (const std::exception &) {
+      // Events from other libraries may contain NaN or INF values which cannot
+      // be represented in JSON. See
+      // https://github.com/software-mansion/react-native-reanimated/issues/1776
+      // for details.
+      return;
     }
+
     handler_(eventKey->toString(), eventAsString);
   }
 

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -70,7 +70,6 @@ class EventHandler : public HybridClass<EventHandler> {
       // for details.
       return;
     }
-
     handler_(eventKey->toString(), eventAsString);
   }
 


### PR DESCRIPTION
## Description
Applies the iOS fix in https://github.com/software-mansion/react-native-reanimated/pull/2896 for android.

Fixes:
- #2662
- #2814
- #2914

## Changes
Fix crash when handling event containing NaN or INF values

## Test code and steps to reproduce
tested by manually inserting NaN and INF values in receiveEvent.java

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
