### PR TITLE
Add -Wextra flag to CMake

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} -DREANIMATED_VERSION=${REANIMATED_VERSION} -DHERMES_ENABLE_DEBUGGER=${HERMES_ENABLE_DEBUGGER}")
 
-string(APPEND CMAKE_CXX_FLAGS " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all -std=c++17 -Wall -Werror")
+string(APPEND CMAKE_CXX_FLAGS " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all -std=c++17 -Wall -Werror -Wextra")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
     string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")


### PR DESCRIPTION
## Summary

As a continuation of https://github.com/software-mansion/react-native-reanimated/pull/4719 PR, let's add the `-Wextra` flag to the CMake compilation command. It'll help us to keep better code quality.

`-Wextra` docs page: https://clang.llvm.org/docs/DiagnosticsReference.html#wextra
