### PR TITLE
Optimize `useAnimatedReaction` even more

### DIFF
--- a/src/reanimated2/hook/useAnimatedReaction.ts
+++ b/src/reanimated2/hook/useAnimatedReaction.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { BasicWorkletFunction, WorkletFunction } from '../commonTypes';
 import { startMapper, stopMapper } from '../core';
 import { DependencyList } from './commonTypes';
@@ -18,8 +18,6 @@ export function useAnimatedReaction<T>(
   react: AnimatedReactionWorkletFunction<T>,
   dependencies: DependencyList
 ): void {
-  const previous = useRef({ value: null as T | null }).current;
-
   let inputs = Object.values(prepare._closure ?? {});
 
   if (shouldBeUseWeb()) {
@@ -41,6 +39,7 @@ export function useAnimatedReaction<T>(
   }
 
   useEffect(() => {
+    const previous = { value: null as T | null };
     const fun = () => {
       'worklet';
       const input = prepare();


### PR DESCRIPTION
## Summary

This PR aims to optimize `useAnimatedReaction` even more because why not.

In the essence, we only pass `previous` to worklet closure and when we do so, we freeze the object, so it's always `{ value: true }`, thus there's no need to store it using `useRef`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
