### PR TITLE
[Shared Element Transition] Restore X-axis origin

### DIFF
--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -558,7 +558,8 @@ static REASharedTransitionManager *_sharedTransitionManager;
                                                    forTag:viewTag
                                        isSharedTransition:YES];
       float originYByParent = [viewSourcePreviousSnapshot.values[@"originYByParent"] floatValue];
-      CGRect frame = CGRectMake(view.frame.origin.x, originYByParent, view.frame.size.width, view.frame.size.height);
+      float originXByParent = [viewSourcePreviousSnapshot.values[@"originXByParent"] floatValue];
+      CGRect frame = CGRectMake(originXByParent, originYByParent, view.frame.size.width, view.frame.size.height);
       [view setFrame:frame];
     }
     if ([_viewsToHide containsObject:viewTag]) {


### PR DESCRIPTION
## Summary

Restore the X-axis origin after the shared animation. Previously I was restoring only Y origin to handle the screen with a header, but X origin restoring is required when the screen has its transition animation.