### PR TITLE
Use timeout of 100ms on semaphore in performOperations

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -276,7 +276,9 @@
       [strongSelf.uiManager setNeedsLayout];
     });
     if (trySynchronously) {
-      dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+      // Timeout of 100ms, otherwise this will freeze the app when standard Animated API animations
+      // are run in parallel to reanimated animations
+      dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 100000000));
     }
 
     if (_mounting) {


### PR DESCRIPTION
## Description

Timeout of 100ms allows to avoid freezing the app when standard Animated API animations are run in parallel with reanimated animations. This addresses #2327 and similar issues.

## Screenshots / GIFs

When the app was freezing, if you attach it to Xcode and pause execution, it always stops on the line that I changed:

<img width="1438" alt="Screenshot 2022-03-17 at 02 23 39" src="https://user-images.githubusercontent.com/4147152/158881444-a190f04e-9da7-4d4a-ad0a-8a9ded6c4190.png">

## Test code and steps to reproduce

I'll try to make a reproducible demo where the freeze issue occurs, and where this PR is fixing it.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
