### PR TITLE
Reorder fields in `ShadowTreeCloner`

### DIFF
--- a/Common/cpp/headers/Fabric/ShadowTreeCloner.h
+++ b/Common/cpp/headers/Fabric/ShadowTreeCloner.h
@@ -31,8 +31,8 @@ class ShadowTreeCloner {
   void updateYogaChildren();
 
  private:
-  PropsParserContext propsParserContext_;
   std::shared_ptr<NewestShadowNodesRegistry> newestShadowNodesRegistry_;
+  PropsParserContext propsParserContext_;
   std::set<ShadowNode *> yogaChildrenUpdates_;
 };
 


### PR DESCRIPTION
## Description

This PR fixes `warning: field 'newestShadowNodesRegistry_' will be initialized after field 'propsParserContext_' [-Wreorder]` when compiling Reanimated sources for Android with Fabric enabled.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
