### PR TITLE
ConfigureProps by JSI

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -70,7 +70,9 @@ NativeReanimatedModule::NativeReanimatedModule(
       mapperRegistry(std::make_shared<MapperRegistry>()),
       eventHandlerRegistry(std::make_shared<EventHandlerRegistry>()),
       requestRender(platformDepMethodsHolder.requestRender),
-      propObtainer(propObtainer) {
+      propObtainer(propObtainer),
+      configurePropsPlatformFunction(
+          platformDepMethodsHolder.configurePropsFunction) {
   auto requestAnimationFrame = [=](FrameCallback callback) {
     frameCallbacks.push_back(callback);
     maybeRequestRender();
@@ -240,6 +242,14 @@ jsi::Value NativeReanimatedModule::enableLayoutAnimations(
     jsi::Runtime &rt,
     const jsi::Value &config) {
   FeaturesConfig::setLayoutAnimationEnabled(config.getBool());
+  return jsi::Value::undefined();
+}
+
+jsi::Value NativeReanimatedModule::configureProps(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps) {
+  configurePropsPlatformFunction(rt, uiProps, nativeProps);
   return jsi::Value::undefined();
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -108,6 +108,16 @@ static jsi::Value SPEC_PREFIX(enableLayoutAnimations)(
   return jsi::Value::undefined();
 }
 
+static jsi::Value SPEC_PREFIX(configureProps)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->configureProps(rt, std::move(args[0]), std::move(args[1]));
+  return jsi::Value::undefined();
+}
+
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
@@ -129,6 +139,7 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
   methodMap_["getViewProp"] = MethodMetadata{3, SPEC_PREFIX(getViewProp)};
   methodMap_["enableLayoutAnimations"] =
       MethodMetadata{2, SPEC_PREFIX(enableLayoutAnimations)};
+  methodMap_["configureProps"] = MethodMetadata{2, SPEC_PREFIX(configureProps)};
 }
 
 } // namespace reanimated

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -70,6 +70,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   jsi::Value enableLayoutAnimations(jsi::Runtime &rt, const jsi::Value &config)
       override;
+  jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) override;
 
   void onRender(double timestampMs);
   void onEvent(std::string eventName, std::string eventAsString);
@@ -89,6 +93,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       propObtainer;
   std::function<void(double)> onRenderCallback;
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy;
+  ConfigurePropsFunction configurePropsPlatformFunction;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -63,6 +63,10 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
   virtual jsi::Value enableLayoutAnimations(
       jsi::Runtime &rt,
       const jsi::Value &config) = 0;
+  virtual jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) = 0;
 };
 
 } // namespace reanimated

--- a/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
+++ b/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
@@ -22,6 +22,10 @@ using MeasuringFunction =
     std::function<std::vector<std::pair<std::string, double>>(int)>;
 using TimeProviderFunction = std::function<double(void)>;
 using SetGestureStateFunction = std::function<void(int, int)>;
+using ConfigurePropsFunction = std::function<void(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps)>;
 
 struct PlatformDepMethodsHolder {
   RequestRender requestRender;
@@ -30,6 +34,7 @@ struct PlatformDepMethodsHolder {
   MeasuringFunction measuringFunction;
   TimeProviderFunction getCurrentTime;
   SetGestureStateFunction setGestureStateFunction;
+  ConfigurePropsFunction configurePropsFunction;
 };
 
 } // namespace reanimated

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -149,6 +149,12 @@ void NativeProxy::installJSIBindings() {
     this->layoutAnimations->cthis()->notifyAboutEnd(tag, (isCancelled) ? 1 : 0);
   };
 
+  auto configurePropsFunction = [=](jsi::Runtime &rt,
+                                    const jsi::Value &uiProps,
+                                    const jsi::Value &nativeProps) {
+    this->configureProps(rt, uiProps, nativeProps);
+  };
+
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =
       std::make_shared<LayoutAnimationsProxy>(
           notifyAboutProgress, notifyAboutEnd);
@@ -164,7 +170,7 @@ void NativeProxy::installJSIBindings() {
       measuringFunction,
       getCurrentTime,
       setGestureStateFunction,
-  };
+      configurePropsFunction};
 
   auto module = std::make_shared<NativeReanimatedModule>(
       jsCallInvoker_,
@@ -270,6 +276,24 @@ void NativeProxy::setGestureState(int handlerTag, int newState) {
   auto method =
       javaPart_->getClass()->getMethod<void(int, int)>("setGestureState");
   method(javaPart_.get(), handlerTag, newState);
+}
+
+void NativeProxy::configureProps(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps) {
+  auto method = javaPart_->getClass()
+                    ->getMethod<void(
+                        ReadableNativeArray::javaobject,
+                        ReadableNativeArray::javaobject)>("configureProps");
+  method(
+      javaPart_.get(),
+      ReadableNativeArray::newObjectCxxArgs(
+          std::move(jsi::dynamicFromValue(rt, uiProps)))
+          .get(),
+      ReadableNativeArray::newObjectCxxArgs(
+          std::move(jsi::dynamicFromValue(rt, nativeProps)))
+          .get());
 }
 
 } // namespace reanimated

