### PR TITLE
[Reanimated2] Added missing FrameCallback type in globals

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -965,8 +965,13 @@ task prepareThirdPartyNdkHeaders(dependsOn:[
 ) {}
 
 def nativeBuildDependsOn(dependsOnTask) {
-    def buildTasks = tasks.findAll({ task ->
-        !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake")) })
+    def buildTasks = tasks.findAll({ task -> (
+        !task.name.contains("Clean")
+        && (task.name.contains("externalNative")
+            || task.name.contains("CMake")
+            || task.name.contains("generateJsonModel")
+        )
+    ) })
     buildTasks.forEach { task -> task.dependsOn(dependsOnTask) }
 }
 

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -11,7 +11,7 @@ export type FrameInfo = {
   timeSinceFirstFrame: number;
 };
 
-interface FrameCallbackRegistryUI {
+export interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, CallbackDetails>;
   activeFrameCallbacks: Set<number>;
   previousFrameTimestamp: number | null;

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,6 +1,11 @@
-import { AnimatedStyle, StyleProps, MeasuredDimensions } from './commonTypes';
-import { ReanimatedConsole } from './core';
-import { NativeReanimated } from './NativeReanimated/NativeReanimated';
+import type {
+  AnimatedStyle,
+  StyleProps,
+  MeasuredDimensions,
+} from './commonTypes';
+import type { ReanimatedConsole } from './core';
+import type { NativeReanimated } from './NativeReanimated/NativeReanimated';
+import type { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
 
 declare global {
   const _WORKLET: boolean;
@@ -39,7 +44,7 @@ declare global {
   const ReanimatedDataMock: {
     now: () => number;
   };
-
+  const _frameCallbackRegistry: FrameCallbackRegistryUI;
   namespace NodeJS {
     interface Global {
       _WORKLET: boolean;
@@ -78,6 +83,7 @@ declare global {
       ReanimatedDataMock: {
         now: () => number;
       };
+      _frameCallbackRegistry: FrameCallbackRegistryUI;
     }
   }
 }


### PR DESCRIPTION
## Description

I added the missing `_frameCallbackRegistry` property to the globals variables declaration. And I used recommended syntax with `import type` - https://stackoverflow.com/questions/61412000/do-i-need-to-use-the-import-type-feature-of-typescript-3-8-if-all-of-my-import