### PR TITLE
Enable UI runtime debugging on v8

### DIFF
--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -20,6 +20,9 @@ using namespace facebook;
 using namespace react;
 
 std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
+#if defined(ANDROID) && JS_RUNTIME_V8
+    const jsi::Runtime *runtime,
+#endif
     std::shared_ptr<MessageQueueThread> jsQueue) {
 #if JS_RUNTIME_HERMES
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime =
@@ -37,7 +40,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
   config->enableInspector = false;
   config->appName = "reanimated";
-  return rnv8::createSharedV8Runtime(runtime_, std::move(config));
+  return rnv8::createSharedV8Runtime(runtime, std::move(config));
 #else
   // This is required by iOS, because there is an assertion in the destructor
   // that the thread was indeed `quit` before

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
 
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
   config->enableInspector = true;
-  config->appName = "reanimated";
+  config->appName = "Reanimated Runtime";
   return rnv8::createSharedV8Runtime(runtime, std::move(config));
 #else
   // This is required by iOS, because there is an assertion in the destructor

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
   jsQueue->quitSynchronous();
 
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
-  config->enableInspector = false;
+  config->enableInspector = true;
   config->appName = "reanimated";
   return rnv8::createSharedV8Runtime(runtime, std::move(config));
 #else

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
@@ -21,6 +21,9 @@ using namespace react;
 class ReanimatedRuntime {
  public:
   static std::shared_ptr<jsi::Runtime> make(
+#if defined(ANDROID) && JS_RUNTIME_V8
+      const jsi::Runtime *runtime,
+#endif
       std::shared_ptr<MessageQueueThread> jsQueue);
 };
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -202,8 +202,11 @@ void NativeProxy::installJSIBindings(
   };
 
   auto jsQueue = std::make_shared<JMessageQueueThread>(messageQueueThread);
-  std::shared_ptr<jsi::Runtime> animatedRuntime =
-      ReanimatedRuntime::make(jsQueue);
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ReanimatedRuntime::make(
+#if JS_RUNTIME_V8
+      runtime_,
+#endif
+      jsQueue);
 
   auto workletRuntimeValue =
       runtime_->global()

--- a/docs/docs/guide/debugging_tables/tables.tsx
+++ b/docs/docs/guide/debugging_tables/tables.tsx
@@ -50,7 +50,7 @@ export function SummaryTable() {
             <td className={styles.cellNormal}>Android</td>
             <td className={styles.cellNotAvailable}>N/A</td>
             <td className={styles.cellNormal}>⚛️ ✅ ²</td>
-            <td className={styles.cellNormal}>⚛️</td>
+            <td className={styles.cellNormal}>⚛️ ✅ ²</td>
           </tr>
           <tr>
             <td className={styles.cellNormal}>iOS</td>
@@ -65,7 +65,7 @@ export function SummaryTable() {
             <td className={styles.cellNormal}>Android</td>
             <td className={styles.cellNotAvailable}>N/A</td>
             <td className={styles.cellNormal}>⚛️ ✅ ²</td>
-            <td className={styles.cellNormal}>⚛️</td>
+            <td className={styles.cellNormal}>⚛️ ✅ ²</td>
           </tr>
           <tr>
             <td className={styles.cellNormal}>iOS</td>
@@ -168,7 +168,7 @@ export function ChromeDevToolsTable() {
           <td className={styles.cellNormal}>Android</td>
           <td className={styles.cellNotAvailable}>N/A</td>
           <td className={styles.cellNormal}>⚛️ ✅</td>
-          <td className={styles.cellNormal}>⚛️</td>
+          <td className={styles.cellNormal}>⚛️ ✅</td>
         </tr>
         <tr>
           <td className={styles.cellNormal}>iOS</td>
@@ -197,7 +197,7 @@ export function FlipperTable() {
           <td className={styles.cellNormal}>Android</td>
           <td className={styles.cellNotAvailable}>N/A</td>
           <td className={styles.cellNormal}>⚛️ ✅</td>
-          <td className={styles.cellNormal}>⚛️</td>
+          <td className={styles.cellNormal}>⚛️ ✅</td>
         </tr>
         <tr>
           <td className={styles.cellNormal}>iOS</td>


### PR DESCRIPTION
## Description

This PR fixes the initialization of the V8 runtime as well as enabling debugging for Reanimated's runtime.

The debugger can be accessed at [chrome://inspect](chrome://inspect) at the moment, with possible support in the `reanimated` Flipper plugin in the future, since it is listed at [localhost:8081/json](localhost:8081/json).

Thanks to @Kudo for this suggestion

## Features

TL;DR: Works slightly better than Hermes, since V8 has better integration with Chrome DevTools so we get hints for
`global` objects and inline current runtime values (see video below).

- Setting breakpoints
- Console is responsive
- I did not find any regressions

FabricExample app crashes after second reload regardless of if DevTools are connected, but this also happens when `enableInspector` is set to `false` in `ReanimatedRuntime.cpp` so it is most likely not an issue on our end (or at least doesn't have anything to do with debugging).

https://user-images.githubusercontent.com/10947344/191940046-b45b2e22-33f1-41bc-85c9-c17d89f16fed.mp4

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [x] Updated documentation
- [ ] Ensured that CI passes
