### PR TITLE
Move @types/invariant to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "dependencies": {
     "@babel/plugin-transform-object-assign": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@types/invariant": "^2.2.35",
     "invariant": "^2.2.4",
     "lodash.isequal": "^4.5.0",
     "setimmediate": "^1.0.5",
@@ -101,6 +100,7 @@
     "@types/babel__core": "^7.1.18",
     "@types/babel__generator": "^7.6.4",
     "@types/babel__traverse": "^7.14.2",
+    "@types/invariant": "^2.2.35",
     "@types/jest": "^27.4.0",
     "@types/react-native": "^0.66.0",
     "@typescript-eslint/eslint-plugin": "^5.11.0",


### PR DESCRIPTION
## Description

This PR moves @types/invariant to devDependecies as suggested by @hendryems in #3770.

Since there is only one occurrence of `invariant` in our codebase, first I thought we can replace this check with some simple JS code (if + throw new Error). However, invariant is also a dependency of react-native, so it makes no difference in terms of number of dependencies if we also rely on it.

## Changes

- Move @types/invariant to devDependencies

## Test code and steps to reproduce

Just see if everything works before release.
