### PR TITLE
Fix null array reference in utilities

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -52,6 +52,7 @@ def assert_no_multiple_instances(react_native_info)
 
   lib_instances_in_react_native_node_modules = %x[find #{react_native_info[:react_native_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
   lib_instances_in_react_native_node_modules_array = lib_instances_in_react_native_node_modules.split("\n")
+  lib_instances_in_reanimated_node_modules_array = Array.new
   reanimated_instances = lib_instances_in_react_native_node_modules_array.length()
   if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir]
     lib_instances_in_reanimated_node_modules = %x[find #{react_native_info[:reanimated_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -65,7 +65,7 @@ def assert_no_multiple_instances(react_native_info)
       location['/package.json'] = ''
       parsed_location += "- " + location + "\n"
     end
-    raise "[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsed_location
+    raise "[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/next/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsed_location
   end
 end
 


### PR DESCRIPTION
## Description
This PR addresses the issue #3754
Invalid RNReanimated.podspec file: no implicit conversion of nil into Array. IOS when updating from reanimated 2.8.0 to 2.12.0 caused by  (https://github.com/software-mansion/react-native-reanimated/blob/05c93b02ede93950904812239fbe95366e372ab6/scripts/reanimated_utils.rb#L63) as its possible that we can have multiple instances of react-native-reanimated in the same node_modules directory (i.e. we require `react-native-reanimated` and one of our dependencies also requires it). If this happens to be the case, the condition that there are multiple react native reanimated instances is evaluated as `true`. As we attempt to evaluate the `parsed_location` its possible that `lib_instances_in_reanimated_node_modules_array` may be null if `react_native` and the `react_native_reanimated` modules are under the same `node_modules` folder (which is the case for most apps except the example app which the script was likely predicated upon).

## Changes

### Fixed 
 - Fixes an issue with pod file that caused a `no implicit conversion of nil into Array` exception by initializing `lib_instances_in_reanimated_node_modules_array` to an Array.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
