### PR TITLE
Fix issue causing ANR when performing sync layout updates

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -36,6 +36,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -218,13 +219,11 @@ public class NodesManager implements EventDispatcherListener {
             }
           });
       if (trySynchronously) {
-        while (true) {
-          try {
-            semaphore.acquire();
-            break;
-          } catch (InterruptedException e) {
-            // noop
-          }
+        try {
+          semaphore.tryAcquire(16, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+          // if the thread is interruped we just continue and let the layout update happen
+          // asynchronously
         }
       }
     }

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -96,6 +96,8 @@ using namespace facebook::react;
   BOOL _tryRunBatchUpdatesSynchronously;
   REAEventHandler _eventHandler;
   volatile void (^_mounting)(void);
+  NSObject *_syncLayoutUpdatesWaitLock;
+  volatile BOOL _syncLayoutUpdatesWaitTimedOut;
   NSMutableDictionary<NSNumber *, ComponentUpdate *> *_componentUpdateBuffer;
   NSMutableDictionary<NSNumber *, UIView *> *_viewRegistry;
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -123,6 +125,7 @@ using namespace facebook::react;
     _operationsInBatch = [NSMutableDictionary new];
     _componentUpdateBuffer = [NSMutableDictionary new];
     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
+    _syncLayoutUpdatesWaitLock = [NSObject new];
   }
 
   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
@@ -241,8 +244,14 @@ using namespace facebook::react;
 - (BOOL)uiManager:(RCTUIManager *)manager performMountingWithBlock:(RCTUIManagerMountingBlock)block
 {
   RCTAssert(_mounting == nil, @"Mouting block is expected to not be set");
-  _mounting = block;
-  return YES;
+  @synchronized (_syncLayoutUpdatesWaitLock) {
+    if (_syncLayoutUpdatesWaitTimedOut) {
+      return NO;
+    } else {
+      _mounting = block;
+      return YES;
+    }
+  }
 }
 
 - (void)performOperations
@@ -260,6 +269,7 @@ using namespace facebook::react;
 
     __weak __typeof__(self) weakSelf = self;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    _syncLayoutUpdatesWaitTimedOut = NO;
     RCTExecuteOnUIManagerQueue(^{
       __typeof__(self) strongSelf = weakSelf;
       if (strongSelf == nil) {
@@ -276,7 +286,7 @@ using namespace facebook::react;
       }
 
       if (canUpdateSynchronously) {
-        [strongSelf.uiManager runSyncUIUpdatesWithObserver:self];
+        [strongSelf.uiManager runSyncUIUpdatesWithObserver:strongSelf];
         dispatch_semaphore_signal(semaphore);
       }
       // In case canUpdateSynchronously=true we still have to send uiManagerWillPerformMounting event
@@ -284,7 +294,16 @@ using namespace facebook::react;
       [strongSelf.uiManager setNeedsLayout];
     });
     if (trySynchronously) {
-      dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+      // The 16ms timeout here aims to match the frame duration. It may make sense to read that parameter
+      // from CADisplayLink but it is easier to hardcode it for the time being.
+      // The reason why we use frame duration here is that if takes longer than one frame to complete layout tasks
+      // there is no point of synchronizing layout with the UI interaction as we get that one frame delay anyways.
+      long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 16 * NSEC_PER_MSEC));
+      if (result != 0) {
+        @synchronized (_syncLayoutUpdatesWaitLock) {
+          _syncLayoutUpdatesWaitTimedOut = YES;
+        }
+      }
     }
 
     if (_mounting) {

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -244,7 +244,7 @@ using namespace facebook::react;
 - (BOOL)uiManager:(RCTUIManager *)manager performMountingWithBlock:(RCTUIManagerMountingBlock)block
 {
   RCTAssert(_mounting == nil, @"Mouting block is expected to not be set");
-  @synchronized (_syncLayoutUpdatesWaitLock) {
+  @synchronized(_syncLayoutUpdatesWaitLock) {
     if (_syncLayoutUpdatesWaitTimedOut) {
       return NO;
     } else {
@@ -300,7 +300,7 @@ using namespace facebook::react;
       // there is no point of synchronizing layout with the UI interaction as we get that one frame delay anyways.
       long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 16 * NSEC_PER_MSEC));
       if (result != 0) {
-        @synchronized (_syncLayoutUpdatesWaitLock) {
+        @synchronized(_syncLayoutUpdatesWaitLock) {
           _syncLayoutUpdatesWaitTimedOut = YES;
         }
       }


### PR DESCRIPTION
## Summary

This PR addresses the problem from #3879 on iOS where application would fall into a deadlock when performing synchronous layout updates. The reason for the issue was that sync layout updates requires UI thread to lock and wait for layout thread to perform some tasks. On the other hand, layout thread sometimes schedules UI tasks to be performed synchronously (with `dispatch_sync` mechanism).

The solution this PR implements is to add a timeout on waiting and fallback to updating layout props asynchronously. This feels like a right approach as the cases when dispatch_sync is used are relatively rare and the consequences of updating layout asynchronously aren't serious (there will be a one frame delay for that one update).

This solution is based on #3082 but on top of just adding the timeout we also need to make sure that the executed operations are properly mounted. The problem with #3082 was that when the UI thread times out we still use `runSyncUIUpdatesWithObserver` call on the layout thread which in turn results in the mounting block being stored and expected to be run on the locked UI thread afterwards. If the thread times out we may hit an issue when the mounting block is set but never executed which would have serious implications. 


## Test plan
Tested this with repro scenario provided in #3946 that relies on `@react-native-community/datetimepicker` library