### PR TITLE
Add `interpolateColor` mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -211,6 +211,7 @@ const Reanimated = {
   diffClamp: NOOP,
   interpolate: NOOP,
   interpolateNode: NOOP,
+  interpolateColor: NOOP,
   interpolateColors: NOOP,
   max: (a, b) => Math.max(getValue(a), getValue(b)),
   min: (a, b) => Math.min(getValue(a), getValue(b)),


### PR DESCRIPTION
## Description

`interpolateColor is not a function` was encountered during test when `reanimated` is mocked, it was, in fact, missing from `mock.js`

I think there's more of this (#2895), what's a good way to add all of the missing ones?

## Changes

add `interpolateColor` to `mock.js`

## Test code and steps to reproduce

```js
// jest.setup.js
jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
```

Test render a component that has interpolateColors.

## Checklist

- [?] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes