### PR TITLE
Fix V8 integration for Reanimated V3

### DIFF
--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -21,13 +21,17 @@ jobs:
       group: build_v8-${{ matrix.working-directory }}
       cancel-in-progress: true
     steps:
+      - name: Check out
+        uses: actions/checkout@v1
+        with:
+          path: 'reanimated_repo'
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
       # - name: Install dependencies
       #   working-directory: app
       #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
-        run: node app/node_modules/react-native-reanimated/.github/workflows/helper/configureV8.js
+        run: node reanimated_repo/.github/workflows/helper/configureV8.js
       # - name: Build Android app
       #   working-directory: app/android
       #   run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -24,12 +24,12 @@ jobs:
       steps:
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
-      - name: Install dependencies
-        working-directory: app
-        run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
+      # - name: Install dependencies
+      #   working-directory: app
+      #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
         working-directory: app
         run: node .github/helper/configureV8.js
-      - name: Build Android app
-        working-directory: app/android
-        run: ./gradlew assembleDebug --console=plain
+      # - name: Build Android app
+      #   working-directory: app/android
+      #   run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -1,0 +1,32 @@
+name: Test V8 on Android
+on:
+  pull_request:
+    paths:
+      - 'android/**'
+      - 'Common/**'
+      - 'FabricExample/package.json'
+      - 'Example/package.json'
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        working-directory: [0.70.4]
+      fail-fast: false
+    concurrency:
+      group: build_v8-${{ matrix.working-directory }}
+      cancel-in-progress: true
+    steps:
+      steps:
+      - name: Create react app
+        run: npx react-native init app --version ${{ matrix.working-directory }}
+      - name: Install dependencies
+        working-directory: app
+        run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
+      - name: Build Android app
+        working-directory: app/android
+        run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -21,14 +21,10 @@ jobs:
       group: build_v8-${{ matrix.working-directory }}
       cancel-in-progress: true
     steps:
-      - name: A
-        run: pwd && ls -la
       - name: Check out
         uses: actions/checkout@v3
         with:
           path: 'reanimated_repo'
-      - name: B
-        run: pwd && ls -la
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
       - name: Install dependencies

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -21,7 +21,6 @@ jobs:
       group: build_v8-${{ matrix.working-directory }}
       cancel-in-progress: true
     steps:
-      steps:
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
       # - name: Install dependencies

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -27,7 +27,7 @@ jobs:
       #   working-directory: app
       #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
-        run: node ./.github/workflows/helper/configureV8.js
+        run: node app/node_modules/react-native-reanimated/.github/workflows/helper/configureV8.js
       # - name: Build Android app
       #   working-directory: app/android
       #   run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -30,12 +30,12 @@ jobs:
       - name: B
         run: pwd && ls -la
       - name: Create react app
-        run: cd .. && npx react-native init app --version ${{ matrix.working-directory }}
+        run: npx react-native init app --version ${{ matrix.working-directory }}
       # - name: Install dependencies
       #   working-directory: app
       #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
-        run: cd .. && node reanimated_repo/.github/workflows/helper/configureV8.js
+        run: node reanimated_repo/.github/workflows/helper/configureV8.js
       # - name: Build Android app
       #   working-directory: app/android
       #   run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -33,7 +33,7 @@ jobs:
         run: npx react-native init app --version ${{ matrix.working-directory }}
       - name: Install dependencies
         working-directory: app
-        run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
+        run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }} react-native-v8 v8-android-jit
       - name: Configure V8
         run: node reanimated_repo/.github/workflows/helper/configureV8.js
       - name: Build Android app

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -31,11 +31,11 @@ jobs:
         run: pwd && ls -la
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
-      # - name: Install dependencies
-      #   working-directory: app
-      #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
+      - name: Install dependencies
+        working-directory: app
+        run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
         run: node reanimated_repo/.github/workflows/helper/configureV8.js
-      # - name: Build Android app
-      #   working-directory: app/android
-      #   run: ./gradlew assembleDebug --console=plain
+      - name: Build Android app
+        working-directory: app/android
+        run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -27,7 +27,6 @@ jobs:
       #   working-directory: app
       #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
