### PR TITLE
fix `Error` Variable scope conflicts, and remove duplicate `Date`

### DIFF
--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -10,7 +10,7 @@ var _worklet_5359970077727_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
-  var _e = [new Error(), -3, -20];
+  var _e = [new global.Error(), -3, -20];
   var _f = function _f() {
     return {
       res: x + objX.x
@@ -33,7 +33,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     console.log('test');
   };
@@ -57,7 +57,7 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(x) {
     var bar = 'worklet';
     var baz = \\"worklet\\";
@@ -86,7 +86,7 @@ exports[`babel plugin supports SequenceExpression, many arguments 1`] = `
 function App() {
   (0, 3, fun)({
     onStart: function () {
-      var _e = [new Error(), 1, -20];
+      var _e = [new global.Error(), 1, -20];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -106,7 +106,7 @@ exports[`babel plugin supports SequenceExpression, with objectHook 1`] = `
 function App() {
   (0, useAnimatedGestureHandler)({
     onStart: function () {
-      var _e = [new Error(), 1, -20];
+      var _e = [new global.Error(), 1, -20];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -126,7 +126,7 @@ exports[`babel plugin supports SequenceExpression, with worklet 1`] = `
 function App() {
   (0, fun)({
     onStart: function () {
-      var _e = [new Error(), 1, -20];
+      var _e = [new global.Error(), 1, -20];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -150,7 +150,7 @@ function App() {
   };
   (0, fun)({
     onStart: function () {
-      var _e = [new Error(), -2, -20];
+      var _e = [new global.Error(), -2, -20];
       var _f = function _f() {
         var a = obj.a;
       };
@@ -173,7 +173,7 @@ var _worklet_2022702330805_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), -2, -20];
+  var _e = [new global.Error(), -2, -20];
   var _f = function _f(t) {
     if (t > 0) {
       return a + foo(t - 1);
@@ -200,7 +200,7 @@ var _worklet_16669311443114_init_data = {
 function Box() {
   var offset = (0, _reactNativeReanimated.useSharedValue)(0);
   var animatedStyles = (0, _reactNativeReanimated.useAnimatedStyle)(function () {
-    var _e = [new Error(), -2, -20];
+    var _e = [new global.Error(), -2, -20];
     var _f = function _f() {
       return {
         transform: [{
@@ -233,7 +233,7 @@ exports[`babel plugin transforms spread operator in worklets for arrays 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     var bar = [4, 5];
     var baz = [1].concat([2, 3], bar);
@@ -252,7 +252,7 @@ exports[`babel plugin transforms spread operator in worklets for function argume
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
@@ -275,7 +275,7 @@ var _worklet_2015887751437_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(arg) {
     var _console;
     (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
@@ -294,7 +294,7 @@ exports[`babel plugin transforms spread operator in worklets for objects 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     var bar = {
       d: 4,
@@ -321,7 +321,7 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -339,7 +339,7 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -366,7 +366,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, [{
     key: \\"bar\\",
     get: function () {
-      var _e = [new Error(), -2, -20];
+      var _e = [new global.Error(), -2, -20];
       var _f = function _f() {
         return x + 2;
       };
@@ -389,7 +389,7 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     return {
       width: 50
@@ -409,7 +409,7 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     return {
       width: 50
@@ -429,7 +429,7 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     return {
       width: 50
@@ -458,7 +458,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, [{
     key: \\"bar\\",
     value: function () {
-      var _e = [new Error(), 1, -20];
+      var _e = [new global.Error(), 1, -20];
       var _f = function _f(x) {
         return x + 2;
       };
@@ -479,7 +479,7 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -498,7 +498,7 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new Error(), 1, -20];
+    var _e = [new global.Error(), 1, -20];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -518,7 +518,7 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new Error(), 1, -20];
+    var _e = [new global.Error(), 1, -20];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -538,7 +538,7 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new Error(), 1, -20];
+    var _e = [new global.Error(), 1, -20];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -558,7 +558,7 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new Error(), 1, -20];
+    var _e = [new global.Error(), 1, -20];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -586,7 +586,7 @@ var _worklet_232586479291_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f() {
     console.log('onBegin');
   };
@@ -596,7 +596,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.__stackDetails = _e;
   return _f;
 }()).onStart(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(_event) {
     console.log('onStart');
   };
@@ -606,7 +606,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.__stackDetails = _e;
   return _f;
 }()).onEnd(function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(_event, _success) {
     console.log('onEnd');
   };
@@ -633,7 +633,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, null, [{
     key: \\"bar\\",
     value: function () {
-      var _e = [new Error(), 1, -20];
+      var _e = [new global.Error(), 1, -20];
       var _f = function _f(x) {
         return x + 2;
       };
@@ -654,7 +654,7 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new Error(), 1, -20];
+  var _e = [new global.Error(), 1, -20];
   var _f = function _f(x) {
     return x + 2;
   };

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -10,7 +10,7 @@ var _worklet_5359970077727_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
-  var _e = [new global.Error(), -3, -20];
+  var _e = [new global.Error(), -3, -27];
   var _f = function _f() {
     return {
       res: x + objX.x
@@ -33,7 +33,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var f = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     console.log('test');
   };
@@ -57,7 +57,7 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(x) {
     var bar = 'worklet';
     var baz = \\"worklet\\";
@@ -86,7 +86,7 @@ exports[`babel plugin supports SequenceExpression, many arguments 1`] = `
 function App() {
   (0, 3, fun)({
     onStart: function () {
-      var _e = [new global.Error(), 1, -20];
+      var _e = [new global.Error(), 1, -27];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -106,7 +106,7 @@ exports[`babel plugin supports SequenceExpression, with objectHook 1`] = `
 function App() {
   (0, useAnimatedGestureHandler)({
     onStart: function () {
-      var _e = [new global.Error(), 1, -20];
+      var _e = [new global.Error(), 1, -27];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -126,7 +126,7 @@ exports[`babel plugin supports SequenceExpression, with worklet 1`] = `
 function App() {
   (0, fun)({
     onStart: function () {
-      var _e = [new global.Error(), 1, -20];
+      var _e = [new global.Error(), 1, -27];
       var _f = function _f() {};
       _f._closure = {};
       _f.__initData = _worklet_4434179069699_init_data;
@@ -150,7 +150,7 @@ function App() {
   };
   (0, fun)({
     onStart: function () {
-      var _e = [new global.Error(), -2, -20];
+      var _e = [new global.Error(), -2, -27];
       var _f = function _f() {
         var a = obj.a;
       };
@@ -173,7 +173,7 @@ var _worklet_2022702330805_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), -2, -20];
+  var _e = [new global.Error(), -2, -27];
   var _f = function _f(t) {
     if (t > 0) {
       return a + foo(t - 1);
@@ -200,7 +200,7 @@ var _worklet_16669311443114_init_data = {
 function Box() {
   var offset = (0, _reactNativeReanimated.useSharedValue)(0);
   var animatedStyles = (0, _reactNativeReanimated.useAnimatedStyle)(function () {
-    var _e = [new global.Error(), -2, -20];
+    var _e = [new global.Error(), -2, -27];
     var _f = function _f() {
       return {
         transform: [{
@@ -233,7 +233,7 @@ exports[`babel plugin transforms spread operator in worklets for arrays 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     var bar = [4, 5];
     var baz = [1].concat([2, 3], bar);
@@ -252,7 +252,7 @@ exports[`babel plugin transforms spread operator in worklets for function argume
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
@@ -275,7 +275,7 @@ var _worklet_2015887751437_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(arg) {
     var _console;
     (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
@@ -294,7 +294,7 @@ exports[`babel plugin transforms spread operator in worklets for objects 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     var bar = {
       d: 4,
@@ -321,7 +321,7 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -339,7 +339,7 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -366,7 +366,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, [{
     key: \\"bar\\",
     get: function () {
-      var _e = [new global.Error(), -2, -20];
+      var _e = [new global.Error(), -2, -27];
       var _f = function _f() {
         return x + 2;
       };
@@ -389,7 +389,7 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     return {
       width: 50
@@ -409,7 +409,7 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     return {
       width: 50
@@ -429,7 +429,7 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var animatedStyle = useAnimatedStyle(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     return {
       width: 50
@@ -458,7 +458,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, [{
     key: \\"bar\\",
     value: function () {
-      var _e = [new global.Error(), 1, -20];
+      var _e = [new global.Error(), 1, -27];
       var _f = function _f(x) {
         return x + 2;
       };
@@ -479,7 +479,7 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(x) {
     return x + 2;
   };
@@ -498,7 +498,7 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new global.Error(), 1, -20];
+    var _e = [new global.Error(), 1, -27];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -518,7 +518,7 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new global.Error(), 1, -20];
+    var _e = [new global.Error(), 1, -27];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -538,7 +538,7 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new global.Error(), 1, -20];
+    var _e = [new global.Error(), 1, -27];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -558,7 +558,7 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
 };
 useAnimatedGestureHandler({
   onStart: function () {
-    var _e = [new global.Error(), 1, -20];
+    var _e = [new global.Error(), 1, -27];
     var _f = function _f(event) {
       console.log(event);
     };
@@ -586,7 +586,7 @@ var _worklet_232586479291_init_data = {
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f() {
     console.log('onBegin');
   };
@@ -596,7 +596,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.__stackDetails = _e;
   return _f;
 }()).onStart(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(_event) {
     console.log('onStart');
   };
@@ -606,7 +606,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   _f.__stackDetails = _e;
   return _f;
 }()).onEnd(function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(_event, _success) {
     console.log('onEnd');
   };
@@ -633,7 +633,7 @@ var Foo = function () {
   (0, _createClass2.default)(Foo, null, [{
     key: \\"bar\\",
     value: function () {
-      var _e = [new global.Error(), 1, -20];
+      var _e = [new global.Error(), 1, -27];
       var _f = function _f(x) {
         return x + 2;
       };
@@ -654,7 +654,7 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   location: \\"${ process.cwd() }/jest tests fixture\\"
 };
 var foo = function () {
-  var _e = [new global.Error(), 1, -20];
+  var _e = [new global.Error(), 1, -27];
   var _f = function _f(x) {
     return x + 2;
   };

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -456,7 +456,7 @@ function makeWorklet(t, fun, state) {
               t.identifier('Error'),
             ), []),
             t.numericLiteral(lineOffset),
-            t.numericLiteral(-20), // the placement of opening bracket after Exception in line that defined '_e' variable
+            t.numericLiteral(-27), // the placement of opening bracket after Exception in line that defined '_e' variable
           ])
         ),
       ])

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -46,7 +46,6 @@ const globals = new Set([
   'Uint32Array',
   'Float32Array',
   'Float64Array',
-  'Date',
   'HermesInternal',
   'JSON',
   'Math',
@@ -452,7 +451,10 @@ function makeWorklet(t, fun, state) {
         t.variableDeclarator(
           t.identifier('_e'),
           t.arrayExpression([
-            t.newExpression(t.identifier('Error'), []),
+            t.newExpression(t.memberExpression(
+              t.identifier('global'),
+              t.identifier('Error'),
+            ), []),
             t.numericLiteral(lineOffset),
             t.numericLiteral(-20), // the placement of opening bracket after Exception in line that defined '_e' variable
           ])


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

The babel plugin transformed the code and added some helper code, it uses `new Error()` to get the call stack. this works in general unless you have a variable called `Error` in the local scope, in this case, It references the wrong Object. this PR uses `global.Error` to avoid this.

`'Date'` is duplicated in this `global` array, and I removed the second one.

## Test plan

```jsx
import { useState } from 'react';
import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
import Error from './components/Error'; // imported an arrow function component named 'Error'

const App = () => {
  const [hasError, setHasError] = useState(false);
  const offset = useSharedValue(0);
  // `new Error()` not working here, because `Error` reference to the function component, it's a arrow function, not a function or class
  const animatedStyles = useAnimatedStyle(() => ({ transform: [{ translateX: offset.value * 255 }] }), []);

  if (hasError) return <Error />;
  return <Animated.View style={animatedStyles} />;
};
```
