### PR TITLE
Fix iOS Warning: RCTBridge required dispatch_sync to load REAModule

### DIFF
--- a/Example/index-template.js
+++ b/Example/index-template.js
@@ -1,4 +1,4 @@
-import { AppRegistry, LogBox, Platform } from 'react-native';
+import { AppRegistry, Platform } from 'react-native';
 import { name as appName } from './app.json';
 import ${component} from '${path}';
 
@@ -9,7 +9,3 @@ if (Platform.OS === 'web') {
   const rootTag = document.getElementById('root');
   AppRegistry.runApplication(appName, { rootTag });
 }
-
-LogBox.ignoreLogs([
-  'RCTBridge required dispatch_sync to load REAModule. This may lead to deadlocks',
-]);

--- a/Example/index.js
+++ b/Example/index.js
@@ -1,4 +1,4 @@
-import { AppRegistry, LogBox, Platform } from 'react-native';
+import { AppRegistry, Platform } from 'react-native';
 import { name as appName } from './app.json';
 import App from './src/App';
 
@@ -9,7 +9,3 @@ if (Platform.OS === 'web') {
   const rootTag = document.getElementById('root');
   AppRegistry.runApplication(appName, { rootTag });
 }
-
-LogBox.ignoreLogs([
-  'RCTBridge required dispatch_sync to load REAModule. This may lead to deadlocks',
-]);

--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -56,10 +56,12 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
 RCT_EXPORT_MODULE(ReanimatedModule);
 
+#ifdef RCT_NEW_ARCH_ENABLED
 + (BOOL)requiresMainQueueSetup
 {
   return YES;
 }
+#endif // RCT_NEW_ARCH_ENABLED
 
 - (void)invalidate
 {


### PR DESCRIPTION
## Description

Fixes #3678. Reverts part of #3555 for Paper.

On Paper, the warning "RCTBridge required dispatch_sync to load REAModule" was gone when I removed `requiresMainQueueSetup` method introduced in #3678. However, the PR description explicitly states that this method was added in order to eliminate the following warning:

> This is because the `init` method was not present before and after adding it, it caused this warning:
> 
> `Module RCTImagePickerManager requires main queue setup since it overrides init but doesn't implement 'requiresMainQueueSetup'. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.`

However, after the removal of `requiresMainQueueSetup` no warning appears, so I assume that it is in fact not necessary to initialize REAModule on main queue, thus it's safe to remove `requiresMainQueueSetup`.

On Fabric, removing `requiresMainQueueSetup` it crashes the app on reload, so I've left it as it is for now. We may address this inconsistency in a separate PR.
