### PR TITLE
[Shared Element Transition] Fix: view disappeared after layout animation

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -531,7 +531,7 @@ static BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     [self setNewProps:before.values forView:view];
   }
 
-  if (_hasAnimationForTag(viewTag, @"sharedElementTransition")) {
+  if (_hasAnimationForTag(viewTag, @"sharedElementTransition") && [type isEqual:@"entering"]) {
     [_sharedTransitionManager notifyAboutNewView:view];
   }
 }

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -68,8 +68,10 @@
 
 - (void)setupAsyncSharedTransitionForViews:(NSArray<UIView *> *)views
 {
-  NSArray *sharedViews = [self sortViewsByTags:views];
-  _sharedElements = [self getSharedElementForCurrentTransition:sharedViews withNewElements:YES];
+  if ([views count] > 0) {
+    NSArray *sharedViews = [self sortViewsByTags:views];
+    _sharedElements = [self getSharedElementForCurrentTransition:sharedViews withNewElements:YES];
+  }
 }
 
 - (BOOL)setupSyncSharedTransitionForViews:(NSArray<UIView *> *)views


### PR DESCRIPTION
## Summary

I added a check to prevent adding already existing views to the shared transition registry. The issue only occurred when the view had a layout animation, as the registry is cleared after the animation ends. Afterwards, views from the registry were removed from their parent view. In the case of a shared transition, the parent screen is a custom temporary transition container, but in the case of a regular layout animation, the super view is the original parent. As a result, the view disappeared.