### PR TITLE
Allow to run a sequence of one animation

### DIFF
--- a/src/reanimated2/animation/sequence.ts
+++ b/src/reanimated2/animation/sequence.ts
@@ -63,11 +63,6 @@ export function withSequence(
         now: Timestamp,
         previousAnimation: SequenceAnimation
       ): void {
-        if (animations.length === 1) {
-          throw Error(
-            'withSequence() animation require more than one animation as argument'
-          );
-        }
         animation.animationIndex = 0;
         if (previousAnimation === undefined) {
           previousAnimation = animations[


### PR DESCRIPTION
## Description

This PR allows to run a sequence of just one animation. It makes little sense, but this is no reason to crash the whole app.

## Changes

Removed code that throws exception when there's just one animation in a sequence.

It was added in https://github.com/software-mansion/react-native-reanimated/commit/66232c6579f429c74819af6c7ad076a6a3929d72 but removing it doesn't break the app.

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
