### PR TITLE
Fix animations not running when Chrome Debugger is attached

### DIFF
--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -1,6 +1,6 @@
 import { reportFatalErrorOnJS } from './errors';
 import NativeReanimatedModule from './NativeReanimated';
-import { isChromeDebugger, isJest } from './PlatformChecker';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from './PlatformChecker';
 import {
   runOnJS,
   setupMicrotasks,
@@ -141,6 +141,7 @@ export function initializeUIRuntime() {
 
   const IS_JEST = isJest();
   const IS_CHROME_DEBUGGER = isChromeDebugger();
+  const IS_NATIVE = !shouldBeUseWeb();
 
   if (IS_JEST) {
     // requestAnimationFrame react-native jest's setup is incorrect as it polyfills
@@ -182,7 +183,7 @@ export function initializeUIRuntime() {
       };
     }
 
-    if (!IS_JEST) {
+    if (IS_NATIVE) {
       setupMicrotasks();
       setupRequestAnimationFrame();
     }


### PR DESCRIPTION
## Summary

This PR fixes a bug in v3 which prevents animations from running when Chrome Debugger is attached (or, in general, when web implementation of Reanimated is used). Originally reported by @coayscue.

## Test plan

In order to reproduce the issue, you can simply force use web implementation in `PlatformChecker.ts`:

```diff
 export function isChromeDebugger(): boolean {
-  return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
+  return true;
 }
```

When testing gesture-based examples, you will also need to make this change in `gesture.ts`:

```diff
 export function isRemoteDebuggingEnabled(): boolean {
   // react-native-reanimated checks if in remote debugging in the same way
   // @ts-ignore global is available but node types are not included
-  return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
+  return true;
 }
```
