### PR TITLE
Fix monorepo-CI

### DIFF
--- a/.github/workflows/build-monorepo.yml
+++ b/.github/workflows/build-monorepo.yml
@@ -1,4 +1,3 @@
-# random change just to trigger a CI test
 name: Test monorepo build
 on:
   pull_request:

--- a/.github/workflows/build-monorepo.yml
+++ b/.github/workflows/build-monorepo.yml
@@ -1,3 +1,4 @@
+# random change just to trigger a CI test
 name: Test monorepo build
 on:
   pull_request:

--- a/ios/LayoutReanimation/REASnapshot.m
+++ b/ios/LayoutReanimation/REASnapshot.m
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <RNReanimated/REAScreensHelper.h>
 #import <RNReanimated/REASnapshot.h>
+#import <React/RCTView.h>
 #import <React/UIView+React.h>
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
## Summary

Current main CI is broken because of:
```
/Users/runner/work/react-native-reanimated/react-native-reanimated/monorepo/RootApp/node_modules/react-native-reanimated/ios/LayoutReanimation/REASnapshot.m:87:38: use of undeclared identifier 'RCTView'
_values[@"borderRadius"] = @(((RCTView *)view).borderRadius);
```
This PR try to resolve this issue by adding `RCTView.h` import. What is strange the problem exists only in monorepo.
## Test plan

See CI status
![image](https://github.com/software-mansion/react-native-reanimated/assets/36106620/9faa6187-be9a-48fa-bb84-f8a4c9256d7c)