--- a/android/src/main/cpp/headers/NativeProxy.h
+++ b/android/src/main/cpp/headers/NativeProxy.h
@@ -119,6 +119,10 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   void scrollTo(int viewTag, double x, double y, bool animated);
   void setGestureState(int handlerTag, int newState);
   std::vector<std::pair<std::string, double>> measure(int viewTag);
+  void configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps);
 
   explicit NativeProxy(
       jni::alias_ref<NativeProxy::jhybridobject> jThis,

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -8,6 +8,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableNativeArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -19,8 +20,11 @@ import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
 import com.swmansion.reanimated.layoutReanimation.LayoutAnimations;
 import com.swmansion.reanimated.layoutReanimation.NativeMethodsHolder;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class NativeProxy {
 
@@ -178,6 +182,22 @@ public class NativeProxy {
   @DoNotStrip
   private float[] measure(int viewTag) {
     return mNodesManager.measure(viewTag);
+  }
+
+  @DoNotStrip
+  private void configureProps(ReadableNativeArray uiProps, ReadableNativeArray nativeProps) {
+    Set<String> nativePropsSet = convertProps(nativeProps);
+    Set<String> uiPropsSet = convertProps(uiProps);
+    mNodesManager.configureProps(nativePropsSet, uiPropsSet);
+  }
+
+  private Set<String> convertProps(ReadableNativeArray props) {
+    Set<String> propsSet = new HashSet<>();
+    ArrayList<Object> propsList = props.toArrayList();
+    for (int i = 0; i < propsList.size(); i++) {
+      propsSet.add((String) propsList.get(i));
+    }
+    return propsSet;
   }
 
   @DoNotStrip

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -186,9 +186,9 @@ public class NativeProxy {
 
   @DoNotStrip
   private void configureProps(ReadableNativeArray uiProps, ReadableNativeArray nativeProps) {
-    Set<String> nativePropsSet = convertProps(nativeProps);
     Set<String> uiPropsSet = convertProps(uiProps);
-    mNodesManager.configureProps(nativePropsSet, uiPropsSet);
+    Set<String> nativePropsSet = convertProps(nativeProps);
+    mNodesManager.configureProps(uiPropsSet, nativePropsSet);
   }
 
   private Set<String> convertProps(ReadableNativeArray props) {

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -464,9 +464,9 @@ public class NodesManager implements EventDispatcherListener {
     mEventMapping.remove(key);
   }
 
-  public void configureProps(Set<String> nativePropsSet, Set<String> uiPropsSet) {
-    nativeProps = nativePropsSet;
+  public void configureProps(Set<String> uiPropsSet, Set<String> nativePropsSet) {
     uiProps = uiPropsSet;
+    nativeProps = nativePropsSet;
   }
 
   public void getValue(int nodeID, Callback callback) {

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -212,28 +212,6 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
   }
 
   @ReactMethod
-  public void configureProps(ReadableArray nativePropsArray, ReadableArray uiPropsArray) {
-    int size = nativePropsArray.size();
-    final Set<String> nativeProps = new HashSet<>(size);
-    for (int i = 0; i < size; i++) {
-      nativeProps.add(nativePropsArray.getString(i));
-    }
-
-    size = uiPropsArray.size();
-    final Set<String> uiProps = new HashSet<>(size);
-    for (int i = 0; i < size; i++) {
-      uiProps.add(uiPropsArray.getString(i));
-    }
-    mOperations.add(
-        new UIThreadOperation() {
-          @Override
-          public void execute(NodesManager nodesManager) {
-            nodesManager.configureProps(nativeProps, uiProps);
-          }
-        });
-  }
-
-  @ReactMethod
   public void getValue(final int nodeID, final Callback callback) {
     mOperations.add(
         new UIThreadOperation() {

--- a/ios/REAModule.m
+++ b/ios/REAModule.m
@@ -126,15 +126,6 @@ RCT_EXPORT_METHOD(detachEvent
   }];
 }
 
-RCT_EXPORT_METHOD(configureProps
-                  : (nonnull NSArray<NSString *> *)nativeProps uiProps
-                  : (nonnull NSArray<NSString *> *)uiProps)
-{
-  [self addOperationBlock:^(REANodesManager *nodesManager) {
-    [nodesManager configureProps:[NSSet setWithArray:nativeProps] uiProps:[NSSet setWithArray:uiProps]];
-  }];
-}
-
 RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)nodeID newValue : (nonnull NSNumber *)newValue)
 {
   [self addOperationBlock:^(REANodesManager *nodesManager) {

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -64,7 +64,8 @@ typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
 
 // configuration
 
-- (void)configureNativeProps:(nonnull NSSet<NSString *> *)nativeProps andUiProps:(nonnull NSSet<NSString *> *)uiProps;
+- (void)configureUiProps:(nonnull NSSet<NSString *> *)uiPropsSet
+          andNativeProps:(nonnull NSSet<NSString *> *)nativePropsSet;
 
 - (void)updateProps:(nonnull NSDictionary *)props
       ofViewWithTag:(nonnull NSNumber *)viewTag

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -64,7 +64,7 @@ typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
 
 // configuration
 
-- (void)configureProps:(nonnull NSSet<NSString *> *)nativeProps uiProps:(nonnull NSSet<NSString *> *)uiProps;
+- (void)configureNativeProps:(nonnull NSSet<NSString *> *)nativeProps andUiProps:(nonnull NSSet<NSString *> *)uiProps;
 
 - (void)updateProps:(nonnull NSDictionary *)props
       ofViewWithTag:(nonnull NSNumber *)viewTag

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -504,7 +504,7 @@
   }
 }
 
-- (void)configureProps:(NSSet<NSString *> *)nativeProps uiProps:(NSSet<NSString *> *)uiProps
+- (void)configureNativeProps:(NSSet<NSString *> *)nativeProps andUiProps:(NSSet<NSString *> *)uiProps
 {
   _uiProps = uiProps;
   _nativeProps = nativeProps;

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -504,10 +504,11 @@
   }
 }
 
-- (void)configureNativeProps:(NSSet<NSString *> *)nativeProps andUiProps:(NSSet<NSString *> *)uiProps
+- (void)configureUiProps:(nonnull NSSet<NSString *> *)uiPropsSet
+          andNativeProps:(nonnull NSSet<NSString *> *)nativePropsSet
 {
-  _uiProps = uiProps;
-  _nativeProps = nativeProps;
+  _uiProps = uiPropsSet;
+  _nativeProps = nativePropsSet;
 }
 
 - (BOOL)isNotNativeViewFullyMounted:(NSNumber *)viewTag

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -232,7 +232,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
                                     jsi::Runtime &rt, const jsi::Value &uiProps, const jsi::Value &nativeProps) {
     NSSet *uiPropsSet = convertProps(rt, uiProps);
     NSSet *nativePropsSet = convertProps(rt, nativeProps);
-    [reanimatedModule.nodesManager configureNativeProps:nativePropsSet andUiProps:uiPropsSet];
+    [reanimatedModule.nodesManager configureUiProps:uiPropsSet andNativeProps:nativePropsSet];
   };
 
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -217,6 +217,25 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     }
   };
 
+  auto configurePropsFunction = [reanimatedModule](
+                                    jsi::Runtime &rt, const jsi::Value &uiProps, const jsi::Value &nativeProps) {
+    NSMutableSet *usPropsSet = [[NSMutableSet alloc] init];
+    jsi::Array propsNames = uiProps.asObject(rt).asArray(rt);
+    for (int i = 0; i < propsNames.size(rt); i++) {
+      NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
+      [usPropsSet addObject:propName];
+    }
+
+    NSMutableSet *nativePropsSet = [[NSMutableSet alloc] init];
+    propsNames = nativeProps.asObject(rt).asArray(rt);
+    for (int i = 0; i < propsNames.size(rt); i++) {
+      NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
+      [nativePropsSet addObject:propName];
+    }
+
+    [reanimatedModule.nodesManager configureProps:usPropsSet uiProps:nativePropsSet];
+  };
+
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =
       std::make_shared<LayoutAnimationsProxy>(notifyAboutProgress, notifyAboutEnd);
   std::weak_ptr<jsi::Runtime> wrt = animatedRuntime;
@@ -269,7 +288,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       measuringFunction,
       getCurrentTime,
       setGestureStateFunction,
-  };
+      configurePropsFunction};
 
   module = std::make_shared<NativeReanimatedModule>(
       jsInvoker,

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -125,6 +125,17 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
 }
 
