### PR TITLE
Initialize CADisplayLink on UI thread

### DIFF
--- a/ios/REANodesManager.h
+++ b/ios/REANodesManager.h
@@ -10,6 +10,7 @@
 typedef void (^REAOnAnimationCallback)(CADisplayLink *displayLink);
 typedef void (^REANativeAnimationOp)(RCTUIManager *uiManager);
 typedef void (^REAEventHandler)(id<RCTEvent> event);
+typedef void (^CADisplayLinkOperation)(CADisplayLink *displayLink);
 
 #ifdef RCT_NEW_ARCH_ENABLED
 typedef void (^REAPerformOperations)();

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -175,8 +175,6 @@ using namespace facebook::react;
 
 - (CADisplayLink *)getDisplayLink
 {
-  RCTAssertMainQueue();
-
   if (!_displayLink) {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -217,7 +217,7 @@ using namespace facebook::react;
     _shouldFlushUpdateBuffer = false;
   }
 #endif
-  [[self getDisplayLink] setPaused:true];
+  [[self getDisplayLink] setPaused:YES];
 
   return self;
 }
@@ -274,7 +274,7 @@ using namespace facebook::react;
 
 - (void)stopUpdatingOnAnimationFrame
 {
-  [[self getDisplayLink] setPaused:true];
+  [[self getDisplayLink] setPaused:YES];
 }
 
 - (void)onAnimationFrame:(CADisplayLink *)displayLink

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -272,13 +272,6 @@ using namespace facebook::react;
 
 - (void)startUpdatingOnAnimationFrame
 {
-  // Setting _currentAnimationTimestamp here is connected with manual triggering of performOperations
-  // in operationsBatchDidComplete. If new node has been created and clock has not been started,
-  // _displayLink won't be initialized soon enough and _displayLink.timestamp will be 0.
-  // However, CADisplayLink is using CACurrentMediaTime so if there's need to perform one more
-  // evaluation, it could be used it here. In usual case, CACurrentMediaTime is not being used in
-  // favor of setting it with _displayLink.timestamp in onAnimationFrame method.
-  _currentAnimationTimestamp = CACurrentMediaTime();
   if (_displayLink) {
     [_displayLink setPaused:false];
   }
@@ -293,10 +286,6 @@ using namespace facebook::react;
 
 - (void)onAnimationFrame:(CADisplayLink *)displayLink
 {
-  if (_displayLink) {
-    _currentAnimationTimestamp = _displayLink.timestamp;
-  }
-
   NSArray<REAOnAnimationCallback> *callbacks = _onAnimationCallbacks;
   _onAnimationCallbacks = [NSMutableArray new];
 

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -206,7 +206,7 @@ using namespace facebook::react;
   }
 #endif
 
-  RCTExecuteOnMainQueue(^void() {
+  RCTExecuteOnMainQueue(^() {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -192,10 +192,12 @@ using namespace facebook::react;
     };
   }
 
-  _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
-  _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
-  [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-  [_displayLink setPaused:true];
+  RCTExecuteOnMainQueue(^void() {
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    [_displayLink setPaused:true];
+  });
   return self;
 }
 #else
@@ -211,11 +213,12 @@ using namespace facebook::react;
     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
     _shouldFlushUpdateBuffer = false;
   }
-
-  _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
-  _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
-  [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-  [_displayLink setPaused:true];
+  RCTExecuteOnMainQueue(^void() {
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    [_displayLink setPaused:true];
+  });
   return self;
 }
 #endif

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -217,8 +217,9 @@ using namespace facebook::react;
     _shouldFlushUpdateBuffer = false;
   }
 #endif
-  [[self getDisplayLink] setPaused:YES];
-
+  RCTExecuteOnMainQueue(^{
+    [[self getDisplayLink] setPaused:YES];
+  });
   return self;
 }
 

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -226,9 +226,7 @@ using namespace facebook::react;
 - (void)invalidate
 {
   _eventHandler = nil;
-  if (_displayLink) {
-    [_displayLink invalidate];
-  }
+  [_displayLink invalidate];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -240,7 +238,7 @@ using namespace facebook::react;
 
 - (void)operationsBatchDidComplete
 {
-  if (_displayLink && ![_displayLink isPaused]) {
+  if (![_displayLink isPaused]) {
     // if display link is set it means some of the operations that have run as a part of the batch
     // requested updates. We want updates to be run in the same frame as in which operations have
     // been scheduled as it may mean the new view has just been mounted and expects its initial
@@ -272,16 +270,12 @@ using namespace facebook::react;
 
 - (void)startUpdatingOnAnimationFrame
 {
-  if (_displayLink) {
-    [_displayLink setPaused:false];
-  }
+  [_displayLink setPaused:false];
 }
 
 - (void)stopUpdatingOnAnimationFrame
 {
-  if (_displayLink) {
-    [_displayLink setPaused:true];
-  }
+  [_displayLink setPaused:true];
 }
 
 - (void)onAnimationFrame:(CADisplayLink *)displayLink
@@ -556,7 +550,7 @@ using namespace facebook::react;
 
 - (void)maybeFlushUIUpdatesQueue
 {
-  if (_displayLink && [_displayLink isPaused]) {
+  if ([_displayLink isPaused]) {
     [self performOperations];
   }
 }

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -180,6 +180,7 @@ using namespace facebook::react;
   if (!_displayLink) {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   }
   return _displayLink;
 }
@@ -216,7 +217,6 @@ using namespace facebook::react;
     _shouldFlushUpdateBuffer = false;
   }
 #endif
-  [[self getDisplayLink] addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   [[self getDisplayLink] setPaused:true];
 
   return self;
@@ -269,7 +269,7 @@ using namespace facebook::react;
 
 - (void)startUpdatingOnAnimationFrame
 {
-  [[self getDisplayLink] setPaused:false];
+  [[self getDisplayLink] setPaused:NO];
 }
 
 - (void)stopUpdatingOnAnimationFrame

--- a/ios/REANodesManager.mm
+++ b/ios/REANodesManager.mm
@@ -191,15 +191,6 @@ using namespace facebook::react;
       // no-op
     };
   }
-
-  RCTExecuteOnMainQueue(^void() {
-    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
-    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
-    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-    [_displayLink setPaused:true];
-  });
-  return self;
-}
 #else
 - (instancetype)initWithModule:(REAModule *)reanimatedModule uiManager:(RCTUIManager *)uiManager
 {
@@ -213,6 +204,8 @@ using namespace facebook::react;
     _viewRegistry = [_uiManager valueForKey:@"_viewRegistry"];
     _shouldFlushUpdateBuffer = false;
   }
+#endif
+
   RCTExecuteOnMainQueue(^void() {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
@@ -221,7 +214,6 @@ using namespace facebook::react;
   });
   return self;
 }
