### PR TITLE
Add react-native-v8 support

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 14)
-set (CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -DON_ANDROID -DONANDROID -DFOR_HERMES=${FOR_HERMES} -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare")
+set (CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -DON_ANDROID -DONANDROID -fexceptions -fno-omit-frame-pointer -frtti -Wno-sign-compare")
 
 if(${NATIVE_DEBUG})
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
@@ -16,10 +16,8 @@ set (PACKAGE_NAME "reanimated")
 set (SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 
 if(${CLIENT_SIDE_BUILD})
-    set (NODE_MODULES_DIR "${CMAKE_SOURCE_DIR}/../../")
     set (COMMON_SRC_DIR "${CMAKE_SOURCE_DIR}/../Common")
 else()
-    set (NODE_MODULES_DIR "../node_modules")
     set (COMMON_SRC_DIR "${SRC_DIR}/main/Common")
 endif()
 
@@ -86,7 +84,6 @@ target_include_directories(
         "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/turbomodule/core"
         "${NODE_MODULES_DIR}/react-native/ReactCommon/turbomodule"
-        "${NODE_MODULES_DIR}/hermes-engine/android/include/"
         "${COMMON_SRC_DIR}/cpp/headers/Tools"
         "${COMMON_SRC_DIR}/cpp/headers/SpecTools"
         "${COMMON_SRC_DIR}/cpp/headers/NativeModules"
@@ -99,25 +96,11 @@ target_include_directories(
 )
 
 # find libraries
-
 file (GLOB LIBRN_DIR "${RN_SO_DIR}/${ANDROID_ABI}")
-file (GLOB HERMES_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
 
 find_library(
         LOG_LIB
         log
-)
-find_library(
-        HERMES_LIB
-        hermes
-        PATHS ${HERMES_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-find_library(
-        JSEXECUTOR_LIB
-        jscexecutor
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
 )
 find_library(
         FOLLY_JSON_LIB
@@ -161,7 +144,20 @@ endif()
 
 set_target_properties(${PACKAGE_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
-if(${FOR_HERMES})
+if(${JS_RUNTIME} STREQUAL "hermes")
+    string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_HERMES=1")
+    target_include_directories(
+            ${PACKAGE_NAME}
+            PRIVATE
+            "${JS_RUNTIME_DIR}/android/include"
+    )
+    file (GLOB HERMES_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
+    find_library(
+            HERMES_LIB
+            hermes
+            PATHS ${HERMES_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
     target_link_libraries(
             ${PACKAGE_NAME}
             ${LOG_LIB}
@@ -173,7 +169,40 @@ if(${FOR_HERMES})
             ${REACT_NATIVE_JNI_LIB}
             android
     )
+elseif(${JS_RUNTIME} STREQUAL "v8")
+    string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_V8=1")
+    target_include_directories(
+            ${PACKAGE_NAME}
+            PRIVATE
+            "${JS_RUNTIME_DIR}/src"
+    )
+    file (GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/*/jni/${ANDROID_ABI}")
+    find_library(
+            V8EXECUTOR_LIB
+            v8executor
+            PATHS ${V8_SO_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
+    target_link_libraries(
+            ${PACKAGE_NAME}
+            ${LOG_LIB}
+            ${JSI_LIB}
+            ${V8EXECUTOR_LIB}
+            ${GLOG_LIB}
+            ${FBJNI_LIB}
+            ${FOLLY_JSON_LIB}
+            ${REACT_NATIVE_JNI_LIB}
+            android
+    )
 else()
+    set (ignoreMe "${JS_RUNTIME_DIR}")
+    string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_JSC=1")
+    find_library(
+            JSEXECUTOR_LIB
+            jscexecutor
+            PATHS ${LIBRN_DIR}
+            NO_CMAKE_FIND_ROOT_PATH
+    )
     target_link_libraries(
             ${PACKAGE_NAME}
             ${LOG_LIB}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,17 +130,20 @@ abstract class replaceSoTask extends DefaultTask {
     }
 }
 
-def detectAAR(minor, engine) {
+def detectAAR(minor, jsRuntime) {
     def rnMinorVersionCopy = Integer.parseInt(minor)
-    def aar = file("react-native-reanimated-${rnMinorVersionCopy}-${engine}.aar")
+    def aar = file("react-native-reanimated-${rnMinorVersionCopy}-${jsRuntime}.aar")
 
     if (aar.exists()) {
         println "AAR for react-native-reanimated has been found\n$aar"
         return aar
+    } else if (jsRuntime == "v8") {
+        // always build from source for v8
+        return null
     } else {
         while (!aar.exists() && rnMinorVersionCopy >= 63) {
             rnMinorVersionCopy -= 1
-            aar = file("react-native-reanimated-${rnMinorVersionCopy}-${engine}.aar")
+            aar = file("react-native-reanimated-${rnMinorVersionCopy}-${jsRuntime}.aar")
         }
 
         if (rnMinorVersionCopy < 63) {
@@ -164,15 +167,19 @@ def detectAAR(minor, engine) {
 }
 
 def detectJsRuntime() {
-    def runtimeType = "jsc"
-    rootProject.getSubprojects().forEach({project ->
-        if (project.plugins.hasPlugin("com.android.application")) {
-            if (project.ext.react.enableHermes) {
-                runtimeType = "hermes"
-            }
-        }
-    })
-    return runtimeType
+    // Returns the js runtime explicitly requested in the environment variable
+    if (System.getenv("JS_RUNTIME")) {
+        return System.getenv("JS_RUNTIME")
+    }
+
+    // Detect js runtime from project setup
+    def defaultRuntimeType = "jsc";
+    def v8Project = rootProject.getSubprojects().find { project -> project.name == "react-native-v8" }
+    if (v8Project != null) {
+        return "v8"
+    }
+    def appProject = rootProject.getSubprojects().find { project -> project.plugins.hasPlugin("com.android.application") }
+    return appProject.ext.react.enableHermes ? "hermes" : defaultRuntimeType
 }
 
 def detectReanimatedConfig() {
@@ -217,8 +224,8 @@ def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.
 def reactNativeVersion = reactNativeManifestAsJson.version as String
 def (major, minor, patch) = reactNativeVersion.tokenize('.')
 def rnMinorVersion = Integer.parseInt(minor)
-def engine = detectJsRuntime()
-def aar = detectAAR(minor, engine)
+def JS_RUNTIME = detectJsRuntime()
+def aar = detectAAR(minor, JS_RUNTIME)
 boolean BUILD_FROM_SOURCE = shouldBuildFromSource(aar)
 
 def getTaskByPath(project, String appName, String secondPart, String flavorString, String lastPart) {
@@ -309,13 +316,6 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeThirdParty = new File("$reactNative/ReactAndroid/src/main/jni/third-party")
 
 def _stackProtectorFlag = true
-def FOR_HERMES = ""
-
-if (findProject(":app")) {
-    FOR_HERMES = project(":app").ext.react.enableHermes;
-} else {
-    FOR_HERMES = System.getenv("FOR_HERMES") == "True";
-}
 
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
@@ -341,6 +341,20 @@ def follyReplaceContent = '''
   } while (r == -1 && errno == EINTR);
   return r;
 '''
+
+def nodeModulesDir = CLIENT_SIDE_BUILD
+    ? project.getProjectDir().getParentFile().getParent()
+    : Paths.get(project.getProjectDir().getParent(), "node_modules").toString()
+
+def jsRuntimeDir = {
+    if (JS_RUNTIME == "hermes") {
+        return Paths.get(nodeModulesDir, "hermes-engine")
+    } else if (JS_RUNTIME == "v8") {
+        return findProject(":react-native-v8").getProjectDir().getParent()
+    } else {
+        return Paths.get(nodeModulesDir, "react-native", "ReactCommon", "jsi")
+    }
+}.call()
 
 buildscript {
     repositories {
@@ -380,7 +394,9 @@ android {
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DBOOST_VERSION=${BOOST_VERSION}",
                         "-DBUILD_DIR=${buildDir}",
-                        "-DFOR_HERMES=${FOR_HERMES}",
+                        "-DNODE_MODULES_DIR=${nodeModulesDir}",
+                        "-DJS_RUNTIME=${JS_RUNTIME}",
+                        "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",
                         "--clean-first"
                 abiFilters (*reactNativeArchitectures())
@@ -702,6 +718,15 @@ afterEvaluate {
     nativeBuildDependsOn(prepareThirdPartyNdkHeaders)
     nativeBuildDependsOn(extractAARHeaders)
     nativeBuildDependsOn(extractSOFiles)
+
+    if (JS_RUNTIME == "v8") {
+        def buildTasks = tasks.findAll({ task ->
+            !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake") || task.name.startsWith("generateJsonModel")) })
+        buildTasks.forEach { task ->
+            def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
+            task.dependsOn(":react-native-v8:copy${buildType}JniLibsProjectOnly")
+        }
+    }
 }
 
 if (CLIENT_SIDE_BUILD) {

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -7,8 +7,10 @@
 #include <memory>
 #include <string>
 
-#if FOR_HERMES
+#if JS_RUNTIME_HERMES
 #include <hermes/hermes.h>
+#elif JS_RUNTIME_V8
+#include <v8runtime/V8RuntimeFactory.h>
 #else
 #include <jsi/JSCRuntime.h>
 #endif
@@ -129,11 +131,16 @@ void NativeProxy::installJSIBindings() {
   auto setGestureStateFunction = [this](int handlerTag, int newState) -> void {
     setGestureState(handlerTag, newState);
   };
-#if FOR_HERMES
+#if JS_RUNTIME_HERMES
   auto config =
       ::hermes::vm::RuntimeConfig::Builder().withEnableSampleProfiling(false);
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::hermes::makeHermesRuntime(config.build());
+#elif JS_RUNTIME_V8
+  rnv8::V8RuntimeConfig config;
+  config.enableInspector = false;
+  config.appName = "reanimated";
+  std::shared_ptr<jsi::Runtime> animatedRuntime = rnv8::createV8Runtime(config);
 #else
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();

--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -12,13 +12,9 @@ version_name=("68" "67" "66" "65" "64")
 for index in {0..4}
 do
   yarn add react-native@"${versions[$index]}"
-  for for_hermes in "True" "False"
+  for js_runtime in "hermes" "jsc"
   do
-    engine="jsc"
-    if [ "$for_hermes" == "True" ]; then
-      engine="hermes"
-    fi
-    echo "engine=${engine}"
+    echo "js_runtime=${js_runtime}"
 
     cd android 
 
@@ -43,7 +39,7 @@ do
 
     ./gradlew clean
 
-    CLIENT_SIDE_BUILD="False" FOR_HERMES=${for_hermes} ./gradlew :assembleDebug --no-build-cache --rerun-tasks
+    CLIENT_SIDE_BUILD="False" JS_RUNTIME=${js_runtime} ./gradlew :assembleDebug --no-build-cache --rerun-tasks
 
     cd ./rnVersionPatch/$versionNumber
     if [ $(find . | grep 'java') ];
@@ -60,8 +56,8 @@ do
 
     cd $ROOT
 
-    rm -rf android/react-native-reanimated-"${version_name[$index]}-${engine}".aar
-    cp android/build/outputs/aar/*.aar android/react-native-reanimated-"${version_name[$index]}-${engine}".aar
+    rm -rf android/react-native-reanimated-"${version_name[$index]}-${js_runtime}".aar
+    cp android/build/outputs/aar/*.aar android/react-native-reanimated-"${version_name[$index]}-${js_runtime}".aar
   done
 done
 


### PR DESCRIPTION
## Description

Add react-native-v8 support. Fixes #1897

## Changes

- modify `FOR_HERMES: boolean` to `JS_RUNTIME = "hermes" | "jsc" | "v8"` in build scripts.
- in android `NativeProxy.cpp`, will have `JS_RUNTIME_HERMES=1`, `JS_RUNTIME_V8=1` or `JS_RUNTIME_JSC=1` to make preprocessor easier to support three different js runtimes.
- to save reanimated published npm package size, this pr does not prebuild aar for v8 support.

## Test code and steps to reproduce

local package built from `createNPMPackage.sh`
- ✅ react-native 0.67 + jsc + prebuilt reanimated aar
- ✅ react-native 0.67 + hermes + prebuilt reanimated aar
- ✅ react-native 0.67 + jsc + building reanimated from source (remove `node_modules/react-native-reanimated/android/*.aar`)
- ✅ react-native 0.67 + hermes + building reanimated from source (remove `node_modules/react-native-reanimated/android/*.aar`)
- ✅ react-native 0.67 + react-native-v8 + building reanimated from source

detailed steps to test v8 projects:

- `npx react-native init TestApp`
- install react-native-v8 from [the steps](https://github.com/Kudo/react-native-v8#installation-for-react-native--066). alternatively, i personally use [this automation script](https://github.com/Kudo/react-native-v8/tree/main/scripts) 😁
- `yarn add file:/path/to/local-build-react-native-reanimated.tgz` (from `createNPMPackage.sh`)
- modify `babel.config.js` for reanimated.
- `yarn android`

let me know if a minimal v8 example is preferred. i can prepare one if needed.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
