### PR TITLE
Fixed typo in RNReanimated.podspec

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -38,7 +38,7 @@ rescue
     rescue
       # should never happen
       reactVersion = '0.68.0'
-      puts "[RNReanimated] Unable to recognized your `react-native` version! Default `react-native` version: " + reactVersion
+      puts "[RNReanimated] Unable to recognize your `react-native` version! Default `react-native` version: " + reactVersion
     end
   end
 end


### PR DESCRIPTION
## Description

Fixes a minor typo in the podspec file

## Changes

RNReanimated.podspec/line 41

Before:

```
puts "[RNReanimated] Unable to recognized your `react-native` version! Default `react-native` version: " + reactVersion
```

After:

```
puts "[RNReanimated] Unable to recognize your `react-native` version! Default `react-native` version: " + reactVersion
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
