### PR TITLE
fixed jsi interface injection to allow brown field app use the library

### DIFF
--- a/ios/native/UIResponder+Reanimated.h
+++ b/ios/native/UIResponder+Reanimated.h
@@ -4,7 +4,7 @@
 #ifndef RCT_NEW_ARCH_ENABLED
 #ifndef DONT_AUTOINSTALL_REANIMATED
 
-@interface UIResponder (Reanimated) <RCTCxxBridgeDelegate>
+@interface NSObject (Reanimated) <RCTCxxBridgeDelegate>
 
 @end
 

--- a/ios/native/UIResponder+Reanimated.mm
+++ b/ios/native/UIResponder+Reanimated.mm
@@ -16,7 +16,7 @@ typedef JSCExecutorFactory ExecutorFactory;
 #ifndef RCT_NEW_ARCH_ENABLED
 #ifndef DONT_AUTOINSTALL_REANIMATED
 
-@implementation UIResponder (Reanimated)
+@implementation NSObject (Reanimated)
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
   const auto installer = reanimated::REAJSIExecutorRuntimeInstaller(bridge, NULL);


### PR DESCRIPTION
## Summary

It's not necessary to extend UIResponder since in the implantation file, there is no usage of the methods from UIResponder. Instead, people will have issue with third party libraries which are handling the bridge, e.g. CodePush. RCTBridge is only require you to have NSObject and this should works.

## Test plan

Have an app and let codepush to handle the bridge initialization. 
