### PR TITLE
Fix scrollTo on Fabric

### DIFF
--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -86,7 +86,7 @@ export function dispatchCommand(
   args: Array<unknown>
 ): void {
   'worklet';
-  if (!_WORKLET || !isNative || !global._IS_FABRIC) {
+  if (!_WORKLET || !isNative) {
     return;
   }
 

--- a/src/reanimated2/errors.ts
+++ b/src/reanimated2/errors.ts
@@ -53,5 +53,6 @@ export function reportFatalErrorOnJS({
   error.name = 'ReanimatedError';
   // @ts-ignore React Native's ErrorUtils implementation extends the Error type with jsEngine field
   error.jsEngine = 'reanimated';
-  global.__ErrorUtils.reportFatalError(error);
+  // @ts-ignore the reportFatalError method is an internal method of ErrorUtils not exposed in the type definitions
+  global.ErrorUtils.reportFatalError(error);
 }


### PR DESCRIPTION
## Summary

The flag `_IS_FABRIC` is only defined on React Runtime, we can't use them on Reanimated Runtime. I removed the check of this flag for Reanimated Runtime because this one prevents any `_dispatchCommand` call.

## Test plan

Run any scrollTo example on Fabric
