### PR TITLE
Fix Fabric crash in `NativeReanimatedModule::removeShadowNodeFromRegistry`

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -597,9 +597,8 @@ void NativeReanimatedModule::performOperations() {
 
 void NativeReanimatedModule::removeShadowNodeFromRegistry(
     jsi::Runtime &rt,
-    const jsi::Value &shadowNodeValue) {
-  auto shadowNode = shadowNodeFromValue(rt, shadowNodeValue);
-  tagsToRemove_.push_back(shadowNode->getTag());
+    const jsi::Value &tag) {
+  tagsToRemove_.push_back(tag.asNumber());
 }
 
 void NativeReanimatedModule::dispatchCommand(

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -242,7 +242,9 @@ export default function createAnimatedComponent(
           this.props.animatedProps.viewDescriptors.remove(this._viewTag);
         }
         if (global._IS_FABRIC) {
-          const shadowNodeWrapper = getShadowNodeWrapperFromRef(this);
+          const shadowNodeWrapper = makeShareableShadowNodeWrapper(
+            getShadowNodeWrapperFromRef(this)
+          );
           runOnUI(() => {
             'worklet';
             _removeShadowNodeFromRegistry(shadowNodeWrapper);

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -242,12 +242,10 @@ export default function createAnimatedComponent(
           this.props.animatedProps.viewDescriptors.remove(this._viewTag);
         }
         if (global._IS_FABRIC) {
-          const shadowNodeWrapper = makeShareableShadowNodeWrapper(
-            getShadowNodeWrapperFromRef(this)
-          );
+          const viewTag = this._viewTag;
           runOnUI(() => {
             'worklet';
-            _removeShadowNodeFromRegistry(shadowNodeWrapper);
+            _removeShadowNodeFromRegistry(viewTag);
           })();
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes a Fabric crash in `NativeReanimatedModule::removeShadowNodeFromRegistry`. I don't know the exact root cause but I know how to fix it.

First, I added missing `makeShareableShadowNodeWrapper` call. However, since only the view tag is required on the native side, there's no need to pass the whole ShadowNodeWrapper, so I simply grab the view tag from `this._viewTag` and pass it to the cleanup worklet via closure.

## Steps to reproduce the issue

1. Launch FabricExample on iOS
2. Open "forwardRef & useImperativeHandle" example
3. Increase animation duration to 3000 ms
4. Randomly click both buttons
5. Go to previous screen
6. Crash

https://user-images.githubusercontent.com/20516055/216365412-edb406ad-6947-4cdf-94aa-5b82bd079fab.mp4

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
