### PR TITLE
type all style props with `AnimateStyle`

### DIFF
--- a/FabricExample/react-native-reanimated-tests.tsx
+++ b/FabricExample/react-native-reanimated-tests.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable react-hooks/rules-of-hooks */
 import React, { useState, useCallback, forwardRef } from 'react';
@@ -120,7 +118,7 @@ function CreateAnimatedFlatListTest1() {
       if (Math.random()) {
         return null;
       }
-      return <View style={{ width: 100 }}></View>;
+      return <View style={{ width: 100 }} />;
     },
     []
   );
@@ -156,6 +154,22 @@ function CreateAnimatedFlatListTest2() {
         renderItem={({ item, index }) => <View key={item.id} />}
       />
     </>
+  );
+}
+
+function CreateAnimatedFlatListTest3(
+  contentContainerStyle: React.ComponentProps<
+    typeof AnimatedFlatList
+  >['contentContainerStyle']
+) {
+  const newContentContainerStyle = [contentContainerStyle, { flex: 1 }];
+
+  return (
+    <AnimatedFlatList
+      data={[{ foo: 1 }]}
+      renderItem={() => null}
+      contentContainerStyle={newContentContainerStyle}
+    />
   );
 }
 

--- a/FabricExample/react-native-reanimated-tests.tsx
+++ b/FabricExample/react-native-reanimated-tests.tsx
@@ -118,7 +118,7 @@ function CreateAnimatedFlatListTest1() {
       if (Math.random()) {
         return null;
       }
-      return <View style={{ width: 100 }} />;
+      return <View style={{ width: 100 }}></View>;
     },
     []
   );

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -160,7 +160,7 @@ declare module 'react-native-reanimated' {
     type PickStyles<T> = Pick<
       T,
       {
-        [Key in keyof T]-?: T[Key] extends StyleProp<ViewStyle> ? Key : never;
+        [Key in keyof T]-?: Key extends `${string}Style` ? Key : never;
       }[keyof T]
     >;
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -157,10 +157,21 @@ declare module 'react-native-reanimated' {
       ? T['style']
       : Record<string, unknown>;
 
+    type PickStyles<T> = Pick<
+      T,
+      {
+        [Key in keyof T]-?: T[Key] extends StyleProp<ViewStyle> ? Key : never;
+      }[keyof T]
+    >;
+
     export type AnimateProps<P extends object> = {
-      [K in keyof Omit<P, 'style'>]: P[K] | AnimatedNode<P[K]>;
+      [K in keyof Omit<P, keyof PickStyles<P> | 'style'>]:
+        | P[K]
+        | AnimatedNode<P[K]>;
     } & {
       style?: StyleProp<AnimateStyle<StylesOrDefault<P>>>;
+    } & {
+      [K in keyof PickStyles<P>]: StyleProp<AnimateStyle<P[K]>>;
     } & {
       animatedProps?: Partial<AnimateProps<P>>;
       layout?:


### PR DESCRIPTION
## Description

Style type properties (properties that extends `StyleProp<ViewStyle>`) can be defined with other property names than "style". For example `contentContainerStyle` in `FlatList`. Current implementation of `AnimateProps` defines all style type properties as `AnimatedNode<StyleProp<...>>` except the regular `style` property. The regular `style` property is being typed as `StyleProp<AnimateStyle<StyleProp<ViewStyle>>`. I think the type definition for all style type properties should act similarly.

## Changes

- Extend `AnimateStyle` so all properties ending with "Style" (for example "textStyle" and "contentContainerStyle") is being typed as `StyleProp<AnimateStyle<StyleProp<ViewStyle>>`.

## Test code and steps to reproduce

Added a test in "FabricExample/react-native-reanimated-tests.tsx" named "CreateAnimatedFlatListTest3" illustrating the problem and that shows that the proposed change fixes it.

## Checklist

- [ ] Included code example that can be used to test this change
- [x] Updated TS types
- [x] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [x] Ensured that CI passes
