### PR TITLE
Fix gradle build for monorepos with projects having 2-level directory depth

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,6 +104,11 @@ def resolveReactNativeDirectory() {
     if (reactNativeFromProjectNodeModules.exists()) {
         return reactNativeFromProjectNodeModules
     }
+
+    def reactNativeFromWorkspaceNodeModules = file("${rootProject.projectDir}/../../node_modules/react-native")
+    if (reactNativeFromWorkspaceNodeModules.exists()) {
+        return reactNativeFromWorkspaceNodeModules
+    }
     
     def reactNativeFromNodeModulesWithReanimated = file("${projectDir}/../../react-native")
     if (reactNativeFromNodeModulesWithReanimated.exists()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #3836

Many monorepos use a folder structure of `<monorepo>/(apps|packages)/...` and the current grade build only checks one level up

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

N/A
