### PR TITLE
Fix NPE in AnimationsManager during app shutdown

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -229,24 +229,27 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   private void removeLeftovers() {
-    HashSet<Integer> roots = new HashSet<>();
-    // go through ready to remove from bottom to top
-    for (int tag : mToRemove) {
-      View view = mViewForTag.get(tag);
-      if (view == null) {
-        try {
-          view = mUIManager.resolveView(tag);
-          mViewForTag.put(tag, view);
-        } catch (IllegalViewOperationException ignored) {
-          continue;
+    //mToRemove may be null if onCatalystInstanceDestroy was called first
+    if(mToRemove != null){
+      HashSet<Integer> roots = new HashSet<>();
+      // go through ready to remove from bottom to top
+      for (int tag : mToRemove) {
+        View view = mViewForTag.get(tag);
+        if (view == null) {
+          try {
+            view = mUIManager.resolveView(tag);
+            mViewForTag.put(tag, view);
+          } catch (IllegalViewOperationException ignored) {
+            continue;
+          }
         }
+        findRoot(view, roots);
       }
-      findRoot(view, roots);
-    }
-    for (int tag : roots) {
-      View view = mViewForTag.get(tag);
-      if (view != null) {
-        dfs(view, view, mToRemove);
+      for (int tag : roots) {
+        View view = mViewForTag.get(tag);
+        if (view != null) {
+          dfs(view, view, mToRemove);
+        }
       }
     }
   }


### PR DESCRIPTION


## Description
Fixes https://github.com/software-mansion/react-native-reanimated/issues/3265
<!--
Description and motivation for this PR.




-->

## Changes
Add null check in AnimationsManager.java to `removeLeftovers` since the `mToRemove` can be set to null if app is shut down (for example by react-native-restart) before the callback fires.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ N/A ] Included code example that can be used to test this change
- [ N/A ] Updated TS types
- [ N/A ] Added TS types tests
- [ N/A ] Added unit / integration tests
- [ N/A ] Updated documentation
- [ ] Ensured that CI passes
