### PR TITLE
Cancel animation for modals

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -499,7 +499,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
   private boolean removeOrAnimateExitRecursive(View view, boolean shouldRemove) {
     int tag = view.getId();
     ViewManager viewManager = resolveViewManager(tag);
-    
+
     if (viewManager != null) {
       String viewManagerName = viewManager.getName();
       if (viewManagerName.equals("RCTModalHostView")

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -499,13 +499,16 @@ public class AnimationsManager implements ViewHierarchyObserver {
   private boolean removeOrAnimateExitRecursive(View view, boolean shouldRemove) {
     int tag = view.getId();
     ViewManager viewManager = resolveViewManager(tag);
-
-    if (viewManager != null
-        && (viewManager.getName().equals("RCTModalHostView")
-            || viewManager.getName().equals("RNSScreen")
-            || viewManager.getName().equals("RNSScreenStack"))) {
-      cancelAnimationsRecursive(view);
-      return false;
+    
+    if (viewManager != null) {
+      String viewManagerName = viewManager.getName();
+      if (viewManagerName.equals("RCTModalHostView")
+          || viewManagerName.equals("RNSScreen")
+          || viewManagerName.equals("RNSScreenStack")) {
+        // don't run exiting animation when ScreenStack, Screen, or Modal are removing
+        cancelAnimationsRecursive(view);
+        return false;
+      }
     }
 
     boolean hasExitAnimation =

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -500,7 +500,12 @@ public class AnimationsManager implements ViewHierarchyObserver {
     int tag = view.getId();
     ViewManager viewManager = resolveViewManager(tag);
 
-    if (viewManager != null && viewManager.getName().equals("RNSScreenStack")) {
+    if (
+      viewManager != null && (
+      viewManager.getName().equals("RCTModalHostView") ||
+      viewManager.getName().equals("RNSScreen") ||
+      viewManager.getName().equals("RNSScreenStack")
+    )) {
       cancelAnimationsRecursive(view);
       return false;
     }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -500,12 +500,10 @@ public class AnimationsManager implements ViewHierarchyObserver {
     int tag = view.getId();
     ViewManager viewManager = resolveViewManager(tag);
 
-    if (
-      viewManager != null && (
-      viewManager.getName().equals("RCTModalHostView") ||
-      viewManager.getName().equals("RNSScreen") ||
-      viewManager.getName().equals("RNSScreenStack")
-    )) {
+    if (viewManager != null
+        && (viewManager.getName().equals("RCTModalHostView")
+            || viewManager.getName().equals("RNSScreen")
+            || viewManager.getName().equals("RNSScreenStack"))) {
       cancelAnimationsRecursive(view);
       return false;
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4422

Fixes the bug with Android freezing when Layout Animations are used in a modal.

## Test plan

1. clone the example repository https://github.com/ceceppa/reanimated-3-bug
2. apply the fix in this PR (or copy the code into your own project)
3. build and run on Android
4. open the model
5. close the modal
6. open the modal again -> without the fix in this PR, this will fail as the UI becomes unresponsive
