### PR TITLE
[Shared Element Transition] Problem with headers

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
@@ -330,10 +330,6 @@ public class SharedTransitionManager {
 
   protected void makeSnapshot(View view) {
     Snapshot snapshot = new Snapshot(view);
-    View screen = findScreen(view);
-    if (screen != null) {
-      snapshot.originY -= screen.getTop();
-    }
     mSnapshotRegistry.put(view.getId(), snapshot);
   }
 
@@ -403,7 +399,9 @@ public class SharedTransitionManager {
       return;
     }
     ViewGroup viewGroup = (ViewGroup) view;
-    makeSnapshot(view);
+    if (mAnimationsManager.hasAnimationForTag(view.getId(), "sharedElementTransition")) {
+      makeSnapshot(view);
+    }
     for (int i = 0; i < viewGroup.getChildCount(); i++) {
       View child = viewGroup.getChildAt(i);
       visitNativeTreeAndMakeSnapshot(child);

--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -254,7 +254,7 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       if (container != null
           && viewManagerName.equals("RNSScreen")
           && mReaLayoutAnimator != null) {
-        boolean hasHeader = topScreenHasHeader((ViewGroup) container);
+        boolean hasHeader = checkIfTopScreenHasHeader((ViewGroup) container);
         if (!hasHeader || !container.isLayoutRequested()) {
           mReaLayoutAnimator.getAnimationsManager().viewsDidLayout();
         }
@@ -265,19 +265,17 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
     }
   }
 
-  private boolean topScreenHasHeader(ViewGroup screenStack) {
-    boolean hasHeader;
+  private boolean checkIfTopScreenHasHeader(ViewGroup screenStack) {
     try {
       ViewGroup fragment = (ViewGroup)screenStack.getChildAt(0);
       ViewGroup screen = (ViewGroup)fragment.getChildAt(0);
       View headerConfig = screen.getChildAt(0);
       Field field = headerConfig.getClass().getDeclaredField("mIsHidden");
       field.setAccessible(true);
-      hasHeader = !field.getBoolean(headerConfig);
+      return !field.getBoolean(headerConfig);
     } catch (NullPointerException | NoSuchFieldException | IllegalAccessException e) {
       return false;
     }
-    return hasHeader;
   }
 
   @Override

--- a/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/reactNativeVersionPatch/nativeHierarchyManager/latest/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -254,12 +254,30 @@ public class ReanimatedNativeHierarchyManager extends NativeViewHierarchyManager
       if (container != null
           && viewManagerName.equals("RNSScreen")
           && mReaLayoutAnimator != null) {
-        ((ReaLayoutAnimator) mReaLayoutAnimator).getAnimationsManager().viewsDidLayout();
+        boolean hasHeader = topScreenHasHeader((ViewGroup) container);
+        if (!hasHeader || !container.isLayoutRequested()) {
+          mReaLayoutAnimator.getAnimationsManager().viewsDidLayout();
+        }
       }
     } catch (IllegalViewOperationException e) {
       // (IllegalViewOperationException) == (vm == null)
       e.printStackTrace();
     }
+  }
+
+  private boolean topScreenHasHeader(ViewGroup screenStack) {
+    boolean hasHeader;
+    try {
+      ViewGroup fragment = (ViewGroup)screenStack.getChildAt(0);
+      ViewGroup screen = (ViewGroup)fragment.getChildAt(0);
+      View headerConfig = screen.getChildAt(0);
+      Field field = headerConfig.getClass().getDeclaredField("mIsHidden");
+      field.setAccessible(true);
+      hasHeader = !field.getBoolean(headerConfig);
+    } catch (NullPointerException | NoSuchFieldException | IllegalAccessException e) {
+      return false;
+    }
+    return hasHeader;
   }
 
   @Override

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -485,7 +485,9 @@
     BOOL isScreenDetached = [self getScreenForView:view].superview == nil;
     NSNumber *originY = viewSourcePreviousSnapshot.values[@"originY"];
     if (isScreenDetached) {
-      viewSourcePreviousSnapshot.values[@"originY"] = viewSourcePreviousSnapshot.values[@"originYByParent"];
+      float originYByParent = [viewSourcePreviousSnapshot.values[@"originYByParent"] floatValue];
+      float headerHeight = [viewSourcePreviousSnapshot.values[@"headerHeight"] floatValue];
+      viewSourcePreviousSnapshot.values[@"originY"] = @(originYByParent + headerHeight);
     }
     [_animationManager progressLayoutAnimationWithStyle:viewSourcePreviousSnapshot.values
                                                  forTag:view.reactTag

--- a/ios/LayoutReanimation/REASnapshot.m
+++ b/ios/LayoutReanimation/REASnapshot.m
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <RNReanimated/REASnapshot.h>
+#import <React/UIView+React.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
   _values[@"globalOriginY"] = _values[@"originY"];
   _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.bounds.size.width];
   _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.bounds.size.height];
+
+  UIView *navigationContainer = view.reactViewController.navigationController.view;
+  UIView *header = [navigationContainer.subviews count] > 1 ? navigationContainer.subviews[1] : nil;
+  if (header != nil) {
+    _values[@"headerHeight"] = @(header.frame.size.height);
+  } else {
+    _values[@"headerHeight"] = @(0);
+  }
 
   return self;
 }


### PR DESCRIPTION
## Summary

PR contains improvements in snapshotting view properties. 
- Android - Now animation will start when the screen has an attached header. In effect, the values in the snapshot will be valid.
- iOS - I replaced the old approach by detecting the screen header and adding information about header size to the snapshot.