### PR TITLE
Fix build package CI warnings

### DIFF
--- a/.github/workflows/build-npm-package-action.yml
+++ b/.github/workflows/build-npm-package-action.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
 
       - name: Install NDK

--- a/.github/workflows/build-npm-package-action.yml
+++ b/.github/workflows/build-npm-package-action.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
 
@@ -42,7 +42,7 @@ jobs:
       - run: echo "PACKAGE_NAME=$(ls -l | egrep -o "react-native-reanimated-(.*)(=?\.tgz)")" >> $GITHUB_ENV
       
       - name: Upload npm package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }}
           path: '*.tgz'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Android build folder
         if: ${{ inputs.upload_binaries }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: android-build-output
           path: android-build-output.zip


### PR DESCRIPTION
## Summary

This PR removes the following warnings that appear when building package on CI:

<img width="1117" alt="warnings" src="https://user-images.githubusercontent.com/20516055/212144919-115026e9-7df7-4bfd-b3ea-dfc8f5fdbdf8.png">

Before: https://github.com/software-mansion/react-native-reanimated/actions/runs/3902166126

After: https://github.com/software-mansion/react-native-reanimated/actions/runs/3904875919


## Test plan

Check if package is okay.
