### PR TITLE
Disable text measurement cache to fix animating text

### DIFF
--- a/Common/cpp/Fabric/ReanimatedUIManagerBinding.cpp
+++ b/Common/cpp/Fabric/ReanimatedUIManagerBinding.cpp
@@ -5,6 +5,7 @@
 #include "NewestShadowNodesRegistry.h"
 
 #include <react/renderer/debug/SystraceSection.h>
+#include <react/renderer/core/CoreFeatures.h>
 
 #include <utility>
 
@@ -36,6 +37,10 @@ void ReanimatedUIManagerBinding::createAndInstallIfNeeded(
         reinterpret_cast<UIManagerBindingPublic *>(&*uiManagerBinding);
     return std::move(uiManagerBindingPublic->eventHandler_);
   }();
+
+  // We can not cache text measurements, because we need to calculate it on each animation frame.
+  CoreFeatures::cacheNSTextStorage = false;
+  CoreFeatures::cacheLastTextMeasurement = false
 
   auto reanimatedUiManagerBinding =
       std::make_shared<ReanimatedUIManagerBinding>(


### PR DESCRIPTION


## Summary

- Disable caching text to fix text animations of Fabric.

## Test plan

- Before

https://github.com/software-mansion/react-native-reanimated/assets/56194058/47af48fe-b766-463e-b672-47f490c60e77

- After

https://github.com/software-mansion/react-native-reanimated/assets/56194058/a710d751-f1c2-46c1-b8d4-963996d20348

