### PR TITLE
Fix layout after entering animation ends

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -119,10 +119,7 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
   if ([_enteringViews containsObject:tag] && !removeView) {
     REASnapshot *target = _enteringViewTargetValues[tag];
     if (target != nil) {
-      NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
-      RCTComponentData *componentData = dataComponenetsByName[@"RCTView"];
-      _enteringViewTargetValues[[view reactTag]] = [[REASnapshot alloc] init:view];
-      [self setNewProps:target.values forView:view withComponentData:componentData];
+      [self setNewProps:target.values forView:view];
     }
   }
   [_enteringViews removeObject:tag];
@@ -158,9 +155,7 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (void)progressLayoutAnimationWithStyle:(NSDictionary *)newStyle forTag:(NSNumber *)tag
 {
-  NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  RCTComponentData *componentData = dataComponenetsByName[@"RCTView"];
-  [self setNewProps:[newStyle mutableCopy] forView:[self viewForTag:tag] withComponentData:componentData];
+  [self setNewProps:[newStyle mutableCopy] forView:[self viewForTag:tag]];
 }
 
 - (double)getDoubleOrZero:(NSNumber *)number
@@ -170,6 +165,13 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     return 0;
   }
   return doubleValue;
+}
+
+- (void)setNewProps:(NSMutableDictionary *)newProps forView:(UIView *)view
+{
+  NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
+  RCTComponentData *componentData = dataComponenetsByName[@"RCTView"];
+  [self setNewProps:newProps forView:view withComponentData:componentData];
 }
 
 - (void)setNewProps:(NSMutableDictionary *)newProps
@@ -400,10 +402,8 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
       [self onViewUpdate:view before:before after:after];
     }
   } else if ([type isEqual:@"layout"] && [_enteringViews containsObject:[view reactTag]]) {
-    NSMutableDictionary *dataComponenetsByName = [_uiManager valueForKey:@"_componentDataByName"];
-    RCTComponentData *componentData = dataComponenetsByName[@"RCTView"];
     _enteringViewTargetValues[[view reactTag]] = [[REASnapshot alloc] init:view];
-    [self setNewProps:before.values forView:view withComponentData:componentData];
+    [self setNewProps:before.values forView:view];
   }
 }
 


### PR DESCRIPTION
## Description

Currently, if a React render happens during an `entering` layout animation and causes the layout of the animated component to change, that component will continue it's animation and remain at the position it finished.
This changes the behaviour of `entering` animations to instead move the component to the correct place after the animation finishes.
This issue (and this change) doesn't affect screens with `layout` layout animations, since these are already combined with `entering`.

## Changes

<!--
Please describe things you've changed here, make a **high level** overview, if change is simple you can omit this section.

For example:

- Added `foo` method which add bouncing animation
- Updated `about.md` docs
- Added caching in CI builds

-->

## Screenshots / GIFs

### Before
![Simulator Screen Recording - iPhone 13 - 2022-11-18 at 15 29 54](https://user-images.githubusercontent.com/49338439/202728217-4a1f4a88-10aa-425f-bf40-e6f91ab5a355.gif)


### After
![Simulator Screen Recording - iPhone 13 - 2022-11-18 at 15 37 39](https://user-images.githubusercontent.com/49338439/202729725-cba5e2f0-993e-4429-95ac-6872efd4b9c1.gif)

## Test code and steps to reproduce

<!--
Please include code that can be used to test this change and short description how this example should work.
This snippet should be as minimal as possible and ready to be pasted into editor (don't exclude exports or remove "not important" parts of reproduction example)
-->

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
