### PR TITLE
Register for events by name

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -475,11 +475,15 @@ bool NativeReanimatedModule::isThereAnyLayoutProp(
 
 bool NativeReanimatedModule::handleEvent(
     const std::string &eventName,
-    const int viewTag,
+    const int emitterReactTag,
     const jsi::Value &payload,
     double currentTime) {
   eventHandlerRegistry->processEvent(
-      *runtimeManager_->runtime, currentTime, eventName, viewTag, payload);
+      *runtimeManager_->runtime,
+      currentTime,
+      eventName,
+      emitterReactTag,
+      payload);
 
   // TODO: return true if Reanimated successfully handled the event
   // to avoid sending it to JavaScript

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -510,11 +510,10 @@ bool NativeReanimatedModule::handleRawEvent(
   if (eventType.rfind("top", 0) == 0) {
     eventType = "on" + eventType.substr(3);
   }
-  std::string eventName = std::to_string(tag) + eventType;
   jsi::Runtime &rt = *runtimeManager_->runtime.get();
   jsi::Value payload = payloadFactory(rt);
 
-  auto res = handleEvent(eventName, std::move(payload), currentTime);
+  auto res = handleEvent(eventType, tag, std::move(payload), currentTime);
   // TODO: we should call performOperations conditionally if event is handled
   // (res == true), but for now handleEvent always returns false. Thankfully,
   // performOperations does not trigger a lot of code if there is nothing to be

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -410,14 +410,6 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimation(
   return jsi::Value::undefined();
 }
 
-void NativeReanimatedModule::onEvent(
-    double eventTimestamp,
-    const std::string &eventName,
-    const jsi::Value &payload) {
-  eventHandlerRegistry->processEvent(
-      *runtimeManager_->runtime, eventTimestamp, eventName, payload);
-}
-
 bool NativeReanimatedModule::isAnyHandlerWaitingForEvent(
     std::string eventName) {
   return eventHandlerRegistry->isAnyHandlerWaitingForEvent(eventName);
@@ -483,9 +475,11 @@ bool NativeReanimatedModule::isThereAnyLayoutProp(
 
 bool NativeReanimatedModule::handleEvent(
     const std::string &eventName,
+    const int viewTag,
     const jsi::Value &payload,
     double currentTime) {
-  onEvent(currentTime, eventName, payload);
+  eventHandlerRegistry->processEvent(
+      *runtimeManager_->runtime, currentTime, eventName, viewTag, payload);
 
   // TODO: return true if Reanimated successfully handled the event
   // to avoid sending it to JavaScript

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -113,7 +113,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   bool handleEvent(
       const std::string &eventName,
-      const int viewTag,
+      const int emitterReactTag,
       const jsi::Value &payload,
       double currentTime);
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -106,11 +106,6 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   void onRender(double timestampMs);
 
-  void onEvent(
-      double eventTimestamp,
-      const std::string &eventName,
-      const jsi::Value &payload);
-
   bool isAnyHandlerWaitingForEvent(std::string eventName);
 
   void maybeRequestRender();
@@ -118,6 +113,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   bool handleEvent(
       const std::string &eventName,
+      const int viewTag,
       const jsi::Value &payload,
       double currentTime);
 

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -37,8 +37,8 @@ void EventHandlerRegistry::processEvent(
         handlersForEvent.push_back(handler.second);
       }
     }
-    handlersIt =
-        eventMappings.find(std::to_string(emitterReactTag) + eventName);
+    auto eventHash = std::to_string(emitterReactTag) + eventName;
+    handlersIt = eventMappings.find(eventHash);
     if (handlersIt != eventMappings.end()) {
       for (auto handler : handlersIt->second) {
         handlersForEvent.push_back(handler.second);

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -26,11 +26,18 @@ void EventHandlerRegistry::processEvent(
     jsi::Runtime &rt,
     double eventTimestamp,
     const std::string &eventName,
+    const int viewTag,
     const jsi::Value &eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
     const std::lock_guard<std::mutex> lock(instanceMutex);
     auto handlersIt = eventMappings.find(eventName);
+    if (handlersIt != eventMappings.end()) {
+      for (auto handler : handlersIt->second) {
+        handlersForEvent.push_back(handler.second);
+      }
+    }
+    handlersIt = eventMappings.find(std::to_string(viewTag) + eventName);
     if (handlersIt != eventMappings.end()) {
       for (auto handler : handlersIt->second) {
         handlersForEvent.push_back(handler.second);

--- a/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -26,7 +26,7 @@ void EventHandlerRegistry::processEvent(
     jsi::Runtime &rt,
     double eventTimestamp,
     const std::string &eventName,
-    const int viewTag,
+    const int emitterReactTag,
     const jsi::Value &eventPayload) {
   std::vector<std::shared_ptr<WorkletEventHandler>> handlersForEvent;
   {
@@ -37,7 +37,8 @@ void EventHandlerRegistry::processEvent(
         handlersForEvent.push_back(handler.second);
       }
     }
-    handlersIt = eventMappings.find(std::to_string(viewTag) + eventName);
+    handlersIt =
+        eventMappings.find(std::to_string(emitterReactTag) + eventName);
     if (handlersIt != eventMappings.end()) {
       for (auto handler : handlersIt->second) {
         handlersForEvent.push_back(handler.second);

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -31,6 +31,7 @@ class EventHandlerRegistry {
       jsi::Runtime &rt,
       double eventTimestamp,
       const std::string &eventName,
+      const int viewTag,
       const jsi::Value &eventPayload);
 
   bool isAnyHandlerWaitingForEvent(const std::string &eventName);

--- a/Common/cpp/Registries/EventHandlerRegistry.h
+++ b/Common/cpp/Registries/EventHandlerRegistry.h
@@ -31,7 +31,7 @@ class EventHandlerRegistry {
       jsi::Runtime &rt,
       double eventTimestamp,
       const std::string &eventName,
-      const int viewTag,
+      const int emitterReactTag,
       const jsi::Value &eventPayload);
 
   bool isAnyHandlerWaitingForEvent(const std::string &eventName);

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -347,7 +347,7 @@ double NativeProxy::getCurrentTime() {
 
 void NativeProxy::handleEvent(
     jni::alias_ref<JString> eventName,
-    jint targetTag,
+    jint emitterReactTag,
     jni::alias_ref<react::WritableMap> event) {
   // handles RCTEvents from RNGestureHandler
   // TODO: convert event directly to jsi::Value without JSON serialization

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -382,7 +382,7 @@ void NativeProxy::handleEvent(
   }
 
   nativeReanimatedModule_->handleEvent(
-      eventName->toString(), targetTag, payload, this->getCurrentTime());
+      eventName->toString(), emitterReactTag, payload, this->getCurrentTime());
 }
 
 void NativeProxy::progressLayoutAnimation(

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -346,11 +346,10 @@ double NativeProxy::getCurrentTime() {
 }
 
 void NativeProxy::handleEvent(
-    jni::alias_ref<JString> eventKey,
+    jni::alias_ref<JString> eventName,
+    jint targetTag,
     jni::alias_ref<react::WritableMap> event) {
   // handles RCTEvents from RNGestureHandler
-  auto eventName = eventKey->toString();
-
   // TODO: convert event directly to jsi::Value without JSON serialization
   std::string eventAsString;
   try {
@@ -383,7 +382,7 @@ void NativeProxy::handleEvent(
   }
 
   nativeReanimatedModule_->handleEvent(
-      eventName, payload, this->getCurrentTime());
+      eventName->toString(), targetTag, payload, this->getCurrentTime());
 }
 
 void NativeProxy::progressLayoutAnimation(

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -234,7 +234,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
 #endif
   void handleEvent(
       jni::alias_ref<JString> eventName,
-      jint targetTag,
+      jint emitterReactTag,
       jni::alias_ref<react::WritableMap> event);
 
   void progressLayoutAnimation(

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -66,8 +66,9 @@ class EventHandler : public HybridClass<EventHandler> {
 
   void receiveEvent(
       jni::alias_ref<JString> eventKey,
+      jint targetTag,
       jni::alias_ref<react::WritableMap> event) {
-    handler_(eventKey, event);
+    handler_(eventKey, targetTag, event);
   }
 
   static void registerNatives() {
@@ -81,11 +82,12 @@ class EventHandler : public HybridClass<EventHandler> {
 
   explicit EventHandler(std::function<void(
                             jni::alias_ref<JString>,
+                            jint targetTag,
                             jni::alias_ref<react::WritableMap>)> handler)
       : handler_(std::move(handler)) {}
 
   std::function<
-      void(jni::alias_ref<JString>, jni::alias_ref<react::WritableMap>)>
+      void(jni::alias_ref<JString>, jint, jni::alias_ref<react::WritableMap>)>
       handler_;
 };
 
@@ -231,7 +233,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   std::vector<std::pair<std::string, double>> measure(int viewTag);
 #endif
   void handleEvent(
-      jni::alias_ref<JString> eventKey,
+      jni::alias_ref<JString> eventName,
+      jint targetTag,
       jni::alias_ref<react::WritableMap> event);
 
   void progressLayoutAnimation(

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -66,9 +66,9 @@ class EventHandler : public HybridClass<EventHandler> {
 
   void receiveEvent(
       jni::alias_ref<JString> eventKey,
-      jint targetTag,
+      jint emitterReactTag,
       jni::alias_ref<react::WritableMap> event) {
-    handler_(eventKey, targetTag, event);
+    handler_(eventKey, emitterReactTag, event);
   }
 
   static void registerNatives() {
@@ -82,7 +82,7 @@ class EventHandler : public HybridClass<EventHandler> {
 
   explicit EventHandler(std::function<void(
                             jni::alias_ref<JString>,
-                            jint targetTag,
+                            jint emitterReactTag,
                             jni::alias_ref<react::WritableMap>)> handler)
       : handler_(std::move(handler)) {}
 

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
@@ -26,7 +26,7 @@ public class EventHandler implements RCTEventEmitter {
   }
 
   public native void receiveEvent(
-      String eventKey, int emitterReactTag, @Nullable WritableMap event);
+      String eventName, int emitterReactTag, @Nullable WritableMap event);
 
   @Override
   public void receiveTouches(

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
@@ -22,10 +22,10 @@ public class EventHandler implements RCTEventEmitter {
   @Override
   public void receiveEvent(int targetTag, String eventName, @Nullable WritableMap event) {
     String resolvedEventName = mCustomEventNamesResolver.resolveCustomEventName(eventName);
-    receiveEvent(targetTag + resolvedEventName, event);
+    receiveEvent(resolvedEventName, targetTag, event);
   }
 
-  public native void receiveEvent(String eventKey, @Nullable WritableMap event);
+  public native void receiveEvent(String eventKey, int targetTag, @Nullable WritableMap event);
 
   @Override
   public void receiveTouches(

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/EventHandler.java
@@ -20,12 +20,13 @@ public class EventHandler implements RCTEventEmitter {
   }
 
   @Override
-  public void receiveEvent(int targetTag, String eventName, @Nullable WritableMap event) {
+  public void receiveEvent(int emitterReactTag, String eventName, @Nullable WritableMap event) {
     String resolvedEventName = mCustomEventNamesResolver.resolveCustomEventName(eventName);
-    receiveEvent(resolvedEventName, targetTag, event);
+    receiveEvent(resolvedEventName, emitterReactTag, event);
   }
 
-  public native void receiveEvent(String eventKey, int targetTag, @Nullable WritableMap event);
+  public native void receiveEvent(
+      String eventKey, int emitterReactTag, @Nullable WritableMap event);
 
   @Override
   public void receiveTouches(

--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -9,7 +9,7 @@
 
 typedef void (^REAOnAnimationCallback)(CADisplayLink *displayLink);
 typedef void (^REANativeAnimationOp)(RCTUIManager *uiManager);
-typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
+typedef void (^REAEventHandler)(id<RCTEvent> event);
 
 #ifdef RCT_NEW_ARCH_ENABLED
 typedef void (^REAPerformOperations)();

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -188,6 +188,7 @@ using namespace facebook::react;
     _componentUpdateBuffer = [NSMutableDictionary new];
     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
     _eventHandler = ^(id<RCTEvent> event) {
+      // no-op
     };
   }
 

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -187,6 +187,8 @@ using namespace facebook::react;
     _operationsInBatch = [NSMutableDictionary new];
     _componentUpdateBuffer = [NSMutableDictionary new];
     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
+    _eventHandler = ^(id<RCTEvent> event) {
+    };
   }
 
   _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
@@ -371,25 +373,19 @@ using namespace facebook::react;
 
 - (void)dispatchEvent:(id<RCTEvent>)event
 {
-  NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, RCTNormalizeInputEventName(event.eventName)];
-
-  NSString *eventHash = [NSString stringWithFormat:@"%@%@", event.viewTag, event.eventName];
-
-  if (_eventHandler != nil) {
-    __weak REAEventHandler eventHandler = _eventHandler;
-    __weak __typeof__(self) weakSelf = self;
-    RCTExecuteOnMainQueue(^void() {
-      __typeof__(self) strongSelf = weakSelf;
-      if (strongSelf == nil) {
-        return;
-      }
-      if (eventHandler == nil) {
-        return;
-      }
-      eventHandler(eventHash, event);
-      [strongSelf performOperations];
-    });
-  }
+  __weak REAEventHandler eventHandler = _eventHandler;
+  __weak __typeof__(self) weakSelf = self;
+  RCTExecuteOnMainQueue(^void() {
+    __typeof__(self) strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
+    }
+    if (eventHandler == nil) {
+      return;
+    }
+    eventHandler(event);
+    [strongSelf performOperations];
+  });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -289,12 +289,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
     std::string eventName = [event.eventName UTF8String];
-    int viewTag = [event.viewTag intValue];
+    int emitterReactTag = [event.viewTag intValue];
     id eventData = [event arguments][2];
     jsi::Runtime &rt = *nativeReanimatedModule->runtimeManager_->runtime;
     jsi::Value payload = convertObjCObjectToJSIValue(rt, eventData);
     double currentTime = CACurrentMediaTime() * 1000;
-    nativeReanimatedModule->handleEvent(eventName, viewTag, payload, currentTime);
+    nativeReanimatedModule->handleEvent(eventName, emitterReactTag, payload, currentTime);
   }];
 
   std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule = nativeReanimatedModule; // to avoid retain cycle

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -286,14 +286,15 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   scheduler->setRuntimeManager(nativeReanimatedModule->runtimeManager_);
 
-  [reaModule.nodesManager registerEventHandler:^(NSString *eventNameNSString, id<RCTEvent> event) {
+  [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
-    std::string eventName = [eventNameNSString UTF8String];
+    std::string eventName = [event.eventName UTF8String];
+    int viewTag = [event.viewTag intValue];
     id eventData = [event arguments][2];
     jsi::Runtime &rt = *nativeReanimatedModule->runtimeManager_->runtime;
     jsi::Value payload = convertObjCObjectToJSIValue(rt, eventData);
     double currentTime = CACurrentMediaTime() * 1000;
-    nativeReanimatedModule->handleEvent(eventName, payload, currentTime);
+    nativeReanimatedModule->handleEvent(eventName, viewTag, payload, currentTime);
   }];
 
   std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule = nativeReanimatedModule; // to avoid retain cycle

--- a/src/reanimated2/WorkletEventHandler.ts
+++ b/src/reanimated2/WorkletEventHandler.ts
@@ -54,6 +54,10 @@ export default class WorkletEventHandler<T extends NativeEvent<T>> {
     }
   }
 
+  registerForEventByName(eventName: string) {
+    this.registrations.push(registerEventHandler(eventName, this.worklet));
+  }
+
   unregisterFromEvents(): void {
     this.registrations.forEach((id) => unregisterEventHandler(id));
     this.registrations = [];


### PR DESCRIPTION
## Summary

The current event mechanism allows us to register for an event only when we know the react tag of the event emitter. This PR adds the possibility to register on events just by event name without knowing the emitter react tag. It'll be helpful for shared transition progress feature: https://github.com/software-mansion/react-native-reanimated/pull/4421

## Test plan

I tested it on iOS/Android & Paper/Fabric

<details>
<summary>code</summary>

```js
import * as React from 'react';
import { View, Button } from 'react-native';
import { ParamListBase } from '@react-navigation/native';
import {
  createNativeStackNavigator,
  NativeStackScreenProps,
} from '@react-navigation/native-stack';
import Animated, { useEvent } from 'react-native-reanimated';

const Stack = createNativeStackNavigator();

function Screen1({ navigation }: NativeStackScreenProps<ParamListBase>) {
  return (
    <View style={{ flex: 1 }}>
      <Animated.View
        style={{ width: 150, height: 150, backgroundColor: 'red' }}
        sharedTransitionTag="tag1"
      />
      <Button title="Screen2" onPress={() => navigation.navigate('Screen2')} />
      <Button title="Screen3" onPress={() => navigation.navigate('Screen3')} />
    </View>
  );
}

function Screen2({ navigation }: NativeStackScreenProps<ParamListBase>) {
  return (
    <View style={{ flex: 1, marginTop: 50 }}>
      <Animated.View
        style={{ width: 100, height: 100, backgroundColor: 'green' }}
        sharedTransitionTag="tag1"
      />
      <Button title="Screen1" onPress={() => navigation.navigate('Screen1')} />
      <Button title="Screen3" onPress={() => navigation.navigate('Screen3')} />
    </View>
  );
}

function Screen3({ navigation }: NativeStackScreenProps<ParamListBase>) {
  return (
    <View style={{ flex: 1 }}>
      <Animated.View
        style={{ width: 100, height: 100, backgroundColor: 'blue' }}
        sharedTransitionTag="tag1"
      />
      <Button title="Screen1" onPress={() => navigation.navigate('Screen1')} />
      <Button title="Screen2" onPress={() => navigation.navigate('Screen2')} />
    </View>
  );
}

export default function ManyScreensExample() {
  const event = useEvent((event) => {
    'worklet'
    console.log(event);
  });
  // event.current.registerForEventByName('topTransitionProgress');
  event.current.registerForEventByName('onTransitionProgress');
  return (
    <Stack.Navigator>
      <Stack.Screen
        name="Screen1"
        component={Screen1}
        options={{ headerShown: true }}
      />
      <Stack.Screen
        name="Screen2"
        component={Screen2}
        options={{ headerShown: true }}
      />
      <Stack.Screen
        name="Screen3"
        component={Screen3}
        options={{ headerShown: true }}
      />
    </Stack.Navigator>
  );
}
```
</details>

```js
const event = useEvent((event) => {
  'worklet'
  console.log(event);
});
event.current.registerForEventByName('topTransitionProgress'); // for iOS
event.current.registerForEventByName('onTransitionProgress'); // for Android
```

https://github.com/software-mansion/react-native-reanimated/assets/36106620/783e6e1d-6f78-4981-b303-d5fb4b6b6cb4

