### PR TITLE
Temporarily remove ESLint rule that breaks plugin's linting in VSCode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,6 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: './tsconfig.json',
-  },
   extends: [
     'standard',
     'plugin:@typescript-eslint/recommended',
@@ -37,7 +34,7 @@ module.exports = {
     ],
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-var-requires': 'warn',
-    '@typescript-eslint/no-duplicate-type-constituents': 'error',
+    // '@typescript-eslint/no-duplicate-type-constituents': 'error', // TODO this currently breaks ESLint for VSCode in plugin
     eqeqeq: 'error',
     'no-unreachable': 'error',
   },

--- a/plugin/.eslintrc.js
+++ b/plugin/.eslintrc.js
@@ -5,4 +5,3 @@ module.exports = {
     'curly': 'error',
   },
   ignorePatterns: ['**/*.d.ts','jestUtils.ts']};
-  

--- a/plugin/.eslintrc.js
+++ b/plugin/.eslintrc.js
@@ -1,10 +1,8 @@
 module.exports = {
   root: true,
   extends: '../.eslintrc.js',
-  parserOptions: {
-    project: './tsconfig.json',
-  },
   rules: {
     'curly': 'error',
   },
   ignorePatterns: ['**/*.d.ts','jestUtils.ts']};
+  

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -13,6 +13,5 @@
     "declaration": true,
     "declarationDir": "types"
   },
-  "files": ["src/plugin.ts"],
-  "include":["src/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

With changes from #4672 developing plugin is difficult because VSCode has problem resolving correct `tsconfig` and linting doesn't work in the editor (but it works in the CLI at least). This PR removes this rule till proper solution is found.

![image](https://github.com/software-mansion/react-native-reanimated/assets/40713406/311dfdeb-637d-49cd-808d-75d151cb75c8)


