### PR TITLE
Raise error when cpplint is not installed

### DIFF
--- a/scripts/cpplint.sh
+++ b/scripts/cpplint.sh
@@ -3,5 +3,6 @@
 if which cpplint >/dev/null; then
   cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments,-build/c++11,-runtime/int,-runtime/references --quiet --recursive Common/cpp android/src/main/cpp
 else
-  echo "warning: cpplint not installed, download from https://github.com/cpplint/cpplint"
+  echo "error: cpplint not installed, download from https://github.com/cpplint/cpplint" 1>&2
+  exit 1
 fi


### PR DESCRIPTION
## Summary

This PR changes the behavior of `yarn lint:cpp` script when cpplint is not found.

## Test plan

Dude trust me
