### PR TITLE
Fix isWeb is not a function

### DIFF
--- a/src/reanimated2/animation/decay.ts
+++ b/src/reanimated2/animation/decay.ts
@@ -38,6 +38,8 @@ export interface InnerDecayAnimation
   current: number;
 }
 
+const IS_WEB = isWeb();
+
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
 type withDecayType = (
   userConfig: DecayConfig,
@@ -49,7 +51,6 @@ export const withDecay = function (
   callback?: AnimationCallback
 ): Animation<DecayAnimation> {
   'worklet';
-  const IS_WEB = isWeb();
 
   return defineAnimation<DecayAnimation>(0, () => {
     'worklet';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
`const IS_WEB = isWeb();` was accidentaly moved inside the `'worklet'` function in this [PR](https://github.com/software-mansion/react-native-reanimated/pull/4519) on `decay.ts`

This PR moves it outside the `'worket'` function.

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/4656
