### PR TITLE
Invalidate display link instead of pausing it when invalidating the nodes manager

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -143,7 +143,7 @@
 - (void)invalidate
 {
   _eventHandler = nil;
-  [self stopUpdatingOnAnimationFrame];
+  [_displayLink invalidate];
 }
 
 - (void)operationsBatchDidComplete


### PR DESCRIPTION
## Description

Invalidate display link instead of pausing it when invalidating the nodes manager

Pausing the display link on invalidation will still make it call the onAnimationFrame selector one more time as its already schedule. When this happens animation blocks will be called and crash while accessing the jsi runtime thats already dealloced.

Fixes #2035
Fixes #2899

## Test code and steps to reproduce

See #2035 for reproduction
