### PR TITLE
Bump react-native version in V8 CI

### DIFF
--- a/.github/workflows/build-v8.yml
+++ b/.github/workflows/build-v8.yml
@@ -12,7 +12,7 @@ on:
       - main
 
 env:
-  REACT_NATIVE_VERSION: "0.70.5"
+  REACT_NATIVE_VERSION: "0.71.3"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

This PR bumps `react-native` version from 0.70.5 to 0.71.3 because of the failing CI after the successful release of `react-native-v8@2.0` which requires `react-native>=0.71.0`.

## Test plan

Just see if the V8 CI is green.
