### PR TITLE
Set default scrollEventThrottle

### DIFF
--- a/app/src/examples/ArticleProgressExample.tsx
+++ b/app/src/examples/ArticleProgressExample.tsx
@@ -47,10 +47,7 @@ export default function ArticleProgressExample() {
   return (
     <SafeAreaView>
       <Animated.View style={[styles.progressBar, progressBarAnimatedStyle]} />
-      <Animated.ScrollView
-        ref={scrollViewRef}
-        scrollEventThrottle={16}
-        style={styles.articleScrollView}>
+      <Animated.ScrollView ref={scrollViewRef} style={styles.articleScrollView}>
         <Animated.Text ref={textRef}>{loremIpsum}</Animated.Text>
       </Animated.ScrollView>
     </SafeAreaView>

--- a/app/src/examples/IPodExample.tsx
+++ b/app/src/examples/IPodExample.tsx
@@ -134,7 +134,6 @@ export default function IPodExample(): React.ReactElement {
         ref={animatedRef}
         horizontal={true}
         style={styles.scroll}
-        scrollEventThrottle={1}
         showsHorizontalScrollIndicator={false}
         onScroll={scrollHandler}>
         {data.map(({ artist, song }, i) => {

--- a/app/src/examples/ScrollEventExample.tsx
+++ b/app/src/examples/ScrollEventExample.tsx
@@ -49,10 +49,7 @@ export default function ScrollEventExample(): React.ReactElement {
         <Animated.View style={[styles.box, stylez]} />
       </View>
       <View style={[styles.half, { height }]}>
-        <Animated.ScrollView
-          style={styles.scroll}
-          scrollEventThrottle={1}
-          onScroll={scrollHandler}>
+        <Animated.ScrollView style={styles.scroll} onScroll={scrollHandler}>
           <View style={styles.placeholder} />
           <View style={styles.placeholder} />
           <View style={styles.placeholder} />

--- a/app/src/examples/ScrollViewExample.tsx
+++ b/app/src/examples/ScrollViewExample.tsx
@@ -10,10 +10,7 @@ export default function ScrollViewExample() {
   });
 
   return (
-    <Animated.ScrollView
-      scrollEventThrottle={16}
-      onScroll={scrollHandler}
-      style={styles.scrollView}>
+    <Animated.ScrollView onScroll={scrollHandler} style={styles.scrollView}>
       {[...Array(100)].map((_, i) => (
         <Text key={i} style={styles.text}>
           {i}

--- a/app/src/examples/ScrollViewOffsetExample.tsx
+++ b/app/src/examples/ScrollViewOffsetExample.tsx
@@ -33,7 +33,6 @@ export default function ScrollViewOffsetExample() {
       <Animated.ScrollView
         ref={aref}
         scrollViewOffset={scrollHandler}
-        scrollEventThrottle={16}
         style={styles.scrollView}>
         {[...Array(100)].map((_, i) => (
           <Text key={i} style={styles.text}>

--- a/app/src/examples/WorkletExample.tsx
+++ b/app/src/examples/WorkletExample.tsx
@@ -213,7 +213,7 @@ function ThrowErrorFromUseAnimatedScrollHandlerDemo() {
 
   return (
     <View style={{ height: 100 }}>
-      <Animated.ScrollView scrollEventThrottle={16} onScroll={scrollHandler}>
+      <Animated.ScrollView onScroll={scrollHandler}>
         <View
           style={{
             width: 100,
@@ -241,7 +241,7 @@ function ThrowErrorFromUseScrollViewOffsetDemo() {
 
   return (
     <View style={{ height: 100 }}>
-      <Animated.ScrollView scrollEventThrottle={16} ref={aref}>
+      <Animated.ScrollView ref={aref}>
         <View
           style={{
             width: 100,

--- a/docs/docs/api/hooks/useAnimatedScrollHandler.md
+++ b/docs/docs/api/hooks/useAnimatedScrollHandler.md
@@ -94,8 +94,7 @@ function ScrollExample() {
       <Animated.View style={[styles.box, stylez]} />
       <Animated.ScrollView
         style={styles.scroll}
-        onScroll={scrollHandler}
-        scrollEventThrottle={16}>
+        onScroll={scrollHandler}>
         <Content />
       </Animated.ScrollView>
     </View>

--- a/docs/docs/api/hooks/useScrollViewOffset.md
+++ b/docs/docs/api/hooks/useScrollViewOffset.md
@@ -42,7 +42,6 @@ function ScrollViewOffsetExample() {
       <View style={styles.divider} />
       <Animated.ScrollView
         ref={aref}
-        scrollEventThrottle={16}
         style={styles.scrollView}>
         {[...Array(100)].map((_, i) => (
           <Text key={i} style={styles.text}>

--- a/docs/docs/api/miscellaneous/interpolate.md
+++ b/docs/docs/api/miscellaneous/interpolate.md
@@ -95,7 +95,6 @@ export default function Test() {
       />
 
       <Animated.ScrollView
-        scrollEventThrottle={1}
         style={StyleSheet.absoluteFill}
         onScroll={scrollHandler}></Animated.ScrollView>
     </View>

--- a/src/reanimated2/component/ScrollView.tsx
+++ b/src/reanimated2/component/ScrollView.tsx
@@ -26,6 +26,13 @@ const AnimatedScrollView: AnimatedScrollViewFC = forwardRef(
         scrollViewOffset
       );
     }
+
+    if (!restProps.scrollEventThrottle) {
+      // Set default scrollEventThrottle to 16, because user expects
+      // to have continuous scroll events
+      restProps.scrollEventThrottle = 16;
+    }
+
     return <AnimatedScrollViewComponent ref={aref} {...restProps} />;
   }
 );

--- a/src/reanimated2/component/ScrollView.tsx
+++ b/src/reanimated2/component/ScrollView.tsx
@@ -28,9 +28,9 @@ const AnimatedScrollView: AnimatedScrollViewFC = forwardRef(
     }
 
     if (!restProps.scrollEventThrottle) {
-      // Set default scrollEventThrottle to 16, because user expects
+      // Set default scrollEventThrottle to 8, because user expects
       // to have continuous scroll events
-      restProps.scrollEventThrottle = 16;
+      restProps.scrollEventThrottle = 8;
     }
 
     return <AnimatedScrollViewComponent ref={aref} {...restProps} />;


### PR DESCRIPTION
## Summary

The inspiration for this changes are two issues:
- https://github.com/software-mansion/react-native-reanimated/issues/4585#issuecomment-1595921845
- https://github.com/software-mansion/react-native-reanimated/pull/4416/commits/4137d1a7d4ddba180c54582c2e1036a285c0ba3e

Users expect continuous scroll events. But the default value of [scrollEventThrottle](https://reactnative.dev/docs/scrollview#scrolleventthrottle-ios) is 0, which results in the scroll event being sent only once each time the view is scrolled. Which is easy to forget about it and in effect, it seems like a Reanimated issue. I know that this is a change of default ScrollView behavior but I believe that it would be less confusing for the users.