### PR TITLE
Remove unnecessary recursion from getInlinePropsUpdate

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -184,17 +184,30 @@ function getInlinePropsUpdate(inlineProps: Record<string, any>) {
   const update: Record<string, any> = {};
   for (const [key, styleValue] of Object.entries(inlineProps)) {
     if (key === 'transform') {
-      update[key] = styleValue.map((transform: Record<string, any>) => {
-        return getInlinePropsUpdate(transform);
-      });
-    } else if (isSharedValue(styleValue)) {
-      update[key] = styleValue.value;
+      update[key] = getInlineTransformPropsUpdate(update[key]);
     } else {
-      update[key] = styleValue;
+      update[key] = updateProp(styleValue);
     }
   }
   return update;
 }
+
+const getInlineTransformPropsUpdate = (inlineProps: Record<string, any>) => {
+  'worklet';
+  const update: Record<string, any> = {};
+  for (const [key, styleValue] of Object.entries(inlineProps)) {
+    update[key] = updateProp(styleValue);
+  }
+  return update;
+};
+
+const updateProp = (styleValue: any) => {
+  'worklet';
+  if (isSharedValue(styleValue)) {
+    return styleValue.value;
+  }
+  return styleValue;
+};
 
 interface AnimatedProps extends Record<string, unknown> {
   viewDescriptors?: ViewDescriptorsSet;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
_This PR is a part of an ongoing effort of revalidating hosting for worklets. See #4449 for more details.
Since arrow function expressions cannot be simply called recursively, recursion has to be changed to stack iteration._

After discussion with @piaskowyk it was concluded recursion in this function is unnecessary and was done in the first place to avoid code duplication.

TODO:
- [ ] Improve test plan 

## Test plan

Since we generally don't have unit tests for inner functions, like this one, I'd gladly collect some use cases to create unit tests for it. Aside from that - `yarn test`.
