### PR TITLE
Moved (de)registration of ReanimatedCommitHook to its con/de-structor

### DIFF
--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -8,6 +8,16 @@
 using namespace facebook::react;
 
 namespace reanimated {
+ReanimatedCommitHook::ReanimatedCommitHook(
+    const std::shared_ptr<PropsRegistry> &propsRegistry,
+    const std::shared_ptr<UIManager> &uiManager)
+    : propsRegistry_(propsRegistry), uiManager_(uiManager) {
+  uiManager_->registerCommitHook(*this);
+}
+
+ReanimatedCommitHook::~ReanimatedCommitHook() {
+  uiManager_->unregisterCommitHook(*this);
+}
 
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -15,7 +15,7 @@ ReanimatedCommitHook::ReanimatedCommitHook(
   uiManager_->registerCommitHook(*this);
 }
 
-ReanimatedCommitHook::~ReanimatedCommitHook() {
+ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
   uiManager_->unregisterCommitHook(*this);
 }
 

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -8,6 +8,7 @@
 using namespace facebook::react;
 
 namespace reanimated {
+
 ReanimatedCommitHook::ReanimatedCommitHook(
     const std::shared_ptr<PropsRegistry> &propsRegistry,
     const std::shared_ptr<UIManager> &uiManager)

--- a/Common/cpp/Fabric/ReanimatedCommitHook.h
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.h
@@ -17,7 +17,7 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
       const std::shared_ptr<PropsRegistry> &propsRegistry,
       const std::shared_ptr<UIManager> &uiManager);
 
-  ~ReanimatedCommitHook() noexcept;
+  ~ReanimatedCommitHook() noexcept override;
 
   void commitHookWasRegistered(UIManager const &) const noexcept override {}
 

--- a/Common/cpp/Fabric/ReanimatedCommitHook.h
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.h
@@ -15,8 +15,9 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
  public:
   ReanimatedCommitHook(
       const std::shared_ptr<PropsRegistry> &propsRegistry,
-      const std::shared_ptr<UIManager> &uiManager)
-      : propsRegistry_(propsRegistry), uiManager_(uiManager) {}
+      const std::shared_ptr<UIManager> &uiManager);
+
+  ~ReanimatedCommitHook() noexcept;
 
   void commitHookWasRegistered(UIManager const &) const noexcept override {}
 
@@ -27,8 +28,6 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
       RootShadowNode::Shared const &oldRootShadowNode,
       RootShadowNode::Unshared const &newRootShadowNode)
       const noexcept override;
-
-  virtual ~ReanimatedCommitHook() noexcept = default;
 
  private:
   std::shared_ptr<PropsRegistry> propsRegistry_;

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -53,7 +53,6 @@ NativeProxy::NativeProxy(
   uiManager_ = binding->getScheduler()->getUIManager();
   commitHook_ =
       std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager_);
-  uiManager_->registerCommitHook(*commitHook_);
 #endif
 }
 
@@ -65,9 +64,6 @@ NativeProxy::~NativeProxy() {
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
   nativeReanimatedModule_->cleanupSensors();
-#ifdef RCT_NEW_ARCH_ENABLED
-  uiManager_->unregisterCommitHook(*commitHook_);
-#endif // RCT_NEW_ARCH_ENABLED
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(

--- a/ios/REAModule.mm
+++ b/ios/REAModule.mm
@@ -104,7 +104,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   react_native_assert(uiManager.get() != nil);
   propsRegistry_ = std::make_shared<PropsRegistry>();
   commitHook_ = std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager);
-  uiManager->registerCommitHook(*commitHook_);
   [self setUpNativeReanimatedModule:uiManager];
 }
 


### PR DESCRIPTION
## Summary

`ReanimatedCommitHook` was not unregister during shutdown of iOS module so I moved responsibility of registration and deregistration to constructor and destructor of that class making use of RAII allowing me to skip unnecessary calls.

## Test plan

None
