### PR TITLE
Fix plugin crashes when no options are being passed to it

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -450,7 +450,7 @@ function makeWorklet(t, fun, state) {
   const workletHash = hash(funString);
 
   let location = state.file.opts.filename;
-  if (state.opts.relativeSourceLocation) {
+  if (state.opts && state.opts.relativeSourceLocation) {
     const path = require('path');
     location = path.relative(state.cwd, location);
   }


### PR DESCRIPTION
## Description

Currently when adding the plugin to `babel.config.js` without passing any options to it, `state.opts` will be undefined causing the webpack build to fail because it can't read relativeSourceLocation of undefined.-->

## Changes

- Added check wheter plugin options are being passed before accesing them

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
