### PR TITLE
Rename `runtime_` to `rnRuntime_` in NativeProxy

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -29,7 +29,7 @@ using namespace react;
 
 NativeProxy::NativeProxy(
     jni::alias_ref<NativeProxy::javaobject> jThis,
-    jsi::Runtime *rt,
+    jsi::Runtime *rnRuntime,
     std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker,
     std::shared_ptr<Scheduler> scheduler,
     jni::global_ref<LayoutAnimations::javaobject> _layoutAnimations
@@ -40,7 +40,7 @@ NativeProxy::NativeProxy(
 #endif
     )
     : javaPart_(jni::make_global(jThis)),
-      runtime_(rt),
+      rnRuntime_(rnRuntime),
       jsCallInvoker_(jsCallInvoker),
       layoutAnimations_(std::move(_layoutAnimations)),
       scheduler_(scheduler)
@@ -110,7 +110,7 @@ void NativeProxy::installJSIBindings(
     /**/) {
   auto jsQueue = std::make_shared<JMessageQueueThread>(messageQueueThread);
   std::shared_ptr<jsi::Runtime> uiRuntime =
-      ReanimatedRuntime::make(runtime_, jsQueue);
+      ReanimatedRuntime::make(rnRuntime_, jsQueue);
 
   auto nativeReanimatedModule = std::make_shared<NativeReanimatedModule>(
       jsCallInvoker_,
@@ -143,7 +143,7 @@ void NativeProxy::installJSIBindings(
   //  reactScheduler_->addEventListener(eventListener_);
 #endif
 
-  auto &rt = *runtime_;
+  auto &rt = *rnRuntime_;
   setGlobalProperties(rt, uiRuntime);
   registerEventHandler();
   setupLayoutAnimations();

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -176,7 +176,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
  private:
   friend HybridBase;
   jni::global_ref<NativeProxy::javaobject> javaPart_;
-  jsi::Runtime *runtime_;
+  jsi::Runtime *rnRuntime_;
   std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker_;
   std::shared_ptr<NativeReanimatedModule> nativeReanimatedModule_;
   jni::global_ref<LayoutAnimations::javaobject> layoutAnimations_;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR renames ambiguous variable `runtime_` to `rnRuntime_` in NativeProxy class on Android.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
