### PR TITLE
Fix Layout Animation restart

### DIFF
--- a/src/reanimated2/layoutReanimation/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/animationsManager.ts
@@ -35,7 +35,6 @@ function stopObservingProgress(
 function createLayoutAnimationManager() {
   'worklet';
   const enteringAnimationForTag = new Map();
-  const sharedTransitionForTag = new Map();
   const mutableValuesForTag = new Map();
 
   return {
@@ -64,15 +63,8 @@ function createLayoutAnimationManager() {
         value = makeUIMutable(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
+        stopObservingProgress(tag, value, false, false);
         value._value = style.initialValues;
-      }
-
-      if (sharedTransitionForTag.get(tag)) {
-        stopObservingProgress(tag, value, true, false);
-      }
-
-      if (type === 'sharedElementTransition') {
-        sharedTransitionForTag.set(tag, currentAnimation);
       }
 
       // @ts-ignore The line below started failing because I added types to the method – don't have time to fix it right now
@@ -81,7 +73,6 @@ function createLayoutAnimationManager() {
       animation.callback = (finished?: boolean) => {
         if (finished) {
           enteringAnimationForTag.delete(tag);
-          sharedTransitionForTag.delete(tag);
           mutableValuesForTag.delete(tag);
           const shouldRemoveView = type === 'exiting';
           stopObservingProgress(tag, value, finished, shouldRemoveView);


### PR DESCRIPTION
In #4043 I changed the restarting animation logic in `animationManager.ts`. Accidentally I removed restarting animation for the rest of the Layout Animations. Fortunately, I found a better way to handle restart animation for both LA and SET animations types.