### PR TITLE
Replace console.error with throw new Error

### DIFF
--- a/__tests__/checkVersion.test.ts
+++ b/__tests__/checkVersion.test.ts
@@ -5,30 +5,21 @@ import {
 const { version: packageVersion } = require('../package.json');
 
 describe('checkCppVersion', () => {
-  let spyOnConsoleError: jest.SpyInstance;
-
   beforeEach(() => {
     global._REANIMATED_VERSION_CPP = packageVersion;
-    spyOnConsoleError = jest
-      .spyOn(console, 'error')
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      .mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete global._REANIMATED_VERSION_CPP;
-    spyOnConsoleError.mockRestore();
   });
 
   it('checks version successfully', () => {
-    checkCppVersion();
-    expect(console.error).not.toHaveBeenCalled();
+    expect(checkCppVersion).not.toThrow();
   });
 
   it('throws error when version is undefined', () => {
     delete global._REANIMATED_VERSION_CPP;
-    checkCppVersion();
-    expect(console.error).toHaveBeenCalled();
+    expect(checkCppVersion).toThrow();
   });
 });
 

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -24,13 +24,12 @@ export class NativeReanimated {
     this.native = native;
     if (native) {
       if (this.InnerNativeModule === undefined) {
-        console.error(
+        throw new Error(
           `[Reanimated] The native part of Reanimated doesn't seem to be initialized. This could be caused by\n\
   - not rebuilding the app after installing or upgrading Reanimated\n\
   - trying to run Reanimated on an unsupported platform\n\
   - running in a brownfield app without manually initializing the native library`
         );
-        return;
       }
       checkCppVersion();
     }

--- a/src/reanimated2/platform-specific/checkCppVersion.ts
+++ b/src/reanimated2/platform-specific/checkCppVersion.ts
@@ -3,14 +3,13 @@ import { jsVersion } from './jsVersion';
 export function checkCppVersion() {
   const cppVersion = global._REANIMATED_VERSION_CPP;
   if (cppVersion === undefined) {
-    console.error(
+    throw new Error(
       `[Reanimated] Couldn't determine the version of the native part of Reanimated. Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must use the exact version which is bundled into Expo SDK.`
     );
-    return;
   }
   const ok = matchVersion(jsVersion, cppVersion);
   if (!ok) {
-    console.error(
+    throw new Error(
       `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs. ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
     );
   }

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -85,9 +85,6 @@ const DETECT_CYCLIC_OBJECT_DEPTH_THRESHOLD = 30;
 // We use it to check if later on the function reenters with the same object
 let processedObjectAtThresholdDepth: any;
 
-// We only want to show mismatch error once so we use this flag to track it
-let didShowPluginVersionMismatchError = false;
-
 export function makeShareableCloneRecursive<T>(
   value: any,
   shouldPersistRemote = false,
@@ -141,13 +138,8 @@ export function makeShareableCloneRecursive<T>(
         if (value.__workletHash !== undefined) {
           // we are converting a worklet
           if (__DEV__) {
-            if (
-              // We don't want this error to be logged more than once.
-              !didShowPluginVersionMismatchError &&
-              value.__version !== jsVersion
-            ) {
-              didShowPluginVersionMismatchError = true;
-              console.error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${value.__version}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`,
+            if (value.__version !== jsVersion) {
+              throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${value.__version}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`,
               \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again.`);
             }
             registerWorkletStackDetails(


### PR DESCRIPTION
## Summary

This PR changes the behavior of the app when version mismatch is detected. Previously, we called `console.error` in such case, but the app still continued to execute. This PR replaces `console.error` with `throw new Error` which stops the execution and shows full-screen LogBox.

| Before | After |
|:-:|:-:|
| <img width="459" alt="before" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/4b58c8f8-350a-4d17-8c3a-51a9a3cf1fc9"> | <img width="459" alt="after" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/53cd425f-4da1-4ff4-86c8-776fdcbfe4a0"> |
