### PR TITLE
Disable check for the same path

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -34,8 +34,8 @@ def find_config()
   result[:is_tvos_target] = react_native_json['name'] == 'react-native-tvos'
   result[:react_native_version] = react_native_json['version']
   result[:react_native_minor_version] = react_native_json['version'].split('.')[1].to_i
-  result[:react_native_node_modules_dir] = react_native_node_modules_dir
-  result[:reanimated_node_modules_dir] = File.join(__dir__, '..', '..')
+  result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
+  result[:reanimated_node_modules_dir] = File.expand_path(File.join(__dir__, '..', '..'))
   result[:react_native_common_dir] = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')
 
   return result
@@ -47,10 +47,13 @@ def assert_no_multiple_instances(react_native_info)
   end
 
   lib_instances_in_react_native_node_modules = %x[find #{react_native_info[:react_native_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
-  lib_instances_in_reanimated_node_modules = %x[find #{react_native_info[:reanimated_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
   lib_instances_in_react_native_node_modules_array = lib_instances_in_react_native_node_modules.split("\n")
-  lib_instances_in_reanimated_node_modules_array = lib_instances_in_reanimated_node_modules.split("\n")
-  reanimated_instances = lib_instances_in_react_native_node_modules_array.length() + lib_instances_in_reanimated_node_modules_array.length()
+  reanimated_instances = lib_instances_in_react_native_node_modules_array.length()
+  if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir]
+    lib_instances_in_reanimated_node_modules = %x[find #{react_native_info[:reanimated_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
+    lib_instances_in_reanimated_node_modules_array = lib_instances_in_reanimated_node_modules.split("\n")
+    reanimated_instances += lib_instances_in_reanimated_node_modules_array.length()
+  end
   if reanimated_instances > 1
     parsed_location = ''
     for location in lib_instances_in_react_native_node_modules_array + lib_instances_in_reanimated_node_modules_array


### PR DESCRIPTION
## Description

I disabled the second multiple instance assertion if React Native and Reanimated are in the same node modules location.