### PR TITLE
fix: Fix nested Worklets not transpiling properly

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -864,12 +864,12 @@ module.exports = function ({ types: t }) {
     },
     visitor: {
       CallExpression: {
-        enter(path, state) {
+        exit(path, state) {
           processWorklets(t, path, state);
         },
       },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
-        enter(path, state) {
+        exit(path, state) {
           processIfWorkletNode(t, path, state);
           processIfGestureHandlerEventCallbackFunctionNode(t, path, state);
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

The latest Babel plugin does not transpile nested worklets properly.

For example:

```ts
function outer() {
  'worklet'
  const inner = () => {
    'worklet'
    return 5
  }
  inner()
}
```

Does not work. 

This PR fixes that by reversing the order in which Babel executes (`enter` -> `exit`)

Credits to @Szymon20000 & @chrfalch for figuring this one out, just wanted to push this upstream.


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
