### PR TITLE
fix: ReDoS when parsing colors

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -8,7 +8,7 @@
 
 /* eslint no-bitwise: 0 */
 import { Platform } from 'react-native';
-import { makeRemote, makeShareable, isConfigured } from './core';
+import { isConfigured, makeRemote, makeShareable } from './core';
 
 interface RGB {
   r: number;
@@ -23,7 +23,7 @@ interface HSV {
 }
 
 // var INTEGER = '[-+]?\\d+';
-const NUMBER = '[-+]?\\d*\\.?\\d+';
+const NUMBER = '[-+]?\\d*(?:\\.\\d*)?';
 const PERCENTAGE = NUMBER + '%';
 
 function call(...args: unknown[]): string {


### PR DESCRIPTION
## Summary

This fix was launched in release 2.10. I cannot upgrade my dependencies from 2.8 to 2.10 but I would like to fix this issue that synk auditied me.

## Test plan

I copied the code from [here](#3382) so I suppose it is already tested.
