### PR TITLE
Add nightly CI status to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ low level abstraction for the Animated library API to be built
 on top of and hence allow for much greater flexibility especially when it
 comes to gesture based interactions.
 
+### Nightly CI state
+
+|CI state|
+|---|
+|[![Nightly npm package](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-nightly-npm-package.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-nightly-npm-package.yml)|
+|[![Nightly monorepo test](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-monorepo-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-monorepo-nightly.yml)|
 ## Installation
 
 Check out the [installation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) section of our docs for the detailed installation instructions.


### PR DESCRIPTION
## Summary

This PR adds CI badges info to the main Readme.md, this informs us faster about potential failures.

<img width="320" alt="Screenshot 2023-07-17 at 08 36 47" src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/9f258b2f-870c-4bad-98b7-31210b1b7224">
