### PR TITLE
fix concurrency issues in android's keyboard listener

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -14,8 +14,8 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.swmansion.reanimated.BuildConfig;
 import com.swmansion.reanimated.nativeProxy.KeyboardEventDataUpdater;
 import java.lang.ref.WeakReference;
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ReanimatedKeyboardEventListener {
   enum KeyboardState {
@@ -39,7 +39,8 @@ public class ReanimatedKeyboardEventListener {
   private final WeakReference<ReactApplicationContext> reactContext;
   private int nextListenerId = 0;
   private KeyboardState state;
-  private final HashMap<Integer, KeyboardEventDataUpdater> listeners = new HashMap<>();
+  private final ConcurrentHashMap<Integer, KeyboardEventDataUpdater> listeners = 
+      new ConcurrentHashMap<>();
   private boolean isStatusBarTranslucent = false;
 
   public ReanimatedKeyboardEventListener(WeakReference<ReactApplicationContext> reactContext) {
@@ -144,6 +145,10 @@ public class ReanimatedKeyboardEventListener {
   }
 
   private void bringBackWindowInsets() {
+    if (reactContext.get() == null || reactContext.get().getCurrentActivity() == null) {
+      return;
+    }
+
     WindowCompat.setDecorFitsSystemWindows(
         reactContext.get().getCurrentActivity().getWindow(), !isStatusBarTranslucent);
     ViewCompat.setOnApplyWindowInsetsListener(getRootView(), null);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In the playstore crashes report for our app I saw several errors from the `ReanimatedKeyboardEventListener`. 

First:

<details>
  <summary>
`ConcurrentModificationException`
</summary>

  ```
Exception java.util.ConcurrentModificationException:
  at java.util.HashMap$HashIterator.nextNode (HashMap.java:1441)
  at java.util.HashMap$ValueIterator.next (HashMap.java:1470)
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener.updateKeyboard (ReanimatedKeyboardEventListener.java:81)
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener.access$100 (ReanimatedKeyboardEventListener.java:20)
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener$WindowInsetsCallback.onProgress (ReanimatedKeyboardEventListener.java:114)
  at androidx.core.view.WindowInsetsAnimationCompat$Impl30$ProxyCallback.onProgress (WindowInsetsAnimationCompat.java:1022)
  at android.view.View.dispatchWindowInsetsAnimationProgress (View.java:12085)
  at android.view.ViewGroup.dispatchWindowInsetsAnimationProgress (ViewGroup.java:7828)
  at android.view.ViewRootInsetsControllerHost.dispatchWindowInsetsAnimationProgress (ViewRootInsetsControllerHost.java:107)
  at android.view.InsetsController.lambda$new$3$android-view-InsetsController (InsetsController.java:690)
  at android.view.InsetsController$$ExternalSyntheticLambda10.run
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1301)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1309)
  at android.view.Choreographer.doCallbacks (Choreographer.java:923)
  at android.view.Choreographer.doFrame (Choreographer.java:848)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1283)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8757)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
  ```

</details>

This is caused by the normal `HashMap` used to keep track of the listeners, and should be fixed by using a `ConcurrentHashMap`, which is capable of handling concurrent modifications

The second issue:


<details>
  <summary>
`NullPointerException`
</summary>

  ```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener.bringBackWindowInsets (ReanimatedKeyboardEventListener.java:148)
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener.$r8$lambda$E4DwXS7X3BmDCqDm-57x5QcAB5k
  at com.swmansion.reanimated.keyboardObserver.ReanimatedKeyboardEventListener$$ExternalSyntheticLambda0.run
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:246)
  at android.app.ActivityThread.main (ActivityThread.java:8633)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:602)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1130)
  ```

</details>

Looks like it is possible for the `bringBackWindowInsets` method to be called at moments when the react context or the activity used to render react is not fully ready.  

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
