### PR TITLE
Fix main by adding missing `ts-prune-ignore-next`

### DIFF
--- a/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
+++ b/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
@@ -34,6 +34,7 @@ export function isAffineMatrixFlat(x: unknown): x is AffineMatrixFlat {
   );
 }
 
+// ts-prune-ignore-next This function is exported to be tested
 export function isAffineMatrix(x: unknown): x is AffineMatrix {
   'worklet';
   return (
@@ -53,6 +54,7 @@ export function flatten(matrix: AffineMatrix): AffineMatrixFlat {
   return matrix.flat() as AffineMatrixFlat;
 }
 
+// ts-prune-ignore-next This function is exported to be tested
 export function unflatten(m: AffineMatrixFlat): AffineMatrix {
   'worklet';
   return [
@@ -334,6 +336,7 @@ function gramSchmidtAlgorithm(matrix: AffineMatrix): {
   };
 }
 
+// ts-prune-ignore-next This function is exported to be tested
 export function decomposeMatrix(
   unknownTypeMatrix: AffineMatrixFlat | AffineMatrix
 ): TransformMatrixDecomposition {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Since I've forgot to merge my PR before merging I have to fix main 😎

Our tool detecting unused code, `ts-prune` reports functions used only in tests and inside a module. Indeed we export 3 functions only for purpose of testing, which is considered to be an anti-pattern (but IMHO it is a very good practice to test low level functions instead of only high level ones). It seems hard to configure `ts-prune` to change it's behaviour. On the other hand I like the idea of adding
```
// ts-prune-ignore-next This function is exported to be tested
```
in each occurrence of the situation, since it always give some potentially valuble information to the reader. Also the situation (exporting function which is imported in test files only) does not happen often (only 3 times in whole codebase).

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
## Test plan
Just CI
<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