+static NSSet *convertProps(jsi::Runtime &rt, const jsi::Value &props)
+{
+  NSMutableSet *propsSet = [[NSMutableSet alloc] init];
+  jsi::Array propsNames = props.asObject(rt).asArray(rt);
+  for (int i = 0; i < propsNames.size(rt); i++) {
+    NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
+    [propsSet addObject:propName];
+  }
+  return propsSet;
+}
+
 std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     RCTBridge *bridge,
     std::shared_ptr<CallInvoker> jsInvoker)
@@ -219,20 +230,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   auto configurePropsFunction = [reanimatedModule](
                                     jsi::Runtime &rt, const jsi::Value &uiProps, const jsi::Value &nativeProps) {
-    NSMutableSet *uiPropsSet = [[NSMutableSet alloc] init];
-    jsi::Array propsNames = uiProps.asObject(rt).asArray(rt);
-    for (int i = 0; i < propsNames.size(rt); i++) {
-      NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
-      [uiPropsSet addObject:propName];
-    }
-
-    NSMutableSet *nativePropsSet = [[NSMutableSet alloc] init];
-    propsNames = nativeProps.asObject(rt).asArray(rt);
-    for (int i = 0; i < propsNames.size(rt); i++) {
-      NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
-      [nativePropsSet addObject:propName];
-    }
-
+    NSSet *uiPropsSet = convertProps(rt, uiProps);
+    NSSet *nativePropsSet = convertProps(rt, nativeProps);
     [reanimatedModule.nodesManager configureNativeProps:nativePropsSet andUiProps:uiPropsSet];
   };
 

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -219,11 +219,11 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   auto configurePropsFunction = [reanimatedModule](
                                     jsi::Runtime &rt, const jsi::Value &uiProps, const jsi::Value &nativeProps) {
-    NSMutableSet *usPropsSet = [[NSMutableSet alloc] init];
+    NSMutableSet *uiPropsSet = [[NSMutableSet alloc] init];
     jsi::Array propsNames = uiProps.asObject(rt).asArray(rt);
     for (int i = 0; i < propsNames.size(rt); i++) {
       NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
-      [usPropsSet addObject:propName];
+      [uiPropsSet addObject:propName];
     }
 
     NSMutableSet *nativePropsSet = [[NSMutableSet alloc] init];
@@ -233,7 +233,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       [nativePropsSet addObject:propName];
     }
 
