### PR TITLE
Fix #3771 for more use cases

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -17,7 +17,7 @@ def find_config()
     :react_native_common_dir => nil,
   }
 
-  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Dir.pwd}" && node --print "require.resolve('react-native/package.json')"`), '..')
+  react_native_node_modules_dir = File.join(File.dirname(`cd "#{__dir__}" && node --print "require.resolve('react-native/package.json')"`), '..')
   react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
 
   if react_native_json == nil

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -17,7 +17,7 @@ def find_config()
     :react_native_common_dir => nil,
   }
 
-  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Dir.pwd}" && node --print "require.resolve('react-native/package.json')"`), '..')
   react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
 
   if react_native_json == nil


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

When react native is integrated with Existing Apps, the ios folder is not inside RN project, but outside of RN project.  cd to "Pod::Config.instance.installation_root.to_s" cannot resolve "react-native/package.json", then react_native_node_modules_dir will not be correct. So we should change it into "Dir.pwd", which directly resolve path from this library itself, not matter where the native iOS folder is.


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

Move react native project into a existing ios project. and run "pod install".
<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
