### PR TITLE
Remove start script in root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0-rc.0",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "yarn run format:js && yarn run lint:js && yarn run test:unit",
     "test:unit": "jest",
     "lint": "yarn lint:js && yarn lint:cpp && yarn lint:java",


### PR DESCRIPTION
## Description

This PR removes `start` script from top-level `package.json`.

You never want to run `yarn start` here.

Run `cd Example` or `cd FabricExample` and then run `yarn start`.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

- Removed `start` script from top-level `package.json`

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
