### PR TITLE
Ensure global objects initialization for web

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ if (!webGlobalIsInitialized) {
     but we need to use `webGlobalIsInitialized` somewhere to ensure function execution, 
     in another way, the bundler can remove unused variables. 
   */
-  console.error('[Reanimated] Unable to initialize global objects for WEB.');
+  console.error('[Reanimated] Unable to initialize global objects for web.');
 }
 
 export * from './reanimated2';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 // tree-shaken side effects
-import './reanimated2/js-reanimated/global';
+import webGlobalIsInitialized from './reanimated2/js-reanimated/global';
+if (!webGlobalIsInitialized) {
+  /* 
+    `webGlobalIsInitialized` should always be `true`, 
+    but we need to use `webGlobalIsInitialized` somewhere to ensure function execution, 
+    in another way, the bundler can remove unused variables. 
+  */
+  console.error('[Reanimated] Unable to initialize global objects for WEB.');
+}
 
 export * from './reanimated2';
 export * as default from './Animated';

--- a/src/reanimated2/js-reanimated/global.ts
+++ b/src/reanimated2/js-reanimated/global.ts
@@ -1,38 +1,40 @@
 // In order to keep bundle size down, we treat this file as a polyfill for Web.
 
 import { shouldBeUseWeb } from '../PlatformChecker';
-
-if (shouldBeUseWeb()) {
-  global._frameTimestamp = null;
-  global._setGlobalConsole = (_val) => {
-    // noop
-  };
-  global._measure = () => {
-    console.warn(
-      "[Reanimated] You can't use `measure` with Chrome Debugger or with web version"
-    );
-    return {
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      pageX: 0,
-      pageY: 0,
+export default (() => {
+  if (shouldBeUseWeb()) {
+    global._frameTimestamp = null;
+    global._setGlobalConsole = (_val) => {
+      // noop
     };
-  };
-  global._scrollTo = () => {
-    console.warn(
-      "[Reanimated] You can't use `scrollTo` with Chrome Debugger or with web version"
-    );
-  };
-  global._dispatchCommand = () => {
-    console.warn(
-      "[Reanimated] You can't use `scrollTo` or `dispatchCommand` methods with Chrome Debugger or with web version"
-    );
-  };
-  global._setGestureState = () => {
-    console.warn(
-      "[Reanimated] You can't use `setGestureState` with Chrome Debugger or with web version"
-    );
-  };
-}
+    global._measure = () => {
+      console.warn(
+        "[Reanimated] You can't use `measure` with Chrome Debugger or with web version"
+      );
+      return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        pageX: 0,
+        pageY: 0,
+      };
+    };
+    global._scrollTo = () => {
+      console.warn(
+        "[Reanimated] You can't use `scrollTo` with Chrome Debugger or with web version"
+      );
+    };
+    global._dispatchCommand = () => {
+      console.warn(
+        "[Reanimated] You can't use `scrollTo` or `dispatchCommand` methods with Chrome Debugger or with web version"
+      );
+    };
+    global._setGestureState = () => {
+      console.warn(
+        "[Reanimated] You can't use `setGestureState` with Chrome Debugger or with web version"
+      );
+    };
+  }
+  return true;
+})();

--- a/src/reanimated2/js-reanimated/global.ts
+++ b/src/reanimated2/js-reanimated/global.ts
@@ -1,7 +1,7 @@
 // In order to keep bundle size down, we treat this file as a polyfill for Web.
 
 import { shouldBeUseWeb } from '../PlatformChecker';
-export default (() => {
+const initializeGlobalsForWeb = () => {
   if (shouldBeUseWeb()) {
     global._frameTimestamp = null;
     global._setGlobalConsole = (_val) => {
@@ -37,4 +37,6 @@ export default (() => {
     };
   }
   return true;
-})();
+};
+
+export default initializeGlobalsForWeb();

--- a/src/reanimated2/js-reanimated/global.ts
+++ b/src/reanimated2/js-reanimated/global.ts
@@ -41,9 +41,10 @@ const initializeGlobalsForWeb = () => {
 
 /*
   If a file doesn't export anything, tree shaking doesn't pack 
-  them into the JS bundle. In effect, the code inside of this 
-  file will never execute. That is why we wrapped initialization 
-  code into a function, and we called in during creating module export.
+  it into the JS bundle. In effect, the code inside of this file 
+  will never execute. That is why we wrapped initialization code 
+  into a function, and we call this one during creating 
+  the module export object.
 */
 
 export default initializeGlobalsForWeb();

--- a/src/reanimated2/js-reanimated/global.ts
+++ b/src/reanimated2/js-reanimated/global.ts
@@ -39,4 +39,11 @@ const initializeGlobalsForWeb = () => {
   return true;
 };
 
+/*
+  If a file doesn't export anything, tree shaking doesn't pack 
+  them into the JS bundle. In effect, the code inside of this 
+  file will never execute. That is why we wrapped initialization 
+  code into a function, and we called in during creating module export.
+*/
+
 export default initializeGlobalsForWeb();


### PR DESCRIPTION
## Description

The PR with tree shaking moved global objects initialization for web to another file and then imported it into the `index` file (`import './reanimated2/js-reanimated/global';`). However, the Webpack can lazy import modules, but we don't have any call to this module, so global objects were never initialized.

Fixes #3355