### PR TITLE
Fix monorepo CI

### DIFF
--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -34,10 +34,10 @@ jobs:
           mkdir packages
       - name: Create RootApp
         working-directory: monorepo
-        run: npx react-native@next init RootApp ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Create PackageApp
         working-directory: monorepo/packages
-        run: npx react-native@next init PackageApp ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp

--- a/.github/workflows/build-monorepo.yml
+++ b/.github/workflows/build-monorepo.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - "@tomekzaw/fix-monorepo-ci"
 
 jobs:
   build_android_reanimated_non_hoisted:

--- a/.github/workflows/build-monorepo.yml
+++ b/.github/workflows/build-monorepo.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - "@tomekzaw/fix-monorepo-ci"
 
 jobs:
   build_android_reanimated_non_hoisted:


### PR DESCRIPTION
## Description

This PR fixes the following error which occurs on iOS monorepo CI during `npx react-native init` phase:
```
✖ Installing Bundler
error Your Ruby version is 3.0.4, but your Gemfile specified 2.7.5
```

SInce we already run `pod install` once the project setup is complete, the solution is to add `--skip-install` flag which prevents installing dependencies during init.
