### PR TITLE
Use `getBool` instead of `asBool`

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -675,7 +675,7 @@ jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
         handler.asObject(rt).asFunction(rt).call(
             rt, jsi::Value(keyboardState), jsi::Value(height));
       },
-      isStatusBarTranslucent.asBool());
+      isStatusBarTranslucent.getBool());
 }
 
 void NativeReanimatedModule::unsubscribeFromKeyboardEvents(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

JSI's `asBool` was only added in RN 69. This PR changes `asBool` to `getBool` call in order to support older RN versions.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
