### PR TITLE
Source build: support reactNativeArchitectures

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -329,6 +329,11 @@ if (findProject(":app")) {
     FOR_HERMES = System.getenv("FOR_HERMES") == "True";
 }
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 // You need to have following folders in this directory:
 //   - boost_1_63_0
 //   - double-conversion-1.1.6
@@ -389,7 +394,7 @@ android {
                         "-DFOR_HERMES=${FOR_HERMES}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",
                         "--clean-first"
-                abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
+                abiFilters (*reactNativeArchitectures())
                 _stackProtectorFlag ? (cppFlags("-fstack-protector-all")) : null
             }
         }


### PR DESCRIPTION
## Description

React native support this property to allow building for specific architectures only.

## Changes

Add support for reactNativeArchitectures like in https://github.com/facebook/react-native/blob/main/ReactAndroid/build.gradle#L227.

## Test code and steps to reproduce

Use source build with the latest react-native version and run react-native start-android.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
