### PR TITLE
Add @babel/core as peer dependency which is required by @babel/plugin-transform-object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@babel/core": "^7.0.0-0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",


### PR DESCRIPTION
## Description

@babel/plugin-transform-object-assign requires to have @babel/core as peer dependency. That warning is provided by yarn when using the latest version reanimated version 2.6.0.

![Screen Shot 2022-04-11 at 9 46 31 pm](https://user-images.githubusercontent.com/7427545/162733058-1ccc1c38-f9c2-4634-901b-300ec0e810ef.png)

## Changes

- Added @babel/core as peer dependency.

### Before

- Create template project
- Add reanimated
- Run yarn install
- That will output a warning that reanimated is missing a peer dependency.

### After

- Create template project
- Add reanimated
- Run yarn install
- No warning for reanimated.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
