### PR TITLE
Remove gesture-gandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "*",
     "@babel/preset-typescript": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

The gesture-handler isn't required as a peer dependency.