### PR TITLE
Fix host obj reference loop

### DIFF
--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -258,6 +258,8 @@ type AnimationToDecoration<T extends AnimationObject | StyleLayoutAnimation> =
     ? NextAnimation<SequenceAnimation>
     : AnimatableValue | T;
 
+const IS_NATIVE = NativeReanimatedModule.native;
+
 export function defineAnimation<
   T extends AnimationObject | StyleLayoutAnimation
 >(starting: AnimationToDecoration<T>, factory: () => T): T {
@@ -272,7 +274,7 @@ export function defineAnimation<
     return animation;
   };
 
-  if (_WORKLET || !NativeReanimatedModule.native) {
+  if (_WORKLET || !IS_NATIVE) {
     return create();
   }
   // @ts-ignore: eslint-disable-line


### PR DESCRIPTION
## Summary

Some recent changes (#4060 and #4024) resulted in introducing a reference loop. The reason was that we started capturing the whole module as host object due to the fact we referenced the module in `defineAnimation` method. As a result, the VM wouldn't deallocate properly and we started getting instance checker crashes on reloads.

## Test plan

Start app on iOS. Try out reloading JS several times -> no crash.