### PR TITLE
Fix `runOnUI` import in ScrollToExample

### DIFF
--- a/FabricExample/src/ScrollToExample.tsx
+++ b/FabricExample/src/ScrollToExample.tsx
@@ -1,5 +1,9 @@
 /* global _WORKLET */
-import Animated, { runOnUI, scrollTo, useAnimatedRef } from 'react-native-reanimated';
+import Animated, {
+  runOnUI,
+  scrollTo,
+  useAnimatedRef,
+} from 'react-native-reanimated';
 import { Button, StyleSheet, Switch, Text, View } from 'react-native';
 
 import React from 'react';

--- a/FabricExample/src/ScrollToExample.tsx
+++ b/FabricExample/src/ScrollToExample.tsx
@@ -1,9 +1,8 @@
 /* global _WORKLET */
-import Animated, { scrollTo, useAnimatedRef } from 'react-native-reanimated';
+import Animated, { runOnUI, scrollTo, useAnimatedRef } from 'react-native-reanimated';
 import { Button, StyleSheet, Switch, Text, View } from 'react-native';
 
 import React from 'react';
-import { runOnUI } from '../../src/reanimated2/core';
 
 export default function ScrollToExample() {
   const [animated, setAnimated] = React.useState(true);


### PR DESCRIPTION
## Summary

This PR fixes the import of `runOnUI` in ScrollToExample.tsx

## Test plan

Launch FabricExample, open ScrollToExample and check if it works.
