### PR TITLE
Add web-specific version of `fabricUtils`

### DIFF
--- a/src/reanimated2/fabricUtils.web.ts
+++ b/src/reanimated2/fabricUtils.web.ts
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+
+import { ShadowNodeWrapper } from './commonTypes';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findHostInstance_DEPRECATED = (_ref: React.Component) => null;
+
+export function getShadowNodeWrapperFromHostInstance(
+  hostInstance: unknown
+): ShadowNodeWrapper {
+  // @ts-ignore Fabric
+  return hostInstance._internalInstanceHandle.stateNode.node;
+}
+
+export function getShadowNodeWrapperFromRef(
+  ref: React.Component
+): ShadowNodeWrapper {
+  return getShadowNodeWrapperFromHostInstance(findHostInstance_DEPRECATED(ref));
+}


### PR DESCRIPTION
## Description

`require('react-native/Libraries/Renderer/shims/ReactFabric').findHostInstance_DEPRECATED;` is causing a bunch of errors on web. I believe that webpack resolves require statically, so the surrounding `try .. catch` doesn't help.

## Changes

- adds a separate `fabricUtils.web.ts` file that doesn't try to load `findHostInstance_DEPRECATED` function, since Fabric is not supported on web at the moment

## Test code and steps to reproduce

I tested it on `reanimated-2-playground` with updated dependencies.
Running it on web with 3.0.0-rc.0 ends with a lot of errors. After this change the errors should be gone.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
