### PR TITLE
docs: update mock definition in Testing with Jest guide

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -13,10 +13,10 @@ First, make sure that your tests run with Node version 16 or newer.
 Add the following line to your `jest-setup.js` file:
 
 ```js
-require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
+jest.mock("react-native-reanimated", () =>
+  require("react-native-reanimated/mock")
+);
 ```
-
-`setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.
 
 To be sure, check if your `jest.config.js` file contains:
 


### PR DESCRIPTION
## Summary

It is a fix for misleading information in `Testing with Jest` guide related to left Reanimatedv2 mock definition which is no longer available in Reanimatedv3.

## Test plan

I was running into error
```
  ● Test suite failed to run

    Cannot find module 'react-native-reanimated/lib/reanimated2/jestUtils' from 'tests/setupTests.ts'
```

After replacing   
```
require("react-native-reanimated/lib/reanimated2/jestUtils").setUpTests();
```
with
```
jest.mock("react-native-reanimated", () =>
  require("react-native-reanimated/mock")
);
```
I got rid of that error