-#endif
 
 - (void)invalidate
 {

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -51,9 +51,11 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 - (void)runUpdater
 {
   if (!_displayLink) {
-    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
-    _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
-    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    RCTExecuteOnMainQueue(^() {
+      _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
+      _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+      [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    })
   }
   _displayLink.paused = NO;
   [self updateKeyboardFrame];

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -37,8 +37,10 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 
 - (CADisplayLink *)getDisplayLink
 {
+  RCTAssertMainQueue();
+
   if (!_displayLink) {
-    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(updateKeyboardFrame)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   }

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -63,7 +63,6 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 - (void)runUpdater
 {
   if (![self getDisplayLink]) {
-    [[self getDisplayLink] addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
     [[self getDisplayLink] setPaused:YES];
   } else {
     [[self getDisplayLink] setPaused:NO];

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -62,12 +62,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 
 - (void)runUpdater
 {
-  if (![self getDisplayLink]) {
-    [[self getDisplayLink] setPaused:YES];
-  } else {
-    [[self getDisplayLink] setPaused:NO];
-  }
-
+  [[self getDisplayLink] setPaused:NO];
   [self updateKeyboardFrame];
 }
 

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
   if (!_displayLink) {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
   }
   return _displayLink;
 }
@@ -63,9 +64,9 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 {
   if (![self getDisplayLink]) {
     [[self getDisplayLink] addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-    [[self getDisplayLink] setPaused:true];
+    [[self getDisplayLink] setPaused:YES];
   } else {
-    [_displayLink setPaused:false];
+    [[self getDisplayLink] setPaused:NO];
   }
 
   [self updateKeyboardFrame];
@@ -84,7 +85,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
       _state = _state == OPENING ? OPEN : CLOSED;
     }
     // stop display link updates if no animation is running
-    [[self getDisplayLink] setPaused:true];
+    [[self getDisplayLink] setPaused:YES];
   }
 
   for (NSString *key in _listeners.allKeys) {

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -63,11 +63,11 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
       strongSelf->_displayLink.preferredFramesPerSecond =
           120; // will fallback to 60 fps for devices without Pro Motion display
       [strongSelf->_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
-      strongSelf->_displayLink.paused = NO;
+      [strongSelf->_displayLink setPaused:false];
     });
 
   } else {
-    _displayLink.paused = NO;
+    [_displayLink setPaused:false];
   }
 
   [self updateKeyboardFrame];
@@ -86,9 +86,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
       _state = _state == OPENING ? OPEN : CLOSED;
     }
     // stop display link updates if no animation is running
-    if (_displayLink) {
-      _displayLink.paused = YES;
-    }
+    [_displayLink setPaused:true];
   }
 
   for (NSString *key in _listeners.allKeys) {
@@ -160,10 +158,8 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 {
   RCTUnsafeExecuteOnMainQueueSync(^() {
     [self->_listeners removeAllObjects];
-    if (_displayLink) {
-      [self->_displayLink invalidate];
-      self->_displayLink = nil;
-    };
+    [self->_displayLink invalidate];
+    self->_displayLink = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
   });
 }

--- a/ios/keyboardObserver/REAKeyboardEventObserver.m
+++ b/ios/keyboardObserver/REAKeyboardEventObserver.m
@@ -37,8 +37,6 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 
 - (CADisplayLink *)getDisplayLink
 {
-  RCTAssertMainQueue();
-
   if (!_displayLink) {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onAnimationFrame:)];
     _displayLink.preferredFramesPerSecond = 120; // will fallback to 60 fps for devices without Pro Motion display


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Some users have observed following thread lock:

<details><summary>Error log</summary>

```
Thread 0 - com.apple.main-thread - (TH_STATE_WAITING)
0  libsystem_kernel.dylib +0x1c88  ___psynch_mutexwait
1  libsystem_pthread.dylib +0x2110 __pthread_mutex_firstfit_lock_wait
2  libsystem_pthread.dylib +0x9314 __pthread_mutex_firstfit_lock_slow
3  QuartzCore +0xa07cc             CA::Display::DisplayLinkItem::set_preferred_fps_range(CAFrameRateRange, bool, bool)
4  QuartzCore +0x3a918             CA::Display::DisplayLink::update_timer_locked(bool)
5  QuartzCore +0x3a504             CA::Display::DisplayLink::update_timer(bool)
6  QuartzCore +0xbf40c             CA::Display::DisplayLink::callback(_CADisplayTimer*, unsigned long long, unsigned long long, unsigned long long, bool, void*)
7  QuartzCore +0x39410             display_timer_callback(__CFMachPort*, void*, long, void*)
8  CoreFoundation +0x79d50         ___CFMachPortPerform
9  CoreFoundation +0x97144         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__
10 CoreFoundation +0x98e34         ___CFRunLoopDoSource1
11 CoreFoundation +0x7a654         ___CFRunLoopRun
12 CoreFoundation +0x7f3e8         _CFRunLoopRunSpecific
13 GraphicsServices +0x1358        _GSEventRunModal
14 UIKitCore +0x39d6e4             -[UIApplication _run]
15 UIKitCore +0x39d348             _UIApplicationMain
16 MyApp +0x720c                 main (AppDelegate.swift:24:7)
17 dyld +0x15de8                   start

Thread 13 - com.facebook.react.JavaScript - (TH_STATE_WAITING)
0  libsystem_kernel.dylib +0x17bc  ___ulock_wait
1  libsystem_platform.dylib +0xfac __os_unfair_lock_lock_slow
2  QuartzCore +0xd09ec             CA::Display::DisplayLinkItem::update_link(__CFRunLoop*)
3  MyAppReactNative +0x205698    -[REANodesManager initWithModule:uiManager:] (REANodesManager.mm:214:3)
4  MyAppReactNative +0x200e30    -[REAModule setBridge:] (REAModule.mm:202:19)
5  Foundation +0x69788             -[NSObject(NSKeyValueCoding) setValue:forKey:]
6  MyAppReactNative +0x2c6aec    -[RCTModuleData setBridgeForInstance] (RCTModuleData.mm:267:7)
7  MyAppReactNative +0x2c6964    -[RCTModuleData setUpInstanceAndBridge:] (RCTModuleData.mm:221:7)
8  MyAppReactNative +0x2c73dc    -[RCTModuleData instance] (RCTModuleData.mm:406:7)
9  MyAppReactNative +0x2cc9f0    facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&, int, (anonymous namespace)::SchedulingContext) (RCTNativeModule.mm:196:67)
10 MyAppReactNative +0x2cc820    facebook::react::RCTNativeModule::callSerializableNativeHook(unsigned int, folly::dynamic&&) (RCTNativeModule.mm:143:10)
11 MyAppReactNative +0x3cb198    facebook::react::JSIExecutor::nativeCallSyncHook(facebook::jsi::Value const*, unsigned long) (JSIExecutor.cpp:493:40)
12 MyAppReactNative +0x5e37f0    std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const (function.h:512:16)
13 hermes +0x131d8                 0x131d8 (0x130b0 + 296)
14 hermes +0x2702c                 0x2702c (0x26f94 + 152)
15 hermes +0x4625c                 0x4625c (0x45764 + 2808)
16 hermes +0x45718                 0x45718 (0x45698 + 128)
17 hermes +0x8a640                 0x8a640 (0x89f90 + 1712)
18 hermes +0x658c                  0x658c (0x64ac + 224)
19 hermes +0x63d4                  facebook::hermes::HermesRuntime::evaluateJavaScriptWithSourceMap(std::__1::shared_ptr<facebook::jsi::Buffer const> const&, std::__1::shared_ptr<facebook::jsi::Buffer const> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
20 hermes +0x76f4                  0x76f4 (0x76dc + 24)
21 MyAppReactNative +0x38e19c    facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::evaluateJavaScript(std::__1::shared_ptr<facebook::jsi::Buffer const> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) (decorator.h:118:20)
22 MyAppReactNative +0x3c9704    facebook::react::JSIExecutor::loadBundle(std::__1::unique_ptr<facebook::react::JSBigString const, std::__1::default_delete<facebook::react::JSBigString const> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) (JSIExecutor.cpp:157:13)
23 MyAppReactNative +0x35f59c    facebook::react::NativeToJsBridge::loadBundle(std::__1::unique_ptr<facebook::react::RAMBundleRegistry, std::__1::default_delete<facebook::react::RAMBundleRegistry> >, std::__1::unique_ptr<facebook::react::JSBigString const, std::__1::default_delete<facebook::react::JSBigString const> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)::$_1::operator()(facebook::react::JSExecutor*) (NativeToJsBridge.cpp:146:21)
24 MyAppReactNative +0x3606ac    std::__1::__function::__func<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8, std::__1::allocator<facebook::react::NativeToJsBridge::runOnExecutorQueue(std::__1::function<void (facebook::react::JSExecutor*)>)::$_8>, void ()>::operator()() (function.h:512:16)
25 MyAppReactNative +0x2b6950    facebook::react::tryAndReturnError(std::__1::function<void ()> const&) (function.h:512:16)
26 MyAppReactNative +0x2c33e0    facebook::react::RCTMessageThread::tryFunc(std::__1::function<void ()> const&) (RCTMessageThread.mm:69:20)
27 MyAppReactNative +0x2c31f4    ___ZN8facebook5react16RCTMessageThread8runAsyncENSt3__18functionIFvvEEE_block_invoke (function.h:512:16)
28 CoreFoundation +0x436dc         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__
29 CoreFoundation +0xaa20c         ___CFRunLoopDoBlocks
30 CoreFoundation +0x7a714         ___CFRunLoopRun
31 CoreFoundation +0x7f3e8         _CFRunLoopRunSpecific
32 MyAppReactNative +0x2ac2cc    +[RCTCxxBridge runRunLoop] (RCTCxxBridge.mm:336:12)
33 Foundation +0x5b540             ___NSThread__start__
34 libsystem_pthread.dylib +0x16b4 __pthread_start
```
</details>

This PR moves initialisation of CADisplayLink into UI thread, which may solve the problem

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
