### PR TITLE
add the missing BounceIn to the mock file

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -164,6 +164,7 @@ const ReanimatedV2 = {
   'ZoomOutEasyUp',
   'ZoomOutEasyDown',
 
+  'BounceIn',
   'BounceInDown',
   'BounceInUp',
   'BounceInLeft',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
Found a mock issue when I writing a test with jest for my own react native component which used the `BounceIn.delay` animation, it will throw an error saying: `Cannot read properties of undefined (reading 'delay')`.
After the investigation, it turns out the `BounceIn` was missing in the mock file, so I opened this PR to resolve this issue.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
