### PR TITLE
Fix CI concurrency again

### DIFF
--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     concurrency:
-      group: static-root-${{ github.ref }}
+      group: validate-java-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
## Description

This PR removes duplicate `concurrency.group` key by renaming one key to `validate-java-...`.
