### PR TITLE
Documentation fixes (part 2)

### DIFF
--- a/docs/docs/api/animations/cancelAnimation.md
+++ b/docs/docs/api/animations/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Cancels animation linked with given shared value.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/docs/api/animations/withDecay.md
+++ b/docs/docs/api/animations/withDecay.md
@@ -23,7 +23,7 @@ Allowed parameters are listed below:
 | rubberBandFactor  | 0.6     | Factor to modify rubberBandEffect force (optional)    |
 
 ##### `velocityFactor`
-The default unit of velocity in decay is pixel per second but it can be problematic when you want to animate value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to more matched for the required domain.
+The default unit of velocity in decay is pixels per second but it can be problematic when you want to animate a value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to fit the required domain.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/docs/api/animations/withDelay.md
+++ b/docs/docs/api/animations/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/docs/api/animations/withRepeat.md
+++ b/docs/docs/api/animations/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/docs/api/animations/withTiming.md
+++ b/docs/docs/api/animations/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/docs/api/miscellaneous/getRelativeCoords.md
+++ b/docs/docs/api/miscellaneous/getRelativeCoords.md
@@ -10,7 +10,7 @@ Determines the location on the screen, relative to the given view. It might be u
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread). This ref should be passed as a prop to view relative to which we want to know coordinates.
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread). This ref should be passed as a prop to the view relative to which we want to know coordinates.
 
 #### x
 

--- a/docs/docs/api/miscellaneous/interpolate.md
+++ b/docs/docs/api/miscellaneous/interpolate.md
@@ -40,7 +40,7 @@ If a string is provided, the provided extrapolation type is applied to both side
 :::info
 Available extrapolation types:
 * `Extrapolation.CLAMP` - clamps the value to the edge of the output range
-* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.IDENTITY` - returns the value that is being interpolated
 * `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:

--- a/docs/docs/api/miscellaneous/interpolate.md
+++ b/docs/docs/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolation.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolation.IDENTITY` - returns value that is being interpolate
-* `Extrapolation.EXTEND` - approximates value even outside the range
+* `Extrapolation.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/docs/api/miscellaneous/runOnUI.md
+++ b/docs/docs/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/docs/api/miscellaneous/runonJS.md
+++ b/docs/docs/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/docs/api/miscellaneous/runonJS.md
+++ b/docs/docs/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/docs/api/nativeMethods/measure.md
+++ b/docs/docs/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/docs/api/nativeMethods/scrollTo.md
+++ b/docs/docs/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/docs/fundamentals/architecture.md
+++ b/docs/docs/fundamentals/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/docs/fundamentals/custom_events.md
+++ b/docs/docs/fundamentals/custom_events.md
@@ -4,11 +4,11 @@ title: Custom Events
 sidebar_label: Custom Events
 ---
 
