### PR TITLE
Fix CI concurrency

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         working-directory: [Example, FabricExample]
     concurrency:
-      group: android-${{ github.ref }}
+      group: android-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         working-directory: [Example, FabricExample]
     concurrency:
-      group: ios-${{ github.ref }}
+      group: ios-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         working-directory: [Example, FabricExample]
     concurrency:
-      group: static-example-${{ github.ref }}
+      group: typescript-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
## Description

This PR should hopefully fix CI jobs for Example and FabricExample apps being cancelled by using `matrix.working_directory` variable in `concurrency.group` identifier.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
