### PR TITLE
Fix TypeError: 'viewTag' is read-only on Animated.createAnimatedComponent(FlashList)

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -241,7 +241,7 @@ export default function createAnimatedComponent(
 
     _attachNativeEvents() {
       const node = this._getEventViewRef();
-      const viewTag = findNodeHandle(options?.setNativeProps ? this : node);
+      let viewTag = findNodeHandle(options?.setNativeProps ? this : node);
       const componentName = Component.displayName || Component.name;
 
       if (componentName?.endsWith('FlashList') && this._component) {


### PR DESCRIPTION
## Summary

Fixes #3933.

`viewTag` is declared as `const` but for FlashList component we overwrite it afterwards. However, this doesn't trigger an error since there is a `// @ts-ignore` in the previous line.