### PR TITLE
Remove `HAS_JS_WEAK_OBJECTS` definition

### DIFF
--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -10,8 +10,6 @@
 #include "RuntimeManager.h"
 #include "Scheduler.h"
 
-#define HAS_JS_WEAK_OBJECTS (JS_RUNTIME_HERMES || JS_RUNTIME_V8)
-
 using namespace facebook;
 
 namespace reanimated {


### PR DESCRIPTION
## Summary

I noticed that `HAS_JS_WEAK_OBJECTS` is no longer used so it makes sense to remove it from our codebase.

## Test plan

Just see if the Example and FabricExample apps compile.
