### PR TITLE
Add missing argument `oneWayReadsOnly` in react-native-reanimated.d.ts

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -763,7 +763,10 @@ declare module 'react-native-reanimated' {
   type DependencyList = ReadonlyArray<any>;
 
   // reanimated2 hooks
-  export function useSharedValue<T>(initialValue: T): SharedValue<T>;
+  export function useSharedValue<T>(
+    initialValue: T,
+    oneWayReadsOnly = false
+  ): SharedValue<T>;
 
   export function useDerivedValue<T>(
     processor: () => T,


### PR DESCRIPTION
## Summary

This PR copies the signature of `useSharedValue` from useSharedValue.ts to react-native-reanimated.d.ts so it includes the missing argument `oneWayReadsOnly`.

https://github.com/software-mansion/react-native-reanimated/blob/d3aea040f6ebacb9d29bbb1766cc9effdaeac0a7/src/reanimated2/hook/useSharedValue.ts#L6-L9

## Test plan

Check if CI is green.