### PR TITLE
Flush animation-frame and immediates on keyboard event to follow same flow as other types of events

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -135,8 +135,18 @@ export function subscribeForKeyboardEvents(
   eventHandler: (state: number, height: number) => void,
   options: AnimatedKeyboardOptions
 ): number {
+  // TODO: this should really go with the same code path as other events, that is
+  // via registerEventHandler. For now we are copying the code from there.
+  function handleAndFlushImmediates(state: number, height: number) {
+    'worklet';
+    const now = performance.now();
+    global.__frameTimestamp = now;
+    eventHandler(state, height);
+    global.__flushAnimationFrame(now);
+    global.__frameTimestamp = undefined;
+  }
   return NativeReanimatedModule.subscribeForKeyboardEvents(
-    makeShareableCloneRecursive(eventHandler),
+    makeShareableCloneRecursive(handleAndFlushImmediates),
     options.isStatusBarTranslucentAndroid ?? false
   );
 }


### PR DESCRIPTION
## Summary

This diff fixes an issue with animated views not updating when animating along keyboard. This problem regressed after #3970 where we changed the logic of when enqueued callbacks for animation frame and immediates are flushed. The logic has been moved from c++ to js and we added some code to execute animation frame and immediates as a part of event handling process. However, keyboard events have a separate flow of providing event data (we should unify this at some point), and we missed updating it in that place.

This PR adds similar logic to [what we use for regular events](https://github.com/software-mansion/react-native-reanimated/blob/535b5d64c0720da3a9a39d99a67e878fe09b5154/src/reanimated2/core.ts#L117) into the code responsible for handling keyboard events.

## Test plan

Run animated keyboard example on iOS and Android.