### PR TITLE
Fixed useFrameCallback hook not running on UI thread

### DIFF
--- a/src/reanimated2/frameCallback/FrameCallbackRegistry.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistry.ts
@@ -4,66 +4,72 @@ export interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, () => void>;
   frameCallbackActive: Set<number>;
   isFrameCallbackRunning: boolean;
-  runAnimation: () => void;
+  runCallbacks: () => void;
   registerFrameCallback: (callback: () => void, callbackId: number) => void;
   unregisterFrameCallback: (frameCallbackId: number) => void;
   manageStateFrameCallback: (frameCallbackId: number, state: boolean) => void;
 }
 
-export default class FrameCallbackRegistry {
+const prepareUIRegistry = runOnUI(() => {
+  'worklet';
+
+  const frameCallbackRegistry: FrameCallbackRegistryUI = {
+    frameCallbackRegistry: new Map<number, () => void>(),
+    frameCallbackActive: new Set<number>(),
+    isFrameCallbackRunning: false,
+
+    runCallbacks() {
+      const loop = () => {
+        this.frameCallbackActive.forEach((key: number) => {
+          const callback = this.frameCallbackRegistry.get(key);
+          callback!();
+        });
+
+        if (this.frameCallbackActive.size > 0) {
+          requestAnimationFrame(loop);
+        } else {
+          this.isFrameCallbackRunning = false;
+        }
+      };
+
+      if (!this.isFrameCallbackRunning) {
+        requestAnimationFrame(loop);
+        this.isFrameCallbackRunning = true;
+      }
+    },
+
+    registerFrameCallback(callback: () => void, callbackId: number) {
+      this.frameCallbackRegistry.set(callbackId, callback);
+    },
+
+    unregisterFrameCallback(frameCallbackId: number) {
+      this.manageStateFrameCallback(frameCallbackId, false);
+      this.frameCallbackRegistry.delete(frameCallbackId);
+    },
+
+    manageStateFrameCallback(frameCallbackId: number, state: boolean) {
+      if (frameCallbackId === -1) {
+        return;
+      }
+      if (state) {
+        this.frameCallbackActive.add(frameCallbackId);
+        this.runCallbacks();
+      } else {
+        this.frameCallbackActive.delete(frameCallbackId);
+      }
+    },
+  };
+
+  global._frameCallbackRegistry = frameCallbackRegistry;
+});
+
+export default class FrameCallbackRegistryJS {
   private nextCallbackId = 0;
 
   constructor() {
-    runOnUI(() => {
-      'worklet';
-
-      global._frameCallbackRegistry = {
-        frameCallbackRegistry: new Map<number, () => void>(),
-        frameCallbackActive: new Set<number>(),
-        isFrameCallbackRunning: false,
-
-        runAnimation() {
-          const loop = () => {
-            this.frameCallbackActive.forEach((key: number) => {
-              const callback = this.frameCallbackRegistry.get(key);
-              callback!();
-            });
-
-            if (this.frameCallbackActive.size > 0) {
-              requestAnimationFrame(loop);
-            } else {
-              this.isFrameCallbackRunning = false;
-            }
-          };
-
-          if (!this.isFrameCallbackRunning) {
-            requestAnimationFrame(loop);
-            this.isFrameCallbackRunning = true;
-          }
-        },
-
-        registerFrameCallback(callback: () => void, callbackId: number) {
-          this.frameCallbackRegistry.set(callbackId, callback);
-        },
-
-        unregisterFrameCallback(frameCallbackId: number) {
-          this.manageStateFrameCallback(frameCallbackId, false);
-          this.frameCallbackRegistry.delete(frameCallbackId);
-        },
-
-        manageStateFrameCallback(frameCallbackId: number, state: boolean) {
-          if (frameCallbackId === -1) {
-            return;
-          }
-          if (state) {
-            this.frameCallbackActive.add(frameCallbackId);
-            this.runAnimation();
-          } else {
-            this.frameCallbackActive.delete(frameCallbackId);
-          }
-        },
-      };
-    })();
+    if (global._frameCallbackRegistry === undefined) {
+      prepareUIRegistry();
+    }
   }
 
   registerFrameCallback(callback: () => void): number {

--- a/src/reanimated2/frameCallback/FrameCallbackRegistry.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistry.ts
@@ -1,54 +1,101 @@
+import { runOnUI } from '../';
+
+export interface FrameCallbackRegistryUI {
+  frameCallbackRegistry: Map<number, () => void>;
+  frameCallbackActive: Set<number>;
+  isFrameCallbackRunning: boolean;
+  runAnimation: () => void;
+  registerFrameCallback: (callback: () => void, callbackId: number) => void;
+  unregisterFrameCallback: (frameCallbackId: number) => void;
+  manageStateFrameCallback: (frameCallbackId: number, state: boolean) => void;
+}
+
 export default class FrameCallbackRegistry {
   private nextCallbackId = 0;
-  private frameCallbackRegistry = new Map<number, () => void>();
-  private frameCallbackActive = new Set<number>();
-  private isFrameCallbackRunning = false;
 
-  private runAnimation() {
-    const loop = () => {
-      this.frameCallbackActive.forEach((key) => {
-        const callback = this.frameCallbackRegistry.get(key);
-        callback!();
-      });
+  constructor() {
+    runOnUI(() => {
+      'worklet';
 
-      if (this.frameCallbackActive.size > 0) {
-        requestAnimationFrame(loop);
-      } else {
-        this.isFrameCallbackRunning = false;
-      }
-    };
+      global._frameCallbackRegistry = {
+        frameCallbackRegistry: new Map<number, () => void>(),
+        frameCallbackActive: new Set<number>(),
+        isFrameCallbackRunning: false,
 
-    if (!this.isFrameCallbackRunning) {
-      requestAnimationFrame(loop);
-      this.isFrameCallbackRunning = true;
-    }
+        runAnimation() {
+          const loop = () => {
+            this.frameCallbackActive.forEach((key: number) => {
+              const callback = this.frameCallbackRegistry.get(key);
+              callback!();
+            });
+
+            if (this.frameCallbackActive.size > 0) {
+              requestAnimationFrame(loop);
+            } else {
+              this.isFrameCallbackRunning = false;
+            }
+          };
+
+          if (!this.isFrameCallbackRunning) {
+            requestAnimationFrame(loop);
+            this.isFrameCallbackRunning = true;
+          }
+        },
+
+        registerFrameCallback(callback: () => void, callbackId: number) {
+          this.frameCallbackRegistry.set(callbackId, callback);
+        },
+
+        unregisterFrameCallback(frameCallbackId: number) {
+          this.manageStateFrameCallback(frameCallbackId, false);
+          this.frameCallbackRegistry.delete(frameCallbackId);
+        },
+
+        manageStateFrameCallback(frameCallbackId: number, state: boolean) {
+          if (frameCallbackId === -1) {
+            return;
+          }
+          if (state) {
+            this.frameCallbackActive.add(frameCallbackId);
+            this.runAnimation();
+          } else {
+            this.frameCallbackActive.delete(frameCallbackId);
+          }
+        },
+      };
+    })();
   }
 
   registerFrameCallback(callback: () => void): number {
     if (!callback) {
       return -1;
     }
+
     const callbackId = this.nextCallbackId;
     this.nextCallbackId++;
-    this.frameCallbackRegistry.set(callbackId, callback);
+
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.registerFrameCallback(callback, callbackId);
+    })();
 
     return callbackId;
   }
 
   unregisterFrameCallback(frameCallbackId: number): void {
-    this.manageStateFrameCallback(frameCallbackId, false);
-    this.frameCallbackRegistry.delete(frameCallbackId);
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.unregisterFrameCallback(frameCallbackId);
+    })();
   }
 
   manageStateFrameCallback(frameCallbackId: number, state: boolean): void {
-    if (frameCallbackId === -1) {
-      return;
-    }
-    if (state) {
-      this.frameCallbackActive.add(frameCallbackId);
-      this.runAnimation();
-    } else {
-      this.frameCallbackActive.delete(frameCallbackId);
-    }
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.manageStateFrameCallback(
+        frameCallbackId,
+        state
+      );
+    })();
   }
 }

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
@@ -1,0 +1,43 @@
+import { runOnUI } from '..';
+import { prepareUIRegistry } from './FrameCallbackRegistryUI';
+
+export default class FrameCallbackRegistryJS {
+  private nextCallbackId = 0;
+
+  constructor() {
+    prepareUIRegistry();
+  }
+
+  registerFrameCallback(callback: () => void): number {
+    if (!callback) {
+      return -1;
+    }
+
+    const callbackId = this.nextCallbackId;
+    this.nextCallbackId++;
+
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.registerFrameCallback(callback, callbackId);
+    })();
+
+    return callbackId;
+  }
+
+  unregisterFrameCallback(frameCallbackId: number): void {
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.unregisterFrameCallback(frameCallbackId);
+    })();
+  }
+
+  manageStateFrameCallback(frameCallbackId: number, state: boolean): void {
+    runOnUI(() => {
+      'worklet';
+      global._frameCallbackRegistry.manageStateFrameCallback(
+        frameCallbackId,
+        state
+      );
+    })();
+  }
+}

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -1,6 +1,6 @@
-import { runOnUI } from '../';
+import { runOnUI } from '..';
 