-Apart from gestures and scroll events, Reanimated 2.x exposes low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
+Apart from gestures and scroll events, Reanimated 2.x exposes a low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to the `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
 
 ## Handling events from custom animated component
 
-Let's say that you want to animate pagination dots based on custom component which exposes its scroll value - for that example we will use [pager](https://github.com/callstack/react-native-pager-view) component.
+Let's say that you want to animate pagination dots based on a custom component which exposes its scroll value - in this example we will use the [pager](https://github.com/callstack/react-native-pager-view) component.
 
 ```js
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
@@ -28,9 +28,9 @@ const PagerExample = () => {
 };
 ```
 
-Here, we create animated pager with a scroll shared value, which will keep current pager's scroll value.
+Here, we create and animated pager with a scroll shared value, which will keep the pager's current scroll value.
 
-Next, we create custom handler hook to listen for native events from pager component and process them inside worklets.
+Next, we create a custom handler hook to listen for native events from the pager component and process them inside a worklet.
 
 ```js
 const scrollHandler = useAnimatedPagerScrollHandler({
@@ -41,9 +41,9 @@ const scrollHandler = useAnimatedPagerScrollHandler({
 });
 ```
 
-`useAnimatedPagerScrollHandler` is our custom hook - in _onPageScroll_ worklet we have access to current pager's page position and offset, combined together, give us scroll position, which we can use to animate components or compute by how much density points pager content is offset.
+`useAnimatedPagerScrollHandler` is our custom hook - in the _onPageScroll_ worklet we have access to the pager's current page position and offset. Combined together they give us the scroll position, which we can use to animate components or compute by how much the pager's content is offset.
 
-To implement custom hook we will use two low-level methods - `useHandler` and `useEvent`
+To implement our custom hook we will use two low-level methods - `useHandler` and `useEvent`
 
 ```js
 function useAnimatedPagerScrollHandler(handlers, dependencies) {
@@ -64,8 +64,8 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
 }
 ```
 
-`useHandler` is responsible for providing context object for our handler, and an information whether it should be rebuilt.
+`useHandler` is responsible for providing a context object for our handler and information whether it should be rebuilt.
 
-`useEvent` is returning worklet event handler, which passed to animated component, will provide native events that can be handled on UI thread
+`useEvent` is returning a worklet event handler, which passed to an animated component, will provide native events that can be handled on the UI thread
 
-For full example, checkout Example App (look for Custom Handler Example - Pager)
+For a full example, checkout our Example App (look for _Custom Handler Example - Pager_)

--- a/docs/docs/fundamentals/layout_animations.md
+++ b/docs/docs/fundamentals/layout_animations.md
@@ -4,12 +4,12 @@ title: Layout Animations
 sidebar_label: Layout Animations
 --- 
 
-#### Layout Animation - the easiest way to animate entering/exiting/layout of your components.
+#### Layout Animations - the easiest way to animate the entering/exiting/layout of your components.
 
-In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate an appearance of any view.
+In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate the appearance of any view.
 
-During unmounting of components from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated make a pretty animation of disappearing of component for you.
+When unmounting a component from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated inlcludes gorgeous exit animations for your components.
 
-### [Read more about LayoutAnimation](./../api/LayoutAnimations/entryAnimations)
+### [Read more about LayoutAnimations](./../api/LayoutAnimations/entryAnimations)
 
 <iframe width="940px" height="557px" src="https://www.youtube.com/embed/6UXfS6FI674" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/docs/fundamentals/troubleshooting.md
+++ b/docs/docs/fundamentals/troubleshooting.md
@@ -24,3 +24,8 @@ Depending on how spread is used you may try one of the following alternatives:
 - `[...Array(length)].map` idiom: `Array(length).fill().map()`
 - merging objects: [`Object.assign()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
 - spreading args in function: [`func.apply()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
+
+### `Export namespace should be first transformed by 'babel/plugin-proposal-export-namespace-from'`
+
+This error usually happens, when you forget to add the babel plugin in your `babel.plugin.js`. Please make
+sure you have added it.

--- a/docs/docs/fundamentals/web-support.md
+++ b/docs/docs/fundamentals/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 

--- a/docs/versioned_docs/version-2.0.x/api/cancelAnimation.md
+++ b/docs/versioned_docs/version-2.0.x/api/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Starts a time-based animation.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/versioned_docs/version-2.0.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.0.x/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolate.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolate.IDENTITY` - returns value that is being interpolate
-* `Extrapolate.EXTEND` - approximates value even outside the range
+* `Extrapolate.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolate.IDENTITY` - returns the value that is being interpolated
+* `Extrapolate.EXTEND` - approximates the value even outside the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/versioned_docs/version-2.0.x/api/miscellaneous/runOnUI.md
+++ b/docs/versioned_docs/version-2.0.x/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.0.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.0.x/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/versioned_docs/version-2.0.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.0.x/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.0.x/api/nativeMethods/measure.md
+++ b/docs/versioned_docs/version-2.0.x/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/versioned_docs/version-2.0.x/api/nativeMethods/scrollTo.md
+++ b/docs/versioned_docs/version-2.0.x/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/versioned_docs/version-2.0.x/api/withDelay.md
+++ b/docs/versioned_docs/version-2.0.x/api/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/versioned_docs/version-2.0.x/api/withRepeat.md
+++ b/docs/versioned_docs/version-2.0.x/api/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/versioned_docs/version-2.0.x/api/withTiming.md
+++ b/docs/versioned_docs/version-2.0.x/api/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.0.x/architecture.md
+++ b/docs/versioned_docs/version-2.0.x/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/versioned_docs/version-2.0.x/web-support.md
+++ b/docs/versioned_docs/version-2.0.x/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 

--- a/docs/versioned_docs/version-2.1.x/api/cancelAnimation.md
+++ b/docs/versioned_docs/version-2.1.x/api/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Starts a time-based animation.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/versioned_docs/version-2.1.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.1.x/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolate.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolate.IDENTITY` - returns value that is being interpolate
-* `Extrapolate.EXTEND` - approximates value even outside the range
+* `Extrapolate.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolate.IDENTITY` - returns the value that is being interpolated
+* `Extrapolate.EXTEND` - approximates the value even outside the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/versioned_docs/version-2.1.x/api/miscellaneous/runOnUI.md
+++ b/docs/versioned_docs/version-2.1.x/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.1.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.1.x/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/versioned_docs/version-2.1.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.1.x/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.1.x/api/nativeMethods/measure.md
+++ b/docs/versioned_docs/version-2.1.x/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/versioned_docs/version-2.1.x/api/nativeMethods/scrollTo.md
+++ b/docs/versioned_docs/version-2.1.x/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/versioned_docs/version-2.1.x/api/withDelay.md
+++ b/docs/versioned_docs/version-2.1.x/api/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/versioned_docs/version-2.1.x/api/withRepeat.md
+++ b/docs/versioned_docs/version-2.1.x/api/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/versioned_docs/version-2.1.x/api/withTiming.md
+++ b/docs/versioned_docs/version-2.1.x/api/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.1.x/architecture.md
+++ b/docs/versioned_docs/version-2.1.x/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/versioned_docs/version-2.1.x/web-support.md
+++ b/docs/versioned_docs/version-2.1.x/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 

--- a/docs/versioned_docs/version-2.2.x/api/cancelAnimation.md
+++ b/docs/versioned_docs/version-2.2.x/api/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Starts a time-based animation.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/versioned_docs/version-2.2.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.2.x/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolate.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolate.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolate.IDENTITY` - returns value that is being interpolate
-* `Extrapolate.EXTEND` - approximates value even outside the range
+* `Extrapolate.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolate.IDENTITY` - returns the value that is being interpolated
+* `Extrapolate.EXTEND` - approximates the value even outside the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/versioned_docs/version-2.2.x/api/miscellaneous/runOnUI.md
+++ b/docs/versioned_docs/version-2.2.x/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.2.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.2.x/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/versioned_docs/version-2.2.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.2.x/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.2.x/api/nativeMethods/measure.md
+++ b/docs/versioned_docs/version-2.2.x/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/versioned_docs/version-2.2.x/api/nativeMethods/scrollTo.md
+++ b/docs/versioned_docs/version-2.2.x/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/versioned_docs/version-2.2.x/api/withDecay.md
+++ b/docs/versioned_docs/version-2.2.x/api/withDecay.md
@@ -21,8 +21,7 @@ Allowed parameters are listed below:
 | velocityFactor | 1       | Factor to modify velocity unit (optional)    |
 
 ##### `velocityFactor`
-The default unit of velocity in decay is pixel per second but it can be problematic when you want to animate value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to more matched for the required domain.
-
+The default unit of velocity in decay is pixels per second but it can be problematic when you want to animate a value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to fit the required domain.
 #### `callback` [function]\(optional\)
 
 The provided function will be called when the animation is complete.

--- a/docs/versioned_docs/version-2.2.x/api/withDelay.md
+++ b/docs/versioned_docs/version-2.2.x/api/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/versioned_docs/version-2.2.x/api/withRepeat.md
+++ b/docs/versioned_docs/version-2.2.x/api/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/versioned_docs/version-2.2.x/api/withTiming.md
+++ b/docs/versioned_docs/version-2.2.x/api/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.2.x/architecture.md
+++ b/docs/versioned_docs/version-2.2.x/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/versioned_docs/version-2.2.x/web-support.md
+++ b/docs/versioned_docs/version-2.2.x/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 

--- a/docs/versioned_docs/version-2.3.x/api/animations/cancelAnimation.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Cancels animation linked with given shared value.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/versioned_docs/version-2.3.x/api/animations/withDecay.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/withDecay.md
@@ -21,8 +21,7 @@ Allowed parameters are listed below:
 | velocityFactor | 1       | Factor to modify velocity unit (optional)    |
 
 ##### `velocityFactor`
-The default unit of velocity in decay is pixel per second but it can be problematic when you want to animate value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to more matched for the required domain.
-
+The default unit of velocity in decay is pixels per second but it can be problematic when you want to animate a value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to fit the required domain.
 #### `callback` [function]\(optional\)
 
 The provided function will be called when the animation is complete.

--- a/docs/versioned_docs/version-2.3.x/api/animations/withDelay.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/versioned_docs/version-2.3.x/api/animations/withRepeat.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/versioned_docs/version-2.3.x/api/animations/withTiming.md
+++ b/docs/versioned_docs/version-2.3.x/api/animations/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/getRelativeCoords.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/getRelativeCoords.md
@@ -10,7 +10,7 @@ Determines the location on the screen, relative to the given view. It might be u
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread). This ref should be passed as a prop to view relative to which we want to know coordinates.
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread). This ref should be passed as a prop to the view relative to which we want to know coordinates.
 
 #### x
 

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/interpolate.md
@@ -40,7 +40,7 @@ If a string is provided, the provided extrapolation type is applied to both side
 :::info
 Available extrapolation types:
 * `Extrapolation.CLAMP` - clamps the value to the edge of the output range
-* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.IDENTITY` - returns the value that is being interpolated
 * `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolation.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolation.IDENTITY` - returns value that is being interpolate
-* `Extrapolation.EXTEND` - approximates value even outside the range
+* `Extrapolation.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/runOnUI.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/versioned_docs/version-2.3.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.3.x/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.3.x/api/nativeMethods/measure.md
+++ b/docs/versioned_docs/version-2.3.x/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/versioned_docs/version-2.3.x/api/nativeMethods/scrollTo.md
+++ b/docs/versioned_docs/version-2.3.x/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/versioned_docs/version-2.3.x/fundamentals/architecture.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/versioned_docs/version-2.3.x/fundamentals/custom_events.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/custom_events.md
@@ -4,11 +4,11 @@ title: Custom Events
 sidebar_label: Custom Events
 ---
 
-Apart from gestures and scroll events, Reanimated 2.x exposes low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
+Apart from gestures and scroll events, Reanimated 2.x exposes a low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to the `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
 
 ## Handling events from custom animated component
 
-Let's say that you want to animate pagination dots based on custom component which exposes its scroll value - for that example we will use [pager](https://github.com/callstack/react-native-pager-view) component.
+Let's say that you want to animate pagination dots based on a custom component which exposes its scroll value - in this example we will use the [pager](https://github.com/callstack/react-native-pager-view) component.
 
 ```js
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
@@ -28,9 +28,9 @@ const PagerExample = () => {
 };
 ```
 
-Here, we create animated pager with a scroll shared value, which will keep current pager's scroll value.
+Here, we create and animated pager with a scroll shared value, which will keep the pager's current scroll value.
 
-Next, we create custom handler hook to listen for native events from pager component and process them inside worklets.
+Next, we create a custom handler hook to listen for native events from the pager component and process them inside a worklet.
 
 ```js
 const scrollHandler = useAnimatedPagerScrollHandler({
@@ -41,9 +41,9 @@ const scrollHandler = useAnimatedPagerScrollHandler({
 });
 ```
 
-`useAnimatedPagerScrollHandler` is our custom hook - in _onPageScroll_ worklet we have access to current pager's page position and offset, combined together, give us scroll position, which we can use to animate components or compute by how much density points pager content is offset.
+`useAnimatedPagerScrollHandler` is our custom hook - in the _onPageScroll_ worklet we have access to the pager's current page position and offset. Combined together they give us the scroll position, which we can use to animate components or compute by how much the pager's content is offset.
 
-To implement custom hook we will use two low-level methods - `useHandler` and `useEvent`
+To implement our custom hook we will use two low-level methods - `useHandler` and `useEvent`
 
 ```js
 function useAnimatedPagerScrollHandler(handlers, dependencies) {
@@ -64,8 +64,8 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
 }
 ```
 
-`useHandler` is responsible for providing context object for our handler, and an information whether it should be rebuilt.
+`useHandler` is responsible for providing a context object for our handler and information whether it should be rebuilt.
 
-`useEvent` is returning worklet event handler, which passed to animated component, will provide native events that can be handled on UI thread
+`useEvent` is returning a worklet event handler, which passed to an animated component, will provide native events that can be handled on the UI thread
 
-For full example, checkout Example App (look for Custom Handler Example - Pager)
+For a full example, checkout our Example App (look for _Custom Handler Example - Pager_)

--- a/docs/versioned_docs/version-2.3.x/fundamentals/layout_animations.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/layout_animations.md
@@ -4,12 +4,12 @@ title: Layout Animations
 sidebar_label: Layout Animations
 --- 
 
-#### Layout Animation - the easiest way to animate entering/exiting/layout of your components.
+#### Layout Animations - the easiest way to animate the entering/exiting/layout of your components.
 
-In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate an appearance of any view.
+In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate the appearance of any view.
 
-During unmounting of components from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated make a pretty animation of disappearing of component for you.
+When unmounting a component from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated inlcludes gorgeous exit animations for your components.
 
-### [Read more about LayoutAnimation](./../api/LayoutAnimations/entryAnimations)
+### [Read more about LayoutAnimations](./../api/LayoutAnimations/entryAnimations)
 
 <iframe width="940px" height="557px" src="https://www.youtube.com/embed/6UXfS6FI674" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/versioned_docs/version-2.3.x/fundamentals/web-support.md
+++ b/docs/versioned_docs/version-2.3.x/fundamentals/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 

--- a/docs/versioned_docs/version-2.5.x/api/animations/cancelAnimation.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/cancelAnimation.md
@@ -4,7 +4,7 @@ title: cancelAnimation
 sidebar_label: cancelAnimation
 ---
 
-Cancels animation linked with given shared value.
+Cancels animation linked to given shared value.
 
 ### Arguments
 

--- a/docs/versioned_docs/version-2.5.x/api/animations/withDecay.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/withDecay.md
@@ -21,8 +21,7 @@ Allowed parameters are listed below:
 | velocityFactor | 1       | Factor to modify velocity unit (optional)    |
 
 ##### `velocityFactor`
-The default unit of velocity in decay is pixel per second but it can be problematic when you want to animate value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to more matched for the required domain.
-
+The default unit of velocity in decay is pixels per second but it can be problematic when you want to animate a value not related to pixels for example opacity `[0, 1]` or progress bar `[0, 1]`. In this case, you can use `velocityFactor` property with value `< 1` to modify the velocity of change to fit the required domain.
 #### `callback` [function]\(optional\)
 
 The provided function will be called when the animation is complete.

--- a/docs/versioned_docs/version-2.5.x/api/animations/withDelay.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/withDelay.md
@@ -7,7 +7,7 @@ sidebar_label: withDelay
 Allows for the provided animation to start with a specified delay.
 
 In case the value for which we are starting the delayed animation is running a previous animation, that animation won't be cancelled until the new animation starts after the delay.
-If you want the animation to cancel immediately, use [`cancelAnimation`](cancelAnimation) method.
+If you want the animation to cancel immediately, use the [`cancelAnimation`](cancelAnimation) method.
 
 ### Arguments
 
@@ -25,7 +25,7 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-Timing animation will start on the `sharedValue` after one second.
+The timing animation will start on the `sharedValue` after one second.
 
 ```js
 sharedValue.value = withDelay(1000, withTiming(70));

--- a/docs/versioned_docs/version-2.5.x/api/animations/withRepeat.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/withRepeat.md
@@ -14,7 +14,7 @@ The animation that will be repeated.
 
 #### `numberOfReps` [number] (default: `2`)
 
-Number of repetations that the animation is going to be run for.
+Number of repetitions that the animation is going to be run for.
 When negative, the animation will be repeated forever (until the shared value is torn down or the animation is cancelled).
 
 #### `reverse` [bool] (default: `false`)
@@ -26,7 +26,7 @@ The option is not supported for animation wrapped using other animation modifier
 
 #### `callback` [function]\(optional\)
 
-This function will be called when all repetitions of provided animation are complete or when `withRepeat` is cancelled.
+This function will be called when all repetitions of the provided animation are complete or when `withRepeat` is cancelled.
 In case the animation is cancelled, the callback will receive `false` as the argument, otherwise it will receive `true`.
 
 ### Returns
@@ -35,13 +35,13 @@ This method returns an animation object. It can be either assigned directly to a
 
 ## Example
 
-The provided shared value will animate from its current value to 70 using timing animation, and then back to the original value.
+The provided shared value will animate from its current value to 70 using a timing animation, and then back to the original value.
 
 ```js
 sharedValue.value = withRepeat(withTiming(70), 2, true);
 ```
 
-One more example with the callbacks
+One more example with callbacks:
 
 ```js
 sharedValue.value = withRepeat(

--- a/docs/versioned_docs/version-2.5.x/api/animations/withTiming.md
+++ b/docs/versioned_docs/version-2.5.x/api/animations/withTiming.md
@@ -34,7 +34,7 @@ Allowed parameters are listed below:
 | duration | 300                | How long the animation should last                     |
 | easing   | in-out quad easing | Worklet that drives the easing curve for the animation |
 
-For `easing` parameter we recommend using one of the pre-configured worklets defined in `Easing` module.
+For the `easing` parameter we recommend using one of the pre-configured worklets defined in the `Easing` module.
 
 #### `callback` [function]\(optional\)
 

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/getRelativeCoords.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/getRelativeCoords.md
@@ -10,7 +10,7 @@ Determines the location on the screen, relative to the given view. It might be u
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread). This ref should be passed as a prop to view relative to which we want to know coordinates.
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread). This ref should be passed as a prop to the view relative to which we want to know coordinates.
 
 #### x
 

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/interpolate.md
@@ -40,7 +40,7 @@ If a string is provided, the provided extrapolation type is applied to both side
 :::info
 Available extrapolation types:
 * `Extrapolation.CLAMP` - clamps the value to the edge of the output range
-* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.IDENTITY` - returns the value that is being interpolated
 * `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/interpolate.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/interpolate.md
@@ -4,17 +4,17 @@ title: Interpolate
 sidebar_label: Interpolate
 ---
 
-Sometimes you need to map value from one range to another. This is where you should use `interpolate` functions which approximates values between points in the output range and lets you map value inside the input range to corresponded approximation in the output range. It also supports few types of Extrapolation to enable mapping outside the range.
+Sometimes you need to map a value from one range to another. This is where you should use the `interpolate` function which approximates values between points in the output range and lets you map a value inside the input range to a corresponding approximation in the output range. It also supports a few types of Extrapolation to enable mapping outside the range.
 
 :::info
-Be aware that `interpolate` was renamed in reanimated v2 to `interpolateNode` and should not be confused with `interpolate` from the new API. When using interpolate imported directly from react-native-reanimated v1, in v2 you should use interpolateNode instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
+Be aware that `interpolate` was renamed to `interpolateNode` in Reanimated v2 and should not be confused with `interpolate` from the new API. When using `interpolate` imported directly from react-native-reanimated v1, in v2 you should use `interpolateNode` instead. If you were using a class member method AnimatedValue.interpolate, no change is necessary.
 :::
 
 ### Arguments
 
 #### `value` [Float]
 
-Value from within input range that should be map into value from output range.
+Value from within the input range that should be mapped to a value from the output range.
 
 #### `input range` [Float[]]
 
@@ -26,7 +26,7 @@ An array of Floats that contains points that indicate the range of the output va
 
 #### `extrapolation type` [Object | String]
 
-Can be either object or string. If the object is passed it should specify extrapolation explicit for the right and left sides. If extrapolation for the side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
+Can be either an object or a string. If an object is passed it should specify extrapolation explicitly for the right and left sides. If extrapolation for a side is not provided, it defaults to `Extrapolation.EXTEND`. Example extrapolation type object:
 
 ```js
 const extrapolation = {
@@ -35,13 +35,13 @@ const extrapolation = {
 }
 ```
 
-If the string is provided, the provided extrapolation type is applied to both sides.
+If a string is provided, the provided extrapolation type is applied to both sides.
 
 :::info
 Available extrapolation types:
-* `Extrapolation.CLAMP` - clamps value to the edge of the output range.
-* `Extrapolation.IDENTITY` - returns value that is being interpolate
-* `Extrapolation.EXTEND` - approximates value even outside the range
+* `Extrapolation.CLAMP` - clamps the value to the edge of the output range
+* `Extrapolation.IDENTITY` - returns the evalue that is being interpolated
+* `Extrapolation.EXTEND` - approximates the value even outside of the range
 
 Available extrapolation string values:
 * `clamp`

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/runOnUI.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/runOnUI.md
@@ -4,13 +4,13 @@ title: runOnUI
 sidebar_label: runOnUI
 ---
 
-Enables executing worklet function on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI JS context.
+Enables executing worklet functions on the UI thread. Note that UI execution is asynchronous from the caller’s perspective. When you pass arguments, they will be copied to the UI context.
 
 ### Arguments
 
 #### `fn` [function]
 
-The first and the only argument is a worklet function that is supposed to be run.
+The first and only argument is a worklet function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/runonJS.md
@@ -4,11 +4,11 @@ title: runOnJS
 sidebar_label: runOnJS
 ---
 
-When you call a function on UI thread you can't be sure if you call a worklet or a callback from JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
+When you call a function on the UI thread you can't be sure if you're calling a worklet or a callback from the JS thread. To make it more transparent we introduced `runOnJS`, which calls a callback asynchronously. An exception will be thrown if you call a JS callback without this function.
 
 :::info
 
-If you want to invoke some function from external library in `runOnJS` please wrap it into a separate function.
+If you want to invoke some function from an external library in `runOnJS` please wrap it in a separate function.
 
 Code like this may not work:
 
@@ -29,7 +29,7 @@ useDerivedValue(() => {
 });
 ```
 
-This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have an access to `this` inside a called function.
+This is because internally `runOnJS` uses `Object.defineProperty`. Therefore if we want to call a method of some object we may not have access to `this` inside the called function.
 
 This code shows how it works:
 
@@ -42,9 +42,10 @@ class A {
 
 const a = new A();
 const ob = {};
-Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo }); // we do something like this in runOnJS
+// We do something like this in runOnJS
+Object.defineProperty(ob, 'foo', { enumerable: false, value: a.foo });
 
-a.foo(5); // normal [this] access
+a.foo(5); // Normal [this] access
 ob.foo(5); // [this] is not correct
 ```
 
@@ -54,11 +55,11 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is a function which is supposed to be run.
+The first and the only argument is the function that is supposed to be run.
 
 ### Returns
 
-`runOnJS` returns a function which can be safely run from UI thread.
+`runOnJS` returns a function which can be safely run from the UI thread.
 
 ## Example
 

--- a/docs/versioned_docs/version-2.5.x/api/miscellaneous/runonJS.md
+++ b/docs/versioned_docs/version-2.5.x/api/miscellaneous/runonJS.md
@@ -55,7 +55,7 @@ ob.foo(5); // [this] is not correct
 
 #### `fn` [function]
 
-The first and the only argument is the function that is supposed to be run.
+The first and only argument is the function that is supposed to be run.
 
 ### Returns
 

--- a/docs/versioned_docs/version-2.5.x/api/nativeMethods/measure.md
+++ b/docs/versioned_docs/version-2.5.x/api/nativeMethods/measure.md
@@ -6,7 +6,7 @@ sidebar_label: measure
 
 Determines the location on screen, width, and height of the given view. Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using [`onLayout`](https://reactnative.dev/docs/view#onlayout) instead.
 
-This function is implemented on native platforms only. On the web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native(it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way(note it's asynchronous so if you want to make it synchronous you should use `Promise`):
+This function is implemented on native platforms only. On web, it's sufficient to use a standard version of the `measure` which is available on most of the default components provided by React Native (it's [here](https://github.com/facebook/react-native/blob/65975dd28de0a7b8b8c4eef6479bf7eee5fcfb93/Libraries/Renderer/shims/ReactNativeTypes.js#L105)). In such a case it should be invoked in the following way (note it's asynchronous so if you want to make it synchronous you should use `Promise`):
 
 ```javascript
 const aref = useAnimatedRef();
@@ -25,7 +25,7 @@ new Promise((resolve, reject) => {
 
 #### animatedRef
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 ### Returns
 
@@ -55,4 +55,4 @@ const Comp = () => {
 
 ### Note
 
-You can use `measure()` only on rendered components. Good practice is to wrap function call with `try{} catch{}` if there is a possibility to call function on item which is not rendered, for example: invisible item on screen from FlatList.
+You can use `measure()` only on rendered components. A good practice is to wrap the function call with a `try{} catch{}` block if there is a risk of calling the function on an item which is not rendered, for example: an invisible off screen item from FlatList.

--- a/docs/versioned_docs/version-2.5.x/api/nativeMethods/scrollTo.md
+++ b/docs/versioned_docs/version-2.5.x/api/nativeMethods/scrollTo.md
@@ -4,9 +4,9 @@ title: scrollTo
 sidebar_label: scrollTo
 ---
 
-Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags(which might occur when it would be asynchronous and based on a lot of events).
+Provides synchronous scroll on the UI thread to a given offset using an animated ref to a scroll view. This allows performing smooth scrolling without lags (which might have otherwise occured when it was asynchronous and based on lots of events).
 
-This function is implemented on native platforms only. On the web it's sufficient to use a standard version of the `scrollTo` which comes with a `ScrollView` component(it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
+This function is implemented on native platforms only. On web it's sufficient to use a standard version of `scrollTo` which comes with a `ScrollView` component (it's [here](https://github.com/facebook/react-native/blob/aebccd3f923c920bd85fb9e5fbdd2a8a75d3ad3d/Libraries/Components/ScrollView/ScrollView.js#L834)). In such a case it should be invoked in the following way:
 
 ```javascript
 const aref = useAnimatedRef();
@@ -17,7 +17,7 @@ aref.current.scrollTo({ x, y });
 
 #### `animatedRef`
 
-The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is a Reanimated's extension of a standard React's ref(delivers view tag on the UI thread).
+The product of [`useAnimatedRef`](../hooks/useAnimatedRef) which is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread).
 
 #### `x-cord` [Float]
 

--- a/docs/versioned_docs/version-2.5.x/fundamentals/architecture.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/architecture.md
@@ -1,9 +1,9 @@
 ---
 id: architecture
-title: Reanimated 2.x architecture
+title: Reanimated's 2.x architecture
 sidebar_label: Architecture
 ---
 
 > Due to time constraints we weren't able to finish this page.
-> We will be posting more content online about new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
+> We will be posting more content online about the new Reanimated architecture and also [host a webinar](https://swmansion.com/academy).
 > The content that we prepare for the posts and webinars will be later made available here.

--- a/docs/versioned_docs/version-2.5.x/fundamentals/custom_events.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/custom_events.md
@@ -4,11 +4,11 @@ title: Custom Events
 sidebar_label: Custom Events
 ---
 
-Apart from gestures and scroll events, Reanimated 2.x exposes low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
+Apart from gestures and scroll events, Reanimated 2.x exposes a low-level API to create custom animated event handlers for custom animated components. With this API you can create handler hooks similar to the `useAnimatedGestureHandler` and `useAnimatedScrollHandler`.
 
 ## Handling events from custom animated component
 
-Let's say that you want to animate pagination dots based on custom component which exposes its scroll value - for that example we will use [pager](https://github.com/callstack/react-native-pager-view) component.
+Let's say that you want to animate pagination dots based on a custom component which exposes its scroll value - in this example we will use the [pager](https://github.com/callstack/react-native-pager-view) component.
 
 ```js
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
@@ -28,9 +28,9 @@ const PagerExample = () => {
 };
 ```
 
-Here, we create animated pager with a scroll shared value, which will keep current pager's scroll value.
+Here, we create and animated pager with a scroll shared value, which will keep the pager's current scroll value.
 
-Next, we create custom handler hook to listen for native events from pager component and process them inside worklets.
+Next, we create a custom handler hook to listen for native events from the pager component and process them inside a worklet.
 
 ```js
 const scrollHandler = useAnimatedPagerScrollHandler({
@@ -41,9 +41,9 @@ const scrollHandler = useAnimatedPagerScrollHandler({
 });
 ```
 
-`useAnimatedPagerScrollHandler` is our custom hook - in _onPageScroll_ worklet we have access to current pager's page position and offset, combined together, give us scroll position, which we can use to animate components or compute by how much density points pager content is offset.
+`useAnimatedPagerScrollHandler` is our custom hook - in the _onPageScroll_ worklet we have access to the pager's current page position and offset. Combined together they give us the scroll position, which we can use to animate components or compute by how much the pager's content is offset.
 
-To implement custom hook we will use two low-level methods - `useHandler` and `useEvent`
+To implement our custom hook we will use two low-level methods - `useHandler` and `useEvent`
 
 ```js
 function useAnimatedPagerScrollHandler(handlers, dependencies) {
@@ -64,8 +64,8 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
 }
 ```
 
-`useHandler` is responsible for providing context object for our handler, and an information whether it should be rebuilt.
+`useHandler` is responsible for providing a context object for our handler and information whether it should be rebuilt.
 
-`useEvent` is returning worklet event handler, which passed to animated component, will provide native events that can be handled on UI thread
+`useEvent` is returning a worklet event handler, which passed to an animated component, will provide native events that can be handled on the UI thread
 
-For full example, checkout Example App (look for Custom Handler Example - Pager)
+For a full example, checkout our Example App (look for _Custom Handler Example - Pager_)

--- a/docs/versioned_docs/version-2.5.x/fundamentals/layout_animations.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/layout_animations.md
@@ -4,12 +4,12 @@ title: Layout Animations
 sidebar_label: Layout Animations
 --- 
 
-#### Layout Animation - the easiest way to animate entering/exiting/layout of your components.
+#### Layout Animations - the easiest way to animate the entering/exiting/layout of your components.
 
-In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate an appearance of any view.
+In React Native every component appears instantly whenever you add it to the component hierarchy. It's not something we are used to in the real world. Layout Animations are here to address the problem and help you animate the appearance of any view.
 
-During unmounting of components from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated make a pretty animation of disappearing of component for you.
+When unmounting a component from the hierarchy of views, it just disappears in the next frame. However you can beautify this process using Exiting Animations. Reanimated inlcludes gorgeous exit animations for your components.
 
-### [Read more about LayoutAnimation](./../api/LayoutAnimations/entryAnimations)
+### [Read more about LayoutAnimations](./../api/LayoutAnimations/entryAnimations)
 
 <iframe width="940px" height="557px" src="https://www.youtube.com/embed/6UXfS6FI674" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/versioned_docs/version-2.5.x/fundamentals/web-support.md
+++ b/docs/versioned_docs/version-2.5.x/fundamentals/web-support.md
@@ -4,27 +4,27 @@ title: Web Support
 sidebar_label: Web Support
 ---
 
-Since
+Since the
 [2.0.0-alpha.7](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.0.0-alpha.7)
 release it's possible to launch reanimated 2 in a web browser. For that case all of the functionalities are implemented purely in javascript, hence the efficiency of the animations might drop.
 
-If you use
+If you use our
 [playground](https://github.com/software-mansion-labs/reanimated-2-playground)
-and want to start the app in the browser, just type:
+app and want to start it in the browser just type:
 ```shell
 yarn web
 ```
 
-If you want to start example applications from the 
+If you want to start the example applications from the 
 [reanimated repository](https://github.com/software-mansion/react-native-reanimated)
-you need to run a following command inside the `Example` directory:
+you need to run the following command inside the `Example` directory:
 ```shell
 yarn start-web
 ```
 
 ## Webpack support
 
-If you want to use Reanimated in `webpack` app you should add extra configuration to your `webpack` config.
+If you want to use Reanimated in a `webpack` app you should adjust your `webpack` config.
 
 Example webpack config file with Reanimated support:
 


### PR DESCRIPTION
# List of changes to the documentation

I only read through `next` and fixed the issues that appeared there and checked if they also appeared in older, versioned docs. If there are issues in the old docs, that have been removed in `next` then I have not looked for them.

1. Minor fixes in `fundamentals/custom_events.md` in versions *next* and *2.3-2.5*
2. Minor fixes in `fundamentals/layout_animations.md` in versions *next* and *2.3-2.5*
3. Minor fixes in `fundamentals/architecture.md` in versions *next* and *2.0-2.5*
4. Minor fixes in `fundamentals/web-support.md` in versions *next* and *2.0-2.5*
5. Added ‘forgot to add babel plugin’ error to `troubleshooting.md` in *next*
6. Minor fixes in `api/cancelAnimation.md` in versions *next* and *2.0-2.5*
7. Replaced incorrect description `Starts a time-based animation.` with `Cancels the animation linked to given shared value.` in versions `2.0-2.2`.
8. Minor fixes in `api/withDecay.md` in versions *next* and *2.3-2.5*
9. Minor fixes in `api/withDelay.md` in versions *next* and *2.0-2.5*
10. Minor fixes in `api/withRepeat.md` in versions *next* and *2.0-2.5*
11. Minor fixes in `api/withTiming.md` in versions *next* and *2.0-2.5*
12. Minor fixes in `api/measure.md` in versions *next* and *2.0-2.5*
13. Minor fixes in `api/scrollTo.md` in versions *next* and *2.0-2.5*
14. Minor fixes in `api/getRelativeCoords.md` in versions *next* and *2.0-2.5*
15. Minor fixes in `api/interpolate.md` in versions *next* and *2.0-2.5*
16. Minor fixes in `api/runOnJS` in versions *next* and *2.0-2.5*
17. Improved code style in example in ‘api/runOnJS`  in versions *next* and *2.0-2.5*
18. Minor fixes in `api/runOnUI` in versions *next* and *2.0-2.5*