### PR TITLE
Fix CI config for Java linter

### DIFF
--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - 'android/src/java**'
+      - 'android/src/java/**'
   push:
     branches:
       - main

--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - 'android/src/java/**'
+      - 'android/src/main/java/**'
   push:
     branches:
       - main

--- a/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -150,13 +150,13 @@ public class NativeProxy {
     // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
     if (mContext.get().getApplicationContext() instanceof ReactApplication) {
       final DevSupportManager devSupportManager =
-              ((ReactApplication) mContext.get().getApplicationContext())
-                      .getReactNativeHost()
-                      .getReactInstanceManager()
-                      .getDevSupportManager();
+          ((ReactApplication) mContext.get().getApplicationContext())
+              .getReactNativeHost()
+              .getReactInstanceManager()
+              .getDevSupportManager();
 
       devSupportManager.addCustomDevOption(
-              "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
+          "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes Java linter not firing automatically for PRs with changes to Java files.

## Changes

- Fixed path for Java linter
- Fixed formatting in NativeProxy.java

## Test code and steps to reproduce

1. Check that "Java Lint" appears on the list of checks for this PR.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
