### PR TITLE
Use angle bracket imports

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REASnapshot.h>
 #import <React/RCTUIManager.h>
-#import "REASnapshot.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -1,9 +1,9 @@
-#import "REAAnimationsManager.h"
+#import <RNReanimated/REAAnimationsManager.h>
+#import <RNReanimated/REAUIManager.h>
 #import <React/RCTComponentData.h>
 #import <React/RCTTextView.h>
 #import <React/UIView+Private.h>
 #import <React/UIView+React.h>
-#import "REAUIManager.h"
 
 @interface REAAnimationsManager ()
 

--- a/ios/LayoutReanimation/REASnapshot.m
+++ b/ios/LayoutReanimation/REASnapshot.m
@@ -1,5 +1,5 @@
-#import "REASnapshot.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REASnapshot.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/LayoutReanimation/REAUIManager.h
+++ b/ios/LayoutReanimation/REAUIManager.h
@@ -1,7 +1,7 @@
+#import <RNReanimated/REAAnimationsManager.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDefines.h>
 #import <React/RCTUIManager.h>
-#import "REAAnimationsManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -1,8 +1,8 @@
-#import "REAUIManager.h"
 #import <Foundation/Foundation.h>
-#include "FeaturesConfig.h"
-#import "REAIOSScheduler.h"
-#include "Scheduler.h"
+#import <RNReanimated/FeaturesConfig.h>
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/Scheduler.h>
 
 #import <React/RCTComponentData.h>
 #import <React/RCTLayoutAnimation.h>

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -3,7 +3,6 @@
 #import <RNReanimated/REAIOSScheduler.h>
 #import <RNReanimated/REAUIManager.h>
 #import <RNReanimated/Scheduler.h>
-
 #import <React/RCTComponentData.h>
 #import <React/RCTLayoutAnimation.h>
 #import <React/RCTLayoutAnimationGroup.h>

--- a/ios/Nodes/REAAlwaysNode.h
+++ b/ios/Nodes/REAAlwaysNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAAlwaysNode : REANode <REAFinalNode>
 @end

