### PR TITLE
Optimize previous style calculation in `styleUpdater`

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -353,7 +353,7 @@ function jestStyleUpdater(
 
   // calculate diff
   const diff = styleDiff(oldValues, newValues);
-  state.last = Object.assign({}, oldValues, newValues);
+  state.last = Object.assign(oldValues, diff);
 
   if (Object.keys(diff).length !== 0) {
     updatePropsJestWrapper(

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -244,7 +244,7 @@ function styleUpdater(
         requestAnimationFrame(frame);
       }
     }
-    state.last = Object.assign({}, oldValues, newValues);
+    state.last = Object.assign(oldValues, newValues);
     const style = getStyleWithoutAnimations(state.last);
     if (style) {
       updateProps(viewDescriptors, style, maybeViewRef);

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -244,7 +244,7 @@ function styleUpdater(
         requestAnimationFrame(frame);
       }
     }
-    state.last = Object.assign({}, oldValues, newValues);
+    state.last = Object.assign(oldValues, diff);
     const style = getStyleWithoutAnimations(state.last);
     if (style) {
       updateProps(viewDescriptors, style, maybeViewRef);

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -244,7 +244,7 @@ function styleUpdater(
         requestAnimationFrame(frame);
       }
     }
-    state.last = Object.assign(oldValues, diff);
+    state.last = Object.assign({}, oldValues, newValues);
     const style = getStyleWithoutAnimations(state.last);
     if (style) {
       updateProps(viewDescriptors, style, maybeViewRef);

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -254,7 +254,7 @@ function styleUpdater(
     state.animations = [];
 
     const diff = styleDiff(oldValues, newValues);
-    state.last = Object.assign({}, oldValues, newValues);
+    state.last = Object.assign(oldValues, diff);
     if (diff) {
       updateProps(viewDescriptors, newValues, maybeViewRef);
     }


### PR DESCRIPTION
## Summary

This PR contains two little optimizations in `styleUpdater`:

1. Since we never use `oldValues` again (because references the same object as `state.last` does before we overwrite it in the very same line), we can re-use this instance instead of creating a new one.
2. Since we just calculated the difference between the new and old styles, we can overwrite `oldValues` just with `diff` instead of `newValues` because the values that are not present in `diff` are the same in `oldValues` and `newValues`.

Co-authored-by: @kmagiera

## Test plan

Just check if BokehExample works.
