### PR TITLE
Add the missing type declaration of the `ComplexAnimationBuilder` class.

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -970,6 +970,16 @@ declare module 'react-native-reanimated' {
     restSpeedThreshold(
       restSpeedThresholdFactor: number
     ): ComplexAnimationBuilder;
+
+    static withInitialValues(
+      values: StyleProps
+    ): BaseAnimationBuilder
+
+    withInitialValues(
+      values: StyleProps
+    ): BaseAnimationBuilder
+
+    getAnimationAndConfig(): LayoutAnimationAndConfig
   }
 
   export class Layout extends ComplexAnimationBuilder {}


### PR DESCRIPTION
## Add the missing type declaration of the `ComplexAnimationBuilder` class.

Add type declarations for the three methods: withInitialValues(static), withInitialValues, and getAnimationAndConfig.

The specific location of the file:
https://github.com/software-mansion/react-native-reanimated/blob/1c4bb8501d71d10eabcbe1ca537d999b913d5aa1/src/reanimated2/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts#L121

## Test plan

None.
