### PR TITLE
Avoid multiple rAF calls over JSI when called on the same frame

### DIFF
--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -73,6 +73,7 @@ declare global {
     reportFatalError: (error: Error) => void;
   };
   const _frameCallbackRegistry: FrameCallbackRegistryUI;
+  const requestAnimationFrame: (callback: (time: number) => void) => number;
   const console: Console;
 
   namespace NodeJS {
@@ -138,6 +139,7 @@ declare global {
       __workletsCache?: Map<string, (...args: any[]) => any>;
       __handleCache?: WeakMap<any, any>;
       __mapperRegistry?: MapperRegistry;
+      requestAnimationFrame: (callback: (time: number) => void) => number;
       console: Console;
     }
   }

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -1,5 +1,6 @@
 import { reportFatalErrorOnJS } from './errors';
 import NativeReanimatedModule from './NativeReanimated';
+import { isJest } from './PlatformChecker';
 import { runOnUI, runOnJS } from './threads';
 
 // callGuard is only used with debug builds
@@ -87,6 +88,8 @@ Possible solutions are:
 export function initializeUIRuntime() {
   NativeReanimatedModule.installCoreFunctions(callGuardDEV, valueUnpacker);
 
+  const IS_JEST = isJest();
+
   const capturableConsole = console;
   runOnUI(() => {
     'worklet';
@@ -110,27 +113,31 @@ export function initializeUIRuntime() {
       info: runOnJS(capturableConsole.info),
     };
 
-    const nativeRequestAnimationFrame = global.requestAnimationFrame;
-    let callbacks: Array<(time: number) => void> = [];
-    global.requestAnimationFrame = (
-      callback: (timestamp: number) => void
-    ): number => {
-      callbacks.push(callback);
-      if (callbacks.length === 1) {
-        // We schedule native requestAnimationFrame only when the first callback
-        // is added and then use it to execute all the enqueued callbacks. Once
-        // the callbacks are run, we clear the array.
-        nativeRequestAnimationFrame((timestamp) => {
-          const currentCallbacks = callbacks;
-          callbacks = [];
-          currentCallbacks.forEach((f) => f(timestamp));
-        });
-      }
-      // Reaminated currently does not support cancelling calbacks requested with
-      // requestAnimationFrame. We return -1 as identifier which isn't in line
-      // with the spec but it should give users better clue in case they actually
-      // attempt to store the value returned from rAF and use it for cancelling.
-      return -1;
-    };
+    if (!IS_JEST) {
+      // Jest mocks requestAnimationFrame API and it does not like if that mock gets overridden
+      // so we avoid doing requestAnimationFrame batching in Jest environment.
+      const nativeRequestAnimationFrame = global.requestAnimationFrame;
+      let callbacks: Array<(time: number) => void> = [];
+      global.requestAnimationFrame = (
+        callback: (timestamp: number) => void
+      ): number => {
+        callbacks.push(callback);
+        if (callbacks.length === 1) {
+          // We schedule native requestAnimationFrame only when the first callback
+          // is added and then use it to execute all the enqueued callbacks. Once
+          // the callbacks are run, we clear the array.
+          nativeRequestAnimationFrame((timestamp) => {
+            const currentCallbacks = callbacks;
+            callbacks = [];
+            currentCallbacks.forEach((f) => f(timestamp));
+          });
+        }
+        // Reaminated currently does not support cancelling calbacks requested with
+        // requestAnimationFrame. We return -1 as identifier which isn't in line
+        // with the spec but it should give users better clue in case they actually
+        // attempt to store the value returned from rAF and use it for cancelling.
+        return -1;
+      };
+    }
   })();
 }

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -109,5 +109,28 @@ export function initializeUIRuntime() {
       error: runOnJS(capturableConsole.error),
       info: runOnJS(capturableConsole.info),
     };
+
+    const nativeRequestAnimationFrame = global.requestAnimationFrame;
+    let callbacks: Array<(time: number) => void> = [];
+    global.requestAnimationFrame = (
+      callback: (timestamp: number) => void
+    ): number => {
+      callbacks.push(callback);
+      if (callbacks.length === 1) {
+        // We schedule native requestAnimationFrame only when the first callback
+        // is added and then use it to execute all the enqueued callbacks. Once
+        // the callbacks are run, we clear the array.
+        nativeRequestAnimationFrame((timestamp) => {
+          const currentCallbacks = callbacks;
+          callbacks = [];
+          currentCallbacks.forEach((f) => f(timestamp));
+        });
+      }
+      // Reaminated currently does not support cancelling calbacks requested with
+      // requestAnimationFrame. We return -1 as identifier which isn't in line
+      // with the spec but it should give users better clue in case they actually
+      // attempt to store the value returned from rAF and use it for cancelling.
+      return -1;
+    };
   })();
 }

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -132,7 +132,7 @@ export function initializeUIRuntime() {
             currentCallbacks.forEach((f) => f(timestamp));
           });
         }
-        // Reaminated currently does not support cancelling calbacks requested with
+        // Reanimated currently does not support cancelling calbacks requested with
         // requestAnimationFrame. We return -1 as identifier which isn't in line
         // with the spec but it should give users better clue in case they actually
         // attempt to store the value returned from rAF and use it for cancelling.


### PR DESCRIPTION
## Summary

This PR overrides requestAnimationFrame on the UI runtime such that it keeps a list of callbacks for a given frame locally and only calls into the native requestAnimationFrame once in every frame where the method gets triggered.

This results in a greatly reduced number of calls that need to happen over JSI in case where there are multiple components/values being animated at the same time. This also, apparently, fixes a crash in BokehExample on android that was due to some race condition issues in the naitve requestAnimationFrame implementation. Calling it only once in a given frame resolves that issue.

## Test plan

Run BokehExample on Android with the number of circles bumped up to 300. The app should not crash and perform well on an emulator (note that 300 will be too high for low-end devices but still the app shouldn't crash).
