### PR TITLE
Fix monorepo worklow

### DIFF
--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -63,11 +63,11 @@ jobs:
       - name: Build iOS app RootApp
         if: ${{ inputs.platform == 'iOS' }}
         working-directory: monorepo/RootApp
-        run: yarn react-native run-ios
+        run: yarn react-native run-ios --simulator='iPhone 14'
       - name: Build iOS app PackageApp
         if: ${{ inputs.platform == 'iOS' }}
         working-directory: monorepo/packages/PackageApp
-        run: yarn react-native run-ios
+        run: yarn react-native run-ios --simulator='iPhone14'
 
       - name: Build Android RootApp
         if: ${{ inputs.platform == 'Android' }}

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Build iOS app PackageApp
         if: ${{ inputs.platform == 'iOS' }}
         working-directory: monorepo/packages/PackageApp
-        run: yarn react-native run-ios --simulator='iPhone14'
+        run: yarn react-native run-ios --simulator='iPhone 14'
 
       - name: Build Android RootApp
         if: ${{ inputs.platform == 'Android' }}


### PR DESCRIPTION
## Summary

Fixing our red main as `react native run-ios` is having troubles with launching a default (non-specified) simulator.

## Test plan

CI is the way.
