### PR TITLE
Make @babel/preset-typescript a full dependency as it's used at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "homepage": "https://github.com/software-mansion/react-native-reanimated#readme",
   "dependencies": {
     "@babel/plugin-transform-object-assign": "^7.16.7",
+    "@babel/preset-typescript": "^7.16.7",
     "@types/invariant": "^2.2.35",
     "invariant": "^2.2.4",
     "lodash.isequal": "^4.5.0",
@@ -83,14 +84,12 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*",
-    "@babel/preset-typescript": "*"
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/preset-env": "^7.16.11",
-    "@babel/preset-typescript": "^7.16.7",
     "@react-native-community/bob": "^0.17.1",
     "@react-native-community/eslint-config": "^0.0.5",
     "@testing-library/jest-native": "^4.0.4",


### PR DESCRIPTION
## Description

Follow up to #3077 makes `@babel/preset-typescript` a full dependency to properly solve runtime issues for users without `@babel/preset-typescript` present.

Previously I added it as a `peerDependency` but a soft warning at package install time is too easy to miss.

## Changes

Add `@babel/preset-typescript` to `dependencies` to fix error: `Cannot find module '@babel/preset-typescript'`

## Test code and steps to reproduce

### Before

1. `npx react-native init MyApp --template react-native-template-typescript`
2. [Install Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
3. Run app
4. Get error! 💥 
6. Install `@babel/preset-typescript`
7. Error sorted ✅ 

### After

1. `npx react-native init MyApp --template react-native-template-typescript`
2. [Install Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
3. Run app
4. No error ✅ 

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
