### PR TITLE
Restore `isConfigured` function

### DIFF
--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -30,6 +30,22 @@ export type ReanimatedConsole = Pick<
   'debug' | 'log' | 'warn' | 'info' | 'error'
 >;
 
+/**
+ * @returns `true` in Reanimated 3, doesn't exist in Reanimated 2 or 1
+ */
+export const isReanimated3 = () => true;
+
+// Superseded by check in `/src/threads.ts`.
+// Used by `react-navigation` to detect if using Reanimated 2 or 3.
+/**
+ * @deprecated This function was superseded by other checks.
+ * We keep it here for backward compatibility reasons.
+ * If you need to check if you are using Reanimated 3 or Reanimated 2
+ * please use `isReanimated3` function instead.
+ * @returns `true` in Reanimated 3, doesn't exist in Reanimated 2
+ */
+export const isConfigured = isReanimated3;
+
 // this is for web implementation
 global._WORKLET = false;
 global._log = function (s: string) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

`isConfigured` was an internal check that due it's directory's `index.ts` having `export * from ./core` was available as a direct import from `react-native-reanimated`. Therefore we cannot simply remove it in a minor version - deleting it raised https://github.com/react-navigation/react-navigation/issues/11498, `react-navigation` uses this function [here](https://github.com/react-navigation/react-navigation/blob/24c03924397a6e59aba9f6b74a9c5cb4b939d9e1/packages/react-native-drawer-layout/src/views/Drawer.tsx#L56) to detect Reanimated 3 since Reanimated 2 didn't have this function.

This PR restores this function, marks it as deprecated and adds a separate `public` check to detect Reanimated 3.

## Test plan

🚀

## Note

We should probably locate more functions that are exported as a part of public API but they shouldn't be.
