### PR TITLE
fix: use ShadowNode types from namespace

### DIFF
--- a/Common/cpp/Fabric/FabricUtils.cpp
+++ b/Common/cpp/Fabric/FabricUtils.cpp
@@ -89,10 +89,10 @@ LayoutMetrics UIManager_getRelativeLayoutMetrics(
       shadowNode.getFamily(), *layoutableAncestorShadowNode, policy);
 }
 
-SharedShadowNode UIManager_cloneNode(
+ShadowNode::Shared UIManager_cloneNode(
     const UIManager *uiManager,
     const ShadowNode::Shared &shadowNode,
-    const SharedShadowNodeSharedList &children,
+    const ShadowNode::SharedListOfShared &children,
     const RawProps *rawProps) {
   auto delegate_ = getDelegateFromUIManager(uiManager);
   auto contextContainer_ = getContextContainerFromUIManager(uiManager);

--- a/Common/cpp/Fabric/ReanimatedUIManagerBinding.cpp
+++ b/Common/cpp/Fabric/ReanimatedUIManagerBinding.cpp
@@ -64,7 +64,7 @@ static inline ShadowNode::Shared cloneNode(
     UIManager *uiManager,
     NewestShadowNodesRegistry *newestShadowNodesRegistry,
     const ShadowNode::Shared &shadowNode,
-    const SharedShadowNodeSharedList &children = nullptr,
+    const ShadowNode::SharedListOfShared &children = nullptr,
     const RawProps *rawProps = nullptr) {
   {
     auto lock = newestShadowNodesRegistry->createLock();

--- a/Common/cpp/headers/Fabric/FabricUtils.h
+++ b/Common/cpp/headers/Fabric/FabricUtils.h
@@ -64,10 +64,10 @@ LayoutMetrics UIManager_getRelativeLayoutMetrics(
     ShadowNode const *ancestorShadowNode,
     LayoutableShadowNode::LayoutInspectingPolicy policy);
 
-SharedShadowNode UIManager_cloneNode(
+ShadowNode::Shared UIManager_cloneNode(
     const UIManager *uiManager,
     const ShadowNode::Shared &shadowNode,
-    const SharedShadowNodeSharedList &children = nullptr,
+    const ShadowNode::SharedListOfShared &children = nullptr,
     const RawProps *rawProps = nullptr);
 
 void UIManager_appendChild(


### PR DESCRIPTION
## Description

This PR updates c++ types to use `ShadowNode` namespace.
This change is required to compile Reanimated with RN v70.

## Changes

`SharedShadowNode` -> `ShadowNode::Shared`
`SharedShadowNodeSharedList` -> `ShadowNode::SharedListOfShared`


