### PR TITLE
Extend the set of layout animation mocks

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -16,6 +16,18 @@ class BaseAnimationMock {
     return this;
   }
 
+  springify(_: number) {
+    return this;
+  }
+
+  damping(_: number) {
+    return this;
+  }
+
+  stiffness(_: number) {
+    return this;
+  }
+
   withCallback(_: (finsihed: boolean) => void) {
     return this;
   }
@@ -26,6 +38,10 @@ class BaseAnimationMock {
 
   withInitialValues() {
     return this;
+  }
+
+  build() {
+    return () => ({ initialValues: {}, animations: {} });
   }
 }
 
@@ -174,6 +190,13 @@ const ReanimatedV2 = {
   'RollInRight',
   'RollOutLeft',
   'RollOutRight',
+
+  'Layout',
+  'CurvedTransition',
+  'JumpingTransition',
+  'SequencedTransition',
+  'FadingTransition',
+  'EntryExitTransition',
 ].forEach((k) =>
   Object.assign(ReanimatedV2, {
     [k]: new BaseAnimationMock(),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR extends https://github.com/software-mansion/react-native-reanimated/pull/3801 by introducing layout animation types and modifiers that those animation types require to be fully functional.

Currently, the tests fail with something like:
```
TypeError: Cannot read properties of undefined (reading 'delay')

 > 107 |   const transition = CurvedTransition.delay(10).duration(10),
       |                                       ^
```

## Test plan

Creating a test (e.g. using React Native Testing Library) of a component containing any of the freshly added layout animation types and / or chained modifiers they support. E.g.:
```tsx
const MyComponent = () => (
  <Animated.View layout={CurvedTransition.delay(10).duration(10)} />
)

test('test the test', () => {
  const screen = render(<MyComponent />)
})
```
The above example fails before the patch from this PR is introduced and succeeds afterward.


## Question

One question to resolve is how closely the mocks should match the real api in the context of which modifiers apply to witch animation types (e.g. not all animation types support `.stiffness()`). Doing so would require more complex mocks that are also harder to maintain for the need to keeping them in sync. An alternative, simpler approach is to add all the modifiers to all the animations - I figure it's okay since these kinds of mocks are not directly consumed in the tests - they just serve enabling test-rendering components utilising layout animations without errors. The latter is the approach I went with, but lmk if you think the other one is a better fit.
