### PR TITLE
Remove unnecessary import

### DIFF
--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -6,10 +6,6 @@
 #include <utility>
 #include <vector>
 
-#ifdef RCT_NEW_ARCH_ENABLED
-#include <react/renderer/uimanager/primitives.h>
-#endif
-
 #include "ReanimatedRuntime.h"
 #include "RuntimeManager.h"
 #include "Scheduler.h"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR removes an import which became redundant after #4024.

## Test plan

Check if `Shareables.h` compiles successfully.
