### PR TITLE
Fixed sourceMap typo in plugin.js

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -559,7 +559,7 @@ function makeWorklet(t, fun, state) {
   if (sourceMapString) {
     initDataObjectExpression.properties.push(
       t.objectProperty(
-        t.identifier('__sourceMap'),
+        t.identifier('sourceMap'),
         t.stringLiteral(sourceMapString)
       )
     );


### PR DESCRIPTION
## Summary

Fixed a typo in `plugin.js` that would provide wrong identifier for `sourceMap` and lead to undefined behaviour on error red box.

## Test plan

UI error throws from `ExampleWorklet`.
