### PR TITLE
Fix useFrameCallback fast refresh

### DIFF
--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -15,7 +15,8 @@ export interface FrameCallbackRegistryUI {
   frameCallbackRegistry: Map<number, CallbackDetails>;
   activeFrameCallbacks: Set<number>;
   previousFrameTimestamp: number | null;
-  runCallbacks: () => void;
+  runCallbacks: (callId: number) => void;
+  nextCallId: number;
   registerFrameCallback: (
     callback: (frameInfo: FrameInfo) => void,
     callbackId: number
@@ -31,9 +32,13 @@ export const prepareUIRegistry = runOnUIImmediately(() => {
     frameCallbackRegistry: new Map<number, CallbackDetails>(),
     activeFrameCallbacks: new Set<number>(),
     previousFrameTimestamp: null,
+    nextCallId: 0,
 
-    runCallbacks() {
+    runCallbacks(callId) {
       const loop = (timestamp: number) => {
+        if (callId !== this.nextCallId) {
+          return;
+        }
         if (this.previousFrameTimestamp === null) {
           this.previousFrameTimestamp = timestamp;
         }
@@ -75,7 +80,7 @@ export const prepareUIRegistry = runOnUIImmediately(() => {
       // runCallback() should only be called after registering a callback,
       // so if there is only one active callback, then it means that there were
       // zero previously and the loop isn't running yet.
-      if (this.activeFrameCallbacks.size === 1) {
+      if (this.activeFrameCallbacks.size === 1 && callId === this.nextCallId) {
         requestAnimationFrame(loop);
       }
     },
@@ -101,12 +106,15 @@ export const prepareUIRegistry = runOnUIImmediately(() => {
       }
       if (state) {
         this.activeFrameCallbacks.add(callbackId);
-        this.runCallbacks();
+        this.runCallbacks(this.nextCallId);
       } else {
         const callback = this.frameCallbackRegistry.get(callbackId)!;
         callback.startTime = null;
 
         this.activeFrameCallbacks.delete(callbackId);
+        if (this.activeFrameCallbacks.size === 0) {
+          this.nextCallId += 1;
+        }
       }
     },
   };

--- a/src/reanimated2/hook/useFrameCallback.ts
+++ b/src/reanimated2/hook/useFrameCallback.ts
@@ -31,7 +31,6 @@ export function useFrameCallback(
     ref.current.setActive(ref.current.isActive);
 
     return () => {
-      ref.current.setActive(false);
       frameCallbackRegistry.unregisterFrameCallback(ref.current.callbackId);
       ref.current.callbackId = -1;
     };

--- a/src/reanimated2/hook/useFrameCallback.ts
+++ b/src/reanimated2/hook/useFrameCallback.ts
@@ -31,6 +31,7 @@ export function useFrameCallback(
     ref.current.setActive(ref.current.isActive);
 
     return () => {
+      ref.current.setActive(false);
       frameCallbackRegistry.unregisterFrameCallback(ref.current.callbackId);
       ref.current.callbackId = -1;
     };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the problem of multiple callbacks after fast refresh

To prevent multiple loops, we use this if statement 
```
// runCallback() should only be called after registering a callback,
// so if there is only one active callback, then it means that there were
// zero previously and the loop isn't running yet.
if (this.activeFrameCallbacks.size === 1) {
  requestAnimationFrame(loop);
}
```
The problem with fast refresh is that we unregister the callback and immediately register new.
Before unregistration is completed we register new one, so the previous loop doesn't stop.
We also start second loop, because we have one active frame. So in the end, after each fast refresh, we add new loop that execute the same callback.

To fix it, I added variable `newCallId` and pass it to each `runCallbacks` call, whenever we delete last item from active callbacks, we increment newCallId variable. Inside `runCallbacks` we check if the function execution is related with the newest `callId`. If not, we stop function execution.

## Test plan

- Example app
- Flipper
