### PR TITLE
Fix lib directory structure generated by builder-bob

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,12 +166,7 @@
     "output": "lib",
     "targets": [
       "module",
-      [
-        "typescript",
-        {
-          "project": "tsconfig.json"
-        }
-      ]
+      "typescript"
     ]
   },
   "sideEffects": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,13 +15,5 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "exclude": [
-    "app",
-    "docs",
-    "Example",
-    "FabricExample",
-    "plugin",
-    "TVOSExample",
-    "WebExample"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently our `tsconfig.json` and config for react-native-builder-bob in `package.json` are misconfigured and we are getting type declarations for tests and typetests. PR removes them and restores proper structure.

| Before | After |
|--------|--------|
|  <img width="331" alt="Screenshot 2023-05-25 at 08 14 06" src="https://github.com/software-mansion/react-native-reanimated/assets/40713406/31706cda-e844-41f5-87fe-b97d08aec742"> | <img width="321" alt="Screenshot 2023-05-25 at 08 15 17" src="https://github.com/software-mansion/react-native-reanimated/assets/40713406/00782729-84c1-4eea-ae52-0a7b33c66e72"> |

`tsconfig.json` doesn't need to be specified in builder-bob configuration as it [takes root tsconfig by default](https://github.com/callstack/react-native-builder-bob#typescript).


## Test plan

Unit tests should suffice.
