### PR TITLE
docs: Change yarn to npx example readme

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -8,12 +8,12 @@
 ### Running on iOS
 
 - `yarn pod-install` - to install pods
-- `yarn react-native run-ios` - to run the app
+- `npx react-native run-ios` - to run the app
 
 ### Running on Android
 
 - [install NDK in version 21.3.6528147 or higher](https://developer.android.com/studio/projects/install-ndk)
-- `yarn react-native run-android` - to run the app
+- `npx react-native run-android` - to run the app
 
 **Note:** Android compiles fairly long due to native dependencies. To shorten consecutive builds, load the project into android studio and run it from there. Same applies to iOS so you can use XCode for running the example.
 


### PR DESCRIPTION
## Description

The reason for this is that `yarn react-native run-ios` doesn't work, `npx react-native run-ios` or `npx react-native run-android` will work cause npx runs the react native script while yarn doesn't!

**NPX** stands for Node Package eXecute. It is simply an NPM package runner. It allows developers to execute any Javascript Package available on the NPM registry without even installing it. NPX is installed automatically with NPM version 5.2.0 and above.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

- doc changes in example to be able to run the app

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
