### PR TITLE
Add shareable HostFunction

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -257,11 +257,7 @@ jsi::Value NativeReanimatedModule::makeShareableClone(
       auto function = object.asFunction(rt);
       if (function.isHostFunction(rt)) {
         shareable = std::make_shared<ShareableHostFunction>(
-            runtimeHelper,
-            rt,
-            function.getHostFunction(rt),
-            function.getProperty(rt, "name").asString(rt).utf8(rt),
-            function.getProperty(rt, "length").asNumber());
+            runtimeHelper, rt, std::move(function));
       } else {
         shareable = std::make_shared<ShareableRemoteFunction>(
             runtimeHelper, rt, std::move(function));

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -254,8 +254,14 @@ jsi::Value NativeReanimatedModule::makeShareableClone(
     } else if (!object.getProperty(rt, "__init").isUndefined()) {
       shareable = std::make_shared<ShareableHandle>(runtimeHelper, rt, object);
     } else if (object.isFunction(rt)) {
-      shareable = std::make_shared<ShareableRemoteFunction>(
-          runtimeHelper, rt, object.asFunction(rt));
+      auto function = object.asFunction(rt);
+      if (function.isHostFunction(rt)) {
+        shareable = std::make_shared<ShareableHostFunction>(
+            runtimeHelper, rt, function.getHostFunction(rt));
+      } else {
+        shareable = std::make_shared<ShareableRemoteFunction>(
+            runtimeHelper, rt, std::move(function));
+      }
     } else if (object.isArray(rt)) {
       if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
         shareable = std::make_shared<RetainingShareable<ShareableArray>>(

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -256,8 +256,8 @@ jsi::Value NativeReanimatedModule::makeShareableClone(
     } else if (object.isFunction(rt)) {
       auto function = object.asFunction(rt);
       if (function.isHostFunction(rt)) {
-        shareable = std::make_shared<ShareableHostFunction>(
-            runtimeHelper, rt, std::move(function));
+        shareable =
+            std::make_shared<ShareableHostFunction>(rt, std::move(function));
       } else {
         shareable = std::make_shared<ShareableRemoteFunction>(
             runtimeHelper, rt, std::move(function));

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -257,7 +257,11 @@ jsi::Value NativeReanimatedModule::makeShareableClone(
       auto function = object.asFunction(rt);
       if (function.isHostFunction(rt)) {
         shareable = std::make_shared<ShareableHostFunction>(
-            runtimeHelper, rt, function.getHostFunction(rt));
+            runtimeHelper,
+            rt,
+            function.getHostFunction(rt),
+            function.getProperty(rt, "name").asString(rt).utf8(rt),
+            function.getProperty(rt, "length").asNumber());
       } else {
         shareable = std::make_shared<ShareableRemoteFunction>(
             runtimeHelper, rt, std::move(function));

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -281,7 +281,9 @@ class ShareableHostFunction : public Shareable {
       jsi::Runtime &rt,
       jsi::Function function)
       : Shareable(HostFunctionType),
-        hostFunction_(function.getHostFunction(rt)),
+        hostFunction_(
+            (assert(function.isHostFunction(rt)),
+             function.getHostFunction(rt))),
         name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
         paramCount_(function.getProperty(rt, "length").asNumber()) {}
 

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -116,6 +116,7 @@ class Shareable {
     HandleType,
     SynchronizedDataHolder,
     HostObjectType,
+    HostFunctionType,
   };
 
   explicit Shareable(ValueType valueType) : valueType_(valueType) {}
@@ -271,6 +272,22 @@ class ShareableHostObject : public Shareable {
 
  protected:
   std::shared_ptr<jsi::HostObject> hostObject_;
+};
+
+class ShareableHostFunction : public Shareable {
+ public:
+  ShareableHostFunction(
+      const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
+      jsi::Runtime &rt,
+      jsi::HostFunctionType hostFunction)
+      : Shareable(HostFunctionType), hostFunction_(hostFunction) {}
+  jsi::Value toJSValue(jsi::Runtime &rt) override {
+    return jsi::Function::createFromHostFunction(
+        rt, jsi::PropNameID::forAscii(rt, "HostFunction"), 0, hostFunction_);
+  }
+
+ protected:
+  jsi::HostFunctionType hostFunction_;
 };
 
 class ShareableWorklet : public ShareableObject {

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -289,7 +289,7 @@ class ShareableHostFunction : public Shareable {
 
   jsi::Value toJSValue(jsi::Runtime &rt) override {
     return jsi::Function::createFromHostFunction(
-        rt, jsi::PropNameID::forAscii(rt, name_), paramCount_, hostFunction_);
+        rt, jsi::PropNameID::forUtf8(rt, name_), paramCount_, hostFunction_);
   }
 
  protected:

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -286,6 +286,18 @@ class ShareableHostFunction : public Shareable {
         hostFunction_(hostFunction),
         name_(name),
         paramCount_(paramCount) {}
+
+  ShareableHostFunction(
+      const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
+      jsi::Runtime &rt,
+      jsi::Function function)
+      : ShareableHostFunction(
+            runtimeHelper,
+            rt,
+            function.getHostFunction(rt),
+            function.getProperty(rt, "name").asString(rt).utf8(rt),
+            function.getProperty(rt, "length").asNumber()) {}
+
   jsi::Value toJSValue(jsi::Runtime &rt) override {
     return jsi::Function::createFromHostFunction(
         rt, jsi::PropNameID::forAscii(rt, name_), paramCount_, hostFunction_);

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -276,10 +276,7 @@ class ShareableHostObject : public Shareable {
 
 class ShareableHostFunction : public Shareable {
  public:
-  ShareableHostFunction(
-      const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
-      jsi::Runtime &rt,
-      jsi::Function function)
+  ShareableHostFunction(jsi::Runtime &rt, jsi::Function function)
       : Shareable(HostFunctionType),
         hostFunction_(
             (assert(function.isHostFunction(rt)),

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -279,24 +279,11 @@ class ShareableHostFunction : public Shareable {
   ShareableHostFunction(
       const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
       jsi::Runtime &rt,
-      jsi::HostFunctionType hostFunction,
-      const std::string &name,
-      const unsigned int paramCount)
-      : Shareable(HostFunctionType),
-        hostFunction_(hostFunction),
-        name_(name),
-        paramCount_(paramCount) {}
-
-  ShareableHostFunction(
-      const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
-      jsi::Runtime &rt,
       jsi::Function function)
-      : ShareableHostFunction(
-            runtimeHelper,
-            rt,
-            function.getHostFunction(rt),
-            function.getProperty(rt, "name").asString(rt).utf8(rt),
-            function.getProperty(rt, "length").asNumber()) {}
+      : Shareable(HostFunctionType),
+        hostFunction_(function.getHostFunction(rt)),
+        name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
+        paramCount_(function.getProperty(rt, "length").asNumber()) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override {
     return jsi::Function::createFromHostFunction(

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -279,15 +279,22 @@ class ShareableHostFunction : public Shareable {
   ShareableHostFunction(
       const std::shared_ptr<JSRuntimeHelper> &runtimeHelper,
       jsi::Runtime &rt,
-      jsi::HostFunctionType hostFunction)
-      : Shareable(HostFunctionType), hostFunction_(hostFunction) {}
+      jsi::HostFunctionType hostFunction,
+      const std::string &name,
+      const unsigned int paramCount)
+      : Shareable(HostFunctionType),
+        hostFunction_(hostFunction),
+        name_(name),
+        paramCount_(paramCount) {}
   jsi::Value toJSValue(jsi::Runtime &rt) override {
     return jsi::Function::createFromHostFunction(
-        rt, jsi::PropNameID::forAscii(rt, "HostFunction"), 0, hostFunction_);
+        rt, jsi::PropNameID::forAscii(rt, name_), paramCount_, hostFunction_);
   }
 
  protected:
   jsi::HostFunctionType hostFunction_;
+  std::string name_;
+  unsigned int paramCount_;
 };
 
 class ShareableWorklet : public ShareableObject {


### PR DESCRIPTION
## Summary

This PR adds support for passing JSI HostFunctions to worklet runtime as a follow-up to #4024 which makes it possible for JSI HostObjects.

Previously, it was possible only to pass HostObjects:

```tsx
import { TurboModuleRegistry } from 'react-native';
import { runOnUI } from 'react-native-reanimated';

export default function App() {
  const Clipboard = TurboModuleRegistry.getEnforcing('Clipboard');
  Clipboard.setString('hello world');

  runOnUI(() => {
    'worklet';
    console.log(Clipboard);
    Clipboard.getString().then(console.log);
  })();

  return null;
}
```

This PR makes it possible to pass HostFunctions as well:

```tsx
import { runOnUI } from 'react-native-reanimated';

export default function App() {
  const turboModuleProxy = global.__turboModuleProxy;
  console.log(turboModuleProxy);

  runOnUI(() => {
    'worklet';
    console.log(turboModuleProxy.toString());
    const Clipboard = turboModuleProxy('Clipboard');
    console.log(Clipboard);
    Clipboard.setString('hello world');
    Clipboard.getString().then(console.log);
  })();

  return null;
}
```

Output:

![](https://user-images.githubusercontent.com/20516055/221600131-ef843777-6e15-4b5f-b1da-f2011eba4752.png)

## Caution

This is a breaking change since previously it was still possible to call such HostFunctions on the main JS runtime from worklets using `runOnJS`, however after this change it will throw the following error:

> Incompatible object passed to scheduleOnJS. It is only allowed to schedule functions defined on the React Native JS runtime this way.

The workaround is to wrap the HostFunction inside a regular JS function and pass the wrapper to the worklet, as explained in https://github.com/software-mansion/react-native-reanimated/pull/4117#issuecomment-1488820542.

Also, some HostFunctions may be unsafe to be called from two threads at once without proper synchronization, use it wisely.

Also, `ShareableHostFunction` constructor accepts `jsi::Function` but you shouldn't pass regular JS functions to it.

## Test plan

Run the attached demo in FabricExample.
