### PR TITLE
Add warning when measuring flattened view on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -1,5 +1,7 @@
 package com.swmansion.reanimated;
 
+import static java.lang.Float.NaN;
+
 import android.view.View;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.GuardedRunnable;
@@ -56,7 +58,7 @@ public class NodesManager implements EventDispatcherListener {
       view = mUIManager.resolveView(viewTag);
     } catch (IllegalViewOperationException e) {
       e.printStackTrace();
-      return (new float[] {});
+      return (new float[] {NaN, NaN, NaN, NaN, NaN, NaN});
     }
     return NativeMethodsHelper.measure(view);
   }

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -45,6 +45,11 @@ export function measure(
   if (result.x === -1234567) {
     throw new Error(`The view with tag ${viewTag} could not be measured`);
   }
+  if (isNaN(result.x)) {
+    console.warn(
+      'Trying to measure a component which gets view-flattened on Android. To disable view-flattening, set `collapsable={false}` on this component.'
+    );
+  }
   return result;
 }
 


### PR DESCRIPTION
## Description

Resolves #3188. See https://github.com/software-mansion/react-native-reanimated/issues/3188#issuecomment-1196795764 for details.

## Changes

- Return array of NaNs instead of zero-length array when Android view is not found in `measure`
- Add console.warn with user-friendly message when `measure` returns NaNs

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

Copy `App.tsx` and `components/Ripple.tsx` from https://snack.expo.dev/@boxedition/ripple-measure-random-values

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
