### PR TITLE
Fix symlinks

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -46,7 +46,7 @@ rescue
 end
 
 if isUserApp
-  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-reanimated/"]
+  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-reanimated/package.json"]
   libInstancesArray = libInstances.split("\n")
   if libInstancesArray.length() > 1
     parsedLocation = ''

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,11 @@
 import com.android.Version
 
+import java.nio.file.Files
 import java.nio.file.Paths
+import java.nio.file.Path
 import org.apache.tools.ant.filters.ReplaceTokens
 import groovy.json.JsonSlurper
+import java.util.stream.Stream
 
 /**
  * Finds the path of the installed npm package with the given name using Node's
@@ -110,19 +113,21 @@ boolean CLIENT_SIDE_BUILD = resolveClientSideBuild()
 if (CLIENT_SIDE_BUILD) {
     configurations.maybeCreate("default")
 
+    Stream<Path> pathStream = Files.find(
+            Paths.get(rootDir.parent),
+            Integer.MAX_VALUE,
+            (path, basicFileAttributes) -> { path.toString().endsWith("/react-native-reanimated/package.json") }
+    )
+
     String parsedLocation = ""
-    def libInstancesCount = Files.walk(Paths.get(rootDir.parent))
-        .filter(path -> {
-            def isLibInstance = path.toString().endsWith("/react-native-reanimated/package.json")
-            if (isLibInstance) {
-                parsedLocation += "- " + path.toString().replace("/package.json", "\n")
-            }
-            return isLibInstance
-        })
-        .count()
+    def libInstancesCount = 0
+    pathStream.forEach(path -> {
+        parsedLocation += "- " + path.toString().replace("/package.json", "\n")
+        libInstancesCount++
+    })
     if (libInstancesCount > 1) {
         String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
-        throw new Exception(exceptionMessage);
+        throw new Exception(exceptionMessage)
     }
 }
 def reactNative = resolveReactNativeDirectory()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,18 +110,19 @@ boolean CLIENT_SIDE_BUILD = resolveClientSideBuild()
 if (CLIENT_SIDE_BUILD) {
     configurations.maybeCreate("default")
 
-    def libInstanceCounter = 0;
-    String parsedLocation = "";
-    fileTree(rootDir.parent).visit { FileVisitDetails details ->
-        def path = details.file.path
-        if (path.contains("/react-native-reanimated/package.json")) {
-            libInstanceCounter++;
-            parsedLocation += "- " + path.replace("/package.json", "\n")
-        }
-        if (libInstanceCounter > 1) {
-            String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
-            throw new Exception(exceptionMessage);
-        }
+    String parsedLocation = ""
+    def libInstancesCount = Files.walk(Paths.get(rootDir.parent))
+        .filter(path -> {
+            def isLibInstance = path.toString().endsWith("/react-native-reanimated/package.json")
+            if (isLibInstance) {
+                parsedLocation += "- " + path.toString().replace("/package.json", "\n")
+            }
+            return isLibInstance
+        })
+        .count()
+    if (libInstancesCount > 1) {
+        String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
+        throw new Exception(exceptionMessage);
     }
 }
 def reactNative = resolveReactNativeDirectory()


### PR DESCRIPTION
## Description

The old version didn't work when someone installed reanimated from Github due to yarn/npm breaking symlinks. Package manager changes symlinks `DirName -> ../../DirName` to `DirName -> DirName`. The previous implementation throws exceptions, but the new one can ignore broken symlinks.