### PR TITLE
Fix attaching a scroll event if the scrollable component is not the root view

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -189,15 +189,17 @@ export default function createAnimatedComponent(
       this._attachAnimatedStyles();
     }
 
+    _getEventViewRef() {
+      // Make sure to get the scrollable node for components that implement
+      // `ScrollResponder.Mixin`.
+      return this._component?.getScrollableNode
+        ? this._component.getScrollableNode()
+        : this._component;
+    }
+
     _attachNativeEvents() {
-      let viewTag = findNodeHandle(this);
-
-      const componentName = Component.displayName || Component.name;
-
-      if (componentName?.endsWith('FlashList') && this._component) {
-        // @ts-ignore it's FlashList specific: https://github.com/Shopify/flash-list/blob/218f314e63806b4fe926741ef73f8b9cd6ebc7eb/src/FlashList.tsx#L815
-        viewTag = findNodeHandle(this._component.getScrollableNode());
-      }
+      const node = this._getEventViewRef();
+      const viewTag = findNodeHandle(options?.setNativeProps ? this : node);
 
       for (const key in this.props) {
         const prop = this.props[key];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #3873
`getScrollableNode()` works not only on FlashLists, but also on RN scrollable components (ScrollView, Flatlist). It's brought back from [there](https://github.com/software-mansion/react-native-reanimated/commit/5829e95b5e452761c659cb7fb73bb98a630f86c1#diff-fdad18d3281131f92aa76c0969f84d27f2314251842763fedbc756df07b1eab7L234)


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
- tested on the repro from the issue (https://github.com/diogoquintas/reanimated-scroll-issue)
- tested on several examples from the example app (examples related to scroll events and events in general for example chat heads)
- tested on FlashList