### PR TITLE
Fix typo in `ReanimatedFlatListProps`

### DIFF
--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -26,11 +26,11 @@ const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
   return cellRenderer;
 };
 
-export interface ReanimatedFlatlistProps<ItemT> extends FlatListProps<ItemT> {
+export interface ReanimatedFlatListProps<ItemT> extends FlatListProps<ItemT> {
   itemLayoutAnimation?: ILayoutAnimationBuilder;
 }
 
-type ReanimatedFlatListFC<T = any> = React.FC<ReanimatedFlatlistProps<T>>;
+type ReanimatedFlatListFC<T = any> = React.FC<ReanimatedFlatListProps<T>>;
 
 const ReanimatedFlatlist: ReanimatedFlatListFC = ({
   itemLayoutAnimation,


### PR DESCRIPTION
## Description

This PR renames `ReanimatedFlatlistProps` to `ReanimatedFlatListProps` for consistency reasons.

## Changes

- Changed `ReanimatedFlatlistProps` to `ReanimatedFlatListProps`

## Test code and steps to reproduce

1. Check if TypeScript CI job passes

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
