### PR TITLE
Hide `back-to-top` button in the documentation

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -666,3 +666,7 @@ header > .container {
 * {
   scroll-behavior: smooth;
 }
+
+.theme-back-to-top-button {
+  display: none;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Hides the `back-to-top` button in the documentation. Same as https://github.com/software-mansion/react-native-gesture-handler/pull/2398.

## Test plan

Build the docs and scroll a bit.
