### PR TITLE
Fix unnecessary calls startMapper/stopMapper in useAnimatedReaction

### DIFF
--- a/src/reanimated2/hook/useAnimatedReaction.ts
+++ b/src/reanimated2/hook/useAnimatedReaction.ts
@@ -21,8 +21,8 @@ export function useAnimatedReaction<T>(
   const previous = useSharedValue<T | null>(null);
   if (dependencies === undefined) {
     dependencies = [
-      Object.values(prepare._closure ?? {}),
-      Object.values(react._closure ?? {}),
+      ...Object.values(prepare._closure ?? {}),
+      ...Object.values(react._closure ?? {}),
       prepare.__workletHash,
       react.__workletHash,
     ];


### PR DESCRIPTION
## Summary
Hey!
If we do not specify an array of dependencies in useAnimatedReaction and prepare or react has external dependent values (._closure), then the startMapper and stopMapper methods will be called an extra time on each render, even if the external values have not changed.

## Test plan
If the functional component has such a block of code, then useEffect is called inside useAnimatedReaction on every render before these changes.
```
  const value = 1;
  useAnimatedReaction(
    () => value,
    () => {},
  );
```
