### PR TITLE
Detect two versions of Reanimated

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -4,6 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 reactVersion = '0.0.0'
 reactTargetTvOS = false
+isUserApp = false
 
 begin
   # standard app
@@ -12,6 +13,7 @@ begin
   reactJson = JSON.parse(File.read(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json")))
   reactVersion = reactJson["version"]
   reactTargetTvOS = reactJson["name"] == "react-native-tvos"
+  isUserApp = true
 rescue
   begin
     # monorepo
@@ -40,6 +42,20 @@ rescue
       reactVersion = '0.68.0'
       puts "[RNReanimated] Unable to recognized your `react-native` version! Default `react-native` version: " + reactVersion
     end
+  end
+end
+
+if isUserApp
+  libInstances = %x[find ../../ -name "package.json" | grep "reanimated"]
+  libInstancesArray = libInstances.split("\n")
+  if libInstancesArray.length() > 1
+    parsedLocation = ''
+    for location in libInstancesArray
+      location['../../'] = '- '
+      location['/package.json'] = ''
+      parsedLocation += location + "\n"
+    end
+    raise "[Reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multpile-versions-of-reanimated-was-detected \n\nConflict beetween: \n" + parsedLocation
   end
 end
 

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -7,7 +7,7 @@ reactTargetTvOS = false
 isUserApp = false
 
 begin
-  # standard app
+  # user app
   # /appName/node_modules/react-native-reanimated/RNReanimated.podspec
   # /appName/node_modules/react-native/package.json
   reactJson = JSON.parse(File.read(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json")))
@@ -46,7 +46,7 @@ rescue
 end
 
 if isUserApp
-  libInstances = %x[find ../../ -name "package.json" | grep "reanimated"]
+  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-reanimated/"]
   libInstancesArray = libInstances.split("\n")
   if libInstancesArray.length() > 1
     parsedLocation = ''
@@ -55,7 +55,7 @@ if isUserApp
       location['/package.json'] = ''
       parsedLocation += location + "\n"
     end
-    raise "[Reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multpile-versions-of-reanimated-was-detected \n\nConflict beetween: \n" + parsedLocation
+    raise "[Reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation
   end
 end
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,6 +99,20 @@ def getPlaygroundAppName() { // only for the development
 boolean CLIENT_SIDE_BUILD = resolveBuildType()
 if (CLIENT_SIDE_BUILD) {
     configurations.maybeCreate("default")
+
+    def libInstanceCounter = 0;
+    String parsedLocation = "";
+    fileTree(rootDir.parent).visit { FileVisitDetails details ->
+        def path = details.file.path
+        if (path.contains("reanimated/package.json")) {
+            libInstanceCounter++;
+            parsedLocation += "- " + path.replace("/package.json", "\n")
+        }
+        if (libInstanceCounter > 1) {
+            String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multpile-versions-of-reanimated-was-detected \n\nConflict beetween: \n" + parsedLocation + "\n";
+            throw new Exception(exceptionMessage);
+        }
+    }
 }
 def reactNative = resolveReactNativeDirectory()
 def reactNativeManifest = file("$reactNative/package.json")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,12 +104,12 @@ if (CLIENT_SIDE_BUILD) {
     String parsedLocation = "";
     fileTree(rootDir.parent).visit { FileVisitDetails details ->
         def path = details.file.path
-        if (path.contains("reanimated/package.json")) {
+        if (path.contains("/react-native-reanimated/package.json")) {
             libInstanceCounter++;
             parsedLocation += "- " + path.replace("/package.json", "\n")
         }
         if (libInstanceCounter > 1) {
-            String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multpile-versions-of-reanimated-was-detected \n\nConflict beetween: \n" + parsedLocation + "\n";
+            String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
             throw new Exception(exceptionMessage);
         }
     }

--- a/docs/docs/fundamentals/troubleshooting.md
+++ b/docs/docs/fundamentals/troubleshooting.md
@@ -32,7 +32,7 @@ sure you have added it.
 
 ### Multpile versions of Reanimated was detected
 
-This error usually happens when in your project exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside your `node_modules` instead of using it as a peer dependency. In this situation cause that two different versions of Reanimated JS module try to use the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
+This error usually happens when in your project exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside their own `node_modules` instead of using it as a peer dependency. In this situation cause that two different versions of Reanimated JS module try to use the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
 
 You can check which libraries are using Reanimated, for example, with the command:
 ```bash

--- a/docs/docs/fundamentals/troubleshooting.md
+++ b/docs/docs/fundamentals/troubleshooting.md
@@ -29,3 +29,31 @@ Depending on how spread is used you may try one of the following alternatives:
 
 This error usually happens, when you forget to add the babel plugin in your `babel.plugin.js`. Please make
 sure you have added it.
+
+### Multpile versions of Reanimated was detected
+
+This error usually happens when in your project exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside your `node_modules` instead of using it as a peer dependency. In this situation cause that two different versions of Reanimated JS module try to use the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
+
+If you use `yarn` you should add [`resolution` property](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
+```json
+"resolutions": {
+  "react-native-reanimated": <Reanimated version>
+}
+```
+
+If you use `npm` you should add [`overrides` property](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides).
+```json
+"overrides": {
+  "react-native-reanimated": <Reanimated version>
+}
+```
+
+After that you need to run you package manager again
+
+```bash
+yarn
+```
+or
+```bash
+npm install
+```

--- a/docs/docs/fundamentals/troubleshooting.md
+++ b/docs/docs/fundamentals/troubleshooting.md
@@ -34,6 +34,11 @@ sure you have added it.
 
 This error usually happens when in your project exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside your `node_modules` instead of using it as a peer dependency. In this situation cause that two different versions of Reanimated JS module try to use the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
 
+You can check which libraries are using Reanimated, for example, with the command:
+```bash
+npm why react-native-reanimated
+``` 
+
 If you use `yarn` you should add [`resolution` property](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
 ```json
 "resolutions": {

--- a/docs/docs/fundamentals/troubleshooting.md
+++ b/docs/docs/fundamentals/troubleshooting.md
@@ -30,9 +30,9 @@ Depending on how spread is used you may try one of the following alternatives:
 This error usually happens, when you forget to add the babel plugin in your `babel.plugin.js`. Please make
 sure you have added it.
 
-### Multpile versions of Reanimated was detected
+### Multiple versions of Reanimated were detected
 
-This error usually happens when in your project exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside their own `node_modules` instead of using it as a peer dependency. In this situation cause that two different versions of Reanimated JS module try to use the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
+This error usually happens when in your project there exists more than one instance of Reanimated. It can occur when some of your dependency has installed Reanimated inside their own `node_modules` instead of using it as a peer dependency. In this case two different versions of Reanimated JS module try to install the same Native Module. You can resolve this problem manually by modifying your `package.json` file.
 
 You can check which libraries are using Reanimated, for example, with the command:
 ```bash
@@ -54,7 +54,6 @@ If you use `npm` you should add [`overrides` property](https://docs.npmjs.com/cl
 ```
 
 After that you need to run you package manager again
-
 ```bash
 yarn
 ```


### PR DESCRIPTION
## Description

When a project exists with more than one instance of Reanimated, two versions of Reanimated JS module try to use the same Native Module. It can occur when some of your dependency has installed Reanimated inside their own `node_modules` instead of using it as a peer dependency. The problem is, for example, when the old version of JS tries to call a removed function in a newer version of the native module or can call twice initialization of the native module and override existing data. The solution to this issue is to modify the `package.json` file, requiring only one reanimated version. [Details in the documentation.](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected)

Fixes https://github.com/software-mansion/react-native-reanimated/issues/3333

## Solution
You can check which libraries are using Reanimated, for example, with the command:
```bash
npm why react-native-reanimated
``` 

If you use `yarn` you should add [`resolution` property](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
```json
"resolutions": {
  "react-native-reanimated": <Reanimated version>
}
```

If you use `npm` you should add [`overrides` property](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides).
```json
"overrides": {
  "react-native-reanimated": <Reanimated version>
}
```

After that you need to run you package manager again

```bash
yarn
```
or
```bash
npm install
```