### PR TITLE
expose convertToRGBA to the types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -461,6 +461,9 @@ declare module 'react-native-reanimated' {
     colorSpace?: 'RGB' | 'HSV',
     options?: InterpolationOptions
   ): T;
+  
+  export type ParsedColorArray = [number, number, number, number];
+  export function convertToRGBA(color: unknown): ParsedColorArray;
 
   export enum ColorSpace {
     RGB = 0,


### PR DESCRIPTION
Because Skia is using a different type this function is useful when interpolating colors therefore it would be useful to have it exposed through the types
