### PR TITLE
Add missing name to workflow

### DIFF
--- a/.github/workflows/build-monorepo-nightly.yml
+++ b/.github/workflows/build-monorepo-nightly.yml
@@ -1,3 +1,4 @@
+name: Run nightly monorepo test
 on:
   schedule:
     - cron: '37 19 * * *' # at 21:37 every day


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently its displayed name is `.github/workflows/build-monorepo-nightly.yml` 😿 

## Test plan

Yes
