### PR TITLE
Don't cast `Text` to any when creating `AnimatedText`

### DIFF
--- a/src/reanimated2/component/Text.ts
+++ b/src/reanimated2/component/Text.ts
@@ -1,6 +1,6 @@
 import { Text } from 'react-native';
 import createAnimatedComponent from '../../createAnimatedComponent';
 
-export const AnimatedText = createAnimatedComponent(Text as any);
+export const AnimatedText = createAnimatedComponent(Text);
 
 export type AnimatedText = typeof AnimatedText & Text;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

The `AnimatedText` component is created by calling `createAnimatedComponent` on a React Native's `Text` but for some reason, it was being cast to `any` first, resulting in all the props on the animated component being erased.
