### PR TITLE
Bump react-native in FabricExample to 0.69.0

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.69.0-rc.0)
-  - FBReactNativeSpec (0.69.0-rc.0):
+  - FBLazyVector (0.69.0)
+  - FBReactNativeSpec (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Core (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
   - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.2.0)
+  - Flipper-DoubleConversion (3.2.0.1)
   - Flipper-Fmt (7.1.7)
   - Flipper-Folly (2.6.10):
     - Flipper-Boost-iOSX
@@ -23,7 +23,7 @@ PODS:
     - Flipper-Glog
     - libevent (~> 2.1.12)
     - OpenSSL-Universal (= 1.1.1100)
-  - Flipper-Glog (0.5.0.4)
+  - Flipper-Glog (0.5.0.5)
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.4.3):
     - Flipper-Folly (~> 2.6)
@@ -73,7 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.11.0)
+  - hermes-engine (0.69.0)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -98,532 +98,532 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.69.0-rc.0)
-  - RCTTypeSafety (0.69.0-rc.0):
-    - FBLazyVector (= 0.69.0-rc.0)
-    - RCTRequired (= 0.69.0-rc.0)
-    - React-Core (= 0.69.0-rc.0)
-  - React (0.69.0-rc.0):
-    - React-Core (= 0.69.0-rc.0)
-    - React-Core/DevSupport (= 0.69.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.0)
-    - React-RCTActionSheet (= 0.69.0-rc.0)
-    - React-RCTAnimation (= 0.69.0-rc.0)
-    - React-RCTBlob (= 0.69.0-rc.0)
-    - React-RCTImage (= 0.69.0-rc.0)
-    - React-RCTLinking (= 0.69.0-rc.0)
-    - React-RCTNetwork (= 0.69.0-rc.0)
-    - React-RCTSettings (= 0.69.0-rc.0)
-    - React-RCTText (= 0.69.0-rc.0)
-    - React-RCTVibration (= 0.69.0-rc.0)
-  - React-bridging (0.69.0-rc.0):
+  - RCTRequired (0.69.0)
+  - RCTTypeSafety (0.69.0):
+    - FBLazyVector (= 0.69.0)
+    - RCTRequired (= 0.69.0)
+    - React-Core (= 0.69.0)
+  - React (0.69.0):
+    - React-Core (= 0.69.0)
+    - React-Core/DevSupport (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-RCTActionSheet (= 0.69.0)
+    - React-RCTAnimation (= 0.69.0)
+    - React-RCTBlob (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+    - React-RCTLinking (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - React-RCTSettings (= 0.69.0)
+    - React-RCTText (= 0.69.0)
+    - React-RCTVibration (= 0.69.0)
+  - React-bridging (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi (= 0.69.0-rc.0)
-  - React-callinvoker (0.69.0-rc.0)
-  - React-Codegen (0.69.0-rc.0):
-    - FBReactNativeSpec (= 0.69.0-rc.0)
+    - React-jsi (= 0.69.0)
+  - React-callinvoker (0.69.0)
+  - React-Codegen (0.69.0):
+    - FBReactNativeSpec (= 0.69.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Core (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-rncore (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Core (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-rncore (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Core (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.0)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-Core/Default (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.69.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-    - Yoga
-  - React-Core/Default (0.69.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-    - Yoga
-  - React-Core/DevSupport (0.69.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.0)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-jsinspector (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.69.0-rc.0):
+  - React-Core/CoreModulesHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.69.0-rc.0):
+  - React-Core/Default (0.69.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-Core/DevSupport (0.69.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-jsinspector (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.69.0-rc.0):
+  - React-Core/RCTAnimationHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.69.0-rc.0):
+  - React-Core/RCTBlobHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.69.0-rc.0):
+  - React-Core/RCTImageHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.69.0-rc.0):
+  - React-Core/RCTLinkingHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.69.0-rc.0):
+  - React-Core/RCTNetworkHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.69.0-rc.0):
+  - React-Core/RCTSettingsHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.69.0-rc.0):
+  - React-Core/RCTTextHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.69.0-rc.0):
+  - React-Core/RCTVibrationHeaders (0.69.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.0)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-Core/Default
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
     - Yoga
-  - React-CoreModules (0.69.0-rc.0):
+  - React-Core/RCTWebSocket (0.69.0):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/CoreModulesHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-RCTImage (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-cxxreact (0.69.0-rc.0):
+    - React-Core/Default (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - Yoga
+  - React-CoreModules (0.69.0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/CoreModulesHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-cxxreact (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsinspector (= 0.69.0-rc.0)
-    - React-logger (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-    - React-runtimeexecutor (= 0.69.0-rc.0)
-  - React-Fabric (0.69.0-rc.0):
+    - React-callinvoker (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsinspector (= 0.69.0)
+    - React-logger (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+    - React-runtimeexecutor (= 0.69.0)
+  - React-Fabric (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Fabric/animations (= 0.69.0-rc.0)
-    - React-Fabric/attributedstring (= 0.69.0-rc.0)
-    - React-Fabric/butter (= 0.69.0-rc.0)
-    - React-Fabric/componentregistry (= 0.69.0-rc.0)
-    - React-Fabric/componentregistrynative (= 0.69.0-rc.0)
-    - React-Fabric/components (= 0.69.0-rc.0)
-    - React-Fabric/config (= 0.69.0-rc.0)
-    - React-Fabric/core (= 0.69.0-rc.0)
-    - React-Fabric/debug_core (= 0.69.0-rc.0)
-    - React-Fabric/debug_renderer (= 0.69.0-rc.0)
-    - React-Fabric/imagemanager (= 0.69.0-rc.0)
-    - React-Fabric/leakchecker (= 0.69.0-rc.0)
-    - React-Fabric/mounting (= 0.69.0-rc.0)
-    - React-Fabric/runtimescheduler (= 0.69.0-rc.0)
-    - React-Fabric/scheduler (= 0.69.0-rc.0)
-    - React-Fabric/telemetry (= 0.69.0-rc.0)
-    - React-Fabric/templateprocessor (= 0.69.0-rc.0)
-    - React-Fabric/textlayoutmanager (= 0.69.0-rc.0)
-    - React-Fabric/uimanager (= 0.69.0-rc.0)
-    - React-Fabric/utils (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/animations (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Fabric/animations (= 0.69.0)
+    - React-Fabric/attributedstring (= 0.69.0)
+    - React-Fabric/butter (= 0.69.0)
+    - React-Fabric/componentregistry (= 0.69.0)
+    - React-Fabric/componentregistrynative (= 0.69.0)
+    - React-Fabric/components (= 0.69.0)
+    - React-Fabric/config (= 0.69.0)
+    - React-Fabric/core (= 0.69.0)
+    - React-Fabric/debug_core (= 0.69.0)
+    - React-Fabric/debug_renderer (= 0.69.0)
+    - React-Fabric/imagemanager (= 0.69.0)
+    - React-Fabric/leakchecker (= 0.69.0)
+    - React-Fabric/mounting (= 0.69.0)
+    - React-Fabric/runtimescheduler (= 0.69.0)
+    - React-Fabric/scheduler (= 0.69.0)
+    - React-Fabric/telemetry (= 0.69.0)
+    - React-Fabric/templateprocessor (= 0.69.0)
+    - React-Fabric/textlayoutmanager (= 0.69.0)
+    - React-Fabric/uimanager (= 0.69.0)
+    - React-Fabric/utils (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/animations (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/attributedstring (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/attributedstring (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/butter (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/butter (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/componentregistry (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/componentregistry (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/componentregistrynative (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/componentregistrynative (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Fabric/components/activityindicator (= 0.69.0-rc.0)
-    - React-Fabric/components/image (= 0.69.0-rc.0)
-    - React-Fabric/components/inputaccessory (= 0.69.0-rc.0)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.69.0-rc.0)
-    - React-Fabric/components/modal (= 0.69.0-rc.0)
-    - React-Fabric/components/root (= 0.69.0-rc.0)
-    - React-Fabric/components/safeareaview (= 0.69.0-rc.0)
-    - React-Fabric/components/scrollview (= 0.69.0-rc.0)
-    - React-Fabric/components/slider (= 0.69.0-rc.0)
-    - React-Fabric/components/text (= 0.69.0-rc.0)
-    - React-Fabric/components/textinput (= 0.69.0-rc.0)
-    - React-Fabric/components/unimplementedview (= 0.69.0-rc.0)
-    - React-Fabric/components/view (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/activityindicator (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-Fabric/components/activityindicator (= 0.69.0)
+    - React-Fabric/components/image (= 0.69.0)
+    - React-Fabric/components/inputaccessory (= 0.69.0)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.69.0)
+    - React-Fabric/components/modal (= 0.69.0)
+    - React-Fabric/components/root (= 0.69.0)
+    - React-Fabric/components/safeareaview (= 0.69.0)
+    - React-Fabric/components/scrollview (= 0.69.0)
+    - React-Fabric/components/slider (= 0.69.0)
+    - React-Fabric/components/text (= 0.69.0)
+    - React-Fabric/components/textinput (= 0.69.0)
+    - React-Fabric/components/unimplementedview (= 0.69.0)
+    - React-Fabric/components/view (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/activityindicator (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/image (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/image (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/inputaccessory (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/inputaccessory (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/legacyviewmanagerinterop (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/legacyviewmanagerinterop (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/modal (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/modal (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/root (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/root (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/safeareaview (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/safeareaview (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/scrollview (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/scrollview (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/slider (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/slider (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/text (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/text (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/textinput (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/textinput (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/unimplementedview (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/unimplementedview (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/components/view (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/components/view (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
     - Yoga
-  - React-Fabric/config (0.69.0-rc.0):
+  - React-Fabric/config (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/core (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/core (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/debug_core (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/debug_core (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/debug_renderer (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/debug_renderer (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/imagemanager (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/imagemanager (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-RCTImage (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/leakchecker (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/leakchecker (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/mounting (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/mounting (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/runtimescheduler (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/runtimescheduler (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/scheduler (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/scheduler (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/telemetry (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/telemetry (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/templateprocessor (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/templateprocessor (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/textlayoutmanager (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/textlayoutmanager (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
     - React-Fabric/uimanager
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/uimanager (0.69.0-rc.0):
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/uimanager (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-Fabric/utils (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-Fabric/utils (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.0-rc.0)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-graphics (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-graphics (0.69.0-rc.0):
+    - RCTRequired (= 0.69.0)
+    - RCTTypeSafety (= 0.69.0)
+    - React-graphics (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-graphics (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.0-rc.0)
-  - React-hermes (0.69.0-rc.0):
+    - React-Core/Default (= 0.69.0)
+  - React-hermes (0.69.0):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCT-Folly/Futures (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-jsiexecutor (= 0.69.0-rc.0)
-    - React-jsinspector (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-  - React-jsi (0.69.0-rc.0):
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-jsiexecutor (= 0.69.0)
+    - React-jsinspector (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+  - React-jsi (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.69.0-rc.0)
-  - React-jsi/Default (0.69.0-rc.0):
+    - React-jsi/Default (= 0.69.0)
+  - React-jsi/Default (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsi/Fabric (0.69.0-rc.0):
+  - React-jsi/Fabric (0.69.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.69.0-rc.0):
+  - React-jsiexecutor (0.69.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
-  - React-jsinspector (0.69.0-rc.0)
-  - React-logger (0.69.0-rc.0):
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-perflogger (= 0.69.0)
+  - React-jsinspector (0.69.0)
+  - React-logger (0.69.0):
     - glog
   - react-native-safe-area-context (4.2.5):
     - RCT-Folly
@@ -648,78 +648,78 @@ PODS:
     - react-native-safe-area-context/common
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.69.0-rc.0)
-  - React-RCTActionSheet (0.69.0-rc.0):
-    - React-Core/RCTActionSheetHeaders (= 0.69.0-rc.0)
-  - React-RCTAnimation (0.69.0-rc.0):
+  - React-perflogger (0.69.0)
+  - React-RCTActionSheet (0.69.0):
+    - React-Core/RCTActionSheetHeaders (= 0.69.0)
+  - React-RCTAnimation (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTAnimationHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTBlob (0.69.0-rc.0):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTAnimationHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTBlob (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTBlobHeaders (= 0.69.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-RCTNetwork (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTFabric (0.69.0-rc.0):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTBlobHeaders (= 0.69.0)
+    - React-Core/RCTWebSocket (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTFabric (0.69.0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - React-Core (= 0.69.0-rc.0)
-    - React-Fabric (= 0.69.0-rc.0)
-    - React-RCTImage (= 0.69.0-rc.0)
-  - React-RCTImage (0.69.0-rc.0):
+    - React-Core (= 0.69.0)
+    - React-Fabric (= 0.69.0)
+    - React-RCTImage (= 0.69.0)
+  - React-RCTImage (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTImageHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-RCTNetwork (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTLinking (0.69.0-rc.0):
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTLinkingHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTNetwork (0.69.0-rc.0):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTImageHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-RCTNetwork (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTLinking (0.69.0):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTLinkingHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTNetwork (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTNetworkHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTSettings (0.69.0-rc.0):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTNetworkHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTSettings (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.0-rc.0)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTSettingsHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-RCTText (0.69.0-rc.0):
-    - React-Core/RCTTextHeaders (= 0.69.0-rc.0)
-  - React-RCTVibration (0.69.0-rc.0):
+    - RCTTypeSafety (= 0.69.0)
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTSettingsHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-RCTText (0.69.0):
+    - React-Core/RCTTextHeaders (= 0.69.0)
+  - React-RCTVibration (0.69.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.0-rc.0)
-    - React-Core/RCTVibrationHeaders (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.69.0-rc.0)
-  - React-rncore (0.69.0-rc.0)
-  - React-runtimeexecutor (0.69.0-rc.0):
-    - React-jsi (= 0.69.0-rc.0)
-  - ReactCommon/turbomodule/core (0.69.0-rc.0):
+    - React-Codegen (= 0.69.0)
+    - React-Core/RCTVibrationHeaders (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - ReactCommon/turbomodule/core (= 0.69.0)
+  - React-rncore (0.69.0)
+  - React-runtimeexecutor (0.69.0):
+    - React-jsi (= 0.69.0)
+  - ReactCommon/turbomodule/core (0.69.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.0-rc.0)
-    - React-callinvoker (= 0.69.0-rc.0)
-    - React-Core (= 0.69.0-rc.0)
-    - React-cxxreact (= 0.69.0-rc.0)
-    - React-jsi (= 0.69.0-rc.0)
-    - React-logger (= 0.69.0-rc.0)
-    - React-perflogger (= 0.69.0-rc.0)
+    - React-bridging (= 0.69.0)
+    - React-callinvoker (= 0.69.0)
+    - React-Core (= 0.69.0)
+    - React-cxxreact (= 0.69.0)
+    - React-jsi (= 0.69.0)
+    - React-logger (= 0.69.0)
+    - React-perflogger (= 0.69.0)
   - RNGestureHandler (2.4.2):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
@@ -786,10 +786,10 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - Flipper (= 0.125.0)
   - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.2.0)
+  - Flipper-DoubleConversion (= 3.2.0.1)
   - Flipper-Fmt (= 7.1.7)
   - Flipper-Folly (= 2.6.10)
-  - Flipper-Glog (= 0.5.0.4)
+  - Flipper-Glog (= 0.5.0.5)
   - Flipper-PeerTalk (= 0.0.4)
   - Flipper-RSocket (= 1.4.3)
   - FlipperKit (= 0.125.0)
@@ -880,7 +880,7 @@ EXTERNAL SOURCES:
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
-    :path: "../node_modules/react-native/sdks/hermes/hermes-engine.podspec"
+    :podspec: "../node_modules/react-native/sdks/hermes/hermes-engine.podspec"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -958,59 +958,59 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: b99cb3346bc0db29ef3b9f26238129ae91418ea2
-  FBReactNativeSpec: 3ebcd656e2db52b6f833c5b9d2ba1756fdb9b6eb
+  FBLazyVector: f98dec9f199b7b51db586fe0140f509fabd5cc54
+  FBReactNativeSpec: a18ce612cc55071c8b5fc186125e60d993e749bc
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
+  Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
   Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
   Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
-  Flipper-Glog: 87bc98ff48de90cb5b0b5114ed3da79d85ee2dd4
+  Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  hermes-engine: 231d0c9a432723593f5a87d36e76037df9a71392
+  hermes-engine: 03851318b18b534b671ea435fad2202154135c72
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
-  RCTRequired: fe0ae0f056792ef5a5108ce8565efc160012c6f3
-  RCTTypeSafety: cf61e70b396160fbd8f95f98188f254466f438c1
-  React: 85323d4724a0e422e26f7bc50031852d259756d8
-  React-bridging: 3f19645f2594a8cf51b7f7bce7236ac1fcdb8204
-  React-callinvoker: 2e50e37f3b8acfef761e99e0c5d29a6ac405ab76
-  React-Codegen: 212377e11ee3c1de83f3a4cc1da42e8a0d90d3e3
-  React-Core: 62261aaf0e198c9124d2968c3ccfe8eeb95b457b
-  React-CoreModules: e5da64dc1db1eac77d956a736c9fd0d34eb60d99
-  React-cxxreact: c7523fc0cccb8d581b813d249f10222b9253aab5
-  React-Fabric: 305be3389c4440ff3b4825ac8b3ff67bd62c43f5
-  React-graphics: 951ada4d4e1588cf854e875844de593ccfef61cb
-  React-hermes: bfa0434453c06fbce9359a8062295d613ed0be73
-  React-jsi: b6b28546d9b336ba904593b1ae9df0f4655ef4b5
-  React-jsiexecutor: 268169e1c5fe99720ae460a46cf3ff838ae7b356
-  React-jsinspector: 0ccc540558e64184f46f89fb38c71eeedb5599ef
-  React-logger: 05263294a3b1b814eabfa0262e83afc1bb671fbc
+  RCTRequired: eff60a46da0f496a6c76c8f60108c20626860d27
+  RCTTypeSafety: 8cc8a45d0e2f93f1b42b5b2bbf23c4143f19935a
+  React: 8a8fc19196a41141ecb5bde33c97091cdc25ccd8
+  React-bridging: 543858c1fc01ed8264585c5a2646305d20225840
+  React-callinvoker: cc62aa541f261cee6f990f870dbf6aff38f97eef
+  React-Codegen: 7e911be8678357bfae75ff60ba6231780c68e949
+  React-Core: 7faa8679c6f38b5462a71d55b399483f46365e44
+  React-CoreModules: 3a51e8d50928a8593ea44606c00ffa60db95222f
+  React-cxxreact: 51a2239091bc13a3c0b5b1cb445b1585a483df2d
+  React-Fabric: af0fa77fddba0f13b775856ae19117934ec5cfb0
+  React-graphics: 2d0bc92b641fb84924ff55f98161391ce5112372
+  React-hermes: 585652ef95faf9ad06066b3b27fe336b6cc44e64
+  React-jsi: 80aef7359ddaacd86f7247fec6a8dff4db099dc6
+  React-jsiexecutor: b2a049b9f156342f6037ccb0c8acf69f923d3089
+  React-jsinspector: 6aced68014b275b7abd073c9598b0affd0e1669c
+  React-logger: bcf33ce10afa135158c72635e621ddb94126c610
   react-native-safe-area-context: a9616f1fd257ff31946b518266a62f50dbcb3d5b
-  React-perflogger: f82caf4672545fea50f2d7bed51c8329a2167cbc
-  React-RCTActionSheet: 7ade12a6dd0cd780938fea3d34e5335f853694c2
-  React-RCTAnimation: 6eb99a3c54c5ebfab4714eb34c1b2d95ae2e6027
-  React-RCTBlob: 8306ac052e4fc9d1cf9387081a432f68d1921ddc
-  React-RCTFabric: 1e1ca38bed50b6e271f209e4100ca0bbab52f761
-  React-RCTImage: b9ea6cd8fee6399f4fc059cf8e586bc810d97376
-  React-RCTLinking: f6aa965fdfd2255a4987af9d0e64dd155f1c75b5
-  React-RCTNetwork: 6f9d0b198adbaa417334393306b24c4d855dd396
-  React-RCTSettings: 3a73a69bc9cf0abdd5ebf48b21aa720408edb6fc
-  React-RCTText: 3554d694cf2f816a652e7c671a73bbbb57e53e4c
-  React-RCTVibration: 6f181c21dbf4f1f8b67580124ef428dba25fb682
-  React-rncore: 2b6ce224b88bbb0d624291d5505372cdcc799f31
-  React-runtimeexecutor: 078762b7835bf03fd11109fb4b505d1f1b70fdc2
-  ReactCommon: 34dea1fbf479d4cfe4b40bd9310f3d08e5f90943
+  React-perflogger: aa48956d87bae67fc847acc196fae97928b96cd3
+  React-RCTActionSheet: 4eaab2b885130ce9a88c8fdac5f1992315da80f6
+  React-RCTAnimation: 5e91e3ceb988838fa43615bb602181be30d2b26e
+  React-RCTBlob: 4fc8f15c018635668dec9b577f46acf75f604a68
+  React-RCTFabric: e22d23ecc2c1672c3a53feff7862e5ec04e6ff7c
+  React-RCTImage: 53ece22415c499ea18f0acafc2bc7ea89517a78c
+  React-RCTLinking: 0211dd109987c22d9b51d187498cac55a43fe24e
+  React-RCTNetwork: 540c0087fd0382c9b959169eb0e3727306f5d812
+  React-RCTSettings: d1e584c83392d1babbe5e731af10c2726d2545e2
+  React-RCTText: 9c5de1f593a548a2dbeb991ee01c88bef86f0659
+  React-RCTVibration: 7549ef7b07aad1cc629f4c6d88c325366f26423c
+  React-rncore: 0a5131510415ca520866410f3504832de3d6f753
+  React-runtimeexecutor: 7ad268dee53d001697e13264c6bc8e95a902352e
+  ReactCommon: 74a3b8ee497c6d50ce86ef57e15c4c5bf654b83d
   RNGestureHandler: ac67226292cd5e67e7203d682a7e39f85d7b88a9
   RNReanimated: 0302eab362af3c4068c3cb5663bede53b7299881
   RNScreens: 592316e0744de3b640e90c335a45aad13088381a
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: fbc3321a51479606cd0c676e1a79176f9b5b9ae2
+  Yoga: 4935173923cabaa830e195be3e8e4cac045a8f90
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 5cc367b51a8e533adb079d4bb5d6532252436368

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -10,13 +10,13 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "ts-check": "yarn tsc --noEmit",
     "lint:js": "yarn eslint src/ && yarn prettier --check src/",
-    "postinstall": "patch-package && echo 73fa47c9c033e2f1bf10ebab9ac58f02c94ffff9 > ./node_modules/react-native/sdks/.hermesversion"
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
     "react": "18.0.0",
-    "react-native": "0.69.0-rc.0",
+    "react-native": "0.69.0",
     "react-native-gesture-handler": "^2.4.2",
     "react-native-reanimated": "link:../",
     "react-native-safe-area-context": "^4.2.5",
@@ -34,7 +34,7 @@
     "babel-jest": "^26.6.3",
     "eslint": "^8.12.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.70.1",
+    "metro-react-native-babel-preset": "^0.70.3",
     "patch-package": "^6.4.7",
     "prettier": "^2.6.1",
     "react-test-renderer": "18.0.0",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -1353,42 +1353,42 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/cli-clean@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-8.0.0-alpha.3.tgz#3a46c464688c661cec01e5cc5affe3a628e46c94"
-  integrity sha512-BvLtODk+CMJ60qjK25+KuIfXMixBof9OPjB8K5sgaLkSdC/PXWKrxrVhU2pVsGVrNj0PtpLZqm/U3HKyLmyttw==
+"@react-native-community/cli-clean@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-8.0.0.tgz#c8fc6e8d6a84c90ca0839d48080a87ad455613db"
+  integrity sha512-VY/kwyH5xp6oXiB9bcwa+I9W5k6WR/nX3s85FuMW76hSlgG1UVAGL04uZPwYlSmMZuSOSuoXOaIjJ7wAvQMBpg==
   dependencies:
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     prompts "^2.4.0"
 
-"@react-native-community/cli-config@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-8.0.0-alpha.3.tgz#bab85bd0efadb28ac45fc8f2ffa2aeef23bc4779"
-  integrity sha512-cG2WfbIZAEGOuaf6MuhoI3cafe7q6hh3AE4p7HCr1e5BigMYaM9hqXtqjib1/2O9ejyMS/44noohQwPWcfJAZg==
+"@react-native-community/cli-config@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-8.0.2.tgz#dd033cf51fae2b046304b40bb166f577165c6c48"
+  integrity sha512-q0mL6QBzoLDHmlvkAKdgioIsMeyvvgRyu0WVLvT/v5DX6OVRvq4UEULLEY+7/P+760nPBQo4Ou1KqpP/SxmbXA==
   dependencies:
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-tools" "^8.0.0"
     cosmiconfig "^5.1.0"
     deepmerge "^3.2.0"
     glob "^7.1.3"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-8.0.0-alpha.3.tgz#167c53fc45c29c1dfce34a0118e2819b7aeb85d9"
-  integrity sha512-yDNSI6VXucOQR5353pp1Kck+3n0eqy0vFaUyrwEZQo9hoMgXJCHLqMbPWSxfc1QeuSlfwmTF/PqLipgOvrINWg==
+"@react-native-community/cli-debugger-ui@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-8.0.0.tgz#98263dc525e65015e2d6392c940114028f87e8e9"
+  integrity sha512-u2jq06GZwZ9sRERzd9FIgpW6yv4YOW4zz7Ym/B8eSzviLmy3yI/8mxJtvlGW+J8lBsfMcQoqJpqI6Rl1nZy9yQ==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-8.0.0-alpha.3.tgz#f49c5eccda08d775d499872038f120194bd06bf6"
-  integrity sha512-AF0XFNkRD/3lndCKc4TtN0PKLgDKKYrmqIW4VQenvXj6cmNSnPEzZx1dzltGwxmYKyMZvS0tHYEOZg9FTYKYuA==
+"@react-native-community/cli-doctor@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-8.0.2.tgz#2f166812d9b410de66e811fe2d84512157322289"
+  integrity sha512-XOimZcBR8n0Ipuk0iXfbZwxrt1r+2fZnskInZRf3SkYrLIKzDLF+ylKbNWJeuMWZSz9lQimo2cI/978bH1JQGw==
   dependencies:
-    "@react-native-community/cli-config" "^8.0.0-alpha.3"
-    "@react-native-community/cli-platform-ios" "^8.0.0-alpha.3"
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-config" "^8.0.2"
+    "@react-native-community/cli-platform-ios" "^8.0.2"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     envinfo "^7.7.2"
@@ -1403,23 +1403,23 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/cli-hermes@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-8.0.0-alpha.3.tgz#4869c5e2ed0a1a366df8f628677f5ffd7103f602"
-  integrity sha512-tYlbHbzn/QavR46/gsdPDgou0jNpZosZUz9nTPHluqHKjHwKoTklK+w6Kg80mzZnki2GnAnmAZH5hbdvkSHlYA==
+"@react-native-community/cli-hermes@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-8.0.2.tgz#d0c3945b4093128d3095032595c3112378c5cc5e"
+  integrity sha512-RZ9uHTf3UFtGTYxq88uENJEdaDB8ab+YPBDn+Li1u78IKwNeL04F0A1A3ab3hYUkG4PEPnL2rkYSlzzNFLOSPQ==
   dependencies:
-    "@react-native-community/cli-platform-android" "^8.0.0-alpha.3"
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-platform-android" "^8.0.2"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
 
-"@react-native-community/cli-platform-android@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-8.0.0-alpha.3.tgz#d6c3a1342d43d2d107a6d2fba2cb459a2b1ad36c"
-  integrity sha512-/D4vdRlsKqX/qb0WBfBkzKRdMe77KUdnh115PQnFSQNI7pRkViU+OYLashHZoW5cN3IlF+PW2i6UjObVOb6D1g==
+"@react-native-community/cli-platform-android@^8.0.0", "@react-native-community/cli-platform-android@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-8.0.2.tgz#5e408f06a33712263c2a4c4ef3fde4e43c660585"
+  integrity sha512-pAEkt+GULesr8FphTpaNYSmu+O1CPQ2zCXkAg4kRd0WXpq3BsVqomyDWd/eMXTkY/yYQMGl6KilU2p9r/hnfhA==
   dependencies:
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     fs-extra "^8.1.0"
@@ -1429,12 +1429,12 @@
     logkitty "^0.7.1"
     slash "^3.0.0"
 
-"@react-native-community/cli-platform-ios@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-8.0.0-alpha.3.tgz#251d3723774babc499e599e4f2667b1203f57407"
-  integrity sha512-V8129DhF0r4cFwkkQcShkYDtRCCPAhAexgYdbzqF42GMK6pQMIfWoMagkBH6QuGYT2FGsrWPGFa+XZi3YVv+Qg==
+"@react-native-community/cli-platform-ios@^8.0.0", "@react-native-community/cli-platform-ios@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-8.0.2.tgz#603079d9def2f2159a40f9905a26c19dbbe6f0ef"
+  integrity sha512-LxWzj6jIZr5Ot893TKFbt0/T3WkVe6pbc/FSTo+TDQq1FQr/Urv16Uqn0AcL4IX2O1g3Qd13d0vtR/Cdpn3VNw==
   dependencies:
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     execa "^1.0.0"
     glob "^7.1.3"
@@ -1443,13 +1443,13 @@
     ora "^5.4.1"
     plist "^3.0.2"
 
-"@react-native-community/cli-plugin-metro@^8.0.0-alpha.5":
-  version "8.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-8.0.0-alpha.5.tgz#c3539cda24ece8bc3e7576196dc89161994787f8"
-  integrity sha512-G2ZqdX2HAokIzNpfT+hK8XNXYb1NSCzqe/ke5FobhrsRsU8S1d0/+MV+g59w34VHG5MdJXXSLl3Cq3ddDOd25w==
+"@react-native-community/cli-plugin-metro@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-8.0.0.tgz#0b355a7a6fe93b347ec32b3edb3b2cd96b04dfd8"
+  integrity sha512-eIowV2ZRbzIWL3RIKVUUSahntXTuAeKzBSsFuhffLZphsV+UdKdtg5ATR9zbq7nsKap4ZseO5DkVqZngUkC7iQ==
   dependencies:
-    "@react-native-community/cli-server-api" "^8.0.0-alpha.3"
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-server-api" "^8.0.0"
+    "@react-native-community/cli-tools" "^8.0.0"
     chalk "^4.1.2"
     metro "^0.70.1"
     metro-config "^0.70.1"
@@ -1459,13 +1459,13 @@
     metro-runtime "^0.70.1"
     readline "^1.3.0"
 
-"@react-native-community/cli-server-api@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-8.0.0-alpha.3.tgz#2b00b3d7544754de8edcfae0e099f693d73ff75d"
-  integrity sha512-0dOU4AlFTjFqmgw3vRB9D5l4qOyWk/rTy1W90mhf2htJrXgxOHSsbbTnVGw/FfckaIw7dSGAuH7Q0795Laa2sQ==
+"@react-native-community/cli-server-api@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-8.0.0.tgz#562fee6da9f880531db2af1d3439efb7309281f8"
+  integrity sha512-TxUs3sMl9clt7sdv30XETc6VRzyaEli2vDrk3TB5W5o5nSd1PmQdP4ccdGLO/nDRXwOy72QmmXlYWMg1XGU0Gg==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "^8.0.0-alpha.3"
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
+    "@react-native-community/cli-debugger-ui" "^8.0.0"
+    "@react-native-community/cli-tools" "^8.0.0"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.0"
@@ -1474,10 +1474,10 @@
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-8.0.0-alpha.3.tgz#0791c49eb11b39efc19a9670156056df6afddf7a"
-  integrity sha512-laul2kNNygqZ9Y4jCy+cvBia8imb9Q9jGO00ObXGn1n7pvnPeS6JwbopYBI73Wk2yQrWaxcgrBnLFJ3LBXGm1w==
+"@react-native-community/cli-tools@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-8.0.0.tgz#2ca9177d7cdf352f6863f278cdacd44066d10473"
+  integrity sha512-jA4y8CebrRZaOJFjc5zMOnls4KfHkBl2FUtBZV2vcWuedQHa6JVwo+KO88ta3Ysby3uY0+mrZagZfXk7c0mrBw==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
@@ -1489,27 +1489,27 @@
     semver "^6.3.0"
     shell-quote "^1.7.3"
 
-"@react-native-community/cli-types@^8.0.0-alpha.3":
-  version "8.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-8.0.0-alpha.3.tgz#27b9cd6f3425cfd677ef1d1c43cd9ab7d0bedd85"
-  integrity sha512-vWyAdsbxMUTPetW/VOo3tzbD8qzQr0ZWI+r+g8wd1bifndei9C6zl6zOOQq6hZQQpm28H+XkpxtvRnu9ISx1vw==
+"@react-native-community/cli-types@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-8.0.0.tgz#72d24178e5ed1c2d271da43e0a4a4f59178f261a"
+  integrity sha512-1lZS1PEvMlFaN3Se1ksyoFWzMjk+YfKi490GgsqKJln9gvFm8tqVPdnXttI5Uf2DQf3BMse8Bk8dNH4oV6Ewow==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@^8.0.0-alpha.4":
-  version "8.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-8.0.0-alpha.5.tgz#f727f459d1d64b44535b4250b30fbd082de297bf"
-  integrity sha512-9BrOcUDoob0Mp5Ml69QmBfx4SOu4Ud/ee34LxUjHwTUy22VMFvHf8sQCdJWzA7DN9rY0qL8yrjDelh8i2QRUPQ==
+"@react-native-community/cli@^8.0.0":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-8.0.2.tgz#d3657017a5438862881e9e773ab4d252e3afa950"
+  integrity sha512-IwG3f6gKPlJucFH1Ex0SMD1P1rtOpdR9lloWoBZh3y0dbUbsNtiZZz0zJjZFm/2mtrIihplL7Yz3LmQBNm7xBQ==
   dependencies:
-    "@react-native-community/cli-clean" "^8.0.0-alpha.3"
-    "@react-native-community/cli-config" "^8.0.0-alpha.3"
-    "@react-native-community/cli-debugger-ui" "^8.0.0-alpha.3"
-    "@react-native-community/cli-doctor" "^8.0.0-alpha.3"
-    "@react-native-community/cli-hermes" "^8.0.0-alpha.3"
-    "@react-native-community/cli-plugin-metro" "^8.0.0-alpha.5"
-    "@react-native-community/cli-server-api" "^8.0.0-alpha.3"
-    "@react-native-community/cli-tools" "^8.0.0-alpha.3"
-    "@react-native-community/cli-types" "^8.0.0-alpha.3"
+    "@react-native-community/cli-clean" "^8.0.0"
+    "@react-native-community/cli-config" "^8.0.2"
+    "@react-native-community/cli-debugger-ui" "^8.0.0"
+    "@react-native-community/cli-doctor" "^8.0.2"
+    "@react-native-community/cli-hermes" "^8.0.2"
+    "@react-native-community/cli-plugin-metro" "^8.0.0"
+    "@react-native-community/cli-server-api" "^8.0.0"
+    "@react-native-community/cli-tools" "^8.0.0"
+    "@react-native-community/cli-types" "^8.0.0"
     chalk "^4.1.2"
     commander "^2.19.0"
     execa "^1.0.0"
@@ -5007,16 +5007,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.70.1.tgz#532c766fc3200acdd11259c62f993ee483eab8e7"
-  integrity sha512-KjQt1zbjXSw40lN98YY1+MNcZzhyEobjpGKKlDo7JWEEYan4dKlRnujymdJNG8v/fXLY4WdB3vcLR/qIWHRZhQ==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    hermes-parser "0.6.0"
-    metro-source-map "0.70.1"
-    nullthrows "^1.1.1"
-
 metro-babel-transformer@0.70.3:
   version "0.70.3"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.70.3.tgz#dca61852be273824a4b641bd1ecafff07ff3ad1f"
@@ -5083,52 +5073,7 @@ metro-minify-uglify@0.70.3:
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.1.tgz#d71c3630645014c7095fe94655f4c003a6a457ff"
-  integrity sha512-E7jCbHyb+HTA00AqO/XxURCNFc68KU9nJo7zMDGt4EjwcUP80RaBzK1O4/GborQzkWM4wjIuQMnYX6xWYuV5ag==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.2.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.5.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    react-refresh "^0.4.0"
-
-metro-react-native-babel-preset@0.70.3, metro-react-native-babel-preset@^0.70.1:
+metro-react-native-babel-preset@0.70.3, metro-react-native-babel-preset@^0.70.3:
   version "0.70.3"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.70.3.tgz#1c77ec4544ecd5fb6c803e70b21284d7483e4842"
   integrity sha512-4Nxc1zEiHEu+GTdEMEsHnRgfaBkg8f/Td3+FcQ8NTSvs+xL3LBrQy6N07idWSQZHIdGFf+tTHvRfSIWLD8u8Tg==
@@ -5173,20 +5118,7 @@ metro-react-native-babel-preset@0.70.3, metro-react-native-babel-preset@^0.70.1:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.1.tgz#db41af492d3857128f8297334d2752c2efa61827"
-  integrity sha512-0484t7uASQX9JAIhvTfKiheaTM3hjPvPwFMP+8JpTGd/GNY0r0dPxC0XSFah5fJBA7WM6UTuaqChik3wU0JsCA==
-  dependencies:
-    "@babel/core" "^7.14.0"
-    babel-preset-fbjs "^3.4.0"
-    hermes-parser "0.6.0"
-    metro-babel-transformer "0.70.1"
-    metro-react-native-babel-preset "0.70.1"
-    metro-source-map "0.70.1"
-    nullthrows "^1.1.1"
-
-metro-react-native-babel-transformer@^0.70.1:
+metro-react-native-babel-transformer@0.70.3, metro-react-native-babel-transformer@^0.70.1:
   version "0.70.3"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.70.3.tgz#195597c32488f820aa9e441bbca7c04fe7de7a2d"
   integrity sha512-WKBU6S/G50j9cfmFM4k4oRYprd8u3qjleD4so1E2zbTNILg+gYla7ZFGCAvi2G0ZcqS2XuGCR375c2hF6VVvwg==
@@ -5206,31 +5138,12 @@ metro-resolver@0.70.3, metro-resolver@^0.70.1:
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.70.1.tgz#3f592a76f46b4441dc724e7e0523b531a2ac9a3e"
-  integrity sha512-E3aY2rGckJDgtpr2Uvlkhoadl5AF5q0OUkxgPilztj5uzK0PAqQtNn1U3kluZ4obfQGv7nBCp+CBadpsbGuO3g==
-
 metro-runtime@0.70.3, metro-runtime@^0.70.1:
   version "0.70.3"
   resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.70.3.tgz#09231b9d05dcbdfb5a13df0a45307273e6fe1168"
   integrity sha512-22xU7UdXZacniTIDZgN2EYtmfau2pPyh97Dcs+cWrLcJYgfMKjWBtesnDcUAQy3PHekDYvBdJZkoQUeskYTM+w==
   dependencies:
     "@babel/runtime" "^7.0.0"
-
-metro-source-map@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.70.1.tgz#f72a21065ace07e19a3696314360d0dc65a00528"
-  integrity sha512-3VO6yLU0OKa7GM/FCyStT9/n+lDRIuomXbZdoE82NO2RTJfptKg1UphLcJ/wbs5GqBRT8zXyd3eRTwW7AAfeZg==
-  dependencies:
-    "@babel/traverse" "^7.14.0"
-    "@babel/types" "^7.0.0"
-    invariant "^2.2.4"
-    metro-symbolicate "0.70.1"
-    nullthrows "^1.1.1"
-    ob1 "0.70.1"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
 
 metro-source-map@0.70.3:
   version "0.70.3"
@@ -5244,18 +5157,6 @@ metro-source-map@0.70.3:
     nullthrows "^1.1.1"
     ob1 "0.70.3"
     source-map "^0.5.6"
-    vlq "^1.0.0"
-
-metro-symbolicate@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.70.1.tgz#fe2098447662dd70396a33482c0961c5ab020ecb"
-  integrity sha512-PQDlvjLDGv9r1wa8Ykmykr0ob6bkBdcOE3oxjAGw2umi7zjINZ8mMVfmHIRDK0vEh7DNHWp/aYTX9o4BN3Fmbg==
-  dependencies:
-    invariant "^2.2.4"
-    metro-source-map "0.70.1"
-    nullthrows "^1.1.1"
-    source-map "^0.5.6"
-    through2 "^2.0.1"
     vlq "^1.0.0"
 
 metro-symbolicate@0.70.3:
@@ -5417,7 +5318,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -5429,6 +5330,13 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@2.0.0:
   version "2.0.0"
@@ -5578,11 +5486,6 @@ nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
-
-ob1@0.70.1:
-  version "0.70.1"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.70.1.tgz#852d8907b45e86841c81b422115312642f69883f"
-  integrity sha512-YRqBTXhelJAke5+avvEHki7qSrjTW/FgTrOnTJMpytXnnaaJZ6EnjSFOJQwSbMktE18nVaCAvI6kbOv2K6ZqFQ==
 
 ob1@0.70.3:
   version "0.70.3"
@@ -6077,10 +5980,10 @@ react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-codegen@^0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.15.tgz#ff664909dad8d7d8c6c3c8ff74ad548cf15956f9"
-  integrity sha512-kxOwGM9Jmz476NGZCq/kJswX4rD8c0kXCkZ6UNszAs+LbtlT8D2dyJeH2RRxLSZXDFUcvbgKWQNcHTidzmvYkA==
+react-native-codegen@^0.69.1:
+  version "0.69.1"
+  resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.69.1.tgz#3632be2f24464e6fad8dd11a25d1b6f3bc2c7d0b"
+  integrity sha512-TOZEqBarczcyYN3iZE3VpKkooOevaAzBq9n7lU0h9mQUvtRhLVyolc+a5K6cWI0e4v4K69I0MqzjPcPeFKo32Q==
   dependencies:
     "@babel/parser" "^7.14.0"
     flow-parser "^0.121.0"
@@ -6119,15 +6022,15 @@ react-native-screens@software-mansion/react-native-screens#568e588817538740dff23
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native@0.69.0-rc.0:
-  version "0.69.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.0-rc.0.tgz#ca1e53d9af9cfab89e8cae9b0773d370ff15bfa8"
-  integrity sha512-Kad5Avi2WuYPkJ71qUS6ZQKZPLtCSoD6ctp/e0fsnI2ix627NuKS/WiK0naLVkGLv5FiHSrVu3GAvY1JXy0KNg==
+react-native@0.69.0:
+  version "0.69.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.0.tgz#16cb7f02d8253fb4e69ea56e878afd1e797b0292"
+  integrity sha512-TBaoNMaxxVLRNNxNXmi8sauxSv6LXF5O6apoUPHVYC1Tr9dP0DqiQP2ngHHJM9ysxxIkX47OTho028HRbkgTCA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
-    "@react-native-community/cli" "^8.0.0-alpha.4"
-    "@react-native-community/cli-platform-android" "^8.0.0-alpha.3"
-    "@react-native-community/cli-platform-ios" "^8.0.0-alpha.3"
+    "@react-native-community/cli" "^8.0.0"
+    "@react-native-community/cli-platform-android" "^8.0.0"
+    "@react-native-community/cli-platform-ios" "^8.0.0"
     "@react-native/assets" "1.0.0"
     "@react-native/normalize-color" "2.0.0"
     "@react-native/polyfills" "2.0.0"
@@ -6139,21 +6042,22 @@ react-native@0.69.0-rc.0:
     invariant "^2.2.4"
     jsc-android "^250230.2.1"
     memoize-one "^5.0.0"
-    metro-react-native-babel-transformer "0.70.1"
-    metro-runtime "0.70.1"
-    metro-source-map "0.70.1"
+    metro-react-native-babel-transformer "0.70.3"
+    metro-runtime "0.70.3"
+    metro-source-map "0.70.3"
+    mkdirp "^0.5.1"
     nullthrows "^1.1.1"
     pretty-format "^26.5.2"
     promise "^8.0.3"
     react-devtools-core "4.24.0"
-    react-native-codegen "^0.0.15"
+    react-native-codegen "^0.69.1"
     react-native-gradle-plugin "^0.0.7"
     react-refresh "^0.4.0"
     react-shallow-renderer "16.14.1"
     regenerator-runtime "^0.13.2"
     scheduler "^0.21.0"
     stacktrace-parser "^0.1.3"
-    use-subscription ">=1.0.0 <1.6.0"
+    use-sync-external-store "^1.0.0"
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
@@ -7235,12 +7139,10 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-"use-subscription@>=1.0.0 <1.6.0":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
-  dependencies:
-    object-assign "^4.1.1"
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Description

This PR upgrades react-native from 0.69.0-rc.0 to 0.69.0 stable in FabricExample.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
