### PR TITLE
Memoize ReanimatedModule in `sendEvent`

### DIFF
--- a/ios/RCTEventDispatcher+Reanimated.h
+++ b/ios/RCTEventDispatcher+Reanimated.h
@@ -1,3 +1,5 @@
+#ifndef RCT_NEW_ARCH_ENABLED
+
 #import <Foundation/Foundation.h>
 #import <React/RCTEventDispatcher.h>
 
@@ -10,3 +12,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RCTEventDispatcher+Reanimated.h
+++ b/ios/RCTEventDispatcher+Reanimated.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTEventDispatcher (Reanimated)
 
-- (void)reanimated_sentEvent:(id<RCTEvent>)event;
+- (void)reanimated_sendEvent:(id<RCTEvent>)event;
 
 @end
 

--- a/ios/RCTEventDispatcher+Reanimated.m
+++ b/ios/RCTEventDispatcher+Reanimated.m
@@ -1,4 +1,7 @@
+#ifndef RCT_NEW_ARCH_ENABLED
+
 #import <RNReanimated/RCTEventDispatcher+Reanimated.h>
+#import <RNReanimated/REAModule.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTEventDispatcher.h>
 #import <objc/message.h>
@@ -7,8 +10,11 @@
 
 - (void)reanimated_sendEvent:(id<RCTEvent>)event
 {
-  // Pass the event to Reanimated
-  [[[self bridge] moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
+  static __weak REAModule *reaModule;
+  if (reaModule == nil) {
+    reaModule = [[self bridge] moduleForName:@"ReanimatedModule"];
+  }
+  [reaModule eventDispatcherWillDispatchEvent:event];
 
   // Pass the event to React Native by calling the original method
   [self reanimated_sendEvent:event];
@@ -26,3 +32,5 @@
 }
 
 @end
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RCTEventDispatcher+Reanimated.m
+++ b/ios/RCTEventDispatcher+Reanimated.m
@@ -5,13 +5,13 @@
 
 @implementation RCTEventDispatcher (Reanimated)
 
-- (void)reanimated_sentEvent:(id<RCTEvent>)event
+- (void)reanimated_sendEvent:(id<RCTEvent>)event
 {
   // Pass the event to Reanimated
   [[[self bridge] moduleForName:@"ReanimatedModule"] eventDispatcherWillDispatchEvent:event];
 
   // Pass the event to React Native by calling the original method
-  [self reanimated_sentEvent:event];
+  [self reanimated_sendEvent:event];
 }
 
 + (void)load
@@ -20,7 +20,7 @@
   dispatch_once(&onceToken, ^{
     Class class = [self class];
     Method originalMethod = class_getInstanceMethod(class, @selector(sendEvent:));
-    Method swizzledMethod = class_getInstanceMethod(class, @selector(reanimated_sentEvent:));
+    Method swizzledMethod = class_getInstanceMethod(class, @selector(reanimated_sendEvent:));
     method_exchangeImplementations(originalMethod, swizzledMethod);
   });
 }

--- a/ios/RCTEventDispatcher+Reanimated.m
+++ b/ios/RCTEventDispatcher+Reanimated.m
@@ -10,6 +10,7 @@
 
 - (void)reanimated_sendEvent:(id<RCTEvent>)event
 {
+  // Pass the event to Reanimated
   static __weak REAModule *reaModule;
   if (reaModule == nil) {
     reaModule = [[self bridge] moduleForName:@"ReanimatedModule"];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds `static __weak REAModule *reaModule;` variable which stores the result of `[[self bridge] moduleForName:@"ReanimatedModule"]` so we can call it only once during initialization instead of on each event.

When `REAModule` is deallocated, all `__weak` pointers are automatically replaced with `nil` so it doesn't leak any resources as well as works fine after a reload.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
