### PR TITLE
fix: android layout reanimation null pointer exception (2959)

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -1,5 +1,6 @@
 package com.swmansion.reanimated.layoutReanimation;
 
+import android.app.Activity;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
@@ -368,12 +369,15 @@ public class AnimationsManager implements ViewHierarchyObserver {
       preparedValues.put(key, PixelUtil.toDIPFromPixel((int) values.get(key)));
     }
 
-    DisplayMetrics displaymetrics = new DisplayMetrics();
-    mContext.getCurrentActivity().getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-    int height = displaymetrics.heightPixels;
-    int width = displaymetrics.widthPixels;
-    preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(width));
-    preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(height));
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    Activity currentActivity = mContext.getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+      int height = displayMetrics.heightPixels;
+      int width = displayMetrics.widthPixels;
+      preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(width));
+      preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(height));
+    }
     return preparedValues;
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -377,6 +377,9 @@ public class AnimationsManager implements ViewHierarchyObserver {
       int width = displayMetrics.widthPixels;
       preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(width));
       preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(height));
+    } else {
+      preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(0));
+      preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(0));
     }
     return preparedValues;
   }


### PR DESCRIPTION
## Description
ReactApplicationContext.getCurentContext sometimes return null. This causes a crash (NullPointerException) in reanimated due to not checking if context exists. As per react native's examples, we can only measure device metrics when current activity is not null (https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java#L56)

Fixes #2959.

## Changes

Check if current activity is not null before measuring the device.
