### PR TITLE
Fix animated refs on Fabric

### DIFF
--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -6,11 +6,20 @@ import { getTag } from '../NativeMethods';
 import { getShadowNodeWrapperFromHostInstance } from '../fabricUtils';
 import {
   makeShareableCloneRecursive,
+  makeShareableShadowNodeWrapper,
   registerShareableMapping,
 } from '../shareables';
 
+function getShareableShadowNodeFromComponent(
+  component: Component
+): ShadowNodeWrapper {
+  return makeShareableShadowNodeWrapper(
+    getShadowNodeWrapperFromHostInstance(component)
+  );
+}
+
 const getTagValueFunction = global._IS_FABRIC
-  ? getShadowNodeWrapperFromHostInstance
+  ? getShareableShadowNodeFromComponent
   : getTag;
 
 export function useAnimatedRef<T extends Component>(): RefObjectFunction<T> {


### PR DESCRIPTION
## Summary

This PR fixes crash on Fabric when using synchronous measure/scrollTo etc – this error was a regression introduced in #3722.

The issue was that did not transform shadow node wrapper ref into shareable ref. Shareable ref was necessary for the UI side to recognize and extract the shadow node wrapper that was needed for the sync calls to execute.

## Test plan

Run FabricExample, use "Measure on UI" on the "Measure Example" screen and "ScrollTo on UI" button on the "ScrollTo Example" screen.