### PR TITLE
Change nightly version numbering

### DIFF
--- a/scripts/set-nightly-version.js
+++ b/scripts/set-nightly-version.js
@@ -11,10 +11,19 @@ const currentCommit = exec('git rev-parse HEAD', {
 }).stdout.trim();
 const shortCommit = currentCommit.slice(0, 9);
 
-const version = `0.0.0-${dateIdentifier}-${shortCommit}`;
-
 const packageJsonPath = 'package.json';
 const packageJson = JSON.parse(cat(packageJsonPath));
+
+const currentVersion = packageJson.version;
+if (currentVersion.includes('nightly')) {
+  throw new Error('Cannot set nightly version on nightly version');
+}
+
+const [major, minor, patch] = currentVersion.split('.');
+const version = `${major}.${
+  Number(minor) + 1
+}.${patch}-nightly-${dateIdentifier}-${shortCommit}`;
+
 packageJson.version = version;
 fs.writeFileSync(
   packageJsonPath,

--- a/scripts/set-nightly-version.js
+++ b/scripts/set-nightly-version.js
@@ -20,9 +20,8 @@ if (currentVersion.includes('nightly')) {
 }
 
 const [major, minor, patch] = currentVersion.split('.');
-const version = `${major}.${
-  Number(minor) + 1
-}.${patch}-nightly-${dateIdentifier}-${shortCommit}`;
+const nextMinor = Number(minor) + 1;
+const version = `${major}.${nextMinor}.${patch}-nightly-${dateIdentifier}-${shortCommit}`;
 
 packageJson.version = version;
 fs.writeFileSync(


### PR DESCRIPTION
## Summary

This PR changes nightly version numbering from `0.0.0-yyyymmdd-commithash` to `<x>.<y+1>.<z>-nightly-yyyymmdd-commithash` to keep things analogous to react-native (see [here](https://www.npmjs.com/package/react-native?activeTab=versions)) as well as to fix failing Android builds due to conditionals in build.gradle and RNReanimated.podspec which use major version for build config.

## Test plan

1. Clone the repository
2. Run `node scripts/set-nightly-version.js`
3. Check if the version in `package.json` and `jsVersion.ts` starts with `3.2.0-nightly-`
