### PR TITLE
fix: use null prototype for LayoutAnimationRepository config

### DIFF
--- a/src/reanimated2/layoutReanimation/LayoutAnimationRepository.ts
+++ b/src/reanimated2/layoutReanimation/LayoutAnimationRepository.ts
@@ -7,7 +7,7 @@ import { processColor } from '../Colors';
 runOnUI(() => {
   'worklet';
 
-  const configs: Record<string, any> = {};
+  const configs: Record<string, any> = Object.create(null);
   const enteringAnimationForTag: Record<string, any> = {};
 
   global.LayoutAnimationRepository = {


### PR DESCRIPTION
## Description

Prevent the `configs` object from having properties inherited from `Object.prototype`, such as `toString` or `__proto__`. Otherwise, using these properties could potentially have a security impact.

## Changes

Changed the prototype of the `configs` object so it doesn't inherit from `Object.prototype`, as regular JS objects do by default.


## Test code and steps to reproduce

Couldn't find a test case that I could base on to demonstrate how this could present a risk.

An example of the problem caused by using an object inheriting from `Object.prototype` can be demonstrated by the following line (corresponding to the `startAnimationForTag` function):

```js
const style = configs[tag][type](yogaValues);
```

If both `tag` and `type` had the value `constructor`, style would have the result of evaluating `configs.constructor.constructor(yogaValues)`, which in many platforms would be the same as `new Function(yogaValues)`. This could potentially be used to create functions with malicious code. Although I suspect the conditions to make this work would be hard to achieve, it's probably better to get rid of this potential threat by using null prototypes.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
