### PR TITLE
[iOS][Layout Animations] Remove `exiting` views from UIManager's view registry

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -33,8 +33,8 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 - (REASnapshot *)prepareSnapshotBeforeMountForView:(UIView *)view;
 - (BOOL)wantsHandleRemovalOfView:(UIView *)view;
 - (void)removeAnimationsFromSubtree:(UIView *)view;
-- (void)reattachChildren:(NSArray<UIView *> *)children
-             toContainer:(UIView *)container
+- (void)reattachChildren:(NSArray<id<RCTComponent>> *)children
+             toContainer:(id<RCTComponent>)container
                atIndices:(NSArray<NSNumber *> *)indices;
 - (void)onViewCreate:(UIView *)view after:(REASnapshot *)after;
 - (void)onViewUpdate:(UIView *)view before:(REASnapshot *)before after:(REASnapshot *)after;

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -33,7 +33,9 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 - (REASnapshot *)prepareSnapshotBeforeMountForView:(UIView *)view;
 - (BOOL)wantsHandleRemovalOfView:(UIView *)view;
 - (void)removeAnimationsFromSubtree:(UIView *)view;
-- (void)removeChildren:(NSArray<UIView *> *)children fromContainer:(UIView *)container;
+- (void)reattachChildren:(NSArray<UIView *> *)children
+             toContainer:(UIView *)container
+               atIndices:(NSArray<NSNumber *> *)indices;
 - (void)onViewCreate:(UIView *)view after:(REASnapshot *)after;
 - (void)onViewUpdate:(UIView *)view before:(REASnapshot *)before after:(REASnapshot *)after;
 

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -33,9 +33,9 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 - (REASnapshot *)prepareSnapshotBeforeMountForView:(UIView *)view;
 - (BOOL)wantsHandleRemovalOfView:(UIView *)view;
 - (void)removeAnimationsFromSubtree:(UIView *)view;
-- (void)reattachChildren:(NSArray<id<RCTComponent>> *)children
-             toContainer:(id<RCTComponent>)container
-               atIndices:(NSArray<NSNumber *> *)indices;
+- (void)reattachAnimatedChildren:(NSArray<id<RCTComponent>> *)children
+                     toContainer:(id<RCTComponent>)container
+                       atIndices:(NSArray<NSNumber *> *)indices;
 - (void)onViewCreate:(UIView *)view after:(REASnapshot *)after;
 - (void)onViewUpdate:(UIView *)view before:(REASnapshot *)before after:(REASnapshot *)after;
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -336,9 +336,9 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
   return YES;
 }
 
