### PR TITLE
[Fabric] Define `configurePropsFunction` only on Paper

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -178,6 +178,12 @@ void NativeProxy::installJSIBindings(
     std::string str = result->toStdString();
     return jsi::Value(rt, jsi::String::createFromAscii(rt, str.c_str()));
   };
+
+  auto configurePropsFunction = [=](jsi::Runtime &rt,
+                                    const jsi::Value &uiProps,
+                                    const jsi::Value &nativeProps) {
+    this->configureProps(rt, uiProps, nativeProps);
+  };
 #endif
 
   auto registerSensorFunction =
@@ -232,12 +238,6 @@ void NativeProxy::installJSIBindings(
 
   auto notifyAboutEnd = [=](int tag, bool isCancelled) {
     this->layoutAnimations->cthis()->notifyAboutEnd(tag, (isCancelled) ? 1 : 0);
-  };
-
-  auto configurePropsFunction = [=](jsi::Runtime &rt,
-                                    const jsi::Value &uiProps,
-                                    const jsi::Value &nativeProps) {
-    this->configureProps(rt, uiProps, nativeProps);
   };
 
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =


### PR DESCRIPTION
## Description

This PR moves the definition of `configurePropsFunction` into `#else` block since it is used only on Paper, fixing the following warning on Android:

```
../../../../src/main/cpp/NativeProxy.cpp:237:8: warning: unused variable 'configurePropsFunction'
```

## Changes

- Define `configurePropsFunction` only on Paper

## Test code and steps to reproduce

1. Check if both Example and FabricExample apps for Android successfully compile on CI

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
