### PR TITLE
Set right ReactAndroid version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1035,7 +1035,7 @@ dependencies {
         if (isPackageBuild()) {
             implementation "com.facebook.react:react-android:" + REACT_NATIVE_VERSION
         } else {
-            implementation "com.facebook.react:react-android:0.71.5" // version substituted by RNGP
+            implementation "com.facebook.react:react-android:" // version substituted by RNGP
         }
         if (JS_RUNTIME == "hermes") {
             if (isPackageBuild()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1033,13 +1033,13 @@ dependencies {
 
     if (REACT_NATIVE_MINOR_VERSION >= 71) {
         if (isPackageBuild()) {
-            implementation "com.facebook.react:react-android:+"
+            implementation "com.facebook.react:react-android:" + REACT_NATIVE_VERSION
         } else {
-            implementation "com.facebook.react:react-android:" // version substituted by RNGP
+            implementation "com.facebook.react:react-android:0.71.5" // version substituted by RNGP
         }
         if (JS_RUNTIME == "hermes") {
             if (isPackageBuild()) {
-                implementation "com.facebook.react:hermes-android:+"
+                implementation "com.facebook.react:hermes-android:" + REACT_NATIVE_VERSION
             } else {
                 implementation "com.facebook.react:hermes-android:" // version substituted by RNGP
             }


### PR DESCRIPTION
## Summary

To fix this kind of error with the package:
<img src="https://user-images.githubusercontent.com/36106620/229480376-b4b6954c-4591-4a42-badd-a4dbbca81ac0.png" width="300px" />
We need to specific grade dependencies. The `+` sign instead of fix version breaks the package build for `rn@0.7.+` because `rn@0.72.0-rc.0` was released.