### PR TITLE
Add worklet to easing back return function

### DIFF
--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -171,7 +171,10 @@ function elastic(bounciness = 1): EasingFn {
  */
 function back(s = 1.70158): (t: number) => number {
   'worklet';
-  return (t) => t * t * ((s + 1) * t - s);
+  return (t) => {
+    'worklet';
+    return t * t * ((s + 1) * t - s);
+  };
 }
 
 /**

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -109,7 +109,10 @@ function cubic(t: number): number {
  */
 function poly(n: number): EasingFn {
   'worklet';
-  return (t) => Math.pow(t, n);
+  return (t) => {
+    'worklet';
+    return Math.pow(t, n);
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

Missing `worklet` directive in the return function of `Easing.back()` results in an error shown below.

![Simulator Screen Shot - iPhone 13 - 2022-04-11 at 15 17 54](https://user-images.githubusercontent.com/24809327/162742779-58a25540-8208-46dc-bd51-2beeb618a4d0.png)



## Changes

Add `worklet` directive at the top of the return function of `Easing.back` function


## Test code and steps to reproduce

```
import { Button, View } from 'react-native';
import React from 'react';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withTiming,
  Easing,
} from "react-native-reanimated";

export default function EasingBackExample() {
  const anim = useSharedValue(0);

const animStyles = useAnimatedStyle(() => {
    const translateY = interpolate(
      pitaAnim.value,
      [0, 1],
      [0, 200],
      Extrapolate.EXTEND,
    );
    return {
      transform: [{ translateY: translateY }],
    };
  });

const runAnimation = () => {
   anim.value = withTiming(1, {
        duration: 600,
        easing: Easing.back(1),
      });
}

  return (
    <View>
       <Animated.View
            style={[
              {
                width: 120,
                height: 120,
                backgroundColor: "red"
              },
              animStyles,
            ]}
          />
      <Button title="Animate" onPress={runAnimation} />
    </View>
  );
}

```

## Checklist

- [x] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
