### PR TITLE
Fix issues with relative paths when bundling web apps

### DIFF
--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { ShareableRef, ShareableSyncDataHolderRef } from '../commonTypes';
 import { LayoutAnimationFunction } from '../layoutReanimation';
-import { version as jsVersion } from '../../../package.json';
+import { checkVersion } from '../platform-specific/checkVersion';
 
 export class NativeReanimated {
   native: boolean;
@@ -15,31 +15,7 @@ export class NativeReanimated {
     this.InnerNativeModule = global.__reanimatedModuleProxy;
     this.native = native;
     if (native) {
-      this.checkVersion();
-    }
-  }
-
-  checkVersion(): void {
-    const cppVersion = global._REANIMATED_VERSION_CPP;
-    const ok = (() => {
-      if (
-        jsVersion.match(/^\d+\.\d+\.\d+$/) &&
-        cppVersion.match(/^\d+\.\d+\.\d+$/)
-      ) {
-        // x.y.z, compare only major and minor, skip patch
-        const [jsMajor, jsMinor] = jsVersion.split('.');
-        const [cppMajor, cppMinor] = cppVersion.split('.');
-        return jsMajor === cppMajor && jsMinor === cppMinor;
-      } else {
-        // alpha, beta or rc, compare everything
-        return jsVersion === cppVersion;
-      }
-    })();
-    if (!ok) {
-      console.error(
-        `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs. ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
-      );
-      // TODO: detect Expo managed workflow
+      checkVersion();
     }
   }
 

--- a/src/reanimated2/platform-specific/checkVersion.ts
+++ b/src/reanimated2/platform-specific/checkVersion.ts
@@ -1,0 +1,28 @@
+import { version as jsVersion } from '../../../package.json';
+
+/**
+ * Checks that native and js versions of reanimated match.
+ */
+export function checkVersion(): void {
+  const cppVersion = global._REANIMATED_VERSION_CPP;
+  const ok = (() => {
+    if (
+      jsVersion.match(/^\d+\.\d+\.\d+$/) &&
+      cppVersion.match(/^\d+\.\d+\.\d+$/)
+    ) {
+      // x.y.z, compare only major and minor, skip patch
+      const [jsMajor, jsMinor] = jsVersion.split('.');
+      const [cppMajor, cppMinor] = cppVersion.split('.');
+      return jsMajor === cppMajor && jsMinor === cppMinor;
+    } else {
+      // alpha, beta or rc, compare everything
+      return jsVersion === cppVersion;
+    }
+  })();
+  if (!ok) {
+    console.error(
+      `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs. ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
+    );
+    // TODO: detect Expo managed workflow
+  }
+}

--- a/src/reanimated2/platform-specific/checkVersion.web.ts
+++ b/src/reanimated2/platform-specific/checkVersion.web.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/**
+ * Checks that native and js versions of reanimated match.
+ * Stubbed for web, where this check is unnecessary.
+ */
+export function checkVersion(): void {}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Fixes issues when bundling web apps using reanimated due to relative path to `package.json` being wrongly resolved in prebuild reanimated modules.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->