### PR TITLE
[Shared Element Transition] Fix exiting animations on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
@@ -49,7 +49,7 @@ public class SharedTransitionManager {
   }
 
   protected void viewsDidLayout() {
-    startSharedTransitionForViews(mAddedSharedViews, true);
+    tryStartSharedTransitionForViews(mAddedSharedViews, true);
     mAddedSharedViews.clear();
   }
 
@@ -57,8 +57,8 @@ public class SharedTransitionManager {
     if (tagsToDelete != null) {
       visitTreeForTags(tagsToDelete, new SnapshotTreeVisitor());
 
-      boolean startedAnimation = startSharedTransitionForViews(mRemovedSharedViews, false);
-      if (!startedAnimation) {
+      boolean animationStarted = tryStartSharedTransitionForViews(mRemovedSharedViews, false);
+      if (!animationStarted) {
         return;
       }
       ConfigCleanerTreeVisitor configCleanerTreeVisitor = new ConfigCleanerTreeVisitor();
@@ -88,7 +88,8 @@ public class SharedTransitionManager {
     mNativeMethodsHolder = nativeMethods;
   }
 
-  private boolean startSharedTransitionForViews(List<View> sharedViews, boolean withNewElements) {
+  private boolean tryStartSharedTransitionForViews(
+      List<View> sharedViews, boolean withNewElements) {
     if (sharedViews.isEmpty()) {
       return false;
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
@@ -57,7 +57,10 @@ public class SharedTransitionManager {
     if (tagsToDelete != null) {
       visitTreeForTags(tagsToDelete, new SnapshotTreeVisitor());
 
-      startSharedTransitionForViews(mRemovedSharedViews, false);
+      boolean startedAnimation = startSharedTransitionForViews(mRemovedSharedViews, false);
+      if (!startedAnimation) {
+        return;
+      }
       ConfigCleanerTreeVisitor configCleanerTreeVisitor = new ConfigCleanerTreeVisitor();
       for (View removedSharedView : mRemovedSharedViews) {
         visitTree(removedSharedView, configCleanerTreeVisitor);
@@ -85,19 +88,20 @@ public class SharedTransitionManager {
     mNativeMethodsHolder = nativeMethods;
   }
 
-  private void startSharedTransitionForViews(List<View> sharedViews, boolean withNewElements) {
+  private boolean startSharedTransitionForViews(List<View> sharedViews, boolean withNewElements) {
     if (sharedViews.isEmpty()) {
-      return;
+      return false;
     }
     sortViewsByTags(sharedViews);
     List<SharedElement> sharedElements =
         getSharedElementsForCurrentTransition(sharedViews, withNewElements);
     if (sharedElements.isEmpty()) {
-      return;
+      return false;
     }
     setupTransitionContainer();
     reparentSharedViewsForCurrentTransition(sharedElements);
     startSharedTransition(sharedElements);
+    return true;
   }
 
   private void sortViewsByTags(List<View> views) {

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -383,8 +383,8 @@
                            }
                            return false;
                          }];
-  BOOL startedAnimation = [self setupSyncSharedTransitionForViews:removedViews];
-  if (startedAnimation) {
+  BOOL animationStarted = [self setupSyncSharedTransitionForViews:removedViews];
+  if (animationStarted) {
     for (UIView *view in removedViews) {
       [_animationManager clearAnimationConfigForTag:view.reactTag];
     }


### PR DESCRIPTION
## Summary

I shouldn't clear the layout animation config when the shared element transition doesn't start. Without this check, the exiting layout animation couldn't start because LayoutAnimationManager doesn't contain the view config.

## Test plan

Run exiting layout animation on Android.
