### PR TITLE
Update docs about testing after recent changes

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -56,7 +56,8 @@ If you have custom babel configuration for testing, make sure that Reanimated's 
 
 #### Timers
 
-You can use jest timers to control animation
+You can use Jest's fake timers to control animation progress.
+Check [the full guide about mocking timers on Jest documentation website](https://jestjs.io/docs/timer-mocks).
 
 ```js
 jest.useFakeTimers();
@@ -75,9 +76,12 @@ jest.advanceTimersByTime(250);
 
 ## Example
 
-Timer:
+The below code shows an example of test that runs a 250ms of animation and verifies the component style after that point in time.
 
 ```js
+// Setup fake timers – this can be done before the tests are run
+jest.useFakeTimers();
+
 test('stop in the middle of animation', () => {
   const style = { width: 0 };
 
@@ -89,7 +93,7 @@ test('stop in the middle of animation', () => {
   expect(view).toHaveAnimatedStyle(style);
 
   fireEvent.press(button);
-  advanceAnimationByTime(250); // if whole animation duration is a 500ms
+  jest.advanceAnimationByTime(250); // if whole animation duration is a 500ms
   style.width = 50; // value of component width after 250ms of animation
   expect(view).toHaveAnimatedStyle(style);
 });

--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -1,20 +1,25 @@
 ---
 id: testing
-title: "Testing with Jest"
-sidebar_label: "Testing with Jest"
+title: 'Testing with Jest'
+sidebar_label: 'Testing with Jest'
 ---
 
 Reanimated test mocks use web implementation of Reanimated2. Before you begin using Reanimated mocks you need some setup actions.
 
 ## Setup
 
+First, make sure that your tests run with Node version 16 or newer.
+
 Add the following line to your `jest-setup.js` file:
+
 ```js
 require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
 ```
+
 `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.
 
 To be sure, check if your `jest.config.js` file contains:
+
 ```js
 ...
 preset: 'react-native',
@@ -28,17 +33,21 @@ If you use Jest in a version **older than 28**, you should set `setupFiles` prop
 
 :::
 
-If you have custom babel configuration for testing, make sure that Reanimated's babel plugin is enabled for that environment.
+If you have custom babel configuration for testing, make sure that Reanimated's babel plugin is enabled in that environment.
 
 ## API
 
 #### Style checker
+
 - Checking equality of selected styles with current component styles
+
   #### `expect(component).toHaveAnimatedStyle(expectedStyle)`
+
   `component` - tested component
   `expectedStyle` - contains expected styles of testing component, for example `{ width: 100 }`
 
 - Checking equality of all current component styles with expected styles
+
   #### `expect(component).toHaveAnimatedStyle(expectedStyle, {exact: true})`
 
 - You can get all styles of tested component by using `getDefaultStyle`
@@ -46,55 +55,52 @@ If you have custom babel configuration for testing, make sure that Reanimated's 
   `component` - tested component
 
 #### Timers
+
 You can use jest timers to control animation
+
 ```js
-jest.useFakeTimers(); // jest.useFakeTimers('legacy') for jest >= 27
+jest.useFakeTimers();
 // call animation
 jest.runAllTimers();
 ```
-If you want more control over animation, you can use Reanimated wrapper for timers:
+
+If you want more control over animation, you can use `jest.advanceTimersByTime` to move to a certain point in the animation:
+
 ```js
-withReanimatedTimer(() => {
-  // call animation
-})
+jest.useFakeTimers();
+// call animation
+jest.advanceTimersByTime(250);
+// make assertions on what you expect the styles of a component should be after 250ms
 ```
-Inside of `withReanimatedTimer` you can use `advanceAnimationByTime(timeInMs)` or `advanceAnimationByFrame(amountOfFrames)` functions
-- Advance animation by a specified number of frames. You can specify the running duration of the animation and check the value of styles afterward.
-  #### `advanceAnimationByTime(timeInMs)`
-  `timeInMs` - the duration specifying for how long animation should be advanced forward. Should have an integer value.
-- Advance animation by specific amount of animation frame.
-  #### `advanceAnimationByFrame(numberOfFrames)`
-  `numberOfFrames` - number of animation frames to run. Should have an integer value.
 
 ## Example
 
 Timer:
 
 ```js
-test('stop in a middle of animation', () => {
-  withReanimatedTimer(() => {
-    const style = { width: 0 };
+test('stop in the middle of animation', () => {
+  const style = { width: 0 };
 
-    const { getByTestId } = render(<AnimatedComponent />);
-    const view = getByTestId('view');
-    const button = getByTestId('button');
+  const { getByTestId } = render(<AnimatedComponent />);
+  const view = getByTestId('view');
+  const button = getByTestId('button');
 
-    expect(view.props.style.width).toBe(0);
-    expect(view).toHaveAnimatedStyle(style);
+  expect(view.props.style.width).toBe(0);
+  expect(view).toHaveAnimatedStyle(style);
 
-    fireEvent.press(button);
-    advanceAnimationByTime(250); // if whole animation duration is a 500ms
-    style.width = 46.08; // value of component width after 250ms of animation
-    expect(view).toHaveAnimatedStyle(style);
-  });
+  fireEvent.press(button);
+  advanceAnimationByTime(250); // if whole animation duration is a 500ms
+  style.width = 50; // value of component width after 250ms of animation
+  expect(view).toHaveAnimatedStyle(style);
 });
 ```
 
-More example tests you can see in our repository
+Check links below for full examples of tests from Reanimated repo
+
 - [SharedValue.test.js](https://github.com/software-mansion/react-native-reanimated/tree/main/__tests__/SharedValue.test.js)
 - [Animation.test.js](https://github.com/software-mansion/react-native-reanimated/tree/main/__tests__/Animation.test.js)
 
 ## Recommended testing library
 
-- [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/)
+- [@testing-library/react-native](https://testing-library.com/docs/react-native-testing-library)
 - [@testing-library/react-hooks](https://react-hooks-testing-library.com/) - for dealing with hooks

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -149,7 +149,7 @@ const afterTest = () => {
 
 export const withReanimatedTimer = (animationTest) => {
   console.warn(
-    'This method is deprecated, you shoulddefine your own before and after test hooks to enable jest.useFakeTimers(). Check out the documentation for details on testing'
+    'This method is deprecated, you should define your own before and after test hooks to enable jest.useFakeTimers(). Check out the documentation for details on testing'
   );
   beforeTest();
   animationTest();


### PR DESCRIPTION
## Summary

This diff updates documentation about testing to remove mentions of `withReanimatedTimer` that we no longer require to use.

## Test plan

Run md preview and check if the testing page look alright