### PR TITLE
fix: dependency downloads on v3

### DIFF
--- a/FabricExample/android/gradle.properties
+++ b/FabricExample/android/gradle.properties
@@ -30,7 +30,7 @@ FLIPPER_VERSION=0.125.0
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+reactNativeArchitectures=arm64-v8a
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/FabricExample/android/gradle.properties
+++ b/FabricExample/android/gradle.properties
@@ -30,7 +30,7 @@ FLIPPER_VERSION=0.125.0
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=arm64-v8a
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,21 +52,17 @@ def resolveBuildType() {
 def resolveClientSideBuild() {
     def clientSideBuild = System.getenv("CLIENT_SIDE_BUILD")
     if (clientSideBuild != null) {
-        println "Resolving CLIENT_SIDE_BUILD to ${clientSideBuild == "True"} due to env var"
         return clientSideBuild == "True"
     }
 
     if (hasProperty("clientSideBuild")) {
-        println "Resolving CLIENT_SIDE_BUILD to ${property("clientSideBuild") == "true"} due to project property"
         return property("clientSideBuild") == "true"
     }
 
     if (isDeveloperMode()) {
-        println "Resolving CLIENT_SIDE_BUILD to false due to developer mode"
         return false
     }
 
-    println "Resolving CLIENT_SIDE_BUILD to true by defaulting"
     return true
 }
 
@@ -157,11 +153,6 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeThirdParty = new File("$reactNativeRootDir/ReactAndroid/src/main/jni/third-party")
 def reactNativeAndroidDownloadDir = new File("$reactNativeRootDir/ReactAndroid/build/downloads")
 
-println "reactNativeThirdParty ${reactNativeThirdParty}"
-println "customDownloadsDir ${customDownloadsDir}"
-println "downloadsDir ${downloadsDir}"
-println "thirdPartyNdkDir ${thirdPartyNdkDir}"
-
 def _stackProtectorFlag = true
 
 def CMAKE_NODE_MODULES_DIR = CLIENT_SIDE_BUILD
@@ -210,14 +201,10 @@ def reactNativeArchitectures() {
 //   - glog-0.3.5
 def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 
-println "dependenciesPath ${dependenciesPath}"
-
 // The Boost library is a very large download (>100MB).
 // If Boost is already present on your system, define the REACT_NATIVE_BOOST_PATH env variable
 // and the build will use that.
 def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
-
-println "boostPath ${boostPath}"
 
 def follyReplaceContent = '''
   ssize_t r;
@@ -405,15 +392,11 @@ Task resolveGlog = resolveTaskFactory("resolveGlog", "glog-${GLOG_VERSION}.tar.g
 
 def reactNativeAndroidProject = findProject(":ReactAndroid")
 if (reactNativeAndroidProject != null) {
-    println "ReactAndroid project $reactNativeAndroidProject"
-    println "Before after evaluate block"
     reactNativeAndroidProject.afterEvaluate {
-        println "Inside afterEvaluate block"
         def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
         resolveTasks.forEach({ t ->
             def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + t.name.replace("resolve", ""))
             if (reactAndroidDownloadTask != null) {
-                println "Setting dependency between $t.name & $reactAndroidDownloadTask.name"
                 t.dependsOn(reactAndroidDownloadTask)
             }
         })

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -379,8 +379,8 @@ def resolveTaskFactory(String name, String artifactLocalName, File reactNativeAn
             }
 
             // If it is not the case we check whether it was downloaded by ReactAndroid project
-            def boostTar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-            return boostTar.isFile()
+            def tarFile = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+            return tarFile.isFile()
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -394,10 +394,10 @@ def reactNativeAndroidProject = findProject(":ReactAndroid")
 if (reactNativeAndroidProject != null) {
     reactNativeAndroidProject.afterEvaluate {
         def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
-        resolveTasks.forEach({ t ->
-            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + t.name.replace("resolve", ""))
+        resolveTasks.forEach({ task ->
+            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + task.name.replace("resolve", ""))
             if (reactAndroidDownloadTask != null) {
-                t.dependsOn(reactAndroidDownloadTask)
+                task.dependsOn(reactAndroidDownloadTask)
             }
         })
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -422,7 +422,6 @@ if (reactNativeAndroidProject != null) {
     println "Failed to find :ReactAndroid project -> explicit dependency between download tasks is not set."
 }
 
-
 task downloadBoost(dependsOn: resolveBoost, type: Download) {
     def transformedVersion = BOOST_VERSION.replace("_", ".")
     def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -401,8 +401,8 @@ if (reactNativeAndroidProject != null) {
             }
         })
     }
-} else {
-    println "Failed to find :ReactAndroid project -> explicit dependency between download tasks is not set. This is fine if you are using Paper architecture."
+} else if (isNewArchitectureEnabled()) {
+    throw new GradleScriptException("[Reanimated] Failed to find `:ReactAndroid` project. Explicit dependency between download tasks cannot be set.")
 }
 
 task downloadBoost(dependsOn: resolveBoost, type: Download) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,6 +155,7 @@ def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File(
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
 def reactNativeThirdParty = new File("$reactNativeRootDir/ReactAndroid/src/main/jni/third-party")
+def reactNativeAndroidDownloadDir = new File("$reactNativeRootDir/ReactAndroid/build/downloads")
 
 def _stackProtectorFlag = true
 
@@ -369,8 +370,85 @@ task createNativeDepsDirectories(dependsOn: applyJavaPatches) {
     thirdPartyNdkDir.mkdirs()
 }
 
-task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
+task resolveBoost(dependsOn: createNativeDepsDirectories, type: Copy) {
+    def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"
+
+    from reactNativeAndroidDownloadDir
+    include artifactLocalName
+    into downloadsDir
+
+    onlyIf {
+        // First we check whether the file is already in our download directory
+        if (file("$downloadsDir/$artifactLocalName").isFile()) {
+            return false
+        }
+
+        // If it is not the case we check whether it was downloaded by ReactAndroid project
+        def boostTar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+        return boostTar.isFile()
+    }
+}
+
+task resolveDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy) {
+    def artifactLocalName = "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"
+
+    from reactNativeAndroidDownloadDir
+    include artifactLocalName
+    into downloadsDir
+
+    onlyIf {
+        // First we check whether the file is already in our download directory
+        if (file("$downloadsDir/$artifactLocalName").isFile()) {
+            return false
+        }
+
+        // If it is not the case we check whether it was downloaded by ReactAndroid project
+        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+        return tar.isFile()
+    }
+}
+
+task resolveFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
+    def artifactLocalName = "folly-${FOLLY_VERSION}.tar.gz"
+
+    from reactNativeAndroidDownloadDir
+    include artifactLocalName
+    into downloadsDir
+
+    onlyIf {
+        // First we check whether the file is already in our download directory
+        if (file("$downloadsDir/$artifactLocalName").isFile()) {
+            return false
+        }
+
+        // If it is not the case we check whether it was downloaded by ReactAndroid project
+        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+        return tar.isFile()
+    }
+}
+
+task resolveGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
+    def artifactLocalName = "glog-${GLOG_VERSION}.tar.gz"
+
+    from reactNativeAndroidDownloadDir
+    include artifactLocalName
+    into downloadsDir
+
+    onlyIf {
+        // First we check whether the file is already in our download directory
+        if (file("$downloadsDir/$artifactLocalName").isFile()) {
+            return false
+        }
+
+        // If it is not the case we check whether it was downloaded by ReactAndroid project
+        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+        return tar.isFile()
+    }
+}
+
+task downloadBoost(dependsOn: resolveBoost, type: Download) {
     def transformedVersion = BOOST_VERSION.replace("_", ".")
+    def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"
     def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/boost_${BOOST_VERSION}.tar.gz"
     if (REACT_NATIVE_MINOR_VERSION < 69) {
         srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/boost_${BOOST_VERSION}.tar.gz"
@@ -378,7 +456,7 @@ task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     src(srcUrl)
     onlyIfNewer(true)
     overwrite(false)
-    dest(new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
+    dest(new File(downloadsDir, artifactLocalName))
 }
 
 task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
@@ -392,7 +470,7 @@ task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
     }
 }
 
-task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Download) {
+task downloadDoubleConversion(dependsOn: resolveDoubleConversion, type: Download) {
     src("https://github.com/google/double-conversion/archive/v${DOUBLE_CONVERSION_VERSION}.tar.gz")
     onlyIfNewer(true)
     overwrite(false)
@@ -408,7 +486,7 @@ task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleC
     into("$thirdPartyNdkDir/double-conversion")
 }
 
-task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
+task downloadFolly(dependsOn: resolveFolly, type: Download) {
     src("https://github.com/facebook/folly/archive/v${FOLLY_VERSION}.tar.gz")
     onlyIfNewer(true)
     overwrite(false)
@@ -427,7 +505,7 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     into("$thirdPartyNdkDir/folly")
 }
 
-task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
+task downloadGlog(dependsOn: resolveGlog, type: Download) {
     src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
     onlyIfNewer(true)
     overwrite(false)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -157,6 +157,11 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeThirdParty = new File("$reactNativeRootDir/ReactAndroid/src/main/jni/third-party")
 def reactNativeAndroidDownloadDir = new File("$reactNativeRootDir/ReactAndroid/build/downloads")
 
+println "reactNativeThirdParty ${reactNativeThirdParty}"
+println "customDownloadsDir ${customDownloadsDir}"
+println "downloadsDir ${downloadsDir}"
+println "thirdPartyNdkDir ${thirdPartyNdkDir}"
+
 def _stackProtectorFlag = true
 
 def CMAKE_NODE_MODULES_DIR = CLIENT_SIDE_BUILD
@@ -205,10 +210,14 @@ def reactNativeArchitectures() {
 //   - glog-0.3.5
 def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 
+println "dependenciesPath ${dependenciesPath}"
+
 // The Boost library is a very large download (>100MB).
 // If Boost is already present on your system, define the REACT_NATIVE_BOOST_PATH env variable
 // and the build will use that.
 def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
+
+println "boostPath ${boostPath}"
 
 def follyReplaceContent = '''
   ssize_t r;
@@ -370,7 +379,7 @@ task createNativeDepsDirectories(dependsOn: applyJavaPatches) {
     thirdPartyNdkDir.mkdirs()
 }
 
-task resolveBoost(dependsOn: createNativeDepsDirectories, type: Copy) {
+Task resolveBoost = task resolveBoost(dependsOn: createNativeDepsDirectories, type: Copy) {
     def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"
 
     from reactNativeAndroidDownloadDir
@@ -389,7 +398,7 @@ task resolveBoost(dependsOn: createNativeDepsDirectories, type: Copy) {
     }
 }
 
-task resolveDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy) {
+Task resolveDoubleConversion = task resolveDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy) {
     def artifactLocalName = "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"
 
     from reactNativeAndroidDownloadDir
@@ -408,7 +417,7 @@ task resolveDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy)
     }
 }
 
