### PR TITLE
Add hermes cache on CI on ios

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - "@graszka22/ios-ci-cache"
+
 jobs:
   build:
     # runs-on: macos-latest // issue: https://github.com/actions/virtual-environments/issues/4060

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - "@graszka22/ios-ci-speedup"
+      - "@graszka22/ios-ci-cache"
 jobs:
   build:
     # runs-on: macos-latest // issue: https://github.com/actions/virtual-environments/issues/4060
@@ -31,6 +31,13 @@ jobs:
       - name: Install node dependencies
         working-directory: ${{ matrix.working-directory }}
         run: yarn
+      - name: Cache hermes build ios
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-ios-hermes-engine
+        with:
+          path: ${{ matrix.working-directory }}/node_modules/react-native/sdks/hermes
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.working-directory }}-${{ hashFiles('**/react-native/package.json', '**/patches/react-native+**') }}
       - name: Install pods
         working-directory: ${{ matrix.working-directory }}/ios
         run: RN_ARCHITECTURES="iphonesimulator_x86_64" pod install

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - "@graszka22/ios-ci-cache"
 
 jobs:
   build:


### PR DESCRIPTION
## Description
Depends on https://github.com/software-mansion/react-native-reanimated/pull/3256.
This pr simply caches hermes build, reducing build time on CI.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
