### PR TITLE
Unify naming of `NativeReanimatedModule` and `REAModule` instances

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -491,13 +491,13 @@ void NativeProxy::setGlobalProperties(
 }
 
 void NativeProxy::setupLayoutAnimations() {
-  auto weakModule =
+  auto weakNativeReanimatedModule =
       std::weak_ptr<NativeReanimatedModule>(nativeReanimatedModule_);
 
   layoutAnimations_->cthis()->setAnimationStartingBlock(
-      [weakModule](
+      [weakNativeReanimatedModule](
           int tag, int type, alias_ref<JMap<jstring, jstring>> values) {
-        auto nativeReanimatedModule = weakModule.lock();
+        auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
         if (nativeReanimatedModule == nullptr) {
           return;
         }
@@ -530,9 +530,9 @@ void NativeProxy::setupLayoutAnimations() {
             rt, tag, static_cast<LayoutAnimationType>(type), yogaValues);
       });
 
-  layoutAnimations_->cthis()->setHasAnimationBlock([weakModule](
+  layoutAnimations_->cthis()->setHasAnimationBlock([weakNativeReanimatedModule](
                                                        int tag, int type) {
-    auto nativeReanimatedModule = weakModule.lock();
+    auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
     if (nativeReanimatedModule == nullptr) {
       return false;
     }
@@ -542,8 +542,8 @@ void NativeProxy::setupLayoutAnimations() {
   });
 
   layoutAnimations_->cthis()->setClearAnimationConfigBlock(
-      [weakModule](int tag) {
-        auto nativeReanimatedModule = weakModule.lock();
+      [weakNativeReanimatedModule](int tag) {
+        auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
         if (nativeReanimatedModule == nullptr) {
           return;
         }
@@ -553,8 +553,9 @@ void NativeProxy::setupLayoutAnimations() {
       });
 
   layoutAnimations_->cthis()->setCancelAnimationForTag(
-      [weakModule](int tag, int type, jboolean cancelled, jboolean removeView) {
-        if (auto nativeReanimatedModule = weakModule.lock()) {
+      [weakNativeReanimatedModule](
+          int tag, int type, jboolean cancelled, jboolean removeView) {
+        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
           jsi::Runtime &rt = *nativeReanimatedModule->runtimeManager_->runtime;
           nativeReanimatedModule->layoutAnimationsManager()
               .cancelLayoutAnimation(
@@ -567,8 +568,8 @@ void NativeProxy::setupLayoutAnimations() {
       });
 
   layoutAnimations_->cthis()->setFindPrecedingViewTagForTransition(
-      [weakModule](int tag) {
-        if (auto nativeReanimatedModule = weakModule.lock()) {
+      [weakNativeReanimatedModule](int tag) {
+        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
           return nativeReanimatedModule->layoutAnimationsManager()
               .findPrecedingViewTagForTransition(tag);
         } else {

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -115,7 +115,7 @@ void NativeProxy::installJSIBindings(
   std::shared_ptr<ErrorHandler> errorHandler =
       std::make_shared<AndroidErrorHandler>(scheduler_);
 
-  auto module = std::make_shared<NativeReanimatedModule>(
+  auto nativeReanimatedModule = std::make_shared<NativeReanimatedModule>(
       jsCallInvoker_,
       scheduler_,
       animatedRuntime,
@@ -127,20 +127,21 @@ void NativeProxy::installJSIBindings(
 #endif
       getPlatformDependentMethods());
 
-  scheduler_->setRuntimeManager(module->runtimeManager_);
-  nativeReanimatedModule_ = module;
+  scheduler_->setRuntimeManager(nativeReanimatedModule->runtimeManager_);
+  nativeReanimatedModule_ = nativeReanimatedModule;
 
 #ifdef RCT_NEW_ARCH_ENABLED
   Binding *binding = fabricUIManager->getBinding();
   std::shared_ptr<UIManager> uiManager =
       binding->getScheduler()->getUIManager();
-  module->setUIManager(uiManager);
-  module->setPropsRegistry(propsRegistry_);
+  nativeReanimatedModule->setUIManager(uiManager);
+  nativeReanimatedModule->setPropsRegistry(propsRegistry_);
   propsRegistry_ = nullptr;
 //  removed temporary, new event listener mechanism need fix on the RN side
 //  eventListener_ = std::make_shared<EventListener>(
-//      [module, getCurrentTime](const RawEvent &rawEvent) {
-//        return module->handleRawEvent(rawEvent, getCurrentTime());
+//      [nativeReanimatedModule, getCurrentTime](const RawEvent &rawEvent) {
+//        return nativeReanimatedModule->handleRawEvent(rawEvent,
+//        getCurrentTime());
 //      });
 //  reactScheduler_ = binding->getScheduler();
 //  reactScheduler_->addEventListener(eventListener_);
@@ -154,7 +155,7 @@ void NativeProxy::installJSIBindings(
   rt.global().setProperty(
       rt,
       jsi::PropNameID::forAscii(rt, "__reanimatedModuleProxy"),
-      jsi::Object::createFromHostObject(rt, module));
+      jsi::Object::createFromHostObject(rt, nativeReanimatedModule));
 }
 
 bool NativeProxy::isAnyHandlerWaitingForEvent(std::string s) {
@@ -496,12 +497,13 @@ void NativeProxy::setupLayoutAnimations() {
   layoutAnimations_->cthis()->setAnimationStartingBlock(
       [weakModule](
           int tag, int type, alias_ref<JMap<jstring, jstring>> values) {
-        auto module = weakModule.lock();
-        if (module == nullptr) {
+        auto nativeReanimatedModule = weakModule.lock();
+        if (nativeReanimatedModule == nullptr) {
           return;
         }
-        auto &rt = *module->runtimeManager_->runtime;
-        auto errorHandler = module->runtimeManager_->errorHandler;
+        auto &rt = *nativeReanimatedModule->runtimeManager_->runtime;
+        auto errorHandler =
+            nativeReanimatedModule->runtimeManager_->errorHandler;
 
         jsi::Object yogaValues(rt);
         for (const auto &entry : *values) {
@@ -524,48 +526,50 @@ void NativeProxy::setupLayoutAnimations() {
           }
         }
 
-        module->layoutAnimationsManager().startLayoutAnimation(
+        nativeReanimatedModule->layoutAnimationsManager().startLayoutAnimation(
             rt, tag, static_cast<LayoutAnimationType>(type), yogaValues);
       });
 
-  layoutAnimations_->cthis()->setHasAnimationBlock(
-      [weakModule](int tag, int type) {
-        auto module = weakModule.lock();
-        if (module == nullptr) {
-          return false;
-        }
+  layoutAnimations_->cthis()->setHasAnimationBlock([weakModule](
+                                                       int tag, int type) {
+    auto nativeReanimatedModule = weakModule.lock();
+    if (nativeReanimatedModule == nullptr) {
+      return false;
+    }
 
-        return module->layoutAnimationsManager().hasLayoutAnimation(
-            tag, static_cast<LayoutAnimationType>(type));
-      });
+    return nativeReanimatedModule->layoutAnimationsManager().hasLayoutAnimation(
+        tag, static_cast<LayoutAnimationType>(type));
+  });
 
   layoutAnimations_->cthis()->setClearAnimationConfigBlock(
       [weakModule](int tag) {
-        auto module = weakModule.lock();
-        if (module == nullptr) {
+        auto nativeReanimatedModule = weakModule.lock();
+        if (nativeReanimatedModule == nullptr) {
           return;
         }
 
-        module->layoutAnimationsManager().clearLayoutAnimationConfig(tag);
+        nativeReanimatedModule->layoutAnimationsManager()
+            .clearLayoutAnimationConfig(tag);
       });
 
   layoutAnimations_->cthis()->setCancelAnimationForTag(
       [weakModule](int tag, int type, jboolean cancelled, jboolean removeView) {
-        if (auto module = weakModule.lock()) {
-          jsi::Runtime &rt = *module->runtimeManager_->runtime;
-          module->layoutAnimationsManager().cancelLayoutAnimation(
-              rt,
-              tag,
-              static_cast<LayoutAnimationType>(type),
-              cancelled,
-              removeView);
+        if (auto nativeReanimatedModule = weakModule.lock()) {
+          jsi::Runtime &rt = *nativeReanimatedModule->runtimeManager_->runtime;
+          nativeReanimatedModule->layoutAnimationsManager()
+              .cancelLayoutAnimation(
+                  rt,
+                  tag,
+                  static_cast<LayoutAnimationType>(type),
+                  cancelled,
+                  removeView);
         }
       });
 
   layoutAnimations_->cthis()->setFindPrecedingViewTagForTransition(
       [weakModule](int tag) {
-        if (auto module = weakModule.lock()) {
-          return module->layoutAnimationsManager()
+        if (auto nativeReanimatedModule = weakModule.lock()) {
+          return nativeReanimatedModule->layoutAnimationsManager()
               .findPrecedingViewTagForTransition(tag);
         } else {
           return -1;

--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -45,7 +45,7 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
   __weak RCTSurfacePresenter *_surfacePresenter;
   std::shared_ptr<PropsRegistry> propsRegistry_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
-  std::weak_ptr<NativeReanimatedModule> reanimatedModule_;
+  std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule_;
 #else
   NSMutableArray<AnimatedOperation> *_operations;
 #endif
@@ -91,9 +91,9 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)setUpNativeReanimatedModule:(std::shared_ptr<UIManager>)uiManager
 {
-  if (auto reanimatedModule = reanimatedModule_.lock()) {
-    reanimatedModule->setUIManager(uiManager);
-    reanimatedModule->setPropsRegistry(propsRegistry_);
+  if (auto nativeReanimatedModule = weakNativeReanimatedModule_.lock()) {
+    nativeReanimatedModule->setUIManager(uiManager);
+    nativeReanimatedModule->setPropsRegistry(propsRegistry_);
   }
 }
 
@@ -136,16 +136,16 @@ RCT_EXPORT_MODULE(ReanimatedModule);
     if (strongSelf == nil) {
       return;
     }
-    if (auto reanimatedModule = strongSelf->reanimatedModule_.lock()) {
+    if (auto nativeReanimatedModule = strongSelf->weakNativeReanimatedModule_.lock()) {
       auto eventListener =
-          std::make_shared<facebook::react::EventListener>([reanimatedModule](const RawEvent &rawEvent) {
+          std::make_shared<facebook::react::EventListener>([nativeReanimatedModule](const RawEvent &rawEvent) {
             if (!RCTIsMainQueue()) {
               // event listener called on the JS thread, let's ignore this event
               // as we cannot safely access worklet runtime here
               // and also we don't care about topLayout events
               return false;
             }
-            return reanimatedModule->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
+            return nativeReanimatedModule->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
           });
       [scheduler addEventListener:eventListener];
     }
@@ -267,7 +267,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   if (jsiRuntime) {
     jsi::Runtime &runtime = *jsiRuntime;
 
-    auto reanimatedModule = reanimated::createReanimatedModule(self.bridge, self.bridge.jsCallInvoker);
+    auto nativeReanimatedModule = reanimated::createReanimatedModule(self.bridge, self.bridge.jsCallInvoker);
 
     auto workletRuntimeValue = runtime.global()
                                    .getProperty(runtime, "ArrayBuffer")
@@ -276,7 +276,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
                                    .callAsConstructor(runtime, {static_cast<double>(sizeof(void *))});
     uintptr_t *workletRuntimeData =
         reinterpret_cast<uintptr_t *>(workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
-    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtimeManager_->runtime.get());
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(nativeReanimatedModule->runtimeManager_->runtime.get());
 
     runtime.global().setProperty(runtime, "_WORKLET_RUNTIME", workletRuntimeValue);
 
@@ -294,10 +294,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
     runtime.global().setProperty(
         runtime,
         jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
-        jsi::Object::createFromHostObject(runtime, reanimatedModule));
+        jsi::Object::createFromHostObject(runtime, nativeReanimatedModule));
 
 #ifdef RCT_NEW_ARCH_ENABLED
-    reanimatedModule_ = reanimatedModule;
+    weakNativeReanimatedModule_ = nativeReanimatedModule;
     if (_surfacePresenter != nil) {
       // reload, uiManager is null right now, we need to wait for `installReanimatedAfterReload`
       [self injectDependencies:runtime];

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -296,10 +296,10 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     nativeReanimatedModule->handleEvent(eventName, payload, currentTime);
   }];
 
-  std::weak_ptr<NativeReanimatedModule> weakModule = nativeReanimatedModule; // to avoid retain cycle
+  std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule = nativeReanimatedModule; // to avoid retain cycle
 #ifdef RCT_NEW_ARCH_ENABLED
   [reaModule.nodesManager registerPerformOperations:^() {
-    if (auto nativeReanimatedModule = weakModule.lock()) {
+    if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
       nativeReanimatedModule->performOperations();
     }
   }];
@@ -308,7 +308,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   [animationsManager
       setAnimationStartingBlock:^(
           NSNumber *_Nonnull tag, LayoutAnimationType type, NSDictionary *_Nonnull values, NSNumber *depth) {
-        auto nativeReanimatedModule = weakModule.lock();
+        auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
         if (nativeReanimatedModule == nullptr) {
           return;
         }
@@ -333,7 +333,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       }];
 
   [animationsManager setHasAnimationBlock:^(NSNumber *_Nonnull tag, LayoutAnimationType type) {
-    auto nativeReanimatedModule = weakModule.lock();
+    auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
     if (nativeReanimatedModule == nullptr) {
       return NO;
     }
@@ -343,7 +343,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   }];
 
   [animationsManager setAnimationRemovingBlock:^(NSNumber *_Nonnull tag) {
-    auto nativeReanimatedModule = weakModule.lock();
+    auto nativeReanimatedModule = weakNativeReanimatedModule.lock();
     if (nativeReanimatedModule == nullptr) {
       return;
     }
@@ -352,7 +352,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   [animationsManager
       setCancelAnimationBlock:^(NSNumber *_Nonnull tag, LayoutAnimationType type, BOOL cancelled, BOOL removeView) {
-        if (auto nativeReanimatedModule = weakModule.lock()) {
+        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
           if (auto runtime = wrt.lock()) {
             jsi::Runtime &rt = *runtime;
             nativeReanimatedModule->layoutAnimationsManager().cancelLayoutAnimation(
@@ -362,7 +362,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       }];
 
   [animationsManager setFindPrecedingViewTagForTransitionBlock:^NSNumber *_Nullable(NSNumber *_Nonnull tag) {
-    if (auto nativeReanimatedModule = weakModule.lock()) {
+    if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
       int resultTag =
           nativeReanimatedModule->layoutAnimationsManager().findPrecedingViewTagForTransition([tag intValue]);
       return resultTag == -1 ? nil : @(resultTag);

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -157,7 +157,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   auto maybeFlushUIUpdatesQueueFunction = [nodesManager]() { [nodesManager maybeFlushUIUpdatesQueue]; };
 
-  auto requestRender = [nodesManager, &nativeReanimatedModule](std::function<void(double)> onRender, jsi::Runtime &rt) {
+  auto requestRender = [nodesManager](std::function<void(double)> onRender, jsi::Runtime &rt) {
     [nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
       double frameTimestamp = calculateTimestampWithSlowAnimations(displayLink.targetTimestamp) * 1000;
       onRender(frameTimestamp);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR aims to rename `module` variable which holds an instance of `NativeReanimatedModule` because `module` is a keyword since C++20. From now on, we will use the following naming convention:

* `std::shared_ptr<NativeReanimatedModule> nativeReanimatedModule`
* `std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule`
* `REAModule* reaModule` (iOS)

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
