### PR TITLE
fix circular require in Colors.ts and make better web compatibility

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -13,7 +13,6 @@ import { interpolate } from './interpolation';
 // @ts-ignore JS file
 import { Extrapolate } from '../reanimated1/derived';
 import { SharedValue } from './commonTypes';
-import { useSharedValue } from './hook/useSharedValue';
 
 interface RGB {
   r: number;
@@ -54,9 +53,8 @@ type Matchers = {
 };
 function getMatchers(): Matchers {
   'worklet';
-  const cachedMatchers: Matchers = _WORKLET
-    ? uiCachedMatchers
-    : jsCachedMatchers;
+  const cachedMatchers: Matchers =
+    Platform.OS !== 'web' && _WORKLET ? uiCachedMatchers : jsCachedMatchers;
   if (cachedMatchers.rgb === undefined) {
     cachedMatchers.rgb = new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER));
     cachedMatchers.rgba = new RegExp(
@@ -770,19 +768,6 @@ export interface InterpolateConfig {
   outputRange: readonly (string | number)[];
   colorSpace: ColorSpace;
   cache: SharedValue<InterpolateRGB | InterpolateHSV | null>;
-}
-
-export function useInterpolateConfig(
-  inputRange: readonly number[],
-  outputRange: readonly (string | number)[],
-  colorSpace = ColorSpace.RGB
-): SharedValue<InterpolateConfig> {
-  return useSharedValue({
-    inputRange,
-    outputRange,
-    colorSpace,
-    cache: makeMutable(null),
-  });
 }
 
 export const interpolateSharableColor = (

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -13,6 +13,7 @@ import { interpolate } from './interpolation';
 // @ts-ignore JS file
 import { Extrapolate } from '../reanimated1/derived';
 import { SharedValue } from './commonTypes';
+import { isWeb } from './PlatformChecker'
 
 interface RGB {
   r: number;
@@ -54,7 +55,7 @@ type Matchers = {
 function getMatchers(): Matchers {
   'worklet';
   const cachedMatchers: Matchers =
-    Platform.OS !== 'web' && _WORKLET ? uiCachedMatchers : jsCachedMatchers;
+    !isWeb() && _WORKLET ? uiCachedMatchers : jsCachedMatchers;
   if (cachedMatchers.rgb === undefined) {
     cachedMatchers.rgb = new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER));
     cachedMatchers.rgba = new RegExp(
@@ -452,7 +453,7 @@ export const rgbaColor = (
   alpha = 1
 ): number | string => {
   'worklet';
-  if (Platform.OS === 'web' || !_WORKLET) {
+  if (isWeb() || !_WORKLET) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
 

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -13,7 +13,7 @@ import { interpolate } from './interpolation';
 // @ts-ignore JS file
 import { Extrapolate } from '../reanimated1/derived';
 import { SharedValue } from './commonTypes';
-import { isWeb } from './PlatformChecker'
+import { isWeb } from './PlatformChecker';
 
 interface RGB {
   r: number;

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -7,7 +7,7 @@
 // @ts-ignore reanimated1/Easing is JS file
 import EasingNode from '../reanimated1/Easing';
 import { Bezier } from './Bezier';
-import { Platform } from 'react-native';
+import { isWeb } from './PlatformChecker'
 
 /**
  * The `Easing` module implements common easing functions. This module is used
@@ -295,7 +295,7 @@ function createChecker(
   /* should return Animated.Value or worklet */
   function checkIfReaOne(): any {
     'worklet';
-    if (arguments && (Platform.OS === 'web' || !_WORKLET)) {
+    if (arguments && (isWeb() || !_WORKLET)) {
       for (let i = 0; i < arguments.length; i++) {
         const arg = arguments[i];
         if (arg && arg.__nodeID) {
@@ -314,7 +314,7 @@ function createChecker(
     // @ts-ignore this is implicitly any - TODO
     const res = worklet.apply(this, arguments);
     if (
-      (Platform.OS === 'web' || !_WORKLET) &&
+      (isWeb() || !_WORKLET) &&
       res &&
       typeof res === 'function' &&
       res.__worklet

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -7,6 +7,7 @@
 // @ts-ignore reanimated1/Easing is JS file
 import EasingNode from '../reanimated1/Easing';
 import { Bezier } from './Bezier';
+import { Platform } from 'react-native';
 
 /**
  * The `Easing` module implements common easing functions. This module is used
@@ -294,7 +295,7 @@ function createChecker(
   /* should return Animated.Value or worklet */
   function checkIfReaOne(): any {
     'worklet';
-    if (arguments && !_WORKLET) {
+    if (arguments && (Platform.OS === 'web' || !_WORKLET)) {
       for (let i = 0; i < arguments.length; i++) {
         const arg = arguments[i];
         if (arg && arg.__nodeID) {
@@ -312,7 +313,12 @@ function createChecker(
     }
     // @ts-ignore this is implicitly any - TODO
     const res = worklet.apply(this, arguments);
-    if (!_WORKLET && res && typeof res === 'function' && res.__worklet) {
+    if (
+      (Platform.OS === 'web' || !_WORKLET) &&
+      res &&
+      typeof res === 'function' &&
+      res.__worklet
+    ) {
       return createChecker(res, workletName, arguments);
     }
     return res;

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -7,7 +7,7 @@
 // @ts-ignore reanimated1/Easing is JS file
 import EasingNode from '../reanimated1/Easing';
 import { Bezier } from './Bezier';
-import { isWeb } from './PlatformChecker'
+import { isWeb } from './PlatformChecker';
 
 /**
  * The `Easing` module implements common easing functions. This module is used

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -4,7 +4,7 @@
 import { Component } from 'react';
 import { findNodeHandle } from 'react-native';
 import { RefObjectFunction } from './hook/useAnimatedRef';
-import { isChromeDebugger, isWeb } from './PlatformChecker'
+import { isChromeDebugger, isWeb } from './PlatformChecker';
 
 export function getTag(
   view: null | number | React.Component<any, any> | React.ComponentClass<any>

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Component } from 'react';
-import { findNodeHandle } from 'react-native';
+import { findNodeHandle, Platform } from 'react-native';
 import { RefObjectFunction } from './hook/useAnimatedRef';
 import { isChromeDebugger } from './PlatformChecker';
 
@@ -25,7 +25,7 @@ export function measure(
   animatedRef: RefObjectFunction<Component>
 ): MeasuredDimensions {
   'worklet';
-  if (!_WORKLET || isChromeDebugger()) {
+  if (Platform.OS === 'web' || !_WORKLET || isChromeDebugger()) {
     console.warn('[reanimated.measure] method cannot be used on RN side!');
     return {
       x: NaN,
@@ -51,7 +51,7 @@ export function scrollTo(
   animated: boolean
 ): void {
   'worklet';
-  if (!_WORKLET && !isChromeDebugger()) {
+  if ((Platform.OS === 'web' || !_WORKLET) && !isChromeDebugger()) {
     return;
   }
   const viewTag = animatedRef();
@@ -60,7 +60,7 @@ export function scrollTo(
 
 export function setGestureState(handlerTag: number, newState: number): void {
   'worklet';
-  if (!_WORKLET && !isChromeDebugger()) {
+  if ((Platform.OS === 'web' || !_WORKLET) && !isChromeDebugger()) {
     console.warn(
       '[Reanimated] You can not use setGestureState in non-worklet function.'
     );

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -2,9 +2,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { Component } from 'react';
-import { findNodeHandle, Platform } from 'react-native';
+import { findNodeHandle } from 'react-native';
 import { RefObjectFunction } from './hook/useAnimatedRef';
-import { isChromeDebugger } from './PlatformChecker';
+import { isChromeDebugger, isWeb } from './PlatformChecker'
 
 export function getTag(
   view: null | number | React.Component<any, any> | React.ComponentClass<any>
@@ -25,7 +25,7 @@ export function measure(
   animatedRef: RefObjectFunction<Component>
 ): MeasuredDimensions {
   'worklet';
-  if (Platform.OS === 'web' || !_WORKLET || isChromeDebugger()) {
+  if (isWeb() || !_WORKLET || isChromeDebugger()) {
     console.warn('[reanimated.measure] method cannot be used on RN side!');
     return {
       x: NaN,
@@ -51,7 +51,7 @@ export function scrollTo(
   animated: boolean
 ): void {
   'worklet';
-  if ((Platform.OS === 'web' || !_WORKLET) && !isChromeDebugger()) {
+  if ((isWeb() || !_WORKLET) && !isChromeDebugger()) {
     return;
   }
   const viewTag = animatedRef();
@@ -60,7 +60,7 @@ export function scrollTo(
 
 export function setGestureState(handlerTag: number, newState: number): void {
   'worklet';
-  if ((Platform.OS === 'web' || !_WORKLET) && !isChromeDebugger()) {
+  if ((isWeb() || !_WORKLET) && !isChromeDebugger()) {
     console.warn(
       '[Reanimated] You can not use setGestureState in non-worklet function.'
     );

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { makeMutable } from './core';
 import { SharedValue } from './commonTypes';
 import { Descriptor } from './hook/commonTypes';
-import { isWeb } from './PlatformChecker'
+import { isWeb } from './PlatformChecker';
 
 export interface ViewRefSet<T> {
   items: Set<T>;
@@ -24,8 +24,7 @@ export interface ViewDescriptorsSet {
   ) => void;
 }
 
-const scheduleUpdates =
-  isWeb() ? requestAnimationFrame : setImmediate;
+const scheduleUpdates = isWeb() ? requestAnimationFrame : setImmediate;
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const ref = useRef<ViewDescriptorsSet | null>(null);

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { makeMutable } from './core';
 import { SharedValue } from './commonTypes';
 import { Descriptor } from './hook/commonTypes';
-import { Platform } from 'react-native';
+import { isWeb } from './PlatformChecker'
 
 export interface ViewRefSet<T> {
   items: Set<T>;
@@ -25,7 +25,7 @@ export interface ViewDescriptorsSet {
 }
 
 const scheduleUpdates =
-  Platform.OS === 'web' ? requestAnimationFrame : setImmediate;
+  isWeb() ? requestAnimationFrame : setImmediate;
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const ref = useRef<ViewDescriptorsSet | null>(null);

--- a/src/reanimated2/animation/decay.ts
+++ b/src/reanimated2/animation/decay.ts
@@ -6,7 +6,7 @@ import {
   AnimatableValue,
   Timestamp,
 } from './commonTypes';
-import { isWeb } from '../PlatformChecker'
+import { isWeb } from '../PlatformChecker';
 
 interface DecayConfig {
   deceleration?: number;

--- a/src/reanimated2/animation/decay.ts
+++ b/src/reanimated2/animation/decay.ts
@@ -6,7 +6,7 @@ import {
   AnimatableValue,
   Timestamp,
 } from './commonTypes';
-import { Platform } from 'react-native';
+import { isWeb } from '../PlatformChecker'
 
 interface DecayConfig {
   deceleration?: number;
@@ -46,7 +46,7 @@ export function withDecay(
     'worklet';
     const config: DefaultDecayConfig = {
       deceleration: 0.998,
-      velocityFactor: Platform.OS !== 'web' ? 1 : 1000,
+      velocityFactor: !isWeb() ? 1 : 1000,
       velocity: 0,
     };
     if (userConfig) {
@@ -56,7 +56,7 @@ export function withDecay(
       );
     }
 
-    const VELOCITY_EPS = Platform.OS !== 'web' ? 1 : 1 / 20;
+    const VELOCITY_EPS = !isWeb() ? 1 : 1 / 20;
     const SLOPE_FACTOR = 0.1;
 
     function decay(animation: InnerDecayAnimation, now: number): boolean {

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -15,6 +15,7 @@ import NativeReanimatedModule from '../NativeReanimated';
 import { RepeatAnimation } from './repeat';
 import { SequenceAnimation } from './sequence';
 import { StyleLayoutAnimation } from './styleAnimation';
+import { Platform } from 'react-native';
 
 let IN_STYLE_UPDATER = false;
 
@@ -251,7 +252,7 @@ export function defineAnimation<
     return animation;
   };
 
-  if (_WORKLET || !NativeReanimatedModule.native) {
+  if ((Platform.OS !== 'web' && _WORKLET) || !NativeReanimatedModule.native) {
     return create();
   }
   // @ts-ignore: eslint-disable-line
@@ -272,7 +273,10 @@ export function withStartValue(
   'worklet';
   return defineAnimation(startValue, () => {
     'worklet';
-    if (!_WORKLET && typeof animation === 'function') {
+    if (
+      (Platform.OS === 'web' || !_WORKLET) &&
+      typeof animation === 'function'
+    ) {
       animation = animation();
     }
     (animation as Animation<AnimationObject>).current = startValue;

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -15,7 +15,7 @@ import NativeReanimatedModule from '../NativeReanimated';
 import { RepeatAnimation } from './repeat';
 import { SequenceAnimation } from './sequence';
 import { StyleLayoutAnimation } from './styleAnimation';
-import { Platform } from 'react-native';
+import { isWeb } from '../PlatformChecker'
 
 let IN_STYLE_UPDATER = false;
 
@@ -252,7 +252,7 @@ export function defineAnimation<
     return animation;
   };
 
-  if ((Platform.OS !== 'web' && _WORKLET) || !NativeReanimatedModule.native) {
+  if ((!isWeb() && _WORKLET) || !NativeReanimatedModule.native) {
     return create();
   }
   // @ts-ignore: eslint-disable-line
@@ -274,7 +274,7 @@ export function withStartValue(
   return defineAnimation(startValue, () => {
     'worklet';
     if (
-      (Platform.OS === 'web' || !_WORKLET) &&
+      (isWeb() || !_WORKLET) &&
       typeof animation === 'function'
     ) {
       animation = animation();

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -15,7 +15,7 @@ import NativeReanimatedModule from '../NativeReanimated';
 import { RepeatAnimation } from './repeat';
 import { SequenceAnimation } from './sequence';
 import { StyleLayoutAnimation } from './styleAnimation';
-import { isWeb } from '../PlatformChecker'
+import { isWeb } from '../PlatformChecker';
 
 let IN_STYLE_UPDATER = false;
 
@@ -273,10 +273,7 @@ export function withStartValue(
   'worklet';
   return defineAnimation(startValue, () => {
     'worklet';
-    if (
-      (isWeb() || !_WORKLET) &&
-      typeof animation === 'function'
-    ) {
+    if ((isWeb() || !_WORKLET) && typeof animation === 'function') {
       animation = animation();
     }
     (animation as Animation<AnimationObject>).current = startValue;

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,6 +1,5 @@
 /* global _WORKLET _getCurrentTime _frameTimestamp _eventTimestamp, _setGlobalConsole */
 import NativeReanimatedModule from './NativeReanimated';
-import { Platform } from 'react-native';
 import { nativeShouldBeMock, shouldBeUseWeb, isWeb } from './PlatformChecker';
 import {
   BasicWorkletFunction,
@@ -183,7 +182,7 @@ if (nativeShouldBeMock()) {
 
 export function getTimestamp(): number {
   'worklet';
-  if (Platform.OS === 'web') {
+  if (isWeb()) {
     return (NativeReanimatedModule as JSReanimated).getTimestamp();
   }
   return _getTimestamp();
@@ -352,7 +351,7 @@ export function runOnJS<A extends any[], R>(
   fun: RunOnJSFunction<A, R>
 ): () => void {
   'worklet';
-  if (Platform.OS === 'web' || !_WORKLET) {
+  if (isWeb() || !_WORKLET) {
     return fun;
   }
   if (!fun.__callAsync) {

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -352,7 +352,7 @@ export function runOnJS<A extends any[], R>(
   fun: RunOnJSFunction<A, R>
 ): () => void {
   'worklet';
-  if (!_WORKLET) {
+  if (Platform.OS === 'web' || !_WORKLET) {
     return fun;
   }
   if (!fun.__callAsync) {

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -27,6 +27,7 @@ declare global {
     animated: boolean
   ) => void;
   const _chronoNow: () => number;
+  const performance: { now: () => number };
   namespace NodeJS {
     interface Global {
       __reanimatedWorkletInit: (worklet: WorkletFunction) => void;

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -17,8 +17,10 @@ export default class JSReanimated extends NativeReanimated {
     super(false);
     if (process.env.JEST_WORKER_ID) {
       this.timeProvider = { now: () => Date.now() };
+    } else if (global.performance) {
+      this.timeProvider = { now: () => global.performance.now() };
     } else {
-      this.timeProvider = { now: () => window.performance.now() };
+      this.timeProvider = { now: () => Date.now() };
     }
   }
 


### PR DESCRIPTION
## Description

1. fix circular require in Colors.ts (#2924).

2. make better web compatibility:

`_WORKLET` might cause an undefined ReferenceError under some web-based build target without a global window like wechat miniprogram, so only using `_WORKLET` to detect whether the platform is RN is not proper.

## Changes

1. removed the useless `useInterpolate` function (which also has type error that would interrupt tsc) and `useSharedValue` is no longer cause the circular require problem.

2. adding `Platform.OS === "web"` test before directly testing `_WORKLET` to prevent the undefined ReferenceError under some web-based build target without a global `window`.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