--- a/ios/Nodes/REAAlwaysNode.m
+++ b/ios/Nodes/REAAlwaysNode.m
@@ -1,11 +1,11 @@
-#import "REAAlwaysNode.h"
+#import <RNReanimated/REAAlwaysNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAStyleNode.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAStyleNode.h"
-#import "REAUtils.h"
 
 @implementation REAAlwaysNode {
   NSNumber *_nodeToBeEvaluated;

--- a/ios/Nodes/REABezierNode.h
+++ b/ios/Nodes/REABezierNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REABezierNode : REANode
 

--- a/ios/Nodes/REABezierNode.m
+++ b/ios/Nodes/REABezierNode.m
@@ -1,10 +1,9 @@
-#include <tgmath.h>
-
 #import <RNReanimated/REABezierNode.h>
 #import <RNReanimated/REANodesManager.h>
 #import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
+#include <tgmath.h>
 
 #define EPS 1e-5
 

--- a/ios/Nodes/REABezierNode.m
+++ b/ios/Nodes/REABezierNode.m
@@ -1,10 +1,10 @@
 #include <tgmath.h>
 
+#import <RNReanimated/REABezierNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REABezierNode.h"
-#import "REANodesManager.h"
-#import "REAUtils.h"
 
 #define EPS 1e-5
 

--- a/ios/Nodes/REABlockNode.h
+++ b/ios/Nodes/REABlockNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REABlockNode : REANode
 

--- a/ios/Nodes/REABlockNode.m
+++ b/ios/Nodes/REABlockNode.m
@@ -1,5 +1,5 @@
-#import "REABlockNode.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REABlockNode.h>
+#import <RNReanimated/REANodesManager.h>
 
 @implementation REABlockNode {
   NSArray<NSNumber *> *_block;

--- a/ios/Nodes/REACallFuncNode.h
+++ b/ios/Nodes/REACallFuncNode.h
@@ -1,5 +1,5 @@
 
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REACallFuncNode : REANode
 

--- a/ios/Nodes/REACallFuncNode.m
+++ b/ios/Nodes/REACallFuncNode.m
@@ -1,10 +1,10 @@
 
 
-#import "REACallFuncNode.h"
-#import "REAFunctionNode.h"
-#import "REANodesManager.h"
-#import "REAParamNode.h"
-#import "REAUtils.h"
+#import <RNReanimated/REACallFuncNode.h>
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAUtils.h>
 
 @implementation REACallFuncNode {
   NSNumber *_whatNodeID;

--- a/ios/Nodes/REAClockNodes.h
+++ b/ios/Nodes/REAClockNodes.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAClockNode : REANode
 @property (nonatomic, readonly) BOOL isRunning;

--- a/ios/Nodes/REAClockNodes.m
+++ b/ios/Nodes/REAClockNodes.m
@@ -1,9 +1,9 @@
-#import "REAClockNodes.h"
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAParamNode.h"
-#import "REAUtils.h"
 
 @interface REAClockNode ()
 

--- a/ios/Nodes/REAConcatNode.h
+++ b/ios/Nodes/REAConcatNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAConcatNode : REANode
 

--- a/ios/Nodes/REAConcatNode.m
+++ b/ios/Nodes/REAConcatNode.m
@@ -1,6 +1,6 @@
-#import "REAConcatNode.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAConcatNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAConcatNode {
   NSArray<NSNumber *> *_input;

--- a/ios/Nodes/REACondNode.h
+++ b/ios/Nodes/REACondNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REACondNode : REANode
 

--- a/ios/Nodes/REACondNode.m
+++ b/ios/Nodes/REACondNode.m
@@ -1,8 +1,8 @@
-#import "REACondNode.h"
+#import <RNReanimated/REACondNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
 
 @implementation REACondNode {
   NSNumber *_condNodeID;

--- a/ios/Nodes/READebugNode.h
+++ b/ios/Nodes/READebugNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface READebugNode : REANode
 

--- a/ios/Nodes/READebugNode.m
+++ b/ios/Nodes/READebugNode.m
@@ -1,8 +1,8 @@
-#import "READebugNode.h"
+#import <RNReanimated/READebugNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
 
 @implementation READebugNode {
   NSNumber *_valueNodeID;

--- a/ios/Nodes/REAEventNode.h
+++ b/ios/Nodes/REAEventNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 #import <React/RCTEventDispatcher.h>
 

--- a/ios/Nodes/REAEventNode.h
+++ b/ios/Nodes/REAEventNode.h
@@ -1,5 +1,4 @@
 #import <RNReanimated/REANode.h>
-
 #import <React/RCTEventDispatcher.h>
 
 @interface REAEventNode : REANode

--- a/ios/Nodes/REAEventNode.m
+++ b/ios/Nodes/REAEventNode.m
@@ -1,6 +1,6 @@
-#import "REAEventNode.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAEventNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAEventNode {
   NSArray *_argMapping;

--- a/ios/Nodes/REAFunctionNode.h
+++ b/ios/Nodes/REAFunctionNode.h
@@ -1,5 +1,5 @@
 
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAFunctionNode : REANode
 

--- a/ios/Nodes/REAFunctionNode.m
+++ b/ios/Nodes/REAFunctionNode.m
@@ -1,7 +1,7 @@
 
-#import "REAFunctionNode.h"
-#import "REANodesManager.h"
-#import "REAParamNode.h"
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
 
 @implementation REAFunctionNode {
   NSNumber *_nodeToBeEvaluated;

--- a/ios/Nodes/REAJSCallNode.h
+++ b/ios/Nodes/REAJSCallNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAJSCallNode : REANode
 

--- a/ios/Nodes/REAJSCallNode.m
+++ b/ios/Nodes/REAJSCallNode.m
@@ -1,6 +1,6 @@
-#import "REAJSCallNode.h"
-#import "REAModule.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REAJSCallNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
 
 @implementation REAJSCallNode {
   NSArray<NSNumber *> *_input;

--- a/ios/Nodes/REANode.m
+++ b/ios/Nodes/REANode.m
@@ -1,5 +1,5 @@
-#import "REANode.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REANode.h>
+#import <RNReanimated/REANodesManager.h>
 
 #import <React/RCTDefines.h>
 

--- a/ios/Nodes/REAOperatorNode.h
+++ b/ios/Nodes/REAOperatorNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAOperatorNode : REANode
 

--- a/ios/Nodes/REAOperatorNode.m
+++ b/ios/Nodes/REAOperatorNode.m
@@ -1,7 +1,7 @@
 #include <tgmath.h>
 
-#import "REANodesManager.h"
-#import "REAOperatorNode.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAOperatorNode.h>
 
 typedef id (^REAOperatorBlock)(NSArray<REANode *> *inputNodes);
 

--- a/ios/Nodes/REAOperatorNode.m
+++ b/ios/Nodes/REAOperatorNode.m
@@ -1,7 +1,6 @@
-#include <tgmath.h>
-
 #import <RNReanimated/REANodesManager.h>
 #import <RNReanimated/REAOperatorNode.h>
+#include <tgmath.h>
 
 typedef id (^REAOperatorBlock)(NSArray<REANode *> *inputNodes);
 

--- a/ios/Nodes/REAParamNode.h
+++ b/ios/Nodes/REAParamNode.h
@@ -1,4 +1,4 @@
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @interface REAParamNode : REAValueNode
 

--- a/ios/Nodes/REAParamNode.m
+++ b/ios/Nodes/REAParamNode.m
@@ -1,7 +1,7 @@
-#import "REAParamNode.h"
-#import "REAClockNodes.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAParamNode {
   NSMutableArray<REANodeID> *_argstack;

--- a/ios/Nodes/REAPropsNode.h
+++ b/ios/Nodes/REAPropsNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAPropsNode : REANode <REAFinalNode>
 

--- a/ios/Nodes/REAPropsNode.m
+++ b/ios/Nodes/REAPropsNode.m
@@ -1,8 +1,8 @@
-#import "REAPropsNode.h"
+#import <RNReanimated/REAPropsNode.h>
 
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAStyleNode.h"
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAStyleNode.h>
 
 #import <React/RCTComponentData.h>
 #import <React/RCTLog.h>

--- a/ios/Nodes/REAPropsNode.m
+++ b/ios/Nodes/REAPropsNode.m
@@ -1,9 +1,7 @@
-#import <RNReanimated/REAPropsNode.h>
-
 #import <RNReanimated/REAModule.h>
 #import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAPropsNode.h>
 #import <RNReanimated/REAStyleNode.h>
-
 #import <React/RCTComponentData.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>

--- a/ios/Nodes/REASetNode.h
+++ b/ios/Nodes/REASetNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REASetNode : REANode
 

--- a/ios/Nodes/REASetNode.m
+++ b/ios/Nodes/REASetNode.m
@@ -1,9 +1,9 @@
-#import "REASetNode.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REASetNode.h>
+#import <RNReanimated/REAUtils.h>
+#import <RNReanimated/REAValueNode.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
-#import "REAValueNode.h"
 
 @implementation REASetNode {
   NSNumber *_whatNodeID;

--- a/ios/Nodes/REAStyleNode.h
+++ b/ios/Nodes/REAStyleNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAStyleNode : REANode
 

--- a/ios/Nodes/REAStyleNode.m
+++ b/ios/Nodes/REAStyleNode.m
@@ -1,6 +1,5 @@
-#import <RNReanimated/REAStyleNode.h>
-
 #import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAStyleNode.h>
 
 @implementation REAStyleNode {
   NSMutableDictionary<NSString *, REANodeID> *_styleConfig;

--- a/ios/Nodes/REAStyleNode.m
+++ b/ios/Nodes/REAStyleNode.m
@@ -1,6 +1,6 @@
-#import "REAStyleNode.h"
+#import <RNReanimated/REAStyleNode.h>
 
-#import "REANodesManager.h"
+#import <RNReanimated/REANodesManager.h>
 
 @implementation REAStyleNode {
   NSMutableDictionary<NSString *, REANodeID> *_styleConfig;

--- a/ios/Nodes/REATransformNode.h
+++ b/ios/Nodes/REATransformNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REATransformNode : REANode
 

--- a/ios/Nodes/REATransformNode.m
+++ b/ios/Nodes/REATransformNode.m
@@ -1,6 +1,6 @@
-#import "REATransformNode.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REATransformNode.h>
 #import <React/RCTConvert.h>
-#import "REANodesManager.h"
 
 @implementation REATransformNode {
   NSArray<id> *_transformConfigs;

--- a/ios/Nodes/REAValueNode.h
+++ b/ios/Nodes/REAValueNode.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @class REAValueNode;
 

--- a/ios/Nodes/REAValueNode.h
+++ b/ios/Nodes/REAValueNode.h
@@ -1,5 +1,3 @@
-#import <UIKit/UIKit.h>
-
 #import <RNReanimated/REANode.h>
 
 @class REAValueNode;

--- a/ios/Nodes/REAValueNode.m
+++ b/ios/Nodes/REAValueNode.m
@@ -1,4 +1,4 @@
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAValueNode {
   NSNumber *_value;

--- a/ios/REAEventDispatcher.m
+++ b/ios/REAEventDispatcher.m
@@ -1,4 +1,4 @@
-#import "REAEventDispatcher.h"
+#import <RNReanimated/REAEventDispatcher.h>
 #import <RNReanimated/REAModule.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDefines.h>

--- a/ios/REAModule.h
+++ b/ios/REAModule.h
@@ -5,7 +5,7 @@
 #import <React/RCTUIManagerObserverCoordinator.h>
 #import <React/RCTUIManagerUtils.h>
 
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @interface REAModule : RCTEventEmitter <RCTBridgeModule, RCTEventDispatcherObserver, RCTUIManagerObserver>
 

--- a/ios/REAModule.m
+++ b/ios/REAModule.m
@@ -1,8 +1,7 @@
-#import "REAModule.h"
-
-#import "REANodesManager.h"
-#import "Transitioning/REATransitionManager.h"
-#import "native/NativeProxy.h"
+#import <RNReanimated/NativeProxy.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REATransitionManager.h>
 
 typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-
 #import <RNReanimated/REANode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 
+#import <RNReanimated/REANode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
-#import "REANode.h"
 
 @class REAModule;
 

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -1,7 +1,3 @@
-#import <RNReanimated/REANodesManager.h>
-
-#import <React/RCTConvert.h>
-
 #import <RNReanimated/REAAlwaysNode.h>
 #import <RNReanimated/REABezierNode.h>
 #import <RNReanimated/REABlockNode.h>
@@ -15,6 +11,7 @@
 #import <RNReanimated/REAJSCallNode.h>
 #import <RNReanimated/REAModule.h>
 #import <RNReanimated/REANode.h>
+#import <RNReanimated/REANodesManager.h>
 #import <RNReanimated/REAOperatorNode.h>
 #import <RNReanimated/REAParamNode.h>
 #import <RNReanimated/REAPropsNode.h>
@@ -22,6 +19,7 @@
 #import <RNReanimated/REAStyleNode.h>
 #import <RNReanimated/REATransformNode.h>
 #import <RNReanimated/REAValueNode.h>
+#import <React/RCTConvert.h>
 #import <React/RCTShadowView.h>
 #import <stdatomic.h>
 

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -1,29 +1,29 @@
-#import "REANodesManager.h"
+#import <RNReanimated/REANodesManager.h>
 
 #import <React/RCTConvert.h>
 
+#import <RNReanimated/REAAlwaysNode.h>
+#import <RNReanimated/REABezierNode.h>
+#import <RNReanimated/REABlockNode.h>
+#import <RNReanimated/REACallFuncNode.h>
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REAConcatNode.h>
+#import <RNReanimated/REACondNode.h>
+#import <RNReanimated/READebugNode.h>
+#import <RNReanimated/REAEventNode.h>
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REAJSCallNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANode.h>
+#import <RNReanimated/REAOperatorNode.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAPropsNode.h>
+#import <RNReanimated/REASetNode.h>
+#import <RNReanimated/REAStyleNode.h>
+#import <RNReanimated/REATransformNode.h>
+#import <RNReanimated/REAValueNode.h>
 #import <React/RCTShadowView.h>
 #import <stdatomic.h>
-#import "Nodes/REAAlwaysNode.h"
-#import "Nodes/REABezierNode.h"
-#import "Nodes/REABlockNode.h"
-#import "Nodes/REACallFuncNode.h"
-#import "Nodes/REAClockNodes.h"
-#import "Nodes/REAConcatNode.h"
-#import "Nodes/REACondNode.h"
-#import "Nodes/READebugNode.h"
-#import "Nodes/REAEventNode.h"
-#import "Nodes/REAFunctionNode.h"
-#import "Nodes/REAJSCallNode.h"
-#import "Nodes/REANode.h"
-#import "Nodes/REAOperatorNode.h"
-#import "Nodes/REAParamNode.h"
-#import "Nodes/REAPropsNode.h"
-#import "Nodes/REASetNode.h"
-#import "Nodes/REAStyleNode.h"
-#import "Nodes/REATransformNode.h"
-#import "Nodes/REAValueNode.h"
-#import "REAModule.h"
 
 // Interface below has been added in order to use private methods of RCTUIManager,
 // RCTUIManager#UpdateView is a React Method which is exported to JS but in

--- a/ios/Transitioning/RCTConvert+REATransition.h
+++ b/ios/Transitioning/RCTConvert+REATransition.h
@@ -1,6 +1,5 @@
-#import <React/RCTConvert.h>
-
 #import <RNReanimated/REATransition.h>
+#import <React/RCTConvert.h>
 
 @interface RCTConvert (REATransition)
 

--- a/ios/Transitioning/RCTConvert+REATransition.h
+++ b/ios/Transitioning/RCTConvert+REATransition.h
@@ -1,6 +1,6 @@
 #import <React/RCTConvert.h>
 
-#import "REATransition.h"
+#import <RNReanimated/REATransition.h>
 
 @interface RCTConvert (REATransition)
 

--- a/ios/Transitioning/RCTConvert+REATransition.m
+++ b/ios/Transitioning/RCTConvert+REATransition.m
@@ -1,4 +1,4 @@
-#import "RCTConvert+REATransition.h"
+#import <RNReanimated/RCTConvert+REATransition.h>
 
 @implementation RCTConvert (REATransition)
 

--- a/ios/Transitioning/REAAllTransitions.h
+++ b/ios/Transitioning/REAAllTransitions.h
@@ -1,4 +1,4 @@
-#import "REATransition.h"
+#import <RNReanimated/REATransition.h>
 
 @interface REATransitionGroup : REATransition
 @property (nonatomic) BOOL sequence;

--- a/ios/Transitioning/REAAllTransitions.m
+++ b/ios/Transitioning/REAAllTransitions.m
@@ -1,7 +1,6 @@
-#import <React/RCTViewManager.h>
-
 #import <RNReanimated/RCTConvert+REATransition.h>
 #import <RNReanimated/REAAllTransitions.h>
+#import <React/RCTViewManager.h>
 
 @interface REASnapshotRemover : NSObject <CAAnimationDelegate>
 @end

--- a/ios/Transitioning/REAAllTransitions.m
+++ b/ios/Transitioning/REAAllTransitions.m
@@ -1,7 +1,7 @@
 #import <React/RCTViewManager.h>
 
-#import "RCTConvert+REATransition.h"
-#import "REAAllTransitions.h"
+#import <RNReanimated/RCTConvert+REATransition.h>
+#import <RNReanimated/REAAllTransitions.h>
 
 @interface REASnapshotRemover : NSObject <CAAnimationDelegate>
 @end

--- a/ios/Transitioning/REATransition.h
+++ b/ios/Transitioning/REATransition.h
@@ -2,8 +2,8 @@
 #import <React/RCTView.h>
 #import <UIKit/UIKit.h>
 
-#import "REATransitionAnimation.h"
-#import "REATransitionValues.h"
+#import <RNReanimated/REATransitionAnimation.h>
+#import <RNReanimated/REATransitionValues.h>
 
 // TODO: fix below implementation
 #define IS_LAYOUT_ONLY(view) ([view isKindOfClass:[RCTView class]] && view.backgroundColor == nil)

--- a/ios/Transitioning/REATransition.h
+++ b/ios/Transitioning/REATransition.h
@@ -1,9 +1,8 @@
 #import <QuartzCore/QuartzCore.h>
-#import <React/RCTView.h>
-#import <UIKit/UIKit.h>
-
 #import <RNReanimated/REATransitionAnimation.h>
 #import <RNReanimated/REATransitionValues.h>
+#import <React/RCTView.h>
+#import <UIKit/UIKit.h>
 
 // TODO: fix below implementation
 #define IS_LAYOUT_ONLY(view) ([view isKindOfClass:[RCTView class]] && view.backgroundColor == nil)

--- a/ios/Transitioning/REATransition.m
+++ b/ios/Transitioning/REATransition.m
@@ -1,11 +1,10 @@
 #import <QuartzCore/QuartzCore.h>
-#import <React/RCTConvert.h>
-#import <React/RCTViewManager.h>
-#import <UIKit/UIKit.h>
-
 #import <RNReanimated/RCTConvert+REATransition.h>
 #import <RNReanimated/REATransition.h>
 #import <RNReanimated/REATransitionValues.h>
+#import <React/RCTConvert.h>
+#import <React/RCTViewManager.h>
+#import <UIKit/UIKit.h>
 
 #define DEFAULT_PROPAGATION_SPEED 3
 

--- a/ios/Transitioning/REATransition.m
+++ b/ios/Transitioning/REATransition.m
@@ -3,9 +3,9 @@
 #import <React/RCTViewManager.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+REATransition.h"
-#import "REATransition.h"
-#import "REATransitionValues.h"
+#import <RNReanimated/RCTConvert+REATransition.h>
+#import <RNReanimated/REATransition.h>
+#import <RNReanimated/REATransitionValues.h>
 
 #define DEFAULT_PROPAGATION_SPEED 3
 

--- a/ios/Transitioning/REATransitionAnimation.m
+++ b/ios/Transitioning/REATransitionAnimation.m
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#import "REATransitionAnimation.h"
+#import <RNReanimated/REATransitionAnimation.h>
 
 #define DEFAULT_DURATION 0.25
 

--- a/ios/Transitioning/REATransitionAnimation.m
+++ b/ios/Transitioning/REATransitionAnimation.m
@@ -1,6 +1,5 @@
-#import <UIKit/UIKit.h>
-
 #import <RNReanimated/REATransitionAnimation.h>
+#import <UIKit/UIKit.h>
 
 #define DEFAULT_DURATION 0.25
 

--- a/ios/Transitioning/REATransitionManager.m
+++ b/ios/Transitioning/REATransitionManager.m
@@ -1,9 +1,7 @@
+#import <RNReanimated/REATransition.h>
 #import <RNReanimated/REATransitionManager.h>
-
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
-
-#import <RNReanimated/REATransition.h>
 
 @interface REATransitionManager () <RCTUIManagerObserver>
 @end

--- a/ios/Transitioning/REATransitionManager.m
+++ b/ios/Transitioning/REATransitionManager.m
@@ -1,9 +1,9 @@
-#import "REATransitionManager.h"
+#import <RNReanimated/REATransitionManager.h>
 
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
 
-#import "REATransition.h"
+#import <RNReanimated/REATransition.h>
 
 @interface REATransitionManager () <RCTUIManagerObserver>
 @end

--- a/ios/Transitioning/REATransitionValues.m
+++ b/ios/Transitioning/REATransitionValues.m
@@ -1,8 +1,7 @@
-#import <React/RCTView.h>
-#import <React/RCTViewManager.h>
-
 #import <RNReanimated/REATransition.h>
 #import <RNReanimated/REATransitionValues.h>
+#import <React/RCTView.h>
+#import <React/RCTViewManager.h>
 
 @implementation REATransitionValues
 

--- a/ios/Transitioning/REATransitionValues.m
+++ b/ios/Transitioning/REATransitionValues.m
@@ -1,8 +1,8 @@
 #import <React/RCTView.h>
 #import <React/RCTViewManager.h>
 
-#import "REATransition.h"
-#import "REATransitionValues.h"
+#import <RNReanimated/REATransition.h>
+#import <RNReanimated/REATransitionValues.h>
 
 @implementation REATransitionValues
 

--- a/ios/native/NativeMethods.h
+++ b/ios/native/NativeMethods.h
@@ -1,11 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <RNGestureHandlerStateManager.h>
+#import <RNReanimated/RNGestureHandlerStateManager.h>
 #import <React/RCTUIManager.h>
 #include <string>
-#import <string>
 #include <utility>
 #include <vector>
-#import <vector>
 
 namespace reanimated {
 

--- a/ios/native/NativeMethods.mm
+++ b/ios/native/NativeMethods.mm
@@ -1,4 +1,4 @@
-#import "NativeMethods.h"
+#import <RNReanimated/NativeMethods.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTScrollView.h>
 

--- a/ios/native/NativeProxy.h
+++ b/ios/native/NativeProxy.h
@@ -1,7 +1,7 @@
-#import <React/RCTEventDispatcher.h>
-
 #if __cplusplus
+
 #import <RNReanimated/NativeReanimatedModule.h>
+#import <React/RCTEventDispatcher.h>
 #include <memory>
 
 namespace reanimated {

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -6,17 +6,17 @@
 #import <React/RCTUIManager.h>
 #import <folly/json.h>
 
-#import <RNGestureHandlerStateManager.h>
-#import "LayoutAnimationsProxy.h"
-#import "NativeMethods.h"
-#import "NativeProxy.h"
-#import "REAAnimationsManager.h"
-#import "REAIOSErrorHandler.h"
-#import "REAIOSScheduler.h"
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAUIManager.h"
-#import "ReanimatedSensorContainer.h"
+#import <RNReanimated/LayoutAnimationsProxy.h>
+#import <RNReanimated/NativeMethods.h>
+#import <RNReanimated/NativeProxy.h>
+#import <RNReanimated/REAAnimationsManager.h>
+#import <RNReanimated/REAIOSErrorHandler.h>
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/RNGestureHandlerStateManager.h>
+#import <RNReanimated/ReanimatedSensorContainer.h>
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -1,11 +1,3 @@
-#if TARGET_IPHONE_SIMULATOR
-#import <dlfcn.h>
-#endif
-
-#import <React/RCTFollyConvert.h>
-#import <React/RCTUIManager.h>
-#import <folly/json.h>
-
 #import <RNReanimated/LayoutAnimationsProxy.h>
 #import <RNReanimated/NativeMethods.h>
 #import <RNReanimated/NativeProxy.h>
@@ -17,6 +9,13 @@
 #import <RNReanimated/REAUIManager.h>
 #import <RNReanimated/RNGestureHandlerStateManager.h>
 #import <RNReanimated/ReanimatedSensorContainer.h>
+#import <React/RCTFollyConvert.h>
+#import <React/RCTUIManager.h>
+#import <folly/json.h>
+
+#if TARGET_IPHONE_SIMULATOR
+#import <dlfcn.h>
+#endif
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>

--- a/ios/native/REAIOSErrorHandler.h
+++ b/ios/native/REAIOSErrorHandler.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#import <RNReanimated/ErrorHandler.h>
+#import <RNReanimated/Scheduler.h>
 #include <memory>
 #include <string>
-#include "ErrorHandler.h"
-#include "Scheduler.h"
 
 namespace reanimated {
 

--- a/ios/native/REAIOSErrorHandler.h
+++ b/ios/native/REAIOSErrorHandler.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #import <RNReanimated/ErrorHandler.h>
 #import <RNReanimated/Scheduler.h>
 #include <memory>

--- a/ios/native/REAIOSErrorHandler.mm
+++ b/ios/native/REAIOSErrorHandler.mm
@@ -1,5 +1,5 @@
-#include "REAIOSErrorHandler.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REAIOSErrorHandler.h>
 #import <React/RCTLog.h>
 
 namespace reanimated {

--- a/ios/native/REAIOSLogger.h
+++ b/ios/native/REAIOSLogger.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#import <RNReanimated/ReanimatedHiddenHeaders.h>
 #include <stdio.h>
-#include "ReanimatedHiddenHeaders.h"
 
 namespace reanimated {
 

--- a/ios/native/REAIOSLogger.h
+++ b/ios/native/REAIOSLogger.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #import <RNReanimated/ReanimatedHiddenHeaders.h>
 #include <stdio.h>
 

--- a/ios/native/REAIOSLogger.mm
+++ b/ios/native/REAIOSLogger.mm
@@ -1,5 +1,5 @@
-#include "REAIOSLogger.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REAIOSLogger.h>
 
 namespace reanimated {
 

--- a/ios/native/REAIOSScheduler.h
+++ b/ios/native/REAIOSScheduler.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #import <RNReanimated/Scheduler.h>
 #import <React/RCTUIManager.h>
 #import <ReactCommon/CallInvoker.h>

--- a/ios/native/REAIOSScheduler.h
+++ b/ios/native/REAIOSScheduler.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#import <RNReanimated/Scheduler.h>
 #import <React/RCTUIManager.h>
 #import <ReactCommon/CallInvoker.h>
 #include <stdio.h>
 #include <memory>
-#include "Scheduler.h"
 
 namespace reanimated {
 

--- a/ios/native/REAIOSScheduler.mm
+++ b/ios/native/REAIOSScheduler.mm
@@ -1,5 +1,5 @@
-#include "REAIOSScheduler.h"
-#include "RuntimeManager.h"
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/RuntimeManager.h>
 
 namespace reanimated {
 

--- a/ios/native/REAInitializer.h
+++ b/ios/native/REAInitializer.h
@@ -1,10 +1,3 @@
-//
-//  REAInitializer.h
-//  RNReanimated
-//
-//  Created by Szymon Kapala on 27/07/2021.
-//
-
 #import <Foundation/Foundation.h>
 #import <RNReanimated/NativeProxy.h>
 #import <RNReanimated/REAEventDispatcher.h>

--- a/ios/native/REAInitializer.mm
+++ b/ios/native/REAInitializer.mm
@@ -1,5 +1,5 @@
-#import "REAInitializer.h"
-#import "REAUIManager.h"
+#import <RNReanimated/REAInitializer.h>
+#import <RNReanimated/REAUIManager.h>
 
 @interface RCTEventDispatcher (Reanimated)
 

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -1,6 +1,6 @@
-#import "REAInitializer.h"
-#import "REAUIManager.h"
-#import "UIResponder+Reanimated.h"
+#import <RNReanimated/REAInitializer.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/UIResponder+Reanimated.h>
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>

--- a/ios/sensor/ReanimatedSensor.h
+++ b/ios/sensor/ReanimatedSensor.h
@@ -1,7 +1,7 @@
 #if __has_include(<CoreMotion/CoreMotion.h>)
 #import <CoreMotion/CoreMotion.h>
 #endif
-#import "ReanimatedSensorType.h"
+#import <RNReanimated/ReanimatedSensorType.h>
 
 @interface ReanimatedSensor : NSObject {
   ReanimatedSensorType _sensorType;

--- a/ios/sensor/ReanimatedSensor.m
+++ b/ios/sensor/ReanimatedSensor.m
@@ -1,4 +1,4 @@
-#import "ReanimatedSensor.h"
+#import <RNReanimated/ReanimatedSensor.h>
 
 #if __has_include(<CoreMotion/CoreMotion.h>)
 @implementation ReanimatedSensor

--- a/ios/sensor/ReanimatedSensorContainer.h
+++ b/ios/sensor/ReanimatedSensorContainer.h
@@ -1,4 +1,4 @@
-#import "ReanimatedSensorType.h"
+#import <RNReanimated/ReanimatedSensorType.h>
 
 @interface ReanimatedSensorContainer : NSObject {
   NSNumber *_nextSensorId;

--- a/ios/sensor/ReanimatedSensorContainer.m
+++ b/ios/sensor/ReanimatedSensorContainer.m
@@ -1,6 +1,6 @@
-#import "ReanimatedSensorContainer.h"
 #import <Foundation/Foundation.h>
-#import "ReanimatedSensor.h"
+#import <RNReanimated/ReanimatedSensor.h>
+#import <RNReanimated/ReanimatedSensorContainer.h>
 
 static NSNumber *_nextSensorId = nil;
 


### PR DESCRIPTION
## Description

This PR replaces all occurrences of `#import "Foo.h"` from Reanimated in `ios/` directrory with `#import <RNReanimated/Foo.h>`.

The purpose of this PR is to facilitate versioning of Reanimated when releasing Expo SDKs.

## Changes

- Use angle bracket imports

## Test code and steps to reproduce

1. Run example app on iOS

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
