### PR TITLE
Fixed retain cycle of `REAModule` causing memory leak

### DIFF
--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -51,6 +51,25 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
 RCT_EXPORT_MODULE(ReanimatedModule);
 
+static int instanceCounter = 0;
+
+- (id)init
+{
+  NSAssert(instanceCounter == 0, @"More than one instance of REAModule present");
+  instanceCounter++;
+  return [super init];
+}
+
+- (void)dealloc
+{
+  instanceCounter--;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 - (void)invalidate
 {
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -51,6 +51,8 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
 RCT_EXPORT_MODULE(ReanimatedModule);
 
+// This counts how many instances of REAModule are present. Thanks to this we
+// can easily detect if there is a memory leak (ex. due to a retain cycle).
 static int instanceCounter = 0;
 
 - (id)init

--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -55,7 +55,9 @@ static int instanceCounter = 0;
 
 - (id)init
 {
-  NSAssert(instanceCounter == 0, @"More than one instance of REAModule present");
+  // The counter may be 1 during a reload, because the previous instance
+  // may not have been deallocated in time, but it should not be higher.
+  NSAssert(instanceCounter <= 1, @"More than one REAModule instance present");
   instanceCounter++;
   return [super init];
 }

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -213,8 +213,10 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<REAIOSErrorHandler>(scheduler);
   std::shared_ptr<NativeReanimatedModule> module;
 
-  auto requestRender = [reanimatedModule, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
-    [reanimatedModule.nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
+  auto nodesManager = reanimatedModule.nodesManager;
+
+  auto requestRender = [nodesManager, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
+    [nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
       double frameTimestamp = calculateTimestampWithSlowAnimations(displayLink.targetTimestamp) * 1000;
       jsi::Object global = rt.global();
       jsi::String frameTimestampName = jsi::String::createFromAscii(rt, "_frameTimestamp");
@@ -225,10 +227,10 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   };
 
 #ifdef RCT_NEW_ARCH_ENABLED
-  auto synchronouslyUpdateUIPropsFunction = [reanimatedModule](jsi::Runtime &rt, Tag tag, const jsi::Value &props) {
+  auto synchronouslyUpdateUIPropsFunction = [nodesManager](jsi::Runtime &rt, Tag tag, const jsi::Value &props) {
     NSNumber *viewTag = @(tag);
     NSDictionary *uiProps = convertJSIObjectToNSDictionary(rt, props.asObject(rt));
-    [reanimatedModule.nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
+    [nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
   };
 
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =


### PR DESCRIPTION
## Description

A retain cycle of `REAModule` caused by some lambdas in `NativeProxy` that held a reference to it are removed.

A mechanism for easily detecting such memory leaks in the future is also introduced.

## Changes

Before:
```objective-c
auto requestRender = [reanimatedModule, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
    [reanimatedModule.nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
      double frameTimestamp = calculateTimestampWithSlowAnimations(displayLink.targetTimestamp) * 1000;
      jsi::Object global = rt.global();
      jsi::String frameTimestampName = jsi::String::createFromAscii(rt, "_frameTimestamp");
      global.setProperty(rt, frameTimestampName, frameTimestamp);
      onRender(frameTimestamp);
      global.setProperty(rt, frameTimestampName, jsi::Value::undefined());
    }];
  };

auto synchronouslyUpdateUIPropsFunction = [reanimatedModule](jsi::Runtime &rt, Tag tag, const jsi::Value &props) {
    NSNumber *viewTag = @(tag);
    NSDictionary *uiProps = convertJSIObjectToNSDictionary(rt, props.asObject(rt));
    [reanimatedModule.nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
  };
```

After:
```objective-c
auto nodesManager = reanimatedModule.nodesManager;

auto requestRender = [nodesManager, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
    [nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
      double frameTimestamp = calculateTimestampWithSlowAnimations(displayLink.targetTimestamp) * 1000;
      jsi::Object global = rt.global();
      jsi::String frameTimestampName = jsi::String::createFromAscii(rt, "_frameTimestamp");
      global.setProperty(rt, frameTimestampName, frameTimestamp);
      onRender(frameTimestamp);
      global.setProperty(rt, frameTimestampName, jsi::Value::undefined());
    }];
  };

auto synchronouslyUpdateUIPropsFunction = [nodesManager](jsi::Runtime &rt, Tag tag, const jsi::Value &props) {
    NSNumber *viewTag = @(tag);
    NSDictionary *uiProps = convertJSIObjectToNSDictionary(rt, props.asObject(rt));
    [nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
  };
```

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
