### PR TITLE
Fix backward compatibility with asBool()

### DIFF
--- a/Common/cpp/Tools/JsiUtils.h
+++ b/Common/cpp/Tools/JsiUtils.h
@@ -28,7 +28,7 @@ inline int get<int>(jsi::Runtime &rt, const jsi::Value *value) {
 
 template <>
 inline bool get<bool>(jsi::Runtime &rt, const jsi::Value *value) {
-  return value->asBool();
+  return value->isBool() && value->getBool();
 }
 
 template <>

--- a/Common/cpp/Tools/JsiUtils.h
+++ b/Common/cpp/Tools/JsiUtils.h
@@ -28,7 +28,10 @@ inline int get<int>(jsi::Runtime &rt, const jsi::Value *value) {
 
 template <>
 inline bool get<bool>(jsi::Runtime &rt, const jsi::Value *value) {
-  return value->isBool() && value->getBool();
+  if (!value->isBool()) {
+    throw jsi::JSINativeException("Expected a boolean");
+  }
+  return value->getBool();
 }
 
 template <>


### PR DESCRIPTION
## Summary

`asBool()` is supported by JSI since RN@0.69. I replaced `asBool()` with `getBool()` syntax.

CI fail: https://github.com/piaskowyk/reanimated-rn-version-tester/actions/runs/4281203461/jobs/7453937810