### PR TITLE
Add missing configureLayoutAnimation on web

### DIFF
--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -47,7 +47,9 @@ export default class JSReanimated extends NativeReanimated {
   }
 
   enableLayoutAnimations() {
-    console.warn('[Reanimated] Layout Animations are not supported on web yet.');
+    console.warn(
+      '[Reanimated] Layout Animations are not supported on web yet.'
+    );
   }
 
   configureLayoutAnimation() {

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -47,9 +47,11 @@ export default class JSReanimated extends NativeReanimated {
   }
 
   enableLayoutAnimations() {
-    console.warn(
-      '[Reanimated] enableLayoutAnimations is not available for WEB yet'
-    );
+    console.warn('[Reanimated] Layout Animations are not supported on web yet.');
+  }
+
+  configureLayoutAnimation() {
+    // no-op
   }
 
   registerSensor(


### PR DESCRIPTION
## Summary

This PR adds missing `configureLayoutAnimation` method in `JSReanimated` class and resolves a crash when using Layout Animations on web or while debugging in Chrome.

Fixes #3964.

## Test plan

1. Copy BasicLayoutAnimation.tsx into WebExample/App.tsx
2. Launch WebExample
3. See the error in the browser console
4. Apply this patch
5. ???
6. Profit
