### PR TITLE
Ignore events with malformed JSON payload

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -312,9 +312,16 @@ void NativeProxy::installJSIBindings(
       if (eventJSON == "null") {
         return;
       }
+
       jsi::Runtime &rt = *module->runtime;
-      jsi::Value payload = jsi::Value::createFromJsonUtf8(
-          rt, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
+      jsi::Value payload;
+      try {
+        payload = jsi::Value::createFromJsonUtf8(
+            rt, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
+      } catch (std::exception &) {
+        // Ignore events with malformed JSON payload.
+        return;
+      }
 
       module->handleEvent(eventName, payload, getCurrentTime());
     }


### PR DESCRIPTION
## Summary

This PR should fix "JSON Parse error: Unexpected end of input" error from Hermes VM happening when `JSON.parse` invoked by `jsi::Value::createFromJsonUtf8` (see [here](https://github.com/facebook/react-native/blob/62fa6d9dac185add0b8998fe1a443beaef3a49bc/ReactCommon/jsi/jsi/jsi.cpp#L139-L144)) fails due to malformed payload.

Related issues:
* https://github.com/Expensify/App/issues/14878
* https://github.com/wordpress-mobile/WordPress-Android/issues/16842
* https://github.com/software-mansion/react-native-reanimated/issues/2823

## Test plan

Run Example and FabricExample app on Android.

