### PR TITLE
Fix Fabric crash on reload on iOS

### DIFF
--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -44,7 +44,6 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
   __weak RCTSurfacePresenter *_surfacePresenter;
   std::shared_ptr<NewestShadowNodesRegistry> newestShadowNodesRegistry;
   std::weak_ptr<NativeReanimatedModule> reanimatedModule_;
-  std::shared_ptr<EventListener> eventListener_;
 #else
   NSMutableArray<AnimatedOperation> *_operations;
 #endif
@@ -66,8 +65,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 - (void)invalidate
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-  RCTScheduler *scheduler = [_surfacePresenter scheduler];
-  [scheduler removeEventListener:eventListener_];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 #endif
   [_nodesManager invalidate];
@@ -146,7 +143,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
       return;
     }
     if (auto reanimatedModule = strongSelf->reanimatedModule_.lock()) {
-      self->eventListener_ =
+      auto eventListener =
           std::make_shared<facebook::react::EventListener>([reanimatedModule](const RawEvent &rawEvent) {
             if (!RCTIsMainQueue()) {
               // event listener called on the JS thread, let's ignore this event
@@ -156,7 +153,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
             }
             return reanimatedModule->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
           });
-      [scheduler addEventListener:self->eventListener_];
+      [scheduler addEventListener:eventListener];
     }
   });
 }


### PR DESCRIPTION
## Description

This PR fixes iOS crash on reload of FabricExample app. Most likely the regression was caused by #3332.

## Changes

First, I observed that the crash was gone after I commented out the following line:

https://github.com/software-mansion/react-native-reanimated/blob/1bec9a069371bc27a3319d8c0a7aa31b77a98de7/ios/REAModule.mm#L159

Next, I confirmed that `removeEventListener` was indeed called in `invalidate` here:

https://github.com/software-mansion/react-native-reanimated/blob/1bec9a069371bc27a3319d8c0a7aa31b77a98de7/ios/REAModule.mm#L70

However, this method was called on the ShadowQueue thread while `addEventListener` was called on the JS thread. As this may potentially cause a race condition when accessing internal `std::vector` of EventListeners, I decided to wrap the call with `runtimeExecutor` in order to schedule the call on JS thread, like here:

https://github.com/software-mansion/react-native-reanimated/blob/1bec9a069371bc27a3319d8c0a7aa31b77a98de7/ios/REAModule.mm#L140-L148

This resolved the issue. However, when I set a breakpoint on `removeEventListener`, it was never hit, so the method was actually never called, so I decided to completely remove `removeEventListener` call. After the changes, reloading app works fine, even while `Animated.ScrollView` is being scrolled.

## Test code and steps to reproduce

Launch FabricExample, open useScrollViewOffset example and reload the app a few times while scrolling.
