### PR TITLE
If the user sets a custom `node_modules` location, always use it

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -54,11 +54,18 @@ def assert_no_multiple_instances(react_native_info)
     return
   end
 
+  # Find all instances in the node_modules location where React Native lives
   lib_instances_in_react_native_node_modules = %x[find #{react_native_info[:react_native_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
   lib_instances_in_react_native_node_modules_array = lib_instances_in_react_native_node_modules.split("\n")
+
+  reanimated_instances = lib_instances_in_react_native_node_modules_array.length
+
+  # Find all instances in the node_modules location where RNReanimated lives, unless:
+  #
+  # - It's the same location as React Native (as that would give us the same results); or
+  # - The user passed a custom node_modules location (as that is guaranteed to give multiple instances since the RNReanimated location is relative to this project)
   lib_instances_in_reanimated_node_modules_array = Array.new
-  reanimated_instances = lib_instances_in_react_native_node_modules_array.length()
-  if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir]
+  if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir] && ENV.fetch('REACT_NATIVE_NODE_MODULES_DIR').nil?
     lib_instances_in_reanimated_node_modules = %x[find #{react_native_info[:reanimated_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
     lib_instances_in_reanimated_node_modules_array = lib_instances_in_reanimated_node_modules.split("\n")
     reanimated_instances += lib_instances_in_reanimated_node_modules_array.length()

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -25,6 +25,10 @@ def find_config()
   if custom_react_native_node_modules_dir.nil?
     react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
   else
+    unless File.exist? custom_react_native_node_modules_dir
+      raise "[RNReanimated] The given React Native lookup path #{custom_react_native_node_modules_dir} does not exist"
+    end
+
     react_native_node_modules_dir = custom_react_native_node_modules_dir
   end
 

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -18,7 +18,7 @@ def find_config()
   }
 
   # If the user set a custom location for where to look for React Native, use that
-  custom_react_native_node_modules_dir = ENV.fetch('REACT_NATIVE_NODE_MODULES_DIR')
+  custom_react_native_node_modules_dir = ENV['REACT_NATIVE_NODE_MODULES_DIR']
   if custom_react_native_node_modules_dir.nil?
     react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
   else
@@ -65,7 +65,7 @@ def assert_no_multiple_instances(react_native_info)
   # - It's the same location as React Native (as that would give us the same results); or
   # - The user passed a custom node_modules location (as that is guaranteed to give multiple instances since the RNReanimated location is relative to this project)
   lib_instances_in_reanimated_node_modules_array = Array.new
-  if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir] && ENV.fetch('REACT_NATIVE_NODE_MODULES_DIR').nil?
+  if react_native_info[:react_native_node_modules_dir] != react_native_info[:reanimated_node_modules_dir] && ENV['REACT_NATIVE_NODE_MODULES_DIR'].nil?
     lib_instances_in_reanimated_node_modules = %x[find #{react_native_info[:reanimated_node_modules_dir]} -name "package.json" | grep "/react-native-reanimated/package.json"]
     lib_instances_in_reanimated_node_modules_array = lib_instances_in_reanimated_node_modules.split("\n")
     reanimated_instances += lib_instances_in_reanimated_node_modules_array.length()

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -17,14 +17,15 @@ def find_config()
     :react_native_common_dir => nil,
   }
 
-  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-  react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
-
-  if react_native_json == nil
-    # user configuration, just in case
-    node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-    react_native_json = try_to_parse_react_native_package_json(node_modules_dir)
+  # If the user set a custom location for where to look for React Native, use that
+  custom_react_native_node_modules_dir = ENV.fetch('REACT_NATIVE_NODE_MODULES_DIR')
+  if custom_react_native_node_modules_dir.nil?
+    react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+  else
+    react_native_node_modules_dir = custom_react_native_node_modules_dir
   end
+
+  react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
 
   if react_native_json == nil
     raise '[RNReanimated] Unable to recognize your `react-native` version! Please set environmental variable with `react-native` locations: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install'

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -1,5 +1,8 @@
 def try_to_parse_react_native_package_json(node_modules_dir)
   react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
