### PR TITLE
docs: document withSpring options

### DIFF
--- a/docs/docs/api/animations/withSpring.md
+++ b/docs/docs/api/animations/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.0.x/api/withSpring.md
+++ b/docs/versioned_docs/version-2.0.x/api/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.1.x/api/withSpring.md
+++ b/docs/versioned_docs/version-2.1.x/api/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.2.x/api/withSpring.md
+++ b/docs/versioned_docs/version-2.2.x/api/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.3.x/api/animations/withSpring.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.5.x/api/animations/withSpring.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/withSpring.md
@@ -29,14 +29,14 @@ Currently supported formats are:
 Object carrying spring configuration.
 Allowed parameters are listed below:
 
-| Options                   | Default | Description |
-| ------------------------- | ------- | ----------- |
-| damping                   | 10      |             |
-| mass                      | 1       |             |
-| stiffness                 | 100     |             |
-| overshootClamping         | false   |             |
-| restDisplacementThreshold | 0.01    |             |
-| restSpeedThreshold        | 2       |             |
+| Options                   | Default | Description                                                                       |
+| ------------------------- | ------- | --------------------------------------------------------------------------------- |
+| damping                   | 10      | How hard the animation decelerates.                                               |
+| mass                      | 1       | The weight of the spring. Reducing this value makes the animation faster.         |
+| stiffness                 | 100     | How bouncy the animation is.                                                      |
+| overshootClamping         | false   | Whether the animation can bounce over the specified value.                        |
+| restDisplacementThreshold | 0.01    | The displacement below which the spring is considered to be at rest.              |
+| restSpeedThreshold        | 2       | The speed in pixels per second from which the spring is considered to be at rest. |
 
 #### `callback` [function]\(optional\)
 


### PR DESCRIPTION
## Description

This PR adds descriptions to options of the `withSpring` animation.

https://docs.swmansion.com/react-native-reanimated/docs/api/animations/withSpring


## Screenshots / GIFs

### Before

![image](https://user-images.githubusercontent.com/39658211/175949620-091a7b24-8df1-421f-a822-4f3507872a46.png)

### After

Sorry for the dark theme 🙈

![image](https://user-images.githubusercontent.com/39658211/175949320-e9a4cc64-d2de-4595-84fa-e5c8d4d3531e.png)


## Test code and steps to reproduce

```sh
cd docs/
yarn
yarn start
```

and navigate to http://localhost:3000/react-native-reanimated/docs/api/animations/withSpring

## Checklist

- [x] Updated documentation
