### PR TITLE
Fix 'jsi/JSCRuntime.h' file not found in NativeProxy.mm

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -23,7 +23,11 @@
 #elif __has_include(<hermes/hermes.h>)
 #import <hermes/hermes.h>
 #else
-#import <jsi/JSCRuntime.h>
+#if REACT_NATIVE_MINOR_VERSION >= 71
+#include <jsc/JSCRuntime.h>
+#else
+#include <jsi/JSCRuntime.h>
+#endif // REACT_NATIVE_MINOR_VERSION
 #endif
 
 namespace reanimated {


### PR DESCRIPTION
## Summary

Fixes #3965.

## Test plan

```
npx react-native@next init MyApp --version 0.71.0 --skip-install
yarn add react-native-reanimated@2.14.2
# apply the diff from this PR
cd ios && NO_FLIPPER=1 USE_HERMES=0 RCT_NEW_ARCH_ENABLED=0 pod install
open ios/MyApp.xcworkspace
# build the app from Xcode
```