### PR TITLE
Fix performance.now() in worklets

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -71,21 +71,27 @@ void RuntimeDecorator::decorateRuntime(
           1,
           setGlobalConsole));
 
+  auto chronoNow = [](jsi::Runtime &rt,
+                      const jsi::Value &thisValue,
+                      const jsi::Value *args,
+                      size_t count) -> jsi::Value {
+    double now = std::chrono::system_clock::now().time_since_epoch() /
+        std::chrono::milliseconds(1);
+    return jsi::Value(now);
+  };
+
   rt.global().setProperty(
       rt,
       "_chronoNow",
       jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_chronoNow"),
-          0,
-          [](jsi::Runtime &rt,
-             const jsi::Value &thisValue,
-             const jsi::Value *args,
-             size_t count) -> jsi::Value {
-            double now = std::chrono::system_clock::now().time_since_epoch() /
-                std::chrono::milliseconds(1);
-            return jsi::Value(now);
-          }));
+          rt, jsi::PropNameID::forAscii(rt, "_chronoNow"), 0, chronoNow));
+  jsi::Object performance(rt);
+  performance.setProperty(
+      rt,
+      "now",
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, "now"), 0, chronoNow));
+  rt.global().setProperty(rt, "performance", performance);
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -339,11 +339,6 @@ if (!isWeb() && isConfigured()) {
       info: runOnJS(capturableConsole.info),
     };
     _setGlobalConsole(console);
-    if (global.performance == null) {
-      global.performance = {
-        now: global._chronoNow,
-      } as any; // due to conflict with lib.dom.d.ts -> Performance
-    }
   })();
 }
 


### PR DESCRIPTION
## Description

Adds performance.now on cpp side, instead of the js side. The `global` object is overwritten by reanimated, so adding functions to `global` object on js side doesn't make them visible in global scope. Adding them on cpp side makes them visible in global scope.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Add `console.log(performance.now())` to any worklet.
Before: worklet stops executing
After: worklet works and prints current time

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
