### PR TITLE
Update imports for react-native-reanimated.d.ts

### DIFF
--- a/app/src/examples/OldMeasureExample.tsx
+++ b/app/src/examples/OldMeasureExample.tsx
@@ -167,7 +167,9 @@ function SectionHeader({
   contentHeight,
   show,
 }: SectionHeaderProps) {
-  const applyMeasure = ({ height }: ReturnType<typeof measure>) => {
+  const applyMeasure = ({
+    height,
+  }: NonNullable<ReturnType<typeof measure>>) => {
     'worklet';
     if (contentHeight.value === 0) {
       contentHeight.value = withTiming(height, {
@@ -195,7 +197,10 @@ function SectionHeader({
   } else {
     onActiveImpl = () => {
       'worklet';
-      applyMeasure(measure(animatedRef));
+      const measuredMeasure = measure(animatedRef);
+      if (measuredMeasure !== null) {
+        applyMeasure(measuredMeasure);
+      }
     };
   }
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -23,7 +23,3 @@ declare module 'react' {
     ): void;
   }
 }
-
-declare global {
-  const _WORKLET: boolean;
-}

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -35,26 +35,26 @@ declare module 'react-native-reanimated' {
     PanGestureHandlerGestureEvent,
   } from 'react-native-gesture-handler';
 
-  import('./lib/reanimated2/globals');
+  import('./src/reanimated2/globals');
 
   export type TimingAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').TimingAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').TimingAnimation;
   export type SpringAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').SpringAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').SpringAnimation;
   export type DecayAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').DecayAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').DecayAnimation;
   export type DelayAnimation =
-    import('./lib/types/lib/reanimated2/animation/commonTypes').DelayAnimation;
+    import('./lib/typescript/src/reanimated2/animation/commonTypes').DelayAnimation;
   export type RepeatAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').RepeatAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').RepeatAnimation;
   export type SequenceAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').SequenceAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').SequenceAnimation;
   export type StyleLayoutAnimation =
-    import('./lib/types/lib/reanimated2/animation/index').StyleLayoutAnimation;
+    import('./lib/typescript/src/reanimated2/animation/index').StyleLayoutAnimation;
   export type Animation<T> =
-    import('./lib/types/lib/reanimated2/commonTypes').Animation<T>;
+    import('./lib/typescript/src/reanimated2/commonTypes').Animation<T>;
   export type MeasuredDimensions =
-    import('./lib/types/lib/reanimated2/commonTypes').MeasuredDimensions;
+    import('./lib/typescript/src/reanimated2/commonTypes').MeasuredDimensions;
 
   namespace Animated {
     type Value = string | number | boolean;

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -148,7 +148,7 @@ declare module 'react-native-reanimated' {
       getNode(): ReactNativeFlatList;
     }
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    export interface FlatList<T> extends ReactNativeView<T> {}
+    export interface FlatList<T> extends ReactNativeFlatList<T> {}
 
     type Options<P> = {
       setNativeProps: (ref: any, props: P) => void;


### PR DESCRIPTION
## Summary

In order to get rid of manually written .d.ts file I'm going to try and minimize it first. While trying to do that I found that imports for it are long outdated and resolved to `any`. This PR fixes them and also fixes a small issue stemming from this update in Example app.

## Test plan

😵 
```yarn tsc --noEmit --target es6 --module ESNext --jsx react-native --skipLibCheck true --allowSyntheticDefaultImports true --moduleResolution node --esModuleInterop true --strict true --forceConsistentCasingInFileNames true --resolveJsonModule true app/src/App.tsx```
