### PR TITLE
Show more useful message when using `measure()` in `useAnimatedStyle()`

### DIFF
--- a/docs/docs/api/nativeMethods/measure.md
+++ b/docs/docs/api/nativeMethods/measure.md
@@ -21,14 +21,15 @@ new Promise((resolve, reject) => {
 });
 ```
 
-If you call `measure()` inside of [`useAnimatedStyle()`](../hooks/useAnimatedStyle)
+If you call `measure()` inside [`useAnimatedStyle()`](../hooks/useAnimatedStyle)
 you may get a warning that `measure()` was called from the wrong thread. This
-is safe to ignore, but it you don't want this error to appear then wrap the call
+is safe to ignore, but if you don't want this error to appear then wrap the call
 like this:
 
 ```js
 if (_WORKLET) {
   const measure = measure(animatedRef);
+  // ...
 }
 ```
 

--- a/docs/docs/api/nativeMethods/measure.md
+++ b/docs/docs/api/nativeMethods/measure.md
@@ -21,6 +21,17 @@ new Promise((resolve, reject) => {
 });
 ```
 
+If you call `measure()` inside of [`useAnimatedStyle()`](../hooks/useAnimatedStyle)
+you may get a warning that `measure()` was called from the wrong thread. This
+is safe to ignore, but it you don't want this error to appear then wrap the call
+like this:
+
+```js
+if (_WORKLET) {
+  const measure = measure(animatedRef);
+}
+```
+
 ### Arguments
 
 #### animatedRef

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -22,7 +22,9 @@ export function measure(
       '[Reanimated] measure() cannot be used on web or Chrome Debugger'
     );
     return null;
-  } else if (!_WORKLET) {
+  }
+
+  if (!_WORKLET) {
     console.warn(
       '[Reanimated] measure() was called from the main JS context. Measure is' +
         'only available in the UI runtime. This may also happen if measure()' +

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -19,14 +19,17 @@ export function measure(
   'worklet';
   if (!isNative) {
     console.warn(
-      '[Reanimated] measure() cannot be used for web or Chrome Debugger'
+      '[Reanimated] measure() cannot be used on web or Chrome Debugger'
     );
     return null;
   } else if (!_WORKLET) {
     console.warn(
-      '[Reanimated] measure() was called from the wrong thread. This may happen ' +
-        'if you called measure() in the useAnimatedStyle hook. If you want to' +
-        'prevent this warning then wrap the call with `if (_WORKLET)`.'
+      '[Reanimated] measure() was called from the main JS context. Measure is' +
+        'only available in the UI runtime. This may also happen if measure()' +
+        'was called by a worklet in the useAnimatedStyle hook, because useAnimatedStyle' +
+        'calls the given worklet on the JS runtime during render. If you want to' +
+        'prevent this warning then wrap the call with `if (_WORKLET)`. Then it will' +
+        'only be called on the UI runtime after the render has been completed.'
     );
     return null;
   }

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -17,9 +17,16 @@ export function measure(
   animatedRef: RefObjectFunction<Component>
 ): MeasuredDimensions | null {
   'worklet';
-  if (!_WORKLET || !isNative) {
+  if (!isNative) {
     console.warn(
       '[Reanimated] measure() cannot be used for web or Chrome Debugger'
+    );
+    return null;
+  } else if (!_WORKLET) {
+    console.warn(
+      '[Reanimated] measure() was called from the wrong thread. This may happen ' +
+        'if you called measure() in the useAnimatedStyle hook. If you want to' +
+        'prevent this warning then wrap the call with `if (_WORKLET)`.'
     );
     return null;
   }


### PR DESCRIPTION
## Description

When `measure()` was called inside `useAnimatedStyle()` a warning would appear with the message:

`[Reanimated] measure() cannot be used for web or Chrome Debugger`.

This message isn't very helpful, since we aren't running Chrome Debugger and aren't on web. This was previously shown because `useAnimatedStyle()` runs an initial update on the JS thread.

## Changes

When measure is called from the JS thread, but on native platforms, then show a message that explains why this could be happening.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [x] Ensured that CI passes
