### PR TITLE
Fix createReactDOMStyle import

### DIFF
--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -1,20 +1,22 @@
 import JSReanimated from './JSReanimated';
 import { AnimatedStyle, StyleProps } from '../commonTypes';
-import { Platform } from 'react-native';
+import { isWeb } from '../PlatformChecker';
 
 let createReactDOMStyle: (style: any) => any;
-try {
-  // React Native Web
-  createReactDOMStyle =
-    require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
-} catch (e) {}
-
 let createTransformValue: (transform: any) => any;
-try {
-  // React Native Web 0.19+
-  createTransformValue =
-    require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
-} catch (e) {}
+
+if (isWeb()) {
+  try {
+    createReactDOMStyle =
+      require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
+  } catch (e) {}
+
+  try {
+    // React Native Web 0.19+
+    createTransformValue =
+      require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
+  } catch (e) {}
+}
 
 const reanimatedJS = new JSReanimated();
 
@@ -53,7 +55,6 @@ export const _updatePropsJS = (
       // and always provide setNativeProps function instead (even on React Native Web 0.19+).
       setNativeProps(component, rawStyles);
     } else if (
-      Platform.OS === 'web' &&
       createReactDOMStyle !== undefined &&
       component.style !== undefined
     ) {

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -1,6 +1,13 @@
 import JSReanimated from './JSReanimated';
 import { AnimatedStyle, StyleProps } from '../commonTypes';
-import createReactDOMStyle from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
+import { Platform } from 'react-native';
+
+let createReactDOMStyle: (style: any) => any;
+try {
+  // React Native Web
+  createReactDOMStyle =
+    require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
+} catch (e) {}
 
 let createTransformValue: (transform: any) => any;
 try {
@@ -45,7 +52,7 @@ export const _updatePropsJS = (
       // Also, some components (e.g. from react-native-svg) don't have styles
       // and always provide setNativeProps function instead (even on React Native Web 0.19+).
       setNativeProps(component, rawStyles);
-    } else if (component.style !== undefined) {
+    } else if (Platform.OS === 'web' && component.style !== undefined) {
       // React Native Web 0.19+ no longer provides setNativeProps function,
       // so we need to update DOM nodes directly.
       updatePropsDOM(component, rawStyles);

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -52,7 +52,11 @@ export const _updatePropsJS = (
       // Also, some components (e.g. from react-native-svg) don't have styles
       // and always provide setNativeProps function instead (even on React Native Web 0.19+).
       setNativeProps(component, rawStyles);
-    } else if (Platform.OS === 'web' && component.style !== undefined) {
+    } else if (
+      Platform.OS === 'web' &&
+      createReactDOMStyle !== undefined &&
+      component.style !== undefined
+    ) {
       // React Native Web 0.19+ no longer provides setNativeProps function,
       // so we need to update DOM nodes directly.
       updatePropsDOM(component, rawStyles);


### PR DESCRIPTION
## Summary

Smol fix after #4352 because `react-native-web` may not be installed.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