-    [reanimatedModule.nodesManager configureProps:usPropsSet uiProps:nativePropsSet];
+    [reanimatedModule.nodesManager configureNativeProps:nativePropsSet andUiProps:uiPropsSet];
   };
 
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =

--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -1,4 +1,4 @@
-import ReanimatedModule from './ReanimatedModule';
+import { configureProps as jsiConfigureProps } from './reanimated2/core';
 
 /**
  * Styles allowed to be direcly updated in UI thread
@@ -107,7 +107,7 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
 };
 
 function configureProps(): void {
-  ReanimatedModule.configureProps(
+  jsiConfigureProps(
     Object.keys(NATIVE_THREAD_PROPS_WHITELIST),
     Object.keys(UI_THREAD_PROPS_WHITELIST)
   );

--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -108,8 +108,8 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
 
 function configureProps(): void {
   jsiConfigureProps(
-    Object.keys(NATIVE_THREAD_PROPS_WHITELIST),
-    Object.keys(UI_THREAD_PROPS_WHITELIST)
+    Object.keys(UI_THREAD_PROPS_WHITELIST),
+    Object.keys(NATIVE_THREAD_PROPS_WHITELIST)
   );
 }
 

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -73,4 +73,8 @@ export class NativeReanimated {
   enableLayoutAnimations(flag: boolean): void {
     this.InnerNativeModule.enableLayoutAnimations(flag);
   }
+
+  configureProps(uiProps: string[], nativeProps: string[]): void {
+    this.InnerNativeModule.configureProps(uiProps, nativeProps);
+  }
 }

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -417,6 +417,10 @@ export function enableLayoutAnimations(
   }
 }
 
+export function configureProps(uiProps: string[], nativeProps: string[]): void {
+  NativeReanimatedModule.configureProps(uiProps, nativeProps);
+}
+
 export function jestResetJsReanimatedModule() {
   (NativeReanimatedModule as JSReanimated).jestResetModule();
 }

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -418,7 +418,9 @@ export function enableLayoutAnimations(
 }
 
 export function configureProps(uiProps: string[], nativeProps: string[]): void {
-  NativeReanimatedModule.configureProps(uiProps, nativeProps);
+  if (!nativeShouldBeMock()) {
+    NativeReanimatedModule.configureProps(uiProps, nativeProps);
+  }
 }
 
 export function jestResetJsReanimatedModule() {


### PR DESCRIPTION
## Description

There was a possibility to run updateProps before an update of the allowlist of properties on the native side. It happened because an update of properties allowlist was asynchronous. I added the JSI function to make it update synchronously.