### PR TITLE
[Fabric] Exclude `librrc_root.so`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -252,11 +252,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
-        // For some reason gradle only complains about the duplicated version of libreact_render libraries
-        // while there are more libraries copied in intermediates folder of the lib build directory, we exlude
-        // only the ones that make the build fail (ideally we should only include librnscreens_modules but we
+        // For some reason gradle only complains about the duplicated version of librrc_root and libreact_render libraries
+        // while there are more libraries copied in intermediates folder of the lib build directory, we exclude
+        // only the ones that make the build fail (ideally we should only include libreanimated but we
         // are only allowed to specify exlude patterns)
         exclude "**/libreact_render*.so"
+        exclude "**/librrc_root.so"
     }
     sourceSets.main {
         java {


### PR DESCRIPTION
## Description

This PR resolves the following error during Android build on CI:

```
Execution failed for task ':app:mergeDebugNativeLibs'.
w: Detected multiple Kotlin daemon sessions at build/kotlin/sessions
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/librrc_root.so' from inputs:
      - /home/runner/work/react-native-reanimated/react-native-reanimated/android/build/intermediates/library_jni/debug/jni/arm64-v8a/librrc_root.so
      - /home/runner/work/react-native-reanimated/react-native-reanimated/FabricExample/node_modules/react-native/ReactAndroid/build/intermediates/library_jni/debug/jni/arm64-v8a/librrc_root.so
     If you are using jniLibs and CMake IMPORTED targets, see
     https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

We've already excluded `libreact_render*.so` libraries but this pattern doesn't match `librrc_root.so` which also seems to be dupliated.

## Changes

- Added `exclude "**/librrc_root.so"` in `android/build.gradle`
- Improved comment

## Test code and steps to reproduce

1. Check if Android build passes on CI

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
