### PR TITLE
Fix Jest bundling error

### DIFF
--- a/src/reanimated2/jestUtils.native.ts
+++ b/src/reanimated2/jestUtils.native.ts
@@ -1,0 +1,4 @@
+/*
+ * Stubbed for native, where we don't use this file;
+ */
+export default {};

--- a/src/reanimated2/jestUtils.native.ts
+++ b/src/reanimated2/jestUtils.native.ts
@@ -1,4 +1,0 @@
-/*
- * Stubbed for native, where we don't use this file;
- */
-export default {};

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
-import { isJest } from "./PlatformChecker";
+import { isJest } from './PlatformChecker';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -182,7 +182,13 @@ export const advanceAnimationByFrame = (count) => {
   jest.runOnlyPendingTimers();
 };
 
-const requireFunction = isJest() ? require : () => {};
+const requireFunction = isJest()
+  ? require
+  : () => {
+      throw new Error(
+        '[Reanimated] setUpTests() is available only in Jest environment'
+      );
+    };
 
 export const setUpTests = (userConfig = {}) => {
   let expect = global.expect;

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+
+import { isJest } from "./PlatformChecker";
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
@@ -179,17 +182,19 @@ export const advanceAnimationByFrame = (count) => {
   jest.runOnlyPendingTimers();
 };
 
+const requireFunction = isJest() ? require : () => {};
+
 export const setUpTests = (userConfig = {}) => {
   let expect = global.expect;
   if (expect === undefined) {
-    const expectModule = require('expect');
+    const expectModule = requireFunction('expect');
     expect = expectModule;
     // Starting from Jest 28, "expect" package uses named exports instead of default export.
     // So, requiring "expect" package doesn't give direct access to "expect" function anymore.
     // It gives access to the module object instead.
     // We use this info to detect if the project uses Jest 28 or higher.
     if (typeof expect === 'object') {
-      const jestGlobals = require('@jest/globals');
+      const jestGlobals = requireFunction('@jest/globals');
       expect = jestGlobals.expect;
     }
     if (expect === undefined || expect.extend === undefined) {


### PR DESCRIPTION
## Summary

This PR fixes bundling error which appeared after #4468.

```
error: Error: Unable to resolve module path from /Users/tomekzaw/RNOS/Jest/react-native-reanimated/node_modules/jest-message-util/build/index.js: path could not be found within the project or in these directories:
  ../node_modules
```

```
../node_modules/jest-util/build/requireOrImportModule.js:Invalid call at line 55: import(moduleUrl.href)
```

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
