### PR TITLE
Fix useAnimatedKeyboard inset

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -270,6 +270,7 @@ android {
 
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
+        buildConfigField("int", "REACT_NATIVE_VERSION", rnMinorVersion.toString())
     }
     externalNativeBuild {
         cmake {

--- a/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -56,10 +56,10 @@ public class ReanimatedKeyboardEventListener {
     ViewCompat.setOnApplyWindowInsetsListener(
         rootView,
         (v, insets) -> {
-          int paddingBottom =
-              BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-                  ? 0
-                  : insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+          int paddingBottom = 0;
+          if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && BuildConfig.REACT_NATIVE_VERSION < 70) {
+            paddingBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+          }
           int paddingTop = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
           View content =
               rootView.getRootView().findViewById(com.swmansion.reanimated.R.id.action_bar_root);

--- a/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -11,6 +11,7 @@ import androidx.core.view.WindowInsetsAnimationCompat;
 import androidx.core.view.WindowInsetsCompat;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.PixelUtil;
+import com.swmansion.reanimated.BuildConfig;
 import com.swmansion.reanimated.NativeProxy.KeyboardEventDataUpdater;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -55,7 +56,10 @@ public class ReanimatedKeyboardEventListener {
     ViewCompat.setOnApplyWindowInsetsListener(
         rootView,
         (v, insets) -> {
-          int paddingBottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+          int paddingBottom =
+              BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+                  ? 0
+                  : insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
           int paddingTop = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
           View content =
               rootView.getRootView().findViewById(com.swmansion.reanimated.R.id.action_bar_root);

--- a/docs/docs/api/hooks/useAnimatedKeyboard.md
+++ b/docs/docs/api/hooks/useAnimatedKeyboard.md
@@ -3,6 +3,13 @@ id: useAnimatedKeyboard
 title: useAnimatedKeyboard
 sidebar_label: useAnimatedKeyboard
 ---
+
+:::caution
+
+Android implementation of `useAnimatedKeyboard` is an experimental feature.
+
+:::
+
 With the `useAnimatedKeyboard` hook, you can create animations based on current keyboard position.
 
 On Android, make sure to set `android:windowSoftInputMode` in your `AndroidMainfest.xml` to `adjustResize`. Then, using the `useAnimatedKeyboard` hook disables


### PR DESCRIPTION
## Description


On Paper architecture, we need to manually set the bottom inset to prevent cropping application content by the navigation bottom bar, but this is no longer required on Fabric.

Since rn70 Paper also doesn't need an additional bottom inset.