### PR TITLE
Check for NaN

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -198,9 +198,9 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
 - (double)getSafeDouble:(NSNumber *)number
 {
   double doubleValue = [number doubleValue];
-  //  if (doubleValue != doubleValue) { // NaN != NaN
-  //    return 0;
-  //  }
+  if (doubleValue != doubleValue) { // NaN != NaN
+    return 0;
+  }
   return doubleValue;
 }
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
 
 - (void)removeLeftovers;
 - (void)scheduleCleaning;
+- (double)getSafeDouble:(NSNumber *)number;
 
 @end
 
@@ -194,31 +195,40 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   [self setNewProps:[newStyle mutableCopy] forView:_viewForTag[tag] withComponentData:componentData];
 }
 
+- (double)getSafeDouble:(NSNumber *)number
+{
+  double doubleValue = [number doubleValue];
+  //  if (doubleValue != doubleValue) { // NaN != NaN
+  //    return 0;
+  //  }
+  return doubleValue;
+}
+
 - (void)setNewProps:(NSMutableDictionary *)newProps
               forView:(UIView *)view
     withComponentData:(RCTComponentData *)componentData
 {
   if (newProps[@"height"]) {
-    double height = [newProps[@"height"] doubleValue];
+    double height = [self getSafeDouble:newProps[@"height"]];
     double oldHeight = view.bounds.size.height;
     view.bounds = CGRectMake(0, 0, view.bounds.size.width, height);
     view.center = CGPointMake(view.center.x, view.center.y - oldHeight / 2.0 + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"height"];
   }
   if (newProps[@"width"]) {
-    double width = [newProps[@"width"] doubleValue];
+    double width = [self getSafeDouble:newProps[@"width"]];
     double oldWidth = view.bounds.size.width;
     view.bounds = CGRectMake(0, 0, width, view.bounds.size.height);
     view.center = CGPointMake(view.center.x + view.bounds.size.width / 2.0 - oldWidth / 2.0, view.center.y);
     [newProps removeObjectForKey:@"width"];
   }
   if (newProps[@"originX"]) {
-    double originX = [newProps[@"originX"] doubleValue];
+    double originX = [self getSafeDouble:newProps[@"originX"]];
     view.center = CGPointMake(originX + view.bounds.size.width / 2.0, view.center.y);
     [newProps removeObjectForKey:@"originX"];
   }
   if (newProps[@"originY"]) {
-    double originY = [newProps[@"originY"] doubleValue];
+    double originY = [self getSafeDouble:newProps[@"originY"]];
     view.center = CGPointMake(view.center.x, originY + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"originY"];
   }

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -195,7 +195,7 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   [self setNewProps:[newStyle mutableCopy] forView:_viewForTag[tag] withComponentData:componentData];
 }
 
-- (double)getSafeDouble:(NSNumber *)number
+- (double)getDoubleOrZero:(NSNumber *)number
 {
   double doubleValue = [number doubleValue];
   if (doubleValue != doubleValue) { // NaN != NaN
@@ -209,26 +209,26 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
     withComponentData:(RCTComponentData *)componentData
 {
   if (newProps[@"height"]) {
-    double height = [self getSafeDouble:newProps[@"height"]];
+    double height = [self getDoubleOrZero:newProps[@"height"]];
     double oldHeight = view.bounds.size.height;
     view.bounds = CGRectMake(0, 0, view.bounds.size.width, height);
     view.center = CGPointMake(view.center.x, view.center.y - oldHeight / 2.0 + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"height"];
   }
   if (newProps[@"width"]) {
-    double width = [self getSafeDouble:newProps[@"width"]];
+    double width = [self getDoubleOrZero:newProps[@"width"]];
     double oldWidth = view.bounds.size.width;
     view.bounds = CGRectMake(0, 0, width, view.bounds.size.height);
     view.center = CGPointMake(view.center.x + view.bounds.size.width / 2.0 - oldWidth / 2.0, view.center.y);
     [newProps removeObjectForKey:@"width"];
   }
   if (newProps[@"originX"]) {
-    double originX = [self getSafeDouble:newProps[@"originX"]];
+    double originX = [self getDoubleOrZero:newProps[@"originX"]];
     view.center = CGPointMake(originX + view.bounds.size.width / 2.0, view.center.y);
     [newProps removeObjectForKey:@"originX"];
   }
   if (newProps[@"originY"]) {
-    double originY = [self getSafeDouble:newProps[@"originY"]];
+    double originY = [self getDoubleOrZero:newProps[@"originY"]];
     view.center = CGPointMake(view.center.x, originY + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"originY"];
   }


### PR DESCRIPTION
## Description

`CGPointMake(x, y)` doesn't accept `NaN` as argument. I added a check for this case.

### Example
```js
import React, { memo, useState } from 'react';
import { Button, SafeAreaView, View } from 'react-native';
import Animated, { SlideInDown } from 'react-native-reanimated';

const AppComponent = () => {
  const [count, setCount] = useState(0);
  return (
    <SafeAreaView style={{flex: 1}}>
      <Button title="increment" onPress={() => setCount(v => v + 1)} />
      <View style={{height: 40, overflow: 'hidden'}}>
        <Animated.Text exiting={SlideInDown} key={count}>
          {count}
        </Animated.Text>
      </View>
    </SafeAreaView>
  );
};

export default App;
```

Fixes https://github.com/software-mansion/react-native-reanimated/issues/2878