### PR TITLE
Fix modal SET progress animation on Android

### DIFF
--- a/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
@@ -72,8 +72,19 @@ export class ProgressTransitionManager {
           global.ProgressTransitionRegister.onTransitionEnd();
         }
       );
-      if (Platform.OS === 'ios') {
-        // required by modals
+
+      if (Platform.OS === 'android') {
+        // onFinishTransitioning event is available only on Android and
+        // is used to handle closing modals
+        eventHandler.onDisappear = registerEventHandler(
+          'onFinishTransitioning',
+          () => {
+            'worklet';
+            global.ProgressTransitionRegister.onAndroidFinishTransitioning();
+          }
+        );
+      } else if (Platform.OS === 'ios') {
+        // topDisappear event is required to handle closing modals on iOS
         eventHandler.onDisappear = registerEventHandler('topDisappear', () => {
           'worklet';
           global.ProgressTransitionRegister.onTransitionEnd(true);
@@ -148,6 +159,13 @@ function createProgressTransitionRegister() {
         const snapshot = snapshots.get(viewTag);
         progressAnimation!(viewTag, snapshot, progress);
       }
+    },
+    onAndroidFinishTransitioning: () => {
+      if (toRemove.size === 0) {
+        // it should be ran only on modal closing
+        return;
+      }
+      progressTransitionManager.onTransitionEnd();
     },
     onTransitionEnd: (removeViews = false) => {
       for (const viewTag of currentTransitions) {

--- a/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
@@ -161,11 +161,10 @@ function createProgressTransitionRegister() {
       }
     },
     onAndroidFinishTransitioning: () => {
-      if (toRemove.size === 0) {
+      if (toRemove.size > 0) {
         // it should be ran only on modal closing
-        return;
+        progressTransitionManager.onTransitionEnd();
       }
-      progressTransitionManager.onTransitionEnd();
     },
     onTransitionEnd: (removeViews = false) => {
       for (const viewTag of currentTransitions) {


### PR DESCRIPTION
## Summary

This PR adds missing cleanup and reparenting of shared views after modal close.

## Test plan

|Before|After|
|---|---|
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/79852a34-44c6-48ab-8d83-b460963c154d" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/679ff9ab-3e34-4395-9640-c0dac36be243" /> |