### PR TITLE
Simplify useEvent typing

### DIFF
--- a/src/reanimated2/hook/useAnimatedGestureHandler.ts
+++ b/src/reanimated2/hook/useAnimatedGestureHandler.ts
@@ -1,6 +1,8 @@
+import { MutableRefObject } from 'react';
 import type { Context, WorkletFunction, NativeEvent } from '../commonTypes';
 import type { DependencyList } from './commonTypes';
 import { useEvent, useHandler } from './Hooks';
+import WorkletEventHandler from '../WorkletEventHandler';
 
 interface Handler<T, TContext extends Context> extends WorkletFunction {
   (event: T, context: TContext, isCanceledOrFailed?: boolean): void;
@@ -48,7 +50,7 @@ export function useAnimatedGestureHandler<
 >(
   handlers: GestureHandlers<Payload, TContext>,
   dependencies?: DependencyList
-): (e: T) => void {
+): MutableRefObject<WorkletEventHandler<T> | null> | ((e: T) => void) {
   const { context, doDependenciesDiffer, useWeb } = useHandler<
     Payload,
     TContext
@@ -108,5 +110,5 @@ export function useAnimatedGestureHandler<
     handler,
     ['onGestureHandlerStateChange', 'onGestureHandlerEvent'],
     doDependenciesDiffer
-  ) as unknown as (e: T) => void; // this is not correct but we want to make GH think it receives a function
+  );
 }

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -32,6 +32,10 @@ export const useEvent = function <T extends NativeEvent<T>>(
   eventNames: string[] = [],
   rebuild = false
 ): MutableRefObject<WorkletEventHandler<T> | null> {
+  // For Fabric:
+  // ensure that this return type will pass checks for getting ActionType REANIMATED_WORKLET
+  // in react-native-gesture-handler attachGestureHandler method
+  // to send event directly to Reanimated through reanimatedEventDispatcher
   const initRef = useRef<WorkletEventHandler<T> | null>(null);
   if (initRef.current === null) {
     initRef.current = new WorkletEventHandler(handler, eventNames);

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -12,7 +12,7 @@ import { makeRemote } from '../core';
 import { isWeb, isJest } from '../PlatformChecker';
 import WorkletEventHandler from '../WorkletEventHandler';
 import type { ContextWithDependencies, DependencyList } from './commonTypes';
-import type { NativeSyntheticEvent } from 'react-native';
+
 interface Handler<T, TContext extends Context> extends WorkletFunction {
   (event: T, context: TContext): void;
 }
@@ -27,13 +27,6 @@ interface UseHandlerContext<TContext extends Context> {
   useWeb: boolean;
 }
 
-// TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
-type useEventType = <T extends object>(
-  handler: (e: T) => void,
-  eventNames?: string[],
-  rebuild?: boolean
-) => (e: NativeSyntheticEvent<T>) => void;
-
 export const useEvent = function <T extends NativeEvent<T>>(
   handler: (event: T) => void,
   eventNames: string[] = [],
@@ -47,8 +40,7 @@ export const useEvent = function <T extends NativeEvent<T>>(
   }
 
   return initRef;
-  // TODO TYPESCRIPT This cast is to get rid of .d.ts file.
-} as unknown as useEventType;
+};
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
 type useHandlerType = <T, TContext extends Context = Record<string, never>>(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR reverts types that were used in 3.1.0 without extra casting through `unknown`.

## Test plan

This was found during fixing accordion example for fabric, which finally was resolved with this fix on the react-native-gesture-handler site: https://github.com/software-mansion/react-native-gesture-handler/pull/2555 
