### PR TITLE
Remove unused parameter from endLayoutAnimation

### DIFF
--- a/Common/cpp/Tools/PlatformDepMethodsHolder.h
+++ b/Common/cpp/Tools/PlatformDepMethodsHolder.h
@@ -50,7 +50,7 @@ using TimeProviderFunction = std::function<double(void)>;
 
 using ProgressLayoutAnimationFunction =
     std::function<void(int, jsi::Object newProps, bool isSharedTransition)>;
-using EndLayoutAnimationFunction = std::function<void(int, bool, bool)>;
+using EndLayoutAnimationFunction = std::function<void(int, bool)>;
 
 using RegisterSensorFunction =
     std::function<int(int, int, int, std::function<void(double[], int)>)>;

--- a/android/src/main/cpp/LayoutAnimations.cpp
+++ b/android/src/main/cpp/LayoutAnimations.cpp
@@ -36,14 +36,10 @@ void LayoutAnimations::progressLayoutAnimation(
   method(javaPart_.get(), tag, updates.get(), isSharedTransition);
 }
 
-void LayoutAnimations::endLayoutAnimation(
-    int tag,
-    bool cancelled,
-    bool removeView) {
+void LayoutAnimations::endLayoutAnimation(int tag, bool removeView) {
   static const auto method =
-      javaPart_->getClass()->getMethod<void(int, bool, bool)>(
-          "endLayoutAnimation");
-  method(javaPart_.get(), tag, cancelled, removeView);
+      javaPart_->getClass()->getMethod<void(int, bool)>("endLayoutAnimation");
+  method(javaPart_.get(), tag, removeView);
 }
 
 void LayoutAnimations::setHasAnimationBlock(

--- a/android/src/main/cpp/LayoutAnimations.h
+++ b/android/src/main/cpp/LayoutAnimations.h
@@ -55,7 +55,7 @@ class LayoutAnimations : public jni::HybridClass<LayoutAnimations> {
       int tag,
       const jni::local_ref<JNIHelper::PropsMap> &updates,
       bool isSharedTransition);
-  void endLayoutAnimation(int tag, bool cancelled, bool removeView);
+  void endLayoutAnimation(int tag, bool removeView);
   void clearAnimationConfigForTag(int tag);
   void cancelAnimationForTag(
       int tag,

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -432,9 +432,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
   auto progressLayoutAnimation =
       bindThis(&NativeProxy::progressLayoutAnimation);
 
-  auto endLayoutAnimation = [this](int tag, bool isCancelled, bool removeView) {
-    this->layoutAnimations_->cthis()->endLayoutAnimation(
-        tag, isCancelled, removeView);
+  auto endLayoutAnimation = [this](int tag, bool removeView) {
+    this->layoutAnimations_->cthis()->endLayoutAnimation(tag, removeView);
   };
 
   auto maybeFlushUiUpdatesQueueFunction =

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -225,7 +225,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     setNewProps(newStyle, view, viewManager, parentViewManager, parent.getId(), isSharedTransition);
   }
 
-  public void endLayoutAnimation(int tag, boolean cancelled, boolean removeView) {
+  public void endLayoutAnimation(int tag, boolean removeView) {
     View view = resolveView(tag);
 
     if (view == null) {
@@ -640,7 +640,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
 
   public void cancelAnimationsRecursive(View view) {
     if (mExitingViews.containsKey(view.getId())) {
-      endLayoutAnimation(view.getId(), true, true);
+      endLayoutAnimation(view.getId(), true);
     } else if (view instanceof ViewGroup && mExitingSubviewCountMap.containsKey(view.getId())) {
       cancelAnimationsInSubviews((ViewGroup) view);
     }
@@ -655,7 +655,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
       }
 
       if (mExitingViews.containsKey(child.getId())) {
-        endLayoutAnimation(child.getId(), true, true);
+        endLayoutAnimation(child.getId(), true);
       } else if (child instanceof ViewGroup && mExitingSubviewCountMap.containsKey(child.getId())) {
         cancelAnimationsInSubviews((ViewGroup) child);
       }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
@@ -51,12 +51,12 @@ public class LayoutAnimations {
 
   public native int findPrecedingViewTagForTransition(int tag);
 
-  private void endLayoutAnimation(int tag, boolean cancelled, boolean removeView) {
+  private void endLayoutAnimation(int tag, boolean removeView) {
     AnimationsManager animationsManager = getAnimationsManager();
     if (animationsManager == null) {
       return;
     }
-    animationsManager.endLayoutAnimation(tag, cancelled, removeView);
+    animationsManager.endLayoutAnimation(tag, removeView);
   }
 
   private void progressLayoutAnimation(

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -42,7 +42,7 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>));
 - (void)setFindPrecedingViewTagForTransitionBlock:
     (REAFindPrecedingViewTagForTransitionBlock)findPrecedingViewTagForTransition;
 - (void)setCancelAnimationBlock:(REACancelAnimationBlock)animationCancellingBlock;
-- (void)endLayoutAnimationForTag:(NSNumber *_Nonnull)tag cancelled:(BOOL)cancelled removeView:(BOOL)removeView;
+- (void)endLayoutAnimationForTag:(NSNumber *_Nonnull)tag removeView:(BOOL)removeView;
 - (void)endAnimationsRecursive:(UIView *)view;
 - (void)invalidate;
 - (void)viewDidMount:(UIView *)view withBeforeSnapshot:(REASnapshot *)snapshot withNewFrame:(CGRect)frame;

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -121,7 +121,7 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
   return view;
 }
 
-- (void)endLayoutAnimationForTag:(NSNumber *)tag cancelled:(BOOL)cancelled removeView:(BOOL)removeView
+- (void)endLayoutAnimationForTag:(NSNumber *)tag removeView:(BOOL)removeView
 {
   UIView *view = [self viewForTag:tag];
 

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -198,8 +198,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     }
   };
 
-  auto endLayoutAnimation = [=](int tag, bool isCancelled, bool removeView) {
-    [weakAnimationsManager endLayoutAnimationForTag:@(tag) cancelled:isCancelled removeView:removeView];
+  auto endLayoutAnimation = [=](int tag, bool removeView) {
+    [weakAnimationsManager endLayoutAnimationForTag:@(tag) removeView:removeView];
   };
 
   auto configurePropsFunction = [reaModule](

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -177,7 +177,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     // noop
   };
 
-  auto endLayoutAnimation = [=](int tag, bool isCancelled, bool removeView) {
+  auto endLayoutAnimation = [=](int tag, bool removeView) {
     // noop
   };
 

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -34,11 +34,7 @@ declare global {
     value: Record<string, unknown>,
     isSharedTransition: boolean
   ) => void;
-  var _notifyAboutEnd: (
-    tag: number,
-    finished: boolean,
-    removeView: boolean
-  ) => void;
+  var _notifyAboutEnd: (tag: number, removeView: boolean) => void;
   var _setGestureState: (handlerTag: number, newState: number) => void;
   var _makeShareableClone: (value: any) => any;
   var _updateDataSynchronously: (

--- a/src/reanimated2/layoutReanimation/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/animationsManager.ts
@@ -26,12 +26,11 @@ function startObservingProgress(
 function stopObservingProgress(
   tag: number,
   sharedValue: SharedValue<number>,
-  cancelled: boolean,
   removeView: boolean
 ): void {
   'worklet';
   sharedValue.removeListener(tag + TAG_OFFSET);
-  _notifyAboutEnd(tag, cancelled, removeView);
+  _notifyAboutEnd(tag, removeView);
 }
 
 function createLayoutAnimationManager() {
@@ -70,7 +69,7 @@ function createLayoutAnimationManager() {
         value = makeUIMutable(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
-        stopObservingProgress(tag, value, false, false);
+        stopObservingProgress(tag, value, false);
         value._value = style.initialValues;
       }
 
@@ -82,7 +81,7 @@ function createLayoutAnimationManager() {
           enteringAnimationForTag.delete(tag);
           mutableValuesForTag.delete(tag);
           const shouldRemoveView = type === LayoutAnimationType.EXITING;
-          stopObservingProgress(tag, value, finished, shouldRemoveView);
+          stopObservingProgress(tag, value, shouldRemoveView);
         }
         style.callback &&
           style.callback(finished === undefined ? false : finished);
@@ -96,7 +95,7 @@ function createLayoutAnimationManager() {
       if (!value) {
         return;
       }
-      stopObservingProgress(tag, value, true, true);
+      stopObservingProgress(tag, value, true);
     },
   };
 }

--- a/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
@@ -168,7 +168,7 @@ function createProgressTransitionRegister() {
     },
     onTransitionEnd: (removeViews = false) => {
       for (const viewTag of currentTransitions) {
-        _notifyAboutEnd(viewTag, false, removeViews);
+        _notifyAboutEnd(viewTag, removeViews);
       }
       currentTransitions.clear();
       snapshots.clear();


### PR DESCRIPTION
## Summary

This PR removes unused parameter `canceled` for `endLayoutAnimation` method on both platforms.

## Test plan

Open example with Layout Animation
