### PR TITLE
Change typeof for prototype check to only process plain objects as mappers inputs

### DIFF
--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -115,7 +115,10 @@ export function createMapperRegistry() {
       }
     } else if (inputs.addListener) {
       resultArray.push(inputs);
-    } else if (typeof inputs === 'object') {
+    } else if (inputs.__proto__ === Object.prototype) {
+      // we only extract inputs recursively from "plain" objects here, if object
+      // is of a derivative class (e.g. HostObject on web, or Map) we don't scan
+      // it recursively
       for (const element of Object.values(inputs)) {
         element && extractInputs(element, resultArray);
       }


### PR DESCRIPTION
## Summary

This PR changes the logic on when we scan nested objects provided as mappers' inputs. Before this change we'd do a `typeof` check to test whether it is an object. This check however passes on derived objects such as HostObjects, Maps, etc. Since these types of objects can have very complex structures we want to avoid scanning them recursively and only do that for plain object. We achieve this by testing its prototype and comparing with Object.prototype.

## Test plan

Run test examples in the app
Tested this on web with react-native-skia reanimated AnimateTextOnPath example where a HostObject is used inside a mapper and it was taking ages to process that object recursively.