### PR TITLE
Fix typo on reanimated 2 mock.ts

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -102,7 +102,7 @@ const ReanimatedV2 = {
   'FadeInRight',
   'FadeInLeft',
   'FadeInUp',
-  'FadFadeInDown',
+  'FadeInDown',
   'FadeOut',
   'FadeOutRight',
   'FadeOutLeft',


### PR DESCRIPTION
## Summary

We have a typo on `react-native-reanimated/lib/commonjs/reanimated2/mock`, where `FadeInDown` is typed wrong, and mocked as `FadFadeInDown`. This PR fixes it.

## Test plan

I'm mocking Reanimated on jest in this way, on the new version:
```ts
jest.mock('react-native-reanimated', () => {
  return {
    ...jest.requireActual('react-native-reanimated/mock'),
    ...jest.requireActual(
      'react-native-reanimated/lib/commonjs/reanimated2/mock',
    ),
  };
});
```

But, as this typo makes the Reanimated2 mocks not contain the FadeInDown method, Jest throws this error on files that use this Fade.

<img width="670" alt="Captura de Tela 2023-01-18 às 15 13 44" src="https://user-images.githubusercontent.com/50031755/213261421-b533f182-cb27-48aa-9360-77881394d865.png">

I'm currently fixing it with patch-package, while that isn't officially merged and released. The issue is still present after updating to 3.0.0-rc.10
