### PR TITLE
Remove unnecessary null-checks for mCustomEventNamesResolver

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -27,7 +27,7 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
-import com.swmansion.reanimated.nativeProxy.EventHandlerMock;
+import com.swmansion.reanimated.nativeProxy.NoopEventHandler;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -79,7 +79,7 @@ public class NodesManager implements EventDispatcherListener {
   private final ReactContext mContext;
   private final UIManagerModule mUIManager;
   private ReactApplicationContext mReactApplicationContext;
-  private RCTEventEmitter mCustomEventHandler = new EventHandlerMock();
+  private RCTEventEmitter mCustomEventHandler = new NoopEventHandler();
   private List<OnAnimationFrame> mFrameCallbacks = new ArrayList<>();
   private ConcurrentLinkedQueue<CopiedEvent> mEventQueue = new ConcurrentLinkedQueue<>();
   private double lastFrameTimeMs;

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -27,6 +27,7 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
+import com.swmansion.reanimated.nativeProxy.EventHandlerMock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -78,7 +79,7 @@ public class NodesManager implements EventDispatcherListener {
   private final ReactContext mContext;
   private final UIManagerModule mUIManager;
   private ReactApplicationContext mReactApplicationContext;
-  private RCTEventEmitter mCustomEventHandler;
+  private RCTEventEmitter mCustomEventHandler = new EventHandlerMock();
   private List<OnAnimationFrame> mFrameCallbacks = new ArrayList<>();
   private ConcurrentLinkedQueue<CopiedEvent> mEventQueue = new ConcurrentLinkedQueue<>();
   private double lastFrameTimeMs;
@@ -300,10 +301,7 @@ public class NodesManager implements EventDispatcherListener {
       int viewTag = event.getViewTag();
       String key = viewTag + eventName;
 
-      shouldSaveEvent |=
-          (mCustomEventHandler != null
-              && mNativeProxy != null
-              && mNativeProxy.isAnyHandlerWaitingForEvent(key));
+      shouldSaveEvent |= mNativeProxy != null && mNativeProxy.isAnyHandlerWaitingForEvent(key);
       if (shouldSaveEvent) {
         mEventQueue.offer(new CopiedEvent(event));
       }
@@ -312,18 +310,11 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   private void handleEvent(Event event) {
-    // If the event has a different name in native, convert it to it's JS name.
-    String eventName = mCustomEventNamesResolver.resolveCustomEventName(event.getEventName());
-    int viewTag = event.getViewTag();
-    if (mCustomEventHandler != null) {
-      event.dispatch(mCustomEventHandler);
-    }
+    event.dispatch(mCustomEventHandler);
   }
 
   private void handleEvent(int targetTag, String eventName, @Nullable WritableMap event) {
-    if (mCustomEventHandler != null) {
-      mCustomEventHandler.receiveEvent(targetTag, eventName, event);
-    }
+    mCustomEventHandler.receiveEvent(targetTag, eventName, event);
   }
 
   public UIManagerModule.CustomEventNamesResolver getEventNameResolver() {

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandlerMock.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandlerMock.java
@@ -1,0 +1,18 @@
+package com.swmansion.reanimated.nativeProxy;
+
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class EventHandlerMock implements RCTEventEmitter {
+  @Override
+  public void receiveEvent(int i, String s, @Nullable WritableMap writableMap) {
+    // NOOP
+  }
+
+  @Override
+  public void receiveTouches(String s, WritableArray writableArray, WritableArray writableArray1) {
+    // NOOP
+  }
+}

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NoopEventHandler.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NoopEventHandler.java
@@ -5,14 +5,15 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
-public class EventHandlerMock implements RCTEventEmitter {
+public class NoopEventHandler implements RCTEventEmitter {
   @Override
-  public void receiveEvent(int i, String s, @Nullable WritableMap writableMap) {
+  public void receiveEvent(int targetTag, String eventName, @Nullable WritableMap event) {
     // NOOP
   }
 
   @Override
-  public void receiveTouches(String s, WritableArray writableArray, WritableArray writableArray1) {
+  public void receiveTouches(
+      String eventName, WritableArray touches, WritableArray changedIndices) {
     // NOOP
   }
 }


### PR DESCRIPTION
## Summary

The goal of this PR was to remove unused variables form `private void handleEvent(Event event)`:
```diff
private void handleEvent(Event event) {
-  // If the event has a different name in native, convert it to it's JS name.
-  String eventName = mCustomEventNamesResolver.resolveCustomEventName(event.getEventName());
-  int viewTag = event.getViewTag();
  if (mCustomEventHandler != null) {
    event.dispatch(mCustomEventHandler);
  }
}
```
But then I realized that we can avoid some unnecessary null-checks for mCustomEventHandler. The mCustomEventHandler could be a null value before initialization by void registerEventHandler(RCTEventEmitter handler) method.
