### PR TITLE
Remove unnecessary variables from CMakeLists.txt

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -54,17 +54,6 @@ if(${REACT_NATIVE_TARGET_VERSION} LESS 66)
         )
 endif()
 
-if(${IS_NEW_ARCHITECTURE_ENABLED})
-    set(
-        FABRIC_UTILS_CPP
-        "${COMMON_SRC_DIR}/cpp/Fabric/FabricUtils.cpp"
-    )
-    set(
-        REANIMATED_UI_MANAGER_BINDING_CPP
-        "${COMMON_SRC_DIR}/cpp/Fabric/ReanimatedUIManagerBinding.cpp"
-    )
-endif()
-
 add_library(
         ${PACKAGE_NAME}
         SHARED
@@ -72,8 +61,6 @@ add_library(
         ${SOURCES_ANDROID}
         ${INCLUDE_JSI_CPP}
         ${INCLUDE_JSIDYNAMIC_CPP}
-        ${FABRIC_UTILS_CPP}
-        ${REANIMATED_UI_MANAGER_BINDING_CPP}
 )
 
 # includes


### PR DESCRIPTION
## Description

This PR removes `FABRIC_UTILS_CPP` and `REANIMATED_UI_MANAGER_BINDING_CPP` variables in CMakeLists.txt which are not necessary since the files are already included in `SOURCES_COMMON`. Also, the contents of these files is wrapped inside `#ifdef RCT_NEW_ARCH_ENABLED` so they are effectively empty when compiling for Paper.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
