### PR TITLE
Remove deprecated functions `delay`, `repeat`, `loop`, `sequence`

### DIFF
--- a/src/reanimated2/animation/delay.ts
+++ b/src/reanimated2/animation/delay.ts
@@ -75,15 +75,3 @@ export function withDelay(
     };
   });
 }
-
-/**
- * @deprecated Kept for backward compatibility. Will be removed soon.
- */
-export function delay(
-  delayMs: number,
-  _nextAnimation: NextAnimation<DelayAnimation>
-): Animation<DelayAnimation> {
-  'worklet';
-  console.warn('Method `delay` is deprecated. Please use `withDelay` instead');
-  return withDelay(delayMs, _nextAnimation);
-}

--- a/src/reanimated2/animation/repeat.ts
+++ b/src/reanimated2/animation/repeat.ts
@@ -91,28 +91,3 @@ export function withRepeat(
     } as RepeatAnimation;
   });
 }
-
-/**
- * @deprecated Kept for backward compatibility. Will be removed soon.
- */
-export function repeat(
-  _nextAnimation: NextAnimation<RepeatAnimation>,
-  numberOfReps = 2,
-  reverse = false,
-  callback?: AnimationCallback
-): Animation<RepeatAnimation> {
-  'worklet';
-  console.warn(
-    'Method `repeat` is deprecated. Please use `withRepeat` instead'
-  );
-  return withRepeat(_nextAnimation, numberOfReps, reverse, callback);
-}
-
-export function loop(
-  nextAnimation: NextAnimation<RepeatAnimation>,
-  numberOfLoops = 1
-): Animation<RepeatAnimation> {
-  'worklet';
-  console.warn('Method `loop` is deprecated. Please use `withRepeat` instead');
-  return repeat(nextAnimation, Math.round(numberOfLoops * 2), true);
-}

--- a/src/reanimated2/animation/sequence.ts
+++ b/src/reanimated2/animation/sequence.ts
@@ -83,16 +83,3 @@ export function withSequence(
     }
   );
 }
-
-/**
- * @deprecated Kept for backward compatibility. Will be removed soon.
- */
-export function sequence(
-  ..._animations: NextAnimation<SequenceAnimation>[]
-): Animation<SequenceAnimation> {
-  'worklet';
-  console.warn(
-    'Method `sequence` is deprecated. Please use `withSequence` instead'
-  );
-  return withSequence(..._animations);
-}


### PR DESCRIPTION
## Description

This PR removes the following functions which were deprecated in 2.x:
* `delay` &rarr; use [`withDelay`](https://docs.swmansion.com/react-native-reanimated/docs/api/animations/withDelay/) instead
* `repeat` &rarr; use [`withRepeat`](https://docs.swmansion.com/react-native-reanimated/docs/api/animations/withRepeat/) instead
* `loop` &rarr; use [`withRepeat`](https://docs.swmansion.com/react-native-reanimated/docs/api/animations/withRepeat/) instead
* `sequence` &rarr; use [`withSequence`](https://docs.swmansion.com/react-native-reanimated/docs/api/animations/withSequence/) instead

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

- Removed deprecated functions `delay`, `repeat`, `loop`, `sequence`

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
