### PR TITLE
Fix useAnimatedKeyboard animation restart on iOS

### DIFF
--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -92,6 +92,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
     displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
     [displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   }
+  _shouldInvalidateDisplayLink = false;
 }
 
 - (void)stopAnimation


### PR DESCRIPTION
## Summary

When you try to hide animation during keyboard opening, this ends the current animation and starts another one. I added a missing flag setter to prevent the clearing of the displayLink object.

## Test plan

| Before      | After |
| ----------- | ----------- |
| <video src="https://user-images.githubusercontent.com/36106620/227270299-5f7cd5e6-21b3-47c3-85fb-2860fb9fbac9.mov" /> | <video src="https://user-images.githubusercontent.com/36106620/227269574-bf94ebc9-3132-49d9-bd2d-f5cd8671990c.mov" /> |

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4194
