### PR TITLE
Raise error when using Reanimated 2.x with Fabric enabled

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -54,11 +54,15 @@ end
 
 rnVersion = reactVersion.split('.')[1]
 
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+if fabric_enabled
+  raise "[Reanimated] Reanimated 2.x does not support Fabric. Please upgrade to react-native-reanimated@3.0.0-rc.2 to enable Fabric support. For details, see https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7"
+end
+
 folly_prefix = ""
 if rnVersion.to_i >= 64
   folly_prefix = "RCT-"
 end
-
 
 folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=' + rnVersion
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -48,7 +48,7 @@ if isUserApp
       location['/package.json'] = ''
       parsedLocation += location + "\n"
     end
-    raise "[Reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation
+    raise "[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation
   end
 end
 
@@ -56,7 +56,7 @@ rnVersion = reactVersion.split('.')[1]
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 if fabric_enabled
-  raise "[Reanimated] Reanimated 2.x does not support Fabric. Please upgrade to react-native-reanimated@3.0.0-rc.2 to enable Fabric support. For details, see https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7"
+  raise "[react-native-reanimated] Reanimated 2.x does not support Fabric. Please upgrade to 3.x to use Reanimated with the New Architecture. For details, see https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7"
 end
 
 folly_prefix = ""

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,10 +126,15 @@ if (CLIENT_SIDE_BUILD) {
         libInstancesCount++
     }
     if (libInstancesCount > 1) {
-        String exceptionMessage = "\nMultiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
+        String exceptionMessage = "\n[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
         throw new Exception(exceptionMessage)
     }
 }
+
+if (isNewArchitectureEnabled()) {
+    throw new Exception("\n[react-native-reanimated] Reanimated 2.x does not support Fabric. Please upgrade to 3.x to use Reanimated with the New Architecture. For details, see https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7")
+}
+
 def reactNative = resolveReactNativeDirectory()
 def reactNativeManifest = file("$reactNative/package.json")
 def reactNativeManifestAsJson = new JsonSlurper().parseText(reactNativeManifest.text)


### PR DESCRIPTION
## Description

Android:

![](https://user-images.githubusercontent.com/20516055/189666730-7d98ab6b-42b3-4e5e-9abb-1949018a82b9.png)

iOS:

![](https://user-images.githubusercontent.com/20516055/189667019-a5763e7f-0bb3-4755-82c3-285fc892e99a.png)

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
