### PR TITLE
fix for TypeError: Cannot convert undefined value to object in create…

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -120,7 +120,7 @@ function isInlineStyleTransform(transform: any): boolean {
 }
 
 function hasInlineStyles(style: StyleProps): boolean {
-  return Object.keys(style).some((key) => {
+  return Object.keys(style ?? {}).some((key) => {
     const styleValue = style[key];
     return (
       isSharedValue(styleValue) ||
@@ -139,7 +139,7 @@ function extractSharedValuesMapFromProps(
     if (key === 'style') {
       const styles = flattenArray<StyleProps>(props.style ?? []);
       styles.forEach((style) => {
-        for (const [key, styleValue] of Object.entries(style)) {
+        for (const [key, styleValue] of Object.entries(style ?? {})) {
           if (isSharedValue(styleValue)) {
             inlineProps[key] = styleValue;
           } else if (


### PR DESCRIPTION
…AnimatedComponent

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

after upgrading to Reanimated 3.0, some developer faced an issue with ` ERROR  TypeError: Cannot convert undefined value to object`
issue #4139 

## Test plan

none