### PR TITLE
Fix typo in migration docs

### DIFF
--- a/docs/docs/fundamentals/migration.md
+++ b/docs/docs/fundamentals/migration.md
@@ -9,7 +9,7 @@ When installing Reanimated 2, you will be able to use the old API as well as the
 We made the latest stable Reanimated 1 available from the same package with a few exceptions, as we needed to address some naming collisions.
 Whenever there was a naming collision with Reanimated 1, we'd rename the Reanimated 1 version of such method in order to keep the naming in Reanimated 2 cleaner.
 This strategy made the most sense to us, as we are planning to slowly phase out the old API (we will keep making fixes to Reanimated 1 core but most likely stop new feature development).
-Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed there name.
+Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed their name.
 Thankfully the list of the renamed methods is relatively short, and the renamed methods weren't too frequently used anyways.
 
 ### Renamed methods:

--- a/docs/versioned_docs/version-2.0.0/migration.md
+++ b/docs/versioned_docs/version-2.0.0/migration.md
@@ -9,7 +9,7 @@ When installing Reanimated 2, you will be able to use the old API as well as the
 We made the latest stable Reanimated 1 available from the same package with a few exceptions, as we needed to address some naming collisions.
 Whenever there was a naming collision with Reanimated 1, we'd rename the Reanimated 1 version of such method in order to keep the naming in Reanimated 2 cleaner.
 This strategy made the most sense to us, as we are planning to slowly phase out the old API (we will keep making fixes to Reanimated 1 core but most likely stop new feature development).
-Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed there name.
+Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed their name.
 Thankfully the list of the renamed methods is relatively short, and the renamed methods weren't too frequently used anyways.
 
 ### Renamed methods:

--- a/docs/versioned_docs/version-2.1.0/migration.md
+++ b/docs/versioned_docs/version-2.1.0/migration.md
@@ -9,7 +9,7 @@ When installing Reanimated 2, you will be able to use the old API as well as the
 We made the latest stable Reanimated 1 available from the same package with a few exceptions, as we needed to address some naming collisions.
 Whenever there was a naming collision with Reanimated 1, we'd rename the Reanimated 1 version of such method in order to keep the naming in Reanimated 2 cleaner.
 This strategy made the most sense to us, as we are planning to slowly phase out the old API (we will keep making fixes to Reanimated 1 core but most likely stop new feature development).
-Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed there name.
+Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed their name.
 Thankfully the list of the renamed methods is relatively short, and the renamed methods weren't too frequently used anyways.
 
 ### Renamed methods:

--- a/docs/versioned_docs/version-2.2.0/migration.md
+++ b/docs/versioned_docs/version-2.2.0/migration.md
@@ -9,7 +9,7 @@ When installing Reanimated 2, you will be able to use the old API as well as the
 We made the latest stable Reanimated 1 available from the same package with a few exceptions, as we needed to address some naming collisions.
 Whenever there was a naming collision with Reanimated 1, we'd rename the Reanimated 1 version of such method in order to keep the naming in Reanimated 2 cleaner.
 This strategy made the most sense to us, as we are planning to slowly phase out the old API (we will keep making fixes to Reanimated 1 core but most likely stop new feature development).
-Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed there name.
+Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed their name.
 Thankfully the list of the renamed methods is relatively short, and the renamed methods weren't too frequently used anyways.
 
 ### Renamed methods:

--- a/docs/versioned_docs/version-2.3.0/fundamentals/migration.md
+++ b/docs/versioned_docs/version-2.3.0/fundamentals/migration.md
@@ -9,7 +9,7 @@ When installing Reanimated 2, you will be able to use the old API as well as the
 We made the latest stable Reanimated 1 available from the same package with a few exceptions, as we needed to address some naming collisions.
 Whenever there was a naming collision with Reanimated 1, we'd rename the Reanimated 1 version of such method in order to keep the naming in Reanimated 2 cleaner.
 This strategy made the most sense to us, as we are planning to slowly phase out the old API (we will keep making fixes to Reanimated 1 core but most likely stop new feature development).
-Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed there name.
+Unfortunately, it means that Reanimated 2 introduces some breaking changes to the API, where some methods pulled from Reanimated 1 changed their name.
 Thankfully the list of the renamed methods is relatively short, and the renamed methods weren't too frequently used anyways.
 
 ### Renamed methods:


### PR DESCRIPTION
## Description

I fixed a typo in the migration docs (v1->v2) where the wrong `there` was used. :)

## Changes

Updated typo in v2.3.0 docs.

If wanted, I can fix this typo in older docs too.

## Test code and steps to reproduce

n/a

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
