### PR TITLE
Update RNReanimated.podspec

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -78,7 +78,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency 'FBLazyVector'
   s.dependency 'FBReactNativeSpec'
   s.dependency 'RCTRequired'


### PR DESCRIPTION
s.dependancy should be updated to React-Core as per https://github.com/facebook/react-native/issues/29633#issuecomment-694187116 as it causes the xcode build to fail without legacy build

## Description
Fixes the issue of xcode build failing (with error: Undefined symbol: _RCTRegisterModule) with RNReanimated if not using legacy build (xcode 13) and RN > 0.63

Fixes #2227

## Changes
Updated pod spec s.dependancy to be React-Core instead of React as described as the proposed solution: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test code and steps to reproduce
Add react-native, add react-native-reanimated, run pod install, run xcode build

