### PR TITLE
Remove unimplemented type

### DIFF
--- a/FabricExample/react-native-reanimated-tests.tsx
+++ b/FabricExample/react-native-reanimated-tests.tsx
@@ -35,7 +35,6 @@ import Animated, {
   withSequence,
   withDecay,
   useWorkletCallback,
-  createWorklet,
   runOnUI,
   useAnimatedReaction,
   interpolateColor,
@@ -640,21 +639,6 @@ function UseWorkletCallbackTest() {
   const workletCallback = useWorkletCallback((a: number, b: number) => {
     return a + b;
   }, []);
-
-  runOnUI(() => {
-    const res = workletCallback(1, 1);
-
-    console.log(res);
-  })();
-
-  return <Animated.View style={styles.container} />;
-}
-
-// createWorklet
-function CreateWorkletTest() {
-  const workletCallback = createWorklet((a: number, b: number) => {
-    return a + b;
-  });
 
   runOnUI(() => {
     const res = workletCallback(1, 1);

--- a/plugin.js
+++ b/plugin.js
@@ -14,7 +14,6 @@ const functionArgsToWorkletize = new Map([
   ['useAnimatedScrollHandler', [0]],
   ['useAnimatedReaction', [0, 1]],
   ['useWorkletCallback', [0]],
-  ['createWorklet', [0]],
   // animations' callbacks
   ['withTiming', [2]],
   ['withSpring', [2]],

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -650,9 +650,6 @@ declare module 'react-native-reanimated' {
   ): PropsAdapterFunction;
 
   export function processColor(color: number | string): number;
-  export function createWorklet<A extends any[], R>(
-    fn: (...args: A) => R
-  ): (...args: Parameters<typeof fn>) => R;
 
   export function interpolateColor<T extends string | number>(
     value: number,


### PR DESCRIPTION
## Description

I just removed type form TS for unimplemented method `createWorklet`

This PR should be copied to Reanimated2 branch also.

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/3131