### PR TITLE
Update community page in the documentation

### DIFF
--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -10,25 +10,33 @@ Reanimated community is the best! 🎉  We want to say thank you to all communit
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    </div>
     <div>Krzysztof Magiera</div>
     <a href="https://twitter.com/kzzzf">@kzzzf</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    </div>
     <div>Szymon Kapała</div>
     <a href="https://twitter.com/Turbo_Szymon">@Turbo_Szymon</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    </div>
     <div>Krzysztof Piaskowy</div>
     <a href="https://twitter.com/piaskowyk">@piaskowyk</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    </div>
     <div>Jakub Myśliwiec</div>
     <a href="https://twitter.com/jmysliv">@jmysliv</a>
   </div>
@@ -41,14 +49,18 @@ We really appreciate our sponsors! Thanks to them we can develop our library and
 
   <div class="community-holder-container-item">
     <a href="https://www.shopify.com/">
-      <img class="community-imageHolder" src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      <div class="community-imageHolder">
+        <img src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      </div>
       <div>Shopify</div>
     </a>
   </div>
 
   <div class="community-holder-container-item">
     <a href="https://expo.dev">
-    <img class="community-imageHolder" src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    <div class="community-imageHolder">
+      <img src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    </div>
     <div>Expo</div>
     </a>
   </div>

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -19,14 +19,6 @@ Reanimated community is the best! 🎉  We want to say thank you to all communit
 
   <div class="community-holder-container-item">
     <div class="community-imageHolder">
-      <img src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
-    </div>
-    <div>Szymon Kapała</div>
-    <a href="https://twitter.com/Turbo_Szymon">@Turbo_Szymon</a>
-  </div>
-
-  <div class="community-holder-container-item">
-    <div class="community-imageHolder">
       <img src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
     </div>
     <div>Krzysztof Piaskowy</div>
@@ -35,10 +27,10 @@ Reanimated community is the best! 🎉  We want to say thank you to all communit
 
   <div class="community-holder-container-item">
     <div class="community-imageHolder">
-      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U01GDBF9M9D-54f024a4c134-512" />
     </div>
-    <div>Jakub Myśliwiec</div>
-    <a href="https://twitter.com/jmysliv">@jmysliv</a>
+    <div>Tomasz Zawadzki</div>
+    <a href="https://twitter.com/tomekzaw_">@tomekzaw_</a>
   </div>
 
 </div>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -235,6 +235,9 @@ h6 {
 .github-navbar-logo>span{
   display: none;
 }
+.github-navbar-logo>svg{
+  display: none;
+}
 
 /* .githubStarLink {
   display: flex;

--- a/docs/versioned_docs/version-2.3.x/community.md
+++ b/docs/versioned_docs/version-2.3.x/community.md
@@ -10,25 +10,33 @@ Reanimated community is the best! 🎉  We want to say thank you to all communit
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    </div>
     <div>Krzysztof Magiera</div>
     <a href="https://twitter.com/kzzzf">@kzzzf</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    </div>
     <div>Szymon Kapała</div>
     <a href="https://twitter.com/Turbo_Szymon">@Turbo_Szymon</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    </div>
     <div>Krzysztof Piaskowy</div>
     <a href="https://twitter.com/piaskowyk">@piaskowyk</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    </div>
     <div>Jakub Myśliwiec</div>
     <a href="https://twitter.com/jmysliv">@jmysliv</a>
   </div>
@@ -41,14 +49,18 @@ We really appreciate our sponsors! Thanks to them we can develop our library and
 
   <div class="community-holder-container-item">
     <a href="https://www.shopify.com/">
-      <img class="community-imageHolder" src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      <div class="community-imageHolder">
+        <img src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      </div>
       <div>Shopify</div>
     </a>
   </div>
 
   <div class="community-holder-container-item">
     <a href="https://expo.dev">
-    <img class="community-imageHolder" src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    <div class="community-imageHolder">
+      <img src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    </div>
     <div>Expo</div>
     </a>
   </div>

--- a/docs/versioned_docs/version-2.5.x/community.md
+++ b/docs/versioned_docs/version-2.5.x/community.md
@@ -10,25 +10,33 @@ Reanimated community is the best! 🎉  We want to say thank you to all communit
 <div class="community-holder-container">
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U0F40CATS-d0a2e7559a1b-512" />
+    </div>
     <div>Krzysztof Magiera</div>
     <a href="https://twitter.com/kzzzf">@kzzzf</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-UBHF6F55K-63eefc68a264-512" />
+    </div>
     <div>Szymon Kapała</div>
     <a href="https://twitter.com/Turbo_Szymon">@Turbo_Szymon</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U01029QHCDB-79dd9904eb93-512" />
+    </div>
     <div>Krzysztof Piaskowy</div>
     <a href="https://twitter.com/piaskowyk">@piaskowyk</a>
   </div>
 
   <div class="community-holder-container-item">
-    <img class="community-imageHolder" src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    <div class="community-imageHolder">
+      <img src="https://ca.slack-edge.com/T03Q9AMJJ-U027SRB1QBA-927e57802215-512" />
+    </div>
     <div>Jakub Myśliwiec</div>
     <a href="https://twitter.com/jmysliv">@jmysliv</a>
   </div>
@@ -41,14 +49,18 @@ We really appreciate our sponsors! Thanks to them we can develop our library and
 
   <div class="community-holder-container-item">
     <a href="https://www.shopify.com/">
-      <img class="community-imageHolder" src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      <div class="community-imageHolder">
+        <img src="https://avatars1.githubusercontent.com/u/8085?v=3&s=100" />
+      </div>
       <div>Shopify</div>
     </a>
   </div>
 
   <div class="community-holder-container-item">
     <a href="https://expo.dev">
-    <img class="community-imageHolder" src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    <div class="community-imageHolder">
+      <img src="https://avatars2.githubusercontent.com/u/12504344?v=3&s=100" />
+    </div>
     <div>Expo</div>
     </a>
   </div>


### PR DESCRIPTION
## Description

At the moment the images in the community page in the docs are a bit large. For some reason (I haven't investigated) the class applied to the `img` tag gets overwritten, so I added a `div` wrapping the images and applied the class to that element. Also updated the current team and hidden the arrow next to the GitHub logo in the navbar.

## Changes

Wrapped the images with a div with the correct class applied.
Updated the current team.
Hidden the arrow next to the GitHub logo in the navbar.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

## Test code and steps to reproduce

Visit https://docs.swmansion.com/react-native-reanimated/docs/next/community/ and change version

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
