### PR TITLE
Batch remove from props registry

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -95,10 +95,10 @@ NativeReanimatedModule::NativeReanimatedModule(
     this->updateProps(rt, operations);
   };
 
-  auto removeFromPropsRegistry = [this](
-                                     jsi::Runtime &rt, const jsi::Value &tag) {
-    this->removeFromPropsRegistry(rt, tag);
-  };
+  auto removeFromPropsRegistry =
+      [this](jsi::Runtime &rt, const jsi::Value &viewTags) {
+        this->removeFromPropsRegistry(rt, viewTags);
+      };
 
   auto measure = [this](jsi::Runtime &rt, const jsi::Value &shadowNodeValue) {
     return this->measure(rt, shadowNodeValue);
@@ -644,8 +644,11 @@ void NativeReanimatedModule::performOperations() {
 
 void NativeReanimatedModule::removeFromPropsRegistry(
     jsi::Runtime &rt,
-    const jsi::Value &tag) {
-  tagsToRemove_.push_back(tag.asNumber());
+    const jsi::Value &viewTags) {
+  auto array = viewTags.asObject(rt).asArray(rt);
+  for (size_t i = 0, size = array.size(rt); i < size; ++i) {
+    tagsToRemove_.push_back(array.getValueAtIndex(rt, i).asNumber());
+  }
 }
 
 void NativeReanimatedModule::dispatchCommand(

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -122,7 +122,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   void updateProps(jsi::Runtime &rt, const jsi::Value &operations);
 
-  void removeFromPropsRegistry(jsi::Runtime &rt, const jsi::Value &tag);
+  void removeFromPropsRegistry(jsi::Runtime &rt, const jsi::Value &viewTags);
 
   void performOperations();
 

--- a/Common/cpp/Tools/PlatformDepMethodsHolder.h
+++ b/Common/cpp/Tools/PlatformDepMethodsHolder.h
@@ -25,7 +25,7 @@ using SynchronouslyUpdateUIPropsFunction =
 using UpdatePropsFunction =
     std::function<void(jsi::Runtime &rt, const jsi::Value &operations)>;
 using RemoveFromPropsRegistryFunction =
-    std::function<void(jsi::Runtime &rt, const jsi::Value &tag)>;
+    std::function<void(jsi::Runtime &rt, const jsi::Value &viewTags)>;
 using DispatchCommandFunction = std::function<void(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeValue,

--- a/src/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent.tsx
@@ -17,7 +17,6 @@ import { RNRenderer } from './reanimated2/platform-specific/RNRenderer';
 import {
   configureLayoutAnimations,
   enableLayoutAnimations,
-  runOnUI,
   startMapper,
   stopMapper,
 } from './reanimated2/core';
@@ -53,6 +52,7 @@ import updateProps from './reanimated2/UpdateProps';
 import NativeReanimatedModule from './reanimated2/NativeReanimated';
 import { isSharedValue } from './reanimated2';
 import type { AnimateProps } from './reanimated2/helperTypes';
+import { removeFromPropsRegistry } from './reanimated2/PropsRegistry';
 
 function dummyListener() {
   // empty listener we use to assign to listener properties for which animated
@@ -359,11 +359,7 @@ export default function createAnimatedComponent(
           this.props.animatedProps.viewDescriptors.remove(this._viewTag);
         }
         if (global._IS_FABRIC) {
-          const viewTag = this._viewTag;
-          // TODO: batching
-          runOnUI(() => {
-            _removeFromPropsRegistry!(viewTag);
-          })();
+          removeFromPropsRegistry(this._viewTag);
         }
       }
     }

--- a/src/reanimated2/PropsRegistry.ts
+++ b/src/reanimated2/PropsRegistry.ts
@@ -1,0 +1,23 @@
+import { runOnUI } from './threads';
+
+let viewTags: number[] = [];
+
+export function removeFromPropsRegistry(viewTag: number) {
+  viewTags.push(viewTag);
+  if (viewTags.length === 1) {
+    queueMicrotask(flush);
+  }
+}
+
+function flush() {
+  if (__DEV__ && !global._IS_FABRIC) {
+    throw new Error('PropsRegistry is only available on Fabric');
+  }
+  runOnUI(removeFromPropsRegistryOnUI)(viewTags);
+  viewTags = [];
+}
+
+function removeFromPropsRegistryOnUI(viewTags: number[]) {
+  'worklet';
+  _removeFromPropsRegistry(viewTags);
+}

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -64,7 +64,7 @@ declare global {
         }[]
       ) => void)
     | undefined;
-  var _removeFromPropsRegistry: (tag: number) => void | undefined;
+  var _removeFromPropsRegistry: (viewTags: number[]) => void | undefined;
   var _measurePaper: ((viewTag: number) => MeasuredDimensions) | undefined;
   var _measureFabric:
     | ((shadowNodeWrapper: ShadowNodeWrapper) => MeasuredDimensions)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR addresses the following TODO:

https://github.com/software-mansion/react-native-reanimated/blob/1359a1141ddd538b42d3c6db51d3e7c6fb586fd7/src/createAnimatedComponent.tsx#L363-L366

Previously, we would schedule a worklet via `runOnJS` for each individual unmounted animated component. Each worklet would call JSI binding `_removeFromPropsRegistry`. This PR adds batching layer on JS context and changes the semantics of `_removeFromPropsRegistry` so that it accepts an array of view tags to remove from PropsRegistry.

## Test plan

`PropsRegistry.cpp`

```diff
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include "PropsRegistry.h"
 
+#include <iostream>
 
 namespace reanimated {
 
 std::lock_guard<std::mutex> PropsRegistry::createLock() const {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::cout << "map_.size() = " << map_.size() << std::endl;
+  }
   return std::lock_guard<std::mutex>(mutex_);
 }
```

`PropsRegistry.ts`

```diff
 function flush() {
   if (__DEV__ && !global._IS_FABRIC) {
     throw new Error('PropsRegistry is only available on Fabric');
   }
+  console.log(viewTags.length);
   runOnUI(removeFromPropsRegistryOnUI)(viewTags);
   viewTags = [];
 }
```

FabricExample &rarr; ChessboardExample.tsx

<img width="114" alt="Zrzut ekranu 2023-07-6 o 15 54 01" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/005b52f9-45c5-4db9-a4fd-964793dbf66c">
