### PR TITLE
Make sure style does not regenerate between renders if it is the same.

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -595,9 +595,15 @@ export default function createAnimatedComponent(
         }
       }
       if (!changed) {
-        const lastKeys = Object.keys(this._lastSentStyle);
-        const inputKeys = Object.keys(inputStyle);
-        if (lastKeys.every((k) => inputKeys.includes(k))) {
+        const inputKeys = new Set(Object.keys(inputStyle));
+        let equalKeys = true;
+        for (const key in this._lastSentStyle) {
+          if (!inputKeys.has(key)) {
+            equalKeys = false;
+            break;
+          }
+        }
+        if (equalKeys) {
           return this._lastSentStyle;
         }
       }

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -195,7 +195,7 @@ export default function createAnimatedComponent(
     _isFirstRender = true;
     animatedStyle: { value: StyleProps } = { value: {} };
     initialStyle = {};
-    _lastSentStyle?: StyleProps;
+    _lastSentStyle: StyleProps = {};
     sv: SharedValue<null | Record<string, unknown>> | null;
     _propsAnimated?: PropsAnimated;
     _component: ComponentRef | null = null;
@@ -601,6 +601,7 @@ export default function createAnimatedComponent(
           return this._lastSentStyle;
         }
       }
+      this._lastSentStyle = style;
       return style;
     }
 

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -586,12 +586,12 @@ export default function createAnimatedComponent(
         const value = inputStyle[key];
         if (!hasAnimatedNodes(value)) {
           style[key] = value;
-          changed = changed || style[key] !== this._lastSentStyle?.[key];
+          changed = changed || style[key] !== this._lastSentStyle[key];
         } else if (value instanceof AnimatedValue) {
           // if any style in animated component is set directly to the `Value` we set those styles to the first value of `Value` node in order
           // to avoid flash of default styles when `Value` is being asynchrounously sent via bridge and initialized in the native side.
           style[key] = value._startingValue;
-          changed = changed || style[key] !== this._lastSentStyle?.[key];
+          changed = changed || style[key] !== this._lastSentStyle[key];
         }
       }
       if (!changed) {


### PR DESCRIPTION
## Description
This PR deals with one performance issue generated by creating a new style object on every render.

Any re-rendering of the parent component may make this component to re-render, and it will generate a brand new style property. This calls the re-rendering from the whole tree below this. This can be specially troublesome with components like VirtualizedLists (which have right now performance problems of their own https://github.com/facebook/react-native/pull/31327 ).

## Changes
- Added a new property to store the last sent style of the component.
- Added checks to see if the new resulting style has changed from the last style sent.
- Added another check to make sure any removed variable from the style is also not present in the last sent style.

## Test code and steps to reproduce

Flipper can be used to track the re-renders and the reasons. Any simple three level design should be able to reproduce this error. For example:
```
const Level3 = React.memo(({style}) => (<View style={style} />))
const Level2 = ({style}) => (<Level3 style={style} />)
const AnimatedLevel2 = createAnimatedComponent(View)
const Level1 = () => (<AnimatedLevel2 style={{height:100}} />)
```
If we re-render the Level1, Level3 should not be re-rendered.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
