### PR TITLE
Source build: don't hardcode build dir

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 
 set (PACKAGE_NAME "reanimated")
-set (BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 set (SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 
 if(${CLIENT_SIDE_BUILD})
@@ -37,11 +36,11 @@ file(GLOB sources_android  "${SRC_DIR}/main/cpp/*.cpp")
 
 if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
         set (
-                INCLUDE_JSI_CPP 
+                INCLUDE_JSI_CPP
                 "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
         )
         set (
-                INCLUDE_JSIDYNAMIC_CPP 
+                INCLUDE_JSIDYNAMIC_CPP
                 "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/JSIDynamic.cpp"
         )
 endif()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -386,6 +386,7 @@ android {
                         "-DREACT_NATIVE_TARGET_VERSION=${REACT_VERSION}",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DBOOST_VERSION=${BOOST_VERSION}",
+                        "-DBUILD_DIR=${buildDir}",
                         "-DFOR_HERMES=${FOR_HERMES}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",
                         "--clean-first"


### PR DESCRIPTION
## Description

It is possible to change the gradle build dir so it is not safe to assume it will be under /build.

## Changes

Use the project build dir from gradle in cmake instead of assuming /build.

## Screenshots / GIFs

N/A

## Test code and steps to reproduce

android/build.gradle
```groovy
allprojects {
    buildDir = "${System.getProperty("user.home")}/.gradle/builds/${rootProject.name}/${project.name}"
}
```

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
