### PR TITLE
Get current time as `long` on Android

### DIFF
--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -223,14 +223,12 @@ public class NativeProxy {
   }
 
   @DoNotStrip
-  private String getUptime() {
+  private long getCurrentTime() {
     if (slowAnimationsEnabled) {
       final long ANIMATIONS_DRAG_FACTOR = 10;
-      return Long.toString(
-          this.firstUptime
-              + (SystemClock.uptimeMillis() - this.firstUptime) / ANIMATIONS_DRAG_FACTOR);
+      return this.firstUptime + (SystemClock.uptimeMillis() - this.firstUptime) / ANIMATIONS_DRAG_FACTOR;
     } else {
-      return Long.toString(SystemClock.uptimeMillis());
+      return SystemClock.uptimeMillis();
     }
   }
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -130,11 +130,10 @@ void NativeProxy::installJSIBindings(
 #endif
 
   auto getCurrentTime = [this]() {
-    auto method =
-        javaPart_->getClass()->getMethod<local_ref<JString>()>("getUptime");
-    local_ref<JString> output = method(javaPart_.get());
-    return static_cast<double>(
-        std::strtoll(output->toStdString().c_str(), NULL, 10));
+    static auto method =
+        javaPart_->getClass()->getMethod<jlong()>("getCurrentTime");
+    jlong output = method(javaPart_.get());
+    return static_cast<double>(output);
   };
 
   auto requestRender = [this, getCurrentTime](

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -130,7 +130,7 @@ void NativeProxy::installJSIBindings(
 #endif
 
   auto getCurrentTime = [this]() {
-    static auto method =
+    static const auto method =
         javaPart_->getClass()->getMethod<jlong()>("getCurrentTime");
     jlong output = method(javaPart_.get());
     return static_cast<double>(output);

--- a/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -216,14 +216,12 @@ public class NativeProxy {
   }
 
   @DoNotStrip
-  private String getUptime() {
+  private long getCurrentTime() {
     if (slowAnimationsEnabled) {
       final long ANIMATIONS_DRAG_FACTOR = 10;
-      return Long.toString(
-          this.firstUptime
-              + (SystemClock.uptimeMillis() - this.firstUptime) / ANIMATIONS_DRAG_FACTOR);
+      return this.firstUptime + (SystemClock.uptimeMillis() - this.firstUptime) / ANIMATIONS_DRAG_FACTOR;
     } else {
-      return Long.toString(SystemClock.uptimeMillis());
+      return SystemClock.uptimeMillis();
     }
   }
 


### PR DESCRIPTION
## Description

This PR changes the signature and implementation of Android method used for getting current time from `private String getUptime()` to `private long getCurrentTime()`.

The motivation behind this PR is to eliminate redundant conversions, in particular parsing number from a string:
* Before: `long` &rarr; (`Long.toString`) `String` &rarr; `local_ref<JString>` &rarr; `std::string` &rarr; (`std::strtoll`) &rarr; `double`
* After: `long` &rarr; `jlong` &rarr; `double`

I've also decided to rename method `getUptime` to `getCurrentTime` in order to match the name of lambda in C++ as well as to obtain more informative error message in case of Java/C++ code mismatch (e.g. missing method `getUptime`).

Finally, I've added `static` keyword to FBJNI reference to `getCurrentTime` method for the purpose of memoization. Theoretically this should be safe because the wrapping lambda is recreated on each reload. Besides, we already use `static const` in a few other places. I've tested reloading both on Example and FabricExample app and it seems to work fine. However, it may be worth double-checking if using `static` is safe indeed.

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
