### PR TITLE
Fix crash caused by data race in useAnimatedKeyboard

### DIFF
--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -139,44 +139,48 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 {
   NSNumber *listenerId = [_nextListenerId copy];
   _nextListenerId = [NSNumber numberWithInt:[_nextListenerId intValue] + 1];
-  if ([_listeners count] == 0) {
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+  RCTExecuteOnMainQueue(^() {
+    if ([self->_listeners count] == 0) {
+      NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
 
-    [notificationCenter addObserver:self
-                           selector:@selector(keyboardWillHide:)
-                               name:UIKeyboardWillHideNotification
-                             object:nil];
+      [notificationCenter addObserver:self
+                             selector:@selector(keyboardWillHide:)
+                                 name:UIKeyboardWillHideNotification
+                               object:nil];
 
-    [notificationCenter addObserver:self
-                           selector:@selector(keyboardWillShow:)
-                               name:UIKeyboardWillShowNotification
-                             object:nil];
+      [notificationCenter addObserver:self
+                             selector:@selector(keyboardWillShow:)
+                                 name:UIKeyboardWillShowNotification
+                               object:nil];
 
-    [notificationCenter addObserver:self
-                           selector:@selector(keyboardDidHide:)
-                               name:UIKeyboardDidHideNotification
-                             object:nil];
+      [notificationCenter addObserver:self
+                             selector:@selector(keyboardDidHide:)
+                                 name:UIKeyboardDidHideNotification
+                               object:nil];
 
-    [notificationCenter addObserver:self
-                           selector:@selector(keyboardDidShow:)
-                               name:UIKeyboardDidShowNotification
-                             object:nil];
-  }
+      [notificationCenter addObserver:self
+                             selector:@selector(keyboardDidShow:)
+                                 name:UIKeyboardDidShowNotification
+                               object:nil];
+    }
 
-  [_listeners setObject:listener forKey:listenerId];
-  if (_state == UNKNOWN) {
-    [self recognizeInitialKeyboardState];
-  }
+    [self->_listeners setObject:listener forKey:listenerId];
+    if (self->_state == UNKNOWN) {
+      [self recognizeInitialKeyboardState];
+    }
+  });
   return [listenerId intValue];
 }
 
 - (void)unsubscribeFromKeyboardEvents:(int)listenerId
 {
-  NSNumber *_listenerId = [NSNumber numberWithInt:listenerId];
-  [_listeners removeObjectForKey:_listenerId];
-  if ([_listeners count] == 0) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-  }
+  RCTExecuteOnMainQueue(^() {
+    NSNumber *_listenerId = [NSNumber numberWithInt:listenerId];
+    [self->_listeners removeObjectForKey:_listenerId];
+    if ([self->_listeners count] == 0) {
+      [[NSNotificationCenter defaultCenter] removeObserver:self];
+    }
+  });
 }
 
 - (void)recognizeInitialKeyboardState


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/3568
Fixes https://github.com/software-mansion/react-native-reanimated/issues/3712
Related to https://github.com/software-mansion/react-native-reanimated/pull/3704

The crash was caused because `_listeners` could be accessed by two threads at the same time. For example it could happen that while js thread in `unsubscribeFromKeyboardEvents` was deleting a listener, `updateKeyboardFrame` was iterating over it on the main thread. Now it's synchronised, so only one thread can access `_listeners` at the same time (and `_state` too just in case)

## Test plan

You can reproduce the crash easier by mounting 1000 components that use `useAnimatedKeyboard` in AnimatedKeyboardExample (I tested on simulator). Just enter and exit the example a couple of times.
<details>
  <summary>Example</summary>
  
  ```js
import Animated, {
  useAnimatedStyle,
  useAnimatedKeyboard,
  KeyboardState,
} from 'react-native-reanimated';
import {
  View,
  Button,
  TextInput,
  StyleSheet,
  Keyboard,
  ScrollView,
} from 'react-native';
import React from 'react';

const BOX_SIZE = 50;

function NestedView(): React.ReactElement {
  useAnimatedKeyboard();
  return <View style={styles.nestedView} />;
}

function AnimatedStyleUpdateExample(): React.ReactElement {
  const keyboard = useAnimatedKeyboard();
  const OPENING = KeyboardState.OPENING;
  const style = useAnimatedStyle(() => {
    const color = keyboard.state.value === OPENING ? 'red' : 'blue';

    return {
      backgroundColor: color,
    };
  });
  const translateStyle = useAnimatedStyle(() => {
    return {
      transform: [{ translateY: -keyboard.height.value }],
    };
  });
  const [shouldShowNestedView, setShouldShowNestedView] = React.useState(false);

  return (
    <ScrollView
      contentContainerStyle={styles.container}
      keyboardDismissMode="interactive"
      scrollEnabled={false}>
      <Animated.View style={[styles.box, style]} />
      <Button
        title="Toggle nested view"
        onPress={() => {
          setShouldShowNestedView(!shouldShowNestedView);
        }}
      />
      {new Array(1000).fill(null).map((_, i) => (
        <NestedView key={i} />
      ))}
      <Animated.View style={translateStyle}>
        <Button
          title="Dismiss"
          onPress={() => {
            Keyboard.dismiss();
          }}
        />
        <TextInput style={styles.textInput} autoCorrect  autoFocus/>
      </Animated.View>
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    flexDirection: 'column',
    alignItems: 'center',
    justifyContent: 'space-between',
    paddingVertical: 70,
  },
  box: { width: BOX_SIZE, height: BOX_SIZE, marginBottom: 100 },
  textInput: {
    borderColor: 'blue',
    borderStyle: 'solid',
    borderWidth: 2,
    height: 60,
    width: 200,
  },
  nestedView: {
    width: 100,
    height: 100,
    backgroundColor: '#ffff00',
  },
});

export default AnimatedStyleUpdateExample;

  ```
</details>

