### PR TITLE
Fix crash due to concurrent writes to frameCallbacks vector

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -212,12 +212,12 @@ void NativeReanimatedModule::scheduleOnUI(
   assert(
       shareableWorklet->valueType() == Shareable::WorkletType &&
       "only worklets can be scheduled to run on UI");
-  frameCallbacks.push_back([=](double timestamp) {
+  auto uiRuntime = runtimeHelper->uiRuntime();
+  scheduler->scheduleOnUI([=] {
     jsi::Runtime &rt = *runtimeHelper->uiRuntime();
     auto workletValue = shareableWorklet->getJSValue(rt);
     runtimeHelper->runOnUIGuarded(workletValue);
   });
-  maybeRequestRender();
 }
 
 jsi::Value NativeReanimatedModule::makeSynchronizedDataHolder(

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -212,7 +212,6 @@ void NativeReanimatedModule::scheduleOnUI(
   assert(
       shareableWorklet->valueType() == Shareable::WorkletType &&
       "only worklets can be scheduled to run on UI");
-  auto uiRuntime = runtimeHelper->uiRuntime();
   scheduler->scheduleOnUI([=] {
     jsi::Runtime &rt = *runtimeHelper->uiRuntime();
     auto workletValue = shareableWorklet->getJSValue(rt);


### PR DESCRIPTION
## Summary

This PR fixes crashes related to concurrent writes to a non-thread-safe frameCallbacks vector. The primary role of frameCallbacks vector was to facilitate requestAnimationFrame calls and hence it has not been designed to allow for other than the main thread to append their callbacks. However, after recent rewrite #3722 we introduced a new methods "scheduleOnUI" that was originally meant to interface with a thread-safe scheduler API but was later updated (see c8a77da44a6cf53f14f224f6f15527a26c770f09) to use frameCallbacks in order for errors to be handled using the same code-path the rAF uses. That change introduces a bug in which we'd access and modify that vector from different threads which is undesirable. This PR reverts that change and since #3846 provides a better way of handling JS-errors there is no longer need for scheduleOnUI callbacks to go throught the requestAnimationFrame codepath.

## Test plan

The easiest way to reproduce the crash we could find was by using BokehExample.tsx on Android. This would normally result in a crash after a couple of seconds of running. With the increased number of circles in that example (e.g. 400) the crash would be almost immediate. This change was tested on that example with 400 circles and the crash would not appear even after some time after launch (few minutes).
