### PR TITLE
Fix docs link in reanimated_utils.rb

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -68,7 +68,7 @@ def assert_no_multiple_instances(react_native_info)
       location['/package.json'] = ''
       parsed_location += "- " + location + "\n"
     end
-    raise "[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/next/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsed_location
+    raise "[react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/troubleshooting/#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsed_location
   end
 end
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes a broken link in the error message in `reanimated_utils.rb` which no longer works because `next` version was removed by @kacperkapusciak in #4066.

## Test plan

Check if the URL is valid.
