### PR TITLE
Remove warning when calling `measure` from RN runtime

### DIFF
--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -39,14 +39,6 @@ if (isWeb()) {
   measure = (animatedRef: RefObjectFunction<Component>) => {
     'worklet';
     if (!_WORKLET) {
-      console.warn(
-        '[Reanimated] measure() was called from the main JS context. Measure is ' +
-          'only available in the UI runtime. This may also happen if measure() ' +
-          'was called by a worklet in the useAnimatedStyle hook, because useAnimatedStyle ' +
-          'calls the given worklet on the JS runtime during render. If you want to ' +
-          'prevent this warning then wrap the call with `if (_WORKLET)`. Then it will ' +
-          'only be called on the UI runtime after the render has been completed.'
-      );
       return null;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR removes a warning that would trigger when `measure` function was called from the main RN runtime. 

The main motivation behind adding this `console.warn` was to force the developer to explicitly cover the case when `measure` is called from the RN runtime using `if (_WORKLET) { ... }` guard, which, let's be honest, is quite uncomfortable. On the other hand, when measurement cannot be made, e.g. when called from the UI runtime but when the view is not mounted yet, `measure` returns `null`. It makes sense to merge these two cases since they can be handled identically.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
