### PR TITLE
Fix typos in the installation docs

### DIFF
--- a/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.3.0/fundamentals/installation.md
@@ -4,13 +4,13 @@ title: Installation
 sidebar_label: Installation
 ---
 
-Installing Reanimated requires a couple of additional steps compared to installing most of the popular react-naitve packages.
+Installing Reanimated requires a couple of additional steps compared to installing most of the popular React Native packages.
 Specifically on Android the setup consist of adding additional code to the main application class.
-The steps needed to get reanimated properly configured are listed in the below paragraphs.
+The steps needed to get Reanimated properly configured are listed in the below paragraphs.
 
 ## Installing the package
 
-First step is to install `react-native-reanimated` alpha as a dependency in your project:
+First step is to install `react-native-reanimated` as a dependency in your project:
 
 ```bash
 yarn add react-native-reanimated
@@ -68,7 +68,7 @@ project.ext.react = [
   ...
 ```
 
-You can refer [to this diff](https://github.com/software-mansion-labs/reanimated-2-playground/pull/8/commits/71642dbe7bd96eb41df5b9f59d661ab15f6fc3f8) that presents the set of the above changes made to a fresh react native project in our [Playground repo](https://github.com/software-mansion-labs/reanimated-2-playground).
+You can refer [to this diff](https://github.com/software-mansion-labs/reanimated-2-playground/pull/8/commits/71642dbe7bd96eb41df5b9f59d661ab15f6fc3f8) that presents the set of the above changes made to a fresh React Native project in our [Playground repo](https://github.com/software-mansion-labs/reanimated-2-playground).
 
 ### Proguard
 
@@ -81,9 +81,13 @@ If you're using Proguard, make sure to add rule preventing it from optimizing Tu
 
 ## iOS
 
-As reanimated is setup to configure and install automatically, the only thing you have to do is to run `pod install` in the `ios/` directory. Note that the auto-installation setup works for the standard React Naitve apps, if you have problems setting it up with a custom setup (e.g. brownfield) please start a new issue where we can find a way to guide you through that process.
+As Reanimated is setup to configure and install automatically, the only thing you have to do is to run `pod install` in the `ios/` directory. Note that the auto-installation setup works for the standard React Native apps, if you have problems setting it up with a custom setup (e.g. brownfield) please start a new issue where we can find a way to guide you through that process.
 
 ## Sample React-Native project configured with Reanimated
 
-If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up ion a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
-[Visit the Playground repo here] or copy the command below to do a git clone:
+If you are having trouble configuring Reanimated in your project, or just want to try the library without the need of setting it up on a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React Native app with Reanimated library installed and configured properly.
+[Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
+
+```
+git clone https://github.com/software-mansion-labs/reanimated-2-playground.git
+```


### PR DESCRIPTION
## Description

This PR fixes a couple of typos in the installation steps in the documentation on the `/react-native-reanimated/docs/fundamentals/installation` page.