-export interface FrameCallbackRegistryUI {
+export default interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, () => void>;
   frameCallbackActive: Set<number>;
   isFrameCallbackRunning: boolean;
@@ -10,7 +10,7 @@ export interface FrameCallbackRegistryUI {
   manageStateFrameCallback: (frameCallbackId: number, state: boolean) => void;
 }
 
-const prepareUIRegistry = runOnUI(() => {
+export const prepareUIRegistry = runOnUI(() => {
   'worklet';
 
   const frameCallbackRegistry: FrameCallbackRegistryUI = {
@@ -62,46 +62,3 @@ const prepareUIRegistry = runOnUI(() => {
 
   global._frameCallbackRegistry = frameCallbackRegistry;
 });
-
-export default class FrameCallbackRegistryJS {
-  private nextCallbackId = 0;
-
-  constructor() {
-    if (global._frameCallbackRegistry === undefined) {
-      prepareUIRegistry();
-    }
-  }
-
-  registerFrameCallback(callback: () => void): number {
-    if (!callback) {
-      return -1;
-    }
-
-    const callbackId = this.nextCallbackId;
-    this.nextCallbackId++;
-
-    runOnUI(() => {
-      'worklet';
-      global._frameCallbackRegistry.registerFrameCallback(callback, callbackId);
-    })();
-
-    return callbackId;
-  }
-
-  unregisterFrameCallback(frameCallbackId: number): void {
-    runOnUI(() => {
-      'worklet';
-      global._frameCallbackRegistry.unregisterFrameCallback(frameCallbackId);
-    })();
-  }
-
-  manageStateFrameCallback(frameCallbackId: number, state: boolean): void {
-    runOnUI(() => {
-      'worklet';
-      global._frameCallbackRegistry.manageStateFrameCallback(
-        frameCallbackId,
-        state
-      );
-    })();
-  }
-}

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,6 +1,6 @@
 import { AnimatedStyle, StyleProps } from './commonTypes';
 import { ReanimatedConsole } from './core';
-import { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistry';
+import { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
 import { ShadowNodeWrapper } from './hook/commonTypes';
 import { MeasuredDimensions } from './NativeMethods';
 import { NativeReanimated } from './NativeReanimated/NativeReanimated';

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,5 +1,6 @@
 import { AnimatedStyle, StyleProps } from './commonTypes';
 import { ReanimatedConsole } from './core';
+import { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistry';
 import { ShadowNodeWrapper } from './hook/commonTypes';
 import { MeasuredDimensions } from './NativeMethods';
 import { NativeReanimated } from './NativeReanimated/NativeReanimated';
@@ -44,6 +45,7 @@ declare global {
   const ReanimatedDataMock: {
     now: () => number;
   };
+  const _frameCallbackRegistry: FrameCallbackRegistryUI;
   namespace NodeJS {
     interface Global {
       _setGlobalConsole: (console?: ReanimatedConsole) => void;
@@ -71,6 +73,7 @@ declare global {
       ReanimatedDataMock: {
         now: () => number;
       };
+      _frameCallbackRegistry: FrameCallbackRegistryUI;
     }
   }
 }

--- a/src/reanimated2/hook/useFrameCallback.ts
+++ b/src/reanimated2/hook/useFrameCallback.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import FrameCallbackRegistryJS from '../frameCallback/FrameCallbackRegistry';
+import FrameCallbackRegistryJS from '../frameCallback/FrameCallbackRegistryJS';
 
 export type FrameCallback = {
   setActive: (isActive: boolean) => void;

--- a/src/reanimated2/hook/useFrameCallback.ts
+++ b/src/reanimated2/hook/useFrameCallback.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from 'react';
-import FrameCallbackRegistry from '../frameCallback/FrameCallbackRegistry';
+import FrameCallbackRegistryJS from '../frameCallback/FrameCallbackRegistry';
 
 export type FrameCallback = {
   setActive: (isActive: boolean) => void;
   isActive: boolean;
   callbackId: number;
 };
-const frameCallbackRegistry = new FrameCallbackRegistry();
+const frameCallbackRegistry = new FrameCallbackRegistryJS();
 
 export function useFrameCallback(
   callback: () => void,


### PR DESCRIPTION
## Description

This is a fix for PR #3372. The `useFrameCallback` hook introduced in that PR was not running on the UI thread, which would make the animations choppy if heavy callculations were running on the JS thread.

## Changes

The `useFrameCallback` hook runs on the UI thread now. This can easily be confirmed by adding `console.log(_WORKLET)` in one of the example callbacks. While running the callback `true` should be written out to the console.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
