### PR TITLE
Ignore formatting commits in the blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# .git-blame-ignore-revs
+# feat: add native code formatting (#2196)
+e646dce7b85204cddeea4ef3e1ab971a85830562
+# Fix precommit hook & reformat code (#2497)
+008ee9322f3d2ed3ffef1996cbab50039fb72a3d
+# Flatten headers directory (#3474) 
+bb3e42154807bc9f220d49d3c2a03521f58c2394


### PR DESCRIPTION
## Description

Ignored commits:
* e646dce7b85204cddeea4ef3e1ab971a85830562 #2196 by @WoLewicki 
* 008ee9322f3d2ed3ffef1996cbab50039fb72a3d #2497 by @kacperkapusciak 
* bb3e42154807bc9f220d49d3c2a03521f58c2394 #3474 by @tomekzaw 

Docs: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Before:

<img width="1067" alt="before" src="https://user-images.githubusercontent.com/20516055/199696821-c9390a0b-0766-4afd-983c-cb7b6eff580d.png">

After:

<img width="1077" alt="after" src="https://user-images.githubusercontent.com/20516055/199723261-c411c738-9f33-49eb-83f5-c56aac5cdf1b.png">


