### PR TITLE
Remove commonjs generation

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -13,7 +13,7 @@ First, make sure that your tests run with Node version 16 or newer.
 Add the following line to your `jest-setup.js` file:
 
 ```js
-require('react-native-reanimated/src/reanimated2/jestUtils').setUpTests();
+require('react-native-reanimated').setUpTests();
 ```
 
 `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.

--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -13,7 +13,7 @@ First, make sure that your tests run with Node version 16 or newer.
 Add the following line to your `jest-setup.js` file:
 
 ```js
-require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
+require('react-native-reanimated/src/reanimated2/jestUtils').setUpTests();
 ```
 
 `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.

--- a/docs/versioned_docs/version-2.x/guide/testing.md
+++ b/docs/versioned_docs/version-2.x/guide/testing.md
@@ -10,7 +10,7 @@ Reanimated test mocks use web implementation of Reanimated2. Before you begin us
 
 Add the following line to your `jest-setup.js` file:
 ```js
-require('react-native-reanimated/src/reanimated2/jestUtils').setUpTests();
+require('react-native-reanimated').setUpTests();
 ```
 `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.
 

--- a/docs/versioned_docs/version-2.x/guide/testing.md
+++ b/docs/versioned_docs/version-2.x/guide/testing.md
@@ -10,7 +10,7 @@ Reanimated test mocks use web implementation of Reanimated2. Before you begin us
 
 Add the following line to your `jest-setup.js` file:
 ```js
-require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
+require('react-native-reanimated/src/reanimated2/jestUtils').setUpTests();
 ```
 `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`, setting framerate to 60fps.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "plugin": "cd plugin && yarn && cd ..",
     "app": "cd app && yarn && cd .."
   },
-  "main": "lib/commonjs/index",
+  "main": "lib/module/index",
   "module": "lib/module/index",
   "react-native": "src/index",
   "source": "src/index",
@@ -165,7 +165,6 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      "commonjs",
       "module",
       [
         "typescript",

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -11,3 +11,4 @@ export * from './layoutReanimation';
 export * from './utils';
 export * from './commonTypes';
 export * from './pluginUtils';
+export * from './jestUtils';

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -11,4 +11,3 @@ export * from './layoutReanimation';
 export * from './utils';
 export * from './commonTypes';
 export * from './pluginUtils';
-export * from './jestUtils';

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -182,19 +182,21 @@ export const advanceAnimationByFrame = (count) => {
 export const setUpTests = (userConfig = {}) => {
   let expect = global.expect;
   if (expect === undefined) {
-    const expectModule = import('expect');
-    expect = expectModule;
-    // Starting from Jest 28, "expect" package uses named exports instead of default export.
-    // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
-    // It gives access to the module object instead.
-    // We use this info to detect if the project uses Jest 28 or higher.
-    if (typeof expect === 'object') {
-      const jestGlobals = import('@jest/globals');
-      expect = jestGlobals.expect;
-    }
-    if (expect === undefined || expect.extend === undefined) {
-      expect = expectModule.default;
-    }
+    try {
+      const expectModule = import('expect');
+      expect = expectModule;
+      // Starting from Jest 28, "expect" package uses named exports instead of default export.
+      // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
+      // It gives access to the module object instead.
+      // We use this info to detect if the project uses Jest 28 or higher.
+      if (typeof expect === 'object') {
+        const jestGlobals = import('@jest/globals');
+        expect = jestGlobals.expect;
+      }
+      if (expect === undefined || expect.extend === undefined) {
+        expect = expectModule.default;
+      }
+    } catch (e) {}
   }
 
   frameTime = Math.round(1000 / config.fps);

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -182,14 +182,14 @@ export const advanceAnimationByFrame = (count) => {
 export const setUpTests = (userConfig = {}) => {
   let expect = global.expect;
   if (expect === undefined) {
-    const expectModule = require('expect');
+    const expectModule = import('expect');
     expect = expectModule;
     // Starting from Jest 28, "expect" package uses named exports instead of default export.
     // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
     // It gives access to the module object instead.
     // We use this info to detect if the project uses Jest 28 or higher.
     if (typeof expect === 'object') {
-      const jestGlobals = require('@jest/globals');
+      const jestGlobals = import('@jest/globals');
       expect = jestGlobals.expect;
     }
     if (expect === undefined || expect.extend === undefined) {

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -182,21 +182,19 @@ export const advanceAnimationByFrame = (count) => {
 export const setUpTests = (userConfig = {}) => {
   let expect = global.expect;
   if (expect === undefined) {
-    try {
-      const expectModule = import('expect');
-      expect = expectModule;
-      // Starting from Jest 28, "expect" package uses named exports instead of default export.
-      // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
-      // It gives access to the module object instead.
-      // We use this info to detect if the project uses Jest 28 or higher.
-      if (typeof expect === 'object') {
-        const jestGlobals = import('@jest/globals');
-        expect = jestGlobals.expect;
-      }
-      if (expect === undefined || expect.extend === undefined) {
-        expect = expectModule.default;
-      }
-    } catch (e) {}
+    const expectModule = require('expect');
+    expect = expectModule;
+    // Starting from Jest 28, "expect" package uses named exports instead of default export.
+    // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
+    // It gives access to the module object instead.
+    // We use this info to detect if the project uses Jest 28 or higher.
+    if (typeof expect === 'object') {
+      const jestGlobals = require('@jest/globals');
+      expect = jestGlobals.expect;
+    }
+    if (expect === undefined || expect.extend === undefined) {
+      expect = expectModule.default;
+    }
   }
 
   frameTime = Math.round(1000 / config.fps);

--- a/src/reanimated2/jestUtils.web.ts
+++ b/src/reanimated2/jestUtils.web.ts
@@ -1,0 +1,4 @@
+/*
+ * Stubbed for web, where we don't use this file;
+ */
+export default {};


### PR DESCRIPTION
## Prelude

We have waited for it a long time. 

Here it is.

A perfect summary of weeks time of our work and research - two line fix.

## Summary

Ever since we've adopted CommonJS as target for our built JavaScript files we made it very difficult to our users to properly use Jest with Reanimated. This is due to fact that Reanimated Babel plugin is prone to break hoisting and this becomes critical in CommonJS. This issue had never surfaced before because we were building only for ES modules which can handle the way our plugin works. Therefore, after many talks we've decided to drop support for CommonJS and revert to ES modules only.

Refer to #4449 for _slightly_ more information.

This is likely to fix (I want to wait for confirmation):
- #4347,
- #4197,
- #4185,
- #4175,
- #4136,
- #4001,
- #3971.

## Test plan

- I tested it on the [original repro](https://github.com/kylebake/ReanimatedTestBug) that began this voyage. I recommend using [my fork](https://github.com/tjzel/Reanimated-jest-commonjs-issue) since that repro had some errors coming from used versions of React-Native and Jest. 
__Make sure you use Node 18.15 for it.__
- I also tested it on my university [app](https://github.com/MeowdoptMe/MeowdoptMeApp) that actively uses Jest and Reanimated and using tarball from this PR fixed Jest issues.
