### PR TITLE
Fixed incorrect value for height and state of useAnimatedKeyboard on iOS, fixed occasional crash on dismount on iOS

### DIFF
--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -99,13 +99,21 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 
   CGFloat keyboardHeight = [self computeKeyboardHeight:keyboardView];
   for (NSString *key in _listeners.allKeys) {
-    ((KeyboardEventListenerBlock)_listeners[key])(_state, keyboardHeight);
+    KeyboardEventListenerBlock listener = _listeners[key];
+    if (listener) {
+      listener(_state, keyboardHeight);
+    }
   }
 }
 
 - (CGFloat)computeKeyboardHeight:(UIView *)keyboardView
 {
-  CGFloat keyboardFrameY = [keyboardView.layer presentationLayer].frame.origin.y;
+  CALayer *presentationLayer = [keyboardView.layer presentationLayer];
+  BOOL hasSize = presentationLayer.frame.size.width && presentationLayer.frame.size.height;
+  if (!hasSize) {
+    return 0;
+  }
+  CGFloat keyboardFrameY = presentationLayer.frame.origin.y;
   CGFloat keyboardWindowH = keyboardView.window.bounds.size.height;
   CGFloat keyboardHeight = keyboardWindowH - keyboardFrameY;
   return keyboardHeight;


### PR DESCRIPTION
## Description

Include Fixes for #3568 on iOS, and for incorrect initial values for both the `height` and `state` output of `useAnimatedKeyboard` that occasionally will occur on iOS 16 if the found keyboard view is not actually viewable.