### PR TITLE
Fix Hermes not available on iOS when use_frameworks enabled

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -103,6 +103,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
     "USE_HEADERMAP" => "YES",
     "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
+    "FRAMEWORK_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
   }
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags


### PR DESCRIPTION
## Description

When there are frameworks used and Hermes enabled in the Podfile of your project, RN falls back to JSC in debug mode and crashes in production mode.

This PR makes it possible to use Hermes when there is `use_frameworks!` enabled in the Podfile.

Thanks @Kudo who originally fixed this issue in ReactNative repository: https://github.com/facebook/react-native/pull/34222

## Changes

Added path to `Framework Search Paths` in Podspec of react-native-reanimated.

## Test code and steps to reproduce

1. Create empty ReactNative project
2. Add react-native-reanimated dependency.
3. For ReactNative 0.69.3 apply patch from: https://github.com/facebook/react-native/pull/34222/files
4. Enable frameworks in Podfile: `use_frameworks! :linkage => :static`
5. Build project in debug mode -> you will not see `engine: hermes` in top right corner.
6. Build project in release mode -> app will crash at startup

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
