### PR TITLE
Make babel version detection more verbose

### DIFF
--- a/app/src/examples/BabelVersionCheckExample.tsx
+++ b/app/src/examples/BabelVersionCheckExample.tsx
@@ -21,44 +21,37 @@ function longOffender() {
   b = a;
 }
 
-interface EvilButtonProps {
-  version: string | undefined;
-  long: boolean;
-}
-
-function EvilButton({ version, long }: EvilButtonProps) {
-  function onPress() {
-    if (long) {
-      // @ts-ignore this is fine
-      longOffender.__initData.version = version;
-      runOnUI(longOffender)();
-    } else {
-      // @ts-ignore this is fine
-      shortOffender.__initData.version = version;
-      runOnUI(shortOffender)();
-    }
-  }
-
-  return (
-    <Button
-      onPress={onPress}
-      title={
-        long
-          ? 'long worklet check'
-          : version
-          ? 'wrong version check'
-          : 'undefined version check'
-      }
-    />
-  );
-}
-
 export default function BabelVersionCheckExample() {
+  const handlePress1 = () => {
+    // @ts-ignore this is fine
+    shortOffender.__initData.version = undefined;
+    runOnUI(shortOffender)();
+  };
+
+  const handlePress2 = () => {
+    // @ts-ignore this is fine
+    longOffender.__initData.version = undefined;
+    runOnUI(longOffender)();
+  };
+
+  const handlePress3 = () => {
+    // @ts-ignore this is fine
+    shortOffender.__initData.version = 'x.y.z';
+    runOnUI(shortOffender)();
+  };
+
+  const handlePress4 = () => {
+    // @ts-ignore this is fine
+    longOffender.__initData.version = 'x.y.z';
+    runOnUI(longOffender)();
+  };
+
   return (
     <View style={styles.container}>
-      <EvilButton version={undefined} long={false} />
-      <EvilButton version="wrong version" long={false} />
-      <EvilButton version={undefined} long={true} />
+      <Button onPress={handlePress1} title="Unknown version short worklet" />
+      <Button onPress={handlePress2} title="Unknown version long worklet" />
+      <Button onPress={handlePress3} title="Wrong version short worklet" />
+      <Button onPress={handlePress4} title="Wrong version long worklet" />
     </View>
   );
 }

