### PR TITLE
moveAnimationByTime -> advanceAnimationByTime in docs

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -77,7 +77,7 @@ test('stop in a middle of animation', () => {
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);
-    moveAnimationByTime(250); // if whole animation duration is a 500ms
+    advanceAnimationByTime(250); // if whole animation duration is a 500ms
     style.width = 46.08; // value of component width after 250ms of animation
     expect(view).toHaveAnimatedStyle(style);
   });

--- a/docs/versioned_docs/version-2.0.0/testing.md
+++ b/docs/versioned_docs/version-2.0.0/testing.md
@@ -77,7 +77,7 @@ test('stop in a middle of animation', () => {
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);
-    moveAnimationByTime(250); // if whole animation duration is a 500ms
+    advanceAnimationByTime(250); // if whole animation duration is a 500ms
     style.width = 46.08; // value of component width after 250ms of animation
     expect(view).toHaveAnimatedStyle(style);
   });

--- a/docs/versioned_docs/version-2.1.0/testing.md
+++ b/docs/versioned_docs/version-2.1.0/testing.md
@@ -77,7 +77,7 @@ test('stop in a middle of animation', () => {
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);
-    moveAnimationByTime(250); // if whole animation duration is a 500ms
+    advanceAnimationByTime(250); // if whole animation duration is a 500ms
     style.width = 46.08; // value of component width after 250ms of animation
     expect(view).toHaveAnimatedStyle(style);
   });

--- a/docs/versioned_docs/version-2.2.0/testing.md
+++ b/docs/versioned_docs/version-2.2.0/testing.md
@@ -77,7 +77,7 @@ test('stop in a middle of animation', () => {
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);
-    moveAnimationByTime(250); // if whole animation duration is a 500ms
+    advanceAnimationByTime(250); // if whole animation duration is a 500ms
     style.width = 46.08; // value of component width after 250ms of animation
     expect(view).toHaveAnimatedStyle(style);
   });

--- a/docs/versioned_docs/version-2.3.0/guide/testing.md
+++ b/docs/versioned_docs/version-2.3.0/guide/testing.md
@@ -77,7 +77,7 @@ test('stop in a middle of animation', () => {
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);
-    moveAnimationByTime(250); // if whole animation duration is a 500ms
+    advanceAnimationByTime(250); // if whole animation duration is a 500ms
     style.width = 46.08; // value of component width after 250ms of animation
     expect(view).toHaveAnimatedStyle(style);
   });


### PR DESCRIPTION
## Description

Changed mentions of `moveAnimationByTime` to `advanceAnimationByTime` in code sample (documentation).

## Changes

- replaced `moveAnimationByTime` to `advanceAnimationByTime`

## Test code and steps to reproduce

Try to copy the code from documentation and run it 🙂 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
