### PR TITLE
Fix backward compatibility with react-native <= 0.69

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
   s.dependency 'Yoga'
   s.dependency 'DoubleConversion'
   s.dependency 'glog'
-  if using_hermes && !config[:is_tvos_target]
+  if using_hermes && !config[:is_tvos_target] && config[:react_native_minor_version] >= 70
     s.dependency 'React-hermes'
     s.dependency 'hermes-engine'
   end


### PR DESCRIPTION
## Summary

In https://github.com/software-mansion/react-native-reanimated/pull/4504 we introduced dependency for `React-hermes` in iOS. But this dependency is available since rn@0.70 - more details here: https://github.com/facebook/react-native/commit/b3040ec6244da6ea274654abfd84516de4f5bf52

## Test plan

### CI tests before:
https://github.com/piaskowyk/reanimated-rn-version-tester/actions/runs/5360486792/jobs/9725423101
<img width="1317" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/afd07f2b-cefe-4871-a1ae-e8e723b7d922">

### CI tests after:
https://github.com/piaskowyk/reanimated-rn-version-tester/actions/runs/5364839077
<img width="818" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/e9c62f5c-3902-44aa-a8da-db4144eda34a">
