### PR TITLE
Fix runOnJS on Web and make it asynchronous

### DIFF
--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -2,18 +2,22 @@ import JSReanimated from './JSReanimated';
 import { AnimatedStyle, StyleProps } from '../commonTypes';
 import { isWeb } from '../PlatformChecker';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let createReactDOMStyle: (style: any) => any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let createTransformValue: (transform: any) => any;
 
 if (isWeb()) {
   try {
     createReactDOMStyle =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
   } catch (e) {}
 
   try {
     // React Native Web 0.19+
     createTransformValue =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
   } catch (e) {}
 }
@@ -21,7 +25,9 @@ if (isWeb()) {
 const reanimatedJS = new JSReanimated();
 
 global._makeShareableClone = (c) => c;
-global._scheduleOnJS = queueMicrotask;
+global._scheduleOnJS = (func, args) => {
+  queueMicrotask(() => func(...args));
+};
 
 interface JSReanimatedComponent {
   previousStyle: StyleProps;

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -26,7 +26,11 @@ const reanimatedJS = new JSReanimated();
 
 global._makeShareableClone = (c) => c;
 global._scheduleOnJS = (func, args) => {
-  queueMicrotask(() => func(...args));
+  if (args) {
+    queueMicrotask(() => func(...args));
+  } else {
+    queueMicrotask(func);
+  }
 };
 
 interface JSReanimatedComponent {

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -164,13 +164,10 @@ export function runOnJS<A extends any[], R>(
     // reference to the original remote function in the `__remoteFunction` property.
     fun = fun.__remoteFunction;
   }
-  if (!_WORKLET) {
-    return fun;
-  }
   return (...args) => {
     _scheduleOnJS(
       fun,
-      args.length > 0 ? makeShareableCloneOnUIRecursive(args) : undefined
+      args.length > 0 ? makeShareableCloneOnUIRecursive(args) : []
     );
   };
 }

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -167,7 +167,7 @@ export function runOnJS<A extends any[], R>(
   return (...args) => {
     _scheduleOnJS(
       fun,
-      args.length > 0 ? makeShareableCloneOnUIRecursive(args) : []
+      args.length > 0 ? makeShareableCloneOnUIRecursive(args) : undefined
     );
   };
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR is amending some changes from #4276 where we exchanged `setImmediates` for `queueMicrotask` for `_scheduneOnJS`.

`queueMicrotask` does not take any arguments, only a callback and the change of behaviour stemming from this was not considered in `runOnJS` implementation. This PR fixes this and also makes `runOnJS` actually call `_scheduleOnJS` on web, making it asynchronous and consistent with general behavior of `runOnJS` - before it was unreachable code on web since it would simply return the provided function that was called synchronously.

## Test plan

Run WebExample and see that now `runOnJS` is working properly. I used the following snippet:

```TypeScript
function foo() {
    console.log('hello');
  }

  function foz(str: string) {
    console.log(str);
  }

  runOnJS(foo)();
  runOnJS(foz)('bye');

  function bar() {
    console.log('hello again');
  }

  function baz(str: string) {
    console.log(str);
  }

  runOnUI(() => {
    runOnJS(bar)();
    runOnJS(baz)('bye again');
  })();
```

Before:

<img width="738" alt="Screenshot 2023-06-14 at 13 45 59" src="https://github.com/software-mansion/react-native-reanimated/assets/40713406/e57210fb-078f-4c58-badc-9476683695b6">

After:
<img width="735" alt="Screenshot 2023-06-14 at 13 45 11" src="https://github.com/software-mansion/react-native-reanimated/assets/40713406/23eb27df-f2db-4e18-ad68-bcae37282e0c">


