### PR TITLE
Add user-friendly error message when worklet cannot be created due to missing Babel plugin

### DIFF
--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -27,7 +27,7 @@ if (__DEV__) {
   try {
     runOnUI(() => {
       'worklet';
-    })();
+    });
   } catch (e) {
     throw new Error(
       'Failed to create a worklet. Did you forget to add Reanimated Babel plugin in babel.config.js? See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation#babel-plugin.'

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -23,6 +23,18 @@ export function runOnUI<A extends any[], R>(
   };
 }
 
+if (__DEV__) {
+  try {
+    runOnUI(() => {
+      'worklet';
+    })();
+  } catch (e) {
+    throw new Error(
+      'Failed to create a worklet. Did you forget to add Reanimated Babel plugin in babel.config.js? See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation#babel-plugin.'
+    );
+  }
+}
+
 export function runOnJS<A extends any[], R>(
   fun: ComplexWorkletFunction<A, R>
 ): (...args: A) => void {


### PR DESCRIPTION
## Summary

This PR adds an user-friendly error message when worklet cannot be created due to missing Reanimated Babel plugin.

Before:
![before](https://user-images.githubusercontent.com/20516055/210056688-18ef9023-cd9b-4f05-8384-61c2056fed00.png)

After:
![after](https://user-images.githubusercontent.com/20516055/210056691-23b01891-7b27-493f-af1d-aa4df664d6bf.png)

## Test plan

Check on a fresh RN app without editing `babel.config.js`.
