### PR TITLE
Fix Android remote debugging failure

### DIFF
--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -11,7 +11,7 @@ export class NativeReanimated {
   private InnerNativeModule: any;
 
   constructor(native = true) {
-    if (global.__reanimatedModuleProxy === undefined) {
+    if (global.__reanimatedModuleProxy === undefined && native) {
       const { ReanimatedModule } = NativeModules;
       ReanimatedModule?.installTurboModule();
     }


### PR DESCRIPTION
## Description

This fixes the remote debugging failure on Android using Chrome as installTurboModule is annotated @ReactMethod(isBlockingSynchronousMethod = true) and triggers an error when called in Chrome.

Fixes #3174.

## Test code and steps to reproduce

Tested by attempting to debug on Android simulator and not observing the error anymore.

The last version where remote debugging using Chrome worked was 2.4.1 as the changes to NativeAnimated.ts was introduced in 2.5.0.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
