### PR TITLE
Move `scheduleOnJS` to a separate method

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -74,32 +74,7 @@ NativeReanimatedModule::NativeReanimatedModule(
                           jsi::Runtime &rt,
                           const jsi::Value &remoteFun,
                           const jsi::Value &argsValue) {
-    auto shareableRemoteFun = extractShareableOrThrow<ShareableRemoteFunction>(
-        rt,
-        remoteFun,
-        "Incompatible object passed to scheduleOnJS. It is only allowed to schedule functions defined on the React Native JS runtime this way.");
-    auto shareableArgs = argsValue.isUndefined()
-        ? nullptr
-        : extractShareableOrThrow(rt, argsValue);
-    auto jsRuntime = this->runtimeHelper->rnRuntime();
-    runtimeManager_->scheduler->scheduleOnJS([=] {
-      jsi::Runtime &rt = *jsRuntime;
-      auto remoteFun = shareableRemoteFun->getJSValue(rt);
-      if (shareableArgs == nullptr) {
-        // fast path for remote function w/o arguments
-        remoteFun.asObject(rt).asFunction(rt).call(rt);
-      } else {
-        auto argsArray = shareableArgs->getJSValue(rt).asObject(rt).asArray(rt);
-        auto argsSize = argsArray.size(rt);
-        // number of arguments is typically relatively small so it is ok to
-        // to use VLAs here, hence disabling the lint rule
-        jsi::Value args[argsSize]; // NOLINT(runtime/arrays)
-        for (size_t i = 0; i < argsSize; i++) {
-          args[i] = argsArray.getValueAtIndex(rt, i);
-        }
-        remoteFun.asObject(rt).asFunction(rt).call(rt, args, argsSize);
-      }
-    });
+    this->scheduleOnJS(rt, remoteFun, argsValue);
   };
 
   auto makeShareableClone = [this](jsi::Runtime &rt, const jsi::Value &value) {
@@ -216,6 +191,38 @@ void NativeReanimatedModule::scheduleOnUI(
     jsi::Runtime &rt = *runtimeHelper->uiRuntime();
     auto workletValue = shareableWorklet->getJSValue(rt);
     runtimeHelper->runOnUIGuarded(workletValue);
+  });
+}
+
+void NativeReanimatedModule::scheduleOnJS(
+    jsi::Runtime &rt,
+    const jsi::Value &remoteFun,
+    const jsi::Value &argsValue) {
+  auto shareableRemoteFun = extractShareableOrThrow<ShareableRemoteFunction>(
+      rt,
+      remoteFun,
+      "Incompatible object passed to scheduleOnJS. It is only allowed to schedule functions defined on the React Native JS runtime this way.");
+  auto shareableArgs = argsValue.isUndefined()
+      ? nullptr
+      : extractShareableOrThrow(rt, argsValue);
+  auto jsRuntime = this->runtimeHelper->rnRuntime();
+  runtimeManager_->scheduler->scheduleOnJS([=] {
+    jsi::Runtime &rt = *jsRuntime;
+    auto remoteFun = shareableRemoteFun->getJSValue(rt);
+    if (shareableArgs == nullptr) {
+      // fast path for remote function w/o arguments
+      remoteFun.asObject(rt).asFunction(rt).call(rt);
+    } else {
+      auto argsArray = shareableArgs->getJSValue(rt).asObject(rt).asArray(rt);
+      auto argsSize = argsArray.size(rt);
+      // number of arguments is typically relatively small so it is ok to
+      // to use VLAs here, hence disabling the lint rule
+      jsi::Value args[argsSize]; // NOLINT(runtime/arrays)
+      for (size_t i = 0; i < argsSize; i++) {
+        args[i] = argsArray.getValueAtIndex(rt, i);
+      }
+      remoteFun.asObject(rt).asFunction(rt).call(rt, args, argsSize);
+    }
   });
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -72,6 +72,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       const jsi::Value &newData);
 
   void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) override;
+  void scheduleOnJS(
+      jsi::Runtime &rt,
+      const jsi::Value &remoteFun,
+      const jsi::Value &argsValue);
 
   jsi::Value registerEventHandler(
       jsi::Runtime &rt,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR moves the inline implementation of `scheduleOnJS` from C++ lambda body to a separate method of `NativeReanimatedModule` so that it can be re-used for different purposes 😉 

## Test plan

WorkletExample.tsx &rarr; runOnUI + runOnJS demo