### PR TITLE
Fix pod install error when project path contains space

### DIFF
--- a/.github/workflows/build-monorepo.yml
+++ b/.github/workflows/build-monorepo.yml
@@ -5,6 +5,7 @@ on:
       - .github/workflows/build-monorepo.yml
       - .github/workflows/build-monorepo-action.yml
       - RNReanimated.podspec
+      - scripts/reanimated_utils.rb
       - android/build.gradle
   push:
     branches:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - .github/workflows/ios-build.yml
       - RNReanimated.podspec
+      - scripts/reanimated_utils.rb
       - ios/**
       - Common/**
       - Example/package.json

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -17,7 +17,7 @@ def find_config()
     :react_native_common_dir => nil,
   }
 
-  react_native_node_modules_dir = File.join(File.dirname(`cd #{Pod::Config.instance.installation_root.to_s} && node --print "require.resolve('react-native/package.json')"`), '..')
+  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
   react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
 
   if react_native_json == nil


### PR DESCRIPTION
## Description

Fixes #3771 as suggested by @ahayllas.

## Changes

- Added missing double quotes around project path
- Added reanimated_utils.rb to paths in CI workflows
