### PR TITLE
Remove `__reanimatedWorkletInit` function and `__worklet` property

### DIFF
--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -64,7 +64,7 @@ void ShareableValue::adapt(
       jsi::Object hiddenProperty = hiddenValue.asObject(rt);
       if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
         type = ValueType::FrozenObjectType;
-        if (object.hasProperty(rt, "__worklet") && object.isFunction(rt)) {
+        if (object.hasProperty(rt, "__workletHash") && object.isFunction(rt)) {
           type = ValueType::WorkletFunctionType;
         }
         valueContainer = std::make_unique<FrozenObjectWrapper>(
@@ -99,7 +99,7 @@ void ShareableValue::adapt(
   } else if (value.isObject()) {
     auto object = value.asObject(rt);
     if (object.isFunction(rt)) {
-      if (object.getProperty(rt, "__worklet").isUndefined()) {
+      if (object.getProperty(rt, "__workletHash").isUndefined()) {
         // not a worklet, we treat this as a host function
         type = ValueType::HostFunctionType;
         containsHostFunction = true;

--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -31,20 +31,6 @@ void RuntimeDecorator::decorateRuntime(
       rt, "_LABEL", jsi::String::createFromAscii(rt, label));
 
   jsi::Object dummyGlobal(rt);
-  auto dummyFunction = [](jsi::Runtime &rt,
-                          const jsi::Value &thisValue,
-                          const jsi::Value *args,
-                          size_t count) -> jsi::Value {
-    return jsi::Value::undefined();
-  };
-  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(
-      rt,
-      jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"),
-      1,
-      dummyFunction);
-
-  dummyGlobal.setProperty(
-      rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
 
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -22,7 +22,6 @@ var f = function () {
   _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
   _f.__workletHash = 10184269015616;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -37,7 +36,6 @@ exports[`babel plugin doesn't capture globals 1`] = `
   _f.asString = \\"function f(){console.log('test');}\\";
   _f.__workletHash = 13298016111221;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -59,7 +57,6 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   _f.asString = \\"function foo(x){const bar='worklet';const baz=\\\\\\"worklet\\\\\\";}\\";
   _f.__workletHash = 9810417751380;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -89,7 +86,6 @@ function Box() {
     _f.__workletHash = 7114514849439;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (10:48)\\";
     _f.__optimalization = 3;
-    _f.__worklet = true;
     return _f;
   }());
   return React.createElement(React.Fragment, null, React.createElement(_reactNativeReanimated.default.View, {
@@ -114,7 +110,6 @@ exports[`babel plugin transforms spread operator in worklets for arrays 1`] = `
   _f.asString = \\"function foo(){const bar=[4,5];const baz=[1,...[2,3],...bar];}\\";
   _f.__workletHash = 3161057533258;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -133,7 +128,6 @@ exports[`babel plugin transforms spread operator in worklets for function argume
   _f.asString = \\"function foo(...args){console.log(args);}\\";
   _f.__workletHash = 9866931756941;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -154,7 +148,6 @@ var foo = function () {
   _f.asString = \\"function foo(arg){console.log(...arg);}\\";
   _f.__workletHash = 2015887751437;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -182,7 +175,6 @@ var foo = function () {
   _f.asString = \\"function foo(){const bar={d:4,e:5};const baz={a:1,...{b:2,c:3},...bar};}\\";
   _f.__workletHash = 792186851025;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -197,7 +189,6 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   _f.asString = \\"function _f(x){return x+2;}\\";
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -212,7 +203,6 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   _f.asString = \\"function foo(x){return x+2;}\\";
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -242,7 +232,6 @@ var Foo = function () {
       _f.asString = \\"function get(){const{x}=jsThis._closure;{return x+2;}}\\";
       _f.__workletHash = 2468276954688;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -263,7 +252,6 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -281,7 +269,6 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   _f.__workletHash = 6275510763626;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -299,7 +286,6 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -327,7 +313,6 @@ var Foo = function () {
       _f.asString = \\"function bar(x){return x+2;}\\";
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -345,7 +330,6 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   _f.asString = \\"function foo(x){return x+2;}\\";
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -361,7 +345,6 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
     _f.asString = \\"function _f(event){console.log(event);}\\";
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -378,7 +361,6 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
     _f.asString = \\"function onStart(event){console.log(event);}\\";
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:8)\\";
-    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -395,7 +377,6 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
     _f.asString = \\"function onStart(event){console.log(event);}\\";
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -412,7 +393,6 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
     _f.asString = \\"function _f(event){console.log(event);}\\";
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -430,7 +410,6 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(){console.log('onBegin');}\\";
   _f.__workletHash = 13662490049850;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
-  _f.__worklet = true;
   return _f;
 }()).onStart(function () {
   var _f = function _f(_event) {
@@ -441,7 +420,6 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(_event){console.log('onStart');}\\";
   _f.__workletHash = 16334902412526;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (9:17)\\";
-  _f.__worklet = true;
   return _f;
 }()).onEnd(function () {
   var _f = function _f(_event, _success) {
@@ -452,7 +430,6 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(_event,_success){console.log('onEnd');}\\";
   _f.__workletHash = 4053780716017;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (12:15)\\";
-  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -480,7 +457,6 @@ var Foo = function () {
       _f.asString = \\"function bar(x){return x+2;}\\";
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -498,7 +474,6 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   _f.asString = \\"function _f(x){return x+2;}\\";
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-  _f.__worklet = true;
   return _f;
 }();"
 `;

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -22,9 +22,7 @@ var f = function () {
   _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
   _f.__workletHash = 10184269015616;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:6)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -39,9 +37,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   _f.asString = \\"function f(){console.log('test');}\\";
   _f.__workletHash = 13298016111221;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -63,9 +59,7 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   _f.asString = \\"function foo(x){const bar='worklet';const baz=\\\\\\"worklet\\\\\\";}\\";
   _f.__workletHash = 9810417751380;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -95,9 +89,7 @@ function Box() {
     _f.__workletHash = 7114514849439;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (10:48)\\";
     _f.__optimalization = 3;
-
-    global.__reanimatedWorkletInit(_f);
-
+    _f.__worklet = true;
     return _f;
   }());
   return React.createElement(React.Fragment, null, React.createElement(_reactNativeReanimated.default.View, {
@@ -121,9 +113,7 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   _f.asString = \\"function _f(x){return x+2;}\\";
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -138,9 +128,7 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   _f.asString = \\"function foo(x){return x+2;}\\";
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -170,9 +158,7 @@ var Foo = function () {
       _f.asString = \\"function get(){const{x}=jsThis._closure;{return x+2;}}\\";
       _f.__workletHash = 2468276954688;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-
-      global.__reanimatedWorkletInit(_f);
-
+      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -193,9 +179,7 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -213,9 +197,7 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   _f.__workletHash = 6275510763626;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -233,9 +215,7 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -263,9 +243,7 @@ var Foo = function () {
       _f.asString = \\"function bar(x){return x+2;}\\";
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-
-      global.__reanimatedWorkletInit(_f);
-
+      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -283,9 +261,7 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   _f.asString = \\"function foo(x){return x+2;}\\";
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;
@@ -301,9 +277,7 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
     _f.asString = \\"function _f(event){console.log(event);}\\";
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-
-    global.__reanimatedWorkletInit(_f);
-
+    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -320,9 +294,7 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
     _f.asString = \\"function onStart(event){console.log(event);}\\";
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:8)\\";
-
-    global.__reanimatedWorkletInit(_f);
-
+    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -339,9 +311,7 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
     _f.asString = \\"function onStart(event){console.log(event);}\\";
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-
-    global.__reanimatedWorkletInit(_f);
-
+    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -358,9 +328,7 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
     _f.asString = \\"function _f(event){console.log(event);}\\";
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
-
-    global.__reanimatedWorkletInit(_f);
-
+    _f.__worklet = true;
     return _f;
   }()
 });"
@@ -378,9 +346,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(){console.log('onBegin');}\\";
   _f.__workletHash = 13662490049850;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }()).onStart(function () {
   var _f = function _f(_event) {
@@ -391,9 +357,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(_event){console.log('onStart');}\\";
   _f.__workletHash = 16334902412526;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (9:17)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }()).onEnd(function () {
   var _f = function _f(_event, _success) {
@@ -404,9 +368,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.asString = \\"function _f(_event,_success){console.log('onEnd');}\\";
   _f.__workletHash = 4053780716017;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (12:15)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }());"
 `;
@@ -434,9 +396,7 @@ var Foo = function () {
       _f.asString = \\"function bar(x){return x+2;}\\";
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
-
-      global.__reanimatedWorkletInit(_f);
-
+      _f.__worklet = true;
       return _f;
     }()
   }]);
@@ -454,9 +414,7 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   _f.asString = \\"function _f(x){return x+2;}\\";
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
-
-  global.__reanimatedWorkletInit(_f);
-
+  _f.__worklet = true;
   return _f;
 }();"
 `;

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -103,6 +103,90 @@ function Box() {
 }"
 `;
 
+exports[`babel plugin transforms spread operator in worklets for arrays 1`] = `
+"var foo = function () {
+  var _f = function _f() {
+    var bar = [4, 5];
+    var baz = [1].concat([2, 3], bar);
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function foo(){const bar=[4,5];const baz=[1,...[2,3],...bar];}\\";
+  _f.__workletHash = 3161057533258;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
+  _f.__worklet = true;
+  return _f;
+}();"
+`;
+
+exports[`babel plugin transforms spread operator in worklets for function arguments 1`] = `
+"var foo = function () {
+  var _f = function _f() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    console.log(args);
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function foo(...args){console.log(args);}\\";
+  _f.__workletHash = 9866931756941;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
+  _f.__worklet = true;
+  return _f;
+}();"
+`;
+
+exports[`babel plugin transforms spread operator in worklets for function calls 1`] = `
+"var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+var _toConsumableArray2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/toConsumableArray\\"));
+
+var foo = function () {
+  var _f = function _f(arg) {
+    var _console;
+
+    (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function foo(arg){console.log(...arg);}\\";
+  _f.__workletHash = 2015887751437;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
+  _f.__worklet = true;
+  return _f;
+}();"
+`;
+
+exports[`babel plugin transforms spread operator in worklets for objects 1`] = `
+"var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+var _extends2 = _interopRequireDefault(require(\\"@babel/runtime/helpers/extends\\"));
+
+var foo = function () {
+  var _f = function _f() {
+    var bar = {
+      d: 4,
+      e: 5
+    };
+    var baz = (0, _extends2.default)({
+      a: 1
+    }, {
+      b: 2,
+      c: 3
+    }, {}, bar);
+  };
+
+  _f._closure = {};
+  _f.asString = \\"function foo(){const bar={d:4,e:5};const baz={a:1,...{b:2,c:3},...bar};}\\";
+  _f.__workletHash = 792186851025;
+  _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
+  _f.__worklet = true;
+  return _f;
+}();"
+`;
+
 exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
 "var foo = function () {
   var _f = function _f(x) {

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -75,7 +75,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).not.toContain('_f.__worklet = true;');
+    expect(code).not.toContain('_f.__workletHash');
   });
 
   it('removes comments from worklets', () => {
@@ -183,7 +183,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -197,7 +197,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -211,7 +211,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -225,7 +225,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -243,7 +243,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -259,7 +259,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -275,7 +275,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -290,7 +290,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -304,7 +304,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -318,7 +318,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -334,7 +334,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -348,7 +348,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -362,7 +362,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -376,7 +376,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('_f.__worklet = true;');
+    expect(code).toContain('_f.__workletHash');
     expect(code).toMatchSnapshot();
   });
 
@@ -398,7 +398,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toMatch(/^(.*)(_f\.__worklet = true;(.*)){3}$/s);
+    expect(code).toMatch(/^(.*)(_f\.__workletHash(.*)){3}$/s);
   });
 
   // React Native Gesture Handler

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -75,7 +75,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).not.toContain('__reanimatedWorkletInit');
+    expect(code).not.toContain('_f.__worklet = true;');
   });
 
   it('removes comments from worklets', () => {
@@ -183,7 +183,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -197,7 +197,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -211,7 +211,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -225,7 +225,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -243,7 +243,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -259,7 +259,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -275,7 +275,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).not.toContain('\\"worklet\\";');
     expect(code).toMatchSnapshot();
   });
@@ -290,7 +290,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -304,7 +304,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -318,7 +318,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -334,7 +334,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -348,7 +348,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -362,7 +362,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -376,7 +376,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toContain('__reanimatedWorkletInit');
+    expect(code).toContain('_f.__worklet = true;');
     expect(code).toMatchSnapshot();
   });
 
@@ -398,7 +398,7 @@ describe('babel plugin', () => {
     `;
 
     const { code } = runPlugin(input);
-    expect(code).toMatch(/^(.*)(__reanimatedWorkletInit(.*)){3}$/s);
+    expect(code).toMatch(/^(.*)(_f\.__worklet = true;(.*)){3}$/s);
   });
 
   // React Native Gesture Handler

--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -434,4 +434,54 @@ describe('babel plugin', () => {
     const { code } = runPlugin(input);
     expect(code).toMatchSnapshot();
   });
+
+  it('transforms spread operator in worklets for arrays', () => {
+    const input = `
+      function foo() {
+        'worklet';
+        const bar = [4, 5];
+        const baz = [1, ...[2, 3], ...bar];
+      }
+    `;
+
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
+
+  it('transforms spread operator in worklets for objects', () => {
+    const input = `
+      function foo() {
+        'worklet';
+        const bar = {d: 4, e: 5};
+        const baz = { a: 1, ...{ b: 2, c: 3 }, ...bar };
+      }
+    `;
+
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
+
+  it('transforms spread operator in worklets for function arguments', () => {
+    const input = `
+      function foo(...args) {
+        'worklet';
+        console.log(args);
+      }
+    `;
+
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
+
+  it('transforms spread operator in worklets for function calls', () => {
+    const input = `
+      function foo(arg) {
+        'worklet';
+        console.log(...arg);
+      }
+    `;
+
+    const { code } = runPlugin(input);
+    expect(code).toMatchSnapshot();
+  });
 });

--- a/plugin.js
+++ b/plugin.js
@@ -513,16 +513,18 @@ function makeWorklet(t, fun, fileName) {
 
   statements.push(
     t.expressionStatement(
-      t.callExpression(
+      t.assignmentExpression(
+        '=',
         t.memberExpression(
-          t.identifier('global'),
-          t.identifier('__reanimatedWorkletInit'),
+          t.identifier('_f'),
+          t.identifier('__worklet'),
           false
         ),
-        [privateFunctionId]
+        t.booleanLiteral(true)
       )
     )
   );
+  // TODO: fix spread (inline _toConsumableArray and _mergeObjectsReanimated)
   statements.push(t.returnStatement(privateFunctionId));
 
   const newFun = t.functionExpression(fun.id, [], t.blockStatement(statements));

--- a/plugin.js
+++ b/plugin.js
@@ -524,7 +524,7 @@ function makeWorklet(t, fun, fileName) {
       )
     )
   );
-  // TODO: fix spread (inline _toConsumableArray and _mergeObjectsReanimated)
+
   statements.push(t.returnStatement(privateFunctionId));
 
   const newFun = t.functionExpression(fun.id, [], t.blockStatement(statements));

--- a/plugin.js
+++ b/plugin.js
@@ -511,20 +511,6 @@ function makeWorklet(t, fun, fileName) {
     );
   }
 
-  statements.push(
-    t.expressionStatement(
-      t.assignmentExpression(
-        '=',
-        t.memberExpression(
-          t.identifier('_f'),
-          t.identifier('__worklet'),
-          false
-        ),
-        t.booleanLiteral(true)
-      )
-    )
-  );
-
   statements.push(t.returnStatement(privateFunctionId));
 
   const newFun = t.functionExpression(fun.id, [], t.blockStatement(statements));

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -312,7 +312,7 @@ function createChecker(
     }
     // @ts-ignore this is implicitly any - TODO
     const res = worklet.apply(this, arguments);
-    if (!_WORKLET && res && typeof res === 'function' && res.__worklet) {
+    if (!_WORKLET && res && typeof res === 'function' && res.__workletHash) {
       return createChecker(res, workletName, arguments);
     }
     return res;

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -51,7 +51,6 @@ export interface WorkletFunction {
   _closure?: Context;
   __workletHash?: number;
   __optimalization?: number;
-  __worklet?: boolean;
 }
 
 export interface BasicWorkletFunction<T> extends WorkletFunction {

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -4,7 +4,6 @@ import { Platform } from 'react-native';
 import { nativeShouldBeMock, shouldBeUseWeb, isWeb } from './PlatformChecker';
 import {
   BasicWorkletFunction,
-  WorkletFunction,
   ComplexWorkletFunction,
   SharedValue,
   AnimationObject,
@@ -13,10 +12,6 @@ import {
 } from './commonTypes';
 import { Descriptor } from './hook/commonTypes';
 import JSReanimated from './js-reanimated/JSReanimated';
-
-global.__reanimatedWorkletInit = function (worklet: WorkletFunction) {
-  worklet.__worklet = true;
-};
 
 if (global._setGlobalConsole === undefined) {
   // it can happen when Reanimated plugin wasn't added, but the user uses the only API from version 1
@@ -71,48 +66,6 @@ export const isConfiguredCheck: () => void = () => {
     throw new Error(
       'If you want to use Reanimated 2 then go through our installation steps https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation'
     );
-  }
-};
-
-function _toArrayReanimated<T>(object: Iterable<T> | ArrayLike<T> | T[]): T[] {
-  'worklet';
-  if (Array.isArray(object)) {
-    return object;
-  }
-  if (
-    typeof Symbol !== 'undefined' &&
-    (typeof Symbol === 'function' ? Symbol.iterator : '@@iterator') in
-      Object(object)
-  ) {
-    return Array.from(object);
-  }
-  throw new Error(
-    'Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.'
-  );
-}
-
-function _mergeObjectsReanimated(): unknown {
-  'worklet';
-  // we can't use rest parameters in worklets at the moment
-  // eslint-disable-next-line prefer-rest-params
-  const arr = Array.from(arguments);
-  return Object.assign.apply(null, [arr[0], ...arr.slice(1)]);
-}
-
-global.__reanimatedWorkletInit = function (worklet: WorkletFunction) {
-  worklet.__worklet = true;
-
-  if (worklet._closure) {
-    const closure = worklet._closure;
-    Object.keys(closure).forEach((key) => {
-      if (key === '_toConsumableArray') {
-        closure[key] = _toArrayReanimated;
-      }
-
-      if (key === '_objectSpread') {
-        closure[key] = _mergeObjectsReanimated;
-      }
-    });
   }
 };
 

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,4 +1,4 @@
-import { AnimatedStyle, StyleProps, WorkletFunction } from './commonTypes';
+import { AnimatedStyle, StyleProps } from './commonTypes';
 import { ReanimatedConsole } from './core';
 import { MeasuredDimensions } from './NativeMethods';
 import { NativeReanimated } from './NativeReanimated/NativeReanimated';
@@ -32,7 +32,6 @@ declare global {
   };
   namespace NodeJS {
     interface Global {
-      __reanimatedWorkletInit: (worklet: WorkletFunction) => void;
       _setGlobalConsole: (console?: ReanimatedConsole) => void;
       _log: (s: string) => void;
       _setGestureState: () => void;


### PR DESCRIPTION
## Description

This PR removes `__reanimatedWorkletInit` function as well as `__worklet` property in favor of checking for existence of `__workletHash` property.

Additionally, in the past we've had some problems related to using spread operator in worklets (see #1453). However, this seems to work fine now thanks to the fact that we use `transformSync` to apply other plugins before workletization (in particular, stringification). Check out the attached test example. By the way, spread operator is allowed in `_f.asString` (I've confirmed that by running the unit tests on the main branch).

## Changes

- Removed `__reanimatedWorkletInit` function

## Test code and steps to reproduce

```tsx
import { Button, StyleSheet, View } from 'react-native';

import React from 'react';
import { runOnUI } from 'react-native-reanimated';

function worklet() {
  'worklet';

  const arr = [2, ...[3, 4]];
  console.log(1, ...arr, 5);

  const obj = { b: 2, ...{ c: 3, d: 4 } };
  console.log({ a: 1, ...obj, e: 5 });

  const func = (...args: number[]) => console.log(args);
  func(1, ...[2, 3, 4], 5);
}

export default function WorkletSpreadExample() {
  return (
    <View style={styles.container}>
      <Button title="Run worklet" onPress={() => runOnUI(worklet)()} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

## Checklist

- [x] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [x] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
