### PR TITLE
Don't publish GitHub Pages from Reanimated2 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Publish to GitHub Pages
 on:
   push:
     branches:
-      - Reanimated2
+      - main
 
 jobs:
   publish:


### PR DESCRIPTION
## Description

This PR disables publishing GitHub Pages from Reanimated2 branch because it overwrites the docs from main branch.