### PR TITLE
Added missing `export` keyword to FrameCallback

### DIFF
--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -11,7 +11,7 @@ export type FrameInfo = {
   timeSinceFirstFrame: number;
 };
 
-interface FrameCallbackRegistryUI {
+export interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, CallbackDetails>;
   activeFrameCallbacks: Set<number>;
   previousFrameTimestamp: number | null;

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,9 +1,12 @@
-import { AnimatedStyle, StyleProps } from './commonTypes';
-import { ReanimatedConsole } from './core';
-import { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
-import { ShadowNodeWrapper } from './hook/commonTypes';
-import { MeasuredDimensions } from './NativeMethods';
-import { NativeReanimated } from './NativeReanimated/NativeReanimated';
+import type {
+  AnimatedStyle,
+  StyleProps,
+  MeasuredDimensions,
+} from './commonTypes';
+import type { ReanimatedConsole } from './core';
+import type { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
+import type { ShadowNodeWrapper } from './hook/commonTypes';
+import type { NativeReanimated } from './NativeReanimated/NativeReanimated';
 
 declare global {
   const _WORKLET: boolean;


### PR DESCRIPTION
## Description

Added missing `export` keyword to FrameCallback, and I used syntax `import type` as https://github.com/software-mansion/react-native-reanimated/pull/3683