### PR TITLE
Remove `opacity` from native props list

### DIFF
--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -78,7 +78,6 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
   borderTopLeftRadius: true,
   borderTopRightRadius: true,
   borderTopStartRadius: true,
-  opacity: true,
   elevation: true,
   fontSize: true,
   lineHeight: true,


### PR DESCRIPTION
## Description

Currently, `opacity` prop is listed both in `UI_THREAD_PROPS_WHITELIST` and `NATIVE_THREAD_PROPS_WHITELIST`. However, when splitting props into three groups (namely: UI props, native props and JS props), we always search in the UI props set first, so effectively `opacity` is always animated like a UI prop (which is the expected behaviour). Nevertheless, we would like to avoid confusion by keeping these two sets disjoint, so this PR removes `opacity` from `NATIVE_THREAD_PROPS_WHITELIST`.

## Changes

- Removed `opacity` from native props list

## Test code and steps to reproduce

1. Launch Example app
1. Open Olympic animation demo
1. See if opacity is properly animated

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
