### PR TITLE
Fix typo introduced in #2979

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -557,7 +557,7 @@ declare module 'react-native-reanimated' {
     finished?: boolean,
     current?: AnimatableValue
   ) => void;
-  export type EasingFactoryFunction = { factory: () => EasingFunction };
+  export type EasingFunctionFactory = { factory: () => EasingFunction };
   export interface WithTimingConfig {
     duration?: number;
     easing?: EasingFunction | EasingFunctionFactory;


### PR DESCRIPTION
## Description

#2979 introduced a typo, [as reported here](https://github.com/software-mansion/react-native-reanimated/pull/2979#discussion_r809231482).

🤦🏼 

## Changes

Fixed the typo

## Test code and steps to reproduce

```js
import Animated, {
    useSharedValue,
    withTiming,
    useAnimatedStyle,
    Easing,
  } from 'react-native-reanimated';
  import { View, Button } from 'react-native';
  import React from 'react';
  
  export function TestScreen() {
    const randomWidth = useSharedValue(10);
  
    const config = {
      duration: 500,
      easing: Easing.bezier(0.5, 0.01, 0, 1),
    };
  
    const style = useAnimatedStyle(() => {
      return {
        width: withTiming(randomWidth.value, config),
      };
    });
  
    return (
      <View
        style={{
          flex: 1,
          alignItems: 'center',
          justifyContent: 'center',
          flexDirection: 'column',
        }}>
        <Animated.View
          style={[{ width: 100, height: 80, backgroundColor: 'black', margin: 30 }, style]}
        />
        <Button
          title="toggle"
          onPress={() => {
            randomWidth.value = Math.random() * 350;
          }}
        />
      </View>
    );
  }
```


## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
