### PR TITLE
Make sensors work with different device orientations

### DIFF
--- a/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
@@ -53,13 +53,15 @@ jsi::Value AnimatedSensorModule::registerSensor(
           value.setProperty(rt, "yaw", newValues[4]);
           value.setProperty(rt, "pitch", newValues[5]);
           value.setProperty(rt, "roll", newValues[6]);
-          handler.call(rt, value, orientationDegrees);
+          value.setProperty(rt, "interfaceOrientation", orientationDegrees);
+          handler.call(rt, value);
         } else {
           jsi::Object value(rt);
           value.setProperty(rt, "x", newValues[0]);
           value.setProperty(rt, "y", newValues[1]);
           value.setProperty(rt, "z", newValues[2]);
-          handler.call(rt, value, orientationDegrees);
+          value.setProperty(rt, "interfaceOrientation", orientationDegrees);
+          handler.call(rt, value);
         }
       });
   if (sensorId != -1) {

--- a/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
@@ -22,6 +22,7 @@ jsi::Value AnimatedSensorModule::registerSensor(
     const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
     const jsi::Value &sensorTypeValue,
     const jsi::Value &interval,
+    const jsi::Value &iosReferenceFrame,
     const jsi::Value &sensorDataHandler) {
   SensorType sensorType = static_cast<SensorType>(sensorTypeValue.asNumber());
 
@@ -30,10 +31,11 @@ jsi::Value AnimatedSensorModule::registerSensor(
   int sensorId = platformRegisterSensorFunction_(
       sensorType,
       interval.asNumber(),
+      iosReferenceFrame.asNumber(),
       [sensorType,
        shareableHandler,
-       weakRuntimeHelper =
-           std::weak_ptr<JSRuntimeHelper>(runtimeHelper)](double newValues[]) {
+       weakRuntimeHelper = std::weak_ptr<JSRuntimeHelper>(runtimeHelper)](
+          double newValues[], int orientationDegrees) {
         auto runtimeHelper = weakRuntimeHelper.lock();
         if (runtimeHelper == nullptr || runtimeHelper->uiRuntimeDestroyed) {
           return;
@@ -51,13 +53,13 @@ jsi::Value AnimatedSensorModule::registerSensor(
           value.setProperty(rt, "yaw", newValues[4]);
           value.setProperty(rt, "pitch", newValues[5]);
           value.setProperty(rt, "roll", newValues[6]);
-          handler.call(rt, value);
+          handler.call(rt, value, orientationDegrees);
         } else {
           jsi::Object value(rt);
           value.setProperty(rt, "x", newValues[0]);
           value.setProperty(rt, "y", newValues[1]);
           value.setProperty(rt, "z", newValues[2]);
-          handler.call(rt, value);
+          handler.call(rt, value, orientationDegrees);
         }
       });
   if (sensorId != -1) {

--- a/Common/cpp/AnimatedSensor/AnimatedSensorModule.h
+++ b/Common/cpp/AnimatedSensor/AnimatedSensorModule.h
@@ -35,6 +35,7 @@ class AnimatedSensorModule {
       const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
       const jsi::Value &sensorType,
       const jsi::Value &interval,
+      const jsi::Value &iosReferenceFrame,
       const jsi::Value &sensorDataContainer);
   void unregisterSensor(const jsi::Value &sensorId);
   void unregisterAllSensors();

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -437,9 +437,15 @@ jsi::Value NativeReanimatedModule::registerSensor(
     jsi::Runtime &rt,
     const jsi::Value &sensorType,
     const jsi::Value &interval,
+    const jsi::Value &iosReferenceFrame,
     const jsi::Value &sensorDataHandler) {
   return animatedSensorModule.registerSensor(
-      rt, runtimeHelper, sensorType, interval, sensorDataHandler);
+      rt,
+      runtimeHelper,
+      sensorType,
+      interval,
+      iosReferenceFrame,
+      sensorDataHandler);
 }
 
 void NativeReanimatedModule::unregisterSensor(

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -143,6 +143,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       jsi::Runtime &rt,
       const jsi::Value &sensorType,
       const jsi::Value &interval,
+      const jsi::Value &iosReferenceFrame,
       const jsi::Value &sensorDataContainer) override;
   void unregisterSensor(jsi::Runtime &rt, const jsi::Value &sensorId) override;
 

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -106,7 +106,11 @@ static jsi::Value SPEC_PREFIX(registerSensor)(
     size_t count) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
       ->registerSensor(
-          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+          rt,
+          std::move(args[0]),
+          std::move(args[1]),
+          std::move(args[2]),
+          std::move(args[3]));
 }
 
 static jsi::Value SPEC_PREFIX(unregisterSensor)(
@@ -186,7 +190,7 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
   methodMap_["getViewProp"] = MethodMetadata{3, SPEC_PREFIX(getViewProp)};
   methodMap_["enableLayoutAnimations"] =
       MethodMetadata{2, SPEC_PREFIX(enableLayoutAnimations)};
-  methodMap_["registerSensor"] = MethodMetadata{3, SPEC_PREFIX(registerSensor)};
+  methodMap_["registerSensor"] = MethodMetadata{4, SPEC_PREFIX(registerSensor)};
   methodMap_["unregisterSensor"] =
       MethodMetadata{1, SPEC_PREFIX(unregisterSensor)};
   methodMap_["configureProps"] = MethodMetadata{2, SPEC_PREFIX(configureProps)};

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
@@ -65,6 +65,7 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &sensorType,
       const jsi::Value &interval,
+      const jsi::Value &iosReferenceFrame,
       const jsi::Value &sensorDataContainer) = 0;
   virtual void unregisterSensor(
       jsi::Runtime &rt,

--- a/Common/cpp/Tools/PlatformDepMethodsHolder.h
+++ b/Common/cpp/Tools/PlatformDepMethodsHolder.h
@@ -58,7 +58,7 @@ using ProgressLayoutAnimationFunction = std::function<
 using EndLayoutAnimationFunction = std::function<void(int, bool, bool)>;
 
 using RegisterSensorFunction =
-    std::function<int(int, int, std::function<void(double[])>)>;
+    std::function<int(int, int, int, std::function<void(double[], int)>)>;
 using UnregisterSensorFunction = std::function<void(int)>;
 using SetGestureStateFunction = std::function<void(int, int)>;
 using ConfigurePropsFunction = std::function<void(

--- a/Example/src/AnimatedSensorExample.tsx
+++ b/Example/src/AnimatedSensorExample.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Animated, {
-  withTiming,
   useAnimatedStyle,
   useAnimatedSensor,
   SensorType,
@@ -8,13 +7,12 @@ import Animated, {
 import { View, Button, StyleSheet } from 'react-native';
 
 export default function AnimatedStyleUpdateExample() {
-  const animatedSensor = useAnimatedSensor(SensorType.ROTATION);
+  const animatedSensor = useAnimatedSensor(SensorType.GRAVITY);
   const style = useAnimatedStyle(() => {
-    const pitch = Math.abs(animatedSensor.sensor.value.pitch);
-    const roll = Math.abs(animatedSensor.sensor.value.roll);
+    const x = animatedSensor.sensor.value.x;
+    const y = animatedSensor.sensor.value.y;
     return {
-      height: withTiming(pitch * 200 + 20, { duration: 100 }),
-      width: withTiming(roll * 200 + 20, { duration: 100 }),
+      transform: [{ translateX: x * 5 }, { translateY: y * 5 }],
     };
   });
 
@@ -24,7 +22,9 @@ export default function AnimatedStyleUpdateExample() {
         title={'log data'}
         onPress={() => console.log(animatedSensor.sensor.value)}
       />
-      <Animated.View style={[componentStyle.square, style]} />
+      <Animated.View style={[componentStyle.rect]}>
+        <Animated.View style={[componentStyle.square, style]} />
+      </Animated.View>
     </View>
   );
 }
@@ -36,9 +36,16 @@ const componentStyle = StyleSheet.create({
     alignItems: 'center',
   },
   square: {
-    width: 50,
-    height: 50,
+    width: 10,
+    height: 10,
+    backgroundColor: 'red',
+    position: 'absolute',
+    left: 90,
+    top: 90,
+  },
+  rect: {
+    width: 200,
+    height: 200,
     backgroundColor: 'black',
-    margin: 30,
   },
 });

--- a/Example/src/AnimatedSensorExample.tsx
+++ b/Example/src/AnimatedSensorExample.tsx
@@ -9,8 +9,7 @@ import { View, Button, StyleSheet } from 'react-native';
 export default function AnimatedStyleUpdateExample() {
   const animatedSensor = useAnimatedSensor(SensorType.GRAVITY);
   const style = useAnimatedStyle(() => {
-    const x = animatedSensor.sensor.value.x;
-    const y = animatedSensor.sensor.value.y;
+    const { x, y } = animatedSensor.sensor.value;
     return {
       transform: [{ translateX: x * 5 }, { translateY: y * 5 }],
     };

--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -59,6 +59,7 @@ import SwipeableListExample from './SwipeableListExample';
 import { WaterfallGridExample } from './LayoutReanimation/WaterfallGridExample';
 import WobbleExample from './WobbleExample';
 import { ColorInterpolationExample } from './ColorInterpolationExample';
+import CubesExample from './CubesExample';
 
 LogBox.ignoreLogs(['Calling `getNode()`']);
 
@@ -114,6 +115,10 @@ const SCREENS: Screens = {
   AnimatedSensor: {
     screen: AnimatedSensorExample,
     title: '🆕 Use Animated Sensor',
+  },
+  Cubes: {
+    screen: CubesExample,
+    title: '🆕 Cubes with useAnimatedSensor',
   },
   FrameCallbackExample: {
     screen: FrameCallbackExample,
@@ -326,6 +331,7 @@ export const styles = StyleSheet.create({
   },
   buttonText: {
     backgroundColor: 'transparent',
+    color: 'black',
   },
   button: {
     flex: 1,

--- a/Example/src/CubesExample.tsx
+++ b/Example/src/CubesExample.tsx
@@ -1,0 +1,360 @@
+import React from 'react';
+import Animated, {
+  useAnimatedStyle,
+  useAnimatedSensor,
+  SensorType,
+  IOSReferenceFrame,
+} from 'react-native-reanimated';
+import { View, Button, StyleSheet, Text } from 'react-native';
+
+function eulerToMatrix(pitch: number, roll: number, yaw: number) {
+  'worklet';
+  const s2 = Math.sin(pitch);
+  const c2 = Math.cos(pitch);
+  const s3 = Math.sin(roll);
+  const c3 = Math.cos(roll);
+  const s1 = Math.sin(yaw);
+  const c1 = Math.cos(yaw);
+
+  return [
+    c1 * c3 - s1 * s2 * s3,
+    c3 * s1 + c1 * s2 * s3,
+    -c2 * s3,
+    0,
+
+    -c2 * s1,
+    c1 * c2,
+    s2,
+    0,
+
+    c1 * s3 + c3 * s1 * s2,
+    s1 * s3 - c1 * c3 * s2,
+    c2 * c3,
+    0,
+
+    0,
+    0,
+    0,
+    1,
+  ];
+}
+
+function createIdentityMatrix() {
+  'worklet';
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+}
+
+function reuseTranslate3dCommand(
+  matrixCommand: number[],
+  x: number,
+  y: number,
+  z: number
+) {
+  'worklet';
+  matrixCommand[12] = x;
+  matrixCommand[13] = y;
+  matrixCommand[14] = z;
+}
+
+function multiplyInto(out: number[], a: number[], b: number[]) {
+  'worklet';
+  const a00 = a[0];
+  const a01 = a[1];
+  const a02 = a[2];
+  const a03 = a[3];
+  const a10 = a[4];
+  const a11 = a[5];
+  const a12 = a[6];
+  const a13 = a[7];
+  const a20 = a[8];
+  const a21 = a[9];
+  const a22 = a[10];
+  const a23 = a[11];
+  const a30 = a[12];
+  const a31 = a[13];
+  const a32 = a[14];
+  const a33 = a[15];
+
+  let b0 = b[0];
+  let b1 = b[1];
+  let b2 = b[2];
+  let b3 = b[3];
+  out[0] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[1] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[2] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[3] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+
+  b0 = b[4];
+  b1 = b[5];
+  b2 = b[6];
+  b3 = b[7];
+  out[4] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[5] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[6] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[7] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+
+  b0 = b[8];
+  b1 = b[9];
+  b2 = b[10];
+  b3 = b[11];
+  out[8] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[9] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[10] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[11] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+
+  b0 = b[12];
+  b1 = b[13];
+  b2 = b[14];
+  b3 = b[15];
+  out[12] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
+  out[13] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
+  out[14] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
+  out[15] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+}
+
+function transformOrigin(
+  matrix: number[],
+  origin: { x: number; y: number; z: number }
+) {
+  'worklet';
+  const { x, y, z } = origin;
+
+  const translate = createIdentityMatrix();
+  reuseTranslate3dCommand(translate, x, y, z);
+  multiplyInto(matrix, translate, matrix);
+
+  const untranslate = createIdentityMatrix();
+  reuseTranslate3dCommand(untranslate, -x, -y, -z);
+  multiplyInto(matrix, matrix, untranslate);
+}
+
+function quaternionToMatrix(q: number[]) {
+  'worklet';
+  const [x, y, z, s] = q;
+  return [
+    1 - 2 * y * y - 2 * z * z,
+    2 * x * y - 2 * s * z,
+    2 * x * z + 2 * s * y,
+    0,
+    2 * x * y + 2 * s * z,
+    1 - 2 * x * x - 2 * z * z,
+    2 * y * z - 2 * s * x,
+    0,
+    2 * x * z - 2 * s * y,
+    2 * y * z + 2 * s * x,
+    1 - 2 * x * x - 2 * y * y,
+    0,
+    0,
+    0,
+    0,
+    1,
+  ];
+}
+
+function eulerToQuaternion(pitch: number, roll: number, yaw: number) {
+  'worklet';
+  const c1 = Math.cos(pitch * 0.5);
+  const s1 = Math.sin(pitch * 0.5);
+  const c2 = Math.cos(roll * 0.5);
+  const s2 = Math.sin(roll * 0.5);
+  const c3 = Math.cos(yaw * 0.5);
+  const s3 = Math.sin(yaw * 0.5);
+
+  return [
+    s1 * c2 * c3 - c1 * s2 * s3,
+    c1 * s2 * c3 + s1 * c2 * s3,
+    c1 * c2 * s3 + s1 * s2 * c3,
+    c1 * c2 * c3 - s1 * s2 * s3,
+  ];
+}
+
+function multiplyQuaternions(a: number[], b: number[]) {
+  'worklet';
+  return [
+    a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1],
+    a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0],
+    a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3],
+    a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2],
+  ];
+}
+
+const sidesRotations = [
+  [0, 0, 0],
+  [Math.PI / 2, 0, 0],
+  [-Math.PI / 2, 0, 0],
+  [0, Math.PI / 2, 0],
+  [0, -Math.PI / 2, 0],
+  [Math.PI, 0, 0],
+];
+
+const sidesColors = [
+  '#8B9576',
+  '#0D519A',
+  '#AF351B',
+  '#555E6B',
+  '#7F09E1',
+  '#9DB89A',
+];
+
+function CubeWithEulerAngles() {
+  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+    iosReferenceFrame: IOSReferenceFrame.XArbitraryZVertical,
+    adjustToInterfaceOrientation: true,
+  });
+
+  const sidesStyles = sidesRotations.map((rotation, i) =>
+    useAnimatedStyle(() => {
+      const pitch = animatedSensor.sensor.value.pitch;
+      const roll = animatedSensor.sensor.value.roll;
+      const yaw = animatedSensor.sensor.value.yaw;
+
+      const sideLength = 100;
+      const origin = { x: 0, y: 0, z: -sideLength / 2 };
+
+      const it = eulerToMatrix(rotation[0], rotation[1], rotation[2]);
+      const matrix = eulerToMatrix(pitch, -roll, yaw);
+      multiplyInto(matrix, matrix, it);
+      transformOrigin(matrix, origin);
+
+      return {
+        transform: [{ perspective: 1000 }, { matrix: matrix }],
+        backgroundColor: sidesColors[i],
+      };
+    })
+  );
+
+  return (
+    <View style={componentStyle.boxContainer}>
+      {sidesStyles.map((style, i) => (
+        <Animated.View style={[componentStyle.box, style]} key={i}>
+          <Text>EULER</Text>
+        </Animated.View>
+      ))}
+    </View>
+  );
+}
+
+function CubeWithQuaternions() {
+  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+    adjustToInterfaceOrientation: true,
+  });
+
+  const sidesStyles = sidesRotations.map((rotation, i) =>
+    useAnimatedStyle(() => {
+      const sideLength = 100;
+      const origin = { x: 0, y: 0, z: -sideLength / 2 };
+
+      const q0 = eulerToQuaternion(-rotation[0], -rotation[1], rotation[2]);
+
+      const q1 = [
+        -animatedSensor.sensor.value.qx,
+        animatedSensor.sensor.value.qy,
+        -animatedSensor.sensor.value.qz,
+        animatedSensor.sensor.value.qw,
+      ];
+
+      const q = multiplyQuaternions(q0, q1);
+
+      const matrix = quaternionToMatrix(q);
+      transformOrigin(matrix, origin);
+
+      return {
+        transform: [{ perspective: 1000 }, { matrix: matrix }],
+        backgroundColor: sidesColors[i],
+      };
+    })
+  );
+
+  return (
+    <View style={componentStyle.boxContainer}>
+      {sidesStyles.map((style, i) => (
+        <Animated.View style={[componentStyle.box, style]} key={i}>
+          <Text>QUATERNIONS</Text>
+        </Animated.View>
+      ))}
+    </View>
+  );
+}
+
+export default function CubesExample() {
+  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+    adjustToInterfaceOrientation: true,
+  });
+
+  const compassStyle = useAnimatedStyle(() => {
+    const yaw = animatedSensor.sensor.value.yaw;
+
+    return {
+      transform: [{ rotate: yaw + 'rad' }],
+    };
+  });
+
+  return (
+    <View style={componentStyle.container}>
+      <Button
+        title={'log data'}
+        onPress={() => console.log(animatedSensor.sensor.value)}
+      />
+      <View style={componentStyle.cubesContainer}>
+        <CubeWithQuaternions />
+        <CubeWithEulerAngles />
+      </View>
+
+      <View style={componentStyle.boxContainer}>
+        <Animated.View style={[componentStyle.compass, compassStyle]}>
+          <View style={componentStyle.arrow} />
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
+const componentStyle = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  cubesContainer: {
+    flexDirection: 'row',
+  },
+  square: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'black',
+    margin: 30,
+  },
+  box: {
+    width: 100,
+    height: 100,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    backfaceVisibility: 'hidden',
+  },
+  red: {
+    backgroundColor: 'red',
+  },
+  green: {
+    backgroundColor: 'green',
+  },
+  blue: {
+    backgroundColor: 'blue',
+  },
+  compass: {
+    backgroundColor: 'black',
+    width: 20,
+    height: 100,
+  },
+  arrow: {
+    backgroundColor: 'red',
+    width: 20,
+    height: 20,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
+  boxContainer: {
+    width: 150,
+    height: 150,
+  },
+});

--- a/__tests__/sensors.test.ts
+++ b/__tests__/sensors.test.ts
@@ -1,0 +1,246 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { SensorType, useAnimatedSensor, Value3D, ValueRotation } from '../src/';
+
+let eventHandler: (
+  data: Value3D | ValueRotation,
+  orientationDegrees: number
+) => void;
+
+jest.mock('../src/reanimated2/core', () => {
+  const originalModule = jest.requireActual('../src/reanimated2/core');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    registerSensor: (
+      sensorType: number,
+      interval: number,
+      iosReferenceFrame: number,
+      _eventHandler: (
+        data: Value3D | ValueRotation,
+        orientationDegrees: number
+      ) => void
+    ) => {
+      eventHandler = _eventHandler;
+    },
+  };
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeEqualRounded(data: Value3D | ValueRotation): R;
+    }
+  }
+}
+
+expect.extend({
+  toBeEqualRounded(received, data) {
+    const ok = Object.keys(data).every(
+      (key) => received[key].toFixed(2) === data[key].toFixed(2)
+    );
+
+    return ok
+      ? {
+          pass: true,
+          message: () => ``,
+        }
+      : {
+          pass: false,
+          message: () =>
+            Object.keys(data)
+              .map(
+                (k) =>
+                  `Received [${k}] = ${received[k].toFixed(2)} expected: ${data[
+                    k
+                  ].toFixed(2)}`
+              )
+              .join('\n'),
+        };
+  },
+});
+
+describe('Sensors', () => {
+  it('returns rotation sensors', () => {
+    const { result } = renderHook(() => useAnimatedSensor(SensorType.ROTATION));
+
+    const data = {
+      qw: 0,
+      qx: 1,
+      qy: 2,
+      qz: 3,
+      yaw: 4,
+      pitch: 5,
+      roll: 6,
+    };
+
+    eventHandler(data, 90);
+
+    expect(result.current.sensor.value).toBe(data);
+    expect(result.current.interfaceOrientation.value).toBe(90);
+  });
+
+  it('returns 3d sensor', () => {
+    const { result } = renderHook(() =>
+      useAnimatedSensor(SensorType.ACCELEROMETER)
+    );
+
+    const data = {
+      x: 1,
+      y: 2,
+      z: 3,
+    };
+
+    eventHandler(data, 180);
+
+    expect(result.current.sensor.value).toBe(data);
+    expect(result.current.interfaceOrientation.value).toBe(180);
+  });
+
+  // a handy calculator: https://www.andre-gaschler.com/rotationconverter/
+  it('adjusts orientation of the rotation sensor', () => {
+    const { result } = renderHook(() =>
+      useAnimatedSensor(SensorType.ROTATION, {
+        adjustToInterfaceOrientation: true,
+      })
+    );
+
+    // yaw = 60deg, pitch = 30deg, roll=45deg
+    const data = {
+      qx: 0.02226,
+      qy: 0.4396797,
+      qz: 0.5319757,
+      qw: 0.7233174,
+      yaw: 1.0471976,
+      pitch: 0.5235988,
+      roll: 0.7853982,
+    };
+
+    // portrait orientation
+    act(() => eventHandler({ ...data }, 0));
+
+    const data0 = {
+      qx: 0.02226,
+      qy: 0.4396797,
+      qz: 0.5319757,
+      qw: 0.7233174,
+      yaw: 1.0471976,
+      pitch: 0.5235988,
+      roll: 0.7853982,
+    };
+
+    expect(result.current.sensor.value).toBeEqualRounded(data0);
+    expect(result.current.interfaceOrientation.value).toBe(0);
+
+    // landscape left orientation
+    act(() => eventHandler({ ...data }, 90));
+
+    const data90 = {
+      qx: 0.2951603,
+      qy: -0.3266407,
+      qz: -0.3266407,
+      qw: 0.8363564,
+      yaw: -0.523,
+      pitch: 0.785,
+      roll: -0.523,
+    };
+
+    expect(result.current.sensor.value).toBeEqualRounded(data90);
+    expect(result.current.interfaceOrientation.value).toBe(90);
+
+    // upside down
+    act(() => eventHandler({ ...data }, 180));
+
+    const data180 = {
+      qx: -0.3919038,
+      qy: -0.2005621,
+      qz: -0.3604234,
+      qw: 0.8223632,
+      yaw: -1.0471976,
+      pitch: -0.5235988,
+      roll: -0.7853982,
+    };
+
+    expect(result.current.sensor.value).toBeEqualRounded(data180);
+    expect(result.current.interfaceOrientation.value).toBe(180);
+
+    // landscape right orientation
+    eventHandler(data, 270);
+
+    const data270 = {
+      qx: -0.3266407,
+      qy: -0.2951603,
+      qz: 0.8363564,
+      qw: 0.3266407,
+      yaw: 2.6179939,
+      pitch: -0.7853981,
+      roll: 0.5235988,
+    };
+
+    expect(result.current.sensor.value).toBeEqualRounded(data270);
+    expect(result.current.interfaceOrientation.value).toBe(270);
+  });
+
+  it('adjusts orientation of the 3d sensor', () => {
+    const { result } = renderHook(() =>
+      useAnimatedSensor(SensorType.ACCELEROMETER, {
+        adjustToInterfaceOrientation: true,
+      })
+    );
+
+    const data = {
+      x: 1,
+      y: 2,
+      z: 3,
+    };
+
+    // portrait orientation
+    act(() => eventHandler({ ...data }, 0));
+
+    const data0 = {
+      x: 1,
+      y: 2,
+      z: 3,
+    };
+
+    expect(result.current.sensor.value).toStrictEqual(data0);
+    expect(result.current.interfaceOrientation.value).toBe(0);
+
+    // landscape orientation
+    act(() => eventHandler({ ...data }, 90));
+
+    const data90 = {
+      x: -2,
+      y: 1,
+      z: 3,
+    };
+
+    expect(result.current.sensor.value).toStrictEqual(data90);
+    expect(result.current.interfaceOrientation.value).toBe(90);
+
+    // upside down
+    act(() => eventHandler({ ...data }, 180));
+
+    const data180 = {
+      x: -1,
+      y: -2,
+      z: 3,
+    };
+
+    expect(result.current.sensor.value).toStrictEqual(data180);
+    expect(result.current.interfaceOrientation.value).toBe(180);
+
+    // landscape orientation
+    eventHandler(data, 270);
+
+    const data270 = {
+      x: 2,
+      y: -1,
+      z: 3,
+    };
+
+    expect(result.current.sensor.value).toStrictEqual(data270);
+    expect(result.current.interfaceOrientation.value).toBe(270);
+  });
+});

--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -91,7 +91,7 @@ public class NativeProxy {
       mHybridData = hybridData;
     }
 
-    public native void sensorSetter(float[] value);
+    public native void sensorSetter(float[] value, int orientationDegrees);
   }
 
   @DoNotStrip

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -185,8 +185,11 @@ void NativeProxy::installJSIBindings(
 #endif
 
   auto registerSensorFunction =
-      [this](int sensorType, int interval, std::function<void(double[])> setter)
-      -> int {
+      [this](
+          int sensorType,
+          int interval,
+          int iosReferenceFrame,
+          std::function<void(double[], int)> setter) -> int {
     return this->registerSensor(sensorType, interval, std::move(setter));
   };
   auto unregisterSensorFunction = [this](int sensorId) {
@@ -498,7 +501,7 @@ void NativeProxy::synchronouslyUpdateUIProps(
 int NativeProxy::registerSensor(
     int sensorType,
     int interval,
-    std::function<void(double[])> setter) {
+    std::function<void(double[], int)> setter) {
   static auto method =
       javaPart_->getClass()->getMethod<int(int, int, SensorSetter::javaobject)>(
           "registerSensor");

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -89,14 +89,14 @@ class SensorSetter : public HybridClass<SensorSetter> {
   static auto constexpr kJavaDescriptor =
       "Lcom/swmansion/reanimated/NativeProxy$SensorSetter;";
 
-  void sensorSetter(jni::alias_ref<JArrayFloat> value) {
+  void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
     size_t size = value->size();
     auto elements = value->getRegion(0, size);
     double array[7];
     for (int i = 0; i < size; i++) {
       array[i] = elements[i];
     }
-    callback_(array);
+    callback_(array, orientationDegrees);
   }
 
   static void registerNatives() {
@@ -108,10 +108,10 @@ class SensorSetter : public HybridClass<SensorSetter> {
  private:
   friend HybridBase;
 
-  explicit SensorSetter(std::function<void(double[])> callback)
+  explicit SensorSetter(std::function<void(double[], int)> callback)
       : callback_(std::move(callback)) {}
 
-  std::function<void(double[])> callback_;
+  std::function<void(double[], int)> callback_;
 };
 
 class KeyboardEventDataUpdater : public HybridClass<KeyboardEventDataUpdater> {
@@ -198,7 +198,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   int registerSensor(
       int sensorType,
       int interval,
-      std::function<void(double[])> setter);
+      std::function<void(double[], int)> setter);
   void unregisterSensor(int sensorId);
   void configureProps(
       jsi::Runtime &rt,

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -1,7 +1,11 @@
 package com.swmansion.reanimated.sensor;
 
+import static android.content.Context.WINDOW_SERVICE;
+
 import android.hardware.Sensor;
 import android.hardware.SensorManager;
+import android.view.Display;
+import android.view.WindowManager;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.swmansion.reanimated.NativeProxy;
 import java.lang.ref.WeakReference;
@@ -19,7 +23,9 @@ public class ReanimatedSensor {
       ReanimatedSensorType sensorType,
       int interval,
       NativeProxy.SensorSetter setter) {
-    listener = new ReanimatedSensorListener(setter, interval);
+    WindowManager wm = (WindowManager) reactContext.get().getSystemService(WINDOW_SERVICE);
+    Display display = wm.getDefaultDisplay();
+    listener = new ReanimatedSensorListener(setter, interval, display);
     sensorManager =
         (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
     this.sensorType = sensorType;

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
@@ -4,6 +4,8 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.view.Display;
+import android.view.Surface;
 import com.swmansion.reanimated.NativeProxy;
 
 public class ReanimatedSensorListener implements SensorEventListener {
@@ -16,9 +18,12 @@ public class ReanimatedSensorListener implements SensorEventListener {
   private float[] orientation = new float[3];
   private float[] quaternion = new float[4];
 
-  ReanimatedSensorListener(NativeProxy.SensorSetter setter, double interval) {
+  private final Display display;
+
+  ReanimatedSensorListener(NativeProxy.SensorSetter setter, double interval, Display display) {
     this.setter = setter;
     this.interval = interval;
+    this.display = display;
   }
 
   @Override
@@ -29,6 +34,23 @@ public class ReanimatedSensorListener implements SensorEventListener {
     }
     int sensorType = event.sensor.getType();
     lastRead = current;
+
+    int orientationDegrees;
+    switch (display.getRotation()) {
+      case Surface.ROTATION_90:
+        orientationDegrees = 90;
+        break;
+      case Surface.ROTATION_180:
+        orientationDegrees = 180;
+        break;
+      case Surface.ROTATION_270:
+        orientationDegrees = 270;
+        break;
+      default:
+        orientationDegrees = 0;
+        break;
+    }
+
     if (sensorType == Sensor.TYPE_ROTATION_VECTOR) {
       SensorManager.getQuaternionFromVector(quaternion, event.values);
       SensorManager.getRotationMatrixFromVector(rotation, event.values);
@@ -39,13 +61,15 @@ public class ReanimatedSensorListener implements SensorEventListener {
             quaternion[2], // qy
             quaternion[3], // qz
             quaternion[0], // qw
-            orientation[0], // yaw
-            orientation[1], // pitch
+            // make android consistent with iOS - iOS is better documented here:
+            // https://developer.apple.com/documentation/coremotion/getting_processed_device-motion_data/understanding_reference_frames_and_device_attitude
+            -orientation[0], // yaw
+            -orientation[1], // pitch
             orientation[2] // roll
           };
-      setter.sensorSetter(data);
+      setter.sensorSetter(data, orientationDegrees);
     } else {
-      setter.sensorSetter(event.values);
+      setter.sensorSetter(event.values, orientationDegrees);
     }
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
@@ -61,7 +61,7 @@ public class ReanimatedSensorListener implements SensorEventListener {
             quaternion[2], // qy
             quaternion[3], // qz
             quaternion[0], // qw
-            // make android consistent with iOS - iOS is better documented here:
+            // make Android consistent with iOS, which is better documented here:
             // https://developer.apple.com/documentation/coremotion/getting_processed_device-motion_data/understanding_reference_frames_and_device_attitude
             -orientation[0], // yaw
             -orientation[1], // pitch

--- a/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -88,7 +88,7 @@ public class NativeProxy {
       mHybridData = hybridData;
     }
 
-    public native void sensorSetter(float[] value);
+    public native void sensorSetter(float[] value, int orientationDegrees);
   }
 
   @DoNotStrip

--- a/docs/docs/api/hooks/useAnimatedSensor.md
+++ b/docs/docs/api/hooks/useAnimatedSensor.md
@@ -51,15 +51,16 @@ Values:
 #### `UserConfig: [object]`
 Properties:
 * `interval: [number | auto]` - interval in milliseconds between shared value updates. Pass `'auto'` to select interval based on device frame rate. Default: `'auto'`.
-* `iosReferenceFrame: [[IOSReferenceFrame](#iosreferenceframe-enum)]` - reference frame to use on iOS
+* `iosReferenceFrame: [[IOSReferenceFrame](#iosreferenceframe-enum)]` - reference frame to use on iOS. Default: `Auto`.
 * `adjustToInterfaceOrientation: [boolean]` - whether to adjust measurements to the current interface orientation. For example, in the landscape orientation axes x and y may need to be reversed when drawn on the screen. It's `true` by default.
 
 #### `IOSReferenceFrame: [enum]`
-`IOSReferenceFrame` is an enum describing reference frame to use on iOS. It follows Apple's [documentation](https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe). Default: `XArbitraryCorrectedZVertical`. Possible values:
+`IOSReferenceFrame` is an enum describing reference frame to use on iOS. It follows Apple's [documentation](https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe). Possible values:
 * `XArbitraryZVertical`
 * `XArbitraryCorrectedZVertical`
 * `XMagneticNorthZVertical`
 * `XTrueNorthZVertical`
+* `Auto` - on devices without magnetometer (for example iPods) `XArbitraryZVertical`, on devices with magnetometer `XArbitraryCorrectedZVertical`
 
 #### `3DVector: [object]`
 Properties:

--- a/docs/docs/api/hooks/useAnimatedSensor.md
+++ b/docs/docs/api/hooks/useAnimatedSensor.md
@@ -33,6 +33,7 @@ Properties:
   the flag contains information on the availability of sensors in a device
 * `config`: [[UserConfig](#userconfig-object)]  
   the configuration provided by a user
+* `interfaceOrientation`: [[SharedValue](../../api/hooks/useSharedValue)] contains [[InterfaceOrientation](#interfaceorientation-enum)] contains current interface orientation
 
 #### `SensorType: [enum]`
 `SensorType` is an enum that contains possibly supported sensors.
@@ -46,11 +47,20 @@ Values:
 * `MAGNETIC_FIELD`  
   measurements output as [[3DVector](#3dvector-object)]. Measured in μT.
 * `ROTATION`  
-  measurements output as [[RotationVector](#rotationvector-object)]. [qx, qy, qz, qw] is a normalized quaternion. [yaw, pitch, roll] are rotations measured in radians along respective axes.
+  measurements output as [[RotationVector](#rotationvector-object)]. [qx, qy, qz, qw] is a normalized quaternion. [yaw, pitch, roll] are rotations measured in radians along respective axes. We follow the iOS [convention](https://developer.apple.com/documentation/coremotion/getting_processed_device-motion_data/understanding_reference_frames_and_device_attitude).
 
 #### `UserConfig: [object]`
 Properties:
 * `interval: [number | auto]` - interval in milliseconds between shared value updates. Pass `'auto'` to select interval based on device frame rate. Default: `'auto'`.
+* `iosReferenceFrame: [[IOSReferenceFrame](#iosreferenceframe-enum)]` - reference frame to use on iOS
+* `adjustToInterfaceOrientation: [boolean]` - whether to adjust measurements to the current interface orientation. For example, in the landscape orientation axes x and y may need to be reversed when drawn on the screen. It depends on the use case, so it's `false` by default.
+
+#### `IOSReferenceFrame: [enum]`
+`IOSReferenceFrame` is an enum describing reference frame to use on iOS. It follows Apple's [documentation](https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe). Default: `XArbitraryCorrectedZVertical`. Possible values:
+* `XArbitraryZVertical`
+* `XArbitraryCorrectedZVertical`
+* `XMagneticNorthZVertical`
+* `XTrueNorthZVertical`
 
 #### `3DVector: [object]`
 Properties:
@@ -67,6 +77,13 @@ Properties:
 * `yaw: number`
 * `pitch: number`
 * `roll: number`
+
+#### `InterfaceOrientation: [enum]`
+Values:
+* `ROTATION_0` - default rotation on Android, portrait orientation on iOS
+* `ROTATION_90` - 90 degrees rotation on Android, landscape right orientation on iOS (landscape and home button on the right)
+* `ROTATION_180` - 180 degrees rotation on Android, upside down orientation on iOS
+* `ROTATION_270` - 270 degrees rotation on Android, landscape left orientation on iOS (landscape and home button on the left)
 
 ### Example
 ```js

--- a/docs/docs/api/hooks/useAnimatedSensor.md
+++ b/docs/docs/api/hooks/useAnimatedSensor.md
@@ -33,7 +33,6 @@ Properties:
   the flag contains information on the availability of sensors in a device
 * `config`: [[UserConfig](#userconfig-object)]  
   the configuration provided by a user
-* `interfaceOrientation`: [[SharedValue](../../api/hooks/useSharedValue)] contains [[InterfaceOrientation](#interfaceorientation-enum)] contains current interface orientation
 
 #### `SensorType: [enum]`
 `SensorType` is an enum that contains possibly supported sensors.
@@ -67,6 +66,7 @@ Properties:
 * `x: number`
 * `y: number`
 * `z: number`
+* `interfaceOrientation: [[InterfaceOrientation](#interfaceorientation-enum)]`
 
 #### `RotationVector: [object]`
 Properties:
@@ -77,6 +77,7 @@ Properties:
 * `yaw: number`
 * `pitch: number`
 * `roll: number`
+* `interfaceOrientation: [[InterfaceOrientation](#interfaceorientation-enum)]`
 
 #### `InterfaceOrientation: [enum]`
 Values:

--- a/docs/docs/api/hooks/useAnimatedSensor.md
+++ b/docs/docs/api/hooks/useAnimatedSensor.md
@@ -53,7 +53,7 @@ Values:
 Properties:
 * `interval: [number | auto]` - interval in milliseconds between shared value updates. Pass `'auto'` to select interval based on device frame rate. Default: `'auto'`.
 * `iosReferenceFrame: [[IOSReferenceFrame](#iosreferenceframe-enum)]` - reference frame to use on iOS
-* `adjustToInterfaceOrientation: [boolean]` - whether to adjust measurements to the current interface orientation. For example, in the landscape orientation axes x and y may need to be reversed when drawn on the screen. It depends on the use case, so it's `false` by default.
+* `adjustToInterfaceOrientation: [boolean]` - whether to adjust measurements to the current interface orientation. For example, in the landscape orientation axes x and y may need to be reversed when drawn on the screen. It's `true` by default.
 
 #### `IOSReferenceFrame: [enum]`
 `IOSReferenceFrame` is an enum describing reference frame to use on iOS. It follows Apple's [documentation](https://developer.apple.com/documentation/coremotion/cmattitudereferenceframe). Default: `XArbitraryCorrectedZVertical`. Possible values:

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -219,11 +219,13 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   // sensors
   ReanimatedSensorContainer *reanimatedSensorContainer = [[ReanimatedSensorContainer alloc] init];
-  auto registerSensorFunction = [=](int sensorType, int interval, std::function<void(double[])> setter) -> int {
+  auto registerSensorFunction =
+      [=](int sensorType, int interval, int iosReferenceFrame, std::function<void(double[], int)> setter) -> int {
     return [reanimatedSensorContainer registerSensor:(ReanimatedSensorType)sensorType
                                             interval:interval
-                                              setter:^(double *data) {
-                                                setter(data);
+                                   iosReferenceFrame:iosReferenceFrame
+                                              setter:^(double *data, int orientationDegrees) {
+                                                setter(data, orientationDegrees);
                                               }];
   };
 

--- a/ios/sensor/ReanimatedSensor.h
+++ b/ios/sensor/ReanimatedSensor.h
@@ -7,13 +7,17 @@
   ReanimatedSensorType _sensorType;
   double _interval;
   double _lastTimestamp;
+  int _referenceFrame;
 #if !TARGET_OS_TV
   CMMotionManager *_motionManager;
 #endif
-  void (^_setter)(double[]);
+  void (^_setter)(double[], int);
 }
 
-- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter;
+- (instancetype)init:(ReanimatedSensorType)sensorType
+             interval:(int)interval
+    iosReferenceFrame:(int)iosReferenceFrame
+               setter:(void (^)(double[], int))setter;
 - (bool)initialize;
 - (bool)initializeGyroscope;
 - (bool)initializeAccelerometer;

--- a/ios/sensor/ReanimatedSensor.m
+++ b/ios/sensor/ReanimatedSensor.m
@@ -145,10 +145,12 @@
 
   // _referenceFrame = Auto, on devices without magnetometer fall back to `XArbitraryZVertical`,
   // `XArbitraryCorrectedZVertical` otherwise
-  if (_referenceFrame == 4 && ![_motionManager isMagnetometerAvailable]) {
-    _referenceFrame = 0;
-  } else {
-    _referenceFrame = 1;
+  if (_referenceFrame == 4) {
+    if (![_motionManager isMagnetometerAvailable]) {
+      _referenceFrame = 0;
+    } else {
+      _referenceFrame = 1;
+    }
   }
 
   // the binary shift works here because of the definition of CMAttitudeReferenceFrame

--- a/ios/sensor/ReanimatedSensor.m
+++ b/ios/sensor/ReanimatedSensor.m
@@ -142,6 +142,15 @@
   [_motionManager setDeviceMotionUpdateInterval:_interval];
 
   [_motionManager setShowsDeviceMovementDisplay:YES];
+
+  // _referenceFrame = Auto, on devices without magnetometer fall back to `XArbitraryZVertical`,
+  // `XArbitraryCorrectedZVertical` otherwise
+  if (_referenceFrame == 4 && ![_motionManager isMagnetometerAvailable]) {
+    _referenceFrame = 0;
+  } else {
+    _referenceFrame = 1;
+  }
+
   // the binary shift works here because of the definition of CMAttitudeReferenceFrame
   [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:(1 << _referenceFrame)
                                                       toQueue:[NSOperationQueue mainQueue]

--- a/ios/sensor/ReanimatedSensor.m
+++ b/ios/sensor/ReanimatedSensor.m
@@ -142,6 +142,7 @@
   [_motionManager setDeviceMotionUpdateInterval:_interval];
 
   [_motionManager setShowsDeviceMovementDisplay:YES];
+  // the binary shift works here because of the definition of CMAttitudeReferenceFrame
   [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:(1 << _referenceFrame)
                                                       toQueue:[NSOperationQueue mainQueue]
                                                   withHandler:^(CMDeviceMotion *sensorData, NSError *error) {

--- a/ios/sensor/ReanimatedSensor.m
+++ b/ios/sensor/ReanimatedSensor.m
@@ -3,7 +3,10 @@
 #if __has_include(<CoreMotion/CoreMotion.h>)
 @implementation ReanimatedSensor
 
-- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+- (instancetype)init:(ReanimatedSensorType)sensorType
+             interval:(int)interval
+    iosReferenceFrame:(int)iosReferenceFrame
+               setter:(void (^)(double[], int))setter
 {
   self = [super init];
   _sensorType = sensorType;
@@ -12,6 +15,7 @@
   } else {
     _interval = interval / 1000.0; // in seconds
   }
+  _referenceFrame = iosReferenceFrame;
   _setter = setter;
   _motionManager = [[CMMotionManager alloc] init];
   return self;
@@ -49,7 +53,7 @@
                       return;
                     }
                     double data[] = {sensorData.rotationRate.x, sensorData.rotationRate.y, sensorData.rotationRate.z};
-                    self->_setter(data);
+                    self->_setter(data, [self getInterfaceOrientation]);
                     self->_lastTimestamp = currentTime;
                   }];
 
@@ -75,7 +79,7 @@
                                              sensorData.acceleration.x * G,
                                              sensorData.acceleration.y * G,
                                              sensorData.acceleration.z * G};
-                                         self->_setter(data);
+                                         self->_setter(data, [self getInterfaceOrientation]);
                                          self->_lastTimestamp = currentTime;
                                        }];
 
@@ -100,7 +104,7 @@
                             // convert G to m/s^2
                             double data[] = {
                                 sensorData.gravity.x * G, sensorData.gravity.y * G, sensorData.gravity.z * G};
-                            self->_setter(data);
+                            self->_setter(data, [self getInterfaceOrientation]);
                             self->_lastTimestamp = currentTime;
                           }];
 
@@ -123,7 +127,7 @@
                             }
                             double data[] = {
                                 sensorData.magneticField.x, sensorData.magneticField.y, sensorData.magneticField.z};
-                            self->_setter(data);
+                            self->_setter(data, [self getInterfaceOrientation]);
                             self->_lastTimestamp = currentTime;
                           }];
 
@@ -138,7 +142,7 @@
   [_motionManager setDeviceMotionUpdateInterval:_interval];
 
   [_motionManager setShowsDeviceMovementDisplay:YES];
-  [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXArbitraryZVertical
+  [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:(1 << _referenceFrame)
                                                       toQueue:[NSOperationQueue mainQueue]
                                                   withHandler:^(CMDeviceMotion *sensorData, NSError *error) {
                                                     double currentTime = [[NSProcessInfo processInfo] systemUptime];
@@ -154,7 +158,7 @@
                                                         attitude.yaw,
                                                         attitude.pitch,
                                                         attitude.roll};
-                                                    self->_setter(data);
+                                                    self->_setter(data, [self getInterfaceOrientation]);
                                                     self->_lastTimestamp = currentTime;
                                                   }];
 
@@ -173,6 +177,26 @@
     [_motionManager stopMagnetometerUpdates];
   } else if (_sensorType == ROTATION_VECTOR) {
     [_motionManager stopDeviceMotionUpdates];
+  }
+}
+
+- (int)getInterfaceOrientation
+{
+  UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
+  if (@available(iOS 13.0, *)) {
+    orientation = UIApplication.sharedApplication.windows.firstObject.windowScene.interfaceOrientation;
+  } else {
+    orientation = UIApplication.sharedApplication.statusBarOrientation;
+  }
+  switch (orientation) {
+    case UIInterfaceOrientationLandscapeLeft:
+      return 270;
+    case UIInterfaceOrientationLandscapeRight:
+      return 90;
+    case UIInterfaceOrientationPortraitUpsideDown:
+      return 180;
+    default:
+      return 0;
   }
 }
 

--- a/ios/sensor/ReanimatedSensorContainer.h
+++ b/ios/sensor/ReanimatedSensorContainer.h
@@ -6,7 +6,10 @@
 }
 
 - (instancetype)init;
-- (int)registerSensor:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter;
+- (int)registerSensor:(ReanimatedSensorType)sensorType
+             interval:(int)interval
+    iosReferenceFrame:(int)iosReferenceFrame
+               setter:(void (^)(double[], int))setter;
 - (void)unregisterSensor:(int)sensorId;
 
 @end

--- a/ios/sensor/ReanimatedSensorContainer.m
+++ b/ios/sensor/ReanimatedSensorContainer.m
@@ -14,9 +14,15 @@ static NSNumber *_nextSensorId = nil;
   return self;
 }
 
-- (int)registerSensor:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+- (int)registerSensor:(ReanimatedSensorType)sensorType
+             interval:(int)interval
+    iosReferenceFrame:(int)iosReferenceFrame
+               setter:(void (^)(double[], int))setter
 {
-  ReanimatedSensor *sensor = [[ReanimatedSensor alloc] init:sensorType interval:interval setter:setter];
+  ReanimatedSensor *sensor = [[ReanimatedSensor alloc] init:sensorType
+                                                   interval:interval
+                                          iosReferenceFrame:iosReferenceFrame
+                                                     setter:setter];
   if ([sensor initialize]) {
     NSNumber *sensorId = [_nextSensorId copy];
     _nextSensorId = [NSNumber numberWithInt:[_nextSensorId intValue] + 1];

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -503,6 +503,7 @@ declare module 'react-native-reanimated' {
     XArbitraryCorrectedZVertical = 1,
     XMagneticNorthZVertical = 2,
     XTrueNorthZVertical = 3,
+    Auto = 4,
   }
 
   export type SensorConfig = Partial<{

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -1,8 +1,6 @@
 // Project: https://github.com/software-mansion/react-native-reanimated
 // TypeScript Version: 2.8
 
-import { InterfaceOrientation } from 'src';
-
 declare module 'react-native-reanimated' {
   import {
     ComponentClass,

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -498,9 +498,18 @@ declare module 'react-native-reanimated' {
     ROTATION = 5,
   }
 
-  export type SensorConfig = {
+  export enum IOSReferenceFrame {
+    XArbitraryZVertical = 0,
+    XArbitraryCorrectedZVertical = 1,
+    XMagneticNorthZVertical = 2,
+    XTrueNorthZVertical = 3,
+  }
+
+  export type SensorConfig = Partial<{
     interval: number | 'auto';
-  };
+    adjustToInterfaceOrientation: boolean;
+    iosReferenceFrame: IOSReferenceFrame;
+  }>;
 
   export type Value3D = {
     x: number;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -1,6 +1,8 @@
 // Project: https://github.com/software-mansion/react-native-reanimated
 // TypeScript Version: 2.8
 
+import { InterfaceOrientation } from 'src';
+
 declare module 'react-native-reanimated' {
   import {
     ComponentClass,
@@ -515,6 +517,7 @@ declare module 'react-native-reanimated' {
     x: number;
     y: number;
     z: number;
+    interfaceOrientation: InterfaceOrientation;
   };
 
   export type SensorValue3D = SharedValue<Value3D>;
@@ -527,6 +530,7 @@ declare module 'react-native-reanimated' {
     yaw: number;
     pitch: number;
     roll: number;
+    interfaceOrientation: InterfaceOrientation;
   };
 
   export type SensorValueRotation = SharedValue<ValueRotation>;

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -75,9 +75,15 @@ export class NativeReanimated {
   registerSensor<T>(
     sensorType: number,
     interval: number,
+    iosReferenceFrame: number,
     handler: ShareableRef<T> | ((data: Value3D | ValueRotation) => void)
   ) {
-    return this.InnerNativeModule.registerSensor(sensorType, interval, handler);
+    return this.InnerNativeModule.registerSensor(
+      sensorType,
+      interval,
+      iosReferenceFrame,
+      handler
+    );
   }
 
   unregisterSensor(sensorId: number) {

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -156,6 +156,7 @@ export enum IOSReferenceFrame {
   XArbitraryCorrectedZVertical,
   XMagneticNorthZVertical,
   XTrueNorthZVertical,
+  Auto,
 }
 
 export interface NumericAnimation {

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -151,6 +151,12 @@ export enum SensorType {
   MAGNETIC_FIELD = 4,
   ROTATION = 5,
 }
+export enum IOSReferenceFrame {
+  XArbitraryZVertical,
+  XArbitraryCorrectedZVertical,
+  XMagneticNorthZVertical,
+  XTrueNorthZVertical,
+}
 
 export interface NumericAnimation {
   current?: number;
@@ -178,6 +184,13 @@ export type ValueRotation = {
   pitch: number;
   roll: number;
 };
+
+export enum InterfaceOrientation {
+  ROTATION_0 = 0,
+  ROTATION_90 = 90,
+  ROTATION_180 = 180,
+  ROTATION_270 = 270,
+}
 
 export type ShadowNodeWrapper = object;
 

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -173,6 +173,7 @@ export type Value3D = {
   x: number;
   y: number;
   z: number;
+  interfaceOrientation: InterfaceOrientation;
 };
 
 export type ValueRotation = {
@@ -183,6 +184,7 @@ export type ValueRotation = {
   yaw: number;
   pitch: number;
   roll: number;
+  interfaceOrientation: InterfaceOrientation;
 };
 
 export enum InterfaceOrientation {

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -142,11 +142,16 @@ export function unsubscribeFromKeyboardEvents(listenerId: number): void {
 export function registerSensor(
   sensorType: number,
   interval: number,
-  eventHandler: (data: Value3D | ValueRotation) => void
+  iosReferenceFrame: number,
+  eventHandler: (
+    data: Value3D | ValueRotation,
+    orientationDegrees: number
+  ) => void
 ): number {
   return NativeReanimatedModule.registerSensor(
     sensorType,
     interval,
+    iosReferenceFrame,
     makeShareableCloneRecursive(eventHandler)
   );
 }

--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -118,7 +118,7 @@ export function useAnimatedSensor(
     config: {
       interval: 0,
       adjustToInterfaceOrientation: true,
-      iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
+      iosReferenceFrame: IOSReferenceFrame.Auto,
     },
   });
 
@@ -126,7 +126,7 @@ export function useAnimatedSensor(
     ref.current.config = {
       interval: 'auto',
       adjustToInterfaceOrientation: true,
-      iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
+      iosReferenceFrame: IOSReferenceFrame.Auto,
       ...userConfig,
     };
     const sensorData = ref.current.sensor!;

--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { makeMutable, registerSensor, unregisterSensor } from '../core';
 import {
-  InterfaceOrientation,
   SensorType,
   SharedValue,
   Value3D,
@@ -20,7 +19,6 @@ export type AnimatedSensor = {
   unregister: () => void;
   isAvailable: boolean;
   config: SensorConfig;
-  interfaceOrientation: SharedValue<InterfaceOrientation>;
 };
 
 function initSensorData(
@@ -35,12 +33,14 @@ function initSensorData(
       yaw: 0,
       pitch: 0,
       roll: 0,
+      interfaceOrientation: 0,
     });
   } else {
     return makeMutable<Value3D | ValueRotation>({
       x: 0,
       y: 0,
       z: 0,
+      interfaceOrientation: 0,
     });
   }
 }
@@ -64,22 +64,18 @@ function eulerToQuaternion(pitch: number, roll: number, yaw: number) {
   ];
 }
 
-function adjustRotationToInterfaceOrientation(
-  data: ValueRotation,
-  orientationDegrees: number
-) {
+function adjustRotationToInterfaceOrientation(data: ValueRotation) {
   'worklet';
-  if (orientationDegrees === 90) {
-    const tmp = data.pitch;
-    data.pitch = data.roll;
-    data.roll = -tmp;
-    data.yaw = data.yaw - Math.PI / 2;
-  } else if (orientationDegrees === 270) {
-    const tmp = data.pitch;
-    data.pitch = -data.roll;
-    data.roll = tmp;
-    data.yaw = data.yaw + Math.PI / 2;
-  } else if (orientationDegrees === 180) {
+  const { interfaceOrientation, pitch, roll, yaw } = data;
+  if (interfaceOrientation === 90) {
+    data.pitch = roll;
+    data.roll = -pitch;
+    data.yaw = yaw - Math.PI / 2;
+  } else if (interfaceOrientation === 270) {
+    data.pitch = -roll;
+    data.roll = pitch;
+    data.yaw = yaw + Math.PI / 2;
+  } else if (interfaceOrientation === 180) {
     data.pitch *= -1;
     data.roll *= -1;
     data.yaw *= -1;
@@ -93,20 +89,16 @@ function adjustRotationToInterfaceOrientation(
   return data;
 }
 
-function adjustVectorToInterfaceOrientation(
-  data: Value3D,
-  orientationDegrees: number
-) {
+function adjustVectorToInterfaceOrientation(data: Value3D) {
   'worklet';
-  if (orientationDegrees === 90) {
-    const tmp = data.x;
-    data.x = -data.y;
-    data.y = tmp;
-  } else if (orientationDegrees === 270) {
-    const tmp = data.x;
-    data.x = data.y;
-    data.y = -tmp;
-  } else if (orientationDegrees === 180) {
+  const { interfaceOrientation, x, y } = data;
+  if (interfaceOrientation === 90) {
+    data.x = -y;
+    data.y = x;
+  } else if (interfaceOrientation === 270) {
+    data.x = y;
+    data.y = -x;
+  } else if (interfaceOrientation === 180) {
     data.x *= -1;
     data.y *= -1;
   }
@@ -128,7 +120,6 @@ export function useAnimatedSensor(
       adjustToInterfaceOrientation: true,
       iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
     },
-    interfaceOrientation: makeMutable<InterfaceOrientation>(0),
   });
 
   useEffect(() => {
@@ -143,24 +134,16 @@ export function useAnimatedSensor(
       sensorType,
       ref.current.config.interval === 'auto' ? -1 : ref.current.config.interval,
       ref.current.config.iosReferenceFrame,
-      (data, orientationDegrees) => {
+      (data) => {
         'worklet';
         if (ref.current.config.adjustToInterfaceOrientation) {
           if (sensorType === SensorType.ROTATION) {
-            data = adjustRotationToInterfaceOrientation(
-              data as ValueRotation,
-              orientationDegrees
-            );
+            data = adjustRotationToInterfaceOrientation(data as ValueRotation);
           } else {
-            data = adjustVectorToInterfaceOrientation(
-              data as Value3D,
-              orientationDegrees
-            );
+            data = adjustVectorToInterfaceOrientation(data as Value3D);
           }
         }
         sensorData.value = data;
-        ref.current.interfaceOrientation.value =
-          orientationDegrees as InterfaceOrientation;
       }
     );
 

--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -1,14 +1,18 @@
 import { useEffect, useRef } from 'react';
 import { makeMutable, registerSensor, unregisterSensor } from '../core';
 import {
+  InterfaceOrientation,
   SensorType,
   SharedValue,
   Value3D,
   ValueRotation,
+  IOSReferenceFrame,
 } from '../commonTypes';
 
 export type SensorConfig = {
   interval: number | 'auto';
+  adjustToInterfaceOrientation: boolean;
+  iosReferenceFrame: IOSReferenceFrame;
 };
 
 export type AnimatedSensor = {
@@ -16,6 +20,7 @@ export type AnimatedSensor = {
   unregister: () => void;
   isAvailable: boolean;
   config: SensorConfig;
+  interfaceOrientation: SharedValue<InterfaceOrientation>;
 };
 
 function initSensorData(
@@ -40,9 +45,76 @@ function initSensorData(
   }
 }
 
+// euler angles are in order ZXY, z = yaw, x = pitch, y = roll
+function eulerToQuaternion(pitch: number, roll: number, yaw: number) {
+  'worklet';
+  const c1 = Math.cos(pitch * 0.5);
+  const s1 = Math.sin(pitch * 0.5);
+  const c2 = Math.cos(roll * 0.5);
+  const s2 = Math.sin(roll * 0.5);
+  const c3 = Math.cos(yaw * 0.5);
+  const s3 = Math.sin(yaw * 0.5);
+
+  return [
+    s1 * c2 * c3 - c1 * s2 * s3,
+    c1 * s2 * c3 + s1 * c2 * s3,
+    c1 * c2 * s3 + s1 * s2 * c3,
+    c1 * c2 * c3 - s1 * s2 * s3,
+  ];
+}
+
+function adjustRotationToInterfaceOrientation(
+  data: ValueRotation,
+  orientationDegrees: number
+) {
+  'worklet';
+  if (orientationDegrees === 90) {
+    const tmp = data.pitch;
+    data.pitch = data.roll;
+    data.roll = -tmp;
+    data.yaw = data.yaw - Math.PI / 2;
+  } else if (orientationDegrees === 270) {
+    const tmp = data.pitch;
+    data.pitch = -data.roll;
+    data.roll = tmp;
+    data.yaw = data.yaw + Math.PI / 2;
+  } else if (orientationDegrees === 180) {
+    data.pitch *= -1;
+    data.roll *= -1;
+    data.yaw *= -1;
+  }
+
+  const q = eulerToQuaternion(data.pitch, data.roll, data.yaw);
+  data.qx = q[0];
+  data.qy = q[1];
+  data.qz = q[2];
+  data.qw = q[3];
+  return data;
+}
+
+function adjustVectorToInterfaceOrientation(
+  data: Value3D,
+  orientationDegrees: number
+) {
+  'worklet';
+  if (orientationDegrees === 90) {
+    const tmp = data.x;
+    data.x = -data.y;
+    data.y = tmp;
+  } else if (orientationDegrees === 270) {
+    const tmp = data.x;
+    data.x = data.y;
+    data.y = -tmp;
+  } else if (orientationDegrees === 180) {
+    data.x *= -1;
+    data.y *= -1;
+  }
+  return data;
+}
+
 export function useAnimatedSensor(
   sensorType: SensorType,
-  userConfig?: SensorConfig
+  userConfig?: Partial<SensorConfig>
 ): AnimatedSensor {
   const ref = useRef<AnimatedSensor>({
     sensor: initSensorData(sensorType),
@@ -52,18 +124,42 @@ export function useAnimatedSensor(
     isAvailable: false,
     config: {
       interval: 0,
+      adjustToInterfaceOrientation: false,
+      iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
     },
+    interfaceOrientation: makeMutable<InterfaceOrientation>(0),
   });
 
   useEffect(() => {
-    ref.current.config = { interval: 'auto', ...userConfig };
+    ref.current.config = {
+      interval: 'auto',
+      adjustToInterfaceOrientation: false,
+      iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
+      ...userConfig,
+    };
     const sensorData = ref.current.sensor!;
     const id = registerSensor(
       sensorType,
       ref.current.config.interval === 'auto' ? -1 : ref.current.config.interval,
-      (data) => {
+      ref.current.config.iosReferenceFrame,
+      (data, orientationDegrees) => {
         'worklet';
+        if (ref.current.config.adjustToInterfaceOrientation) {
+          if (sensorType === SensorType.ROTATION) {
+            data = adjustRotationToInterfaceOrientation(
+              data as ValueRotation,
+              orientationDegrees
+            );
+          } else {
+            data = adjustVectorToInterfaceOrientation(
+              data as Value3D,
+              orientationDegrees
+            );
+          }
+        }
         sensorData.value = data;
+        ref.current.interfaceOrientation.value =
+          orientationDegrees as InterfaceOrientation;
       }
     );
 

--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -46,14 +46,15 @@ function initSensorData(
 }
 
 // euler angles are in order ZXY, z = yaw, x = pitch, y = roll
+// https://github.com/mrdoob/three.js/blob/dev/src/math/Quaternion.js#L237
 function eulerToQuaternion(pitch: number, roll: number, yaw: number) {
   'worklet';
-  const c1 = Math.cos(pitch * 0.5);
-  const s1 = Math.sin(pitch * 0.5);
-  const c2 = Math.cos(roll * 0.5);
-  const s2 = Math.sin(roll * 0.5);
-  const c3 = Math.cos(yaw * 0.5);
-  const s3 = Math.sin(yaw * 0.5);
+  const c1 = Math.cos(pitch / 2);
+  const s1 = Math.sin(pitch / 2);
+  const c2 = Math.cos(roll / 2);
+  const s2 = Math.sin(roll / 2);
+  const c3 = Math.cos(yaw / 2);
+  const s3 = Math.sin(yaw / 2);
 
   return [
     s1 * c2 * c3 - c1 * s2 * s3,
@@ -124,7 +125,7 @@ export function useAnimatedSensor(
     isAvailable: false,
     config: {
       interval: 0,
-      adjustToInterfaceOrientation: false,
+      adjustToInterfaceOrientation: true,
       iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
     },
     interfaceOrientation: makeMutable<InterfaceOrientation>(0),
@@ -133,7 +134,7 @@ export function useAnimatedSensor(
   useEffect(() => {
     ref.current.config = {
       interval: 'auto',
-      adjustToInterfaceOrientation: false,
+      adjustToInterfaceOrientation: true,
       iosReferenceFrame: IOSReferenceFrame.XArbitraryCorrectedZVertical,
       ...userConfig,
     };

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -64,6 +64,7 @@ export default class JSReanimated extends NativeReanimated {
   registerSensor(
     sensorType: SensorType,
     interval: number,
+    iosReferenceFrame: number,
     eventHandler: (data: Value3D | ValueRotation) => void
   ): number {
     if (!(this.getSensorName(sensorType) in window)) {

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -87,12 +87,21 @@ export default class JSReanimated extends NativeReanimated {
           2.0 * (qx * qy + qw * qz),
           qw * qw + qx * qx - qy * qy - qz * qz
         );
-        eventHandler({ qw, qx, qy, qz, yaw, pitch, roll });
+        eventHandler({
+          qw,
+          qx,
+          qy,
+          qz,
+          yaw,
+          pitch,
+          roll,
+          interfaceOrientation: 0,
+        });
       };
     } else {
       callback = () => {
         const { x, y, z } = sensor;
-        eventHandler({ x, y, z });
+        eventHandler({ x, y, z, interfaceOrientation: 0 });
       };
     }
     sensor.addEventListener('reading', callback);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

- Adds `adjustToInterfaceOrientation` option that adjusts the sensors values to current device orientation
- Adds `interfaceOrientation` shared value that contains the current interface orientation
- Adds `iosReferenceFrame` option that allows setting ios reference frame. Some reference frames doesn't work for example on iPods but give better results.

## Test plan
- `AnimatedSensorExample.tsx`
- `CubesExample.tsx` - when device faces north the cubes should rotate in the correct way on every device orientation.