### PR TITLE
Add missing worklet directive in `assertVectorsHaveEqualLengths`

### DIFF
--- a/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
+++ b/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
@@ -250,9 +250,10 @@ function transposeMatrix(matrix: AffineMatrix): AffineMatrix {
 }
 
 function assertVectorsHaveEqualLengths(a: number[], b: number[]) {
+  'worklet';
   if (__DEV__ && a.length !== b.length) {
     throw new Error(
-      `Cannot calculate inner product of two vectors of cerent length. Length of ${a} is ${a.length} and length of ${b} is ${b.length}.`
+      `Cannot calculate inner product of two vectors of different lengths. Length of ${a} is ${a.length} and length of ${b} is ${b.length}.`
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the following error that occurs after clicking "GO GO MATRIX" button:

<img width="300" alt="Zrzut ekranu 2023-07-21 o 16 13 21" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/d9d2bda2-3b6d-4d27-9d59-708cc12b966b">

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
