### PR TITLE
Add "guards" on iOS to avoid leaking CADisplayLink instances

### DIFF
--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -79,12 +79,18 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 
 - (void)runAnimation
 {
+  if (displayLink) {
+      return;
+  }
   displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
   [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
 }
 
 - (void)stopAnimation
 {
+  if (!displayLink) {
+      return;
+  }
   [displayLink invalidate];
   displayLink = nil;
   [self updateKeyboardFrame];


### PR DESCRIPTION
## Description

`REAKeyboardEventObserver` could leak `CADisplayLink` instances spinning `updateKeyboardFrame` calls. This happens when you dismiss the keyboard with `interactive` mode. For some reason `runAnimation` is executed several times hiding the previous `displayLink` value and so leaking. This simple PR adds a "guard" to avoid spin another instance if one is active.

## Checklist

- [ ] Included code example that can be used to test this change
- [ ] Updated TS types
- [ ] Added TS types tests
- [ ] Added unit / integration tests
- [ ] Updated documentation
- [ ] Ensured that CI passes
