### PR TITLE
Guard `isSharedValue` against nullish values

### DIFF
--- a/src/reanimated2/utils.ts
+++ b/src/reanimated2/utils.ts
@@ -30,5 +30,5 @@ export function getRelativeCoords(
 
 export function isSharedValue<T>(value: any): value is SharedValue<T> {
   'worklet';
-  return typeof value === 'object' && value._isReanimatedSharedValue === true;
+  return value?._isReanimatedSharedValue === true;
 }


### PR DESCRIPTION
## Summary

Fixes #4129.

This PR expands the guard for the `isSharedValue` util to rule out nullish values (`null` and `undefined`).

This was necessary because `typeof null` returns `object` (some JS shenanigans) and the current implementation would try to access the `_isReanimatedSharedValue` property on that `null` value, causing an exception to be raised (and possibly crashing the app).

## Test plan

```ts
// before
isSharedValue(null) // raises an Exception

// after
isSharedValue(null) // returns `false`
```
