### PR TITLE
Fix spring bug with extra type verification

### DIFF
--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -84,26 +84,25 @@ export function withSpring(
               t,
             });
 
-      if (!config.useDuration) {
-        const { isOvershooting, isVelocity, isDisplacement } =
-          isAnimationTerminatingCalculation(animation, config);
+      animation.current = newPosition;
+      animation.velocity = newVelocity;
 
-        animation.current = newPosition;
-        animation.velocity = newVelocity;
+      const { isOvershooting, isVelocity, isDisplacement } =
+        isAnimationTerminatingCalculation(animation, config);
 
-        const springIsNotInMove =
-          isOvershooting || (isVelocity && isDisplacement);
+      const springIsNotInMove =
+        isOvershooting || (isVelocity && isDisplacement);
 
-        if (springIsNotInMove) {
-          if (config.stiffness !== 0) {
-            animation.velocity = 0;
-            animation.current = toValue;
-          }
-          // clear lastTimestamp to avoid using stale value by the next spring animation that starts after this one
-          animation.lastTimestamp = 0;
-          return true;
+      if (!config.useDuration && springIsNotInMove) {
+        if (config.stiffness !== 0) {
+          animation.velocity = 0;
+          animation.current = toValue;
         }
+        // clear lastTimestamp to avoid using stale value by the next spring animation that starts after this one
+        animation.lastTimestamp = 0;
+        return true;
       }
+
       return false;
     }
 
@@ -138,11 +137,12 @@ export function withSpring(
           (previousAnimation?.startValue as number)
         : Number(animation.toValue) - value;
 
-      animation.velocity = previousAnimation
-        ? triggeredTwice
-          ? previousAnimation.velocity
-          : previousAnimation.velocity + config.velocity
-        : config.velocity;
+      animation.velocity =
+        (previousAnimation
+          ? triggeredTwice
+            ? previousAnimation?.velocity
+            : previousAnimation.velocity + config.velocity
+          : config.velocity) || 0;
 
       if (triggeredTwice) {
         animation.zeta = previousAnimation?.zeta || 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
There is a need to check if velocity from previous animation is undefined.
(Hopefully such a bugs will be soon reported by typescript 😊)

<table>
<tr><td>BEFORE</td><td>AFTER</td></tr>
<tr><td>

https://github.com/software-mansion/react-native-reanimated/assets/56199675/638f0fea-9671-42e6-9d05-2e6717cf3645

</td><td>

https://github.com/software-mansion/react-native-reanimated/assets/56199675/82d656f3-c342-4e8b-9d31-a4bbf4df12a8


</td></tr>
</table>
## Test plan
Tested on added to our bouncing box animation sequence from this issue https://github.com/software-mansion/react-native-reanimated/issues/4510:

```diff

    .onFinalize(() => {
+      offset.value = withSequence(
+        withTiming(20, { duration: 75 }),
+        withTiming(-20, { duration: 75 }),
+        withTiming(20, { duration: 75 }),
+        withSpring(0, { damping: 50, stiffness: 500, mass: 2.8 })
+      );
    });
```


<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
