### PR TITLE
Remove infuriating docs lint from precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "yarn run format:js && yarn run lint:js && yarn run test:unit",
     "test:unit": "jest",
     "test:update-snapshot": "jest --updateSnapshot",
-    "lint": "yarn lint:js && yarn lint:plugin && yarn lint:cpp && yarn lint:java && yarn lint:ios && yarn lint:docs",
+    "lint": "yarn lint:js && yarn lint:plugin && yarn lint:cpp && yarn lint:java && yarn lint:ios",
     "lint:js": "eslint --ext '.js,.ts,.tsx' src __tests__  && yarn prettier --check src __tests__ __typetests__",
     "lint:plugin": "cd plugin && yarn lint && cd ..",
     "lint:docs": "cd docs && yarn lint && cd ..",
@@ -159,8 +159,7 @@
     "android/src/**/*.java": "yarn format:java",
     "android/src/**/*.{h,cpp}": "yarn format:android",
     "ios/**/*.{h,m,mm,cpp}": "yarn format:ios",
-    "Common/**/*.{h,cpp}": "yarn format:common",
-    "docs/**/*.{md,mdx}": "yarn lint:docs"
+    "Common/**/*.{h,cpp}": "yarn format:common"
   },
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently docs have some issue while linting that some file couldn't be found by the linter and is extremely annoying when trying to commit, being forced to commit without precommit check.

Guess automatically linting docs waits for better times.

