### PR TITLE
Add `steps` easing function

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -847,6 +847,7 @@ declare module 'react-native-reanimated' {
       x2: number,
       y2: number
     ): Animated.EasingFunction;
+    steps(n: number, start: boolean): Animated.EasingFunction;
     in(easing: Animated.EasingFunction): Animated.EasingFunction;
     out(easing: Animated.EasingFunction): Animated.EasingFunction;
     inOut(easing: Animated.EasingFunction): Animated.EasingFunction;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -847,7 +847,7 @@ declare module 'react-native-reanimated' {
       x2: number,
       y2: number
     ): Animated.EasingFunction;
-    steps(n: number, start: boolean): Animated.EasingFunction;
+    steps(n?: number, start?: boolean): Animated.EasingFunction;
     in(easing: Animated.EasingFunction): Animated.EasingFunction;
     out(easing: Animated.EasingFunction): Animated.EasingFunction;
     inOut(easing: Animated.EasingFunction): Animated.EasingFunction;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -847,7 +847,7 @@ declare module 'react-native-reanimated' {
       x2: number,
       y2: number
     ): Animated.EasingFunction;
-    steps(n?: number, start?: boolean): Animated.EasingFunction;
+    steps(n?: number, roundToNextStep?: boolean): Animated.EasingFunction;
     in(easing: Animated.EasingFunction): Animated.EasingFunction;
     out(easing: Animated.EasingFunction): Animated.EasingFunction;
     inOut(easing: Animated.EasingFunction): Animated.EasingFunction;

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -275,7 +275,10 @@ function steps(n = 10, start = true): EasingFn {
   return (t) => {
     'worklet';
     const value = Math.min(Math.max(t, 0), 1) * n;
-    return (start ? Math.ceil(value) : Math.floor(value)) / n;
+    if (start) {
+      return Math.ceil(value) / n;
+    }
+    return Math.floor(value) / n;
   };
 }
 

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -264,6 +264,21 @@ function inOut(easing: EasingFn): EasingFn {
   };
 }
 
+/**
+ * The `steps` easing function jumps between discrete values at regular intervals,
+ * creating a stepped animation effect. The `n` parameter determines the number of
+ * steps in the animation, and the `start` parameter determines whether the animation
+ * should start at the beginning or end of each step.
+ */
+function steps(n = 10, start = true): EasingFn {
+  'worklet';
+  const trunc = start ? Math.ceil : Math.floor;
+  return (t) => {
+    'worklet';
+    return trunc(Math.min(Math.max(t, 0), 1) * n) / n;
+  };
+}
+
 const EasingObject = {
   linear,
   ease,
@@ -278,6 +293,7 @@ const EasingObject = {
   bounce,
   bezier,
   bezierFn,
+  steps,
   in: in_,
   out,
   inOut,

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -272,10 +272,10 @@ function inOut(easing: EasingFn): EasingFn {
  */
 function steps(n = 10, start = true): EasingFn {
   'worklet';
-  const trunc = start ? Math.ceil : Math.floor;
   return (t) => {
     'worklet';
-    return trunc(Math.min(Math.max(t, 0), 1) * n) / n;
+    const value = Math.min(Math.max(t, 0), 1) * n;
+    return (start ? Math.ceil(value) : Math.floor(value)) / n;
   };
 }
 

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -267,15 +267,15 @@ function inOut(easing: EasingFn): EasingFn {
 /**
  * The `steps` easing function jumps between discrete values at regular intervals,
  * creating a stepped animation effect. The `n` parameter determines the number of
- * steps in the animation, and the `start` parameter determines whether the animation
+ * steps in the animation, and the `roundToNextStep` parameter determines whether the animation
  * should start at the beginning or end of each step.
  */
-function steps(n = 10, start = true): EasingFn {
+function steps(n = 10, roundToNextStep = true): EasingFn {
   'worklet';
   return (t) => {
     'worklet';
     const value = Math.min(Math.max(t, 0), 1) * n;
-    if (start) {
+    if (roundToNextStep) {
       return Math.ceil(value) / n;
     }
     return Math.floor(value) / n;

--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -99,6 +99,7 @@ const ReanimatedV2 = {
     bounce: ID,
     bezier: () => ({ factory: ID }),
     bezierFn: ID,
+    steps: ID,
     in: ID,
     out: ID,
     inOut: ID,


### PR DESCRIPTION
### Description
This pull request adds a new `steps` easing function to React Native Reanimated. The steps function allows for animations to jump between discrete values, similar to the CSS `steps()` function.

The steps function takes two arguments: `n`, which specifies the number of steps in the animation, and `start`, which specifies whether the animation should start at the beginning (start) or end (end) of the step.

### Usage
```js
rotate.value = withTiming(360, { duration: 60 * 1000, easing: Easing.steps(60, false) })
```

- This function has been tested and is confirmed to be working correctly on both the `Android`, `Expo`, and `Web` platforms.

### Example
- 👉 [expo snack example](https://snack.expo.dev/@alabsi91/react-native-reanimated-steps-easing-function-example)