### PR TITLE
Add flushImmediates to useAnimatedSensor

### DIFF
--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -7,6 +7,7 @@ import {
   ValueRotation,
   IOSReferenceFrame,
 } from '../commonTypes';
+import { flushImmediates } from '../threads';
 
 export type SensorConfig = {
   interval: number | 'auto';
@@ -144,6 +145,7 @@ export function useAnimatedSensor(
           }
         }
         sensorData.value = data;
+        flushImmediates();
       }
     );
 


### PR DESCRIPTION
## Summary

When we update the shared value on the UI thread without animation, we need manually flush queued mappers.
