### PR TITLE
Call assert in `SingleInstanceChecker` only in example apps

### DIFF
--- a/Common/cpp/Tools/SingleInstanceChecker.h
+++ b/Common/cpp/Tools/SingleInstanceChecker.h
@@ -23,7 +23,9 @@ class SingleInstanceChecker {
   void assertWithMessage(bool condition, std::string message) {
     if (!condition) {
       std::cerr << message << std::endl;
-      assert(condition);
+#ifdef IS_REANIMATED_EXAMPLE_APP
+      assert(false);
+#endif
     }
   }
 

--- a/Common/cpp/Tools/SingleInstanceChecker.h
+++ b/Common/cpp/Tools/SingleInstanceChecker.h
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <string>
 
+#ifdef ANDROID
+#include <android/log.h>
+#endif
+
 namespace reanimated {
 
 // This is a class that counts how many instances of a different class there
@@ -22,7 +26,13 @@ class SingleInstanceChecker {
  private:
   void assertWithMessage(bool condition, std::string message) {
     if (!condition) {
-      std::cerr << message << std::endl;
+#ifdef ANDROID
+      __android_log_print(
+          ANDROID_LOG_WARN, "Reanimated", "%s", message.c_str());
+#else
+      std::cerr << "[Reanimated] " << message << std::endl;
+#endif
+
 #ifdef IS_REANIMATED_EXAMPLE_APP
       assert(false);
 #endif

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -13,6 +13,7 @@ folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comm
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 boost_compiler_flags = '-Wno-documentation'
 fabric_flags = fabric_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
+example_flag = config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 version_flag = '-DREANIMATED_VERSION=' + reanimated_package_json["version"]
 
 Pod::Spec.new do |s|
@@ -48,7 +49,7 @@ Pod::Spec.new do |s|
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags + ' -DHERMES_ENABLE_DEBUGGER'
   s.xcconfig = {
     "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/Headers/Public/React-hermes\" \"$(PODS_ROOT)/Headers/Public/hermes-engine\" \"$(PODS_ROOT)/#{config[:react_native_common_dir]}\"",
-    "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags + " " + fabric_flags + " " + version_flag
+    "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags + " " + fabric_flags + " " + example_flag + " " + version_flag
   }
 
   s.requires_arc = true

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -341,5 +341,6 @@ endif()
 # when any of the following variables is not used in some build configuration.
 set (ignoreMe "${CLIENT_SIDE_BUILD}")
 set (ignoreMe "${JS_RUNTIME_DIR}")
+set (ignoreMe "${PLAYGROUND_APP_NAME}")
 set (ignoreMe "${REANIMATED_PACKAGE_BUILD}")
 set (ignoreMe "${BOOST_VERSION}")

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -22,6 +22,10 @@ if(${IS_NEW_ARCHITECTURE_ENABLED})
     string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")
 endif()
 
+if(${IS_REANIMATED_EXAMPLE_APP})
+    string(APPEND CMAKE_CXX_FLAGS " -DIS_REANIMATED_EXAMPLE_APP")
+endif()
+
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     string(APPEND CMAKE_CXX_FLAGS " -DDEBUG")
 endif()
@@ -337,6 +341,5 @@ endif()
 # when any of the following variables is not used in some build configuration.
 set (ignoreMe "${CLIENT_SIDE_BUILD}")
 set (ignoreMe "${JS_RUNTIME_DIR}")
-set (ignoreMe "${PLAYGROUND_APP_NAME}")
 set (ignoreMe "${REANIMATED_PACKAGE_BUILD}")
 set (ignoreMe "${BOOST_VERSION}")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,9 +72,12 @@ def resolveClientSideBuild() {
     return true
 }
 
+def isReanimatedExampleApp() {
+    return safeAppExtGet("isReanimatedExampleApp", false)
+}
+
 def isDeveloperMode() {
-    // developer mode, to run Example app
-    return safeAppExtGet("isReanimatedExampleApp", false) || System.getenv("REANIMATED_PACKAGE_BUILD") == "1"
+    return isReanimatedExampleApp() || System.getenv("REANIMATED_PACKAGE_BUILD") == "1"
 }
 
 def isNewArchitectureEnabled() {
@@ -454,6 +457,7 @@ android {
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DCLIENT_SIDE_BUILD=${CLIENT_SIDE_BUILD}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${isNewArchitectureEnabled()}",
+                        "-DIS_REANIMATED_EXAMPLE_APP=${isReanimatedExampleApp()}",
                         "-DPLAYGROUND_APP_NAME=${getPlaygroundAppName()}",
                         "-DREANIMATED_PACKAGE_BUILD=${REANIMATED_PACKAGE_BUILD}",
                         "-DREANIMATED_VERSION=${REANIMATED_VERSION}"


### PR DESCRIPTION
## Why

Currently, Reanimated crashes on some configurations due to an assert in `SingleInstanceChecker` which was meant to help us detect retain cycles and thus memory leaks in the library at an early stage but actually causes lots of troubles in client apps. This PR changes the behavior of `SingleInstanceChecker` so that it always prints the warning to the console but calls the failing `assert` only in Reanimated example apps (i.e. Example or FabricExample).

## How

This PR wraps the failing assert inside a preprocessor conditional based on the flags passed from `build.gradle` via `CMakeLists.txt` (Android) or `RNReanimated.podspec` (iOS). Additionally, it introduces `__android_log_print` instead of `std::cerr` on Android so that the warning is also visible in logcat.

Android:

<img width="1493" alt="android" src="https://user-images.githubusercontent.com/20516055/229063204-36af61a7-1ace-4a64-bf43-4cb1caceb44f.png">

iOS:

<img width="898" alt="ios" src="https://user-images.githubusercontent.com/20516055/229063251-d1b66d79-58ff-4077-a88c-f8d368d74377.png">

## Test plan

1. Check if `IS_REANIMATED_EXAMPLE_APP` preprocessor definition is properly injected on both platforms:
     - Android: change implementation of `isReanimatedExampleApp` in build.gradle to always return `true`
     - iOS: assign `true` to `result[:is_reanimated_example_app]` in `reanimated_utils.rb`
     - add the following snippet in `SingleInstanceChecker.h`:
     ```cpp
     #ifdef IS_REANIMATED_EXAMPLE_APP
     #error "it works"
     #endif
    ```
2. Check if the example apps crash on reload:
    - modify the condition in `SingleInstanceChecker.h` so that it always fails
    - the app should crash on launch
3. Check if the client apps don't crash on reload but show a warning:
    - modify the condition in `SingleInstanceChecker.h` so that it always fails
    - build the package locally
    - create a new RN app and install Reanimated
    - the app shouldn't crash on launch
    - there should be a warning in Android Logcat / iOS app output console


