### PR TITLE
fix(jestUtils): use global `expect` if available

### DIFF
--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -188,13 +188,14 @@ export const advanceAnimationByFrame = (count) => {
 };
 
 export const setUpTests = (userConfig = {}) => {
-  let expect;
-  try {
-    expect = require('expect');
-  } catch (_) {
-    // for Jest in version 28+
-    const { expect: expectModule } = require('@jest/globals');
-    expect = expectModule;
+  let jestExpect = typeof expect === 'undefined' ? undefined : expect;
+  if (!jestExpect) {
+    try {
+      jestExpect = require('@jest/globals').expect;
+    } catch (_) {
+      // for Jest in version < 25.5
+      jestExpect = require('expect');
+    }
   }
 
   require('setimmediate');
@@ -205,7 +206,7 @@ export const setUpTests = (userConfig = {}) => {
     ...userConfig,
   };
 
-  expect.extend({
+  jestExpect.extend({
     toHaveAnimatedStyle(received, expectedStyle, config = {}) {
       return compareStyle(received, expectedStyle, config);
     },


### PR DESCRIPTION
## Description

Doing `require('expect')` (or `require('@jest/globals')`) is not needed unless Jest is configured with [`injectGlobals: false`](https://jestjs.io/docs/configuration#injectglobals-boolean). So just using the global means less work.

We probably don't even need the fallback to `require('expect')` as `@jest/globals` will exist in any setup where `expect` is not a global.

Closes #3559
Fixes #3553
Fixes #3215

<!--
Description and motivation for this PR.

Inlude Fixes #<number> if this is fixing some issue.

Fixes # .
-->

## Changes

Check for global `expect` before trying to load it through `node_modules`.

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

This now works correctly for Jest 28.

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
