### PR TITLE
Fix Example app with JSC on Android

### DIFF
--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -148,17 +148,20 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
-            // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2]
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
                         defaultConfig.versionCode * 1000 + versionCodes.get(abi)
             }
+
         }
     }
 

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -74,7 +74,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
         entryFile   : "index.js",
-        enableHermes: false,
+        enableHermes: true,
 ]
 def enableHermes = project.ext.react.get("enableHermes", false);
 

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -74,14 +74,17 @@ import com.android.build.OutputFile
 
 project.ext.react = [
         entryFile   : "index.js",
-        enableHermes: true,
+        enableHermes: false,
 ]
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 /**
- * Architectures to build native code for in debug.
+ * Architectures to build native code for.
  */
-def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitectures")
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
 
 apply from: "../../node_modules/react-native/react.gradle"
 
@@ -119,7 +122,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86"
+            include (*reactNativeArchitectures())
         }
     }
     signingConfigs {
@@ -136,10 +139,8 @@ android {
             packagingOptions {
                 doNotStrip "**/**/*.so"
             }
-            if (nativeArchitectures) {
-                ndk {
-                    abiFilters nativeArchitectures.split(',')
-                }
+            ndk {
+                abiFilters (*reactNativeArchitectures())
             }
         }
         release {

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -25,8 +25,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
-        mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -34,9 +32,18 @@ allprojects {
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
-            url "$rootDir/../node_modules/detox/Detox-android"
         }
-        maven { url 'https://www.jitpack.io' }
+        maven {
+            url("$rootDir/../node_modules/detox/Detox-android")
+        }
+        mavenCentral {
+            // We don't want to fetch react-native from Maven Central as there are
+            // older versions over there.
+            content {
+                excludeGroup "com.facebook.react"
+            }
+        }
         google()
+        maven { url 'https://www.jitpack.io' }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -735,6 +735,11 @@ afterEvaluate {
             def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
             task.dependsOn(":react-native-v8:copy${buildType}JniLibsProjectOnly")
         }
+    } else if (JS_RUNTIME == "jsc") {
+      extractAARHeaders.dependsOn(prepareJSC)
+      extractSOFiles.dependsOn(prepareJSC)
+    } else {
+      throw GradleScriptException("Unknown JS runtime ${JS_RUNTIME}.")
     }
 }
 


### PR DESCRIPTION
## Description

The Example app crashes on Android if compiled with JSC instead of Hermes. Error message:

```
2022-09-15 12:34:45.701 15509-15509/com.swmansion.reanimated.example W/System.err: java.lang.UnsatisfiedLinkError: dlopen failed: library "libjsc.so" not found: needed by /data/app/~~YZvjm8gAMg_2TYxNnYOCDA==/com.swmansion.reanimated.example--9SU_U_zrfiGBnf1eSq-kA==/lib/arm64/libjscexecutor.so in namespace classloader-namespace
```

## Cause of crash

The `build.gradle` files in the Example app were outdated, which caused multiple issues. Some of the changes are:

- Added missing 64-bit architectures in some places
- Fixed enabled build abi resolution
- Fixed incorrect maven repositories definition in top-level `build.gradle`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
