### PR TITLE
Added missing link and command in reanimated documentation

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -84,4 +84,8 @@ As reanimated is setup to configure and install automatically, the only thing yo
 ## Sample React-Native project configured with Reanimated
 
 If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up ion a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
-[Visit the Playground repo here] or copy the command below to do a git clone:
+[Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
+
+```
+git clone https://github.com/software-mansion-labs/reanimated-2-playground.git
+```

--- a/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
@@ -68,4 +68,8 @@ As reanimated is setup to configure and install automatically, the only thing yo
 ## Sample React-Native project configured with Reanimated
 
 If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up ion a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
-[Visit the Playground repo here] or copy the command below to do a git clone:
+[Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
+
+```
+git clone https://github.com/software-mansion-labs/reanimated-2-playground.git
+```


### PR DESCRIPTION
## Description

The `Install` section of the documentation was missing a link to the playground repo and a git clone command.

## Changes

The link and command were added to the current documentation as well as version `2.5.x`.

## Screenshots / GIFs

<img width="979" alt="obraz" src="https://user-images.githubusercontent.com/10947344/177309686-23b16f5e-a5fb-4aee-b577-7fff39477a7f.png">

## Test code and steps to reproduce

`n/a`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
