### PR TITLE
Convert c-like `bool` to obj-c-like `BOOL` for `REAHasAnimationBlock`

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -392,8 +392,9 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   }];
 
   [animationsManager setHasAnimationBlock:^(NSNumber *_Nonnull tag, NSString *_Nonnull type) {
-    return weakModule.lock()->layoutAnimationsManager().hasLayoutAnimation(
-        [tag intValue], std::string([type UTF8String]));
+    bool hasLayoutAnimation =
+        weakModule.lock()->layoutAnimationsManager().hasLayoutAnimation([tag intValue], std::string([type UTF8String]));
+    return hasLayoutAnimation ? YES : NO;
   }];
 
   [animationsManager setAnimationRemovingBlock:^(NSNumber *_Nonnull tag) {


### PR DESCRIPTION
## Summary

Fixes #3800

The type `REAHasAnimationBlock` is defined as:
```obj-c
typedef BOOL (^REAHasAnimationBlock)(NSNumber *_Nonnull tag, NSString *_Nonnull type);
```
but lambda from code had `bool (^REAHasAnimationBlock)(NSNumber *_Nonnull tag, NSString *_Nonnull type)` type and it was breaking some build configurations.