### PR TITLE
Gradle backward compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,18 +113,18 @@ boolean CLIENT_SIDE_BUILD = resolveClientSideBuild()
 if (CLIENT_SIDE_BUILD) {
     configurations.maybeCreate("default")
 
-    Stream<Path> pathStream = Files.find(
+    List<Path> paths = Files.find(
             Paths.get(rootDir.parent),
             Integer.MAX_VALUE,
-            (path, basicFileAttributes) -> { path.toString().endsWith("/react-native-reanimated/package.json") }
-    )
+            { path, basicFileAttributes -> path.toString().endsWith("/react-native-reanimated/package.json") }
+    ).toArray()
 
     String parsedLocation = ""
     def libInstancesCount = 0
-    pathStream.forEach(path -> {
+    for (def path in paths) {
         parsedLocation += "- " + path.toString().replace("/package.json", "\n")
         libInstancesCount++
-    })
+    }
     if (libInstancesCount > 1) {
         String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
         throw new Exception(exceptionMessage)


### PR DESCRIPTION
## Description

To resolve the problem with the detection multiple instances of reanimated (https://github.com/software-mansion/react-native-reanimated/pull/3441, https://github.com/software-mansion/react-native-reanimated/pull/3467) I used some lambda expressions in the Gradle file. Unfortunately, Gradle in versions less than 7 doesn't support lambda expression. More info here: https://stackoverflow.com/questions/60688156/lambda-expression-in-groovy
I changes this logic to use the Gradle closure expression and regular loop instead of lambdas.