### PR TITLE
Add `Extrapolation` mock

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -65,6 +65,11 @@ const ReanimatedV2 = {
     out: ID,
     inOut: ID,
   },
+  Extrapolation: {
+    EXTEND: 'extend',
+    CLAMP: 'clamp',
+    IDENTITY: 'identity',
+  },
 
   runOnJS: (fn) => fn,
 };


### PR DESCRIPTION
## Description

v2 mocks is missing `Extrapolation`, getting following error in test:
```
TypeError: Cannot read property 'CLAMP' of undefined
```

## Changes

Add `Extrapolation` mock

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Run test with reference to `Extrapolation.CLAMP`.

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
