### PR TITLE
Remove import cycles in FrameCallbackRegistries

### DIFF
--- a/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
@@ -1,4 +1,4 @@
-import { runOnUI } from '..';
+import { runOnUI } from '../core';
 import { prepareUIRegistry } from './FrameCallbackRegistryUI';
 
 export default class FrameCallbackRegistryJS {

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -1,4 +1,4 @@
-import { runOnUI } from '..';
+import { runOnUI } from '../core';
 
 export default interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, () => void>;


### PR DESCRIPTION
## Description

This PR removes import cycles on `runOnUI` in `FrameCallbackRegistryJS.ts` and `FrameCallbackRegistryUI.ts`.

<img src="https://user-images.githubusercontent.com/20516055/181730440-5dcb239f-795c-4e4e-8b60-bb148e7c9fd6.png" alt="warning" height="600" />

The solution is to import `runOnUI` directly from `core.ts` instead of from `index.ts` which imports it.

## Changes

- Removed import cycles in `FrameCallbackRegistryJS.ts` and `FrameCallbackRegistryUI.ts`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

1. Change `inlineRequires: true` to `inlineRequires: false` in `Example/metro.config.js`
2. Launch the Example app

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
