### PR TITLE
Add type tests for NativeMethods and add AnimatedRef type

### DIFF
--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useState, useCallback, forwardRef } from 'react';
+import React, {
+  useState,
+  useCallback,
+  forwardRef,
+  Component,
+  useRef,
+} from 'react';
 import {
   Text,
   StyleSheet,
@@ -50,6 +56,13 @@ import Animated, {
   Animation,
   // eslint-disable-next-line import/no-unresolved
 } from 'react-native-reanimated';
+import {
+  dispatchCommand,
+  getTag,
+  measure,
+  scrollTo,
+  setGestureState,
+} from '../src/reanimated2/NativeMethods';
 
 class Path extends React.Component<{ fill?: string }> {
   render() {
@@ -737,4 +750,68 @@ function testPartialAnimatedProps() {
   const test5 = (
     <AnimatedImage source={{ uri: 'whatever' }} animatedProps={aps} />
   );
+
+  // NativeMethods:
+  // test getTag
+  function testGetTag() {
+    // @ts-expect-error string is not a valid view
+    const test1 = getTag('whatever');
+    // number is a valid view (shadowNodeRef?)
+    const test2 = getTag(1);
+    // @ts-expect-error by TypeScript standards null is not an object
+    const test4: object = getTag(0);
+    class TestClass extends React.Component {
+      render() {
+        return <View />;
+      }
+    }
+
+    const variable = new TestClass({});
+    // this is valid argument
+    const test5 = getTag(variable);
+    // I don't know how to implement this case
+    // class test6class extends React.Component<any> implements React.ComponentClass {
+    //   constructor(props: any, context?: any) {
+    //     super(props);
+    //   }
+    // }
+  }
+
+  // test measure
+  function testMeasure() {
+    const animatedRef = useAnimatedRef<Animated.View>();
+    measure(animatedRef);
+    const plainRef = useRef<Animated.View>();
+    // @ts-expect-error should only work for Animated refs?
+    measure(plainRef);
+  }
+
+  // test dispatchCommand
+  function testDispatchCommand() {
+    const animatedRef = useAnimatedRef<Animated.View>();
+    dispatchCommand(animatedRef, 'command', [1, 2, 3]);
+    const plainRef = useRef<Animated.View>();
+    // @ts-expect-error should only work for Animated refs?
+    dispatchCommand(plainRef, 'command', [1, 2, 3]);
+    // @ts-expect-error args are not optional
+    dispatchCommand(animatedRef, 'command');
+  }
+
+  // test scrollTo
+  function testScrollTo() {
+    const animatedRef = useAnimatedRef<Animated.ScrollView>();
+    scrollTo(animatedRef, 0, 0, true);
+    const plainRef = useRef<Animated.ScrollView>();
+    // @ts-expect-error should only work for Animated refs
+    scrollTo(plainRef, 0, 0, true);
+    const animatedViewRef = useAnimatedRef<Animated.View>();
+    // @ts-expect-error should only get a scrollable object?
+    scrollTo(animatedViewRef, 0, 0, true);
+  }
+
+  // test setGestureState
+  function testSetGestureState() {
+    setGestureState(1, 2);
+    // not sure what more I can test here
+  }
 }

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -2,7 +2,7 @@
 import { Component } from 'react';
 import { findNodeHandle } from 'react-native';
 import { MeasuredDimensions, ShadowNodeWrapper } from './commonTypes';
-import { RefObjectFunction } from './hook/commonTypes';
+import { AnimatedRef } from './hook/commonTypes';
 import { isChromeDebugger, isWeb, shouldBeUseWeb } from './PlatformChecker';
 
 export function getTag(
@@ -14,11 +14,11 @@ export function getTag(
 const isNative = !shouldBeUseWeb();
 
 export let measure: <T extends Component>(
-  animatedRef: RefObjectFunction<T>
+  animatedRef: AnimatedRef<T>
 ) => MeasuredDimensions | null;
 
 if (isWeb()) {
-  measure = <T extends Component>(animatedRef: RefObjectFunction<T>) => {
+  measure = <T extends Component>(animatedRef: AnimatedRef<T>) => {
     const element = animatedRef() as unknown as HTMLElement; // TODO: fix typing of animated refs on web
     const viewportOffset = element.getBoundingClientRect();
     return {
@@ -31,12 +31,12 @@ if (isWeb()) {
     };
   };
 } else if (isChromeDebugger()) {
-  measure = <T extends Component>(_animatedRef: RefObjectFunction<T>) => {
+  measure = <T extends Component>(_animatedRef: AnimatedRef<T>) => {
     console.warn('[Reanimated] measure() cannot be used with Chrome Debugger.');
     return null;
   };
 } else {
-  measure = <T extends Component>(animatedRef: RefObjectFunction<T>) => {
+  measure = <T extends Component>(animatedRef: AnimatedRef<T>) => {
     'worklet';
     if (!_WORKLET) {
       console.warn(
@@ -81,7 +81,7 @@ if (isWeb()) {
 }
 
 export function dispatchCommand<T extends Component>(
-  animatedRef: RefObjectFunction<T>,
+  animatedRef: AnimatedRef<T>,
   commandName: string,
   args: Array<unknown>
 ): void {
@@ -97,7 +97,7 @@ export function dispatchCommand<T extends Component>(
 }
 
 export let scrollTo: <T extends Component>(
-  animatedRef: RefObjectFunction<T>,
+  animatedRef: AnimatedRef<T>,
   x: number,
   y: number,
   animated: boolean
@@ -105,7 +105,7 @@ export let scrollTo: <T extends Component>(
 
 if (isWeb()) {
   scrollTo = <T extends Component>(
-    animatedRef: RefObjectFunction<T>,
+    animatedRef: AnimatedRef<T>,
     x: number,
     y: number,
     animated: boolean
@@ -117,7 +117,7 @@ if (isWeb()) {
   };
 } else if (isNative && global._IS_FABRIC) {
   scrollTo = <T extends Component>(
-    animatedRef: RefObjectFunction<T>,
+    animatedRef: AnimatedRef<T>,
     x: number,
     y: number,
     animated: boolean
@@ -127,7 +127,7 @@ if (isWeb()) {
   };
 } else if (isNative) {
   scrollTo = <T extends Component>(
-    animatedRef: RefObjectFunction<T>,
+    animatedRef: AnimatedRef<T>,
     x: number,
     y: number,
     animated: boolean
@@ -143,7 +143,7 @@ if (isWeb()) {
   };
 } else {
   scrollTo = <T extends Component>(
-    _animatedRef: RefObjectFunction<T>,
+    _animatedRef: AnimatedRef<T>,
     _x: number,
     _y: number
   ) => {

--- a/src/reanimated2/hook/commonTypes.ts
+++ b/src/reanimated2/hook/commonTypes.ts
@@ -17,3 +17,5 @@ export interface RefObjectFunction<T> {
   current: T | null;
   (component?: T): number | ShadowNodeWrapper;
 }
+
+export type AnimatedRef<T> = RefObjectFunction<T>;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -1,6 +1,6 @@
 import { Component, useRef } from 'react';
 import { useSharedValue } from './useSharedValue';
-import { RefObjectFunction } from './commonTypes';
+import { AnimatedRef, RefObjectFunction } from './commonTypes';
 import { ShadowNodeWrapper } from '../commonTypes';
 import { getTag } from '../NativeMethods';
 import { getShadowNodeWrapperFromHostInstance } from '../fabricUtils';
@@ -23,7 +23,7 @@ const getTagValueFunction = global._IS_FABRIC
   ? getShareableShadowNodeFromComponent
   : getTag;
 
-export function useAnimatedRef<T extends ComponentRef>(): RefObjectFunction<T> {
+export function useAnimatedRef<T extends ComponentRef>(): AnimatedRef<T> {
   const tag = useSharedValue<number | ShadowNodeWrapper | null>(-1);
   const ref = useRef<RefObjectFunction<T>>();
 

--- a/src/reanimated2/utils.ts
+++ b/src/reanimated2/utils.ts
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import { measure } from './NativeMethods';
-import { RefObjectFunction } from './hook/commonTypes';
+import { AnimatedRef } from './hook/commonTypes';
 import { SharedValue } from './commonTypes';
 
 export interface ComponentCoords {
@@ -13,12 +13,12 @@ export interface ComponentCoords {
  * position in the component's local coordinate space.
  */
 export function getRelativeCoords(
-  parentRef: RefObjectFunction<Component>,
+  parentAnimatedRef: AnimatedRef<Component>,
   absoluteX: number,
   absoluteY: number
 ): ComponentCoords | null {
   'worklet';
-  const parentCoords = measure(parentRef);
+  const parentCoords = measure(parentAnimatedRef);
   if (parentCoords === null) {
     return null;
   }


### PR DESCRIPTION
## Summary

_This PR is part of an ongoing effort to get rid of the .d.ts file and use type definitions generated based on the source code._

It's a direct follow-up to #3778.

- Added type tests for `NativeMethods`.
I still need some guidance with them - what exactly do we want to test there and how.
- Added extra type `AnimatedRef<T>` which is an alias to `RefObjectFunction<T>`.
Reason for that was in many parts of code we explicitly ask for an `animatedRef` as an argument and it seems just more logical to have an alias for it.

## Test plan

🚀 
