### PR TITLE
Make single instance assertion work with Gradle Configuration Cache

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 import groovy.json.JsonSlurper
 
+import javax.inject.Inject
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -552,17 +553,14 @@ android {
 }
 
 abstract class NoMultipleInstancesAssertionTask extends DefaultTask {
-    @Input
-    abstract Property<File> getProjectDirFile()
-    @Input
-    abstract Property<File> getRootDirFile()
-    @Input
-    abstract Property<Boolean> getShouldCheck()
-    @Input
-    abstract Property<ObjectFactory> getObjectFactory()
+    @Inject abstract ObjectFactory getObjectFactory()
+
+    @Input abstract Property<File> getProjectDirFile()
+    @Input abstract Property<File> getRootDirFile()
+    @Input abstract Property<Boolean> getShouldCheck()
 
     def findReanimatedInstancesForPath(String path) {
-        return objectFactory.get().fileTree().from(path)
+        return objectFactory.fileTree().from(path)
                 .include("**/react-native-reanimated/package.json")
                 .exclude("**/.yarn/**")
                 .exclude({ Files.isSymbolicLink(it.getFile().toPath()) })
@@ -606,7 +604,6 @@ tasks.register('assertNoMultipleInstances', NoMultipleInstancesAssertionTask) {
     shouldCheck = shouldAssertNoMultipleInstances()
     rootDirFile = rootDir
     projectDirFile = projectDir
-    objectFactory = objects
 }
 
 def NEW_ARCH_ENABLED = isNewArchitectureEnabled()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,8 @@ import com.android.Version
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 import groovy.json.JsonSlurper
+
+import java.nio.file.Files
 import java.nio.file.Paths
 
 /**
@@ -139,41 +141,6 @@ def shouldAssertNoMultipleInstances() {
   } else {
     return true
   }
-}
-
-def findReanimatedInstancesForPath(String path) {
-    return fileTree(path) {
-        include "**/react-native-reanimated/package.json"
-        exclude "**/.yarn/**"
-        exclude {{ file, attr -> attr.isSymbolicLink() }}
-    }.files
-}
-
-def checkNoMultipleInstances() {
-    // Assert there are no multiple installations of Reanimated
-    Set<File> files
-    if (projectDir.path.contains(rootDir.parent)) {
-        // standard app
-        files = findReanimatedInstancesForPath(rootDir.parent + "/node_modules")
-    } else {
-        // monorepo
-        files = findReanimatedInstancesForPath(rootDir.parent + "/node_modules")
-        files.addAll(
-            findReanimatedInstancesForPath(file(projectDir.parent).parent)
-        )
-    }
-    if (files.size() > 1) {
-        String parsedLocation = files.stream().map({
-            File file -> "- " + file.toString().replace("/package.json", "")
-        }).collect().join("\n")
-        String exceptionMessage = "\n[react-native-reanimated] Multiple versions of Reanimated " +
-            "were detected. Only one instance of react-native-reanimated can be installed in a " +
-            "project. You need to resolve the conflict manually. Check out the documentation: " +
-            "https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/" +
-            "troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict " +
-            "between: \n" + parsedLocation + "\n";
-        throw new GradleException(exceptionMessage)
-    }
 }
 
 def getReanimatedVersion() {
@@ -584,15 +551,68 @@ android {
     }
 }
 
-def assertNoMultipleInstances = task assertNoMultipleInstancesTask {
-    onlyIf { shouldAssertNoMultipleInstances() && CLIENT_SIDE_BUILD }
-    doFirst {
-        checkNoMultipleInstances()
+abstract class NoMultipleInstancesAssertionTask extends DefaultTask {
+    @Input
+    abstract Property<File> getProjectDirFile()
+    @Input
+    abstract Property<File> getRootDirFile()
+    @Input
+    abstract Property<Boolean> getShouldCheck()
+    @Input
+    abstract Property<ObjectFactory> getObjectFactory()
+
+    def findReanimatedInstancesForPath(String path) {
+        return objectFactory.get().fileTree().from(path)
+                .include("**/react-native-reanimated/package.json")
+                .exclude("**/.yarn/**")
+                .exclude({ Files.isSymbolicLink(it.getFile().toPath()) })
+                .findAll()
+    }
+
+    @TaskAction
+    def check() {
+        if (shouldCheck.get()) {
+            // Assert there are no multiple installations of Reanimated
+            Set<File> files
+
+            if (projectDirFile.get().parent.contains(rootDirFile.get().parent)) {
+                // standard app
+                files = findReanimatedInstancesForPath(rootDirFile.get().parent + "/node_modules")
+            } else {
+                // monorepo
+                files = findReanimatedInstancesForPath(rootDirFile.get().parent + "/node_modules")
+                files.addAll(
+                    findReanimatedInstancesForPath(projectDirFile.get().parentFile.parent)
+                )
+            }
+
+            if (files.size() > 1) {
+                String parsedLocation = files.stream().map({
+                    File file -> "- " + file.toString().replace("/package.json", "")
+                }).collect().join("\n")
+                String exceptionMessage = "\n[react-native-reanimated] Multiple versions of Reanimated " +
+                        "were detected. Only one instance of react-native-reanimated can be installed in a " +
+                        "project. You need to resolve the conflict manually. Check out the documentation: " +
+                        "https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/" +
+                        "troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict " +
+                        "between: \n" + parsedLocation + "\n"
+                throw new GradleException(exceptionMessage)
+            }
+        }
     }
 }
 
+tasks.register('assertNoMultipleInstances', NoMultipleInstancesAssertionTask) {
+    shouldCheck = shouldAssertNoMultipleInstances()
+    rootDirFile = rootDir
+    projectDirFile = projectDir
+    objectFactory = objects
+}
+
+def NEW_ARCH_ENABLED = isNewArchitectureEnabled()
+
 def assertNoReanimated2WithNewArchitecture = task assertNoReanimated2WithNewArchitectureTask {
-    onlyIf { isNewArchitectureEnabled() && REANIMATED_MAJOR_VERSION == 2 }
+    onlyIf { NEW_ARCH_ENABLED && REANIMATED_MAJOR_VERSION == 2 }
     doFirst {
         throw new GradleException(
             "\n[react-native-reanimated] Reanimated 2.x does not support Fabric. " +
@@ -603,7 +623,7 @@ def assertNoReanimated2WithNewArchitecture = task assertNoReanimated2WithNewArch
 }
 
 def assertLatestReactNativeWithNewArchitecture = task assertLatestReactNativeWithNewArchitectureTask {
-    onlyIf { isNewArchitectureEnabled() && REANIMATED_MAJOR_VERSION == 3 && REACT_NATIVE_MINOR_VERSION < 72 }
+    onlyIf { NEW_ARCH_ENABLED && REANIMATED_MAJOR_VERSION == 3 && REACT_NATIVE_MINOR_VERSION < 72 }
     doFirst {
         throw new GradleException(
             "\n[react-native-reanimated] Reanimated " + REANIMATED_VERSION + " supports the New Architecture " +


### PR DESCRIPTION
## Summary

Makes single instance assertion not break builds when using [Gradle Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:intro).

Related: https://github.com/software-mansion/react-native-gesture-handler/pull/2453

## Test plan

Enable Gradle Configuration Cache by adding `org.gradle.unsafe.configuration-cache=true` in the `gradle.properties` file. If testing on the Example app, remove `disableMultipleInstancesCheck=true`.

Build the app with and without this PR.
