### PR TITLE
Set the opposite sensor values on android to be consistent with iOS

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
@@ -69,7 +69,13 @@ public class ReanimatedSensorListener implements SensorEventListener {
           };
       setter.sensorSetter(data, orientationDegrees);
     } else {
-      setter.sensorSetter(event.values, orientationDegrees);
+      // Set the opposite values to be consistent with iOS
+      float[] data = new float [] {
+        -event.values[0],
+        -event.values[1],
+        -event.values[2]
+      };
+      setter.sensorSetter(data, orientationDegrees);
     }
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensorListener.java
@@ -70,11 +70,7 @@ public class ReanimatedSensorListener implements SensorEventListener {
       setter.sensorSetter(data, orientationDegrees);
     } else {
       // Set the opposite values to be consistent with iOS
-      float[] data = new float [] {
-        -event.values[0],
-        -event.values[1],
-        -event.values[2]
-      };
+      float[] data = new float[] {-event.values[0], -event.values[1], -event.values[2]};
       setter.sensorSetter(data, orientationDegrees);
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

The sensors on Android and iOS return opposite values, which cause inconsistencies. To fix this, I modified the Android sensor listener to return opposite values.
I didn't modify rotation values, because these are the same.

## Test plan

- Ran each sensor and compared the values returned by both platforms
- Tested an example application to confirm that the behavior of the sensors is consistent across both platforms.
