### PR TITLE
Remove _setGloalConsole JSI method

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -54,22 +54,6 @@ void RuntimeDecorator::decorateRuntime(
       rt, jsi::PropNameID::forAscii(rt, "_log"), 1, callback);
   rt.global().setProperty(rt, "_log", log);
 
-  auto setGlobalConsole = [](jsi::Runtime &rt,
-                             const jsi::Value &thisValue,
-                             const jsi::Value *args,
-                             size_t count) -> jsi::Value {
-    rt.global().setProperty(rt, "console", args[0]);
-    return jsi::Value::undefined();
-  };
-  rt.global().setProperty(
-      rt,
-      "_setGlobalConsole",
-      jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_setGlobalConsole"),
-          1,
-          setGlobalConsole));
-
   auto chronoNow = [](jsi::Runtime &rt,
                       const jsi::Value &thisValue,
                       const jsi::Value *args,

--- a/plugin.js
+++ b/plugin.js
@@ -32,7 +32,6 @@ const globals = new Set([
   'this',
   'console',
   'performance',
-  '_setGlobalConsole',
   '_chronoNow',
   'Date',
   'Array',

--- a/src/reanimated2/__mocks__/NativeReanimated.ts
+++ b/src/reanimated2/__mocks__/NativeReanimated.ts
@@ -2,10 +2,6 @@
 // @ts-nocheck
 import MutableValue from './MutableValue';
 
-global._setGlobalConsole = (_val) => {
-  // noop
-};
-
 const NOOP = () => {
   // noop
 };

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -197,7 +197,7 @@ if (!isWeb() && isConfigured()) {
   const capturableConsole = console;
   runOnUI(() => {
     'worklet';
-    // @ts-ignore typescript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtie console version
+    // @ts-ignore TypeScript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtime console version
     global.console = {
       debug: runOnJS(capturableConsole.debug),
       log: runOnJS(capturableConsole.log),

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,4 +1,3 @@
-/* global _setGlobalConsole */
 import NativeReanimatedModule from './NativeReanimated';
 import { nativeShouldBeMock, shouldBeUseWeb, isWeb } from './PlatformChecker';
 import { BasicWorkletFunction, Value3D, ValueRotation } from './commonTypes';
@@ -17,13 +16,6 @@ import { LayoutAnimationFunction } from './layoutReanimation';
 export { stopMapper } from './mappers';
 export { runOnJS, runOnUI } from './threads';
 export { getTimestamp } from './time';
-
-if (global._setGlobalConsole === undefined) {
-  // it can happen when Reanimated plugin wasn't added, but the user uses the only API from version 1
-  global._setGlobalConsole = () => {
-    // noop
-  };
-}
 
 export type ReanimatedConsole = Pick<
   Console,
@@ -205,14 +197,14 @@ if (!isWeb() && isConfigured()) {
   const capturableConsole = console;
   runOnUI(() => {
     'worklet';
-    const console = {
+    // @ts-ignore typescript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtie console version
+    global.console = {
       debug: runOnJS(capturableConsole.debug),
       log: runOnJS(capturableConsole.log),
       warn: runOnJS(capturableConsole.warn),
       error: runOnJS(capturableConsole.error),
       info: runOnJS(capturableConsole.info),
     };
-    _setGlobalConsole(console);
   })();
 }
 

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -6,7 +6,6 @@ import type {
   ShareableRef,
   ShareableSyncDataHolderRef,
 } from './commonTypes';
-import type { ReanimatedConsole } from './core';
 import type { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
 import type { ShadowNodeWrapper } from './hook/commonTypes';
 import { LayoutAnimationStartFunction } from './layoutReanimation';
@@ -19,7 +18,6 @@ declare global {
   const _frameTimestamp: number | null;
   const _eventTimestamp: number;
   const __reanimatedModuleProxy: NativeReanimated;
-  const _setGlobalConsole: (console?: ReanimatedConsole) => void;
   const _log: (s: string) => void;
   const _getCurrentTime: () => number;
   const _getTimestamp: () => number;
@@ -66,6 +64,7 @@ declare global {
     now: () => number;
   };
   const _frameCallbackRegistry: FrameCallbackRegistryUI;
+  const console: Console;
 
   namespace NodeJS {
     interface Global {
@@ -75,7 +74,6 @@ declare global {
       _frameTimestamp: number | null;
       _eventTimestamp: number;
       __reanimatedModuleProxy: NativeReanimated;
-      _setGlobalConsole: (console?: ReanimatedConsole) => void;
       _log: (s: string) => void;
       _getCurrentTime: () => number;
       _getTimestamp: () => number;
@@ -122,6 +120,7 @@ declare global {
       __workletsCache?: Map<string, (...args: any[]) => any>;
       __handleCache?: WeakMap<any, any>;
       __mapperRegistry?: MapperRegistry;
+      console: Console;
     }
   }
 }

--- a/src/reanimated2/js-reanimated/global.ts
+++ b/src/reanimated2/js-reanimated/global.ts
@@ -4,9 +4,6 @@ import { shouldBeUseWeb } from '../PlatformChecker';
 const initializeGlobalsForWeb = () => {
   if (shouldBeUseWeb()) {
     global._frameTimestamp = null;
-    global._setGlobalConsole = (_val) => {
-      // noop
-    };
     global._measure = () => {
       console.warn(
         "[Reanimated] You can't use `measure` with Chrome Debugger or with web version"
@@ -40,10 +37,10 @@ const initializeGlobalsForWeb = () => {
 };
 
 /*
-  If a file doesn't export anything, tree shaking doesn't pack 
-  it into the JS bundle. In effect, the code inside of this file 
-  will never execute. That is why we wrapped initialization code 
-  into a function, and we call this one during creating 
+  If a file doesn't export anything, tree shaking doesn't pack
+  it into the JS bundle. In effect, the code inside of this file
+  will never execute. That is why we wrapped initialization code
+  into a function, and we call this one during creating
   the module export object.
 */
 


### PR DESCRIPTION
## Summary

After #3838 we can now access the main global object via `global` variable. This eliminates a need for _setGlobalConsole JSI method that we'd install in the UI runtime only so that we can set the console object as global on the UI runtime. In this PR we change the call to _setGlobalConsole with just reassigning global.console.

## Test plan

Add some logs in worklets, run the app, see the logs appear on the output, also that console.warn displays in the log box.