### PR TITLE
Fix incorrect build type resolution on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,13 +47,10 @@ def safeExtGet(prop, fallback) {
 }
 
 def resolveBuildType() {
-    def buildType = "debug"
-    tasks.all({ task ->
-        if (task.name == "buildCMakeRelease") {
-            buildType = "release"
-        }
-    })
-    return buildType
+    Gradle gradle = getGradle()
+    String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+    
+    return tskReqStr.contains('Release') ? 'release' : 'debug'
 }
 
 def resolveClientSideBuild() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ def safeExtGet(prop, fallback) {
 
 def resolveBuildType() {
     Gradle gradle = getGradle()
-    String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+    String tskReqStr = gradle.getStartParameter().getTaskRequests()['args'].toString()
     
     return tskReqStr.contains('Release') ? 'release' : 'debug'
 }


### PR DESCRIPTION
## Description

The previous implementation was broken and always detected the release as `debug`. The new implementation correctly recognizes build variants.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
