### PR TITLE
Replace `useRef` with `useSharedValue` in `useAnimatedReaction` to preserve value between renders

### DIFF
--- a/src/reanimated2/hook/useAnimatedReaction.ts
+++ b/src/reanimated2/hook/useAnimatedReaction.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { BasicWorkletFunction, WorkletFunction } from '../commonTypes';
 import { startMapper, stopMapper } from '../core';
 import { DependencyList } from './commonTypes';
+import { useSharedValue } from './useSharedValue';
 import { shouldBeUseWeb } from '../PlatformChecker';
 
 export interface AnimatedReactionWorkletFunction<T> extends WorkletFunction {
@@ -18,7 +19,7 @@ export function useAnimatedReaction<T>(
   react: AnimatedReactionWorkletFunction<T>,
   dependencies: DependencyList
 ): void {
-  const previous = useRef({ value: null as T | null }).current;
+  const previous = useSharedValue<T | null>(null, true);
 
   let inputs = Object.values(prepare._closure ?? {});
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In https://github.com/software-mansion/react-native-reanimated/pull/4466 I've replaced `useSharedValue` with `useRef` to avoid cloning saved objects on every update. This worked really well unless, as it turned out, there was a re-render in between the updates, in which case the saved value would reset back to null.

I think it's because the ref object that was captured in the closure of the worklet responsible for updating was actually a cloned object instead of the real ref, so each update would be applied to the cloned one. This PR reverts `useRef` change and instead passes `true` for `oneWayReadsOnly`, simply preventing the cloning as it was originally done in https://github.com/software-mansion/react-native-reanimated/pull/4466.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4615

## Test plan

Check out the reproduction code from the issue above.
