### PR TITLE
fix: ios build error when using 'use_frameworks!' in Podfile

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -15,7 +15,7 @@ boost_compiler_flags = '-Wno-documentation'
 fabric_flags = fabric_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
 example_flag = config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 version_flag = '-DREANIMATED_VERSION=' + reanimated_package_json["version"]
-using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 Pod::Spec.new do |s|
   

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -15,6 +15,7 @@ boost_compiler_flags = '-Wno-documentation'
 fabric_flags = fabric_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
 example_flag = config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 version_flag = '-DREANIMATED_VERSION=' + reanimated_package_json["version"]
+using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 
 Pod::Spec.new do |s|
   
@@ -90,6 +91,10 @@ Pod::Spec.new do |s|
   s.dependency 'Yoga'
   s.dependency 'DoubleConversion'
   s.dependency 'glog'
+  if using_hermes
+    s.dependency 'React-hermes'
+    s.dependency 'hermes-engine'
+  end
 
   if config[:react_native_minor_version] == 62
     s.dependency 'ReactCommon/callinvoker'

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
   s.dependency 'Yoga'
   s.dependency 'DoubleConversion'
   s.dependency 'glog'
-  if using_hermes
+  if !config[:is_tvos_target] && using_hermes
     s.dependency 'React-hermes'
     s.dependency 'hermes-engine'
   end

--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
   s.dependency 'Yoga'
   s.dependency 'DoubleConversion'
   s.dependency 'glog'
-  if !config[:is_tvos_target] && using_hermes
+  if using_hermes && !config[:is_tvos_target]
     s.dependency 'React-hermes'
     s.dependency 'hermes-engine'
   end


### PR DESCRIPTION
when open 'use_frameworks!' in Podfile, build will fail because of unable to find hermes related headers. We need to declare hermes dependency explicit in podspec

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
