### PR TITLE
Cocoapods: Fix deprecated/removed File.exists method

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -1,6 +1,6 @@
 def try_to_parse_react_native_package_json(node_modules_dir)
   react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
-  if !File.exists?(react_native_package_json_path)
+  if !File.exist?(react_native_package_json_path)
     return nil
   end
   return JSON.parse(File.read(react_native_package_json_path))


### PR DESCRIPTION
Noticed on accident when I upgraded Ruby on accident to 3 - that my `pod install` failed with:

```
[!] Invalid `Podfile` file: 
[!] Invalid `RNReanimated.podspec` file: undefined method `exists?' for File:Class.

 #  from /Users/xx/iOSProjects/xx-app/node_modules/react-native-reanimated/RNReanimated.podspec:5
 #  -------------------------------------------
 #  reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
```

Theres a good deal of other errors after I fixed this one on other projects, but this looks like a safe change to get ahead of the future Ruby upgrade. Yeah I did downgrade back to 2.7.5.

## Summary

Resolves the removed method of `File.exists` in Ruby3. The alternative method of `File.exist` is recommended and already exists on 2.5 for no breaking changes.

https://rubyapi.org/2.5/o/file#method-c-exist-3F

## Test plan

A local working `pod install`
