### PR TITLE
Add explicit error message when building Reanimated 3 for react-native 0.68 with Fabric enabled

### DIFF
--- a/Common/cpp/Fabric/FabricUtils.cpp
+++ b/Common/cpp/Fabric/FabricUtils.cpp
@@ -1,5 +1,10 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#if RNVERSION < 69
+#error \
+    "Reanimated 3 does not support React Native 0.68.x when Fabric is enabled. Please upgrade to React Native 0.69.0 or newer if you want to use Reanimated with the new architecture."
+#endif
+
 #include "FabricUtils.h"
 
 #include <react/renderer/uimanager/UIManagerBinding.h>

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -24,8 +24,15 @@ rescue
     begin
       # Example app in reanimated repo
       # /react-native-reanimated/RNReanimated.podspec
-      # /react-native-reanimated/node_modules/react-native/package.json
-      reactJson = JSON.parse(File.read(File.join(__dir__, "node_modules", "react-native", "package.json")))
+      # /react-native-reanimated/{Example,FabricExample,TVOSExample}/node_modules/react-native/package.json
+      if ENV["ReanimatedTVOSExample"] == "1" then
+        appName = "TVOSExample"
+      elsif ENV["RCT_NEW_ARCH_ENABLED"] == "1" then
+        appName = "FabricExample"
+      else
+        appName = "Example"
+      end
+      reactJson = JSON.parse(File.read(File.join(__dir__, appName, "node_modules", "react-native", "package.json")))
       reactVersion = reactJson["version"]
       reactTargetTvOS = ENV["ReanimatedTVOSExample"] == "1"
     rescue


### PR DESCRIPTION
## Description

This PR adds a compile error when building Reanimated 3 on React Native 0.68 with Fabric enabled.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
