### PR TITLE
Exclude meta-inf from gradle to prevent intermediate compile conflicts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -256,6 +256,8 @@ android {
         println "Native libs debug enabled: ${debugNativeLibraries}"
         doNotStrip debugNativeLibraries ? "**/**/*.so" : ''
         excludes = [
+                "META-INF",
+                "META-INF/**",
                 "**/libc++_shared.so",
                 "**/libfbjni.so",
                 "**/libjsi.so",


### PR DESCRIPTION
When trying to compile Detox and Reanimated from source there is an intermediate dependency conflict stemming from the META-INF folder. To resolve, excluded META-INF from Gradle packagingOptions. 

Please cherrypick onto v2

## Changes



- Exclude meta-inf from gradle to prevent intermediate compile conflicts with Detox



## Checklist

- [] Included code example that can be used to test this change
- [] Updated TS types
- [] Added TS types tests
- [] Added unit / integration tests
- [] Updated documentation
- [ ] Ensured that CI passes
