### PR TITLE
Unify platform checks

### DIFF
--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -17,6 +17,7 @@ import {
   isJest,
   isChromeDebugger,
   shouldBeUseWeb,
+  isWeb,
 } from './reanimated2/PlatformChecker';
 import { initialUpdaterRun } from './reanimated2/animation';
 import {
@@ -323,7 +324,7 @@ export default function createAnimatedComponent(
     }
 
     _detachStyles() {
-      if (Platform.OS === 'web' && this._styles !== null) {
+      if (isWeb() && this._styles !== null) {
         for (const style of this._styles) {
           if (style?.viewsRef) {
             style.viewsRef.remove(this);
@@ -398,7 +399,7 @@ export default function createAnimatedComponent(
       const component = this._component?.getAnimatableRef
         ? this._component.getAnimatableRef()
         : this;
-      if (Platform.OS === 'web') {
+      if (isWeb()) {
         viewTag = findNodeHandle(component);
         viewName = null;
         shadowNodeWrapper = null;

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -7,8 +7,8 @@
  */
 
 /* eslint no-bitwise: 0 */
-import { Platform } from 'react-native';
 import { makeRemote, makeShareable, isConfigured } from './core';
+import { isAndroid, isWeb } from './PlatformChecker';
 
 interface RGB {
   r: number;
@@ -443,6 +443,9 @@ export const blue = (c: number): number => {
   return c & 255;
 };
 
+const IS_WEB = isWeb();
+const IS_ANDROID = isAndroid();
+
 export const rgbaColor = (
   r: number,
   g: number,
@@ -450,7 +453,7 @@ export const rgbaColor = (
   alpha = 1
 ): number | string => {
   'worklet';
-  if (Platform.OS === 'web' || !_WORKLET) {
+  if (IS_WEB || !_WORKLET) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
 
@@ -459,7 +462,7 @@ export const rgbaColor = (
     Math.round(r) * (1 << 16) +
     Math.round(g) * (1 << 8) +
     Math.round(b);
-  if (Platform.OS === 'android') {
+  if (IS_ANDROID) {
     // on Android color is represented as signed 32 bit int
     return c < (1 << 31) >>> 0 ? c : c - 4294967296; // 4294967296 == Math.pow(2, 32);
   }
@@ -622,7 +625,7 @@ export function processColor(color: unknown): number | null | undefined {
     return null;
   }
 
-  if (Platform.OS === 'android') {
+  if (IS_ANDROID) {
     // Android use 32 bit *signed* integer to represent the color
     // We utilize the fact that bitwise operations in JS also operates on
     // signed 32 bit integers, so that we can use those to convert from

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -12,6 +12,10 @@ export function isWeb(): boolean {
   return Platform.OS === 'web';
 }
 
+export function isAndroid(): boolean {
+  return Platform.OS === 'android';
+}
+
 export function shouldBeUseWeb() {
   return isJest() || isChromeDebugger() || isWeb();
 }

--- a/src/reanimated2/animation/decay.ts
+++ b/src/reanimated2/animation/decay.ts
@@ -6,7 +6,7 @@ import {
   AnimatableValue,
   Timestamp,
 } from '../commonTypes';
-import { Platform } from 'react-native';
+import { isWeb } from '../PlatformChecker';
 
 interface DecayConfig {
   deceleration?: number;
@@ -38,6 +38,8 @@ export interface InnerDecayAnimation
   current: number;
 }
 
+const IS_WEB = isWeb();
+
 export function withDecay(
   userConfig: DecayConfig,
   callback?: AnimationCallback
@@ -59,7 +61,7 @@ export function withDecay(
       );
     }
 
-    const VELOCITY_EPS = Platform.OS !== 'web' ? 1 : 1 / 20;
+    const VELOCITY_EPS = IS_WEB ? 1 / 20 : 1;
     const SLOPE_FACTOR = 0.1;
 
     let decay: (animation: InnerDecayAnimation, now: number) => boolean;

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -514,9 +514,9 @@ For more, see the docs: https://docs.swmansion.com/react-native-reanimated/docs/
 
   checkSharedValueUsage(initial.value);
 
-  if (process.env.JEST_WORKER_ID) {
-    return { viewDescriptors, initial: initial, viewsRef, animatedStyle };
+  if (isJest()) {
+    return { viewDescriptors, initial, viewsRef, animatedStyle };
   } else {
-    return { viewDescriptors, initial: initial, viewsRef };
+    return { viewDescriptors, initial, viewsRef };
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR replaces direct platform checks such as `Platform.OS === 'android'` or `process.env.JEST_WORKER_ID` with functions from `PlatformChecker.ts` (or captured constants when used inside worklets).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
