### PR TITLE
Removed unnecessary copies of UIManager and ContextContainer

### DIFF
--- a/Common/cpp/Fabric/FabricUtils.cpp
+++ b/Common/cpp/Fabric/FabricUtils.cpp
@@ -9,10 +9,10 @@ using namespace facebook::react;
 
 namespace reanimated {
 
-std::shared_ptr<const ContextContainer> getContextContainerFromUIManager(
-    const UIManager *uiManager) {
-  return reinterpret_cast<const UIManagerPublic *>(uiManager)
-      ->contextContainer_;
+const ContextContainer &getContextContainerFromUIManager(
+    const UIManager &uiManager) {
+  return *reinterpret_cast<const UIManagerPublic *>(&uiManager)
+              ->contextContainer_;
 }
 
 } // namespace reanimated

--- a/Common/cpp/Fabric/FabricUtils.h
+++ b/Common/cpp/Fabric/FabricUtils.h
@@ -48,8 +48,8 @@ struct SchedulerPublic : public UIManagerDelegate {
 };
 #endif
 
-std::shared_ptr<const ContextContainer> getContextContainerFromUIManager(
-    const UIManager *uiManager);
+const ContextContainer &getContextContainerFromUIManager(
+    const UIManager &uiManager);
 
 } // namespace reanimated
 

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -25,7 +25,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
 
   auto rootNode = newRootShadowNode->ShadowNode::clone(ShadowNodeFragment{});
 
-  ShadowTreeCloner shadowTreeCloner{uiManager_, surfaceId};
+  ShadowTreeCloner shadowTreeCloner{*uiManager_, surfaceId};
 
   {
     auto lock = propsRegistry_->createLock();

--- a/Common/cpp/Fabric/ShadowTreeCloner.cpp
+++ b/Common/cpp/Fabric/ShadowTreeCloner.cpp
@@ -6,11 +6,11 @@
 namespace reanimated {
 
 ShadowTreeCloner::ShadowTreeCloner(
-    std::shared_ptr<UIManager> uiManager,
+    const UIManager &uiManager,
     SurfaceId surfaceId)
     : propsParserContext_{
           surfaceId,
-          *getContextContainerFromUIManager(&*uiManager)} {}
+          getContextContainerFromUIManager(uiManager)} {}
 
 ShadowNode::Unshared ShadowTreeCloner::cloneWithNewProps(
     const ShadowNode::Shared &oldRootNode,

--- a/Common/cpp/Fabric/ShadowTreeCloner.h
+++ b/Common/cpp/Fabric/ShadowTreeCloner.h
@@ -14,7 +14,7 @@ namespace reanimated {
 
 class ShadowTreeCloner {
  public:
-  ShadowTreeCloner(std::shared_ptr<UIManager> uiManager, SurfaceId surfaceId);
+  ShadowTreeCloner(const UIManager &uiManager, SurfaceId surfaceId);
 
   ShadowNode::Unshared cloneWithNewProps(
       const ShadowNode::Shared &oldRootNode,

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -617,7 +617,7 @@ void NativeReanimatedModule::performOperations() {
           auto rootNode =
               oldRootShadowNode.ShadowNode::clone(ShadowNodeFragment{});
 
-          ShadowTreeCloner shadowTreeCloner{uiManager_, surfaceId_};
+          ShadowTreeCloner shadowTreeCloner{*uiManager_, surfaceId_};
 
           {
             auto lock = propsRegistry_->createLock();


### PR DESCRIPTION
## Summary

I noticed that in our `ReanimatedCommitHook` on each commit we copy `shared_ptr` of `UIManager` and `ContextContainer`. I've gone through the code and such copies are not needed as object using them are short-lived without option to deallocation of needed resources.

Those copies can be pretty time consuming due to locks in `shared_ptr` implementation.

## Test plan

Check performance on Android and iOS
