### PR TITLE
Detected debug version of the worklet in release bundle

### DIFF
--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -150,10 +150,11 @@ export function makeShareableCloneRecursive<T>(
             );
             delete value.__stackDetails;
           } else if (value.__stackDetails) {
+            // Detected debug version of the worklet in your release bundle. This
+            // might lead to unexpected issues or errors. Probably one of user
+            // dependencies provided transpile code with debug version of the
+            // Reanimated plugin.
             delete value.__stackDetails;
-            console.warn(
-              `[Reanimated] Detected debug version of worklet in your release bundle. This might lead to unexpected issues or errors. Probably one of you dependencies provided transpiled code with debug version of Reanimated plugin.`
-            );
           }
           // to save on transferring static __initData field of worklet structure
           // we request shareable value to persist its UI counterpart. This means

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -150,9 +150,9 @@ export function makeShareableCloneRecursive<T>(
             );
             delete value.__stackDetails;
           } else if (value.__stackDetails) {
-            // Detected debug version of the worklet in your release bundle. This
+            // Detected debug version of the worklet in release bundle. This
             // might lead to unexpected issues or errors. Probably one of user
-            // dependencies provided transpile code with debug version of the
+            // dependencies provided transpiled code with debug version of the
             // Reanimated plugin.
             delete value.__stackDetails;
           }

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -149,6 +149,11 @@ export function makeShareableCloneRecursive<T>(
               value.__stackDetails
             );
             delete value.__stackDetails;
+          } else if (value.__stackDetails) {
+            delete value.__stackDetails;
+            console.warn(
+              `[Reanimated] Detected debug version of worklet in your release bundle. This might lead to unexpected issues or errors. Probably one of you dependencies provided transpiled code with debug version of Reanimated plugin.`
+            );
           }
           // to save on transferring static __initData field of worklet structure
           // we request shareable value to persist its UI counterpart. This means

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -155,7 +155,7 @@ export function makeShareableCloneRecursive<T>(
             // dependencies provided transpiled code with debug version of the
             // Reanimated plugin.
             throw new Error(
-              '[Reanimated] Using dev bundle in a release app build is not supported.'
+              '[Reanimated] Using dev bundle in a release app build is not supported. Visit https://github.com/software-mansion/react-native-reanimated/issues/4737 to find more information on how to fix this issue.'
             );
           }
           // to save on transferring static __initData field of worklet structure

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -154,7 +154,9 @@ export function makeShareableCloneRecursive<T>(
             // might lead to unexpected issues or errors. Probably one of user
             // dependencies provided transpiled code with debug version of the
             // Reanimated plugin.
-            throw new Error('[Reanimated] Using dev bundle in a release app build is not supported');
+            throw new Error(
+              '[Reanimated] Using dev bundle in a release app build is not supported.'
+            );
           }
           // to save on transferring static __initData field of worklet structure
           // we request shareable value to persist its UI counterpart. This means

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -154,7 +154,7 @@ export function makeShareableCloneRecursive<T>(
             // might lead to unexpected issues or errors. Probably one of user
             // dependencies provided transpiled code with debug version of the
             // Reanimated plugin.
-            delete value.__stackDetails;
+            throw new Error('[Reanimated] Using dev bundle in a release app build is not supported');
           }
           // to save on transferring static __initData field of worklet structure
           // we request shareable value to persist its UI counterpart. This means


### PR DESCRIPTION
## Summary

Fixes: https://github.com/software-mansion/react-native-reanimated/issues/4690

It may happen when one of the user dependencies provided transpiled code with debug version of the Reanimated plugin. In effect, we have a debug version of the work in your release bundle. This might lead to unexpected issues or errors. 😢

I created issue with description how to fix this issue: https://github.com/software-mansion/react-native-reanimated/issues/4737
