### PR TITLE
Fix reference cycle in `checkDuplicateSharedTag`

### DIFF
--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -361,10 +361,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   }];
 #ifdef DEBUG
   [animationsManager setCheckDuplicateSharedTagBlock:^(UIView *view, NSNumber *_Nonnull viewTag) {
-    UIView *screen = [REAScreensHelper getScreenForView:(UIView *)view];
-    auto screenTag = [screen.reactTag intValue];
-    // Here we check if there are duplicate tags (we don't use return bool value currently)
-    nativeReanimatedModule->layoutAnimationsManager().checkDuplicateSharedTag([viewTag intValue], screenTag);
+    if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
+      UIView *screen = [REAScreensHelper getScreenForView:(UIView *)view];
+      auto screenTag = [screen.reactTag intValue];
+      // Here we check if there are duplicate tags (we don't use return bool value currently)
+      nativeReanimatedModule->layoutAnimationsManager().checkDuplicateSharedTag([viewTag intValue], screenTag);
+    }
   }];
 #endif // DEBUG
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR eliminates a shared pointer cycle that prevented `REAModule` from de-allocating and thus caused the assert in `SingleInstanceChecker` to fail.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
