### PR TITLE
Hardcode JS library version in `checkVersion`

### DIFF
--- a/__tests__/versionCheck.test.js
+++ b/__tests__/versionCheck.test.js
@@ -1,0 +1,21 @@
+const {
+  checkVersion,
+} = require('../src/reanimated2/platform-specific/checkVersion');
+const { version: packageVersion } = require('../package.json');
+
+describe('desc', () => {
+  beforeAll(() => {
+    global._REANIMATED_VERSION_CPP = packageVersion;
+    jest.spyOn(console, 'error');
+  });
+
+  afterAll(() => {
+    delete global._REANIMATED_VERSION_CPP;
+    console.error.mockRestore();
+  });
+
+  it('checks version successfully', () => {
+    checkVersion();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -20,6 +20,15 @@ export class NativeReanimated {
     this.InnerNativeModule = global.__reanimatedModuleProxy;
     this.native = native;
     if (native) {
+      if (this.InnerNativeModule === undefined) {
+        console.error(
+          `[Reanimated] The native part of Reanimated doesn't seem to be initialized. This could be caused by\n\
+  - not rebuilding the app after installing or upgrading Reanimated\n\
+  - trying to run Reanimated on an unsupported platform\n\
+  - running in a brownfield app without manually initializing the native library`
+        );
+        return;
+      }
       checkVersion();
     }
   }

--- a/src/reanimated2/platform-specific/checkVersion.ts
+++ b/src/reanimated2/platform-specific/checkVersion.ts
@@ -1,4 +1,4 @@
-import { version as jsVersion } from '../../../package.json';
+const jsVersion = '3.0.0-rc.10';
 
 /**
  * Checks that native and js versions of reanimated match.

--- a/src/reanimated2/platform-specific/checkVersion.ts
+++ b/src/reanimated2/platform-specific/checkVersion.ts
@@ -1,3 +1,8 @@
+/**
+ * We hardcode the version of Reanimated here in order to compare it
+ * with the version used to build the native part of the library in runtime.
+ * Remember to keep this in sync with the version declared in `package.json`
+ */
 const jsVersion = '3.0.0-rc.10';
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
We hardcode the version of Reanimated here in order to compare it with the version used to build the native part of the library in runtime.

Ideally, we'd grab this version from the `package.json` file instead, but this causes issues when packaging the library due to misaligned relative paths.
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
