### PR TITLE
Fix testing example

### DIFF
--- a/docs/docs/guide/testing.md
+++ b/docs/docs/guide/testing.md
@@ -93,7 +93,7 @@ test('stop in the middle of animation', () => {
   expect(view).toHaveAnimatedStyle(style);
 
   fireEvent.press(button);
-  jest.advanceAnimationByTime(250); // if whole animation duration is a 500ms
+  jest.advanceTimersByTime(250); // if whole animation duration is a 500ms
   style.width = 50; // value of component width after 250ms of animation
   expect(view).toHaveAnimatedStyle(style);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
This testing example was using `jest.advanceAnimationByTime`. As far as I understand this method doesn't exist on `jest`. `advanceAnimationByTime` was a API exported by the reanimated lib and [it was deprecated](https://github.com/software-mansion/react-native-reanimated/blob/2426f32095af417f1cfc1789479c3d2ee7c72e18/src/reanimated2/jestUtils.ts#L171). 

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

N/A