### PR TITLE
iOS scheduler optimisation fix

### DIFF
--- a/Common/cpp/Tools/Scheduler.cpp
+++ b/Common/cpp/Tools/Scheduler.cpp
@@ -25,7 +25,7 @@ void Scheduler::triggerUI() {
   // JSI objects and hence it allows for such objects to be garbage collected
   // much sooner.
   // Apparently the scope API is only supported on Hermes at the moment.
-  auto scope = jsi::Scope(*weakRuntimeManager.lock()->runtime);
+  auto scope = jsi::Scope(*weakRuntimeManager_.lock()->runtime);
 #endif
   while (uiJobs.getSize()) {
     auto job = uiJobs.pop();
@@ -40,7 +40,7 @@ void Scheduler::setJSCallInvoker(
 
 void Scheduler::setRuntimeManager(
     std::shared_ptr<RuntimeManager> runtimeManager) {
-  weakRuntimeManager = runtimeManager;
+  weakRuntimeManager_ = runtimeManager;
 }
 
 Scheduler::~Scheduler() {}

--- a/Common/cpp/Tools/Scheduler.cpp
+++ b/Common/cpp/Tools/Scheduler.cpp
@@ -25,7 +25,7 @@ void Scheduler::triggerUI() {
   // JSI objects and hence it allows for such objects to be garbage collected
   // much sooner.
   // Apparently the scope API is only supported on Hermes at the moment.
-  auto scope = jsi::Scope(*runtimeManager.lock()->runtime);
+  auto scope = jsi::Scope(*weakRuntimeManager.lock()->runtime);
 #endif
   while (uiJobs.getSize()) {
     auto job = uiJobs.pop();
@@ -40,7 +40,7 @@ void Scheduler::setJSCallInvoker(
 
 void Scheduler::setRuntimeManager(
     std::shared_ptr<RuntimeManager> runtimeManager) {
-  this->runtimeManager = runtimeManager;
+  weakRuntimeManager = runtimeManager;
 }
 
 Scheduler::~Scheduler() {}

--- a/Common/cpp/Tools/Scheduler.h
+++ b/Common/cpp/Tools/Scheduler.h
@@ -83,7 +83,7 @@ class Scheduler {
   std::atomic<bool> scheduledOnUI{};
   Queue<std::function<void()>> uiJobs;
   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
-  std::weak_ptr<RuntimeManager> runtimeManager;
+  std::weak_ptr<RuntimeManager> weakRuntimeManager;
 };
 
 } // namespace reanimated

--- a/Common/cpp/Tools/Scheduler.h
+++ b/Common/cpp/Tools/Scheduler.h
@@ -83,7 +83,7 @@ class Scheduler {
   std::atomic<bool> scheduledOnUI{};
   Queue<std::function<void()>> uiJobs;
   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
-  std::weak_ptr<RuntimeManager> weakRuntimeManager;
+  std::weak_ptr<RuntimeManager> weakRuntimeManager_;
 };
 
 } // namespace reanimated

--- a/ios/native/REAIOSScheduler.h
+++ b/ios/native/REAIOSScheduler.h
@@ -13,7 +13,6 @@ class REAIOSScheduler : public Scheduler {
  public:
   REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker);
   void scheduleOnUI(std::function<void()> job) override;
-  virtual ~REAIOSScheduler();
 };
 
 } // namespace reanimated

--- a/ios/native/REAIOSScheduler.mm
+++ b/ios/native/REAIOSScheduler.mm
@@ -38,6 +38,4 @@ void REAIOSScheduler::scheduleOnUI(std::function<void()> job)
   }
 }
 
-REAIOSScheduler::~REAIOSScheduler() {}
-
 } // namespace reanimated

--- a/ios/native/REAIOSScheduler.mm
+++ b/ios/native/REAIOSScheduler.mm
@@ -13,7 +13,7 @@ REAIOSScheduler::REAIOSScheduler(std::shared_ptr<CallInvoker> jsInvoker)
 
 void REAIOSScheduler::scheduleOnUI(std::function<void()> job)
 {
-  const auto runtimeManager = weakRuntimeManager.lock();
+  const auto runtimeManager = weakRuntimeManager_.lock();
   if (!runtimeManager) {
     return;
   }
@@ -26,7 +26,7 @@ void REAIOSScheduler::scheduleOnUI(std::function<void()> job)
   Scheduler::scheduleOnUI(job);
 
   if (!this->scheduledOnUI) {
-    __block std::weak_ptr<RuntimeManager> blockRuntimeManager = weakRuntimeManager;
+    __block std::weak_ptr<RuntimeManager> blockRuntimeManager = weakRuntimeManager_;
 
     dispatch_async(dispatch_get_main_queue(), ^{
       if (const auto runtimeManager = blockRuntimeManager.lock()) {


### PR DESCRIPTION
## Summary

I've noticed that `weak_ptr` for `runtimeManager` in iOS scheduler has executed `lock` method but returned `shared_ptr` is not used and thus deallocation immediately. In that case, if we just want to know whether `runtimeManager` `shared_ptr` is alive it's more performant to use `expired` method on `weak_ptr`.

I removed also some dead code:

- in `scheduleOnUI` there was unnecessary block of code checking if it's executed on main thread. If it is on main thread it returns from function several lines above the block and won't be executed.
- unnecessary virtual empty destructor for `REAIOSScheduler`. Base class has already virtual destructor and marking this again does not change anything. 

## Test plan

Check iOS application if works fine.
