### PR TITLE
Fix RCTAppDelegate.h file not found error when `USE_FRAMEWORKS=static`

### DIFF
--- a/ios/native/RCTAppDelegate+Reanimated.h
+++ b/ios/native/RCTAppDelegate+Reanimated.h
@@ -1,8 +1,20 @@
 #if REACT_NATIVE_MINOR_VERSION >= 72 && !defined(RCT_NEW_ARCH_ENABLED) && !defined(DONT_AUTOINSTALL_REANIMATED)
 
 #import <Foundation/Foundation.h>
+
+#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 #import <React-RCTAppDelegate/RCTAppDelegate.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
+// for importing the header from framework, the dash will be transformed to underscore
+#import <React_RCTAppDelegate/RCTAppDelegate.h>
+#endif
+
+#if __has_include(<React-cxxreact/cxxreact/JSExecutor.h>)
 #import <React-cxxreact/cxxreact/JSExecutor.h>
+#elif __has_include(<cxxreact/JSExecutor.h>)
+// for importing the header from framework, "React-cxxreact" will be omitted
+#import <cxxreact/JSExecutor.h>
+#endif
 
 @interface RCTAppDelegate (Reanimated)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #4553. Copied from expo/expo ([link](https://github.com/expo/expo/blob/acf89113e6ecff4841553991e743157cd8e49db1/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h#L8-L13)), originally fixed by @Kudo, thanks to @tsapeta for code pointers.

## Test plan

```
npx react-native@next init MyApp --version 0.72.0-rc.5 --skip-install
cd MyApp
yarn add react-native-reanimated@nightly
cd ios
code Podfile
# :flipper_configuration => FlipperConfiguration.disabled
USE_FRAMEWORKS=static pod install
```

