### PR TITLE
Fix updating props of ScreenStackHeaderConfig on Paper iOS

### DIFF
--- a/app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
+++ b/app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
@@ -20,15 +20,14 @@ import { StyleSheet, View } from 'react-native';
 import React from 'react';
 
 const AnimatedScreenStackHeaderConfig = Animated.createAnimatedComponent(
-  // @ts-ignore it works in FabricExample
+  // @ts-ignore will be fixed with https://github.com/software-mansion/react-native-screens/pull/1760
   ScreenStackHeaderConfig
 );
+Animated.addWhitelistedNativeProps({ title: true });
 
 export default function ScreenStackHeaderConfigBackgroundColorExample() {
   const isPressed = useSharedValue(false);
   const offset = useSharedValue({ x: 0, y: 0 });
-
-  // useJSThreadKiller();
 
   const gesture = Gesture.Pan()
     .minDistance(0)

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -12,6 +12,10 @@
 #import <stdatomic.h>
 #endif
 
+#if __has_include(<RNScreens/RNSScreenStackHeaderConfig.h>)
+#import <RNScreens/RNSScreenStackHeaderConfig.h>
+#endif
+
 #ifdef RCT_NEW_ARCH_ENABLED
 using namespace facebook::react;
 #endif
@@ -368,7 +372,13 @@ using namespace facebook::react;
 
 - (BOOL)isNativeViewMounted:(NSNumber *)viewTag
 {
-  return _viewRegistry[viewTag].superview != nil;
+  UIView *view = _viewRegistry[viewTag];
+#if __has_include(<RNScreens/RNSScreenStackHeaderConfig.h>)
+  if ([view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+    return ((RNSScreenStackHeaderConfig *)view).screenView != nil;
+  }
+#endif
+  return view.superview != nil;
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -373,12 +373,15 @@ using namespace facebook::react;
 - (BOOL)isNativeViewMounted:(NSNumber *)viewTag
 {
   UIView *view = _viewRegistry[viewTag];
+  if (view.superview != nil) {
+    return YES;
+  }
 #if __has_include(<RNScreens/RNSScreenStackHeaderConfig.h>)
   if ([view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
     return ((RNSScreenStackHeaderConfig *)view).screenView != nil;
   }
 #endif
-  return view.superview != nil;
+  return NO;
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Summary

This PR fixes ScreenStackHeaderConfigBackgroundColor example on iOS with Paper.

See also https://github.com/software-mansion/react-native-screens/pull/1760 

https://user-images.githubusercontent.com/20516055/233048052-7c35c443-9e89-497d-9aa5-552d57bb1838.mov

## Test plan

Check if the example works
