### PR TITLE
Make shareable HostObject code more generic

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -265,11 +265,9 @@ jsi::Value NativeReanimatedModule::makeShareableClone(
       } else {
         shareable = std::make_shared<ShareableArray>(rt, object.asArray(rt));
       }
-#ifdef RCT_NEW_ARCH_ENABLED
-    } else if (object.isHostObject<ShadowNodeWrapper>(rt)) {
-      shareable = std::make_shared<ShareableShadowNodeWrapper>(
-          runtimeHelper, rt, object);
-#endif
+    } else if (object.isHostObject(rt)) {
+      shareable = std::make_shared<ShareableHostObject>(
+          runtimeHelper, rt, object.getHostObject(rt));
     } else {
       if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
         shareable = std::make_shared<RetainingShareable<ShareableObject>>(

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -121,9 +121,7 @@ class Shareable {
     RemoteFunctionType,
     HandleType,
     SynchronizedDataHolder,
-#ifdef RCT_NEW_ARCH_ENABLED
-    ShadowNode,
-#endif
+    HostObjectType,
   };
 
   explicit Shareable(ValueType valueType) : valueType_(valueType) {}
@@ -266,26 +264,20 @@ class ShareableObject : public Shareable {
   std::vector<std::pair<std::string, std::shared_ptr<Shareable>>> data_;
 };
 
-#ifdef RCT_NEW_ARCH_ENABLED
-class ShareableShadowNodeWrapper : public Shareable {
- private:
-  react::ShadowNode::Shared shadowNode_;
-
+class ShareableHostObject : public Shareable {
  public:
-  ShareableShadowNodeWrapper(
+  ShareableHostObject(
       const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
       jsi::Runtime &rt,
-      const jsi::Object &wrapperObject)
-      : Shareable(ShadowNode) {
-    shadowNode_ =
-        wrapperObject.getHostObject<ShadowNodeWrapper>(rt)->shadowNode;
-  }
+      const std::shared_ptr<jsi::HostObject> &hostObject)
+      : Shareable(HostObjectType), hostObject_(hostObject) {}
   jsi::Value toJSValue(jsi::Runtime &rt) override {
-    return jsi::Object::createFromHostObject(
-        rt, std::make_shared<ShadowNodeWrapper>(shadowNode_));
+    return jsi::Object::createFromHostObject(rt, hostObject_);
   }
+
+ protected:
+  std::shared_ptr<jsi::HostObject> hostObject_;
 };
-#endif
 
 class ShareableWorklet : public ShareableObject {
  private:

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -34,7 +34,6 @@ import {
   ViewRefSet,
 } from './reanimated2/ViewDescriptorsSet';
 import { getShadowNodeWrapperFromRef } from './reanimated2/fabricUtils';
-import { makeShareableShadowNodeWrapper } from './reanimated2/shareables';
 
 function dummyListener() {
   // empty listener we use to assign to listener properties for which animated
@@ -342,9 +341,7 @@ export default function createAnimatedComponent(
         }
 
         if (global._IS_FABRIC) {
-          shadowNodeWrapper = makeShareableShadowNodeWrapper(
-            getShadowNodeWrapperFromRef(this)
-          );
+          shadowNodeWrapper = getShadowNodeWrapperFromRef(this);
         }
       }
       this._viewTag = viewTag as number;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -6,16 +6,13 @@ import { getTag } from '../NativeMethods';
 import { getShadowNodeWrapperFromHostInstance } from '../fabricUtils';
 import {
   makeShareableCloneRecursive,
-  makeShareableShadowNodeWrapper,
   registerShareableMapping,
 } from '../shareables';
 
 function getShareableShadowNodeFromComponent(
   component: Component
 ): ShadowNodeWrapper {
-  return makeShareableShadowNodeWrapper(
-    getShadowNodeWrapperFromHostInstance(component)
-  );
+  return getShadowNodeWrapperFromHostInstance(component);
 }
 
 const getTagValueFunction = global._IS_FABRIC


### PR DESCRIPTION
## Summary

This PR changes code that was used to handle host objects such that it applies to all kinds of host objects, not only on Fabric and not only to ShadowNodeWrapper classes. This simplifies the codebase a bit, because we get rid of a few code branches with fabric specific checks as well as allows for other types of Host Objects to be made shareable.

Changes that were made cover:
1) changes in shareables c++ code where we remove fabric specific shadow wrapper shareable type and replace it with generic HostObjectType
2) changes on the JS side in shareables.ts where we detect if host object is provided and then we let it be processed by `makeShareableClone` method directly. For this purpose we add code for recognizing whether a given object is a host object or not.
3) we get rid of JS code that was preparing shadow node objects to be made "shareable" (`makeShareableShadowNodeWrapper`) in favor of the generic code added in shareables.ts described above

## Test plan

Run FabricExample both on Hermes and JSC