### PR TITLE
Add missing layout props to configHelper

### DIFF
--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -83,6 +83,12 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
   lineHeight: true,
   textShadowRadius: true,
   letterSpacing: true,
+  aspectRatio: true,
+  columnGap: true, // iOS only
+  end: true, // number or string
+  flexBasis: true, // number or string
+  gap: true,
+  rowGap: true,
   /* strings */
   display: true,
   backfaceVisibility: true,
@@ -98,6 +104,14 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
   textDecorationStyle: true,
   textTransform: true,
   writingDirection: true,
+  alignContent: true,
+  alignItems: true,
+  alignSelf: true,
+  direction: true, // iOS only
+  flexDirection: true,
+  flexWrap: true,
+  justifyContent: true,
+  position: true,
   /* text color */
   color: true,
   tintColor: true,


### PR DESCRIPTION
## Summary

Some [layout props from react-native](https://reactnative.dev/docs/layout-props) were missing from their respective set.

## Test plan

Fixes #4743.
