### PR TITLE
Unregister commit hook on Android

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -53,11 +53,10 @@ NativeProxy::NativeProxy(
 #ifdef RCT_NEW_ARCH_ENABLED
   Binding *binding = fabricUIManager->getBinding();
   RuntimeExecutor runtimeExecutor = getRuntimeExecutorFromBinding(binding);
-  std::shared_ptr<UIManager> uiManager =
-      binding->getScheduler()->getUIManager();
+  uiManager_ = binding->getScheduler()->getUIManager();
   commitHook_ =
-      std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager);
-  uiManager->registerCommitHook(*commitHook_);
+      std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager_);
+  uiManager_->registerCommitHook(*commitHook_);
 #endif
 }
 
@@ -69,6 +68,7 @@ NativeProxy::~NativeProxy() {
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
   nativeReanimatedModule_->cleanupSensors();
+  uiManager_->unregisterCommitHook(*commitHook_);
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -68,7 +68,9 @@ NativeProxy::~NativeProxy() {
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
   nativeReanimatedModule_->cleanupSensors();
+#ifdef RCT_NEW_ARCH_ENABLED
   uiManager_->unregisterCommitHook(*commitHook_);
+#endif // RCT_NEW_ARCH_ENABLED
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -178,6 +178,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   std::shared_ptr<Scheduler> scheduler_;
 #ifdef RCT_NEW_ARCH_ENABLED
   std::shared_ptr<PropsRegistry> propsRegistry_;
+  std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
 
 // removed temporary, new event listener mechanism need fix on the RN side


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the following crash on Android Fabric:

<img width="1624" alt="crash" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/2e2670bf-a633-450e-b4a8-9fc058d80da9">

## Test plan

1. Launch FabricExample on Android
2. Open BubblesExample
3. Reload the app a few times by clicking <kbd>r</kbd>
