### PR TITLE
Fix inverted cell style for inverted Animated.FlatList

### DIFF
--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -52,6 +52,7 @@ import AnimatedSensorExample from './AnimatedSensorExample';
 import AnimatedSharedStyleExample from './AnimatedSharedStyleExample';
 import AnimatedKeyboardExample from './AnimatedKeyboardExample';
 import ScrollViewOffsetExample from './ScrollViewOffsetExample';
+import InvertedFlatListExample from './InvertedFlatListExample';
 
 LogBox.ignoreLogs(['Calling `getNode()`']);
 
@@ -199,6 +200,10 @@ const SCREENS: Screens = {
   ScrollExample: {
     screen: ScrollExample,
     title: 'Scroll Example',
+  },
+  InvertedFlatListExample: {
+    screen: InvertedFlatListExample,
+    title: 'Inverted FlatList Example',
   },
 };
 

--- a/Example/src/InvertedFlatListExample.tsx
+++ b/Example/src/InvertedFlatListExample.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  useAnimatedScrollHandler,
+  interpolate,
+} from 'react-native-reanimated';
+
+const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+const cardSize = 200;
+const cardMargin = 10;
+const cardInterval = cardSize + cardMargin * 2;
+
+function InvertedFlatListExample() {
+  return (
+    <>
+      <List />
+      <List horizontal />
+    </>
+  );
+}
+
+function List({ horizontal }: { horizontal?: boolean }) {
+  const [scrollViewSize, setScrollViewSize] = React.useState(200);
+  const scrollPosition = useSharedValue(0);
+  const isScrolling = useSharedValue(false);
+
+  const scrollHandler = useAnimatedScrollHandler(
+    {
+      onScroll: (event) => {
+        scrollPosition.value = horizontal
+          ? event.contentOffset.x
+          : event.contentOffset.y;
+      },
+      onBeginDrag: () => {
+        isScrolling.value = true;
+      },
+      onEndDrag: () => {
+        isScrolling.value = false;
+      },
+    },
+    [horizontal]
+  );
+
+  const inset = (scrollViewSize - cardInterval) / 2;
+  const containerPadding = horizontal
+    ? { paddingHorizontal: inset }
+    : { paddingVertical: inset };
+
+  return (
+    <Animated.FlatList
+      style={styles.container}
+      contentContainerStyle={[styles.contentContainer, containerPadding]}
+      inverted
+      snapToInterval={cardInterval}
+      decelerationRate="fast"
+      horizontal={horizontal}
+      data={digits}
+      renderItem={({ item, index }) => (
+        <Item index={index} item={item} scrollPosition={scrollPosition} />
+      )}
+      onScroll={scrollHandler}
+      scrollEventThrottle={1}
+      onLayout={(event) =>
+        setScrollViewSize(
+          horizontal
+            ? event.nativeEvent.layout.width
+            : event.nativeEvent.layout.height
+        )
+      }
+    />
+  );
+}
+
+function Item({
+  item,
+  index,
+  scrollPosition,
+}: {
+  item: number;
+  index: number;
+  scrollPosition: Animated.SharedValue<number>;
+}) {
+  const style = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          scale: interpolate(
+            scrollPosition.value,
+            [
+              (index - 1) * cardInterval,
+              index * cardInterval,
+              (index + 1) * cardInterval,
+            ],
+            [0, 1, 0],
+            'clamp'
+          ),
+        },
+      ],
+    };
+  });
+
+  return (
+    <Animated.View style={[styles.card, style]}>
+      <Text style={styles.text}>{item}</Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    margin: 10,
+  },
+  contentContainer: {
+    alignItems: 'center',
+  },
+  card: {
+    width: cardSize,
+    height: cardSize,
+    backgroundColor: 'white',
+    borderRadius: 5,
+    borderColor: '#eee',
+    borderWidth: 1,
+    margin: cardMargin,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    fontSize: 32,
+  },
+});
+
+export default InvertedFlatListExample;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -1,8 +1,14 @@
 import React, { ForwardedRef, forwardRef } from 'react';
