### PR TITLE
Rename `ref` & `aref` -> `animatedRef` in types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -301,7 +301,7 @@ declare module 'react-native-reanimated' {
   ): AnimatedKeyboardInfo;
 
   export function useScrollViewOffset(
-    aref: RefObject<Animated.ScrollView>
+    animatedRef: RefObject<Animated.ScrollView>
   ): SharedValue<number>;
 
   export interface ExitAnimationsValues {
@@ -463,7 +463,7 @@ declare module 'react-native-reanimated' {
     colorSpace?: 'RGB' | 'HSV',
     options?: InterpolationOptions
   ): T;
-  
+
   export type ParsedColorArray = [number, number, number, number];
   export function convertToRGBA(color: unknown): ParsedColorArray;
 
@@ -561,11 +561,11 @@ declare module 'react-native-reanimated' {
   export function useAnimatedRef<T extends Component>(): RefObject<T>;
   export function defineAnimation<T>(starting: any, factory: () => T): number;
   export function measure<T extends Component>(
-    ref: RefObject<T>
+    animatedRef: RefObject<T>
   ): MeasuredDimensions | null;
 
   export function getRelativeCoords(
-    ref: RefObject<Component>,
+    animatedRef: RefObject<Component>,
     x: number,
     y: number
   ): {
@@ -574,7 +574,7 @@ declare module 'react-native-reanimated' {
   };
 
   export function scrollTo(
-    ref: RefObject<ReactNativeScrollView | ScrollView>,
+    animatedRef: RefObject<ReactNativeScrollView | ScrollView>,
     x: number,
     y: number,
     animated: boolean


### PR DESCRIPTION
For better DX and consistency with the docs (current and the new ones) I've decided to rename the first argument of `useScrollViewOffset`, `measure`, `getRelativeCoords`, and `scrollTo` to `animatedRef`.

### Motivation

Just `ref` as an argument  indicates that a plain `const ref = React.useRef()` works with these functions leading to a confusing developer experience.

Also, `aref` is a bit cryptic and a hard thing to look up on the Internet when just starting to learn Reanimated.
