### PR TITLE
Check platform better

### DIFF
--- a/src/reanimated2/NativeReanimated/index.ts
+++ b/src/reanimated2/NativeReanimated/index.ts
@@ -1,10 +1,10 @@
 import reanimatedJS from '../js-reanimated';
-import { nativeShouldBeMock } from '../PlatformChecker';
+import { shouldBeUseWeb } from '../PlatformChecker';
 import { Platform } from 'react-native';
 import { NativeReanimated } from './NativeReanimated';
 
 let exportedModule;
-if (nativeShouldBeMock()) {
+if (shouldBeUseWeb()) {
   exportedModule = reanimatedJS;
 } else {
   exportedModule = new NativeReanimated();


### PR DESCRIPTION
## Description

We need to mock the native module by JS implementation for web, jest, and chrome debugger. We mock it on the condition `nativeShouldBeMock` - `isJest() || isChromeDebugger()` i check it to more proper `shouldBeUseWeb` - `isJest() || isChromeDebugger() || isWeb()`.
It worked because the web had implemented `global.nativeCallSyncHook`, but I am not sure that it will work for every edge case.