### PR TITLE
Catch & ignore IllegalViewOperationException in AnimationsManager#removeLeftovers 

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -233,8 +233,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
     for (int tag : mToRemove) {
       View view = mViewForTag.get(tag);
       if (view == null) {
-        view = mUIManager.resolveView(tag);
-        mViewForTag.put(tag, view);
+        try {
+          view = mUIManager.resolveView(tag);
+          mViewForTag.put(tag, view);
+        } catch (IllegalViewOperationException ignored) {
+        }
       }
       findRoot(view, roots);
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -237,6 +237,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
           view = mUIManager.resolveView(tag);
           mViewForTag.put(tag, view);
         } catch (IllegalViewOperationException ignored) {
+          continue;
         }
       }
       findRoot(view, roots);


### PR DESCRIPTION

## Description

This aims to prevent some of the crashes [reported here](https://github.com/software-mansion/react-native-reanimated/issues/2508#issuecomment-1032330992), however it is likely that it is not final solution to the problem.

## Changes

Catch & ignore IllegalViewOperationException in AnimationsManager#removeLeftovers 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
