### PR TITLE
Fix undefined `ErrorUtils.reportFatalError`

### DIFF
--- a/src/reanimated2/errors.ts
+++ b/src/reanimated2/errors.ts
@@ -53,5 +53,6 @@ export function reportFatalErrorOnJS({
   error.name = 'ReanimatedError';
   // @ts-ignore React Native's ErrorUtils implementation extends the Error type with jsEngine field
   error.jsEngine = 'reanimated';
-  global.__ErrorUtils.reportFatalError(error);
+  // @ts-ignore the reportFatalError method is an internal method of ErrorUtils not exposed in the type definitions
+  global.ErrorUtils.reportFatalError(error);
 }


### PR DESCRIPTION
## Summary

The `__ErrorUtils` is available only in Reanimated Runtime, to use `reportFatalError` we need to use ReactNative internal function available in `ErrorUtils` global object.

## Test plan

```
function fn() {
  'worklet'
  throw new Error('error');
}
runOnUI(fn)()
```
