### PR TITLE
Return `null` instead of `undefined` from `measure` on Fabric

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -584,7 +584,11 @@ jsi::Value NativeReanimatedModule::measure(
       uiManager_, *shadowNode, nullptr, {/* .includeTransform = */ true});
 
   if (layoutMetrics == EmptyLayoutMetrics) {
-    return jsi::Value::undefined();
+    // Originally, in this case React Native returns `{0, 0, 0, 0, 0, 0}`, most
+    // likely due to the type of measure callback function which accepts just an
+    // array of numbers (not null). In Reanimated, `measure` returns
+    // `MeasuredDimensions | null`.
+    return jsi::Value::null();
   }
   auto newestCloneOfShadowNode =
       uiManager_->getNewestCloneOfShadowNode(*shadowNode);

--- a/FabricExample/src/ArticleProgressExample.tsx
+++ b/FabricExample/src/ArticleProgressExample.tsx
@@ -1,3 +1,4 @@
+/* global _WORKLET */
 import React from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 import Animated, {
@@ -13,13 +14,18 @@ export default function ArticleProgressExample() {
   const scrollHandler = useScrollViewOffset(scrollViewRef);
 
   const progressBarAnimatedStyle = useAnimatedStyle(() => {
-    const measuredText = measure(textRef);
-    const measuredScroll = measure(scrollViewRef);
+    if (!_WORKLET) {
+      return { width: 0 };
+    }
 
-    if (!measuredText || !measuredScroll) {
-      return {
-        width: 0,
-      };
+    const measuredText = measure(textRef);
+    if (measuredText === null) {
+      return { width: 0 };
+    }
+
+    const measuredScroll = measure(scrollViewRef);
+    if (measuredScroll === null) {
+      return { width: 0 };
     }
 
     const maxOffset = measuredText.height - measuredScroll.height;

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -33,7 +33,12 @@ export function measure(
   }
 
   const measured = _measure(viewTag);
-  if (measured.x === -1234567) {
+  if (measured === null) {
+    console.warn(
+      `[Reanimated] The view with tag ${viewTag} has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+    );
+    return null;
+  } else if (measured.x === -1234567) {
     console.warn(
       `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response`
     );

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -26,11 +26,11 @@ export function measure(
 
   if (!_WORKLET) {
     console.warn(
-      '[Reanimated] measure() was called from the main JS context. Measure is' +
-        'only available in the UI runtime. This may also happen if measure()' +
-        'was called by a worklet in the useAnimatedStyle hook, because useAnimatedStyle' +
-        'calls the given worklet on the JS runtime during render. If you want to' +
-        'prevent this warning then wrap the call with `if (_WORKLET)`. Then it will' +
+      '[Reanimated] measure() was called from the main JS context. Measure is ' +
+        'only available in the UI runtime. This may also happen if measure() ' +
+        'was called by a worklet in the useAnimatedStyle hook, because useAnimatedStyle ' +
+        'calls the given worklet on the JS runtime during render. If you want to ' +
+        'prevent this warning then wrap the call with `if (_WORKLET)`. Then it will ' +
         'only be called on the UI runtime after the render has been completed.'
     );
     return null;

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -29,7 +29,7 @@ declare global {
   const _removeShadowNodeFromRegistry: (
     shadowNodeWrapper: ShadowNodeWrapper
   ) => void;
-  const _measure: (viewTag: number) => MeasuredDimensions;
+  const _measure: (viewTag: number) => MeasuredDimensions | null;
   const _scrollTo: (
     viewTag: number,
     x: number,
@@ -55,7 +55,7 @@ declare global {
       _IS_FABRIC: boolean;
       __reanimatedModuleProxy: NativeReanimated;
       _frameTimestamp: number | null;
-      _measure: () => MeasuredDimensions;
+      _measure: () => MeasuredDimensions | null;
       _scrollTo: () => void;
       _dispatchCommand: () => void;
       _chronoNow: () => number;


### PR DESCRIPTION
## Description

This PR removes error `Cannot read property 'x' of undefined` when using `measure` function. For details, see changes.

Follow-up of #3598 and #3453.

References:
* https://github.com/facebook/react-native/blob/278dad6438eac8358a6caaf9dc3b192c0b6137e2/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp#L557-L560 – `measure`
* https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/ReactCommon/react/renderer/core/LayoutMetrics.h#L63-L69 – `EmptyLayoutMetrics`

## Changes

* Changed the return value of native measure function from `undefined` to `null` in case of empty layout metrics
* Fixed type of `_measure` function in `globals.d.ts`
* Added appropriate variant of warning message in case of empty layout metrics
* Added missing spaces in other warning message in `measure` function
* Updated Article Progress Example

## Test code and steps to reproduce

Tested on FabricExample app with Article Progress Example.