-- (void)reattachChildren:(NSArray<id<RCTComponent>> *)children
-             toContainer:(id<RCTComponent>)container
-               atIndices:(NSArray<NSNumber *> *)indices
+- (void)reattachAnimatedChildren:(NSArray<id<RCTComponent>> *)children
+                     toContainer:(id<RCTComponent>)container
+                       atIndices:(NSArray<NSNumber *> *)indices
 {
   if (![container isKindOfClass:[UIView class]]) {
     return;

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -336,15 +336,22 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
   return YES;
 }
 
-- (void)reattachChildren:(NSArray<UIView *> *)children
-             toContainer:(UIView *)container
+- (void)reattachChildren:(NSArray<id<RCTComponent>> *)children
+             toContainer:(id<RCTComponent>)container
                atIndices:(NSArray<NSNumber *> *)indices
 {
+  if (![container isKindOfClass:[UIView class]]) {
+    return;
+  }
   for (int i = 0; i < children.count; i++) {
-    UIView *child = [children objectAtIndex:i];
+    id<RCTComponent> child = [children objectAtIndex:i];
+    if (![child isKindOfClass:[UIView class]]) {
+      continue;
+    }
+    UIView *childView = (UIView *)child;
     NSNumber *originalIndex = [indices objectAtIndex:i];
-    if ([self startAnimationsRecursive:child removingSubviewsWithoutAnimations:true]) {
-      [container insertSubview:child atIndex:[originalIndex intValue]];
+    if ([self startAnimationsRecursive:childView removingSubviewsWithoutAnimations:true]) {
+      [(UIView *)container insertSubview:childView atIndex:[originalIndex intValue]];
     }
   }
 }

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -31,7 +31,6 @@
 @end
 
 @implementation REAUIManager {
-  RCTLayoutAnimationGroup *_reactLayoutAnimationGroup;
   NSMutableDictionary<NSNumber *, NSMutableSet<id<RCTComponent>> *> *_toBeRemovedRegister;
   NSMutableDictionary<NSNumber *, NSNumber *> *_parentMapper;
   REAAnimationsManager *_animationsManager;
@@ -45,13 +44,6 @@
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  // setting a layout animation group with a deleting animation in order to
-  // allows us to call a different method in RCTUIManager for cleaning up exiting views
-  RCTLayoutAnimation *deletingAnimation = [[RCTLayoutAnimation alloc] initWithDuration:0 config:@{}];
-  _reactLayoutAnimationGroup = [[RCTLayoutAnimationGroup alloc] initWithCreatingLayoutAnimation:nil
-                                                                        updatingLayoutAnimation:nil
-                                                                        deletingLayoutAnimation:deletingAnimation
-                                                                                       callback:nil];
   if (!_blockSetter) {
     _blockSetter = true;
 
@@ -98,7 +90,9 @@
                 registry:registry];
 
   if (isLayoutAnimationEnabled) {
-    [_animationsManager reattachChildren:permanentlyRemovedChildren toContainer:container atIndices:removeAtIndices];
+    [_animationsManager reattachAnimatedChildren:permanentlyRemovedChildren
+                                     toContainer:container
+                                       atIndices:removeAtIndices];
   }
 }
 

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -98,13 +98,7 @@
                 registry:registry];
 
   if (isLayoutAnimationEnabled) {
-    NSMutableArray<UIView *> *children = [NSMutableArray new];
-    for (id<RCTComponent> child in permanentlyRemovedChildren) {
-      if ([child isKindOfClass:[UIView class]]) {
-        [children addObject:(UIView *)child];
-      }
-    }
-    [_animationsManager reattachChildren:children toContainer:(UIView *)container atIndices:removeAtIndices];
+    [_animationsManager reattachChildren:permanentlyRemovedChildren toContainer:container atIndices:removeAtIndices];
   }
 }
 

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -24,12 +24,6 @@
         removeAtIndices:(NSArray<NSNumber *> *)removeAtIndices
                registry:(NSMutableDictionary<NSNumber *, id<RCTComponent>> *)registry;
 
-- (void)_removeChildren:(NSArray<UIView *> *)children fromContainer:(UIView *)container;
-
-- (void)_removeChildren:(NSArray<UIView *> *)children
-          fromContainer:(UIView *)container
-          withAnimation:(RCTLayoutAnimationGroup *)animation;
-
 - (RCTViewManagerUIBlock)uiBlockWithLayoutUpdateForRootView:(RCTRootShadowView *)rootShadowView;
 
 - (NSArray<id<RCTComponent>> *)_childrenToRemoveFromContainer:(id<RCTComponent>)container
@@ -79,21 +73,6 @@
   }
 }
 
-- (void)_removeChildren:(NSArray<UIView *> *)children
-          fromContainer:(UIView *)container
-          withAnimation:(RCTLayoutAnimationGroup *)animation
-{
-  if (animation == _reactLayoutAnimationGroup) {
-    // if a removed view in this batch has an `exiting` animation,
-    // let REAAnimationsManager handle the removal
-    [_animationsManager removeChildren:children fromContainer:container];
-  } else {
-    // otherwise, if there's a layout animation group set,
-    // delegate to the React Native implementation for layout animations
-    [super _removeChildren:children fromContainer:container withAnimation:animation];
-  }
-}
-
 - (void)_manageChildren:(NSNumber *)containerTag
         moveFromIndices:(NSArray<NSNumber *> *)moveFromIndices
           moveToIndices:(NSArray<NSNumber *> *)moveToIndices
