### PR TITLE
Quick fix for yarn type:generate command failing

### DIFF
--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -6,10 +6,10 @@ ROOT=$(pwd)
 
 unset CI
 
-versions=("0.67.0-rc.4" "0.66.3" "0.65.1" "0.64.3" "0.63.3")
-version_name=("67" "66" "65" "64" "63")
+versions=("0.67.0-rc.4")
+version_name=("67")
 
-for index in {0..4}
+for index in {0..0}
 do
   yarn add react-native@"${versions[$index]}"
   for for_hermes in "True" "False"

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -6,10 +6,10 @@ ROOT=$(pwd)
 
 unset CI
 
-versions=("0.67.0-rc.4")
-version_name=("67")
+versions=("0.67.0-rc.4" "0.66.3" "0.65.1" "0.64.3" "0.63.3")
+version_name=("67" "66" "65" "64" "63")
 
-for index in {0..0}
+for index in {0..4}
 do
   yarn add react-native@"${versions[$index]}"
   for for_hermes in "True" "False"

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -633,7 +633,7 @@ declare module 'react-native-reanimated' {
     inputRange: readonly number[];
     outputRange: readonly (string | number)[];
     colorSpace: ColorSpace;
-    cache: SharedValue<InterpolateRGB | InterpolateHSV>;
+    cache: SharedValue<InterpolateRGB | InterpolateHSV | null>;
   }
 
   export function useInterpolateConfig(

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -769,7 +769,7 @@ export interface InterpolateConfig {
   inputRange: readonly number[];
   outputRange: readonly (string | number)[];
   colorSpace: ColorSpace;
-  cache: SharedValue<InterpolateRGB | InterpolateHSV>;
+  cache: SharedValue<InterpolateRGB | InterpolateHSV | null>;
 }
 
 export function useInterpolateConfig(


### PR DESCRIPTION
## Description

`InterpolateConfig` interface is [declared here](https://github.com/software-mansion/react-native-reanimated/blob/7820ec095de7a719150dc5021561f0b8b0b10f38/src/reanimated2/Colors.ts#L768-L773) as follows:

```ts
export interface InterpolateConfig {
  inputRange: readonly number[];
  outputRange: readonly (string | number)[];
  colorSpace: ColorSpace;
  cache: SharedValue<InterpolateRGB | InterpolateHSV>; // <-- Shared value of non-null type!
}
```

few lines below it is being used:

```ts
export function useInterpolateConfig(
  inputRange: readonly number[],
  outputRange: readonly (string | number)[],
  colorSpace = ColorSpace.RGB
): SharedValue<InterpolateConfig> {
  return useSharedValue({
    inputRange,
    outputRange,
    colorSpace,
    cache: makeMutable(null), // <-- returns shared value of null type
  });
}
```

This caused `yarn type:generate` command to fail (it is launched by `createNPMPackage` script):

![image](https://user-images.githubusercontent.com/50801299/151813246-a55f604a-1290-464c-82a3-124b35235b14.png)

 
## Changes

* Modify `InterpolateConfig` interface, so `cache` is of type: `SharedValue<InterpolateRGB | InterpolateHSV | null>`

```ts
export interface InterpolateConfig {
  inputRange: readonly number[];
  outputRange: readonly (string | number)[];
  colorSpace: ColorSpace;
  cache: SharedValue<InterpolateRGB | InterpolateHSV | null>;
}
```



## Test code and steps to reproduce

Run

```
yarn type:generate
```
and see it fails


## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
