### PR TITLE
Fix runOnJS calling _makeShareableClone on JS

### DIFF
--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -229,11 +229,14 @@ export function makeShareableCloneRecursive<T>(
   return NativeReanimatedModule.makeShareableClone(value, shouldPersistRemote);
 }
 
+// Do not try to call `console.log` inside this function as `runOnJS` will call it
+// and then you get into call stack exceeded. Use _log instead (on UI).
 export function makeShareableCloneOnUIRecursive<T>(value: T): ShareableRef<T> {
   'worklet';
-  if (USE_STUB_IMPLEMENTATION) {
+  if (USE_STUB_IMPLEMENTATION || !_WORKLET) {
     // @ts-ignore web is an interesting place where we don't run a secondary VM on the UI thread
-    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined.
+    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined. We also don't
+    // need to make shareable clones when `runOnJS` is called on JS thread.
     return value;
   }
   function cloneRecursive<T>(value: T): ShareableRef<T> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently if someone calls `runOnJS` from JS thread it will call JS implementation of `_makeShareableClone`. This PR fixes it and also gives a useful comment about the use of `console.log` in fishy places.

## Test plan

Check runOnJS/runOnUI example - it was broken before.

btw. @piaskowyk you were right 😎 
