### PR TITLE
Fix `useAnimatedScrollHandler` not intercepting momentum events on Android

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -483,8 +483,9 @@ export default function createAnimatedComponent(
           has('current', value) &&
           value.current instanceof WorkletEventHandler
         ) {
-          if (value.current.eventNames.length > 0) {
-            value.current.eventNames.forEach((eventName) => {
+          const { eventNames } = value.current;
+          if (eventNames.length > 0) {
+            eventNames.forEach((eventName) => {
               props[eventName] = has('listeners', value.current)
                 ? (value.current.listeners as Record<string, unknown>)[
                     eventName
@@ -493,8 +494,8 @@ export default function createAnimatedComponent(
             });
             if (
               Platform.OS === 'android' &&
-              (value.current.eventNames.includes('onMomentumScrollBegin') ||
-                value.current.eventNames.includes('onMomentumScrollEnd')) &&
+              (eventNames.includes('onMomentumScrollBegin') ||
+                eventNames.includes('onMomentumScrollEnd')) &&
               this.props.onMomentumScrollBegin === undefined &&
               this.props.onMomentumScrollEnd === undefined
             ) {

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -491,6 +491,16 @@ export default function createAnimatedComponent(
                   ]
                 : dummyListener;
             });
+            if (
+              Platform.OS === 'android' &&
+              (value.current.eventNames.includes('onMomentumScrollBegin') ||
+                value.current.eventNames.includes('onMomentumScrollEnd')) &&
+              this.props.onMomentumScrollBegin === undefined &&
+              this.props.onMomentumScrollEnd === undefined
+            ) {
+              // force sendMomentumEvents to be true
+              props.onMomentumScrollEnd = dummyListener;
+            }
           } else {
             props[key] = dummyListener;
           }


### PR DESCRIPTION
## Summary

Fixes #2735, see https://github.com/software-mansion/react-native-reanimated/issues/2735#issuecomment-1381870377 for details.

The main idea behind this PR is to enable emitting momentum events from the native side by enforcing [`sendMomentumEvents`](https://github.com/facebook/react-native/blob/ef6ab3f5cad968d7b2c9127d834429b0f4e1b2cf/Libraries/Components/ScrollView/ScrollView.js#L1741-L1744) to be true.

First, I came up with the following patch in `createAnimatedComponent.tsx`, however this doesn't fully resolve the issue as `setNativeProps` is not supported on Fabric.

```diff
export default function createAnimatedComponent(
         viewTag = findNodeHandle(this._component.recyclerlistview_unsafe);
       }
 
+      if (Platform.OS === 'android' && componentName.endsWith('ScrollView')) {
+        // @ts-ignore fix typing
+        const eventNames = this.props?.onScroll.current.eventNames;
+        if (
+          eventNames.some((eventName: string) => eventName.includes('Momentum'))
+        ) {
+          this._setNativeProps({ sendMomentumEvents: true });
+        }
+      }
+
       for (const key in this.props) {
         const prop = this.props[key];
         if (
@@ -287,7 +297,7 @@ export default function createAnimatedComponent(
       }
     }
 
-    _updateFromNative(props: StyleProps) {
+    _setNativeProps(props: StyleProps) {
       if (options?.setNativeProps) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         options.setNativeProps(this._component!, props);
```

Since we cannot use `setNativeProps`, I had to come up with a solution that changes the props and thus works on both architectures. Here's how it works: if `useAnimatedScrollHandler` has a momentum event listener and simultaneously `Animated.ScrollView` doesn't have any regular JS momentum event listener defined, we add a dummy listener for `onMomentumEnd` (chosen arbitrarily by me) which causes `sendMomentumEvents` to be true and thus enables emitting momentum events on the native side. Currently, the only two momentum events supported by React Native are `onMomentumBegin` and `onMomentumEnd`, see [here](https://github.com/facebook/react-native/blob/8befb740d6cd3de6ead067ac01b70c37d4b5b1bc/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEventType.java#L26-L29), so I hard-coded these names as for now.

Another approach would be to call `setSendMomentumEvents(true)` in the native code which is probably better than adding a dummy listener on JS context.

## Test plan

This PR can be tested on the example from issue description #2735.

Note that `onMomentumEnd` event callback will be called exactly three times, it's not an issue with Reanimated, see https://github.com/software-mansion/react-native-reanimated/issues/2735#issuecomment-1381870377 for details.

Also keep in mind that although `_filterNonAnimatedProps` gets executed during fast refresh (which is correct), for some reason `value.current.eventNames` isn't updated (i.e. it contains the event names from before the update, even if you add or remove some entries inside `useAnimatedScrollHandler`), therefore when testing out the changes most likely you will need to reload the app.

Make sure to test the following cases:
1. No worklet momentum event listener in `useAnimatedScrollHandler`, no JS momentum event listener in `Animated.ScrollView` &rarr; dummy listener shouldn't be registered 😴
2. Some worklet momentum event listener in `useAnimatedScrollHandler`, but no JS momentum event listener in `Animated.ScrollView` &rarr; dummy listener should be registered ✅ 
3. Some worklet momentum event listener in `useAnimatedScrollHandler` and some JS momentum event listener in `Animated.ScrollView` &rarr; dummy listener shouldn't be registered (or overwritten) 😴 

```tsx
  const scrollHandler = useAnimatedScrollHandler({
    onBeginDrag: () => {
      isScrolling.value = true;
      console.log('onBeginDrag');
    },
    onEndDrag: () => {
      isScrolling.value = false;
      console.log('onEndDrag');
    },
    // onMomentumBegin: () => {
    //   console.log('onMomentumBegin');
    // },
    // onMomentumEnd: () => {
    //   console.log('onMomentumEnd');
    // },
  });
```