### PR TITLE
Avoid setImmediate calls on Jest environment

### DIFF
--- a/__tests__/Animation.test.js
+++ b/__tests__/Animation.test.js
@@ -49,20 +49,6 @@ const getDefaultStyle = () => ({
   margin: 30,
 });
 
-const originalAdvanceTimersByTime = jest.advanceTimersByTime;
-
-jest.advanceTimersByTime = (timeMs) => {
-  // This is a workaround for an issue with using setImmediate that's in the jest
-  // environment implemented as a 0-second timeout. Because of the fact we use
-  // setImmediate for scheduling runOnUI tasks as well as executing matters,
-  // starting new animaitons gets delayed be three frames. To compensate for that
-  // we execute pending timers three times before advancing the timers.
-  jest.runOnlyPendingTimers();
-  jest.runOnlyPendingTimers();
-  jest.runOnlyPendingTimers();
-  originalAdvanceTimersByTime(timeMs);
-};
-
 describe('Tests of animations', () => {
   beforeEach(() => {
     jest.useFakeTimers();

--- a/__tests__/InterpolateColor.test.js
+++ b/__tests__/InterpolateColor.test.js
@@ -8,20 +8,6 @@ import Animated, {
   withTiming,
 } from '../src';
 
-const originalAdvanceTimersByTime = jest.advanceTimersByTime;
-
-jest.advanceTimersByTime = (timeMs) => {
-  // This is a workaround for an issue with using setImmediate that's in the jest
-  // environment implemented as a 0-second timeout. Because of the fact we use
-  // setImmediate for scheduling runOnUI tasks as well as executing matters,
-  // starting new animaitons gets delayed be three frames. To compensate for that
-  // we execute pending timers three times before advancing the timers.
-  jest.runOnlyPendingTimers();
-  jest.runOnlyPendingTimers();
-  jest.runOnlyPendingTimers();
-  originalAdvanceTimersByTime(timeMs);
-};
-
 describe('colors interpolation', () => {
   it('interpolates rgb without gamma correction', () => {
     const colors = ['#105060', '#609020'];

--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -97,7 +97,7 @@ export function createMapperRegistry() {
       // to know how many times mappers need to run. As we don't want tests to
       // make any assumptions on that number it is easier to execute mappers
       // immediately for testing purposes and only expect test to advance timers
-      // if they want to make any assertions on the efffects of animations being run.
+      // if they want to make any assertions on the effects of animations being run.
       mapperRun();
     } else if (!runRequested) {
       setImmediate(mapperRun);

--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -1,5 +1,8 @@
 import { SharedValue } from './commonTypes';
+import { isJest } from './PlatformChecker';
 import { runOnUI } from './threads';
+
+const IS_JEST = isJest();
 
 export type Mapper = {
   id: number;
@@ -88,7 +91,15 @@ export function createMapperRegistry() {
   }
 
   function maybeRequestUpdates() {
-    if (!runRequested) {
+    if (IS_JEST) {
+      // On Jest environment we avoid using setImmediate as that'd require test
+      // to advance the clock manually. This on other hand would require tests
+      // to know how many times mappers need to run. As we don't want tests to
+      // make any assumptions on that number it is easier to execute mappers
+      // immediately for testing purposes and only expect test to advance timers
+      // if they want to make any assertions on the efffects of animations being run.
+      mapperRun();
+    } else if (!runRequested) {
       setImmediate(mapperRun);
       runRequested = true;
     }


### PR DESCRIPTION
## Summary

This PR adds Jest specific code to places where we'd used setImmediate. We want to avoid calling setImmediate as it makes writing tests a bit tricky.

The reason is that Jest mocks all the timer-related stuff putting all enqueued function in a single bucket. Then, in order to run these enqueued functions, the test needs to call advanceTimersByTime. It isn't allowed to schedule a callback for the same "tick" which results in the chain of setImmediate calls requiring a several separate runs to advanceTimersByTime. This can be seen in the previous workaround where we had three subsequent calls to that method just in order to start a single animation.

With this change we no longer expect from test to run any additional setup / timer-advancing steps when testing reanimated components and animations.

## Test plan

Run jest tests.