### PR TITLE
Fix crash when handling event containing NaN or INF values

### DIFF
--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -62,7 +62,7 @@ class EventHandler : public HybridClass<EventHandler> {
     if (event != nullptr) {
       try {
         eventAsString = event->toString();
-      } catch (folly::json::parse_error &) {
+      } catch (std::exception &) {
         // Events from other libraries may contain NaN or INF values which
         // cannot be represented in JSON. See
         // https://github.com/software-mansion/react-native-reanimated/issues/1776

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -250,7 +250,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     std::string eventAsString;
     try {
       eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
-    } catch (folly::json::parse_error &) {
+    } catch (std::exception &) {
       // Events from other libraries may contain NaN or INF values which cannot be represented in JSON.
       // See https://github.com/software-mansion/react-native-reanimated/issues/1776 for details.
       return;


### PR DESCRIPTION
## Description
This is a follow up pr of https://github.com/software-mansion/react-native-reanimated/pull/2901 which unfortunately doesn't solve [the issue](https://github.com/software-mansion/react-native-reanimated/issues/2814). I do not fully understand why but the try/catch currently has no effect. It's a bit surprising to me because as far as I can see `folly::json::parse_error` should be the same as `std::exception` but I see that the crash is still happening for us in production after updating to 2.4.1 and I can also reproduce it with the example app.

@piotrekzyla @tomekzaw 

## Changes
Make sure the try/catch actually works by catching a more generic error.

## Test code and steps to reproduce
I tested the code change with the example app by manually adding a `NaN` value to the event.

<img width="880" alt="Screenshot 2022-02-10 at 23 42 36" src="https://user-images.githubusercontent.com/5617793/153509602-097625f2-4516-4a42-9a28-2bd8684e8a38.png">

 
## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
