### PR TITLE
Prevent empty string match in color regex

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -23,7 +23,7 @@ interface HSV {
 }
 
 // var INTEGER = '[-+]?\\d+';
-const NUMBER = '[-+]?\\d*(?:\\.\\d*)?';
+const NUMBER = '[-+]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)';
 const PERCENTAGE = NUMBER + '%';
 
 function call(...args: unknown[]): string {


### PR DESCRIPTION
## Description

PR based on issue requested in comment: https://github.com/software-mansion/react-native-reanimated/pull/3382#issuecomment-1195439278

I updated the regex to prevent empty string matches. 
The new regex `[-+]?(?:\d+(?:\.\d*)?|\.\d+)` - https://regex101.com/r/aHhlXG/1 is equivalent with the old version `[-+]?\d*\.?\d+` - https://regex101.com/r/Z0xMqR/1

I also tested ReDoS, and the new regex is safe.
```
(new RegExp('^[-+]?(?:\d+(?:\.\d*)?|\.\d+)$')).test(`${'1'.repeat(1e6)}z`)
```