### PR TITLE
Fix gradle task order

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -965,8 +965,13 @@ task prepareThirdPartyNdkHeaders(dependsOn:[
 ) {}
 
 def nativeBuildDependsOn(dependsOnTask) {
-    def buildTasks = tasks.findAll({ task ->
-        !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake")) })
+    def buildTasks = tasks.findAll({ task -> (
+        !task.name.contains("Clean")
+        && (task.name.contains("externalNative")
+            || task.name.contains("CMake")
+            || task.name.contains("generateJsonModel")
+        )
+    ) })
     buildTasks.forEach { task -> task.dependsOn(dependsOnTask) }
 }
 


### PR DESCRIPTION
## Description

Fix for the building issue:
```
  ../../../../src/main/cpp/AndroidScheduler.h:3:10: fatal error: 'fbjni/fbjni.h' file not found
  #include <fbjni/fbjni.h>
```
CI fail: https://github.com/piaskowyk/reanimated-rn-version-tester/actions/runs/3250602268/jobs/5334494271

Solution:
We need to execute our tasks before `generateJsonModel` because in this step FBJNI's headers should be unpacked in the proper location. Same as here: https://github.com/software-mansion/react-native-reanimated/blob/376730edb6dc2b610553a0ce87ba7040031e422b/android/build.gradle#L995-L997