### PR TITLE
Update misleading createAnimatedComponent warning

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -246,8 +246,7 @@ export default function createAnimatedComponent(
   invariant(
     typeof Component !== 'function' ||
       (Component.prototype && Component.prototype.isReactComponent),
-    '`createAnimatedComponent` does not support stateless functional components; ' +
-      'use a class component instead.'
+    `Looks like you're passing a ${Component.name} functional component to 'createAnimatedComponent'.\n\n'createAnimatedComponent' relies on passing refs to work correctly. Wrap your functional component with React.forwardRef() or use a class component instead.`
   );
 
   class AnimatedComponent extends React.Component<

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -246,7 +246,7 @@ export default function createAnimatedComponent(
   invariant(
     typeof Component !== 'function' ||
       (Component.prototype && Component.prototype.isReactComponent),
-    `Looks like you're passing a ${Component.name} functional component to 'createAnimatedComponent'.\n\n'createAnimatedComponent' relies on passing refs to work correctly. Wrap your functional component with React.forwardRef() or use a class component instead.`
+    `Looks like you're passing a function component \`${Component.name}\` to \`createAnimatedComponent\` function which supports only class components. Please wrap your function component with \`React.forwardRef()\` or use a class component instead.`
   );
 
   class AnimatedComponent extends React.Component<


### PR DESCRIPTION
## Summary

When writing a new documentation for `createAnimatedComponent` I've found out that this function works not only for class-based components but also for functional components with `React.forwardRef()`. 

This PR updates the warning caused by using plain functional components to guide users to use forwardRef.

## Test plan

When plain functional component is passed to `createAnimatedComponent` the app errors out:

```jsx
function MyComponent(props) {
  return <View {...props} />;
}

const MyAnimatedComponent = Animated.createAnimatedComponent(MyComponent);
```

but warning guides to use `React.forwardRef()`.

![image](https://user-images.githubusercontent.com/39658211/232835478-a0b7942a-c11f-4ae1-8708-3b865ce3241f.png)


When a functional component is wrapped with forwardRef it works just fine:

```jsx
function WrappedView(props, ref) {
  return <View {...props} ref={ref} />;
}

const MyComponent = React.forwardRef(WrappedView);
const MyAnimatedComponent = Animated.createAnimatedComponent(MyComponent);
```

![image](https://user-images.githubusercontent.com/39658211/232835635-b9fc6f4c-ed35-42fe-8daf-8e1bd29ae9ae.png)


<details>
<summary>Ful example to copy & paste</summary>

```jsx
import React from 'react';
import {Button, StyleSheet, View} from 'react-native';
import Animated, {useSharedValue, withSpring} from 'react-native-reanimated';

function WrappedView(props, ref) {
  return <View {...props} ref={ref} />;
}

const MyComponent = React.forwardRef(WrappedView);
const MyAnimatedComponent = Animated.createAnimatedComponent(MyComponent);

export default function App() {
  const width = useSharedValue(100);
  const handlePress = () => {
    width.value = withSpring(width.value + 50);
  };

  return (
    <View style={styles.container}>
      <MyAnimatedComponent style={{...styles.box, width}} />
      <Button onPress={handlePress} title="Click me" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
  },
  box: {
    height: 100,
    backgroundColor: '#b58df1',
    borderRadius: 20,
    marginVertical: 64,
  },
});

```

</details>