-task resolveFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
+Task resolveFolly = task resolveFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
     def artifactLocalName = "folly-${FOLLY_VERSION}.tar.gz"
 
     from reactNativeAndroidDownloadDir
@@ -427,7 +436,7 @@ task resolveFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
     }
 }
 
-task resolveGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
+Task resolveGlog = task resolveGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
     def artifactLocalName = "glog-${GLOG_VERSION}.tar.gz"
 
     from reactNativeAndroidDownloadDir
@@ -445,6 +454,26 @@ task resolveGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
         return tar.isFile()
     }
 }
+
+def reactNativeAndroidProject = findProject(":ReactAndroid")
+if (reactNativeAndroidProject != null) {
+    println "ReactAndroid project $reactNativeAndroidProject"
+    println "Before after evaluate block"
+    reactNativeAndroidProject.afterEvaluate {
+        println "Inside afterEvaluate block"
+        def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
+        resolveTasks.forEach({ t ->
+            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + t.name.replace("resolve", ""))
+            if (reactAndroidDownloadTask != null) {
+                println "Setting dependency between $it.name & $reactAndroidDownloadTask.name"
+                t.dependsOn(reactAndroidDownloadTask)
+            }
+        })
+    }
+} else {
+    println "Failed to find :ReactAndroid project -> explicit dependency between download tasks is not set."
+}
+
 
 task downloadBoost(dependsOn: resolveBoost, type: Download) {
     def transformedVersion = BOOST_VERSION.replace("_", ".")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -393,23 +393,25 @@ Task resolveDoubleConversion = resolveTaskFactory("resolveDoubleConversion", "do
 Task resolveFolly = resolveTaskFactory("resolveFolly", "folly-${FOLLY_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
 Task resolveGlog = resolveTaskFactory("resolveGlog", "glog-${GLOG_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
 
-def reactNativeAndroidProject = findProject(":ReactAndroid")
-if (reactNativeAndroidProject != null) {
-    reactNativeAndroidProject.afterEvaluate {
-        def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
-        resolveTasks.forEach({ task ->
-            String reactAndroidDownloadTaskName = "download" + task.name.replace("resolve", "")
-            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName(reactAndroidDownloadTaskName)
-            if (reactAndroidDownloadTask != null) {
-                task.dependsOn(reactAndroidDownloadTask)
-            } else {
-                throw new GradleScriptException("[Reanimated] Failed to find task named `$reactAndroidDownloadTaskName` in `:ReactAndroid` project." +
-                        " Explicit dependency between it and $task.name task can not be set.")
-            }
-        })
+if (isNewArchitectureEnabled()) {
+    def reactNativeAndroidProject = findProject(":ReactAndroid")
+    if (reactNativeAndroidProject != null) {
+        reactNativeAndroidProject.afterEvaluate {
+            def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
+            resolveTasks.forEach({ task ->
+                String reactAndroidDownloadTaskName = "download" + task.name.replace("resolve", "")
+                def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName(reactAndroidDownloadTaskName)
+                if (reactAndroidDownloadTask != null) {
+                    task.dependsOn(reactAndroidDownloadTask)
+                } else {
+                    logger.warn("[Reanimated] Failed to find task named `$reactAndroidDownloadTaskName` in `:ReactAndroid` project." +
+                            " Explicit dependency between it and $task.name task can not be set.")
+                }
+            })
+        }
+    } else {
+        throw new GradleScriptException("[Reanimated] Failed to find `:ReactAndroid` project. Explicit dependency between download tasks can not be set.")
     }
-} else if (isNewArchitectureEnabled()) {
-    throw new GradleScriptException("[Reanimated] Failed to find `:ReactAndroid` project. Explicit dependency between download tasks can not be set.")
 }
 
 task downloadBoost(dependsOn: resolveBoost, type: Download) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -366,8 +366,8 @@ task createNativeDepsDirectories(dependsOn: applyJavaPatches) {
     thirdPartyNdkDir.mkdirs()
 }
 
-def resolveTaskFactory(String name, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {
-    return tasks.create(name: name.startsWith("resolve") ? name : "resolve" + name, dependsOn: createNativeDepsDirectories, type: Copy) {
+def resolveTaskFactory(String taskName, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {
+    return tasks.create(name: taskName, dependsOn: createNativeDepsDirectories, type: Copy) {
         from reactNativeAndroidDownloadDir
         include artifactLocalName
         into reanimatedDownloadDir

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,17 +52,21 @@ def resolveBuildType() {
 def resolveClientSideBuild() {
     def clientSideBuild = System.getenv("CLIENT_SIDE_BUILD")
     if (clientSideBuild != null) {
+        println "Resolving CLIENT_SIDE_BUILD to ${clientSideBuild == "True"} due to env var"
         return clientSideBuild == "True"
     }
 
     if (hasProperty("clientSideBuild")) {
+        println "Resolving CLIENT_SIDE_BUILD to ${property("clientSideBuild") == "true"} due to project property"
         return property("clientSideBuild") == "true"
     }
 
     if (isDeveloperMode()) {
+        println "Resolving CLIENT_SIDE_BUILD to false due to developer mode"
         return false
     }
 
+    println "Resolving CLIENT_SIDE_BUILD to true by defaulting"
     return true
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -402,7 +402,7 @@ if (reactNativeAndroidProject != null) {
         })
     }
 } else {
-    println "Failed to find :ReactAndroid project -> explicit dependency between download tasks is not set."
+    println "Failed to find :ReactAndroid project -> explicit dependency between download tasks is not set. This is fine if you are using Paper architecture."
 }
 
 task downloadBoost(dependsOn: resolveBoost, type: Download) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -379,81 +379,29 @@ task createNativeDepsDirectories(dependsOn: applyJavaPatches) {
     thirdPartyNdkDir.mkdirs()
 }
 
-Task resolveBoost = task resolveBoost(dependsOn: createNativeDepsDirectories, type: Copy) {
-    def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"
+def resolveTaskFactory(String taskSuffix, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {
+    return tasks.create(name: "resolve" + taskSuffix, dependsOn: createNativeDepsDirectories, type: Copy) {
+        from reactNativeAndroidDownloadDir
+        include artifactLocalName
+        into reanimatedDownloadDir
 
-    from reactNativeAndroidDownloadDir
-    include artifactLocalName
-    into downloadsDir
+        onlyIf {
+            // First we check whether the file is already in our download directory
+            if (file("$reanimatedDownloadDir/$artifactLocalName").isFile()) {
+                return false
+            }
 
-    onlyIf {
-        // First we check whether the file is already in our download directory
-        if (file("$downloadsDir/$artifactLocalName").isFile()) {
-            return false
+            // If it is not the case we check whether it was downloaded by ReactAndroid project
+            def boostTar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
+            return boostTar.isFile()
         }
-
-        // If it is not the case we check whether it was downloaded by ReactAndroid project
-        def boostTar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-        return boostTar.isFile()
     }
 }
 
-Task resolveDoubleConversion = task resolveDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy) {
-    def artifactLocalName = "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"
-
-    from reactNativeAndroidDownloadDir
-    include artifactLocalName
-    into downloadsDir
-
-    onlyIf {
-        // First we check whether the file is already in our download directory
-        if (file("$downloadsDir/$artifactLocalName").isFile()) {
-            return false
-        }
-
-        // If it is not the case we check whether it was downloaded by ReactAndroid project
-        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-        return tar.isFile()
-    }
-}
-
-Task resolveFolly = task resolveFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
-    def artifactLocalName = "folly-${FOLLY_VERSION}.tar.gz"
-
-    from reactNativeAndroidDownloadDir
-    include artifactLocalName
-    into downloadsDir
-
-    onlyIf {
-        // First we check whether the file is already in our download directory
-        if (file("$downloadsDir/$artifactLocalName").isFile()) {
-            return false
-        }
-
-        // If it is not the case we check whether it was downloaded by ReactAndroid project
-        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-        return tar.isFile()
-    }
-}
-
-Task resolveGlog = task resolveGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
-    def artifactLocalName = "glog-${GLOG_VERSION}.tar.gz"
-
-    from reactNativeAndroidDownloadDir
-    include artifactLocalName
-    into downloadsDir
-
-    onlyIf {
-        // First we check whether the file is already in our download directory
-        if (file("$downloadsDir/$artifactLocalName").isFile()) {
-            return false
-        }
-
-        // If it is not the case we check whether it was downloaded by ReactAndroid project
-        def tar = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-        return tar.isFile()
-    }
-}
+Task resolveBoost = resolveTaskFactory("Boost", "boost_${BOOST_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveDoubleConversion = resolveTaskFactory("DoubleConversion", "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveFolly = resolveTaskFactory("Folly", "folly-${FOLLY_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveGlog = resolveTaskFactory("Glog", "glog-${GLOG_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
 
 def reactNativeAndroidProject = findProject(":ReactAndroid")
 if (reactNativeAndroidProject != null) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -379,8 +379,8 @@ task createNativeDepsDirectories(dependsOn: applyJavaPatches) {
     thirdPartyNdkDir.mkdirs()
 }
 
-def resolveTaskFactory(String taskSuffix, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {
-    return tasks.create(name: "resolve" + taskSuffix, dependsOn: createNativeDepsDirectories, type: Copy) {
+def resolveTaskFactory(String name, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {
+    return tasks.create(name: name.startsWith("resolve") ? name : "resolve" + name, dependsOn: createNativeDepsDirectories, type: Copy) {
         from reactNativeAndroidDownloadDir
         include artifactLocalName
         into reanimatedDownloadDir
@@ -398,10 +398,10 @@ def resolveTaskFactory(String taskSuffix, String artifactLocalName, File reactNa
     }
 }
 
-Task resolveBoost = resolveTaskFactory("Boost", "boost_${BOOST_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
-Task resolveDoubleConversion = resolveTaskFactory("DoubleConversion", "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
-Task resolveFolly = resolveTaskFactory("Folly", "folly-${FOLLY_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
-Task resolveGlog = resolveTaskFactory("Glog", "glog-${GLOG_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveBoost = resolveTaskFactory("resolveBoost", "boost_${BOOST_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveDoubleConversion = resolveTaskFactory("resolveDoubleConversion", "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveFolly = resolveTaskFactory("resolveFolly", "folly-${FOLLY_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
+Task resolveGlog = resolveTaskFactory("resolveGlog", "glog-${GLOG_VERSION}.tar.gz", reactNativeAndroidDownloadDir, downloadsDir)
 
 def reactNativeAndroidProject = findProject(":ReactAndroid")
 if (reactNativeAndroidProject != null) {
@@ -413,7 +413,7 @@ if (reactNativeAndroidProject != null) {
         resolveTasks.forEach({ t ->
             def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + t.name.replace("resolve", ""))
             if (reactAndroidDownloadTask != null) {
-                println "Setting dependency between $it.name & $reactAndroidDownloadTask.name"
+                println "Setting dependency between $t.name & $reactAndroidDownloadTask.name"
                 t.dependsOn(reactAndroidDownloadTask)
             }
         })

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -398,14 +398,18 @@ if (reactNativeAndroidProject != null) {
     reactNativeAndroidProject.afterEvaluate {
         def resolveTasks = [resolveBoost, resolveGlog, resolveDoubleConversion, resolveFolly]
         resolveTasks.forEach({ task ->
-            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName("download" + task.name.replace("resolve", ""))
+            String reactAndroidDownloadTaskName = "download" + task.name.replace("resolve", "")
+            def reactAndroidDownloadTask = reactNativeAndroidProject.getTasks().findByName(reactAndroidDownloadTaskName)
             if (reactAndroidDownloadTask != null) {
                 task.dependsOn(reactAndroidDownloadTask)
+            } else {
+                throw new GradleScriptException("[Reanimated] Failed to find task named `$reactAndroidDownloadTaskName` in `:ReactAndroid` project." +
+                        " Explicit dependency between it and $task.name task can not be set.")
             }
         })
     }
 } else if (isNewArchitectureEnabled()) {
-    throw new GradleScriptException("[Reanimated] Failed to find `:ReactAndroid` project. Explicit dependency between download tasks cannot be set.")
+    throw new GradleScriptException("[Reanimated] Failed to find `:ReactAndroid` project. Explicit dependency between download tasks can not be set.")
 }
 
 task downloadBoost(dependsOn: resolveBoost, type: Download) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -379,8 +379,11 @@ def resolveTaskFactory(String taskName, String artifactLocalName, File reactNati
             }
 
             // If it is not the case we check whether it was downloaded by ReactAndroid project
-            def tarFile = Paths.get(reactNativeAndroidDownloadDir.toString(), artifactLocalName).toFile()
-            return tarFile.isFile()
+            if (file("$reactNativeAndroidDownloadDir/$artifactLocalName").isFile()) {
+                return true
+            }
+
+            return false
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,7 @@
 import com.android.Version
-
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.Path
 import org.apache.tools.ant.filters.ReplaceTokens
-import java.util.stream.Stream
+
+import java.nio.file.Paths
 
 /**
  * Finds the path of the installed npm package with the given name using Node's


### PR DESCRIPTION
## Description

Fixes #3523 on v3

Fix for v2 comes with https://github.com/software-mansion/react-native-reanimated/pull/3602

## Changes

Added `resolve<lib>` tasks. Each of them check whether `<lib>` is already downloaded by `:ReactAndroid` project - if so - they copy archive files to `reanimated` downloads directory -> this causes `download<lib>` tasks to not run, as they're up to date.

To achieve this, setting dependency between `resolve<lib>` & `:ReactAndroid:download<lib>` was required.

## Test code and steps to reproduce

I checked it on Reanimated v3:

* [x] `FabricExample` - `rm -fr node_modules && yarn`, run the build for the first time, see that the libraries are downloaded only once by `:ReactAndroid` project. In consecutive builds libraries are not downloaded.
* [x] `Example` - `rm -fr node_modules && yarn`, run the build for the first time, see that the libraries are downloaded by `:react-native-reanimated` project. In consecutive build libraries are not downloaded. 
* [x] Fresh React Native application (both archs)


## Checklist

- [x] Ensured that CI passes
