### PR TITLE
Fix V8 on Android CI build

### DIFF
--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     concurrency:
-      group: build_v8-${{ env.REACT_NATIVE_VERSION }}
+      group: build-v8-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: Check out

--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -11,11 +11,12 @@ on:
     branches:
       - main
 
+env:
+  REACT_NATIVE_VERSION: "0.70.5"
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      REACT_NATIVE_VERSION: "0.70.5"
     concurrency:
       group: build_v8-${{ env.REACT_NATIVE_VERSION }}
       cancel-in-progress: true

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,7 +1,7 @@
 fs = require('fs');
 
 function patchFile(path, find, replace) {
-  const data = fs.readFileSync(path, 'utf8');
+  let data = fs.readFileSync(path, 'utf8');
   data = data.replace(find, replace);
   fs.writeFileSync(path, data);
 }

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,26 +1,24 @@
 fs = require('fs');
 
-function patchFile(path, find, replace, debug = false) {
-  fs.readFile(path, 'utf8', function (err, data) {
-    if (err) {
-      return console.log(err);
-    }
-    data = data.replace(find, replace);
-    if (debug) {
-      console.log(data);
-    }
-    fs.writeFile(path, data, function (err) {
-      if (err) {
-        return console.log(err);
-      }
-    });
-  });
+function patchFile(path, find, replace) {
+  const data = fs.readFileSync(path, 'utf8');
+  data = data.replace(find, replace);
+  fs.writeFileSync(path, data);
 }
 
+const buildGradle = 'app/android/app/build.gradle';
+
+patchFile(buildGradle, 'enableHermes: true,', 'enableHermes: false,');
+
 patchFile(
-  'app/android/app/build.gradle',
-  'enableHermes: true,',
-  'enableHermes: false,'
+  buildGradle,
+  'android {',
+  `android {
+    packagingOptions {
+      // Make sure libjsc.so does not packed in APK
+      exclude "**/libjsc.so"
+    }
+  `
 );
 
 const mainApplicationPath =
@@ -49,16 +47,4 @@ patchFile(
   
   @Override
   protected String getJSMainModuleName() {`
-);
-
-patchFile(
-  mainApplicationPath,
-  'android {',
-  `android {
-    packagingOptions {
-      // Make sure libjsc.so does not packed in APK
-      exclude "**/libjsc.so"
-    }
-  `,
-  true
 );

--- a/.github/workflows/helper/configureV8.js
+++ b/.github/workflows/helper/configureV8.js
@@ -1,12 +1,14 @@
 fs = require('fs');
 
-function patchFile(path, find, replace) {
+function patchFile(path, find, replace, debug = false) {
   fs.readFile(path, 'utf8', function (err, data) {
     if (err) {
       return console.log(err);
     }
     data = data.replace(find, replace);
-
+    if (debug) {
+      console.log(data);
+    }
     fs.writeFile(path, data, function (err) {
       if (err) {
         return console.log(err);
@@ -57,5 +59,6 @@ patchFile(
       // Make sure libjsc.so does not packed in APK
       exclude "**/libjsc.so"
     }
-  `
+  `,
+  true
 );


### PR DESCRIPTION
## Description

This PR fixes the Android V8 CI that wasn't running because `env` is not available in `concurrency.group` context:

<img width="757" alt="Zrzut ekranu 2022-11-7 o 13 41 37" src="https://user-images.githubusercontent.com/20516055/200313029-4201a9d0-777d-431c-ad1f-40afcaf2b17b.png">

Instead, we should use `${{ github.ref }}` to differentiate jobs for different branches/PRs.
