### PR TITLE
Remove `RN_FABRIC_ENABLED` flag in RNReanimated.podspec

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -12,7 +12,7 @@ folly_prefix = config[:react_native_minor_version] >= 64 ? 'RCT-' : ''
 folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=' + config[:react_native_minor_version].to_s
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 boost_compiler_flags = '-Wno-documentation'
-fabric_flags = fabric_enabled ? '-DRN_FABRIC_ENABLED -DRCT_NEW_ARCH_ENABLED' : ''
+fabric_flags = fabric_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
 version_flag = '-DREANIMATED_VERSION=' + reanimated_package_json["version"]
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
## Summary

This PR removes legacy flag `-DRN_FABRIC_ENABLED` argument in Reanimated's podspec in favor of using only `RCT_NEW_ARCH_ENABLED`.

## Test plan

Check if FabricExample works on iOS.
