### PR TITLE
Add ranges in version labels in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -136,7 +136,7 @@ module.exports = {
           editUrl: undefined, // hide edit button
           versions: {
             '2.5.x': {
-              label: '2.5.x – 2.9.x',
+              label: '2.5.x – 2.10.x',
             },
             '2.3.x': {
               label: '2.3.x – 2.4.x',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -136,10 +136,10 @@ module.exports = {
           editUrl: undefined, // hide edit button
           versions: {
             '2.5.x': {
-              label: '2.5.x-2.9.x',
+              label: '2.5.x – 2.9.x',
             },
             '2.3.x': {
-              label: '2.3.x-2.4.x',
+              label: '2.3.x – 2.4.x',
             },
           }
         },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -134,6 +134,14 @@ module.exports = {
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: undefined, // hide edit button
+          versions: {
+            '2.5.x': {
+              label: '2.5.x-2.9.x',
+            },
+            '2.3.x': {
+              label: '2.3.x-2.4.x',
+            },
+          }
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
## Description

The current convention for making a new version in docs is to make a new one when there have been API changes. This is a good solution as it doesn't result in redundant versions of docs that are exactly the same but has one major flaw: it's not obvious what it means. This PR updates the labels to reflect that they cover more than one version of Reanimated.

## Changes

- Added custom labels for docs versions covering more than one minor version

## Screenshots / GIFs

### Before

<img width="938" alt="Screenshot before" src="https://user-images.githubusercontent.com/21055725/191239922-06c61d03-c1bc-47db-8557-1eb65774bb89.png">

### After

<img width="938" alt="Screenshot after" src="https://user-images.githubusercontent.com/21055725/191239936-1b31787b-dd0e-4bf7-a321-7761b0c1aec7.png">


