### PR TITLE
Cherry-pick reanimated v3 podspec changes to v2 to fix warnings

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -94,11 +94,11 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig    = {
     "USE_HEADERMAP" => "YES",
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" "
-  }
-  s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.xcconfig               = {
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" ",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+  }
+  s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags + ' -DHERMES_ENABLE_DEBUGGER'
+  s.xcconfig               = {
     "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
                                "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags  }
 


### PR DESCRIPTION
## Description

This PR fixes the following warning when running `pod install` using the latest stable v2 (2.10.0).

`[!] Can't merge user_target_xcconfig for pod targets: ["RNReanimated", "hermes-engine"]. Singular build setting CLANG_CXX_LANGUAGE_STANDARD has different values.`

The actual fix is ported from the v3 (main) branch which already fixed that issue.

## Changes

- Move CLANG_CXX_LANGUAGE_STANDARD as part of the pod target xconfig section.
   - Note: I have not updated the CLANG_CXX_LANGUAGE_STANDARD value to c++17. I am uncertain if that is something which we should do as part of this PR.
- Add compiler flag to enable the hermes debugger.