### PR TITLE
Fix new implementation iOS crash on reload while animation is running

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -189,9 +189,10 @@ void NativeReanimatedModule::installCoreFunctions(
 NativeReanimatedModule::~NativeReanimatedModule() {
   if (runtimeHelper) {
     runtimeHelper->valueUnpacker = nullptr;
-    // event handler registry stores some JSI values from UI runtime, so it has
-    // to go away before we tear down the runtime
+    // event handler registry and frame callbacks store some JSI values from UI
+    // runtime, so they have to go away before we tear down the runtime
     eventHandlerRegistry.reset();
+    frameCallbacks.clear();
     runtime.reset();
     // make sure uiRuntimeDestroyed is set after the runtime is deallocated
     runtimeHelper->uiRuntimeDestroyed = true;


### PR DESCRIPTION
## Summary

This PR fixes an iOS crash with Hermes on app reload that occurs only if some animation is still running:

<img width="1512" alt="crash" src="https://user-images.githubusercontent.com/20516055/205723759-1ed56999-64e7-4ce6-a4ae-baa686f2b2a4.png">

## Test plan

1. Build and launch Example app on iOS simulator
2. Open Animated Style Update Example
3. Increase duration to 5000 ms
4. Click "Toggle" button
5. Press <kbd>r</kbd> in simulator
6. Make sure the app reloads correctly
