### PR TITLE
Disable `HERMES_ENABLE_DEBUGGER` when building Reanimated 2 AAR package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -473,7 +473,7 @@ android {
         debug {
             externalNativeBuild {
                 cmake {
-                    if (JS_RUNTIME == "hermes" && !isPackageBuild()) {
+                    if (JS_RUNTIME == "hermes" && !REANIMATED_PACKAGE_BUILD) {
                         arguments "-DHERMES_ENABLE_DEBUGGER=1"
                     } else {
                         arguments "-DHERMES_ENABLE_DEBUGGER=0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -473,7 +473,7 @@ android {
         debug {
             externalNativeBuild {
                 cmake {
-                    if (JS_RUNTIME == "hermes") {
+                    if (JS_RUNTIME == "hermes" && !isPackageBuild()) {
                         arguments "-DHERMES_ENABLE_DEBUGGER=1"
                     } else {
                         arguments "-DHERMES_ENABLE_DEBUGGER=0"


### PR DESCRIPTION
## Summary

Fixes #3952.

## Test plan

1. Build Reanimated 2 package on CI
2. Create a new RN 0.70.6 app with Reanimated
3. Copy BokehExample to App.js
4. Build the app in release mode for Android
5. Check if the runtime error is gone
