### PR TITLE
Removed unnecessary lock during committing shadowTree

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -625,24 +625,20 @@ void NativeReanimatedModule::performOperations() {
 
           ShadowTreeCloner shadowTreeCloner{uiManager_, surfaceId_};
 
-          {
-            auto lock = propsRegistry_->createLock();
+          for (const auto &[shadowNode, props] : copiedOperationsQueue) {
+            const ShadowNodeFamily &family = shadowNode->getFamily();
+            react_native_assert(family.getSurfaceId() == surfaceId_);
 
-            for (const auto &[shadowNode, props] : copiedOperationsQueue) {
-              const ShadowNodeFamily &family = shadowNode->getFamily();
-              react_native_assert(family.getSurfaceId() == surfaceId_);
+            auto newRootNode = shadowTreeCloner.cloneWithNewProps(
+                rootNode, family, RawProps(rt, *props));
 
-              auto newRootNode = shadowTreeCloner.cloneWithNewProps(
-                  rootNode, family, RawProps(rt, *props));
-
-              if (newRootNode == nullptr) {
-                // this happens when React removed the component but Reanimated
-                // still tries to animate it, let's skip update for this
-                // specific component
-                continue;
-              }
-              rootNode = newRootNode;
+            if (newRootNode == nullptr) {
+              // this happens when React removed the component but Reanimated
+              // still tries to animate it, let's skip update for this
+              // specific component
+              continue;
             }
+            rootNode = newRootNode;
           }
 
           auto newRoot = std::static_pointer_cast<RootShadowNode>(rootNode);


### PR DESCRIPTION
## Summary

During researching on getting into assert on too many failed commit attempts I've noticed that there is a lock used by both `NativeReanimatedModule` and `ReanimatedCommitHook`. That lock in the first one is not necessary anymore as it doesn't guard anything from `PropsRegistry`. What's more, it may be a cause for some commit attempt to fail due to waiting two threads for each other.

## Test plan

Chessboard example worked fine
