### PR TITLE
Use getBool instead of asBool to make it work with RN pre 69

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -306,7 +306,7 @@ void RuntimeDecorator::decorateUIRuntime(
                   const jsi::Value *args,
                   size_t count) -> jsi::Value {
     endLayoutAnimationFunction(
-        args[0].asNumber(), args[1].asBool(), args[2].asBool());
+        args[0].asNumber(), args[1].getBool(), args[2].getBool());
     return jsi::Value::undefined();
   };
   jsi::Value _notifyAboutEnd = jsi::Function::createFromHostFunction(


### PR DESCRIPTION
## Summary

JSI's `asBool` was only added in RN 69. This PR changes `asBool` to `getBool` calls in order to support older RN versions.

## Test plan

Check if things build on RN 67 and on RN 70