### PR TITLE
Fix nested animated props on iOS

### DIFF
--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -442,6 +442,10 @@ using namespace facebook::react;
 
   void (^addBlock)(NSString *key, id obj, BOOL *stop) = ^(NSString *key, id obj, BOOL *stop) {
     if ([self.uiProps containsObject:key]) {
+      if ([obj isKindOfClass:[NSDictionary class]]) {
+        NSData *data = [NSJSONSerialization dataWithJSONObject:obj options:NSJSONWritingPrettyPrinted error:nil];
+        obj = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      }
       uiProps[key] = obj;
     } else if ([self.nativeProps containsObject:key]) {
       nativeProps[key] = obj;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the [issue](https://github.com/rnmapbox/maps/issues/1200) from the [mapbox](https://github.com/rnmapbox/maps) library on iOS. When a user tried to use nested props with `useAnimatedProp`, they got parsing error.

Fix:
- Added dictionary to JSON conversion, if the prop value is a dictionary in `REANodesManager.mm`


## Test plan

- Run animation using nested props on iOS.
