### PR TITLE
Fix Expo dev menu

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -147,7 +147,7 @@ public class NativeProxy {
   }
 
   private void addDevMenuOption() {
-    // in Expo, ApplicationContext is not instance of ReactApplication
+    // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
     if (mContext.get().getApplicationContext() instanceof ReactApplication) {
       final DevSupportManager devSupportManager =
               ((ReactApplication) mContext.get().getApplicationContext())

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -147,14 +147,17 @@ public class NativeProxy {
   }
 
   private void addDevMenuOption() {
-    final DevSupportManager devSupportManager =
-        ((ReactApplication) mContext.get().getApplicationContext())
-            .getReactNativeHost()
-            .getReactInstanceManager()
-            .getDevSupportManager();
+    // in Expo, ApplicationContext is not instance of ReactApplication
+    if (mContext.get().getApplicationContext() instanceof ReactApplication) {
+      final DevSupportManager devSupportManager =
+              ((ReactApplication) mContext.get().getApplicationContext())
+                      .getReactNativeHost()
+                      .getReactInstanceManager()
+                      .getDevSupportManager();
 
-    devSupportManager.addCustomDevOption(
-        "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
+      devSupportManager.addCustomDevOption(
+              "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
+    }
   }
 
   @DoNotStrip


### PR DESCRIPTION
## Description

In Expo, `ApplicationContext` is not an instance of `ReactApplication`, and the casting caused a runtime exception. I added a check for `instanceof` to make it safe.