### PR TITLE
Remove redundant call to `parseColors`

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -460,15 +460,6 @@ export function useAnimatedStyle<T extends AnimatedStyle>(
       };
     }
 
-    if (!shouldBeUseWeb()) {
-      updaterFn = () => {
-        'worklet';
-        const style = updaterFn();
-        parseColors(style);
-        return style;
-      };
-    }
-
     if (isJest()) {
       fun = () => {
         'worklet';

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -10,7 +10,6 @@ import {
   buildWorkletsHash,
   getStyleWithoutAnimations,
   isAnimated,
-  parseColors,
   styleDiff,
   validateAnimatedStyles,
 } from './utils';
@@ -21,7 +20,7 @@ import {
   ViewDescriptorsSet,
   ViewRefSet,
 } from '../ViewDescriptorsSet';
-import { isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest } from '../PlatformChecker';
 import {
   AnimationObject,
   Timestamp,


### PR DESCRIPTION
## Summary

This PR removes a chunk of code that was supposed to be executed only if a worklet has some optimization applied in Babel plugin but since #3722 completely removes these optimizations, this chunk of code is no longer necessary.

Co-authored-by: @kmagiera @piaskowyk 

## Test plan

Check if BokehExample works correctly. 