### PR TITLE
fix: console.assert is not defined during debug

### DIFF
--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -171,6 +171,7 @@ export function initializeUIRuntime() {
     // setup console
     // @ts-ignore TypeScript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtime console version
     global.console = {
+      assert: runOnJS(capturableConsole.assert),
       debug: runOnJS(capturableConsole.debug),
       log: runOnJS(capturableConsole.log),
       warn: runOnJS(capturableConsole.warn),


### PR DESCRIPTION
## Summary

Fixes #3951 #4263 #4354

## Test plan

I can now successfully debug using React Native Debugger again. Same fix was proposed by @rililive https://github.com/software-mansion/react-native-reanimated/issues/3951#issuecomment-1384223013
