### PR TITLE
Use Node.js 16 on CI

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,6 +3,7 @@ name: Test docs build
 on:
   pull_request:
     paths:
+      - '.github/workflows/docs-check.yml'
       - 'docs/**'
 
 jobs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v1
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -2,6 +2,7 @@ name: Test TypeScript and Lint
 on:
   pull_request:
     paths:
+      - '.github/workflows/static-example-apps-checks.yml'
       - 'Example/**'
       - 'FabricExample/**'
       - '*'

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
       - name: Install root node dependencies
         run: yarn

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -2,6 +2,7 @@ name: Test TypeScript and Lint
 on:
   pull_request:
     paths:
+      - '.github/workflows/static-root-checks.yml'
       - 'src/**'
       - '*'
   push:

--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'yarn'
       - name: Install node dependencies
         run: yarn

--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -2,6 +2,7 @@ name: Java Lint
 on:
   pull_request:
     paths:
+      - '.github/workflows/validate-java.yml'
       - 'android/src/main/java/**'
       - 'android/build.gradle'
   push:

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -2,6 +2,7 @@ name: Validate plugin
 on:
   pull_request:
     paths:
+      - '.github/workflows/validate-plugin.yml'
       - 'plugin/**'
   push:
     branches:

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR upgrades Node.js from 14 to 16 to match React Native 0.72 (see [here](https://github.com/facebook/react-native/blob/2c6edee68e936129644c14736e684a14bd11c55c/packages/react-native/template/package.json#L32-L34)).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
