### PR TITLE
fix: Throw user-friendly error when `.__initData` is not found

### DIFF
--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -39,6 +39,10 @@ function valueUnpacker(objectToUnpack: any, category?: string): any {
     let workletFun = workletsCache.get(workletHash);
     if (workletFun === undefined) {
       const initData = objectToUnpack.__initData;
+      if (initData == null)
+        throw new Error(
+          "The given function could not be parsed as a Worklet. It looks like the Reanimated Babel Plugin is missing, make sure reanimated's babel plugin is installed in your babel.config.js (you should have 'react-native-reanimated/plugin' listed there - also see the above link for details) \n2) Make sure you reset build cache after updating the config, run: yarn start --reset-cache"
+        );
       if (global.evalWithSourceMap) {
         // if the runtime (hermes only for now) supports loading source maps
         // we want to use the proper filename for the location as it guarantees


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

When you forgot to install the Babel Plugin (or are coming from a v2 babel plugin), this is what it looks like:

![Screenshot 2023-03-08 at 17 53 21](https://user-images.githubusercontent.com/15199031/223777828-f99d3c25-f232-4f3d-b987-f05688e6e0ad.png)

A SIGABRT.

With this change, a simple JS error is thrown that tells the user to install the Babel Plugin.


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
