### PR TITLE
Ignore layout animation props on web

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -400,12 +400,11 @@ export default function createAnimatedComponent(
         // TODO update config
         const tag = findNodeHandle(ref);
         if (
+          !shouldBeUseWeb() &&
           (this.props.layout || this.props.entering || this.props.exiting) &&
           tag != null
         ) {
-          if (!shouldBeUseWeb()) {
-            enableLayoutAnimations(true, false);
-          }
+          enableLayoutAnimations(true, false);
           let layout = this.props.layout ? this.props.layout : DefaultLayout;
           let entering = this.props.entering
             ? this.props.entering


### PR DESCRIPTION
## Description

Fixes #3464.

Currently, Layout Animations are implemented only on Android and iOS.

Using `Animated.View` with `entering`, `layout` or `exiting` prop on web should be a no-op, but instead it throws the following error:

```
TypeError: e.LayoutAnimationRepository is undefined
    t createAnimatedComponent.js:151
    setLocalRef createAnimatedComponent.js:149
    default setAndForwardRef.js:7
    r index.js:22
```

In this PR I've changed the implementation of `createAnimatedComponent` to disable configuration of layout animation on web, in particular to avoid calling `global.LayoutAnimationRepository.registerConfig(tag, config);`.