### PR TITLE
Add proxy interface for Animated.FlatList to enable passing itemLayoutAnimation prop

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -280,7 +280,11 @@ declare module 'react-native-reanimated' {
     export interface ScrollView extends ReactNativeScrollView {}
 
     export class Code extends Component<CodeProps> {}
-    export class FlatList<T> extends Component<AnimateProps<FlatListProps<T>>> {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        export interface FlatListPropsWithLayout<T> extends FlatListProps<T> {
+      itemLayoutAnimation: ILayoutAnimationBuilder;
+    }
+    export class FlatList<T> extends Component<AnimateProps<FlatListPropsWithLayout<T>>> {
       itemLayoutAnimation: ILayoutAnimationBuilder;
       getNode(): ReactNativeFlatList;
     }

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -280,7 +280,6 @@ declare module 'react-native-reanimated' {
     export interface ScrollView extends ReactNativeScrollView {}
 
     export class Code extends Component<CodeProps> {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     export interface FlatListPropsWithLayout<T> extends FlatListProps<T> {
       itemLayoutAnimation?: ILayoutAnimationBuilder;
     }

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -281,11 +281,12 @@ declare module 'react-native-reanimated' {
 
     export class Code extends Component<CodeProps> {}
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-        export interface FlatListPropsWithLayout<T> extends FlatListProps<T> {
-      itemLayoutAnimation: ILayoutAnimationBuilder;
+    export interface FlatListPropsWithLayout<T> extends FlatListProps<T> {
+      itemLayoutAnimation?: ILayoutAnimationBuilder;
     }
-    export class FlatList<T> extends Component<AnimateProps<FlatListPropsWithLayout<T>>> {
-      itemLayoutAnimation: ILayoutAnimationBuilder;
+    export class FlatList<T> extends Component<
+      AnimateProps<FlatListPropsWithLayout<T>>
+    > {
       getNode(): ReactNativeFlatList;
     }
     // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
## Summary

Fixed [#4056](https://github.com/software-mansion/react-native-reanimated/issues/4056) by adding proxy interface to the inheritance chain. Also changing `itemLayoutAnimation` to be optional, since it is optional in source files.

## Test plan

build & run `InvertedFlatList` in `Example` app
run `yarn jest`
