### PR TITLE
Fix update props flush for multiple view descriptors

### DIFF
--- a/src/reanimated2/UpdateProps.ts
+++ b/src/reanimated2/UpdateProps.ts
@@ -100,10 +100,10 @@ const createUpdatePropsManager = global._IS_FABRIC
               shadowNodeWrapper: viewDescriptor.shadowNodeWrapper,
               updates,
             });
+            if (operations.length === 1) {
+              queueMicrotask(this.flush);
+            }
           });
-          if (operations.length === 1) {
-            queueMicrotask(this.flush);
-          }
         },
         flush() {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -131,10 +131,10 @@ const createUpdatePropsManager = global._IS_FABRIC
               name: viewDescriptor.name || 'RCTView',
               updates,
             });
+            if (operations.length === 1) {
+              queueMicrotask(this.flush);
+            }
           });
-          if (operations.length === 1) {
-            queueMicrotask(this.flush);
-          }
         },
         flush() {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes a regression introduced in #4503.

If there was more than one view descriptor, `queueMicrotask(this.flush)` would never be called.

## Test plan

ChessboardExample.tsx