### PR TITLE
[Shared Element Transition] Disable animation on swipe back

### DIFF
--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -282,10 +282,13 @@ static REASharedTransitionManager *_sharedTransitionManager;
   UIView *stack = [self getStackForView:screen];
   bool isRemovedInParentStack = [self isRemovedFromHigherStack:screen];
   if (stack != nil && !isRemovedInParentStack) {
-    bool shouldRunTransition =
-        [self isScreen:screen
-            outsideStack:stack] // screen is removed from React tree (navigation.navigate(<screenName>))
-        || [self isScreen:screen onTopOfStack:stack]; // click on button goBack on native header
+    bool isInteractive =
+        [[[screen.reactViewController valueForKey:@"transitionCoordinator"] valueForKey:@"interactive"] boolValue];
+    // screen is removed from React tree (navigation.navigate(<screenName>))
+    bool isScreenRemovedFromReactTree = [self isScreen:screen outsideStack:stack];
+    // click on button goBack on native header
+    bool isTriggeredByGoBackButton = [self isScreen:screen onTopOfStack:stack];
+    bool shouldRunTransition = !isInteractive && (isScreenRemovedFromReactTree || isTriggeredByGoBackButton);
     if (shouldRunTransition) {
       [self runSharedTransitionForSharedViewsOnScreen:screen];
     } else {


### PR DESCRIPTION
## Summary

This PR prevents starting shared transition at screen swipe back on iOS. In the future, for this use case, we want to add a new type of shared animation controlled by transition progress.
