### PR TITLE
Bump react-native-safe-area-context to 4.4.0

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -241,7 +241,7 @@ PODS:
     - glog
   - react-native-pager-view (5.4.1):
     - React-Core
-  - react-native-safe-area-context (4.3.3):
+  - react-native-safe-area-context (4.4.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -533,7 +533,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 1363be638eccfe1aea1b10dd42e632b0397e5ec8
   React-logger: 7bd569e3857d74ed412ce0a5c51f421ff7d4ca7f
   react-native-pager-view: 43f51f45f37ec9715f6c188e4af46ccdf79872e8
-  react-native-safe-area-context: b456e1c40ec86f5593d58b275bd0e9603169daca
+  react-native-safe-area-context: 646452837a27753136982377b1b945df58b31b08
   react-native-slider: 269d81247e2a87358ee03241da55b00c919e4d7a
   React-perflogger: 48c6b363e867d64b682e84f80ca45636bd65e19c
   React-RCTActionSheet: 33c74fe5c754835e3715c300618da9aa2f7203fa
@@ -550,7 +550,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 914b557e20b3b8317b084aca9ff4b4edb95f61e4
   RNGestureHandler: 920eb17f5b1e15dae6e5ed1904045f8f90e0b11e
-  RNReanimated: ff1dba9450916aff36779c4e0d79fbcd38b2bbb6
+  RNReanimated: c3dfd2903fcc1de702c6213980d2b7ffe862b564
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
   RNSVG: 07037623c36f12e41312730622d5f6b3656227ca
   Yoga: 6c8252e38d65aa387daee699eacf027e055e0b31

--- a/Example/package.json
+++ b/Example/package.json
@@ -41,7 +41,7 @@
     "react-native": "0.70.1",
     "react-native-gesture-handler": "^2.6.0",
     "react-native-pager-view": "^5.4.1",
-    "react-native-safe-area-context": "^4.3.3",
+    "react-native-safe-area-context": "^4.4.0",
     "react-native-screens": "^3.17.0",
     "react-native-status-bar-height": "^2.4.0",
     "react-native-svg": "^13.2.0",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -10230,10 +10230,10 @@ react-native-safe-area-context@3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz#06113c6b208f982d68ab5c3cebd199ca93db6941"
   integrity sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==
 
-react-native-safe-area-context@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
-  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
+react-native-safe-area-context@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.0.tgz#481c6815cc3d72e563b9d3fbfe2454180e86dd22"
+  integrity sha512-OZwQzaljWasSD0UGMHxR4Wv8ASxzu48nnyyAWVgJTRu3+w4PYGmyFL4FG3Aidp76EszgMqpLOJENFaZMDNO1xg==
 
 react-native-screens@^3.17.0:
   version "3.17.0"

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -625,21 +625,21 @@ PODS:
   - React-jsinspector (0.70.1)
   - React-logger (0.70.1):
     - glog
-  - react-native-safe-area-context (4.3.3):
+  - react-native-safe-area-context (4.4.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - react-native-safe-area-context/common (= 4.3.3)
-    - react-native-safe-area-context/fabric (= 4.3.3)
+    - react-native-safe-area-context/common (= 4.4.0)
+    - react-native-safe-area-context/fabric (= 4.4.0)
     - ReactCommon/turbomodule/core
-  - react-native-safe-area-context/common (4.3.3):
+  - react-native-safe-area-context/common (4.4.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - react-native-safe-area-context/fabric (4.3.3):
+  - react-native-safe-area-context/fabric (4.4.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1002,7 +1002,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 47201924064085223b63ec7e3ee9fd40ad8508e8
   React-jsinspector: 1363be638eccfe1aea1b10dd42e632b0397e5ec8
   React-logger: 7bd569e3857d74ed412ce0a5c51f421ff7d4ca7f
-  react-native-safe-area-context: 6ab17f921537d721f7315b198d82d6a65a2680f9
+  react-native-safe-area-context: b4002f33b4ba7982bde4c5ade7df3c511538a312
   React-perflogger: 48c6b363e867d64b682e84f80ca45636bd65e19c
   React-RCTActionSheet: 33c74fe5c754835e3715c300618da9aa2f7203fa
   React-RCTAnimation: 2dbf0120d4d1ab7716079b4180f2ca89c465e46b
@@ -1018,7 +1018,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: a11d0c2e14140baf1e449264ca9168ae9ae6bbd0
   ReactCommon: 7f86326b92009925c6dcf93f8e825060171c379f
   RNGestureHandler: 182b4e135cc4fec4988687e2f123e302dc6b4b71
-  RNReanimated: f3fc5589503115973836d6d9d9c8da11eb106ec8
+  RNReanimated: e7b71ef47948f1e2d2626d468e18b3d2fffe9994
   RNScreens: e2cd04caa74748a6e42609a7b84f76c71d70a6ee
   RNSVG: fa7f6f437c90eea1fbc3d142a40365d561824ab3
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.70.1",
     "react-native-gesture-handler": "^2.6.0",
     "react-native-reanimated": "link:../",
-    "react-native-safe-area-context": "^4.3.3",
+    "react-native-safe-area-context": "^4.4.0",
     "react-native-screens": "^3.17.0",
     "react-native-svg": "^13.2.0"
   },

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -6259,10 +6259,10 @@ react-native-gradle-plugin@^0.70.3:
   version "0.0.0"
   uid ""
 
-react-native-safe-area-context@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
-  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
+react-native-safe-area-context@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.0.tgz#481c6815cc3d72e563b9d3fbfe2454180e86dd22"
+  integrity sha512-OZwQzaljWasSD0UGMHxR4Wv8ASxzu48nnyyAWVgJTRu3+w4PYGmyFL4FG3Aidp76EszgMqpLOJENFaZMDNO1xg==
 
 react-native-screens@^3.17.0:
   version "3.17.0"


### PR DESCRIPTION
## Description

This PR bumps `react-native-safe-area-context` from 4.3.3 to 4.4.0 both in Example and FabricExample apps.