### PR TITLE
Fix cmake error on windows

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 import com.android.Version
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.apache.tools.ant.taskdefs.condition.Os
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
 
@@ -181,6 +182,14 @@ def getReanimatedVersion() {
     String reanimatedVersion = json.version
     def (major, minor, patch) = reanimatedVersion.tokenize('.')
     return major.toInteger()
+}
+
+def toPlatformFileString(File path) {
+  def result = path.toString()
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    result = result.replace(File.separatorChar, '/' as char)
+  }
+  return result
 }
 
 boolean CLIENT_SIDE_BUILD = resolveClientSideBuild()
@@ -447,7 +456,7 @@ android {
                         "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DBOOST_VERSION=${BOOST_VERSION}",
-                        "-DREACT_NATIVE_DIR=${reactNativeRootDir.path}",
+                        "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeRootDir)}",
                         "-DJS_RUNTIME=${JS_RUNTIME}",
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -184,12 +184,11 @@ def getReanimatedVersion() {
     return major.toInteger()
 }
 
-def toPlatformFileString(File path) {
-  def result = path.toString()
+def toPlatformFileString(String path) {
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-    result = result.replace(File.separatorChar, '/' as char)
+      path = path.replace(File.separatorChar, '/' as char)
   }
-  return result
+  return path
 }
 
 boolean CLIENT_SIDE_BUILD = resolveClientSideBuild()
@@ -456,7 +455,7 @@ android {
                         "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DBOOST_VERSION=${BOOST_VERSION}",
-                        "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeRootDir)}",
+                        "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeRootDir.path)}",
                         "-DJS_RUNTIME=${JS_RUNTIME}",
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",


### PR DESCRIPTION
## Description
I get cmake error (`Invalid character escape '\K'.`) when using latest Reanimated on RN version 0.64.3, this will fix Android build on windows because latest version of reanimated doesn't provide prebuilt AAR for older version, so it will attempt to rebuild from source

![image](https://user-images.githubusercontent.com/15137312/200750965-a126493a-a1c6-4b62-85d0-c91a9f38bed3.png)

## Changes
- added method `toPlatformFileString(File path)` to android/build.gradle to replace windows file separator character with '/'
- call `toPlatformFileString` on cmake arguments REACT_NATIVE_DIR
- fix sources taken from [this PR](https://github.com/Kudo/react-native-v8/pull/132)

## Test code and steps to reproduce
- create new project with RN v0.64.3
- install latest version of react-native-reanimated
- try to build apk for Android `./gradlew clean installDebug`

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
