### PR TITLE
Resolve `runtime/int` errors in cpplint

### DIFF
--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - '.github/workflows/validate-cpp.yml'
+      - 'scripts/cpplint.sh'
       - 'Common/cpp/**'
       - 'ios/native/**'
       - 'android/src/main/cpp/**'
   pull_request:
     paths:
       - '.github/workflows/validate-cpp.yml'
+      - 'scripts/cpplint.sh'
       - 'Common/cpp/**'
       - 'ios/native/**'
       - 'android/src/main/cpp/**'

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -301,9 +301,9 @@ jsi::Value NativeReanimatedModule::registerEventHandler(
     jsi::Runtime &rt,
     const jsi::Value &eventHash,
     const jsi::Value &worklet) {
-  static unsigned long EVENT_HANDLER_ID = 1;
+  static uint64_t EVENT_HANDLER_ID = 1;
 
-  unsigned long newRegistrationId = EVENT_HANDLER_ID++;
+  uint64_t newRegistrationId = EVENT_HANDLER_ID++;
   auto eventName = eventHash.asString(rt).utf8(rt);
   auto handlerShareable = extractShareableOrThrow(rt, worklet);
 
@@ -322,7 +322,7 @@ jsi::Value NativeReanimatedModule::registerEventHandler(
 void NativeReanimatedModule::unregisterEventHandler(
     jsi::Runtime &rt,
     const jsi::Value &registrationId) {
-  unsigned long id = registrationId.asNumber();
+  uint64_t id = registrationId.asNumber();
   scheduler->scheduleOnUI(
       [=] { eventHandlerRegistry->unregisterEventHandler(id); });
 }

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -10,7 +10,7 @@ void EventHandlerRegistry::registerEventHandler(
   eventHandlers[eventHandler->id] = eventHandler;
 }
 
-void EventHandlerRegistry::unregisterEventHandler(unsigned long id) {
+void EventHandlerRegistry::unregisterEventHandler(uint64_t id) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
   auto handlerIt = eventHandlers.find(id);
   if (handlerIt != eventHandlers.end()) {

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -18,14 +18,14 @@ class WorkletEventHandler;
 class EventHandlerRegistry {
   std::map<
       std::string,
-      std::unordered_map<unsigned long, std::shared_ptr<WorkletEventHandler>>>
+      std::unordered_map<uint64_t, std::shared_ptr<WorkletEventHandler>>>
       eventMappings;
-  std::map<unsigned long, std::shared_ptr<WorkletEventHandler>> eventHandlers;
+  std::map<uint64_t, std::shared_ptr<WorkletEventHandler>> eventHandlers;
   std::mutex instanceMutex;
 
  public:
   void registerEventHandler(std::shared_ptr<WorkletEventHandler> eventHandler);
-  void unregisterEventHandler(unsigned long id);
+  void unregisterEventHandler(uint64_t id);
 
   void processEvent(
       jsi::Runtime &rt,

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -16,7 +16,7 @@ CoreFunction::CoreFunction(
                       .asString(rt)
                       .utf8(rt);
   location_ = "worklet_" +
-      std::to_string(static_cast<unsigned long long>(
+      std::to_string(static_cast<uint64_t>(
           workletObject.getProperty(rt, "__workletHash").getNumber()));
 }
 

--- a/Common/cpp/Tools/WorkletEventHandler.h
+++ b/Common/cpp/Tools/WorkletEventHandler.h
@@ -14,13 +14,13 @@ class WorkletEventHandler {
   friend EventHandlerRegistry;
 
  private:
-  unsigned long id;
+  uint64_t id;
   std::string eventName;
   jsi::Function handler;
 
  public:
   WorkletEventHandler(
-      unsigned long id,
+      uint64_t id,
       std::string eventName,
       jsi::Function &&handler)
       : id(id), eventName(eventName), handler(std::move(handler)) {}

--- a/scripts/cpplint.sh
+++ b/scripts/cpplint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if which cpplint >/dev/null; then
-  cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments,-build/c++11,-runtime/int,-runtime/references --quiet --recursive Common/cpp android/src/main/cpp
+  cpplint --linelength=230 --filter=-legal/copyright,-readability/todo,-build/namespaces,-whitespace/comments,-build/c++11,-runtime/references --quiet --recursive Common/cpp android/src/main/cpp
 else
   echo "warning: cpplint not installed, download from https://github.com/cpplint/cpplint"
 fi


### PR DESCRIPTION
## Summary

This PR replaces all occurrences of `unsigned long` and `unsigned long long` with `uint64_t` in order to make our codebase compliant with C++ code style without having to ignore `runtime/int` errors from cpplint.

## Test plan

* Confirm that `sizeof(unsigned long)` and `sizeof(unsigned long long)` are equal to `sizeof(uint64_t)` i.e. `8` across all target architectures
* Check if Example compiles successfully
