### PR TITLE
Remove version check in FabricUtils.cpp

### DIFF
--- a/Common/cpp/Fabric/FabricUtils.cpp
+++ b/Common/cpp/Fabric/FabricUtils.cpp
@@ -1,10 +1,5 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#if REACT_NATIVE_MINOR_VERSION < 69
-#error \
-    "Reanimated 3 does not support React Native 0.68.x when Fabric is enabled. Please upgrade to React Native 0.69.0 or newer if you want to use Reanimated with the new architecture."
-#endif
-
 #include "FabricUtils.h"
 
 #include <react/renderer/debug/SystraceSection.h>

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -5,6 +5,7 @@ reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json"
 config = find_config()
 assert_no_multiple_instances(config)
 assert_no_reanimated2_with_new_architecture(reanimated_package_json)
+assert_latest_react_native_with_new_architecture(config, reanimated_package_json)
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 folly_prefix = config[:react_native_minor_version] >= 64 ? 'RCT-' : ''

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -79,3 +79,13 @@ def assert_no_reanimated2_with_new_architecture(reanimated_package_json)
     raise "[react-native-reanimated] Reanimated 2.x does not support Fabric. Please upgrade to 3.x to use Reanimated with the New Architecture. For details, see https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7"
   end
 end
+
+def assert_latest_react_native_with_new_architecture(config, reanimated_package_json)
+  reanimated_version = reanimated_package_json['version']
+  reanimated_major_version = reanimated_version.split('.')[0].to_i
+  react_native_minor_version = config[:react_native_minor_version]
+  fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+  if fabric_enabled && reanimated_major_version == 3 && react_native_minor_version < 71
+    raise "[react-native-reanimated] Reanimated " + reanimated_version + " supports the New Architecture only on the latest minor release of React Native. Please upgrade to React Native 0.71.0+ or downgrade to an older version of Reanimated v3"
+  end
+end


### PR DESCRIPTION
## Summary

This PR removes an outdated React Native version check when Fabric is enabled in C++ code since there already exists such mechanism in Android build scripts (see [here](https://github.com/software-mansion/react-native-reanimated/blob/ef888c2cc941d5175b9ac007a237a00ea4c2593d/android/build.gradle#L595-L604)), as well as adds an analogous check on iOS.

## Test plan

Check if FabricExample works on Android and iOS.