@@ -102,40 +81,13 @@
         removeAtIndices:(NSArray<NSNumber *> *)removeAtIndices
                registry:(NSMutableDictionary<NSNumber *, id<RCTComponent>> *)registry
 {
-  if (!reanimated::FeaturesConfig::isLayoutAnimationEnabled()) {
-    [super _manageChildren:containerTag
-           moveFromIndices:moveFromIndices
-             moveToIndices:moveToIndices
-         addChildReactTags:addChildReactTags
-              addAtIndices:addAtIndices
-           removeAtIndices:removeAtIndices
-                  registry:registry];
-    return;
+  bool isLayoutAnimationEnabled = reanimated::FeaturesConfig::isLayoutAnimationEnabled();
+  id<RCTComponent> container;
+  NSArray<id<RCTComponent>> *permanentlyRemovedChildren;
+  if (isLayoutAnimationEnabled) {
+    container = registry[containerTag];
+    permanentlyRemovedChildren = [self _childrenToRemoveFromContainer:container atIndices:removeAtIndices];
   }
-
-  // Reanimated changes /start
-  BOOL isUIViewRegistry = ((id)registry == (id)[self valueForKey:@"_viewRegistry"]);
-  if (isUIViewRegistry) {
-    BOOL wasProxyRemovalSet = [self valueForKey:@"_layoutAnimationGroup"] == _reactLayoutAnimationGroup;
-    BOOL wantProxyRemoval = NO;
-    if (!wasProxyRemovalSet) {
-      id<RCTComponent> container = registry[containerTag];
-      NSArray<id<RCTComponent>> *permanentlyRemovedChildren = [self _childrenToRemoveFromContainer:container
-                                                                                         atIndices:removeAtIndices];
-      for (UIView *removedChild in permanentlyRemovedChildren) {
-        if ([_animationsManager wantsHandleRemovalOfView:removedChild]) {
-          wantProxyRemoval = YES;
-          break;
-        }
-        [_animationsManager removeAnimationsFromSubtree:removedChild];
-      }
-      if (wantProxyRemoval) {
-        // set layout animation group
-        [super setNextLayoutAnimationGroup:_reactLayoutAnimationGroup];
-      }
-    }
-  }
-  // Reanimated changes /end
 
   [super _manageChildren:containerTag
          moveFromIndices:moveFromIndices
@@ -144,6 +96,16 @@
             addAtIndices:addAtIndices
          removeAtIndices:removeAtIndices
                 registry:registry];
+
+  if (isLayoutAnimationEnabled) {
+    NSMutableArray<UIView *> *children = [NSMutableArray new];
+    for (id<RCTComponent> child in permanentlyRemovedChildren) {
+      if ([child isKindOfClass:[UIView class]]) {
+        [children addObject:(UIView *)child];
+      }
+    }
+    [_animationsManager reattachChildren:children toContainer:(UIView *)container atIndices:removeAtIndices];
+  }
 }
 
 - (void)callAnimationForTree:(UIView *)view parentTag:(NSNumber *)parentTag

--- a/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/LayoutReanimation/REAUIManager.mm
@@ -90,6 +90,16 @@
                 registry:registry];
 
   if (isLayoutAnimationEnabled) {
+    // we sort the (index, view) pairs to make sure we insert views back in order
+    NSMutableArray<NSArray<id> *> *removedViewsWithIndices = [NSMutableArray new];
+    for (int i = 0; i < removeAtIndices.count; i++) {
+      removedViewsWithIndices[i] = @[ removeAtIndices[i], permanentlyRemovedChildren[i] ];
+    }
+    [removedViewsWithIndices
+        sortUsingComparator:^NSComparisonResult(NSArray<id> *_Nonnull obj1, NSArray<id> *_Nonnull obj2) {
+          return [(NSNumber *)obj1[0] compare:(NSNumber *)obj2[0]];
+        }];
+
     [_animationsManager reattachAnimatedChildren:permanentlyRemovedChildren
                                      toContainer:container
                                        atIndices:removeAtIndices];

--- a/src/reanimated2/layoutReanimation/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/animationsManager.ts
@@ -1,14 +1,11 @@
 import { runOnUI } from '../core';
 import { withStyleAnimation } from '../animation/styleAnimation';
-import { LogBox } from 'react-native';
 import { SharedValue } from '../commonTypes';
 import { makeUIMutable } from '../mutables';
 import {
   LayoutAnimationFunction,
   LayoutAnimationsValues,
 } from './animationBuilder';
-
-LogBox.ignoreLogs(['Overriding previous layout animation with']);
 
 const TAG_OFFSET = 1e9;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Currently, when views with an `exiting` animation are unmounted, any deleted in that transaction aren't removed from the UIManager's view registry (the mapping of react tags to native views).
This can cause memory leaks of removed views.

This PR restores the original behaviour of UIManager when removing views, allowing it to clean them up properly, and reattaches the views with `exiting` animations after the transaction removing the views has completed.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
- In example app, go to "Entering and Exiting with Layout"
- Set a breakpoint somewhere in `RCTUIManager`, for example `_manageChildren`.
- Press "Toggle" to create the animated views, and note the number of entries in `_viewRegistry`.
- Disable the breakpoint, resume the app and start spamming the toggle button.
- Enable the breakpoint again, and press toggle one more time.
- The number of entries in `_viewRegistry` should be the same as before spamming toggle.