### PR TITLE
Fix useTiming for arrays

### DIFF
--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -215,10 +215,10 @@ function decorateAnimation<T extends AnimationObject | StyleLayoutAnimation>(
     timestamp: Timestamp
   ): boolean => {
     let finished = true;
-    (animation.current as Array<number>).forEach((v, i) => {
+    animation.current = (animation.current as Array<number>).map((v, i) => {
       // @ts-ignore: disable-next-line
       finished &= animation[i].onFrame(animation[i], timestamp);
-      (animation.current as Array<number>)[i] = animation[i].current;
+      return animation[i].current;
     });
 
     return finished;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently animation functions like `withTiming` don't work for arrays.
Animations execute properly, but updating main array is broken.

Cause:
- For some reasons, the line: `(animation.current as Array<number>)[i] = animation[i].current` doesn't update `animation.current` properly


## Test plan

```
const randomArray = useSharedValue([10, 10]);

randomArray.value = withTiming([200, 300]);

const style = useAnimatedStyle(() => {
  return {
    width: randomArray.value[0],
    height: randomArray.value[1],
  };
});
```
