### PR TITLE
Fix ChoreographerCallback double execution

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -81,7 +81,7 @@ public class NodesManager implements EventDispatcherListener {
   private RCTEventEmitter mCustomEventHandler;
   private List<OnAnimationFrame> mFrameCallbacks = new ArrayList<>();
   private ConcurrentLinkedQueue<CopiedEvent> mEventQueue = new ConcurrentLinkedQueue<>();
-  public double currentFrameTimeMs;
+  private double lastFrameTimeMs;
   public Set<String> uiProps = Collections.emptySet();
   public Set<String> nativeProps = Collections.emptySet();
   private ReaCompatibility compatibility;
@@ -234,25 +234,29 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   private void onAnimationFrame(long frameTimeNanos) {
-    currentFrameTimeMs = frameTimeNanos / 1000000.;
+    double currentFrameTimeMs = frameTimeNanos / 1000000.;
 
-    while (!mEventQueue.isEmpty()) {
-      CopiedEvent copiedEvent = mEventQueue.poll();
-      handleEvent(copiedEvent.getTargetTag(), copiedEvent.getEventName(), copiedEvent.getPayload());
-    }
+    if (currentFrameTimeMs != lastFrameTimeMs) {
+      lastFrameTimeMs = currentFrameTimeMs;
 
-    if (!mFrameCallbacks.isEmpty()) {
-      List<OnAnimationFrame> frameCallbacks = mFrameCallbacks;
-      mFrameCallbacks = new ArrayList<>(frameCallbacks.size());
-      for (int i = 0, size = frameCallbacks.size(); i < size; i++) {
-        frameCallbacks.get(i).onAnimationFrame(currentFrameTimeMs);
+      while (!mEventQueue.isEmpty()) {
+        CopiedEvent copiedEvent = mEventQueue.poll();
+        handleEvent(
+            copiedEvent.getTargetTag(), copiedEvent.getEventName(), copiedEvent.getPayload());
       }
-    }
 
-    performOperations();
+      if (!mFrameCallbacks.isEmpty()) {
+        List<OnAnimationFrame> frameCallbacks = mFrameCallbacks;
+        mFrameCallbacks = new ArrayList<>(frameCallbacks.size());
+        for (int i = 0, size = frameCallbacks.size(); i < size; i++) {
+          frameCallbacks.get(i).onAnimationFrame(currentFrameTimeMs);
+        }
+      }
+
+      performOperations();
+    }
 
     mCallbackPosted.set(false);
-
     if (!mFrameCallbacks.isEmpty() || !mEventQueue.isEmpty()) {
       // enqueue next frame
       startUpdatingOnAnimationFrame();

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -236,7 +236,9 @@ public class NodesManager implements EventDispatcherListener {
   private void onAnimationFrame(long frameTimeNanos) {
     double currentFrameTimeMs = frameTimeNanos / 1000000.;
 
-    if (currentFrameTimeMs != lastFrameTimeMs) {
+    if (currentFrameTimeMs > lastFrameTimeMs) {
+      // It is possible for ChoreographerCallback to be executed twice within the same frame
+      // due to frame drops. If this occurs, the additional callback execution should be ignored.
       lastFrameTimeMs = currentFrameTimeMs;
 
       while (!mEventQueue.isEmpty()) {

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -98,9 +98,7 @@ function setupRequestAnimationFrame() {
   // Jest mocks requestAnimationFrame API and it does not like if that mock gets overridden
   // so we avoid doing requestAnimationFrame batching in Jest environment.
   const nativeRequestAnimationFrame = global.requestAnimationFrame;
-
   let animationFrameCallbacks: Array<(timestamp: number) => void> = [];
-  let lastNativeAnimationFrameTimestamp = -1;
 
   global.__flushAnimationFrame = (frameTimestamp: number) => {
     const currentCallbacks = animationFrameCallbacks;
@@ -118,11 +116,6 @@ function setupRequestAnimationFrame() {
       // is added and then use it to execute all the enqueued callbacks. Once
       // the callbacks are run, we clear the array.
       nativeRequestAnimationFrame((timestamp) => {
-        if (lastNativeAnimationFrameTimestamp >= timestamp) {
-          // Make sure we only execute the callbacks once for a given frame
-          return;
-        }
-        lastNativeAnimationFrameTimestamp = timestamp;
         global.__frameTimestamp = timestamp;
         global.__flushAnimationFrame(timestamp);
         global.__frameTimestamp = undefined;

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -98,7 +98,9 @@ function setupRequestAnimationFrame() {
   // Jest mocks requestAnimationFrame API and it does not like if that mock gets overridden
   // so we avoid doing requestAnimationFrame batching in Jest environment.
   const nativeRequestAnimationFrame = global.requestAnimationFrame;
+
   let animationFrameCallbacks: Array<(timestamp: number) => void> = [];
+  let lastNativeAnimationFrameTimestamp = -1;
 
   global.__flushAnimationFrame = (frameTimestamp: number) => {
     const currentCallbacks = animationFrameCallbacks;
@@ -116,6 +118,11 @@ function setupRequestAnimationFrame() {
       // is added and then use it to execute all the enqueued callbacks. Once
       // the callbacks are run, we clear the array.
       nativeRequestAnimationFrame((timestamp) => {
+        if (lastNativeAnimationFrameTimestamp >= timestamp) {
+          // Make sure we only execute the callbacks once for a given frame
+          return;
+        }
+        lastNativeAnimationFrameTimestamp = timestamp;
         global.__frameTimestamp = timestamp;
         global.__flushAnimationFrame(timestamp);
         global.__frameTimestamp = undefined;


### PR DESCRIPTION
## Summary

This PR fixes an issue with long animations. On Android, it was possible to execute ChoreographerCallback twice during the same frame (after frame drop). In effect, existing animations were canceled due to this if-condition in `requestAnimationFrame` method:
```js
nativeRequestAnimationFrame((timestamp) => {
  if (lastNativeAnimationFrameTimestamp >= timestamp) {
    // Make sure we only execute the callbacks once for a given frame
    return;
  }
...
```
To fix it, I moved this check to the native code. When double execution happens I skip the execution of the JS callback, but I still need to schedule another choreographer callback.

## How to test it?
```java
final long[] lastTimestamp = {0};
new GuardedFrameCallback(context) {
  @Override
  protected void doFrameGuarded(long frameTimeNanos) {
    if (lastTimestamp[0] == frameTimeNanos) {
      Log.w("test");
    }
    onAnimationFrame(frameTimeNanos);
    lastTimestamp[0] = frameTimeNanos;
  }
}
```
### Before
- Open SVGExample
- Set a breakpoint in Android Studio at line `Log.w("test");`
- Wait some time until the breakpoint hit
- Pass breakpoint
- Animation will **stop** ❌

### After
- Open SVGExample
- Set a breakpoint in Android Studio at line `Log.w("test");`
- Wait some time until the breakpoint hit
- Pass breakpoint
- Animation will **keep going**  ✅ 