### PR TITLE
Fix `runOnJS` calling `_makeShareableClone` when already on the JS thread

### DIFF
--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -30,12 +30,10 @@ global._makeShareableClone = () => {
   );
 };
 
-global._scheduleOnJS = (func, args) => {
-  if (args) {
-    queueMicrotask(() => func(...args));
-  } else {
-    queueMicrotask(func);
-  }
+global._scheduleOnJS = () => {
+  throw new Error(
+    '[Reanimated] _scheduleOnJS should never be called in JSReanimated.'
+  );
 };
 
 interface JSReanimatedComponent {

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -162,6 +162,10 @@ export function runOnJS<A extends any[], R>(
   fun: ComplexWorkletFunction<A, R>
 ): (...args: A) => void {
   'worklet';
+  if (!IS_NATIVE || !_WORKLET) {
+    // if we are already on the JS thread, we just schedule the worklet on the JS queue
+    return (...args) => queueMicrotask(args ? () => fun(...args) : fun);
+  }
   if (fun.__workletHash) {
     // if `fun` is a worklet, we schedule a call of a remote function `runWorkletOnJS`
     // and pass the worklet as a first argument followed by original arguments

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -164,7 +164,7 @@ export function runOnJS<A extends any[], R>(
   'worklet';
   if (!IS_NATIVE || !_WORKLET) {
     // if we are already on the JS thread, we just schedule the worklet on the JS queue
-    return (...args) => queueMicrotask(args ? () => fun(...args) : fun);
+    return (...args) => queueMicrotask(args.length ? () => fun(...args) : fun);
   }
   if (fun.__workletHash) {
     // if `fun` is a worklet, we schedule a call of a remote function `runWorkletOnJS`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This PR addresses a regression introduced by me in #4780.

<img width="300" alt="bad error" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/3dcd1aa6-5e13-4082-9449-367355e752e3">

After long consideration, it occurred to me that both `_makeShareableClone` and `_scheduleOnJS` were originally meant to represent JSI bindings (i.e. JS functions implemented in C++ and injected via JSI), thus none of them should ever be used when in JSReanimated mode.

This PR moves the implementation of `_scheduleOnJS` to the only place where it's called which enables us to generalize it to cover more cases, in particular calling `runOnJS` on the main React Native runtime.

Kudos for @tjzel for investigating the issue and submitting a hotfix (#4790).

## Test plan

<details>
<summary>App.tsx</summary>

```tsx
import {StyleSheet, View, Button} from 'react-native';

import React from 'react';
import {runOnJS} from 'react-native-reanimated';

export default function App() {
  const handlePress = () => {
    runOnJS(() => {
      'worklet';
      console.log(_WORKLET, 'Hello from the JS runtime!');
    })();
  };

  return (
    <View style={styles.container}>
      <Button onPress={handlePress} title="Click me" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

</details>
