### PR TITLE
Add missing null checks

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -373,13 +373,14 @@ function checkSharedValueUsage(
     for (const element of prop) {
       checkSharedValueUsage(element, currentKey);
     }
-  } else if (typeof prop === 'object' && prop.value === undefined) {
+  } else if (prop && typeof prop === 'object' && prop.value === undefined) {
     // if it's a nested object, run validation for all its props
     for (const key of Object.keys(prop)) {
       checkSharedValueUsage(prop[key], key);
     }
   } else if (
     currentKey !== undefined &&
+    prop &&
     typeof prop === 'object' &&
     prop.value !== undefined
   ) {

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -373,15 +373,19 @@ function checkSharedValueUsage(
     for (const element of prop) {
       checkSharedValueUsage(element, currentKey);
     }
-  } else if (prop && typeof prop === 'object' && prop.value === undefined) {
+  } else if (
+    typeof prop === 'object' &&
+    prop !== null &&
+    prop.value === undefined
+  ) {
     // if it's a nested object, run validation for all its props
     for (const key of Object.keys(prop)) {
       checkSharedValueUsage(prop[key], key);
     }
   } else if (
     currentKey !== undefined &&
-    prop &&
     typeof prop === 'object' &&
+    prop !== null &&
     prop.value !== undefined
   ) {
     // if shared value is passed insted of its value, throw an error

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -167,7 +167,7 @@ export function isAnimated(prop: NestedObjectValues<AnimationObject>): boolean {
   'worklet';
   if (Array.isArray(prop)) {
     return prop.some(isAnimated);
-  } else if (typeof prop === 'object') {
+  } else if (prop && typeof prop === 'object') {
     if (prop.onFrame !== undefined) {
       return true;
     } else {

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -167,7 +167,7 @@ export function isAnimated(prop: NestedObjectValues<AnimationObject>): boolean {
   'worklet';
   if (Array.isArray(prop)) {
     return prop.some(isAnimated);
-  } else if (prop && typeof prop === 'object') {
+  } else if (typeof prop === 'object' && prop !== null) {
     if (prop.onFrame !== undefined) {
       return true;
     } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently, TypeScript guards against returning an object which contains `null` from `useAnimatedStyle`:

<img src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/3efac8f3-a9f3-418a-91a4-e90f1ed40d59" alt="" />


However, if we ignore this error, we will get the following runtime error:

<img src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/fb9d744d-d867-47ca-bf5c-3773a5510202" alt="" width="300" />


This PR adds missing null checks to avoid runtime error in this scenario.

Co-authored-by: @kmagiera

## Test plan

<details>
<summary>App.tsx</summary>

```tsx
import {StyleSheet, View} from 'react-native';

import Animated, {useAnimatedStyle} from 'react-native-reanimated';

import React from 'react';

export default function EmptyExample() {
  const animatedStyle = useAnimatedStyle(() => {
    return {
      width: 100,
      height: 100,
      backgroundColor: 'red',
      display: null,
    };
  });

  return (
    <View style={styles.container}>
      <Animated.View style={animatedStyle} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

</details>