### PR TITLE
Convert to shareable directly from runOnUI

### DIFF
--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -82,6 +82,15 @@ export function runOnUI<A extends any[], R>(
       );
       return;
     }
+    if (__DEV__) {
+      // in DEV mode we call shareable conversion here because in case the object
+      // can't be converted, we will get a meaningful stack-trace as opposed to the
+      // situation when conversion is only done via microtask queue. This does not
+      // make the app particularily less efficient as converted objects are cached
+      // and for a given worklet the conversion only happens once.
+      makeShareableCloneRecursive(worklet);
+      makeShareableCloneRecursive(args);
+    }
     _runOnUIQueue.push([worklet, args]);
     if (_runOnUIQueue.length === 1) {
       queueMicrotask(() => {


### PR DESCRIPTION
## Summary

This PR adds additional call to convert worklet and arguments to shareables directly from runOnUI such that we avoid doing the conversion from the microtasks queue. The reason for that is that if the object to be converted triggers an error (stack exceeded or cyclic object), converting it from microtasks queue makes it difficult to narrow down the actual object that triggered the exception. 

Since make-shareable method keeps a cache of converted objects we can be sure the conversion doesn't happen twice, but nevertheless we only do that in DEV mode.


## Test plan

Run Example app.