-import { FlatList, FlatListProps, LayoutChangeEvent } from 'react-native';
+import {
+  FlatList,
+  FlatListProps,
+  LayoutChangeEvent,
+  StyleSheet,
+} from 'react-native';
 import ReanimatedView from './View';
 import createAnimatedComponent from '../../createAnimatedComponent';
 import { ILayoutAnimationBuilder } from '../layoutReanimation/animationBuilder/commonTypes';
+import { StyleProps } from '../commonTypes';
 
 const AnimatedFlatList = createAnimatedComponent(FlatList as any) as any;
 
@@ -10,12 +16,20 @@ interface AnimatedFlatListProps {
   onLayout: (event: LayoutChangeEvent) => void;
   // implicit `children` prop has been removed in @types/react^18.0.0
   children: React.ReactNode;
+  inverted?: boolean;
+  horizontal?: boolean;
 }
 
-const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
+const createCellRenderer = (
+  itemLayoutAnimation?: ILayoutAnimationBuilder,
+  cellStyle?: StyleProps
+) => {
   const cellRenderer = (props: AnimatedFlatListProps) => {
     return (
-      <ReanimatedView layout={itemLayoutAnimation} onLayout={props.onLayout}>
+      <ReanimatedView
+        layout={itemLayoutAnimation}
+        onLayout={props.onLayout}
+        style={cellStyle}>
         {props.children}
       </ReanimatedView>
     );
@@ -34,9 +48,15 @@ const ReanimatedFlatlist: ReanimatedFlatListFC = forwardRef(
   (props: ReanimatedFlatListProps<any>, ref: ForwardedRef<FlatList>) => {
     const { itemLayoutAnimation, ...restProps } = props;
 
+    const cellStyle = restProps?.inverted
+      ? restProps?.horizontal
+        ? styles.horizontallyInverted
+        : styles.verticallyInverted
+      : undefined;
+
     const cellRenderer = React.useMemo(
-      () => createCellRenderer(itemLayoutAnimation),
-      []
+      () => createCellRenderer(itemLayoutAnimation, cellStyle),
+      [cellStyle]
     );
 
     return (
@@ -48,5 +68,10 @@ const ReanimatedFlatlist: ReanimatedFlatListFC = forwardRef(
     );
   }
 );
+
+const styles = StyleSheet.create({
+  verticallyInverted: { transform: [{ scaleY: -1 }] },
+  horizontallyInverted: { transform: [{ scaleX: -1 }] },
+});
 
 export default ReanimatedFlatlist;


### PR DESCRIPTION
## Description

`Animated.FlatList` currently presents each item flipped when using the `inverted` prop, this due to how the `inverted` props works internally (it literally flips the ScrollView). [In the React  Native codebase](https://github.com/facebook/react-native/blob/29caed22cc1c9a426e524e498cf44cf18df0577e/Libraries/Lists/VirtualizedList.js#L1845-L1850) they then apply a style to each cell item to flip it back to the correct orientation. However this fix isn't applied to Reanimated's `FlatList` implementation because it overrides the `CellRendererComponent` prop.

Fixes #2769

## Changes

I've used the same fix from React Native to correct the implementation in Reanimated and included an example in the Example app so it's easy to verify if this gets regressed in the future.

Before | After
---|---
![Simulator Screen Recording - iPhone 8 - 2022-11-11 at 14 19 48](https://user-images.githubusercontent.com/721323/201256418-0edf01dc-c4df-4a87-8afd-364f0680631b.gif) | ![Simulator Screen Recording - iPhone 8 - 2022-11-11 at 14 18 16](https://user-images.githubusercontent.com/721323/201256429-2c0a216d-a61c-41a0-8528-654a73982b06.gif)

## Test code and steps to reproduce

Check the `Inverted FlatList Example` in the Example app.

## Checklist

- [x] Included code example that can be used to test this change
- [x] ~Updated TS types~
- [x] ~Added TS types tests~
- [ ] Added unit / integration tests
- [x] ~Updated documentation~
- [x] Ensured that CI passes
