### PR TITLE
Add support for sharing RegExp 

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -8,12 +8,7 @@
 
 /* eslint no-bitwise: 0 */
 import { makeShareable, isConfigured } from './core';
-import {
-  makeShareableCloneRecursive,
-  registerShareableMapping,
-} from './shareables';
 import { isAndroid, isWeb } from './PlatformChecker';
-import type { ShareableRef } from './commonTypes';
 
 interface RGB {
   r: number;
@@ -36,39 +31,16 @@ function call(...args: unknown[]): string {
   return '\\(\\s*(' + args.join(')\\s*,\\s*(') + ')\\s*\\)';
 }
 
-type Matchers = {
-  rgb: RegExp;
-  rgba: RegExp;
-  hsl: RegExp;
-  hsla: RegExp;
-  hex3: RegExp;
-  hex4: RegExp;
-  hex6: RegExp;
-  hex8: RegExp;
+const MATCHERS = {
+  rgb: new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER)),
+  rgba: new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER)),
+  hsl: new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
+  hsla: new RegExp('hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)),
+  hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+  hex4: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+  hex6: /^#([0-9a-fA-F]{6})$/,
+  hex8: /^#([0-9a-fA-F]{8})$/,
 };
-
-function createMatchers(): Matchers {
-  'worklet';
-  return {
-    rgb: new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER)),
-    rgba: new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER)),
-    hsl: new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
-    hsla: new RegExp('hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)),
-    hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-    hex4: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-    hex6: /^#([0-9a-fA-F]{6})$/,
-    hex8: /^#([0-9a-fA-F]{8})$/,
-  };
-}
-
-const MATCHERS = createMatchers();
-let UI_MATCHERS: Matchers | ShareableRef<Matchers>;
-if (isConfigured()) {
-  UI_MATCHERS = makeShareableCloneRecursive({ __init: createMatchers });
-  registerShareableMapping(MATCHERS, UI_MATCHERS);
-} else {
-  UI_MATCHERS = MATCHERS;
-}
 
 function hue2rgb(p: number, q: number, t: number): number {
   'worklet';

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -170,6 +170,17 @@ export function makeShareableCloneRecursive<T>(
             depth + 1
           );
         }
+      } else if (value instanceof RegExp) {
+        const pattern = value.source;
+        const flags = value.flags;
+        const handle = makeShareableCloneRecursive({
+          __init: () => {
+            'worklet';
+            return new RegExp(pattern, flags);
+          },
+        });
+        registerShareableMapping(value, handle);
+        return handle as ShareableRef<T>;
       } else {
         // This is reached for object types that are not of plain Object.prototype.
         // We don't support such objects from being transferred as shareables to

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -55,7 +55,7 @@ const INACCESSIBLE_OBJECT = {
     return new Proxy(
       {},
       {
-        get: (_: any, prop: string) => {
+        get: (_: any, prop: string | symbol) => {
           if (prop === '_isReanimatedSharedValue') {
             // not very happy about this check here, but we need to allow for
             // "inaccessible" objects to be tested with isSharedValue check
@@ -67,7 +67,9 @@ const INACCESSIBLE_OBJECT = {
             return false;
           }
           throw new Error(
-            `Trying to access property \`${prop}\` of an object which cannot be sent to the UI runtime.`
+            `Trying to access property \`${String(
+              prop
+            )}\` of an object which cannot be sent to the UI runtime.`
           );
         },
         set: () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Previously, copying RegExp objects between JS and UI threads wasn't supported. This PR adds this functionality and fixes a minor bug in `INACCESSIBLE_OBJECT` error (getter's prop wasn't a string in all cases thus printing an error message could cause another error). 
Since we can copy a RegExp object from JS thread to UI thread from now on, there was no need to keep a shareable clone of `MATCHERS` in `Colors.ts`.


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<details>
<summary>App.tsx</summary>

```tsx
import React from "react";
import { Button, StyleSheet, View } from "react-native";
import Animated, { useSharedValue, withTiming } from "react-native-reanimated";

export default function App() {
  const backgroundColor = useSharedValue("rgb(255, 0, 0)");
  
  const colors = {
    colors_rgb: ["rgb(255, 0, 0)", "rgb(0, 255, 0)", "rgb(0, 0, 255)"],
    colors_rgba: ["rgba(255, 255, 0, 1)", "rgba(255, 255, 0, 0.5)", "rgba(255, 255, 0, 0.1)"],
    colors_hsl: ["hsl(100, 100%, 50%)", "hsl(100, 50%, 50%)", "hsl(100, 0%, 50%)"],
    colors_hsla: ["hsla(150, 100%, 50%, 1)", "hsla(150, 100%, 50%, 0.5)", "hsla(150, 100%, 50%, 0.1)"],
    colors_hex3: ["#00F", "#0F0", "#F00"],
    colors_hex4: ["#FF0F", "#FF09", "#FF01"],
    colors_hex6: ["#AA0000", "#00AA00", "#0000AA"],
    colors_hex8: ["#123456FF", "#12345655", "#12345611"],
  };

  const colorArray = Object.values(colors);
  let mode = 0;
  let i = 0;

  const handlePressColor = () => {
    i = (i+1)%3;
    backgroundColor.value = withTiming(colorArray[mode][i]);
  };
  const handlePressFormat = () => {
    i = 0;
    mode = (mode+1)%8;
    backgroundColor.value = withTiming(colorArray[mode][i]);
  };

  return (
    <View style={styles.container}>
      <Animated.View style={{ ...styles.box, backgroundColor }} />
      <Button onPress={handlePressColor} title="Next color" />
      <Button onPress={handlePressFormat} title="Switch color format" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: "center",
  },
  box: {
    height: 100,
    width: 100,
    borderRadius: 20,
    marginVertical: 64,
  },
});
```

</details>

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
