### PR TITLE
Remove unused parameter from cancelAnimation

### DIFF
--- a/Common/cpp/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/Common/cpp/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -93,12 +93,7 @@ void LayoutAnimationsManager::startLayoutAnimation(
       config->getJSValue(rt));
 }
 
-void LayoutAnimationsManager::cancelLayoutAnimation(
-    jsi::Runtime &rt,
-    int tag,
-    LayoutAnimationType,
-    bool cancelled = true,
-    bool removeView = true) {
+void LayoutAnimationsManager::cancelLayoutAnimation(jsi::Runtime &rt, int tag) {
   jsi::Value layoutAnimationRepositoryAsValue =
       rt.global()
           .getPropertyAsObject(rt, "global")
@@ -106,15 +101,7 @@ void LayoutAnimationsManager::cancelLayoutAnimation(
   jsi::Function cancelLayoutAnimation =
       layoutAnimationRepositoryAsValue.getObject(rt).getPropertyAsFunction(
           rt, "stop");
-  std::shared_ptr<Shareable> config;
-  {
-    auto lock = std::unique_lock<std::mutex>(animationsMutex_);
-    config = sharedTransitionAnimations_[tag];
-  }
-  if (config != nullptr) {
-    cancelLayoutAnimation.call(
-        rt, jsi::Value(tag), config->getJSValue(rt), cancelled, removeView);
-  }
+  cancelLayoutAnimation.call(rt, jsi::Value(tag));
 }
 
 /*

--- a/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
+++ b/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
@@ -35,12 +35,7 @@ class LayoutAnimationsManager {
       LayoutAnimationType type,
       const jsi::Object &values);
   void clearLayoutAnimationConfig(int tag);
-  void cancelLayoutAnimation(
-      jsi::Runtime &rt,
-      int tag,
-      LayoutAnimationType type,
-      bool cancelled /* = true */,
-      bool removeView /* = true */);
+  void cancelLayoutAnimation(jsi::Runtime &rt, int tag);
   int findPrecedingViewTagForTransition(int tag);
 #ifdef DEBUG
   std::string getScreenSharedTagPairString(

--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -90,7 +90,7 @@ public class NativeProxy extends NativeProxyCommon {
             public void clearAnimationConfig(int tag) {}
 
             @Override
-            public void cancelAnimation(int tag, int type, boolean cancelled, boolean removeView) {}
+            public void cancelAnimation(int tag) {}
 
             @Override
             public void checkDuplicateSharedTag(int viewTag, int screenTag) {}

--- a/android/src/main/cpp/LayoutAnimations.cpp
+++ b/android/src/main/cpp/LayoutAnimations.cpp
@@ -76,12 +76,8 @@ void LayoutAnimations::setCancelAnimationForTag(
   this->cancelAnimationBlock_ = cancelAnimationBlock;
 }
 
-void LayoutAnimations::cancelAnimationForTag(
-    int tag,
-    int type,
-    jboolean cancelled,
-    jboolean removeView) {
-  this->cancelAnimationBlock_(tag, type, cancelled, removeView);
+void LayoutAnimations::cancelAnimationForTag(int tag) {
+  this->cancelAnimationBlock_(tag);
 }
 
 bool LayoutAnimations::isLayoutAnimationEnabled() {

--- a/android/src/main/cpp/LayoutAnimations.h
+++ b/android/src/main/cpp/LayoutAnimations.h
@@ -19,8 +19,7 @@ class LayoutAnimations : public jni::HybridClass<LayoutAnimations> {
   using CheckDuplicateSharedTag = std::function<void(int, int)>;
 #endif
   using ClearAnimationConfigBlock = std::function<void(int)>;
-  using CancelAnimationBlock =
-      std::function<void(int, int, jboolean, jboolean)>;
+  using CancelAnimationBlock = std::function<void(int)>;
   using FindPrecedingViewTagForTransitionBlock = std::function<int(int)>;
 
  public:
@@ -57,11 +56,7 @@ class LayoutAnimations : public jni::HybridClass<LayoutAnimations> {
       bool isSharedTransition);
   void endLayoutAnimation(int tag, bool removeView);
   void clearAnimationConfigForTag(int tag);
-  void cancelAnimationForTag(
-      int tag,
-      int type,
-      jboolean cancelled,
-      jboolean removeView);
+  void cancelAnimationForTag(int tag);
   int findPrecedingViewTagForTransition(int tag);
 
  private:

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -566,17 +566,11 @@ void NativeProxy::setupLayoutAnimations() {
       });
 
   layoutAnimations_->cthis()->setCancelAnimationForTag(
-      [weakNativeReanimatedModule](
-          int tag, int type, jboolean cancelled, jboolean removeView) {
+      [weakNativeReanimatedModule](int tag) {
         if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
           jsi::Runtime &rt = *nativeReanimatedModule->runtimeManager_->runtime;
           nativeReanimatedModule->layoutAnimationsManager()
-              .cancelLayoutAnimation(
-                  rt,
-                  tag,
-                  static_cast<LayoutAnimationType>(type),
-                  cancelled,
-                  removeView);
+              .cancelLayoutAnimation(rt, tag);
         }
       });
 

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/LayoutAnimations.java
@@ -44,8 +44,7 @@ public class LayoutAnimations {
 
   public native void clearAnimationConfigForTag(int tag);
 
-  public native void cancelAnimationForTag(
-      int tag, int type, boolean cancelled, boolean removeView);
+  public native void cancelAnimationForTag(int tag);
 
   public native boolean isLayoutAnimationEnabled();
 

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/NativeMethodsHolder.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/NativeMethodsHolder.java
@@ -9,7 +9,7 @@ public interface NativeMethodsHolder {
 
   void clearAnimationConfig(int tag);
 
-  void cancelAnimation(int tag, int type, boolean cancelled, boolean removeView);
+  void cancelAnimation(int tag);
 
   boolean isLayoutAnimationEnabled();
 

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
@@ -605,8 +605,7 @@ public class SharedTransitionManager {
 
   private void cancelAnimation(View view) {
     int viewTag = view.getId();
-    mNativeMethodsHolder.cancelAnimation(
-        viewTag, LayoutAnimations.Types.SHARED_ELEMENT_TRANSITION, true, true);
+    mNativeMethodsHolder.cancelAnimation(viewTag);
   }
 
   private void disableCleaningForViewTag(int viewTag) {

--- a/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -99,10 +99,10 @@ public class NativeProxy extends NativeProxyCommon {
             }
 
             @Override
-            public void cancelAnimation(int tag, int type, boolean cancelled, boolean removeView) {
+            public void cancelAnimation(int tag) {
                 LayoutAnimations layoutAnimations = weakLayoutAnimations.get();
                 if (layoutAnimations != null) {
-                    layoutAnimations.cancelAnimationForTag(tag, type, cancelled, removeView);
+                    layoutAnimations.cancelAnimationForTag(tag);
                 }
             }
 

--- a/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/LayoutReanimation/REAAnimationsManager.h
@@ -21,8 +21,7 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 #ifdef DEBUG
 typedef void (^REACheckDuplicateSharedTagBlock)(UIView *view, NSNumber *_Nonnull viewTag);
 #endif
-typedef void (
-    ^REACancelAnimationBlock)(NSNumber *_Nonnull tag, LayoutAnimationType type, BOOL cancelled, BOOL removeView);
+typedef void (^REACancelAnimationBlock)(NSNumber *_Nonnull tag);
 typedef NSNumber *_Nullable (^REAFindPrecedingViewTagForTransitionBlock)(NSNumber *_Nonnull tag);
 typedef int (^REATreeVisitor)(id<RCTComponent>);
 BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>));

--- a/ios/LayoutReanimation/REASharedTransitionManager.m
+++ b/ios/LayoutReanimation/REASharedTransitionManager.m
@@ -639,7 +639,7 @@ static REASharedTransitionManager *_sharedTransitionManager;
 
 - (void)cancelAnimation:(NSNumber *)viewTag
 {
-  _cancelLayoutAnimation(viewTag, SHARED_ELEMENT_TRANSITION, YES, YES);
+  _cancelLayoutAnimation(viewTag);
 }
 
 - (void)disableCleaningForViewTag:(NSNumber *)viewTag

--- a/ios/native/NativeProxy.mm
+++ b/ios/native/NativeProxy.mm
@@ -346,16 +346,14 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     nativeReanimatedModule->layoutAnimationsManager().clearLayoutAnimationConfig([tag intValue]);
   }];
 
-  [animationsManager
-      setCancelAnimationBlock:^(NSNumber *_Nonnull tag, LayoutAnimationType type, BOOL cancelled, BOOL removeView) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          if (auto uiRuntime = weakUiRuntime.lock()) {
-            jsi::Runtime &rt = *uiRuntime;
-            nativeReanimatedModule->layoutAnimationsManager().cancelLayoutAnimation(
-                rt, [tag intValue], type, cancelled == YES, removeView == YES);
-          }
-        }
-      }];
+  [animationsManager setCancelAnimationBlock:^(NSNumber *_Nonnull tag) {
+    if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
+      if (auto uiRuntime = weakUiRuntime.lock()) {
+        jsi::Runtime &rt = *uiRuntime;
+        nativeReanimatedModule->layoutAnimationsManager().cancelLayoutAnimation(rt, [tag intValue]);
+      }
+    }
+  }];
 
   [animationsManager setFindPrecedingViewTagForTransitionBlock:^NSNumber *_Nullable(NSNumber *_Nonnull tag) {
     if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {


### PR DESCRIPTION
## Summary

The `animationManager[.js].stop(viewTag: number)`([code here](https://github.com/software-mansion/react-native-reanimated/blob/3.3.0/src/reanimated2/layoutReanimation/animationsManager.ts#L89)) method accepts only one argument. This PR removes unnecessary additional arguments passed to this method.
