### PR TITLE
Distinguish between js version and native version on metro's Mismatch…

### DIFF
--- a/src/reanimated2/platform-specific/checkCppVersion.ts
+++ b/src/reanimated2/platform-specific/checkCppVersion.ts
@@ -10,7 +10,7 @@ export function checkCppVersion() {
   const ok = matchVersion(jsVersion, cppVersion);
   if (!ok) {
     throw new Error(
-      `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (js version: ${jsVersion} vs. native version: ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
+      `[Reanimated] Mismatch between JavaScript part (${jsVersion}) and native part of Reanimated (${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
     );
   }
 }

--- a/src/reanimated2/platform-specific/checkCppVersion.ts
+++ b/src/reanimated2/platform-specific/checkCppVersion.ts
@@ -10,7 +10,7 @@ export function checkCppVersion() {
   const ok = matchVersion(jsVersion, cppVersion);
   if (!ok) {
     throw new Error(
-      `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs. ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
+      `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (js version: ${jsVersion} vs. native version: ${cppVersion}). Did you forget to re-build the app after upgrading react-native-reanimated? If you use Expo Go, you must downgrade to ${cppVersion} which is bundled into Expo SDK.`
     );
   }
 }


### PR DESCRIPTION
## Summary

It could be hard to spot the mismatch side, this PR distinguishes the versions (specially useful for the nightly builds) between js side and native side in the Mismatch error that is thrown by metro bundler.
