### PR TITLE
Fix monorepo workflow

### DIFF
--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -25,6 +25,12 @@ jobs:
       group: ${{ inputs.concurrency_group }}
       cancel-in-progress: true
     steps:
+      - name: Create RootApp
+        working-directory: monorepo
+        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
+      - name: Create PackageApp
+        working-directory: monorepo/packages
+        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
       - name: Create monorepo
         run: |
           mkdir monorepo
@@ -32,15 +38,6 @@ jobs:
           echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
           yarn
           mkdir packages
-      - name: Uninstall react-native
-        run: npm uninstall -g react-native
-      - name: Create RootApp
-        working-directory: monorepo
-        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
-      - name: Create PackageApp
-        working-directory: monorepo/packages
-        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
-      
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }}

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -34,10 +34,10 @@ jobs:
           mkdir packages
       - name: Create RootApp
         working-directory: monorepo
-        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
       - name: Create PackageApp
         working-directory: monorepo/packages
-        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
       
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: 'yarn'
       - name: Create monorepo
         run: |
           mkdir monorepo

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -25,24 +25,19 @@ jobs:
       group: ${{ inputs.concurrency_group }}
       cancel-in-progress: true
     steps:
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Create monorepo
-        run: |
-          mkdir monorepo
-          cd monorepo
-          echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
-          yarn
-          mkdir packages
+      - name: Create directories
+        run: mkdir -p monorepo/packages
       - name: Create RootApp
         working-directory: monorepo
         run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Create PackageApp
         working-directory: monorepo/packages
         run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
-      
+      - name: Setup monorepo
+        working-directory: monorepo
+        run: |
+          echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
+          yarn
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }}

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -25,19 +25,25 @@ jobs:
       group: ${{ inputs.concurrency_group }}
       cancel-in-progress: true
     steps:
-      - name: Create directories
-        run: mkdir -p monorepo/packages
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+      - name: Create monorepo
+        run: |
+          mkdir monorepo
+          cd monorepo
+          echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
+          yarn
+          mkdir packages
       - name: Create RootApp
         working-directory: monorepo
         run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Create PackageApp
         working-directory: monorepo/packages
         run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
-      - name: Setup monorepo
-        working-directory: monorepo
-        run: |
-          echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
-          yarn
+      
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }}

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -32,6 +32,8 @@ jobs:
           echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
           yarn
           mkdir packages
+      - name: Uninstall react-native
+        run: npm uninstall -g react-native
       - name: Create RootApp
         working-directory: monorepo
         run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose

--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -25,19 +25,19 @@ jobs:
       group: ${{ inputs.concurrency_group }}
       cancel-in-progress: true
     steps:
+      - name: Create directories
+        run: mkdir -p monorepo/packages
       - name: Create RootApp
         working-directory: monorepo
-        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
+        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Create PackageApp
         working-directory: monorepo/packages
-        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }} --verbose
-      - name: Create monorepo
+        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
+      - name: Setup monorepo
+        working-directory: monorepo
         run: |
-          mkdir monorepo
-          cd monorepo
           echo '{"name":"rnos-monorepo-tester","version":"1.0.0","license":"MIT","private":true,"workspaces":{"packages":["RootApp","packages/PackageApp", "AppA", "AppB"],"nohoist":["**/react","**/react-dom","**/react-native","**/react-native/**","**/react-native-codegen","**/react-native-dev-menu"]}}' > package.json
           yarn
-          mkdir packages
       - name: Install dependencies for RootApp
         working-directory: monorepo/RootApp
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

There seems to be a problem with running `npx react-native` from inside a directory that contains package.json file (see https://github.com/facebook/react-native/issues/34441#issuecomment-1275186909), however I wasn't able to reproduce it locally.

This PR swaps the order of steps, so that `npx react-native` is run before package.json is created.

## Test plan

Just check if CI is green.
