### PR TITLE
Add useReducedMotion hook

### DIFF
--- a/src/reanimated2/hook/Hooks.ts
+++ b/src/reanimated2/hook/Hooks.ts
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAnimatedStyle } from './useAnimatedStyle';
 import type { DependencyList } from './commonTypes';
 import type { useAnimatedPropsType } from '../helperTypes';
+import { AccessibilityInfo } from 'react-native';
 
 // TODO: we should make sure that when useAP is used we are not assigning styles
 // when you need styles to animated you should always use useAS
@@ -13,6 +14,32 @@ export function useWorkletCallback<A extends unknown[], R>(
   deps?: DependencyList
 ): (...args: Parameters<typeof fun>) => R {
   return useCallback(fun, deps ?? []);
+}
+
+export function useReducedMotion(): boolean {
+  const [shouldReduceMotion, setShouldReduceMotion] = useState(false);
+
+  useEffect(() => {
+    const handleChange = (isReduceMotionEnabled: boolean): void => {
+      setShouldReduceMotion(isReduceMotionEnabled);
+    };
+
+    async function init(): Promise<void> {
+      handleChange(await AccessibilityInfo.isReduceMotionEnabled());
+    }
+    init();
+
+    const reduceMotionChangedlistener = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      handleChange
+    );
+
+    return (): void => {
+      reduceMotionChangedlistener.remove();
+    };
+  }, []);
+
+  return shouldReduceMotion;
 }
 
 export { useEvent, useHandler } from './utils';

--- a/src/reanimated2/hook/index.ts
+++ b/src/reanimated2/hook/index.ts
@@ -4,6 +4,7 @@ export {
   useEvent,
   useHandler,
   useWorkletCallback,
+  useReducedMotion,
 } from './Hooks';
 export { useSharedValue } from './useSharedValue';
 export { useAnimatedStyle } from './useAnimatedStyle';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Animations can cause some people to feel unwell. In order to help developers create apps with those people in mind this PR adds a `useReducedMotion` hook that returns a boolean value informing whether the "Reduced Motion" setting is enabled. Using this hook will cause the component to reload whenever the setting changes.

https://github.com/software-mansion/react-native-reanimated/assets/56109050/26d75993-f504-4138-87cc-cde784b7539a

## Test plan
Create an animation that runs conditionally on the value returned from `useReducedMotion` and check the behavior on android and iOS. This code was used in the video:
 
```js
const rotation = useSharedValue(0)
  const shouldReduceMotion = useReducedMotion()

  const animatedStyles = useAnimatedStyle(() => ({
    transform: [{ rotate: shouldReduceMotion ? "0deg" : rotation.value + "deg"}]
  }));

  React.useEffect(() => {
      rotation.value = withRepeat(withTiming(360, {duration: 1000, easing: Easing.linear}), -1)
  }, []);

  return (
    <View style={styles.container}>
      <Animated.View style={[styles.box, animatedStyles]} />
    </View>
  );
```
