### PR TITLE
Add GestureHandlerRootView in WorkletExample

### DIFF
--- a/FabricExample/src/WorkletExample.tsx
+++ b/FabricExample/src/WorkletExample.tsx
@@ -16,6 +16,7 @@ import { Button, Text, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
+  GestureHandlerRootView,
   PanGestureHandler,
 } from 'react-native-gesture-handler';
 
@@ -181,11 +182,13 @@ function ThrowErrorFromGestureDetectorDemo() {
   });
 
   return (
-    <GestureDetector gesture={gesture}>
-      <View style={{ width: 100, height: 100, backgroundColor: 'tomato' }}>
-        <Text>GestureDetector</Text>
-      </View>
-    </GestureDetector>
+    <GestureHandlerRootView>
+      <GestureDetector gesture={gesture}>
+        <View style={{ width: 100, height: 100, backgroundColor: 'tomato' }}>
+          <Text>GestureDetector</Text>
+        </View>
+      </GestureDetector>
+    </GestureHandlerRootView>
   );
 }
 
@@ -197,12 +200,14 @@ function ThrowErrorFromUseAnimatedGestureHandlerDemo() {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={gestureHandler}>
-      <Animated.View
-        style={{ width: 100, height: 100, backgroundColor: 'gold' }}>
-        <Text>PanGestureHandler + useAnimatedGestureHandler</Text>
-      </Animated.View>
-    </PanGestureHandler>
+    <GestureHandlerRootView>
+      <PanGestureHandler onGestureEvent={gestureHandler}>
+        <Animated.View
+          style={{ width: 100, height: 100, backgroundColor: 'gold' }}>
+          <Text>PanGestureHandler + useAnimatedGestureHandler</Text>
+        </Animated.View>
+      </PanGestureHandler>
+    </GestureHandlerRootView>
   );
 }
 

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -1774,11 +1774,6 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
   integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
-"@types/invariant@^2.2.35":
-  version "2.2.35"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.35.tgz#cd3ebf581a6557452735688d8daba6cf0bd5a3be"
-  integrity sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"


### PR DESCRIPTION
## Summary

This PR adds `<GestureHandlerRootView>` in `WorkletExample` that are not necessary unless you paste the demo directly to `App.tsx` and lose 30 minutes of your life trying to figure out what's wrong.

## Test plan

1. Launch FabricExample
2. Check if WorkletExample works
