### PR TITLE
[Android] Cleanup animated sensors in NativeProxy destructor

### DIFF
--- a/Common/cpp/AnimatedSensor/AnimatedSensorModule.h
+++ b/Common/cpp/AnimatedSensor/AnimatedSensorModule.h
@@ -37,6 +37,7 @@ class AnimatedSensorModule {
       const jsi::Value &interval,
       const jsi::Value &sensorDataContainer);
   void unregisterSensor(const jsi::Value &sensorId);
+  void unregisterAllSensors();
 };
 
 } // namespace reanimated

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -199,9 +199,9 @@ NativeReanimatedModule::~NativeReanimatedModule() {
     // runtime, so they have to go away before we tear down the runtime
     eventHandlerRegistry.reset();
     frameCallbacks.clear();
-    runtime.reset();
     // make sure uiRuntimeDestroyed is set after the runtime is deallocated
     runtimeHelper->uiRuntimeDestroyed = true;
+    runtime.reset();
   }
 }
 
@@ -445,6 +445,10 @@ void NativeReanimatedModule::unregisterSensor(
     jsi::Runtime &rt,
     const jsi::Value &sensorId) {
   animatedSensorModule.unregisterSensor(sensorId);
+}
+
+void NativeReanimatedModule::cleanupSensors() {
+  animatedSensorModule.unregisterAllSensors();
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -199,9 +199,9 @@ NativeReanimatedModule::~NativeReanimatedModule() {
     // runtime, so they have to go away before we tear down the runtime
     eventHandlerRegistry.reset();
     frameCallbacks.clear();
+    runtime.reset();
     // make sure uiRuntimeDestroyed is set after the runtime is deallocated
     runtimeHelper->uiRuntimeDestroyed = true;
-    runtime.reset();
   }
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -144,6 +144,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       const jsi::Value &interval,
       const jsi::Value &sensorDataContainer) override;
   void unregisterSensor(jsi::Runtime &rt, const jsi::Value &sensorId) override;
+
+  void cleanupSensors();
+
   jsi::Value subscribeForKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &keyboardEventContainer) override;

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -57,7 +57,7 @@ class JSRuntimeHelper {
       const std::shared_ptr<Scheduler> &scheduler)
       : rnRuntime_(rnRuntime), uiRuntime_(uiRuntime), scheduler_(scheduler) {}
 
-  volatile bool uiRuntimeDestroyed;
+  volatile bool uiRuntimeDestroyed = false;
   std::unique_ptr<CoreFunction> callGuard;
   std::unique_ptr<CoreFunction> valueUnpacker;
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -63,6 +63,11 @@ NativeProxy::NativeProxy(
 NativeProxy::~NativeProxy() {
   // removed temporary, new event listener mechanism need fix on the RN side
   // reactScheduler_->removeEventListener(eventListener_);
+
+  // cleanup all animated sensors here, since NativeProxy
+  // has already been destroyed when AnimatedSensorModule's
+  // destructor is ran
+  _nativeReanimatedModule->cleanupSensors();
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Fixes #3645

The reason for the crash when reloading was that, when the sensor listeners where cleaned up in the `AnimatedSensorModule`'s destructor, the `NativeProxy` object used for calling JNI functions has already been destroyed, causing a null pointer dereference.

This PR moves the sensor listener cleanup to `NativeProxy`'s destructor, where JNI functions are still safe to call.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan
In the Example app:
- go to the "Use Animated Sensor" example
- trigger a reload (e.g. by typing "r" in metro)
- 🤞 for no crash

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