--- a/app/src/examples/BabelVersionCheckExample.tsx
+++ b/app/src/examples/BabelVersionCheckExample.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Pressable, StyleSheet, Text } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 
 function shortOffender() {
@@ -27,7 +27,7 @@ interface EvilButtonProps {
 }
 
 function EvilButton({ version, long }: EvilButtonProps) {
-  function onPressOut() {
+  function onPress() {
     if (long) {
       // @ts-ignore this is fine
       longOffender.__initData.version = version;
@@ -40,15 +40,16 @@ function EvilButton({ version, long }: EvilButtonProps) {
   }
 
   return (
-    <Pressable style={styles.button} onPressOut={onPressOut}>
-      <Text style={styles.text}>
-        {long
+    <Button
+      onPress={onPress}
+      title={
+        long
           ? 'long worklet check'
           : version
           ? 'wrong version check'
-          : 'undefined version check'}
-      </Text>
-    </Pressable>
+          : 'undefined version check'
+      }
+    />
   );
 }
 
@@ -67,19 +68,5 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  button: {
-    backgroundColor: '#4488dd',
-    padding: 10,
-    borderRadius: 50,
-    margin: 10,
-    height: 80,
-    width: 240,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    color: 'white',
-    fontSize: 16,
   },
 });

--- a/app/src/examples/BabelVersionCheckExample.tsx
+++ b/app/src/examples/BabelVersionCheckExample.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Pressable, StyleSheet, Text } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 
-function offender() {
+function shortOffender() {
   'worklet';
   let I = 'am';
   let a = 'very';
@@ -22,31 +22,25 @@ function longOffender() {
 }
 
 interface EvilButtonProps {
-  version?: string;
-  long?: boolean;
+  version: string | undefined;
+  long: boolean;
 }
 
 function EvilButton({ version, long }: EvilButtonProps) {
-  const [pressed, setPressed] = React.useState(false);
-
   function onPressOut() {
-    setPressed(false);
     if (long) {
       // @ts-ignore this is fine
       longOffender.__initData.version = version;
       runOnUI(longOffender)();
     } else {
       // @ts-ignore this is fine
-      offender.__initData.version = version;
-      runOnUI(offender)();
+      shortOffender.__initData.version = version;
+      runOnUI(shortOffender)();
     }
   }
 
   return (
-    <Pressable
-      style={[styles.button, pressed && { backgroundColor: '#3366dd' }]}
-      onPressIn={() => setPressed(true)}
-      onPressOut={onPressOut}>
+    <Pressable style={styles.button} onPressOut={onPressOut}>
       <Text style={styles.text}>
         {long
           ? 'long worklet check'
@@ -58,12 +52,12 @@ function EvilButton({ version, long }: EvilButtonProps) {
   );
 }
 
-export default function BabelVersioningExample() {
+export default function BabelVersionCheckExample() {
   return (
     <View style={styles.container}>
-      <EvilButton />
-      <EvilButton version="wrong version" />
-      <EvilButton long={true} />
+      <EvilButton version={undefined} long={false} />
+      <EvilButton version="wrong version" long={false} />
+      <EvilButton version={undefined} long={true} />
     </View>
   );
 }

--- a/app/src/examples/BabelVersioningExample.tsx
+++ b/app/src/examples/BabelVersioningExample.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { View, Pressable, StyleSheet, Text } from 'react-native';
+import { runOnUI } from 'react-native-reanimated';
+
+function offender() {
+  'worklet';
+  let I = 'am';
+  let a = 'very';
+  let complicated = 'function.';
+  I = a;
+  a = complicated;
+  complicated = I;
+}
+
+function longOffender() {
+  'worklet';
+  let a =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur.';
+  let b = 'what a waste';
+  a = b;
+  b = a;
+}
+
+function giveVersion(version?: string) {
+  // @ts-ignore this is fine
+  offender.__initData.version = version;
+}
+
+function giveVersionLonger(version?: string) {
+  // @ts-ignore this is fine
+  longOffender.__initData.version = version;
+}
+
+function EvilButton({ version, long }: { version?: string; long?: boolean }) {
+  const [pressed, setPressed] = React.useState(false);
+  return (
+    <Pressable
+      style={[styles.button, pressed && { backgroundColor: '#3366DDFF' }]}
+      onPressIn={() => {
+        setPressed(true);
+      }}
+      onPressOut={() => {
+        setPressed(false);
+        if (long) {
+          giveVersionLonger(version);
+          runOnUI(longOffender)();
+        } else {
+          giveVersion(version);
+          runOnUI(offender)();
+        }
+      }}>
+      <Text style={styles.text}>
+        {long
+          ? 'long worklet check'
+          : version
+          ? 'wrong version check'
+          : 'undefined version check'}
+      </Text>
+    </Pressable>
+  );
+}
+
+export default function BabelVersioningExample() {
+  return (
+    <View style={styles.container}>
+      <EvilButton />
+      <EvilButton version="wrong version" />
+      <EvilButton long={true} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    backgroundColor: '#4488DDFF',
+    padding: 10,
+    borderRadius: 50,
+    margin: 10,
+    height: 80,
+    width: 240,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: 'white',
+    fontSize: 16,
+  },
+});

--- a/app/src/examples/BabelVersioningExample.tsx
+++ b/app/src/examples/BabelVersioningExample.tsx
@@ -21,34 +21,32 @@ function longOffender() {
   b = a;
 }
 
-function giveVersion(version?: string) {
-  // @ts-ignore this is fine
-  offender.__initData.version = version;
+interface EvilButtonProps {
+  version?: string;
+  long?: boolean;
 }
 
-function giveVersionLonger(version?: string) {
-  // @ts-ignore this is fine
-  longOffender.__initData.version = version;
-}
-
-function EvilButton({ version, long }: { version?: string; long?: boolean }) {
+function EvilButton({ version, long }: EvilButtonProps) {
   const [pressed, setPressed] = React.useState(false);
+
+  function onPressOut() {
+    setPressed(false);
+    if (long) {
+      // @ts-ignore this is fine
+      longOffender.__initData.version = version;
+      runOnUI(longOffender)();
+    } else {
+      // @ts-ignore this is fine
+      offender.__initData.version = version;
+      runOnUI(offender)();
+    }
+  }
+
   return (
     <Pressable
-      style={[styles.button, pressed && { backgroundColor: '#3366DDFF' }]}
-      onPressIn={() => {
-        setPressed(true);
-      }}
-      onPressOut={() => {
-        setPressed(false);
-        if (long) {
-          giveVersionLonger(version);
-          runOnUI(longOffender)();
-        } else {
-          giveVersion(version);
-          runOnUI(offender)();
-        }
-      }}>
+      style={[styles.button, pressed && { backgroundColor: '#3366dd' }]}
+      onPressIn={() => setPressed(true)}
+      onPressOut={onPressOut}>
       <Text style={styles.text}>
         {long
           ? 'long worklet check'
@@ -77,7 +75,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   button: {
-    backgroundColor: '#4488DDFF',
+    backgroundColor: '#4488dd',
     padding: 10,
     borderRadius: 50,
     margin: 10,

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -93,7 +93,7 @@ import VolumeExample from './VolumeExample';
 import MatrixTransform from './MatrixTransform';
 import PendulumExample from './PendulumExample';
 import DuplicateTagsExample from './SharedElementTransitions/DuplicateTags';
-import BabelVersioningExample from './BabelVersioningExample';
+import BabelVersionCheckExample from './BabelVersionCheckExample';
 
 interface Example {
   icon?: string;
@@ -260,10 +260,10 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'runOnJS / runOnUI',
     screen: WorkletExample,
   },
-  BabelVersioningExample: {
+  BabelVersionCheckExample: {
     icon: '📦',
-    title: 'Babel versioning mismatch',
-    screen: BabelVersioningExample,
+    title: 'Babel version check',
+    screen: BabelVersionCheckExample,
   },
   TransformExample: {
     icon: '🔄',

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -262,7 +262,7 @@ export const EXAMPLES: Record<string, Example> = {
   },
   BabelVersioningExample: {
     icon: '📦',
-    title: 'Babel versioning',
+    title: 'Babel versioning mismatch',
     screen: BabelVersioningExample,
   },
   TransformExample: {

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -93,6 +93,7 @@ import VolumeExample from './VolumeExample';
 import MatrixTransform from './MatrixTransform';
 import PendulumExample from './PendulumExample';
 import DuplicateTagsExample from './SharedElementTransitions/DuplicateTags';
+import BabelVersioningExample from './BabelVersioningExample';
 
 interface Example {
   icon?: string;
@@ -258,6 +259,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🧵',
     title: 'runOnJS / runOnUI',
     screen: WorkletExample,
+  },
+  BabelVersioningExample: {
+    icon: '📦',
+    title: 'Babel versioning',
+    screen: BabelVersioningExample,
   },
   TransformExample: {
     icon: '🔄',

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -143,11 +143,14 @@ export function makeShareableCloneRecursive<T>(
             const babelVersion = value.__initData.version;
             if (babelVersion === undefined) {
               throw new Error(
-                '[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.'
+                `[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin. If you've recently upgraded \`react-native-reanimated\` try resetting your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. Offending code was:
+
+\`${(value.__initData.code as string).substring(0, 255)}\``
               );
             } else if (babelVersion !== jsVersion) {
-              throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`,
-              \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.`);
+              throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin. Offending code was:
+
+\`${(value.__initData.code as string).substring(0, 255)}\``);
             }
             registerWorkletStackDetails(
               value.__workletHash,

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -232,14 +232,11 @@ export function makeShareableCloneRecursive<T>(
   return NativeReanimatedModule.makeShareableClone(value, shouldPersistRemote);
 }
 
-// Do not try to call `console.log` inside this function as `runOnJS` will call it
-// and then you get into call stack exceeded. Use _log instead (on UI).
 export function makeShareableCloneOnUIRecursive<T>(value: T): ShareableRef<T> {
   'worklet';
-  if (USE_STUB_IMPLEMENTATION || !_WORKLET) {
+  if (USE_STUB_IMPLEMENTATION) {
     // @ts-ignore web is an interesting place where we don't run a secondary VM on the UI thread
-    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined. We also don't
-    // need to make shareable clones when `runOnJS` is called on JS thread.
+    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined.
     return value;
   }
   function cloneRecursive<T>(value: T): ShareableRef<T> {

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -229,11 +229,14 @@ export function makeShareableCloneRecursive<T>(
   return NativeReanimatedModule.makeShareableClone(value, shouldPersistRemote);
 }
 
+// Do not try to call `console.log` inside this function as `runOnJS` will call it
+// and then you get into call stack exceeded. Use _log instead (on UI).
 export function makeShareableCloneOnUIRecursive<T>(value: T): ShareableRef<T> {
   'worklet';
-  if (USE_STUB_IMPLEMENTATION) {
+  if (USE_STUB_IMPLEMENTATION || !_WORKLET) {
     // @ts-ignore web is an interesting place where we don't run a secondary VM on the UI thread
-    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined.
+    // see more details in the comment where USE_STUB_IMPLEMENTATION is defined. We also don't
+    // need to make shareable clones when `runOnJS` is called on JS thread.
     return value;
   }
   function cloneRecursive<T>(value: T): ShareableRef<T> {

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -1,5 +1,5 @@
 import NativeReanimatedModule from './NativeReanimated';
-import type { ShareableRef } from './commonTypes';
+import type { ShareableRef, WorkletFunction } from './commonTypes';
 import { shouldBeUseWeb } from './PlatformChecker';
 import { registerWorkletStackDetails } from './errors';
 import { jsVersion } from './platform-specific/jsVersion';
@@ -142,15 +142,16 @@ export function makeShareableCloneRecursive<T>(
           if (__DEV__) {
             const babelVersion = value.__initData.version;
             if (babelVersion === undefined) {
-              throw new Error(
-                `[Reanimated] Unknown version of Reanimated Babel plugin. Using release bundle with debug build of the app is not supported. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin. If you've recently upgraded \`react-native-reanimated\` try resetting your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. Offending code was:
-
-\`${(value.__initData.code as string).substring(0, 255)}\``
-              );
+              throw new Error(`[Reanimated] Unknown version of Reanimated Babel plugin.
+1. Try resetting your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again.
+2. Make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.
+3. Using release bundle with debug build of the app is not supported.
+Offending code was: \`${getWorkletCode(value)}\``);
             } else if (babelVersion !== jsVersion) {
-              throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}). Please clear your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again. If the issue still persists, make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin. Offending code was:
-
-\`${(value.__initData.code as string).substring(0, 255)}\``);
+              throw new Error(`[Reanimated] Mismatch between JavaScript code version and Reanimated Babel plugin version (${jsVersion} vs. ${babelVersion}).        
+1. Try resetting your Metro bundler cache with \`yarn start --reset-cache\`, \`npm start -- --reset-cache\` or \`expo start -c\` and run the app again.
+2. Make sure that none of your dependencies contains already transformed worklets bundled with an outdated version of the Reanimated Babel plugin.
+Offending code was: \`${getWorkletCode(value)}\``);
             }
             registerWorkletStackDetails(
               value.__workletHash,
@@ -230,6 +231,20 @@ export function makeShareableCloneRecursive<T>(
     }
   }
   return NativeReanimatedModule.makeShareableClone(value, shouldPersistRemote);
+}
+
+const WORKLET_CODE_THRESHOLD = 255;
+
+function getWorkletCode(value: WorkletFunction) {
+  // @ts-ignore this is fine
+  const code = value?.__initData?.code;
+  if (!code) {
+    return 'unknown';
+  }
+  if (code.length > WORKLET_CODE_THRESHOLD) {
+    return `${code.substring(0, WORKLET_CODE_THRESHOLD)}...`;
+  }
+  return code;
 }
 
 export function makeShareableCloneOnUIRecursive<T>(value: T): ShareableRef<T> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently the error tells us that something is wrong but we don't have a clue what could be causing it. This PR makes error more verbose, displaying code of the offending worklet. I also added some cheeky Example for that purpose.

## Test plan

Run new `BabelVersioningExample`

🚀 
