### PR TITLE
Guard `createAnimatedComponent` against empty style prop

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -120,6 +120,7 @@ function isInlineStyleTransform(transform: any): boolean {
 }
 
 function hasInlineStyles(style: StyleProps): boolean {
+  if (!style) return false
   return Object.keys(style).some((key) => {
     const styleValue = style[key];
     return (
@@ -139,6 +140,7 @@ function extractSharedValuesMapFromProps(
     if (key === 'style') {
       const styles = flattenArray<StyleProps>(props.style ?? []);
       styles.forEach((style) => {
+        if (!style) return
         for (const [key, styleValue] of Object.entries(style)) {
           if (isSharedValue(styleValue)) {
             inlineProps[key] = styleValue;

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -120,7 +120,7 @@ function isInlineStyleTransform(transform: any): boolean {
 }
 
 function hasInlineStyles(style: StyleProps): boolean {
-  if (!style) return false
+  if (!style) return false;
   return Object.keys(style).some((key) => {
     const styleValue = style[key];
     return (
@@ -140,7 +140,7 @@ function extractSharedValuesMapFromProps(
     if (key === 'style') {
       const styles = flattenArray<StyleProps>(props.style ?? []);
       styles.forEach((style) => {
-        if (!style) return
+        if (!style) return;
         for (const [key, styleValue] of Object.entries(style)) {
           if (isSharedValue(styleValue)) {
             inlineProps[key] = styleValue;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Rendering an `Animated.View` with no styles or an `undefined` value in a styles array was crashing (eg. a view might have a layout animation without any styles)
fixes https://github.com/software-mansion/react-native-reanimated/issues/4139

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
<img width="379" alt="Screen Shot 2023-02-28 at 14 02 07 " src="https://user-images.githubusercontent.com/6730148/221991561-4251d4bb-d442-4e68-a8b9-cb61fa959bf8.png">

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
