### PR TITLE
[Android] Fix build error on older React Native versions

### DIFF
--- a/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -9,17 +9,18 @@
 
 namespace reanimated {
 
-static void logValue(jsi::Runtime &rt, jsi::Value const &value) {
-  if (value.isString()) {
-    Logger::log(value.getString(rt).utf8(rt).c_str());
-  } else if (value.isNumber()) {
-    Logger::log(value.getNumber());
-  } else if (value.isUndefined()) {
-    Logger::log("undefined");
-  } else {
-    Logger::log("unsupported value type");
-  }
-}
+static const std::function<void(jsi::Runtime &, jsi::Value const &)> logValue =
+    [](jsi::Runtime &rt, jsi::Value const &value) {
+      if (value.isString()) {
+        Logger::log(value.getString(rt).utf8(rt).c_str());
+      } else if (value.isNumber()) {
+        Logger::log(value.getNumber());
+      } else if (value.isUndefined()) {
+        Logger::log("undefined");
+      } else {
+        Logger::log("unsupported value type");
+      }
+    };
 
 std::unordered_map<RuntimePointer, RuntimeType>
     &RuntimeDecorator::runtimeRegistry() {
@@ -104,7 +105,8 @@ void RuntimeDecorator::decorateUIRuntime(
   jsi_utils::installJsiFunction(rt, "_updatePropsPaper", updateProps);
   jsi_utils::installJsiFunction(rt, "_scrollTo", scrollTo);
 
-  auto _measure = [measure](jsi::Runtime &rt, int viewTag) -> jsi::Value {
+  std::function<jsi::Value(jsi::Runtime &, int)> _measure =
+      [measure](jsi::Runtime &rt, int viewTag) -> jsi::Value {
     auto result = measure(viewTag);
     jsi::Object resultObject(rt);
     for (auto &i : result) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
Fixes build issue on older (<= 0.64) RN versions of Android caused by template instantiation errors when converting from any Callable (like raw function pointers) to `std::function` in `jsi_utils::installJsiFunction`.
This is resolved by wrapping the problematic functions in lambdas assigned to `std::function` variables before calling `installJsiFunction`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
