### PR TITLE
Improved skipping commits

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -556,9 +556,11 @@ void NativeReanimatedModule::performOperations() {
 
           return newRoot;
         },
-        {.shouldYield = [this]() {
-          return propsRegistry_->shouldSkipCommit();
-        }});
+        {/* .enableStateReconciliation = */ false,
+         /* .mountSynchronously = */ true,
+         /* .shouldYield = */ [this]() {
+           return propsRegistry_->shouldSkipCommit();
+         }});
   });
 }
 

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -540,7 +540,7 @@ void NativeReanimatedModule::performOperations() {
             // Fix for catching nullptr returned from commit hook was introduced
             // in 0.72.4 but we have only check for minor version of React
             // Native so enable that optimization in React Native >= 0.73
-            if (propsRegistry_->shouldSkipCommit()) {
+            if (propsRegistry_->shouldReanimatedSkipCommit()) {
               return nullptr;
             }
 #endif
@@ -564,7 +564,7 @@ void NativeReanimatedModule::performOperations() {
         {/* .enableStateReconciliation = */ false,
          /* .mountSynchronously = */ true,
          /* .shouldYield = */ [this]() {
-           return propsRegistry_->shouldSkipCommit();
+           return propsRegistry_->shouldReanimatedSkipCommit();
          }});
   });
 }

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -536,9 +536,14 @@ void NativeReanimatedModule::performOperations() {
             const ShadowNodeFamily &family = shadowNode->getFamily();
             react_native_assert(family.getSurfaceId() == surfaceId_);
 
+#if REACT_NATIVE_MINOR_VERSION >= 73
+            // Fix for catching nullptr returned from commit hook was introduced
+            // in 0.72.4 but we have only check for minor version of React
+            // Native so enable that optimization in React Native >= 0.73
             if (propsRegistry_->shouldSkipCommit()) {
               return nullptr;
             }
+#endif
 
             auto newRootNode = shadowTreeCloner.cloneWithNewProps(
                 rootNode, family, RawProps(rt, *props));


### PR DESCRIPTION
## Summary

During investigation of race between RN and reanimated shadow tree committing I've noticed that if JS thread commits a new tree (triggering `pleaseSkipReanimatedCommit`) after starting `commit` from reanimated, the latter `commit` may cause JS commit failures.

What's more, additional calls to `shouldReanimatedSkipCommit ` result in avoiding CPU consuming copy operations on nodes and thus seems to work more performant.

I added those checks just before each operation handling and just after full commit.

Chessboard example seemed to work a bit faster that without those changes. I used also profiler and in overall CPU spends less time in ShadowTree.

NOTICE ⚠️ 
This change requires change in RN codebase. PR has been submitted https://github.com/facebook/react-native/pull/38715

## Test plan

Check performance of e.g. chessboard example.
