### PR TITLE
chore: set library namespace in build script

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -431,6 +431,7 @@ apply plugin: "de.undercouch.download"
 
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 30)
+    namespace "com.swmansion.reanimated"
     if (REACT_NATIVE_MINOR_VERSION >= 71) {
         buildFeatures {
             prefab true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Since AGP 8.0 project namespace [**must** be set inside build script](https://issuetracker.google.com/issues/172361895).
It is also the recommended way in [Android docs](https://developer.android.com/studio/build/configure-app-module?authuser=1#set-namespace).

It is also recommended, that the package name definition is removed from Android manifest file, but I've had some problems in `react-native-screens` with RN CLI crashing (as it was expecting the [`package` field](https://github.com/software-mansion/react-native-screens/blob/2a30e22bf1bd432fdd5e2f4d44e42bc3efd44474/android/src/main/AndroidManifest.xml#L3) to exist) & according to [this](https://issuetracker.google.com/issues/200682321?pli=1) conversation it'll still be legal to leave package name definition in Android manifest file as long as it exactly matches the value in build script.

See: https://github.com/software-mansion/react-native-screens/pull/1717

## Test plan

CI 