+
+  puts "[RNReanimated] Looking for React Native configs at #{react_native_package_json_path}..."
+
   if !File.exist?(react_native_package_json_path)
     return nil
   end


### PR DESCRIPTION
## Summary

Users can provide a custom path for where the CocoaPods setup should look for the React Native `node_modules`.

The previous version used the user-defined `REACT_NATIVE_NODE_MODULES_DIR` as a fallback to read the React Native `package.json` but forgot to use it later on when looking for `ReactCommon`.

## Test plan

Admittedly, the main issue this PR aims to solve occurs only in a contrived setup where `node --print "require.resolve('react-native/package.json')"` fails. 

Such a setup can be reproduced by

1. Creating a folder, e.g `cocoapods-test` in the same parent folder as this repository
2. In the new folder, creating a `Podfile` with the following content:

```ruby
# frozen_string_literal: true

RN_PATH = ENV.fetch('TEST_RN_PATH')
rn_utils_path = File.join(RN_PATH, 'scripts', 'react_native_pods.rb')

raise "Could not find React Native utils at #{rn_utils_path}" unless File.exist? rn_utils_path

require_relative rn_utils_path

install! 'cocoapods', integrate_targets: false

abstract_target 'Test' do
  platform :ios, '15.0'

  use_react_native! path: RN_PATH

  if ENV.fetch('TEST_MAIN', 'true') == 'true'
    git = 'https://github.com/software-mansion/react-native-reanimated'
    # Latest main at the time of writing
    commit = 'ce3a2820ae178de4ef265633a40c99783d3b9eac'

    puts '[TEST] Testing against RNReanimated main'
  else
    git = 'https://github.com/wordpress-mobile/react-native-reanimated'
    commit = '18a0922ed2fa269f76462838df155b2f975cc15e'

    puts '[TEST] Testing against RNReanimated PR'
  end

  pod 'RNReanimated', git: git, commit: commit
end
```

Before starting testing, we can set the path to React Native for the `Podfile` to use (different from the one that the library uses), e.g.:

```
export TEST_RN_PATH=../react-native-reanimated/node_modules/react-native
```

We can now test the following scenarios

### 1. `main` + no `REACT_NATIVE_NODE_MODULES_DIR` – Fails

Note: The `rm -rf`s and `pod cache clean...` commands make sure we test from a fresh setup.

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=false \
  REACT_NATIVE_NODE_MODULES_DIR=$PWD/../react-native-reanimated/node_modules \
  pod install
```

```
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'react-native/package.json'
Require stack:
- /Users/gio/Developer/oss/cocoapods-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Function.resolve (node:internal/modules/cjs/helpers:116:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:307:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60)
    at node:internal/main/eval_string:28:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/gio/Developer/oss/cocoapods-test/[eval]' ]
}

Node.js v18.16.0
[!] Failed to load 'RNReanimated' podspec:
[!] Invalid `RNReanimated.podspec` file: no implicit conversion of nil into String.

 #  from /var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/T/d20230707-7863-i915iz/RNReanimated.podspec:5
 #  -------------------------------------------
 #  reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
 #  assert_no_multiple_instances(config)
 #  -------------------------------------------
```

### 2. `main` + `REACT_NATIVE_NODE_MODULES_DIR` – Fails with different message

Notice the uses of `$PWD`, I run into issues when using a relative path. I haven't had a chance to investigate them yet. I think this PR consists in an improvement regardless.

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=true \
  REACT_NATIVE_NODE_MODULES_DIR=$PWD/../react-native-reanimated/node_modules \
  pod install
```

