### PR TITLE
Throw error when worklet version is unknown

### DIFF
--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -141,9 +141,13 @@ export function makeShareableCloneRecursive<T>(
           // we are converting a worklet
           if (__DEV__) {
             const babelVersion = value.__initData.version;
-            if (babelVersion !== jsVersion) {
+            if (babelVersion === undefined) {
+              throw new Error(
+                '[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported.'
+              );
+            } else if (babelVersion !== jsVersion) {
               throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`,
-              \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again.`);
+              \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.`);
             }
             registerWorkletStackDetails(
               value.__workletHash,

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -143,7 +143,7 @@ export function makeShareableCloneRecursive<T>(
             const babelVersion = value.__initData.version;
             if (babelVersion === undefined) {
               throw new Error(
-                '[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported.'
+                '[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.'
               );
             } else if (babelVersion !== jsVersion) {
               throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds a developer-friendly error when worklet version is undefined. Related to #4736. 

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
