### PR TITLE
[Android] fix components being placed under the screen header

### DIFF
--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -82,6 +82,10 @@ class ReaLayoutAnimator extends LayoutAnimationController {
     // otherwise use update animation. This approach is easier than maintaining a list of tags
     // for recently created views.
     if (view.getWidth() == 0 || view.getHeight() == 0) {
+      if (!mAnimationsManager.hasAnimationForTag(view.getId(), "entering")) {
+        super.applyLayoutUpdate(view, x, y, width, height);
+        return;
+      }
       view.layout(x, y, x + width, y + height);
       if (view.getId() != -1) {
         mAnimationsManager.onViewCreate(
@@ -89,12 +93,13 @@ class ReaLayoutAnimator extends LayoutAnimationController {
             (ViewGroup) view.getParent(),
             new Snapshot(view, mWeakNativeViewHierarchyManager.get()));
       }
-    } else {
-      Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManager.get());
-      view.layout(x, y, x + width, y + height);
-      Snapshot after = new Snapshot(view, mWeakNativeViewHierarchyManager.get());
-      mAnimationsManager.onViewUpdate(view, before, after);
+      return;
     }
+
+    Snapshot before = new Snapshot(view, mWeakNativeViewHierarchyManager.get());
+    view.layout(x, y, x + width, y + height);
+    Snapshot after = new Snapshot(view, mWeakNativeViewHierarchyManager.get());
+    mAnimationsManager.onViewUpdate(view, before, after);
   }
 
   /**
@@ -223,33 +228,6 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
 
   private boolean isLayoutAnimationDisabled() {
     return !initOk || !((ReaLayoutAnimator) mReaLayoutAnimator).isLayoutAnimationEnabled();
-  }
-
-  public synchronized void updateLayout(
-      int parentTag, int tag, int x, int y, int width, int height) {
-    super.updateLayout(parentTag, tag, x, y, width, height);
-    if (isLayoutAnimationDisabled()) {
-      return;
-    }
-    try {
-      View viewToUpdate = this.resolveView(tag);
-      ViewManager viewManager = this.resolveViewManager(tag);
-      String viewManagerName = viewManager.getName();
-      View container = resolveView(parentTag);
-      if (container != null
-          && viewManagerName.equals("RNSScreen")
-          && this.mReaLayoutAnimator != null) {
-        this.mReaLayoutAnimator.applyLayoutUpdate(
-            viewToUpdate,
-            (int) container.getX(),
-            (int) container.getY(),
-            container.getWidth(),
-            container.getHeight());
-      }
-    } catch (IllegalViewOperationException e) {
-      // (IllegalViewOperationException) == (vm == null)
-      e.printStackTrace();
-    }
   }
 
   @Override


### PR DESCRIPTION
## Description
Fixes #2906 #3368 #3813

Previously, when layout animations were enabled, when updating layout for `react-native-screens`' `Screen`, we set it's dimensions to the dimensions of the component containing that screen.

On the JS side, header’s height is set to 0 due to it being a wrapper for the native Android/iOS header component, but on the native side, its height is calculated by the system and the information about the new Screen’s height (which is effectively smaller due to that header) is passed to UIManager here: [https://github.com/software-mansion/react-native-screens/blob/100ed4f9ffd5f27ace4d[…]7a00c64/android/src/main/java/com/swmansion/rnscreens/Screen.kt](https://github.com/software-mansion/react-native-screens/blob/100ed4f9ffd5f27ace4ddbb5c5ffbb80e7a00c64/android/src/main/java/com/swmansion/rnscreens/Screen.kt#L74). It seems that the newest implementation of LayoutAnimations is aware of those new values.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

<!--

## Screenshots / GIFs

Here you can add screenshots / GIFs documenting your change.

You can add before / after section if you're changing some behavior.

### Before

### After

-->

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
