### PR TITLE
fix: remove explicit folly version

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -54,7 +54,6 @@ end
 
 folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DRNVERSION=' + rnVersion
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
-folly_version = '2021.06.28.00-v2'
 boost_compiler_flags = '-Wno-documentation'
 fabric_flags = ''
 if fabric_enabled
@@ -101,7 +100,7 @@ Pod::Spec.new do |s|
   if fabric_enabled
     s.dependency "React-RCTFabric"
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
+    s.dependency "RCT-Folly"
   else
     s.dependency "#{folly_prefix}Folly"
   end


### PR DESCRIPTION
## Description

As a version of folly can change between versions of React-native we need to remove an explicit version of `folly_version` from our libraries to let RN infer the correct version.

Change based on https://github.com/th3rdwave/react-native-safe-area-context/commit/eb111ff4eebc8d06ca01e7d12d9661147d03da20

## Changes

Removed explicit folly version from RNReanimated.podspec

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

Build FabricExample/

## Checklist

- [ ] Ensured that CI passes
