### PR TITLE
Pass worklet runtime pointer using ArrayBuffer

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -145,11 +145,22 @@ void NativeProxy::installJSIBindings() {
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();
 #endif
+  auto workletRuntimeValue = runtime_->global()
+    .getProperty(*runtime_, "ArrayBuffer")
+    .asObject(*runtime_)
+    .asFunction(*runtime_)
+    .callAsConstructor(*runtime_, {static_cast<double>(sizeof(void*))});
+  uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+    workletRuntimeValue
+      .getObject(*runtime_)
+      .getArrayBuffer(*runtime_)
+      .data(*runtime_));
+  workletRuntimeData[0] = reinterpret_cast<uintptr_t>(animatedRuntime.get());
+
   runtime_->global().setProperty(
       *runtime_,
       "_WORKLET_RUNTIME",
-      static_cast<double>(
-          reinterpret_cast<std::uintptr_t>(animatedRuntime.get())));
+      workletRuntimeValue);
 
   std::shared_ptr<ErrorHandler> errorHandler =
       std::make_shared<AndroidErrorHandler>(scheduler_);


### PR DESCRIPTION
## Description

If a pointer to worklet jsi:Runtime has large enough value (happens on android 11) static_cast to double is affecting the value.

It's not possible to do reinterpret_cast there because JSC is tagging numeric values, so pointer value can change https://github.com/WebKit/WebKit/blob/8afe31a018b11741abdf9b4d5bb973d7c1d9ff05/Source/JavaScriptCore/API/JSValueRef.cpp#L355

## Changes

Instead of passing value as a number use ArrayBuffer

This is a breaking change, but anyone that is relying on that value should also check for that value existence.

## Test code and steps to reproduce

Did not test it here, but this is exact copy of changes I made in versioned expo code and tested it there 
https://github.com/expo/expo/pull/17194

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
