### PR TITLE
Fix layout animations crash when hiding RN modal

### DIFF
--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -117,6 +117,11 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
   // Reanimated changes /start
   if (isUIViewRegistry) {
     NSMutableDictionary<NSNumber *, id<RCTComponent>> *viewRegistry = [self valueForKey:@"_viewRegistry"];
+    NSMutableDictionary<NSNumber *, NSMutableSet<id<RCTComponent>> *> *toBeRemovedRegisterCopy =
+        [NSMutableDictionary dictionaryWithDictionary:_toBeRemovedRegister];
+    for (NSNumber *key in _toBeRemovedRegister) {
+      toBeRemovedRegisterCopy[key] = [NSMutableSet setWithSet:_toBeRemovedRegister[key]];
+    }
     for (id<RCTComponent> toRemoveChild in _toBeRemovedRegister[containerTag]) {
       NSInteger lastIndex = [container reactSubviews].count - 1;
       if (lastIndex < 0) {
@@ -129,7 +134,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
       ) {
         // we don't want layout animations when removing modals or Screens of native-stack since it brings buggy
         // behavior
-        [_toBeRemovedRegister[container.reactTag] removeObject:toRemoveChild];
+        [toBeRemovedRegisterCopy[container.reactTag] removeObject:toRemoveChild];
         [permanentlyRemovedChildren removeObject:toRemoveChild];
 
       } else {
@@ -137,6 +142,7 @@ std::weak_ptr<reanimated::Scheduler> _scheduler;
         viewRegistry[toRemoveChild.reactTag] = toRemoveChild;
       }
     }
+    _toBeRemovedRegister = toBeRemovedRegisterCopy;
 
     for (UIView *removedChild in permanentlyRemovedChildren) {
       [self callAnimationForTree:removedChild parentTag:containerTag];


### PR DESCRIPTION
## Description

Fixes a crash occurring when using layout animations and hiding RN modal.

Fixes #3286 

## Changes

Firstly make a copy of `_toBeRemovedRegister` dictionary, mutate it while iterating through original and then assign a copy to the original.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Open and close a modal a few times. Doesn't reproduce on expo snack 🤔

```ts
import * as React from 'react';
import { View, StyleSheet, Modal, Button } from 'react-native';
import Constants from 'expo-constants';
import Animated from 'react-native-reanimated';
import {FadeIn} from 'react-native-reanimated';

export default function App() {
  const [modalVisible, setModalVisible] = React.useState(false)
  const [viewVisible, setViewVisible] = React.useState(false)
  const onCloseClick = () => {
    setModalVisible(!modalVisible)
    setViewVisible(!viewVisible)
  }

  return (
    <View style={styles.container}>
      {
        !!viewVisible && (
          <Animated.View 
            entering={FadeIn.duration(300)} 
            exiting={FadeIn.duration(300)} 
            style={{ width: 100, height: 100, backgroundColor: 'blue' }
          }/>
        )
      }
      <Modal animationType="slide" transparent visible={modalVisible} onRequestClose={onCloseClick}>
        <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
        <Button onPress={onCloseClick} title="CLOSE" />
      </Modal>
      <Button onPress={onCloseClick} title="OPEN" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    paddingTop: Constants.statusBarHeight,
    backgroundColor: '#ecf0f1',
    padding: 8,
  },
});
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
