### PR TITLE
Unify event handling on Paper and Fabric

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -388,7 +388,7 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimation(
 }
 
 void NativeReanimatedModule::onEvent(
-    std::string eventName,
+    const std::string &eventName,
     jsi::Value &&payload) {
   try {
     eventHandlerRegistry->processEvent(*runtime, eventName, payload);

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -389,18 +389,9 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimation(
 
 void NativeReanimatedModule::onEvent(
     std::string eventName,
-#ifdef RCT_NEW_ARCH_ENABLED
-    jsi::Value &&payload
-#else
-    std::string eventAsString
-#endif
-    /**/) {
+    jsi::Value &&payload) {
   try {
-#ifdef RCT_NEW_ARCH_ENABLED
     eventHandlerRegistry->processEvent(*runtime, eventName, payload);
-#else
-    eventHandlerRegistry->processEvent(*runtime, eventName, eventAsString);
-#endif
   } catch (std::exception &e) {
     std::string str = e.what();
     this->errorHandler->setError(str);
@@ -477,6 +468,7 @@ bool NativeReanimatedModule::isThereAnyLayoutProp(
   }
   return false;
 }
+#endif // RCT_NEW_ARCH_ENABLED
 
 bool NativeReanimatedModule::handleEvent(
     const std::string &eventName,
@@ -495,6 +487,7 @@ bool NativeReanimatedModule::handleEvent(
   return false;
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
 bool NativeReanimatedModule::handleRawEvent(
     const RawEvent &rawEvent,
     double currentTime) {

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -389,7 +389,7 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimation(
 
 void NativeReanimatedModule::onEvent(
     const std::string &eventName,
-    jsi::Value &&payload) {
+    const jsi::Value &payload) {
   try {
     eventHandlerRegistry->processEvent(*runtime, eventName, payload);
   } catch (std::exception &e) {
@@ -472,14 +472,14 @@ bool NativeReanimatedModule::isThereAnyLayoutProp(
 
 bool NativeReanimatedModule::handleEvent(
     const std::string &eventName,
-    jsi::Value &&payload,
+    const jsi::Value &payload,
     double currentTime) {
   jsi::Runtime &rt = *runtime.get();
   jsi::Object global = rt.global();
   jsi::String eventTimestampName =
       jsi::String::createFromAscii(rt, "_eventTimestamp");
   global.setProperty(rt, eventTimestampName, currentTime);
-  onEvent(eventName, std::move(payload));
+  onEvent(eventName, payload);
   global.setProperty(rt, eventTimestampName, jsi::Value::undefined());
 
   // TODO: return true if Reanimated successfully handled the event

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -98,7 +98,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   void onRender(double timestampMs);
 
-  void onEvent(std::string eventName, jsi::Value &&payload);
+  void onEvent(const std::string &eventName, jsi::Value &&payload);
 
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -98,7 +98,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   void onRender(double timestampMs);
 
-  void onEvent(const std::string &eventName, jsi::Value &&payload);
+  void onEvent(const std::string &eventName, const jsi::Value &payload);
 
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 
@@ -107,7 +107,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   bool handleEvent(
       const std::string &eventName,
-      jsi::Value &&payload,
+      const jsi::Value &payload,
       double currentTime);
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -97,11 +97,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       const jsi::Value &config) override;
 
   void onRender(double timestampMs);
-#ifdef RCT_NEW_ARCH_ENABLED
-  void onEvent(std::string eventName, jsi::Value &&eventAsString);
-#else
-  void onEvent(std::string eventName, std::string eventAsString);
-#endif
+
+  void onEvent(std::string eventName, jsi::Value &&payload);
+
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 
   void maybeRequestRender();

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -25,12 +25,7 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 void EventHandlerRegistry::processEvent(
     jsi::Runtime &rt,
     std::string eventName,
-#ifdef RCT_NEW_ARCH_ENABLED
-    jsi::Value &eventPayload
-#else
-    std::string eventPayload
-#endif
-    /**/) {
+    jsi::Value &eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
     const std::lock_guard<std::mutex> lock(instanceMutex);
@@ -41,35 +36,12 @@ void EventHandlerRegistry::processEvent(
       }
     }
   }
-#ifdef RCT_NEW_ARCH_ENABLED
+
   eventPayload.asObject(rt).setProperty(
       rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
   for (auto handler : handlersForEvent) {
     handler->process(rt, eventPayload);
   }
-#else
-  // We receive here a JS Map with JSON as a value of NativeMap key
-  // { NativeMap: { "jsonProp": "json value" } }
-  // So we need to extract only JSON part
-  std::string delimimter = "NativeMap:";
-  auto positionToSplit = eventPayload.find(delimimter) + delimimter.size();
-  auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
-  auto eventJSON =
-      eventPayload.substr(positionToSplit, lastBracketCharactedPosition);
-
-  if (eventJSON.compare(std::string("null")) == 0) {
-    return;
-  }
-
-  auto eventObject = jsi::Value::createFromJsonUtf8(
-      rt, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
-
-  eventObject.asObject(rt).setProperty(
-      rt, "eventName", jsi::String::createFromUtf8(rt, eventName));
-  for (auto handler : handlersForEvent) {
-    handler->process(rt, eventObject);
-  }
-#endif
 }
 
 bool EventHandlerRegistry::isAnyHandlerWaitingForEvent(std::string eventName) {

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -24,7 +24,7 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 
 void EventHandlerRegistry::processEvent(
     jsi::Runtime &rt,
-    std::string eventName,
+    const std::string &eventName,
     jsi::Value &eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
@@ -44,7 +44,8 @@ void EventHandlerRegistry::processEvent(
   }
 }
 
-bool EventHandlerRegistry::isAnyHandlerWaitingForEvent(std::string eventName) {
+bool EventHandlerRegistry::isAnyHandlerWaitingForEvent(
+    const std::string &eventName) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
   auto it = eventMappings.find(eventName);
   return (it != eventMappings.end()) && (!(it->second).empty());

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -25,7 +25,7 @@ void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
 void EventHandlerRegistry::processEvent(
     jsi::Runtime &rt,
     const std::string &eventName,
-    jsi::Value &eventPayload) {
+    const jsi::Value &eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
     const std::lock_guard<std::mutex> lock(instanceMutex);

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -29,7 +29,7 @@ class EventHandlerRegistry {
 
   void processEvent(
       jsi::Runtime &rt,
-      std::string eventName,
+      const std::string &eventName,
       jsi::Value &eventPayload);
 
   bool isAnyHandlerWaitingForEvent(std::string eventName);

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -32,7 +32,7 @@ class EventHandlerRegistry {
       const std::string &eventName,
       jsi::Value &eventPayload);
 
-  bool isAnyHandlerWaitingForEvent(std::string eventName);
+  bool isAnyHandlerWaitingForEvent(const std::string &eventName);
 };
 
 } // namespace reanimated

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -30,7 +30,7 @@ class EventHandlerRegistry {
   void processEvent(
       jsi::Runtime &rt,
       const std::string &eventName,
-      jsi::Value &eventPayload);
+      const jsi::Value &eventPayload);
 
   bool isAnyHandlerWaitingForEvent(const std::string &eventName);
 };

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -27,17 +27,10 @@ class EventHandlerRegistry {
   void registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler);
   void unregisterEventHandler(unsigned long id);
 
-#ifdef RCT_NEW_ARCH_ENABLED
   void processEvent(
       jsi::Runtime &rt,
       std::string eventName,
       jsi::Value &eventPayload);
-#else
-  void processEvent(
-      jsi::Runtime &rt,
-      std::string eventName,
-      std::string eventPayload);
-#endif
 
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 };

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -287,40 +287,34 @@ void NativeProxy::installJSIBindings(
   _nativeReanimatedModule = module;
   std::weak_ptr<NativeReanimatedModule> weakModule = module;
 
-#ifdef RCT_NEW_ARCH_ENABLED
   this->registerEventHandler([weakModule, getCurrentTime](
-                                 std::string eventName,
-                                 std::string eventAsString) {
+                                 jni::alias_ref<JString> eventKey,
+                                 jni::alias_ref<react::WritableMap> event) {
+    // handles RCTEvents from RNGestureHandler
     if (auto module = weakModule.lock()) {
-      // handles RCTEvents from RNGestureHandler
-
+      auto eventName = eventKey->toString();
+      jsi::Runtime &rt = *module->runtime;
+      std::string eventAsString = "{NativeMap:null}";
+      if (event != nullptr) {
+        try {
+          eventAsString = event->toString();
+        } catch (std::exception &) {
+          // Events from other libraries may contain NaN or INF values which
+          // cannot be represented in JSON. See
+          // https://github.com/software-mansion/react-native-reanimated/issues/1776
+          // for details.
+          return;
+        }
+      }
       std::string eventJSON = eventAsString.substr(
           13, eventAsString.length() - 15); // removes "{ NativeMap: " and " }"
-      jsi::Runtime &rt = *module->runtime;
       jsi::Value payload =
           jsi::valueFromDynamic(rt, folly::parseJson(eventJSON));
       // TODO: support NaN and INF values
       // TODO: convert event directly to jsi::Value without JSON serialization
-
       module->handleEvent(eventName, std::move(payload), getCurrentTime());
     }
   });
-#else
-  this->registerEventHandler(
-      [weakModule, getCurrentTime](
-          std::string eventName, std::string eventAsString) {
-        if (auto module = weakModule.lock()) {
-          jsi::Object global = module->runtime->global();
-          jsi::String eventTimestampName =
-              jsi::String::createFromAscii(*module->runtime, "_eventTimestamp");
-          global.setProperty(
-              *module->runtime, eventTimestampName, getCurrentTime());
-          module->onEvent(eventName, eventAsString);
-          global.setProperty(
-              *module->runtime, eventTimestampName, jsi::Value::undefined());
-        }
-      });
-#endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
   Binding *binding = fabricUIManager->getBinding();
@@ -414,7 +408,9 @@ void NativeProxy::requestRender(std::function<void(double)> onRender) {
 }
 
 void NativeProxy::registerEventHandler(
-    std::function<void(std::string, std::string)> handler) {
+    std::function<
+        void(jni::alias_ref<JString>, jni::alias_ref<react::WritableMap>)>
+        handler) {
   static auto method =
       javaPart_->getClass()->getMethod<void(EventHandler::javaobject)>(
           "registerEventHandler");

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -308,10 +308,10 @@ void NativeProxy::installJSIBindings(
       }
       std::string delimiter = "NativeMap:";
       auto positionToSplit = eventAsString.find(delimiter) + delimiter.size();
-      auto lastBracketCharactedPosition =
+      auto lastBracketCharacterPosition =
           eventAsString.size() - positionToSplit - 1;
       auto eventJSON =
-          eventAsString.substr(positionToSplit, lastBracketCharactedPosition);
+          eventAsString.substr(positionToSplit, lastBracketCharacterPosition);
       if (eventJSON.compare(std::string("null")) == 0) {
         return;
       }

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -62,19 +62,7 @@ class EventHandler : public HybridClass<EventHandler> {
   void receiveEvent(
       jni::alias_ref<JString> eventKey,
       jni::alias_ref<react::WritableMap> event) {
-    std::string eventAsString = "{NativeMap:null}";
-    if (event != nullptr) {
-      try {
-        eventAsString = event->toString();
-      } catch (std::exception &) {
-        // Events from other libraries may contain NaN or INF values which
-        // cannot be represented in JSON. See
-        // https://github.com/software-mansion/react-native-reanimated/issues/1776
-        // for details.
-        return;
-      }
-    }
-    handler_(eventKey->toString(), eventAsString);
+    handler_(eventKey, event);
   }
 
   static void registerNatives() {
@@ -86,10 +74,14 @@ class EventHandler : public HybridClass<EventHandler> {
  private:
   friend HybridBase;
 
-  explicit EventHandler(std::function<void(std::string, std::string)> handler)
+  explicit EventHandler(std::function<void(
+                            jni::alias_ref<JString>,
+                            jni::alias_ref<react::WritableMap>)> handler)
       : handler_(std::move(handler)) {}
 
-  std::function<void(std::string, std::string)> handler_;
+  std::function<
+      void(jni::alias_ref<JString>, jni::alias_ref<react::WritableMap>)>
+      handler_;
 };
 
 class SensorSetter : public HybridClass<SensorSetter> {
@@ -199,8 +191,9 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   bool isAnyHandlerWaitingForEvent(std::string);
   void performOperations();
   void requestRender(std::function<void(double)> onRender);
-  void registerEventHandler(
-      std::function<void(std::string, std::string)> handler);
+  void registerEventHandler(std::function<void(
+                                jni::alias_ref<JString>,
+                                jni::alias_ref<react::WritableMap>)> handler);
   void setGestureState(int handlerTag, int newState);
   int registerSensor(
       int sensorType,

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -75,66 +75,6 @@ static CFTimeInterval calculateTimestampWithSlowAnimations(CFTimeInterval curren
 #endif
 }
 
-// COPIED FROM RCTTurboModule.mm
-static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
-
-static NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value)
-{
-  return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
-}
-
-static NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value)
-{
-  jsi::Array propertyNames = value.getPropertyNames(runtime);
-  size_t size = propertyNames.size(runtime);
-  NSMutableDictionary *result = [NSMutableDictionary new];
-  for (size_t i = 0; i < size; i++) {
-    jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
-    NSString *k = convertJSIStringToNSString(runtime, name);
-    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name));
-    if (v) {
-      result[k] = v;
-    }
-  }
-  return [result copy];
-}
-
-static NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value)
-{
-  size_t size = value.size(runtime);
-  NSMutableArray *result = [NSMutableArray new];
-  for (size_t i = 0; i < size; i++) {
-    // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i)) ?: (id)kCFNull];
-  }
-  return [result copy];
-}
-
-static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value)
-{
-  if (value.isUndefined() || value.isNull()) {
-    return nil;
-  }
-  if (value.isBool()) {
-    return @(value.getBool());
-  }
-  if (value.isNumber()) {
-    return @(value.getNumber());
-  }
-  if (value.isString()) {
-    return convertJSIStringToNSString(runtime, value.getString(runtime));
-  }
-  if (value.isObject()) {
-    jsi::Object o = value.getObject(runtime);
-    if (o.isArray(runtime)) {
-      return convertJSIArrayToNSArray(runtime, o.getArray(runtime));
-    }
-    return convertJSIObjectToNSDictionary(runtime, o);
-  }
-
-  throw std::runtime_error("Unsupported jsi::jsi::Value kind");
-}
-
 static NSSet *convertProps(jsi::Runtime &rt, const jsi::Value &props)
 {
   NSMutableSet *propsSet = [[NSMutableSet alloc] init];
@@ -338,37 +278,15 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   scheduler->setRuntimeManager(module);
 
-#ifdef RCT_NEW_ARCH_ENABLED
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventNameNSString, id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
-
     std::string eventName = [eventNameNSString UTF8String];
     jsi::Runtime &rt = *module->runtime;
-    jsi::Value payload = convertNSDictionaryToJSIObject(rt, [event arguments][2]);
-
+    id eventData = [event arguments][2];
+    jsi::Object payload = [eventData isKindOfClass:[NSDictionary class]] ? convertNSDictionaryToJSIObject(rt, eventData)
+                                                                         : jsi::Object(rt);
     module->handleEvent(eventName, std::move(payload), CACurrentMediaTime() * 1000);
   }];
-#else
-  [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventName, id<RCTEvent> event) {
-    std::string eventNameString([eventName UTF8String]);
-
-    std::string eventAsString;
-    try {
-      eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
-    } catch (std::exception &) {
-      // Events from other libraries may contain NaN or INF values which cannot be represented in JSON.
-      // See https://github.com/software-mansion/react-native-reanimated/issues/1776 for details.
-      return;
-    }
-
-    eventAsString = "{ NativeMap:" + eventAsString + "}";
-    jsi::Object global = module->runtime->global();
-    jsi::String eventTimestampName = jsi::String::createFromAscii(*module->runtime, "_eventTimestamp");
-    global.setProperty(*module->runtime, eventTimestampName, CACurrentMediaTime() * 1000);
-    module->onEvent(eventNameString, eventAsString);
-    global.setProperty(*module->runtime, eventTimestampName, jsi::Value::undefined());
-  }];
-#endif
 
   std::weak_ptr<NativeReanimatedModule> weakModule = module; // to avoid retain cycle
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -280,12 +280,15 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventNameNSString, id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
+    id eventData = [event arguments][2];
+    if (![eventData isKindOfClass:[NSDictionary class]]) {
+      return;
+    }
     std::string eventName = [eventNameNSString UTF8String];
     jsi::Runtime &rt = *module->runtime;
-    id eventData = [event arguments][2];
-    jsi::Object payload = [eventData isKindOfClass:[NSDictionary class]] ? convertNSDictionaryToJSIObject(rt, eventData)
-                                                                         : jsi::Object(rt);
-    module->handleEvent(eventName, std::move(payload), CACurrentMediaTime() * 1000);
+    jsi::Object payload = convertNSDictionaryToJSIObject(rt, eventData);
+    double currentTime = CACurrentMediaTime() * 1000;
+    module->handleEvent(eventName, std::move(payload), currentTime);
   }];
 
   std::weak_ptr<NativeReanimatedModule> weakModule = module; // to avoid retain cycle

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -280,15 +280,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventNameNSString, id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
-    id eventData = [event arguments][2];
-    if (![eventData isKindOfClass:[NSDictionary class]]) {
-      return;
-    }
     std::string eventName = [eventNameNSString UTF8String];
+    id eventData = [event arguments][2];
     jsi::Runtime &rt = *module->runtime;
-    jsi::Object payload = convertNSDictionaryToJSIObject(rt, eventData);
+    jsi::Value payload = convertObjCObjectToJSIValue(rt, eventData);
     double currentTime = CACurrentMediaTime() * 1000;
-    module->handleEvent(eventName, std::move(payload), currentTime);
+    module->handleEvent(eventName, payload, currentTime);
   }];
 
   std::weak_ptr<NativeReanimatedModule> weakModule = module; // to avoid retain cycle

--- a/ios/native/REAJSIUtils.h
+++ b/ios/native/REAJSIUtils.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <jsi/jsi.h>
 
@@ -63,4 +62,63 @@ static jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
   return jsi::Value::undefined();
 }
 
-#endif // RCT_NEW_ARCH_ENABLED
+// Other
+
+static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
+
+static NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value)
+{
+  return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
+}
+
+static NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value)
+{
+  jsi::Array propertyNames = value.getPropertyNames(runtime);
+  size_t size = propertyNames.size(runtime);
+  NSMutableDictionary *result = [NSMutableDictionary new];
+  for (size_t i = 0; i < size; i++) {
+    jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
+    NSString *k = convertJSIStringToNSString(runtime, name);
+    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name));
+    if (v) {
+      result[k] = v;
+    }
+  }
+  return [result copy];
+}
+
+static NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value)
+{
+  size_t size = value.size(runtime);
+  NSMutableArray *result = [NSMutableArray new];
+  for (size_t i = 0; i < size; i++) {
+    // Insert kCFNull when it's `undefined` value to preserve the indices.
+    [result addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i)) ?: (id)kCFNull];
+  }
+  return [result copy];
+}
+
+static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value)
+{
+  if (value.isUndefined() || value.isNull()) {
+    return nil;
+  }
+  if (value.isBool()) {
+    return @(value.getBool());
+  }
+  if (value.isNumber()) {
+    return @(value.getNumber());
+  }
+  if (value.isString()) {
+    return convertJSIStringToNSString(runtime, value.getString(runtime));
+  }
+  if (value.isObject()) {
+    jsi::Object o = value.getObject(runtime);
+    if (o.isArray(runtime)) {
+      return convertJSIArrayToNSArray(runtime, o.getArray(runtime));
+    }
+    return convertJSIObjectToNSDictionary(runtime, o);
+  }
+
+  throw std::runtime_error("Unsupported jsi::Value kind");
+}


### PR DESCRIPTION
## Summary

This PR unifies code responsible for handling events on Paper and Fabric on both platforms.

## Changes

* Remove `#ifdef` for `registerEventHandler` and make it renderer-agnostic
* Use `convertObjCObjectToJSIValue` instead of `convertIdToFollyDynamic`, `folly::toJson` and `jsi::Value::createFromJsonUtf8` on iOS
* Move Obj-C/JSI conversion functions from `NativeProxy.mm` to `REAJSIUtils.h`
* Still use JSON as intermediate format between `ReadableMap` and `jsi::Value` on Android (no known alternatives)
* Pass JNI values to EventHandler function instead of `std::string` (like on iOS we pass `id<RCTEvent>`)
* Use `const jsi::Value &` for event payload
* Use `const std::string &` for event name

<!--
Android:
* `event == nullptr`
* contains NaN/INF values
* `event->toString()` fail
* `{ NativeMap: null }`
* invalid JSON
* normal case

iOS:
* `event == nil`
* `[event arguments][2]` is not a `NSDictionary`
* contains NaN/INF values
* normal case
-->

## Test plan

Check if `GestureHandlerExample.tsx` and `ScrollViewExample.tsx` work on all configurations (Paper/Fabric, Android/iOS).
