### PR TITLE
Fix "unary operator expected" warning in `createNPMPackage.sh`

### DIFF
--- a/createNPMPackage.sh
+++ b/createNPMPackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 yarn bob build
-if [ $1 = "nightly" ];
+if [[ $1 = "nightly" ]];
 then
   node scripts/set-nightly-version.js
 fi


### PR DESCRIPTION
## Description

This PR removes a warning when running script `createNPMPackage.sh` without nightly mode:
```
./createNPMPackage.sh: line 4: [: =: unary operator expected
```

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
