### PR TITLE
Source build: resolve react-native and other packages relative to reanimated package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ def resolveReactNativeDirectory() {
     if (isDeveloperMode()) {
         return file("$projectDir/../node_modules/react-native")
     }
-    return file("$rootDir/../node_modules/react-native")
+    return file("$projectDir/../../react-native")
 }
 
 abstract class replaceSoTask extends DefaultTask {
@@ -655,11 +655,11 @@ repositories {
     mavenLocal()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+        url "$reactNative/android"
     }
     maven {
         // Android JSC is installed from npm
-        url "$rootDir/../node_modules/jsc-android/dist"
+        url "$reactNative/../jsc-android/dist"
     }
     google()
 }
@@ -678,8 +678,8 @@ dependencies {
     extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
     extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
-    def rnAAR = fileTree("${rootDir}/../node_modules/react-native/android").matching({ it.include "**/**/*.aar" }).singleFile
-    def jscAAR = fileTree("${rootDir}/../node_modules/jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
+    def rnAAR = fileTree("$reactNative/android").matching({ it.include "**/**/*.aar" }).singleFile
+    def jscAAR = fileTree("$reactNative/../jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
     extractSO(files(rnAAR, jscAAR))
 }
 


### PR DESCRIPTION
## Description

This will be more reliable in a mono-repo setup. We assume the react-native / other deps are in the same directory as react-native-reanimated instead of assuming it is in rootDir/../node_modules.

## Changes

Use relative path from the react-native-reanimated package instead of project root.

## Test code and steps to reproduce

Use source build in a monorepo.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
