### PR TITLE
Call `shouldGenerateSourceMap` only once

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -204,7 +204,9 @@ function buildWorkletString(t, fun, closureVariables, name, inputMap) {
 
   const code = generate(workletFunction).code;
 
-  if (shouldGenerateSourceMap()) {
+  const includeSourceMap = shouldGenerateSourceMap();
+
+  if (includeSourceMap) {
     // Clear contents array (should be empty anyways)
     inputMap.sourcesContent = [];
     // Include source contents in source map, because Flipper/iframe is not
@@ -215,8 +217,6 @@ function buildWorkletString(t, fun, closureVariables, name, inputMap) {
       );
     }
   }
-
-  const includeSourceMap = shouldGenerateSourceMap();
 
   const transformed = transformSync(code, {
     plugins: [prependClosureVariablesIfNecessary()],


### PR DESCRIPTION
## Summary

This PR stores the result of `shouldGenerateSourceMap` to avoid calling it twice.

## Test plan

Trust me bro
