### PR TITLE
Fix basic support for react-native-macos

### DIFF
--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -16,10 +16,14 @@ export function isAndroid(): boolean {
   return Platform.OS === 'android';
 }
 
+export function isMacos(): boolean {
+  return Platform.OS === 'macos';
+}
+
 export function shouldBeUseWeb() {
-  return isJest() || isChromeDebugger() || isWeb();
+  return isJest() || isChromeDebugger() || isWeb() || isMacos();
 }
 
 export function nativeShouldBeMock() {
-  return isJest() || isChromeDebugger();
+  return isJest() || isChromeDebugger() || isMacos();
 }

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,5 +1,5 @@
 import NativeReanimatedModule from './NativeReanimated';
-import { nativeShouldBeMock, isWeb } from './PlatformChecker';
+import { nativeShouldBeMock, isWeb, isMacos } from './PlatformChecker';
 import type {
   AnimatedKeyboardOptions,
   SensorConfig,
@@ -155,7 +155,7 @@ export function unregisterSensor(sensorId: number): void {
   return sensorContainer.unregisterSensor(sensorId);
 }
 
-if (!isWeb()) {
+if (!isWeb() && !isMacos()) {
   initializeUIRuntime();
 }
 


### PR DESCRIPTION
Hey.
This adds back basic support for react-native-macos.
Ever since >= 2, react-native-macos has been broken.
This is because `shouldBeUseWeb` in `PlatformChecker.ts` not checking for macos.

Related to #4659.