```
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'react-native/package.json'
Require stack:
- /Users/gio/Developer/oss/cocoapods-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Function.resolve (node:internal/modules/cjs/helpers:116:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:307:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60)
    at node:internal/main/eval_string:28:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/gio/Developer/oss/cocoapods-test/[eval]' ]
}

Node.js v18.16.0
[!] Failed to load 'RNReanimated' podspec:
[!] Invalid `RNReanimated.podspec` file: different prefix: "" and "/Users/gio/Developer/oss/cocoapods-test/Pods".

 #  from /var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/T/d20230707-8351-99vkw7/RNReanimated.podspec:5
 #  -------------------------------------------
 #  reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
 #  assert_no_multiple_instances(config)
 #  -------------------------------------------
```

### 3. `main` + Invalid `REACT_NATIVE_NODE_MODULES_DIR` – Fails with different message

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=true \
  REACT_NATIVE_NODE_MODULES_DIR=$PWD/../react-native-reanimated \
  pod install
```

This time, at least, the message points to using `REACT_NATIVE_NODE_MODULES_DIR` unlike the previous ones—even though because of the issues already highlighted, it won't work

```
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'react-native/package.json'
Require stack:
- /Users/gio/Developer/oss/cocoapods-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Function.resolve (node:internal/modules/cjs/helpers:116:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:307:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60)
    at node:internal/main/eval_string:28:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/gio/Developer/oss/cocoapods-test/[eval]' ]
}

Node.js v18.16.0
[!] Failed to load 'RNReanimated' podspec:
[!] Invalid `RNReanimated.podspec` file: [RNReanimated] Unable to recognize your `react-native` version! Please set environmental variable with `react-native` locations: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install.
```

### 4. This PR + no `REACT_NATIVE_NODE_MODULES_DIR` – Fails (as expected) with better message

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=false \
  pod install
```

Still fails, as expected when there are no available `node_modules` but at least it suggests using the `REACT_NATIVE_NODE_MODULES_DIR` environment variable.

```
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'react-native/package.json'
Require stack:
- /Users/gio/Developer/oss/cocoapods-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Function.resolve (node:internal/modules/cjs/helpers:116:19)
    at [eval]:1:9
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:307:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60)
    at node:internal/main/eval_string:28:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/gio/Developer/oss/cocoapods-test/[eval]' ]
}

Node.js v18.16.0
[RNReanimated] Looking for React Native configs at ./../react-native/package.json...
[!] Failed to load 'RNReanimated' podspec:
[!] Invalid `RNReanimated.podspec` file: [RNReanimated] Unable to recognize your `react-native` version! Please set environmental variable with `react-native` locations: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install.

 #  from /var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/T/d20230707-10998-ar912d/RNReanimated.podspec:5
 #  -------------------------------------------
 #  reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
 #  assert_no_multiple_instances(config)
 #  -------------------------------------------
```

### 5. `main` + `REACT_NATIVE_NODE_MODULES_DIR` – Works

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=false \
  REACT_NATIVE_NODE_MODULES_DIR=$PWD/../react-native-reanimated/node_modules \
  pod install
```

This one works, which is the desired behavior 😄 

### 6. `main` + Invalid `REACT_NATIVE_NODE_MODULES_DIR` – Fails (as expected) with better message

```
rm -rf Pods \ 
  && rm -rf build \
  && pod cache clean RNReanimated \
  && TEST_MAIN=false \
  REACT_NATIVE_NODE_MODULES_DIR=$PWD/../react-native-reanimated \
  pod install
```

The failure is expected because the `node_modules` path is invalid. But in this version a user will know the path the install process used, which will be helpful in fixing the issue.

```
[RNReanimated] Looking for React Native configs at /Users/gio/Developer/oss/cocoapods-test/../react-native-reanimated/react-native/package.json...
[!] Failed to load 'RNReanimated' podspec:
[!] Invalid `RNReanimated.podspec` file: [RNReanimated] Unable to recognize your `react-native` version! Please set environmental variable with `react-native` locations: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install.

 #  from /Users/gio/Developer/oss/react-native-reanimated/RNReanimated.podspec:5
 #  -------------------------------------------
 #  reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
 #  assert_no_multiple_instances(config)
 #  -------------------------------------------
```
