### PR TITLE
Restore d.ts file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "!**/__fixtures__",
     "!**/__mocks__",
     "!lib/typescript",
+    "react-native-reanimated.d.ts",
     "android/src/main/AndroidManifest.xml",
     "android/src/main/java/",
     "android/build.gradle",


### PR DESCRIPTION
## Description

The PR [#3365](https://github.com/software-mansion/react-native-reanimated/pull/3365) was partially reverted. We use Bob to generate JS for the web, but we need to have the old d.ts file because of some TypeScript types problems in the d.ts file generated by Bob. Unfortunately, we forgot about restoring the old `react-native-reanimated.d.ts` to the package.

Fixes #3487