### PR TITLE
Fix react-navigation drawer crash:  is not a supported event type

### DIFF
--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -272,7 +272,7 @@ RCT_EXPORT_METHOD(installTurboModule)
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[];
+  return @[ @"onReanimatedCall", @"onReanimatedPropsChange" ];
 }
 
 - (void)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event


### PR DESCRIPTION
## Description

Fixes https://github.com/react-navigation/react-navigation/pull/10639


## Changes

Added back supported events.

## Test code and steps to reproduce

```ts
import * as React from 'react';
import {Button, View} from 'react-native';
import {
  createDrawerNavigator,
  DrawerScreenProps,
} from '@react-navigation/drawer';
import {NavigationContainer} from '@react-navigation/native';

type RootStackParamList = {
  Home: undefined;
  Notifications: undefined;
};

function HomeScreen({
  navigation,
}: DrawerScreenProps<RootStackParamList, 'Home'>) {
  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Button
        onPress={() => navigation.navigate('Notifications')}
        title="Go to notifications"
      />
    </View>
  );
}

function NotificationsScreen({
  navigation,
}: DrawerScreenProps<RootStackParamList, 'Notifications'>) {
  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Button onPress={() => navigation.goBack()} title="Go back home" />
    </View>
  );
}

const Drawer = createDrawerNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <Drawer.Navigator initialRouteName="Home">
        <Drawer.Screen name="Home" component={HomeScreen} />
        <Drawer.Screen name="Notifications" component={NotificationsScreen} />
      </Drawer.Navigator>
    </NavigationContainer>
  );
}

```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
