### PR TITLE
[Shared Element Transition] Improvements after review v1

### DIFF
--- a/Common/cpp/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/Common/cpp/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -96,11 +96,10 @@ void LayoutAnimationsManager::startLayoutAnimation(
 
 /*
   The top screen on the stack triggers the animation, so we need to find
-  the sibling view registered in the past. That's why we look backward.
-
-  We need to find view registered in the same transition group (with the
-  same transition tag) which has been added to that group directly before
-  the one that we provide as an argument.
+  the sibling view registered in the past. This method finds view
+  registered in the same transition group (with the same transition tag)
+  which has been added to that group directly before the one that we
+  provide as an argument.
 */
 int LayoutAnimationsManager::findPrecedingViewTagForTransition(int tag) {
   auto const &groupName = viewTagToSharedTag_[tag];

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -639,7 +639,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     mSharedTransitionManager.onViewsRemoval(tagsToDelete);
   }
 
-  public void doSnapshotOfTopScreenViews(ViewGroup stack) {
+  public void makeSnapshotOfTopScreenViews(ViewGroup stack) {
     mSharedTransitionManager.doSnapshotForTopScreenViews(stack);
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -419,7 +419,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
       if (isPositionAbsolute) {
         Point newPoint = new Point(x, y);
         View viewToUpdateParent = (View) viewToUpdate.getParent();
-        Point convertedPoint = convertAbsoluteToParentRelative(newPoint, viewToUpdateParent);
+        Point convertedPoint = convertScreenLocationToViewCoordinates(newPoint, viewToUpdateParent);
         x = convertedPoint.x;
         y = convertedPoint.y;
       }
@@ -623,7 +623,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     }
   }
 
-  private Point convertAbsoluteToParentRelative(Point fromPoint, View parentView) {
+  private static Point convertScreenLocationToViewCoordinates(Point fromPoint, View parentView) {
     int[] toPoint = {0, 0};
     if (parentView != null) {
       parentView.getLocationOnScreen(toPoint);

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -639,7 +639,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     mSharedTransitionManager.onViewsRemoval(tagsToDelete);
   }
 
-  public void doSnapshotForTopScreenViews(ViewGroup stack) {
+  public void doSnapshotOfTopScreenViews(ViewGroup stack) {
     mSharedTransitionManager.doSnapshotForTopScreenViews(stack);
   }
 

--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -288,7 +288,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     AnimationsManager animationsManager = mReaLayoutAnimator.getAnimationsManager();
     if (viewGroupManager.getName().equals("RNSScreenStack")) {
       if (tagsToDelete == null) {
-        animationsManager.doSnapshotOfTopScreenViews(viewGroup);
+        animationsManager.makeSnapshotOfTopScreenViews(viewGroup);
       } else {
         animationsManager.notifyAboutViewsRemoval(tagsToDelete);
       }

--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -285,7 +285,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     }
 
     // we don't want layout animations in native-stack since it is currently buggy there
-    AnimationsManager animationsManager = ((ReaLayoutAnimator) mReaLayoutAnimator).getAnimationsManager();
+    AnimationsManager animationsManager = mReaLayoutAnimator.getAnimationsManager();
     if (viewGroupManager.getName().equals("RNSScreenStack")) {
       if (tagsToDelete == null) {
         animationsManager.doSnapshotForTopScreenViews(viewGroup);

--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -288,7 +288,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     AnimationsManager animationsManager = mReaLayoutAnimator.getAnimationsManager();
     if (viewGroupManager.getName().equals("RNSScreenStack")) {
       if (tagsToDelete == null) {
-        animationsManager.doSnapshotForTopScreenViews(viewGroup);
+        animationsManager.doSnapshotOfTopScreenViews(viewGroup);
       } else {
         animationsManager.notifyAboutViewsRemoval(tagsToDelete);
       }

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -23,6 +23,8 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 typedef NSNumber *_Nullable (^REAFindPrecedingViewTagForTransitionBlock)(NSNumber *_Nonnull tag);
 typedef int (^REATreeVisitor)(id<RCTComponent>);
 
+BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>));
+
 @interface REAAnimationsManager : NSObject
 
 - (instancetype)initWithUIManager:(RCTUIManager *)uiManager;
@@ -56,7 +58,6 @@ typedef int (^REATreeVisitor)(id<RCTComponent>);
                         type:(NSString *)type
                   yogaValues:(NSDictionary *)yogaValues
                        depth:(NSNumber *)depth;
-- (void)visitTree:(UIView *)view block:(REATreeVisitor)block;
 
 @end
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -9,7 +9,7 @@
 
 typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
 
-static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
+BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 {
   if (!view.reactTag) {
     return NO;
@@ -561,11 +561,6 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
                        depth:(NSNumber *)depth;
 {
   _startAnimationForTag(tag, type, yogaValues, depth);
-}
-
-- (void)visitTree:(UIView *)view block:(REATreeVisitor)block
-{
-  REANodeFind(view, block);
 }
 
 @end

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -207,22 +207,22 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     [newProps removeObjectForKey:@"width"];
   }
 
-  bool updateViewPosition = false;
+  bool needViewPositionUpdate = false;
   double centerX = view.center.x;
   double centerY = view.center.y;
   if (newProps[@"originX"]) {
-    updateViewPosition = true;
+    needViewPositionUpdate = true;
     double originX = [self getDoubleOrZero:newProps[@"originX"]];
     [newProps removeObjectForKey:@"originX"];
     centerX = originX + view.bounds.size.width / 2.0;
   }
   if (newProps[@"originY"]) {
-    updateViewPosition = true;
+    needViewPositionUpdate = true;
     double originY = [self getDoubleOrZero:newProps[@"originY"]];
     [newProps removeObjectForKey:@"originY"];
     centerY = originY + view.bounds.size.height / 2.0;
   }
-  if (updateViewPosition) {
+  if (needViewPositionUpdate) {
     CGPoint newCenter = CGPointMake(centerX, centerY);
     if (convertFromAbsolute) {
       UIView *window = UIApplication.sharedApplication.keyWindow;

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -163,12 +163,7 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
                                   forTag:(NSNumber *)tag
                       isSharedTransition:(BOOL)isSharedTransition
 {
-  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
-  [self setNewProps:[newStyle mutableCopy]
-                  forView:[self viewForTag:tag]
-        withComponentData:componentData
-      convertFromAbsolute:isSharedTransition];
+  [self setNewProps:[newStyle mutableCopy] forView:[self viewForTag:tag] convertFromAbsolute:isSharedTransition];
 }
 
 - (double)getDoubleOrZero:(NSNumber *)number
@@ -182,16 +177,13 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (void)setNewProps:(NSMutableDictionary *)newProps forView:(UIView *)view
 {
-  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
-  [self setNewProps:newProps forView:view withComponentData:componentData convertFromAbsolute:NO];
+  [self setNewProps:newProps forView:view convertFromAbsolute:NO];
 }
 
-- (void)setNewProps:(NSMutableDictionary *)newProps
-                forView:(UIView *)view
-      withComponentData:(RCTComponentData *)componentData
-    convertFromAbsolute:(BOOL)convertFromAbsolute
+- (void)setNewProps:(NSMutableDictionary *)newProps forView:(UIView *)view convertFromAbsolute:(BOOL)convertFromAbsolute
 {
+  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
+  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
   if (newProps[@"height"]) {
     double height = [self getDoubleOrZero:newProps[@"height"]];
     double oldHeight = view.bounds.size.height;

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -182,8 +182,6 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (void)setNewProps:(NSMutableDictionary *)newProps forView:(UIView *)view convertFromAbsolute:(BOOL)convertFromAbsolute
 {
-  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
   if (newProps[@"height"]) {
     double height = [self getDoubleOrZero:newProps[@"height"]];
     double oldHeight = view.bounds.size.height;
@@ -199,22 +197,22 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     [newProps removeObjectForKey:@"width"];
   }
 
-  bool needViewPositionUpdate = false;
+  bool needsViewPositionUpdate = false;
   double centerX = view.center.x;
   double centerY = view.center.y;
   if (newProps[@"originX"]) {
-    needViewPositionUpdate = true;
+    needsViewPositionUpdate = true;
     double originX = [self getDoubleOrZero:newProps[@"originX"]];
     [newProps removeObjectForKey:@"originX"];
     centerX = originX + view.bounds.size.width / 2.0;
   }
   if (newProps[@"originY"]) {
-    needViewPositionUpdate = true;
+    needsViewPositionUpdate = true;
     double originY = [self getDoubleOrZero:newProps[@"originY"]];
     [newProps removeObjectForKey:@"originY"];
     centerY = originY + view.bounds.size.height / 2.0;
   }
-  if (needViewPositionUpdate) {
+  if (needsViewPositionUpdate) {
     CGPoint newCenter = CGPointMake(centerX, centerY);
     if (convertFromAbsolute) {
       UIView *window = UIApplication.sharedApplication.keyWindow;
@@ -225,6 +223,8 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     }
   }
 
+  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
+  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
   [componentData setProps:newProps forView:view];
 }
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -223,8 +223,8 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     }
   }
 
-  NSMutableDictionary *dataComponentsByName = [_uiManager valueForKey:@"_componentDataByName"];
-  RCTComponentData *componentData = dataComponentsByName[@"RCTView"];
+  NSMutableDictionary *componentDataByName = [_uiManager valueForKey:@"_componentDataByName"];
+  RCTComponentData *componentData = componentDataByName[@"RCTView"];
   [componentData setProps:newProps forView:view];
 }
 

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -238,7 +238,6 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (NSDictionary *)prepareDataForAnimatingWorklet:(NSMutableDictionary *)values frameConfig:(FrameConfigType)frameConfig
 {
-  UIView *windowView = UIApplication.sharedApplication.keyWindow;
   if (frameConfig == EnteringFrame) {
     NSDictionary *preparedData = @{
       @"targetWidth" : values[@"width"],
@@ -247,8 +246,8 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
       @"targetOriginY" : values[@"originY"],
       @"targetGlobalOriginX" : values[@"globalOriginX"],
       @"targetGlobalOriginY" : values[@"globalOriginY"],
-      @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
-      @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+      @"windowWidth" : values[@"windowWidth"],
+      @"windowHeight" : values[@"windowHeight"]
     };
     return preparedData;
   } else {
@@ -259,8 +258,8 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
       @"currentOriginY" : values[@"originY"],
       @"currentGlobalOriginX" : values[@"globalOriginX"],
       @"currentGlobalOriginY" : values[@"globalOriginY"],
-      @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
-      @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+      @"windowWidth" : values[@"windowWidth"],
+      @"windowHeight" : values[@"windowHeight"]
     };
     return preparedData;
   }
@@ -269,7 +268,6 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 - (NSDictionary *)prepareDataForLayoutAnimatingWorklet:(NSMutableDictionary *)currentValues
                                           targetValues:(NSMutableDictionary *)targetValues
 {
-  UIView *windowView = UIApplication.sharedApplication.keyWindow;
   NSDictionary *preparedData = @{
     @"currentWidth" : currentValues[@"width"],
     @"currentHeight" : currentValues[@"height"],
@@ -283,8 +281,8 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     @"targetOriginY" : targetValues[@"originY"],
     @"targetGlobalOriginX" : targetValues[@"globalOriginX"],
     @"targetGlobalOriginY" : targetValues[@"globalOriginY"],
-    @"windowWidth" : [NSNumber numberWithDouble:windowView.bounds.size.width],
-    @"windowHeight" : [NSNumber numberWithDouble:windowView.bounds.size.height]
+    @"windowWidth" : currentValues[@"windowWidth"],
+    @"windowHeight" : currentValues[@"windowHeight"]
   };
   return preparedData;
 }

--- a/ios/LayoutReanimation/REASharedTransitionManager.h
+++ b/ios/LayoutReanimation/REASharedTransitionManager.h
@@ -5,7 +5,7 @@
 
 - (void)notifyAboutNewView:(UIView *)view;
 - (void)viewsDidLayout;
-- (BOOL)setupAndStartSharedTransitionForViews:(NSArray<UIView *> *)views;
+- (BOOL)configureAndStartSharedTransitionForViews:(NSArray<UIView *> *)views;
 - (void)finishSharedAnimation:(UIView *)view;
 - (void)setFindPrecedingViewTagForTransitionBlock:
     (REAFindPrecedingViewTagForTransitionBlock)findPrecedingViewTagForTransition;

--- a/ios/LayoutReanimation/REASharedTransitionManager.h
+++ b/ios/LayoutReanimation/REASharedTransitionManager.h
@@ -5,7 +5,7 @@
 
 - (void)notifyAboutNewView:(UIView *)view;
 - (void)viewsDidLayout;
-- (BOOL)setupSyncSharedTransitionForViews:(NSArray<UIView *> *)views;
+- (BOOL)setupAndStartSharedTransitionForViews:(NSArray<UIView *> *)views;
 - (void)finishSharedAnimation:(UIView *)view;
 - (void)setFindPrecedingViewTagForTransitionBlock:
     (REAFindPrecedingViewTagForTransitionBlock)findPrecedingViewTagForTransition;

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -217,6 +217,10 @@ static REASharedTransitionManager *_sharedTransitionManager;
   return nil;
 }
 
+/*
+  Method swizzling is used to get notification from react-native-screens
+  about push or pop screen from stack.
+*/
 - (void)swizzleScreensMethods
 {
 #if LOAD_SCREENS_HEADERS

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -24,7 +24,7 @@
 
 /*
   `_sharedTransitionManager` provides access to current REASharedTransitionManager
-  instance from swizzled methods in react-native-screens. Swizzled methos has
+  instance from swizzled methods in react-native-screens. Swizzled method has
   different context of execution (self != REASharedTransitionManager)
 */
 static REASharedTransitionManager *_sharedTransitionManager;
@@ -287,7 +287,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
     if (shouldRunTransition) {
       [self runSharedTransitionForSharedViewsOnScreen:screen];
     } else {
-      [self doSnapshotForScreenViews:screen];
+      [self makeSnapshotForScreenViews:screen];
     }
   } else {
     // removed stack
@@ -295,7 +295,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
   }
 }
 
-- (void)doSnapshotForScreenViews:(UIView *)screen
+- (void)makeSnapshotForScreenViews:(UIView *)screen
 {
   REANodeFind(screen, ^int(id<RCTComponent> view) {
     NSNumber *viewTag = view.reactTag;

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -22,6 +22,11 @@
   REAAnimationsManager *_animationManager;
 }
 
+/*
+  `_sharedTransitionManager` provides access to current REASharedTransitionManager
+  instance from swizzled methods in react-native-screens. Swizzled methos has
+  different context of execution (self != REASharedTransitionManager)
+*/
 static REASharedTransitionManager *_sharedTransitionManager;
 
 - (instancetype)initWithAnimationsManager:(REAAnimationsManager *)animationManager

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -74,7 +74,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
   _sharedElements = [self getSharedElementForCurrentTransition:sharedViews withNewElements:YES];
 }
 
-- (BOOL)setupSyncSharedTransitionForViews:(NSArray<UIView *> *)views
+- (BOOL)setupAndStartSharedTransitionForViews:(NSArray<UIView *> *)views
 {
   NSArray *sharedViews = [self sortViewsByTags:views];
   NSArray<REASharedElement *> *sharedElements = [self getSharedElementForCurrentTransition:sharedViews
@@ -349,7 +349,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
     }
     return false;
   });
-  BOOL startedAnimation = [self setupSyncSharedTransitionForViews:removedViews];
+  BOOL startedAnimation = [self setupAndStartSharedTransitionForViews:removedViews];
   if (startedAnimation) {
     for (UIView *view in removedViews) {
       [_animationManager clearAnimationConfigForTag:view.reactTag];

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -157,12 +157,12 @@
       }
     }
 
-    REASnapshot *sourceViewSnapshot = [[REASnapshot alloc] init:viewSource withParent:viewSource.superview];
+    REASnapshot *sourceViewSnapshot = [[REASnapshot alloc] initWithAbsolutePosition:viewSource];
     _snapshotRegistry[viewSource.reactTag] = sourceViewSnapshot;
 
     REASnapshot *targetViewSnapshot;
     if (addedNewScreen) {
-      targetViewSnapshot = [[REASnapshot alloc] init:viewTarget withParent:viewTarget.superview];
+      targetViewSnapshot = [[REASnapshot alloc] initWithAbsolutePosition:viewTarget];
       _snapshotRegistry[viewTarget.reactTag] = targetViewSnapshot;
     } else {
       targetViewSnapshot = _snapshotRegistry[viewTarget.reactTag];
@@ -322,8 +322,7 @@
                          block:^int(id<RCTComponent> view) {
                            NSNumber *viewTag = view.reactTag;
                            if ([self->_animationManager hasAnimationForTag:viewTag type:@"sharedElementTransition"]) {
-                             REASnapshot *snapshot = [[REASnapshot alloc] init:(UIView *)view
-                                                                    withParent:((UIView *)view).superview];
+                             REASnapshot *snapshot = [[REASnapshot alloc] initWithAbsolutePosition:(UIView *)view];
                              self->_snapshotRegistry[viewTag] = snapshot;
                            }
                            return false;
@@ -401,7 +400,7 @@
   NSMutableArray<REASharedElement *> *currentSharedElements = [NSMutableArray new];
   for (REASharedElement *sharedElement in _sharedElements) {
     UIView *viewTarget = sharedElement.targetView;
-    REASnapshot *targetViewSnapshot = [[REASnapshot alloc] init:viewTarget withParent:viewTarget.superview];
+    REASnapshot *targetViewSnapshot = [[REASnapshot alloc] initWithAbsolutePosition:viewTarget];
     _snapshotRegistry[viewTarget.reactTag] = targetViewSnapshot;
     sharedElement.targetViewSnapshot = targetViewSnapshot;
     [currentSharedElements addObject:sharedElement];

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -220,6 +220,7 @@
 
 - (void)observeChanges:(UIView *)view
 {
+#if LOAD_SCREENS_HEADERS
   if (view == nil || [_screenHasObserver containsObject:view.reactTag]) {
     return;
   }
@@ -234,11 +235,12 @@
     UIViewController *viewController = [view valueForKey:@"controller"];
     [self swizzleMethod:@selector(viewDidLayoutSubviews)
                    with:@selector(swizzled_viewDidLayoutSubviews)
-               forClass:[viewController class]];
+               forClass:[RNSScreen class]];
     [self swizzleMethod:@selector(notifyWillDisappear)
                    with:@selector(swizzled_notifyWillDisappear)
-               forClass:[view class]];
+               forClass:[RNSScreenView class]];
   });
+#endif
 }
 
 - (void)swizzleMethod:(SEL)originalSelector with:(SEL)swizzledSelector forClass:(Class)originalClass

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -64,17 +64,17 @@ static REASharedTransitionManager *_sharedTransitionManager;
 
 - (void)viewsDidLayout
 {
-  [self setupAsyncSharedTransitionForViews:_addedSharedViews];
+  [self configureAsyncSharedTransitionForViews:_addedSharedViews];
   [_addedSharedViews removeAllObjects];
 }
 
-- (void)setupAsyncSharedTransitionForViews:(NSArray<UIView *> *)views
+- (void)configureAsyncSharedTransitionForViews:(NSArray<UIView *> *)views
 {
   NSArray *sharedViews = [self sortViewsByTags:views];
   _sharedElements = [self getSharedElementForCurrentTransition:sharedViews withNewElements:YES];
 }
 
-- (BOOL)setupAndStartSharedTransitionForViews:(NSArray<UIView *> *)views
+- (BOOL)configureAndStartSharedTransitionForViews:(NSArray<UIView *> *)views
 {
   NSArray *sharedViews = [self sortViewsByTags:views];
   NSArray<REASharedElement *> *sharedElements = [self getSharedElementForCurrentTransition:sharedViews
@@ -82,7 +82,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
   if ([sharedElements count] == 0) {
     return NO;
   }
-  [self setupTransitionContainer];
+  [self configureTransitionContainer];
   [self reparentSharedViewsForCurrentTransition:sharedElements];
   [self startSharedTransition:sharedElements];
   return YES;
@@ -353,7 +353,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
     }
     return false;
   });
-  BOOL startedAnimation = [self setupAndStartSharedTransitionForViews:removedViews];
+  BOOL startedAnimation = [self configureAndStartSharedTransitionForViews:removedViews];
   if (startedAnimation) {
     for (UIView *view in removedViews) {
       [_animationManager clearAnimationConfigForTag:view.reactTag];
@@ -378,14 +378,14 @@ static REASharedTransitionManager *_sharedTransitionManager;
   if ([currentSharedElements count] == 0) {
     return;
   }
-  [self setupTransitionContainer];
+  [self configureTransitionContainer];
   [self reparentSharedViewsForCurrentTransition:_sharedElements];
   [self startSharedTransition:_sharedElements];
   [_addedSharedViews removeAllObjects];
   [_sharedElements removeObjectsInArray:currentSharedElements];
 }
 
-- (void)setupTransitionContainer
+- (void)configureTransitionContainer
 {
   if (!_isSharedTransitionActive) {
     _isSharedTransitionActive = YES;

--- a/ios/LayoutReanimation/REASnapshot.h
+++ b/ios/LayoutReanimation/REASnapshot.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSMutableDictionary *values;
 
 - (instancetype)init:(UIView *)view;
-- (instancetype)init:(UIView *)view withParent:(UIView *)parent;
+- (instancetype)initWithAbsolutePosition:(UIView *)view;
 
 @end
 

--- a/ios/LayoutReanimation/REASnapshot.m
+++ b/ios/LayoutReanimation/REASnapshot.m
@@ -3,45 +3,41 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation REASnapshot {
-  UIView *_view;
-}
+@implementation REASnapshot
 
 - (instancetype)init:(UIView *)view
 {
   self = [super init];
-  _view = view;
-  UIView *windowView = UIApplication.sharedApplication.keyWindow;
-  CGPoint originFromRootPerspective = [[view superview] convertPoint:view.center toView:windowView];
-  _values = [NSMutableDictionary new];
-  _values[@"width"] = [NSNumber numberWithDouble:(double)(view.bounds.size.width)];
-  _values[@"height"] = [NSNumber numberWithDouble:(double)(view.bounds.size.height)];
-  _values[@"originX"] = [NSNumber numberWithDouble:view.center.x - view.bounds.size.width / 2.0];
-  _values[@"originY"] = [NSNumber numberWithDouble:view.center.y - view.bounds.size.height / 2.0];
-  _values[@"globalOriginX"] = [NSNumber numberWithDouble:originFromRootPerspective.x - view.bounds.size.width / 2.0];
-  _values[@"globalOriginY"] = [NSNumber numberWithDouble:originFromRootPerspective.y - view.bounds.size.height / 2.0];
-
+  [self makeSnapshotForView:view useAbsolutePositionOnly:NO];
   return self;
 }
 
-- (instancetype)init:(UIView *)view withParent:(UIView *)parent
+- (instancetype)initWithAbsolutePosition:(UIView *)view
 {
   self = [super init];
-  UIView *mainWindow = UIApplication.sharedApplication.keyWindow;
-  CGPoint absolutePosition = [parent convertPoint:view.center toView:mainWindow];
+  [self makeSnapshotForView:view useAbsolutePositionOnly:YES];
+  return self;
+}
 
+- (void)makeSnapshotForView:(UIView *)view useAbsolutePositionOnly:(BOOL)useAbsolutePositionOnly
+{
+  UIView *mainWindow = UIApplication.sharedApplication.keyWindow;
+  CGPoint absolutePosition = [[view superview] convertPoint:view.center toView:mainWindow];
   _values = [NSMutableDictionary new];
-  _values[@"width"] = [NSNumber numberWithDouble:(double)(view.bounds.size.width)];
-  _values[@"height"] = [NSNumber numberWithDouble:(double)(view.bounds.size.height)];
-  _values[@"originX"] = [NSNumber numberWithDouble:absolutePosition.x - view.bounds.size.width / 2.0];
-  _values[@"originY"] = [NSNumber numberWithDouble:absolutePosition.y - view.bounds.size.height / 2.0];
-  _values[@"originYByParent"] = [NSNumber numberWithDouble:view.center.y - view.bounds.size.height / 2.0];
-  _values[@"globalOriginX"] = _values[@"originX"];
-  _values[@"globalOriginY"] = _values[@"originY"];
   _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.bounds.size.width];
   _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.bounds.size.height];
-
-  return self;
+  _values[@"width"] = [NSNumber numberWithDouble:(double)(view.bounds.size.width)];
+  _values[@"height"] = [NSNumber numberWithDouble:(double)(view.bounds.size.height)];
+  _values[@"globalOriginX"] = [NSNumber numberWithDouble:absolutePosition.x - view.bounds.size.width / 2.0];
+  _values[@"globalOriginY"] = [NSNumber numberWithDouble:absolutePosition.y - view.bounds.size.height / 2.0];
+  if (useAbsolutePositionOnly) {
+    _values[@"originX"] = _values[@"globalOriginX"];
+    _values[@"originY"] = _values[@"globalOriginY"];
+    _values[@"originYByParent"] = [NSNumber numberWithDouble:view.center.y - view.bounds.size.height / 2.0];
+  } else {
+    _values[@"originX"] = [NSNumber numberWithDouble:view.center.x - view.bounds.size.width / 2.0];
+    _values[@"originY"] = [NSNumber numberWithDouble:view.center.y - view.bounds.size.height / 2.0];
+  }
 }
 
 @end

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -178,7 +178,7 @@ declare module 'react-native-reanimated' {
         | EntryExitAnimationFunction
         | Keyframe;
       sharedTransitionTag?: string;
-      sharedTransitionStyle?: any; //TODO: first we need to decide about API for this prop
+      sharedTransitionStyle?: ILayoutAnimationBuilder;
     };
 
     export interface PhysicsAnimationState extends AnimationState {

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -135,7 +135,7 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
     | EntryExitAnimationFunction
     | Keyframe;
   sharedTransitionTag?: string;
-  sharedTransitionStyle?: any;
+  sharedTransitionStyle?: ILayoutAnimationBuilder;
 };
 
 type Options<P> = {


### PR DESCRIPTION
## Summary

This PR contains improvements after the latest reviews form PR with [Shared Element Transition](https://github.com/software-mansion/react-native-reanimated/pull/3827)

Changes:
- Naming improvements
- Get rid of the key-value observer - In the previous implementation I used KVO to change the context of execution. That was because swizzled method changes the context of execution, so the self in the swizzled method is `RNSScreen` instead of `REASharedTransitionManager`. That's why I used KVO to change the context of execution back to `REASharedTransitionManager`
- I used directly `[RNSScreen class]` and `[RNSScreenView class]` in the `swizzleScreensMethods` method, instead of getting it from the instance of screen (`[screen class]`)
- Refactor Snapshot on iOS