### PR TITLE
Various documentation fixes

### DIFF
--- a/docs/docs/fundamentals/about.md
+++ b/docs/docs/fundamentals/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,22 +54,22 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -83,10 +83,10 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.
 
 ### Sponsors
-We really appreciate our sponsors! Thanks to them we can develop our library and make the react-native world a better place. Special thanks for:
+We really appreciate our sponsors! Thanks to them we can develop our library and make the React Native world a better place. Special thanks for:
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">

--- a/docs/docs/fundamentals/about.md
+++ b/docs/docs/fundamentals/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/docs/fundamentals/animations.md
+++ b/docs/docs/fundamentals/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -117,14 +117,14 @@ To illustrate how interruptions perform in practice, please take a look at the b
 ## Customizing Animations
 
 Reanimated currently provides three built-in animation helpers: [`withTiming`](../api/animations/withTiming), [`withSpring`](../api/animations/withSpring), and [`withDecay`](../api/animations/withDecay).
-As there are ways of expanding that with your own, custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), we are not yet ready to document that as we still plan some changes of that part of the API.
-However, the built-in methods along with the animation modifiers (that we discuss later on), already provides a great flexibility.
+There are ways of expanding that with your own custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), but we are not yet ready to document that as we still plan some changes in that part of the API.
+However, the built-in methods along with the animation modifiers (that we discuss later on), already provide great flexibility.
 Below we discuss some of the most common configuration options of the animation helpers, and we refer to the documentation page of [`withTiming`](../api/animations/withTiming) and [`withSpring`](../api/animations/withSpring) for the complete set of parameters.
 
 Both animation helper methods share a similar structure.
 They take target value as the first parameter, configuration object as the second, and finally a callback method as the last parameter.
-Starting from the end, callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
-Callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
+Starting from the end, the callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
+Thr callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
 
 ```js
 <Button
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](../api/animations/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](../api/animations/withDelay), [`withSequence`](../api/animations/withSequence) and [`withRepeat`](../api/animations/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.
+Please check the documentation of the [`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.

--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -5,7 +5,6 @@ sidebar_label: Installation
 ---
 
 Installing Reanimated requires a couple of additional steps compared to installing most of the popular react-native packages.
-Specifically on Android the setup consist of adding additional code to the main application class.
 The steps needed to get reanimated properly configured are listed in the below paragraphs.
 
 ## Installing the package
@@ -70,7 +69,7 @@ No additional steps are necessary.
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add rules preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.swmansion.reanimated.** { *; }
@@ -83,7 +82,7 @@ As reanimated is setup to configure and install automatically, the only thing yo
 
 ## Sample React-Native project configured with Reanimated
 
