### PR TITLE
docs: add clean cache note after adding babel plugin

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -52,6 +52,18 @@ Reanimated plugin has to be listed last.
 
 :::
 
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
+
+:::
+
 ## Android
 
 No additional steps are necessary.

--- a/docs/versioned_docs/version-2.0.x/installation.md
+++ b/docs/versioned_docs/version-2.0.x/installation.md
@@ -73,6 +73,19 @@ Reanimated plugin has to be listed last.
 
 :::
 
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
+
+:::
+
+
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.0.x/installation.md
+++ b/docs/versioned_docs/version-2.0.x/installation.md
@@ -85,7 +85,6 @@ or other.
 
 :::
 
-
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.1.x/installation.md
+++ b/docs/versioned_docs/version-2.1.x/installation.md
@@ -73,6 +73,18 @@ Reanimated plugin has to be listed last.
 
 :::
 
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
+
+:::
+
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.2.x/installation.md
+++ b/docs/versioned_docs/version-2.2.x/installation.md
@@ -73,6 +73,19 @@ Reanimated plugin has to be listed last.
 
 :::
 
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
+
+:::
+
+
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.2.x/installation.md
+++ b/docs/versioned_docs/version-2.2.x/installation.md
@@ -85,7 +85,6 @@ or other.
 
 :::
 
-
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.3.x/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/installation.md
@@ -36,6 +36,18 @@ Reanimated plugin has to be listed last.
 
 :::
 
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
+
+:::
+
 ## Android
 
 1. Turn on Hermes engine by editing `android/app/build.gradle`

--- a/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
@@ -10,7 +10,7 @@ The steps needed to get reanimated properly configured are listed in the below p
 
 ## Installing the package
 
-First step is to install `react-native-reanimated` alpha as a dependency in your project:
+First step is to install `react-native-reanimated` as a dependency in your project:
 
 ```bash
 yarn add react-native-reanimated
@@ -33,6 +33,18 @@ Add Reanimated's babel plugin to your `babel.config.js`:
 :::caution
 
 Reanimated plugin has to be listed last.
+
+:::
+
+:::info
+
+After adding the `react-native-reanimated/plugin` to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
+
+- `yarn start --reset-cache`
+- `npm start -- --reset-cache`
+- `expo start -c`
+
+or other.
 
 :::
 


### PR DESCRIPTION
## Description

During the installation of `react-native-reanimated` it's incredibly common to encounter a false-positive error that is easily fixed by clearing the cache.

This PR adds a note to the docs about cleaning the cache after installing reanimated's babel plugin.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/1875

## Screenshots / GIFs

Sorry for the dark theme 🙈 

<img width="823" alt="image" src="https://user-images.githubusercontent.com/39658211/175934379-b33f8630-b269-40f2-b9bb-481bb5fb8eea.png">


## Test code and steps to reproduce

```sh
cd docs/
yarn
yarn start
```

and navigate to http://localhost:3000/react-native-reanimated/docs/fundamentals/installation

## Checklist

- [x] Updated documentation
