### PR TITLE
Rewrite `isAnimated` function

### DIFF
--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -176,25 +176,15 @@ export function canApplyOptimalisation(upadterFn: WorkletFunction): number {
 
 export function isAnimated(prop: NestedObjectValues<AnimationObject>): boolean {
   'worklet';
-  const propsToCheck: NestedObjectValues<AnimationObject>[] = [prop];
-  while (propsToCheck.length > 0) {
-    const currentProp: NestedObjectValues<AnimationObject> =
-      propsToCheck.pop() as NestedObjectValues<AnimationObject>;
-    if (Array.isArray(currentProp)) {
-      for (const item of currentProp) {
-        propsToCheck.push(item);
-      }
-    } else if (currentProp?.onFrame !== undefined) {
+  if (Array.isArray(prop)) {
+    return prop.some(isAnimated);
+  } else if (typeof prop === 'object') {
+    if (prop.onFrame !== undefined) {
       return true;
-    } else if (typeof currentProp === 'object') {
-      for (const item of Object.values(currentProp)) {
-        propsToCheck.push(item);
-      }
+    } else {
+      return Object.values(prop).some(isAnimated);
     }
-    // if none of the above, it's not the animated prop, check next one
   }
-
-  // when none of the props were animated return false
   return false;
 }
 


### PR DESCRIPTION
## Summary

This PR provides a new better implementation of `isAnimated` utility function as the previous version was very poorly written. The old implementation holds a queue of props to be checked and thus needs to allocate and populate a new array on each call, whereas the new implementation uses recursion instead &ndash; however, in most of the real-world cases, it is never called recursively. Since `isAnimated` is used very frequently throughout the codebase, previously it took ~7% of total execution time. After the changes, it dropped down to ~3%.

Co-authored-by: @kmagiera

## Test plan

Just check if BokehExample works.
