### PR TITLE
Fixed minor Android measure function small performance issue

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -258,18 +258,15 @@ std::vector<std::pair<std::string, double>> NativeProxy::measure(int viewTag) {
   local_ref<JArrayFloat> output = method(javaPart_.get(), viewTag);
   size_t size = output->size();
   auto elements = output->getRegion(0, size);
-  std::vector<std::pair<std::string, double>> result;
 
-  result.push_back({"x", elements[0]});
-  result.push_back({"y", elements[1]});
-
-  result.push_back({"pageX", elements[2]});
-  result.push_back({"pageY", elements[3]});
-
-  result.push_back({"width", elements[4]});
-  result.push_back({"height", elements[5]});
-
-  return result;
+  return {
+      {"x", elements[0]},
+      {"y", elements[1]},
+      {"pageX", elements[2]},
+      {"pageY", elements[3]},
+      {"width", elements[4]},
+      {"height", elements[5]},
+  };
 }
 #endif // RCT_NEW_ARCH_ENABLED
 

--- a/ios/native/NativeMethods.mm
+++ b/ios/native/NativeMethods.mm
@@ -25,16 +25,14 @@ std::vector<std::pair<std::string, double>> measure(int viewTag, RCTUIManager *u
   CGRect frame = view.frame;
   CGRect globalBounds = [view convertRect:view.bounds toView:rootView];
 
-  std::vector<std::pair<std::string, double>> result;
-  result.push_back({"x", frame.origin.x});
-  result.push_back({"y", frame.origin.y});
-
-  result.push_back({"width", globalBounds.size.width});
-  result.push_back({"height", globalBounds.size.height});
-
-  result.push_back({"pageX", globalBounds.origin.x});
-  result.push_back({"pageY", globalBounds.origin.y});
-  return result;
+  return {
+      {"x", frame.origin.x},
+      {"y", frame.origin.y},
+      {"width", globalBounds.size.width},
+      {"height", globalBounds.size.height},
+      {"pageX", globalBounds.origin.x},
+      {"pageY", globalBounds.origin.y},
+  };
 }
 
 void scrollTo(int scrollViewTag, RCTUIManager *uiManager, double x, double y, bool animated)


### PR DESCRIPTION
## Summary

I've noticed that there are some unnecessary reallocations during returning result from Android's measure function. Without any memory reservation, push_back may cause several reallocations and copy of the data.

## Test plan

None
