### PR TITLE
Source build: Support gradle plugin v7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -695,17 +695,19 @@ task downloadNdkBuildDependencies {
 task prepareThirdPartyNdkHeaders(dependsOn:[downloadNdkBuildDependencies, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog]) {
 }
 
-tasks.whenTaskAdded { task ->
-    if (
-        task.name.contains("externalNativeBuild")
-        || task.name.contains("buildCMake")
-    ) {
-        task.dependsOn(prepareThirdPartyNdkHeaders)
-        extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
-        extractSOFiles.dependsOn(prepareThirdPartyNdkHeaders)
-        task.dependsOn(extractAARHeaders)
-        task.dependsOn(extractSOFiles)
-    }
+def nativeBuildDependsOn(dependsOnTask) {
+    def buildTasks = tasks.findAll({ task ->
+        !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake")) })
+    buildTasks.forEach { task -> task.dependsOn(dependsOnTask) }
+}
+
+afterEvaluate {
+    extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
+    extractSOFiles.dependsOn(prepareThirdPartyNdkHeaders)
+
+    nativeBuildDependsOn(prepareThirdPartyNdkHeaders)
+    nativeBuildDependsOn(extractAARHeaders)
+    nativeBuildDependsOn(extractSOFiles)
 }
 
 if (CLIENT_SIDE_BUILD) {


### PR DESCRIPTION
## Description

The task names changed and include the architecture when using the gradle plugin v7. This is compatible with new and old task names.

## Changes

- Register task dependencies in afterEvaluate instead of whenTaskAdded
- Check for tasks containing CMake instead of buildCMake to match tasks like `configureCMakeDebug[arm64-v8a]`
- Make sure task doesn't include Clean to avoid matching clean tasks
- Keep checking for `externalNative` to support older gradle plugin versions

## Test code and steps to reproduce

Use gradle plugin@7

android/build.gradle
```groovy
classpath 'com.android.tools.build:gradle:7.1.1'
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
