### PR TITLE
Use weak object for shareables on V8

### DIFF
--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -14,7 +14,7 @@
 #include "RuntimeManager.h"
 #include "Scheduler.h"
 
-#define HAS_JS_WEAK_OBJECTS JS_RUNTIME_HERMES
+#define HAS_JS_WEAK_OBJECTS (JS_RUNTIME_HERMES || JS_RUNTIME_V8)
 
 using namespace facebook;
 


### PR DESCRIPTION
## Summary

This PR enables weak object implementation for shareables when using V8 runtime.

As @Kudo mentioned in https://github.com/software-mansion/react-native-reanimated/pull/3722#discussion_r1040966675, react-native-v8 exposes weak objects API via JSI (see [here](https://github.com/Kudo/react-native-v8/blob/96a1a2c8a35349967a3ad7219106a3475b85433a/src/v8runtime/V8Runtime.cpp#L982-L997)).

## Test plan

Run Example app with react-native-v8 and check if everything works.
