### PR TITLE
Add @babel/preset-typescript to peerDependencies as it's used at runtime for the worklet plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "*"
+    "react-native-gesture-handler": "*",
+    "@babel/preset-typescript": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",


### PR DESCRIPTION
## Description

Some users are reporting that they get an error of `Cannot find module '@babel/preset-typescript'`

This appears to be because `@babel/preset-typescript` is used at runtime for [the worklet plugin](https://github.com/software-mansion/react-native-reanimated/blob/main/plugin.js#L361). Many React Native projects won't have this dependency by default as it's not included in the [React Native TypeScript template](https://github.com/react-native-community/react-native-template-typescript/blob/main/template/package.json).

Fixes #2746

## Changes

Add `@babel/preset-typescript` to `peerDependencies` to fix error: `Cannot find module '@babel/preset-typescript'`

## Test code and steps to reproduce

1. Spin up a new React Native TypeScript project: `npx react-native init MyApp --template react-native-template-typescript`
2. [Install Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
3. Run app
4. Get error! 💥 
6. Install `@babel/preset-typescript`
7. Error sorted ✅ 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