-If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up ion a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
+If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up on a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```

--- a/docs/docs/fundamentals/shared-values.md
+++ b/docs/docs/fundamentals/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among the fundamental concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](../api/animations/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](../api/animations/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/docs/fundamentals/worklets.md
+++ b/docs/docs/fundamentals/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
           ],
           Hooks: [
             'api/hooks/useAnimatedGestureHandler',
+            'api/hooks/useAnimatedKeyboard',
             'api/hooks/useAnimatedProps',
             'api/hooks/useAnimatedReaction',
             'api/hooks/useAnimatedRef',

--- a/docs/versioned_docs/version-2.0.x/about.md
+++ b/docs/versioned_docs/version-2.0.x/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,23 +54,23 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - We currently only support Hermes JS VM on Android.
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -84,4 +84,4 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.

--- a/docs/versioned_docs/version-2.0.x/about.md
+++ b/docs/versioned_docs/version-2.0.x/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/versioned_docs/version-2.0.x/animations.md
+++ b/docs/versioned_docs/version-2.0.x/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](api/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](api/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](api/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](api/withDelay), [`withSequence`](api/withSequence) and [`withRepeat`](api/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.
+Please check the documentation of the [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.

--- a/docs/versioned_docs/version-2.0.x/animations.md
+++ b/docs/versioned_docs/version-2.0.x/animations.md
@@ -46,7 +46,7 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
 The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](api/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -108,7 +108,7 @@ Interruptions also work correctly for animations defined in `useAnimatedStyle` h
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](api/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 

--- a/docs/versioned_docs/version-2.0.x/installation.md
+++ b/docs/versioned_docs/version-2.0.x/installation.md
@@ -136,7 +136,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add the rule preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.facebook.react.turbomodule.** { *; }

--- a/docs/versioned_docs/version-2.0.x/shared-values.md
+++ b/docs/versioned_docs/version-2.0.x/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among the fundamental concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](api/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](api/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.0.x/worklets.md
+++ b/docs/versioned_docs/version-2.0.x/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {

--- a/docs/versioned_docs/version-2.1.x/about.md
+++ b/docs/versioned_docs/version-2.1.x/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,22 +54,24 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+
+### Known problems and limitations
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -83,4 +85,4 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.

--- a/docs/versioned_docs/version-2.1.x/about.md
+++ b/docs/versioned_docs/version-2.1.x/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/versioned_docs/version-2.1.x/animations.md
+++ b/docs/versioned_docs/version-2.1.x/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](api/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](api/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](api/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](api/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -117,14 +117,14 @@ To illustrate how interruptions perform in practice, please take a look at the b
 ## Customizing Animations
 
 Reanimated currently provides three built-in animation helpers: [`withTiming`](api/withTiming), [`withSpring`](api/withSpring), and [`withDecay`](api/withDecay).
-As there are ways of expanding that with your own, custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), we are not yet ready to document that as we still plan some changes of that part of the API.
-However, the built-in methods along with the animation modifiers (that we discuss later on), already provides a great flexibility.
+There are ways of expanding that with your own custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), but we are not yet ready to document that as we still plan some changes in that part of the API.
+However, the built-in methods along with the animation modifiers (that we discuss later on), already provide great flexibility.
 Below we discuss some of the most common configuration options of the animation helpers, and we refer to the documentation page of [`withTiming`](api/withTiming) and [`withSpring`](api/withSpring) for the complete set of parameters.
 
 Both animation helper methods share a similar structure.
 They take target value as the first parameter, configuration object as the second, and finally a callback method as the last parameter.
-Starting from the end, callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
-Callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
+Starting from the end, the callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
+Thr callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
 
 ```js
 <Button
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](api/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](api/withDelay), [`withSequence`](api/withSequence) and [`withRepeat`](api/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.
+Please check the documentation of the [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.

--- a/docs/versioned_docs/version-2.1.x/installation.md
+++ b/docs/versioned_docs/version-2.1.x/installation.md
@@ -136,7 +136,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add the rule preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.facebook.react.turbomodule.** { *; }

--- a/docs/versioned_docs/version-2.1.x/shared-values.md
+++ b/docs/versioned_docs/version-2.1.x/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among fundamental the concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](api/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](api/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.1.x/worklets.md
+++ b/docs/versioned_docs/version-2.1.x/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {

--- a/docs/versioned_docs/version-2.2.x/about.md
+++ b/docs/versioned_docs/version-2.2.x/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,22 +54,22 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -83,4 +83,4 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.

--- a/docs/versioned_docs/version-2.2.x/about.md
+++ b/docs/versioned_docs/version-2.2.x/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/versioned_docs/version-2.2.x/animations.md
+++ b/docs/versioned_docs/version-2.2.x/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](api/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](api/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](api/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](api/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -117,14 +117,14 @@ To illustrate how interruptions perform in practice, please take a look at the b
 ## Customizing Animations
 
 Reanimated currently provides three built-in animation helpers: [`withTiming`](api/withTiming), [`withSpring`](api/withSpring), and [`withDecay`](api/withDecay).
-As there are ways of expanding that with your own, custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), we are not yet ready to document that as we still plan some changes of that part of the API.
-However, the built-in methods along with the animation modifiers (that we discuss later on), already provides a great flexibility.
+There are ways of expanding that with your own custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), but we are not yet ready to document that as we still plan some changes in that part of the API.
+However, the built-in methods along with the animation modifiers (that we discuss later on), already provide great flexibility.
 Below we discuss some of the most common configuration options of the animation helpers, and we refer to the documentation page of [`withTiming`](api/withTiming) and [`withSpring`](api/withSpring) for the complete set of parameters.
 
 Both animation helper methods share a similar structure.
 They take target value as the first parameter, configuration object as the second, and finally a callback method as the last parameter.
-Starting from the end, callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
-Callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
+Starting from the end, the callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
+Thr callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
 
 ```js
 <Button
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](api/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](api/withDelay), [`withSequence`](api/withSequence) and [`withRepeat`](api/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.
+Please check the documentation of the [`useAnimatedProps`](api/useAnimatedProps) hook for usage examples.

--- a/docs/versioned_docs/version-2.2.x/installation.md
+++ b/docs/versioned_docs/version-2.2.x/installation.md
@@ -136,7 +136,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add the rule preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.facebook.react.turbomodule.** { *; }

--- a/docs/versioned_docs/version-2.2.x/shared-values.md
+++ b/docs/versioned_docs/version-2.2.x/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among the fundamental concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](api/withTiming) or [`withSpring`](api/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](api/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](api/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.2.x/worklets.md
+++ b/docs/versioned_docs/version-2.2.x/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {

--- a/docs/versioned_docs/version-2.3.x/fundamentals/about.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,22 +54,22 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -83,10 +83,10 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.
 
 ### Sponsors
-We really appreciate our sponsors! Thanks to them we can develop our library and make the react-native world a better place. Special thanks for:
+We really appreciate our sponsors! Thanks to them we can develop our library and make the React Native world a better place. Special thanks for:
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">

--- a/docs/versioned_docs/version-2.3.x/fundamentals/about.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/versioned_docs/version-2.3.x/fundamentals/animations.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -117,14 +117,14 @@ To illustrate how interruptions perform in practice, please take a look at the b
 ## Customizing Animations
 
 Reanimated currently provides three built-in animation helpers: [`withTiming`](../api/animations/withTiming), [`withSpring`](../api/animations/withSpring), and [`withDecay`](../api/animations/withDecay).
-As there are ways of expanding that with your own, custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), we are not yet ready to document that as we still plan some changes of that part of the API.
-However, the built-in methods along with the animation modifiers (that we discuss later on), already provides a great flexibility.
+There are ways of expanding that with your own custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), but we are not yet ready to document that as we still plan some changes in that part of the API.
+However, the built-in methods along with the animation modifiers (that we discuss later on), already provide great flexibility.
 Below we discuss some of the most common configuration options of the animation helpers, and we refer to the documentation page of [`withTiming`](../api/animations/withTiming) and [`withSpring`](../api/animations/withSpring) for the complete set of parameters.
 
 Both animation helper methods share a similar structure.
 They take target value as the first parameter, configuration object as the second, and finally a callback method as the last parameter.
-Starting from the end, callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
-Callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
+Starting from the end, the callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
+Thr callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
 
 ```js
 <Button
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/blob/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/blob/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](../api/animations/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](../api/animations/withDelay), [`withSequence`](../api/animations/withSequence) and [`withRepeat`](../api/animations/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.
+Please check the documentation of the[`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.

--- a/docs/versioned_docs/version-2.3.x/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/installation.md
@@ -84,7 +84,7 @@ You can refer [to this diff](https://github.com/software-mansion-labs/reanimated
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add rules preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.swmansion.reanimated.** { *; }

--- a/docs/versioned_docs/version-2.3.x/fundamentals/shared-values.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among the fundamental concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](../api/animations/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](../api/animations/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.3.x/fundamentals/worklets.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {

--- a/docs/versioned_docs/version-2.5.x/fundamentals/about.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/about.md
@@ -22,12 +22,12 @@ Reanimated is a React Native library that allows for creating smooth animations 
 
 ### Motivation
 
-In React Native apps, the application code is executed outside of the application main thread.
-This is one of the key elements of React Native architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
+In React Native apps, the application code is executed outside of the application's main thread.
+This is one of the key elements of React Native's architecture and helps with preventing frame drops in cases where JavaScript has some heavy work to do.
 Unfortunately this design does not play well when it comes to event driven interactions.
 When interacting with a touch screen, the user expects effects on screen to be immediate.
-If updates are happening in a separate thread it is often a case that changes done in the JavaScript thread cannot be reflected in the same frame.
-In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
+If updates are happening in a separate thread it is often the case that changes done in the JavaScript thread cannot be reflected in the same frame.
+In React Native by default all updates are delayed by at least one frame as the communication between the UI and JavaScript threads is asynchronous and the UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
 This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
@@ -36,13 +36,13 @@ This makes it possible to respond to touch events immediately and update the UI 
 ### Library overview
 
 Version 1 of Reanimated has been designed to match React Native's Animated API while providing a more complete set of primitives for defining interactions.
-In version 2 we decided to change the approach in order to address some limitation of version 1 that comes from the declarative API design.
+In version 2 we decided to change the approach in order to address some limitations of version 1 that come from the declarative API design.
 Below we present an overview of things that are new in Reanimated 2 and different from Reanimated 1.
 This is a tl;dr of the remaining parts of the documentation.
 We recommend that you check the full articles to learn the details about each of the listed aspects:
 
-1. interactions and animations are no longer written using unintuitive declarative API, instead they can be written in pure JS, in a form of so-called "worklets".
-   Worklets are pieces of JS code that we extract from the main react-native code and run in a separate JS context on the main thread.
+1. interactions and animations are no longer written using an unintuitive declarative API, instead they can be written in pure JS, in the form of so-called "worklets".
+   Worklets are pieces of JS code that we extract from the main React Native code and run in a separate JS context on the main thread.
    Because of that, worklets have some limitations as to what part of the JS context they can access (we don't want to load the entire JS bundle into the context which runs on the UI thread).
 2. It is still possible to define and pass around "Animated Values", however thanks to the new API, we expect that you'll create much fewer of those for a single animation.
    Also, now, they are actually called "Shared Values" and can carry not only primitive types but also arrays, objects and functions.
@@ -54,22 +54,22 @@ We recommend that you check the full articles to learn the details about each of
 5. With reanimated, we can hook worklets to serve as event handlers.
    Most common case for an event worklet is to modify some shared values.
    As a result, changes made to those values will be reflected in the animated style worklet being triggered, which in turn will result in some view properties being updated.
-   For convenience, Reanimated provides event hook that is tailored to work together with Gesture Handler library and allow you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
+   For convenience, Reanimated provides an event hook that is tailored to work together with Gesture Handler library and allows you to define a separate worklet for handling different handler states (e.g., onStart, onActive, etc.)
 
 ### Known problems and limitations
 
 Reanimated 2 is in an early version.
 As we wanted to share it with the community as soon as we could, the library still has some rough edges and limitations that we plan to address soon.
-Unfortunately some of the limitations come from maturity of React Native's TurboModule architecture that Reanimated 2 relies on.
+Unfortunately some of the limitations come from the immaturity of React Native's TurboModule architecture that Reanimated 2 relies on.
 As a consequence we won't be able to support older versions of React Native and some issues that we yet plan to resolve may require full support of TurboModules which is not yet available to the public.
 
-Below we highlight some of the problems that we are aware of (in most of the cases we actively work on improving these):
+Below we highlight some of the problems that we are aware of (in most cases we are actively working on improving these):
 
 - As the library uses JSI for synchronous native methods access, remote debugging is no longer possible.
-  You can use Flipper for debugging your JS code, however connecting debugger to JS context which runs on the UI thread is not currently supported.
+  You can use Flipper for debugging your JS code, however connecting the debugger to the JS context which runs on the UI thread is not currently supported.
 - Objects passed to worklets from React Native don't have the correct prototype set in JavaScript.
   As a result, such objects aren't enumerable, that is you can't use "for in" constructs, spread operator (three dots), or functions like Object.assign with them.
-- With Reanimated you can't animate virtual components of layout. For example, you can’t animate nested `<Text>` components because React Native changes
+- With Reanimated you can't animate virtual components of a layout. For example, you can’t animate nested `<Text>` components because React Native changes
   ```
   <Text>
      string1
@@ -83,10 +83,10 @@ Below we highlight some of the problems that we are aware of (in most of the cas
      <RCTVirtualText>string2</RCTVirtualText>
   </RCTTextView>
   ```
-  and the `RCTVirtualText` is a virtual component.
+  and `RCTVirtualText` is a virtual component.
 
 ### Sponsors
-We really appreciate our sponsors! Thanks to them we can develop our library and make the react-native world a better place. Special thanks for:
+We really appreciate our sponsors! Thanks to them we can develop our library and make the React Native world a better place. Special thanks for:
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">

--- a/docs/versioned_docs/version-2.5.x/fundamentals/about.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/about.md
@@ -30,7 +30,7 @@ If updates are happening in a separate thread it is often a case that changes do
 In React Native by default all updates are delayed by at least one frame as the communication between UI and JavaScript thread is asynchronous and UI thread never waits for the JavaScript thread to finish processing events.
 On top of the lag with JavaScript playing many roles like running react diffing and updates, executing app's business logic, processing network requests, etc., it is often the case that events can't be immediately processed thus causing even more significant delays.
 Reanimated aims to provide ways of offloading animation and event handling logic off of the JavaScript thread and onto the UI thread.
-This is achieved by defining Reanimated worklets – a tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
+This is achieved by defining Reanimated worklets – tiny chunks of JavaScript code that can be moved to a separate JavaScript VM and executed synchronously on the UI thread.
 This makes it possible to respond to touch events immediately and update the UI within the same frame when the event happens without worrying about the load that is put on the main JavaScript thread.
 
 ### Library overview

--- a/docs/versioned_docs/version-2.5.x/fundamentals/animations.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/animations.md
@@ -5,13 +5,13 @@ sidebar_label: Animations
 ---
 
 Animations are first-class citizens in Reanimated 2.
-The library comes bundled with a number of animation helper methods that makes it very easy to go from immediate property updates into animated ones.
+The library comes bundled with a number of animation helper methods that make it very easy to go from immediate property updates into animated ones.
 
-In the previous article about [Shared Values](shared-values) we learned about `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
+In the previous article about [Shared Values](shared-values) we learned about the `useAnimatedStyle` hook, that allows for creating an association between Reanimated code and view properties.
 We also learned how to perform animated transitions of Shared Values.
 This, however, is not the only way how animations can be started.
-On top of that Reanimated provides a number of animation modifiers and ways how animations can be customized.
-In this article we explore this and other methods that can be used to perform animated view updates.
+On top of that Reanimated provides a number of animation modifiers and ways for animations to be customized.
+In this article we explore the methods that can be used to perform animated view updates.
 
 ## Shared Value Animated Transitions
 
@@ -46,8 +46,8 @@ As a result, when we tap on the "Move" button the animated box jumps to a new, r
 
 ![](/docs/shared-values/sv-immediate.gif)
 
-With Reanimated 2, such Shared Value updates can be transformed to an animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
-The only change that we can do now, is to wrap random offset value in `withSpring` call as shown below:
+With Reanimated 2, such Shared Value updates can be transformed to animated updates by wrapping the target value using one of the animation helpers, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+The only change that we can do now, is to wrap the random offset value with a `withSpring` call as shown below:
 
 ```js {3}
 <Button
@@ -58,7 +58,7 @@ The only change that we can do now, is to wrap random offset value in `withSprin
 />
 ```
 
-This way, instead of assigning a number to Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
+This way, instead of assigning a number to the Shared Value, we make an animation object which is then used to run updates on the Shared Value until it reaches the target.
 As a result the `offset` Shared Value transitions smoothly between the current and the newly assigned random number, which results in a nice spring-based animation in between those states:
 
 ![](/docs/shared-values/sv-spring.gif)
@@ -67,7 +67,7 @@ As a result the `offset` Shared Value transitions smoothly between the current a
 
 Animated Shared Value transitions are not the only way to initiate and run animations.
 It is often the case that we'd like to animate properties that are not directly mapped onto a Shared Value.
-For that, in Reanimated we allow for animations to be specified directly in [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
+For that, in Reanimated we allow for animations to be specified directly in the [`useAnimatedStyle`](../api/hooks/useAnimatedStyle) hook.
 In order to do this you can use the same animation helper methods from Reanimated API, but instead of using it when updating a Shared Value you use it to wrap the style value property:
 
 ```js {5}
@@ -82,7 +82,7 @@ const animatedStyles = useAnimatedStyle(() => {
 });
 ```
 
-As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in `withSpring` call.
+As you can see, the only change compared to the example from the previous section is that we wrapped the value provided to `translateX` offset in a `withSpring` call.
 This tells the Reanimated engine that all updates made to `translateX` offset should be animated using spring.
 With this change added, we no longer need to animate the `offset` Shared Value updates, and can keep those updates being "immediate":
 
@@ -101,14 +101,14 @@ It forces you to have everything defined in one place vs scattered around the co
 Animated UI updates, by definition, take time to perform.
 It is often undesirable to freeze user interactions with the App and wait for transitions to finish.
 While allowing the user to interact with the screen while style properties are being animated, the framework needs to support a way for those animations to be interrupted or reconfigured as they go.
-This is the case for Reanimated animations API as well.
-Whenever you make animated updates of Shared Values, or you specify animations in `useAnimatedStyle` hook, those animations are fully interruptible.
-In the former case, when you make an update to Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
+This is the case for the Reanimated animations API as well.
+Whenever you make animated updates of Shared Values, or you specify animations in the `useAnimatedStyle` hook, those animations are fully interruptible.
+In the former case, when you make an update to a Shared Value that is being animated, the framework won't wait for the previous animation to finish, but will immediately initiate a new transition starting from the current position of the previous animation.
 Interruptions also work correctly for animations defined in `useAnimatedStyle` hook.
 When the style is updated and the target value for a given property has changed compared to the last time when the style hook was run, the new animation will launch immediately starting from the current position of the property.
 
 We believe that the described behavior, when it comes to interruptions, is desirable in the majority of the usecases, and hence we made it the default.
-In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
+In case you'd like to wait with the next animation until the previous one is finished, or in the case you'd like to cancel currently running animation prior to starting a new one, you can still do it using animation callbacks in the former, or the [`cancelAnimation`](../api/animations/cancelAnimation) method in the latter case.
 
 To illustrate how interruptions perform in practice, please take a look at the below video, where we run the example presented earlier, but make much more frequent taps on the button in order to trigger value changes before the animation settles:
 
@@ -117,14 +117,14 @@ To illustrate how interruptions perform in practice, please take a look at the b
 ## Customizing Animations
 
 Reanimated currently provides three built-in animation helpers: [`withTiming`](../api/animations/withTiming), [`withSpring`](../api/animations/withSpring), and [`withDecay`](../api/animations/withDecay).
-As there are ways of expanding that with your own, custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), we are not yet ready to document that as we still plan some changes of that part of the API.
-However, the built-in methods along with the animation modifiers (that we discuss later on), already provides a great flexibility.
+There are ways of expanding that with your own custom animations (animation helpers are built on top of the [worklets](worklets) abstraction), but we are not yet ready to document that as we still plan some changes in that part of the API.
+However, the built-in methods along with the animation modifiers (that we discuss later on), already provide great flexibility.
 Below we discuss some of the most common configuration options of the animation helpers, and we refer to the documentation page of [`withTiming`](../api/animations/withTiming) and [`withSpring`](../api/animations/withSpring) for the complete set of parameters.
 
 Both animation helper methods share a similar structure.
 They take target value as the first parameter, configuration object as the second, and finally a callback method as the last parameter.
-Starting from the end, callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
-Callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
+Starting from the end, the callback is a method that runs when the animation is finished, or when the animation is interrupted/cancelled.
+Thr callback is run with a single argument – a boolean indicating whether the animation has finished executing without cancellation:
 
 ```js
 <Button
@@ -165,11 +165,11 @@ offset.value = withTiming(0, {
 ```
 
 You may want to visit [easings.net](https://easings.net/) and check various easing visualizations.
-To learn how to apply these please refer to [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
+To learn how to apply these please refer to the [Easing.ts](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/Easing.ts) file where all the easing related helper methods are defined.
 
 ### Spring
 
-Unlike timing, spring-based animation does not take a duration as a parameter.
+Unlike timing, spring-based animations do not take duration as a parameter.
 Instead the time it takes for the spring to run is determined by the spring physics (which is configurable), initial velocity, and the distance to travel.
 Below we show an example of how a custom spring animation can be defined and how it compares to the default spring settings.
 Please review [`withSpring`](../api/animations/withSpring) documentation for the complete list of configurable options.
@@ -215,22 +215,22 @@ function Box() {
 
 ![](/docs/animations/twosprings.gif)
 
-Unlike in the previous example, here we define animation in the `useAnimatedStyle` hook.
+Unlike in the previous example, here we define the animation in the `useAnimatedStyle` hook.
 This makes it possible to use a single Shared Value but map that to two View's styles.
 
 ## Animation Modifiers
 
-Beside the ability of adjusting animation options, another way of customizing animations is by using animation modifiers.
+Besides the ability to adjust animation options, another way of customizing animations is by using animation modifiers.
 Currently, Reanimated exposes three modifiers: [`withDelay`](../api/animations/withDelay), [`withSequence`](../api/animations/withSequence) and [`withRepeat`](../api/animations/withRepeat).
-As the name suggests, `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
+As the name suggests, the `withDelay` modifier makes the provided animation to start with a given delay, the `withSequence` modifier allows a number of animations to be provided and will make them run one after another.
 Finally, the `withRepeat` modifier allows for the provided animation to be repeated several times.
 
 Modifiers typically take one or more animation objects with optional configuration as an input, and return an object that represents the modified animation.
 This makes it possible to wrap existing animation helpers (or custom helpers), or make a chain of modifiers when necessary.
 Please refer to the documentation of each of the modifier methods to learn about the ways how they can be parameterized.
 
-Let us now exercise the use of modifiers in practice and build animation that causes a rectangular view to wobble upon a button click.
-We start by rendering the actual view and defining rotation Shared Value that we then use to run the animation:
+Let us now exercise the use of modifiers in practice and build an animation that causes a rectangular view to wobble upon a button click.
+We start by rendering the actual view and defining the rotation Shared Value that we then use to run the animation:
 
 ```js
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
@@ -267,7 +267,7 @@ rotation.value = withRepeat(withTiming(10), 6, true)
 ```
 
 The above code will cause the view to run six repetitions of timing animation between the initial state of the `rotation` value (that is `0`) and value `10`.
-The third parameter passed to the `withRepeat` method makes the animation to run in reverse every other repetition.
+The third parameter passed to the `withRepeat` method makes the animation run in reverse every other repetition.
 Setting the reverse flag to `true` will result in the rotation doing three full loops (from `0` to `10` and back).
 At the end of all six repetitions the rotation will go back to zero.
 Here is what will happen when we click on the "wobble" button:
@@ -292,15 +292,15 @@ In the above code we put three animations in a sequence.
 First, we start a timing to the minimum swing position (`-10` degrees), after that we start a loop that goes between `-10` and `10` degrees six times (same as in the previous implementation).
 Finally, we add a finishing timing animation that makes the rotation go back to zero.
 For the surrounding timing animation we pass a duration that is half of the duration we use for the looped animation.
-It is because those animations make half the distance, thus this way we maintain the similar velocity for the initial, middle and finishing swings.
+It is because those animations make half the distance, thus this way we maintain similar velocities for the initial, middle and finishing swings.
 Below we present the end result:
 
 ![](/docs/animations/wobble.gif)
 
 ## Animating Layout Properties
 
-Reanimated makes it possible for animations to be executed by completely avoiding the main React Native's JavaScript thread.
-Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) cannot impact the performance of animation and hence allows to avoid many unpredictable frame drops.
+Reanimated makes it possible for animations to be executed by completely avoiding React Native's main JavaScript thread.
+Thanks to the animation runner being completely isolated, the application logic (rendering components, fetching and processing data, etc) do not impact the performance of animations and allow to avoid many unpredictable frame drops.
 Developers who are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) and the concept of [Native Driver](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated) may already understand this benefit, and also know that the use of Native Driver is limited to some subset of view properties.
 This, however, is not the case in Reanimated which supports animations of **all** native properties without generating any load on the main JavaScript thread (including layout properties like `width`, `flex`, etc.).
 This, in fact, was already the case since the first version of Reanimated but we'd like to emphasize that again as we receive questions around this topic from time to time.
@@ -323,4 +323,4 @@ Thankfully, Reanimated allows for that, but as the properties do not belong to s
 For this purpose Reanimated exposes a separate hook called `useAnimatedProps`.
 It works in a very similar way to `useAnimatedStyle` but instead of expecting a method that returns the animated styles, we expect the returned object to contain properties that we want to animate.
 Then, in order to hook animated props to a view, we provide the resulting object as `animatedProps` property to the "Animated" version of the view type we want to render (e.g. `Animated.View`).
-Please check the documentation of [`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.
+Please check the documentation of the [`useAnimatedProps`](../api/hooks/useAnimatedProps) hook for usage examples.

--- a/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/installation.md
@@ -5,7 +5,6 @@ sidebar_label: Installation
 ---
 
 Installing Reanimated requires a couple of additional steps compared to installing most of the popular react-native packages.
-Specifically on Android the setup consist of adding additional code to the main application class.
 The steps needed to get reanimated properly configured are listed in the below paragraphs.
 
 ## Installing the package
@@ -54,7 +53,7 @@ No additional steps are necessary.
 
 ### Proguard
 
-If you're using Proguard, make sure to add rule preventing it from optimizing Turbomodule classes:
+If you're using Proguard, make sure to add rules preventing it from optimizing Turbomodule classes:
 
 ```
 -keep class com.swmansion.reanimated.** { *; }
@@ -67,7 +66,7 @@ As reanimated is setup to configure and install automatically, the only thing yo
 
 ## Sample React-Native project configured with Reanimated
 
-If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up ion a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
+If you have troubles configuring Reanimated in your project, or just want to try the library without the need of setting it up on a fresh project we recommend checking our [Reanimated Playground](https://github.com/software-mansion-labs/reanimated-2-playground) repo, which is essentially a fresh React-Native app with Reanimated library installed and configured properly.
 [Visit the Playground repo here](https://github.com/software-mansion-labs/reanimated-2-playground) or copy the command below to do a git clone:
 
 ```

--- a/docs/versioned_docs/version-2.5.x/fundamentals/shared-values.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/shared-values.md
@@ -4,7 +4,7 @@ title: Shared Values
 sidebar_label: Shared Values
 ---
 
-Shared Values are among fundamental concepts behind Reanimated 2.0.
+Shared Values are among the fundamental concepts behind Reanimated 2.0.
 If you are familiar with React Native's [Animated API](https://reactnative.dev/docs/animated) you can compare them to `Animated.Values`.
 They serve a similar purpose of carrying "animateable" data, providing a notion of reactiveness, and driving animations.
 We will discuss each of those key roles of Shared Values in sections below.
@@ -12,12 +12,12 @@ At the end we present a brief overview of the differences between Shared Values 
 
 ## Carrying data
 
-One of the primary goals of Shared Values (hence their name) is to provide a notion of shared memory in Reanimated 2.0.
+One of the primary goals of Shared Values is to provide a notion of shared memory in Reanimated 2.0 (hence their name).
 As you might've learned in the article about [worklets](worklets), Reanimated 2.0 runs animation code in a separate thread using a separate JS VM context.
-Shared Values makes it possible to maintain a reference to a mutable data that can be read and modified securely across those threads.
+Shared Values make it possible to maintain a reference to mutable data that can be read and modified securely across those threads.
 
 Shared Value objects serve as references to pieces of shared data that can be accessed and modified using their `.value` property.
-It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common source of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing `.value` property of it).
+It is important to remember that whether you want to access or update shared data, you should use `.value` property (one of the most common sources of mistakes in Reanimated 2 code, is to expect the Shared Value reference to return the data instead of accessing it's `.value` property).
 
 In order to provide secure and fast ways of accessing shared data across two threads, we had to make some tradeoffs when designing Shared Values.
 As, during animations, updates most of the time happen on the UI thread, Shared Values are optimized to be updated and read from the UI thread.
@@ -36,7 +36,7 @@ const sharedVal = useSharedValue(3.1415);
 The Shared Value constructor hook takes a single argument which is the initial payload of the Shared Value.
 This can be any primitive or nested data like object, array, number, string or boolean.
 
-In order to update Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
+In order to update a Shared Value from the React Native thread or from a worklet running on the UI thread, you should set a new value onto the `.value` property.
 
 ```js {4,7}
 import { useSharedValue } from 'react-native-reanimated';
@@ -52,10 +52,10 @@ function SomeComponent() {
 }
 ```
 
-In the above example we update value asynchronously from the React Native JS thread.
+In the above example we update the value asynchronously from the React Native JS thread.
 Updates can be done synchronously when making them from within a worklet, like so:
 
-```js {5,9}
+```js {7,11}
 import Animated, {
   useSharedValue,
   useAnimatedScrollHandler,
@@ -79,7 +79,7 @@ function SomeComponent({ children }) {
 ```
 
 Above, the scroll handler is a worklet and runs the scroll event logic on the UI thread.
-Updates made in that worklets are synchronous.
+Updates made in that worklet are synchronous.
 
 ## Reactiveness with Shared Values
 
@@ -96,9 +96,9 @@ Under the hood, Reanimated engine builds a graph of dependencies between Shared 
 For example, when we have a Shared Value `x`, a derived value `y` that uses `x`, and an animated style that uses both `x` and `y`, we only re-run the derived value worklet when `x` updates.
 In such a case, we will also always run the derived value `y` updater first prior to running the animated style updater, because the style depends on it.
 
-Let us look now at an example code:
+Let us now look at a code example:
 
-```js {4,8,15}
+```js {3,7,11,17}
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -137,8 +137,8 @@ This is what you will observe:
 ## Driving animations
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
-One of the ways for animation to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
+One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';
@@ -147,9 +147,9 @@ someSharedValue.value = withTiming(50);
 ```
 
 In the above code the `offset` Shared Value instead of being set to `50` immediately, will transition from the current value to `50` using time-based animation.
-Of course, launching animation this way can be done both from the UI and from the React-Native JS thread.
+Of course, launching animations this way can be done both from the UI and from the React Native JS thread.
 Below is a complete code example which is the modified version of the example from the previous section.
-Here, instead of updating `offset` value immediately, we perform an animated transition with a timing curve.
+Here, instead of updating the `offset` value immediately, we perform an animated transition with a timing curve.
 
 ```js {17}
 import Animated, { withSpring } from 'react-native-reanimated';
@@ -182,7 +182,7 @@ As a result, the updates to the view's translation will be smooth:
 
 ![](/docs/shared-values/sv-spring.gif)
 
-If you want to learn how to customize animations or get notified when the animation is finished check the API of animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
+If you want to learn how to customize animations or get notified when the animation is finished check the API of the animation method you want to use, e.g., [`withTiming`](../api/animations/withTiming) or [`withSpring`](../api/animations/withSpring).
 
 ### Animation progress
 
@@ -206,7 +206,7 @@ This behavior is demonstrated on the clip below where we just do more frequent t
 ### Cancelling animations
 
 There are cases in which we want to stop the currently running animation without starting a new one.
-In reanimated, this can be done using [`cancelAnimation`](../api/animations/cancelAnimation) method:
+In reanimated, this can be done using the [`cancelAnimation`](../api/animations/cancelAnimation) method:
 
 ```js
 import { cancelAnimation } from 'react-native-reanimated';

--- a/docs/versioned_docs/version-2.5.x/fundamentals/worklets.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/worklets.md
@@ -4,7 +4,7 @@ title: Worklets
 sidebar_label: Worklets
 ---
 
-The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have “worklet” directive at the top:
+The ultimate goal of worklets was for them to define small pieces of JavaScript code that we run when updating view properties or reacting to events on the UI thread. A natural construct in JavaScript for such a purpose was a simple method. With Reanimated 2 we spawn a secondary JS context on the UI thread that then is able to run JavaScript functions. The only thing that is needed is for that function to have the “worklet” directive at the top:
 
 ```js
 function someWorklet(greeting) {


### PR DESCRIPTION
# List of changes to the documentation

I only read through `next` and fixed the issues that appeared there and checked if they also appeared in older, versioned docs. If there are issues in the old docs, that have been removed in `next` then I have not looked for them.

1. Added `useAnimatedKeyboard` to sidebar in *next*
2. Multiple minor fixes in `fundamentals/about` in versions *next* and *2.0-2.5*
3. Replaced a few `react-native` spellings with `React Native` to make the spelling more consistent in `fundamentals/about` in versions *next* and *2.0-2.5*
4. The sentence `Specifically on Android the setup consist of adding additional code to the main application class.` under `fundamentals/installation` is not true and contradicts the `Android` section that says `No additional steps are necessary.` Removed that sentence in *next* and *2.5*
5. Minor fixes to `fundamentals/worklets` in versions *next* and *2.5*
6. Minor fixes to `fundamentals/shared-values` in versions *next* and *2.5-2.0*
7. Fixed code highlights in `fundamentals/shared-values` in versions *next* and *2.5-2.0*
8. Fixed some incosistent spellings of `React Native` in `fundamentals/shared-values` in versions *next* and *2.5-2.0*
9. Minor fixes to `fundamentals/animations` in versions *next* and *2.5-2.0*