### PR TITLE
Load `RNGestureHandlerModule` lazily on iOS

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -162,8 +162,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     scrollTo(viewTag, uiManager, x, y, animated);
   };
 
-  id<RNGestureHandlerStateManager> gestureHandlerStateManager = [bridge moduleForName:@"RNGestureHandlerModule"];
-  auto setGestureStateFunction = [gestureHandlerStateManager](int handlerTag, int newState) {
+  id<RNGestureHandlerStateManager> gestureHandlerStateManager = nil;
+  auto setGestureStateFunction = [gestureHandlerStateManager, bridge](int handlerTag, int newState) mutable {
+    if (gestureHandlerStateManager == nil) {
+      gestureHandlerStateManager = [bridge moduleForName:@"RNGestureHandlerModule"];
+    }
+
     setGestureState(gestureHandlerStateManager, handlerTag, newState);
   };
 

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,4 +1,3 @@
-import { LogBox } from 'react-native';
 import createAnimatedComponent from './createAnimatedComponent';
 import {
   addWhitelistedNativeProps,
@@ -21,11 +20,3 @@ const Animated = {
 export * from './reanimated2';
 export * from './reanimated1';
 export default Animated;
-
-// I think we can ignore this message as long as Gesture Handler doesn't
-// try to load the Reanimated module. I figured it should be here instead of
-// RNGH because this prevents the message from being displayed for all
-// versions of RNGH.
-LogBox.ignoreLogs([
-  'RCTBridge required dispatch_sync to load RNGestureHandlerModule. This may lead to deadlocks',
-]);


### PR DESCRIPTION
## Description

At the time, the `RNGestureHandlerModule` is loaded when the `createReanimatedModule` method is called. This causes `RCTBridge required dispatch_sync to load RNGestureHandlerModule.` warning to appear. This PR changes it, so the module is loaded only the first time the `setGestureState` function is called.

## Test code and steps to reproduce

Install `react-native-reanimated` and `react-native-gesture-handler` and check if the warning appears.
