### PR TITLE
fix: overriden style type in AnimatedProps

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -156,7 +156,7 @@ declare module 'react-native-reanimated' {
       : Record<string, unknown>;
 
     export type AnimateProps<P extends object> = {
-      [K in keyof P]: P[K] | AnimatedNode<P[K]>;
+      [K in keyof Omit<P, 'style'>]: P[K] | AnimatedNode<P[K]>;
     } & {
       style?: StyleProp<AnimateStyle<StylesOrDefault<P>>>;
     } & {


### PR DESCRIPTION
## Description

Override of `style` props in `AnimatedProps` is conflicting and throw an error. Omitting the `style` key before merging the new interface fix the issue.

Fixes #2968 .

## Changes

Upgrade `AnimatedProps` type.

### Before

<img width="1655" alt="Screen Shot 2022-06-20 at 12 13 42 PM" src="https://user-images.githubusercontent.com/3551795/174580308-4ee93da4-92c6-401c-bd9a-f48e6b69099c.png">

### After

<img width="866" alt="Screen Shot 2022-06-20 at 12 14 01 PM" src="https://user-images.githubusercontent.com/3551795/174580340-87abf015-bae1-437c-b29b-ff6efd72c1f4.png">

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
