### PR TITLE
fix: updates types to support RN 0.71.9

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -68,6 +68,7 @@ declare module 'react-native-reanimated' {
 
     export type TransformStyleTypes = TransformsStyle['transform'] extends
       | readonly (infer T)[]
+      | string
       | undefined
       ? T
       : never;
@@ -78,7 +79,7 @@ declare module 'react-native-reanimated' {
 
     export type AnimateStyle<S> = {
       [K in keyof S]: K extends 'transform'
-        ? AnimatedTransform
+        ? AnimatedTransform | string
         : S[K] extends ReadonlyArray<any>
         ? ReadonlyArray<AnimateStyle<S[K][0]>>
         : S[K] extends object


### PR DESCRIPTION
This commit https://github.com/facebook/react-native/commit/2558c3d4f56776699602b116aff8c22b8bfa176a added string to `transform` type and it broke Reanimated types.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

fixes [#45](https://github.com/software-mansion/react-native-reanimated/issues/4548)