-        working-directory: app
         run: node .github/helper/configureV8.js
       # - name: Build Android app
       #   working-directory: app/android

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -24,18 +24,18 @@ jobs:
       - name: A
         run: pwd && ls -la
       - name: Check out
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
-          path: 'react-native-reanimated/reanimated_repo'
+          path: 'reanimated_repo'
       - name: B
         run: pwd && ls -la
       - name: Create react app
-        run: npx react-native init app --version ${{ matrix.working-directory }}
+        run: cd .. && npx react-native init app --version ${{ matrix.working-directory }}
       # - name: Install dependencies
       #   working-directory: app
       #   run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
       - name: Configure V8
-        run: node reanimated_repo/.github/workflows/helper/configureV8.js
+        run: cd .. && node reanimated_repo/.github/workflows/helper/configureV8.js
       # - name: Build Android app
       #   working-directory: app/android
       #   run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         working-directory: app
         run: yarn add github:software-mansion/react-native-reanimated#${GITHUB_SHA} react-native-v8 v8-android-jit
+      - name: Configure V8
+        working-directory: app
+        run: node .github/helper/configureV8.js
       - name: Build Android app
         working-directory: app/android
         run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v1
         with:
-          path: 'reanimated_repo'
+          path: 'react-native-reanimated/reanimated_repo'
       - name: B
         run: pwd && ls -la
       - name: Create react app

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -13,20 +13,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        working-directory: [0.70.4]
-      fail-fast: false
+    env:
+      REACT_NATIVE_VERSION: "0.70.4"
     concurrency:
-      group: build_v8-${{ matrix.working-directory }}
+      group: build_v8-${{ env.REACT_NATIVE_VERSION }}
       cancel-in-progress: true
     steps:
       - name: Check out
         uses: actions/checkout@v3
         with:
           path: 'reanimated_repo'
-      - name: Create react app
-        run: npx react-native init app --version ${{ matrix.working-directory }}
+      - name: Create React Native app
+        run: npx react-native init app --version ${{ env.REACT_NATIVE_VERSION }}
       - name: Install dependencies
         working-directory: app
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }} react-native-v8 v8-android-jit

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -2,6 +2,7 @@ name: Test V8 on Android
 on:
   pull_request:
     paths:
+      - '.github/workflows/build-v8.yml'
       - 'android/**'
       - 'Common/**'
       - 'FabricExample/package.json'
@@ -14,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      REACT_NATIVE_VERSION: "0.70.4"
+      REACT_NATIVE_VERSION: "0.70.5"
     concurrency:
       group: build_v8-${{ env.REACT_NATIVE_VERSION }}
       cancel-in-progress: true

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -21,10 +21,14 @@ jobs:
       group: build_v8-${{ matrix.working-directory }}
       cancel-in-progress: true
     steps:
+      - name: A
+        run: pwd && ls -la
       - name: Check out
         uses: actions/checkout@v1
         with:
           path: 'reanimated_repo'
