### PR TITLE
docs: Update webpack config requirements.

### DIFF
--- a/docs/docs/fundamentals/web-support.md
+++ b/docs/docs/fundamentals/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {

--- a/docs/versioned_docs/version-2.0.x/web-support.md
+++ b/docs/versioned_docs/version-2.0.x/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {

--- a/docs/versioned_docs/version-2.1.x/web-support.md
+++ b/docs/versioned_docs/version-2.1.x/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {

--- a/docs/versioned_docs/version-2.2.x/web-support.md
+++ b/docs/versioned_docs/version-2.2.x/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {

--- a/docs/versioned_docs/version-2.3.x/fundamentals/web-support.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {

--- a/docs/versioned_docs/version-2.5.x/fundamentals/web-support.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/web-support.md
@@ -28,7 +28,7 @@ If you want to use Reanimated in `webpack` app you should add extra configuratio
 
 Example webpack config file with Reanimated support:
 
-```js {6,14,34}
+```js {6,14,15,34}
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
@@ -42,6 +42,7 @@ module.exports = {
       filename: 'index.html',
       template: './index.html',
     }),
+    new webpack.EnvironmentPlugin({ JEST_WORKER_ID: null }),
     new webpack.DefinePlugin({ process: { env: {} } })
   ],
   module: {


### PR DESCRIPTION
## Description

`process.env.JEST_WORKER_ID` is used in 2 files (`PlatformChecker` and `useAnimatedStyle`) and if webpack doesn't know about it, it replaces the whole `process.env` (which is not empty).

## Changes

Added a line about `JEST_WORKER_ID` to docs.

## Test code and steps to reproduce

Tested on webpack@4.43.0 (in an Expo project) but should work in webpack@5 too.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
