### PR TITLE
Fix unused `debugToken_` in release mode

### DIFF
--- a/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
@@ -122,9 +122,11 @@ class ReanimatedHermesRuntime
  private:
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime_;
   ReanimatedReentrancyCheck reentrancyCheck_;
+#if HERMES_ENABLE_DEBUGGER
 #if REACT_NATIVE_MINOR_VERSION >= 71
   facebook::hermes::inspector::chrome::DebugSessionToken debugToken_;
-#endif
+#endif // REACT_NATIVE_MINOR_VERSION >= 71
+#endif // HERMES_ENABLE_DEBUGGER
 };
 
 } // namespace reanimated


### PR DESCRIPTION
## Summary

This PR fixes a warning that `debugToken_` field is unused in release mode after #3745  which gets escalated to a compile error thanks to `-Werror`.

## Test plan

Check if Example app compiles in release mode.