+      - name: B
+        run: pwd && ls -la
       - name: Create react app
         run: npx react-native init app --version ${{ matrix.working-directory }}
       # - name: Install dependencies

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,0 +1,19 @@
+fs = require('fs');
+
+const buildGradlePath = 'android/app/build.gradle';
+const mainApplicationPath =
+  'android/app/src/main/java/com/app/MainApplication.java';
+
+fs.readFile(buildGradlePath, 'utf8', function (err, data) {
+  if (err) {
+    return console.log(err);
+  }
+  console.log(data);
+});
+
+fs.readFile(mainApplicationPath, 'utf8', function (err, data) {
+  if (err) {
+    return console.log(err);
+  }
+  console.log(data);
+});

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -23,6 +23,7 @@ patchFile(
 
 const mainApplicationPath =
   'app/android/app/src/main/java/com/app/MainApplication.java';
+
 patchFile(
   mainApplicationPath,
   'import java.util.List;',
@@ -36,8 +37,7 @@ patchFile(
 patchFile(
   mainApplicationPath,
   'protected String getJSMainModuleName() {',
-  `
-  protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+  `protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
     return new V8ExecutorFactory(
         getApplicationContext(),
         getPackageName(),

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -5,6 +5,20 @@ const buildGradlePath =
 const mainApplicationPath =
   '../../../../app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
 
+const { exec } = require('child_process');
+
+exec('ls -la', (error, stdout, stderr) => {
+  if (error) {
+    console.log(`error: ${error.message}`);
+    return;
+  }
+  if (stderr) {
+    console.log(`stderr: ${stderr}`);
+    return;
+  }
+  console.log(`stdout: ${stdout}`);
+});
+
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
   console.log(__dirname);
   if (err) {

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,13 +1,12 @@
 fs = require('fs');
 
 const buildGradlePath =
-  '../../../../../app/node_modules/react-native-reanimated/android/app/build.gradle';
+  '../../../../app/node_modules/react-native-reanimated/android/app/build.gradle';
 const mainApplicationPath =
-  '../../../../../app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
+  '../../../../app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
 
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
   console.log(__dirname);
-  console.log(path.dirname(__filename));
   if (err) {
     return console.log(err);
   }

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,8 +1,9 @@
 fs = require('fs');
 
-const buildGradlePath = 'app/android/app/build.gradle';
+const buildGradlePath =
+  'app/node_modules/react-native-reanimated/android/app/build.gradle';
 const mainApplicationPath =
-  'app/android/app/src/main/java/com/app/MainApplication.java';
+  'app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
 
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
   if (err) {

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,9 +1,8 @@
 fs = require('fs');
 
-const buildGradlePath =
-  '../../../../app/node_modules/react-native-reanimated/android/app/build.gradle';
+const buildGradlePath = 'app/android/app/build.gradle';
 const mainApplicationPath =
-  '../../../../app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
+  'app/android/app/src/main/java/com/app/MainApplication.java';
 
 const { exec } = require('child_process');
 
@@ -20,7 +19,6 @@ exec('ls -la', (error, stdout, stderr) => {
 });
 
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
-  console.log(__dirname);
   if (err) {
     return console.log(err);
   }

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -27,10 +27,10 @@ fs.readFile(mainApplicationPath, 'utf8', function (err, data) {
   import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
   import io.csie.kudo.reactnative.v8.executor.V8ExecutorFactory;
   `;
+  data = data.replace('import java.util.List;', imports);
 
   const getJSMainModuleName = 'protected String getJSMainModuleName() {';
   const getJavaScriptExecutorFactory = `
-  @Override
   protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
     return new V8ExecutorFactory(
         getApplicationContext(),
@@ -39,10 +39,18 @@ fs.readFile(mainApplicationPath, 'utf8', function (err, data) {
         getUseDeveloperSupport());
   }
   
+  @Override
   protected String getJSMainModuleName() {`;
-
-  data = data.replace('import java.util.List;', imports);
   data = data.replace(getJSMainModuleName, getJavaScriptExecutorFactory);
+
+  const packagingOptions = `
+  android {
+    packagingOptions {
+      // Make sure libjsc.so does not packed in APK
+      exclude "**/libjsc.so"
+    }
+  `;
+  data = data.replace('android {', packagingOptions);
 
   fs.writeFile(mainApplicationPath, data, function (err) {
     if (err) {

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,11 +1,13 @@
 fs = require('fs');
 
 const buildGradlePath =
-  'app/node_modules/react-native-reanimated/android/app/build.gradle';
+  '../../../../../app/node_modules/react-native-reanimated/android/app/build.gradle';
 const mainApplicationPath =
-  'app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
+  '../../../../../app/node_modules/react-native-reanimated/android/app/src/main/java/com/app/MainApplication.java';
 
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
+  console.log(__dirname);
+  console.log(path.dirname(__filename));
   if (err) {
     return console.log(err);
   }

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -4,30 +4,48 @@ const buildGradlePath = 'app/android/app/build.gradle';
 const mainApplicationPath =
   'app/android/app/src/main/java/com/app/MainApplication.java';
 
-const { exec } = require('child_process');
-
-exec('ls -la', (error, stdout, stderr) => {
-  if (error) {
-    console.log(`error: ${error.message}`);
-    return;
-  }
-  if (stderr) {
-    console.log(`stderr: ${stderr}`);
-    return;
-  }
-  console.log(`stdout: ${stdout}`);
-});
-
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
   if (err) {
     return console.log(err);
   }
-  console.log(data);
+  data = data.replace('enableHermes: true,', 'enableHermes: false,');
+
+  fs.writeFile(buildGradlePath, data, function (err) {
+    if (err) {
+      return console.log(err);
+    }
+  });
 });
 
 fs.readFile(mainApplicationPath, 'utf8', function (err, data) {
   if (err) {
     return console.log(err);
   }
-  console.log(data);
+  const imports = `
+  import java.util.List;
+  import com.facebook.react.bridge.JavaScriptExecutorFactory;
+  import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
+  import io.csie.kudo.reactnative.v8.executor.V8ExecutorFactory;
+  `;
+
+  const getJSMainModuleName = 'protected String getJSMainModuleName() {';
+  const getJavaScriptExecutorFactory = `
+  @Override
+  protected JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+    return new V8ExecutorFactory(
+        getApplicationContext(),
+        getPackageName(),
+        AndroidInfoHelpers.getFriendlyDeviceName(),
+        getUseDeveloperSupport());
+  }
+  
+  protected String getJSMainModuleName() {`;
+
+  data = data.replace(getJSMainModuleName, getJavaScriptExecutorFactory);
+
+  fs.writeFile(mainApplicationPath, data, function (err) {
+    if (err) {
+      return console.log(err);
+    }
+  });
 });

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,8 +1,8 @@
 fs = require('fs');
 
-const buildGradlePath = 'android/app/build.gradle';
+const buildGradlePath = 'app/android/app/build.gradle';
 const mainApplicationPath =
-  'android/app/src/main/java/com/app/MainApplication.java';
+  'app/android/app/src/main/java/com/app/MainApplication.java';
 
 fs.readFile(buildGradlePath, 'utf8', function (err, data) {
   if (err) {

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -41,6 +41,7 @@ fs.readFile(mainApplicationPath, 'utf8', function (err, data) {
   
   protected String getJSMainModuleName() {`;
 
+  data = data.replace('import java.util.List;', imports);
   data = data.replace(getJSMainModuleName, getJavaScriptExecutorFactory);
 
   fs.writeFile(mainApplicationPath, data, function (err) {

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -20,7 +20,7 @@ using namespace facebook;
 using namespace react;
 
 std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
-    jsi::Runtime *reactRuntime,
+    jsi::Runtime *rnRuntime,
     std::shared_ptr<MessageQueueThread> jsQueue) {
 #if JS_RUNTIME_HERMES
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime =
@@ -38,7 +38,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
   config->enableInspector = false;
   config->appName = "reanimated";
-  return rnv8::createSharedV8Runtime(reactRuntime, std::move(config));
+  return rnv8::createSharedV8Runtime(rnRuntime, std::move(config));
 #else
   // This is required by iOS, because there is an assertion in the destructor
   // that the thread was indeed `quit` before

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -20,7 +20,7 @@ using namespace facebook;
 using namespace react;
 
 std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
-    jsi::Runtime *runtime,
+    jsi::Runtime *reactRuntime,
     std::shared_ptr<MessageQueueThread> jsQueue) {
 #if JS_RUNTIME_HERMES
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime =
@@ -38,7 +38,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
   config->enableInspector = false;
   config->appName = "reanimated";
-  return rnv8::createSharedV8Runtime(runtime, std::move(config));
+  return rnv8::createSharedV8Runtime(reactRuntime, std::move(config));
 #else
   // This is required by iOS, because there is an assertion in the destructor
   // that the thread was indeed `quit` before

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp
@@ -20,6 +20,7 @@ using namespace facebook;
 using namespace react;
 
 std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
+    jsi::Runtime *runtime,
     std::shared_ptr<MessageQueueThread> jsQueue) {
 #if JS_RUNTIME_HERMES
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime =
@@ -37,7 +38,7 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
   auto config = std::make_unique<rnv8::V8RuntimeConfig>();
   config->enableInspector = false;
   config->appName = "reanimated";
-  return rnv8::createSharedV8Runtime(runtime_, std::move(config));
+  return rnv8::createSharedV8Runtime(runtime, std::move(config));
 #else
   // This is required by iOS, because there is an assertion in the destructor
   // that the thread was indeed `quit` before

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
@@ -21,7 +21,7 @@ using namespace react;
 class ReanimatedRuntime {
  public:
   static std::shared_ptr<jsi::Runtime> make(
-      jsi::Runtime *reactRuntime,
+      jsi::Runtime *rnRuntime,
       std::shared_ptr<MessageQueueThread> jsQueue);
 };
 

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
@@ -21,6 +21,7 @@ using namespace react;
 class ReanimatedRuntime {
  public:
   static std::shared_ptr<jsi::Runtime> make(
+      jsi::Runtime *runtime,
       std::shared_ptr<MessageQueueThread> jsQueue);
 };
 

--- a/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.h
@@ -21,7 +21,7 @@ using namespace react;
 class ReanimatedRuntime {
  public:
   static std::shared_ptr<jsi::Runtime> make(
-      jsi::Runtime *runtime,
+      jsi::Runtime *reactRuntime,
       std::shared_ptr<MessageQueueThread> jsQueue);
 };
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -203,7 +203,7 @@ void NativeProxy::installJSIBindings(
 
   auto jsQueue = std::make_shared<JMessageQueueThread>(messageQueueThread);
   std::shared_ptr<jsi::Runtime> animatedRuntime =
-      ReanimatedRuntime::make(jsQueue);
+      ReanimatedRuntime::make(runtime_, jsQueue);
 
   auto workletRuntimeValue =
       runtime_->global()

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -32,6 +32,10 @@
 #import <dlfcn.h>
 #endif
 
+@interface RCTBridge (JSIRuntime)
+- (void *)runtime;
+@end
+
 namespace reanimated {
 
 using namespace facebook;
@@ -198,7 +202,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   auto jsQueue = std::make_shared<REAMessageThread>([NSRunLoop currentRunLoop], ^(NSError *error) {
     throw error;
   });
-  std::shared_ptr<jsi::Runtime> animatedRuntime = ReanimatedRuntime::make(jsQueue);
+  auto reactRuntime = reinterpret_cast<facebook::jsi::Runtime *>(reanimatedModule.bridge.runtime);
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ReanimatedRuntime::make(reactRuntime, jsQueue);
 
   std::shared_ptr<Scheduler> scheduler = std::make_shared<REAIOSScheduler>(jsInvoker);
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<REAIOSErrorHandler>(scheduler);

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -202,8 +202,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   auto jsQueue = std::make_shared<REAMessageThread>([NSRunLoop currentRunLoop], ^(NSError *error) {
     throw error;
   });
-  auto reactRuntime = reinterpret_cast<facebook::jsi::Runtime *>(reanimatedModule.bridge.runtime);
-  std::shared_ptr<jsi::Runtime> animatedRuntime = ReanimatedRuntime::make(reactRuntime, jsQueue);
+  auto rnRuntime = reinterpret_cast<facebook::jsi::Runtime *>(reanimatedModule.bridge.runtime);
+  std::shared_ptr<jsi::Runtime> animatedRuntime = ReanimatedRuntime::make(rnRuntime, jsQueue);
 
   std::shared_ptr<Scheduler> scheduler = std::make_shared<REAIOSScheduler>(jsInvoker);
   std::shared_ptr<ErrorHandler> errorHandler = std::make_shared<REAIOSErrorHandler>(scheduler);


### PR DESCRIPTION
## Description

This PR is an attempt to fix V8 integration with Reanimated V3. Current issue:

```
react-native/node_modules/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedRuntime.cpp:40:38: error: use of undeclared identifier 'runtime_'
```

## Changes

Updated `ReanimatedRuntime::make` to accept a new parameter `jsi::Runtime *runtime`, which is necessary to initialize V8

## Test code and steps to reproduce

- Create a new RN app
- Setup the app to have V8 as engine
- Enable the new architecture (might not be necessary)
- Build the Android app
- Confirm the app builds and runs fine with this change

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
