### PR TITLE
Bump `react-native-screens`

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -536,7 +536,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.22.1):
+  - RNScreens (3.23.0):
     - React-Core
     - React-RCTImage
   - RNSVG (13.9.0):
@@ -802,7 +802,7 @@ SPEC CHECKSUMS:
   RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNReanimated: 66449430e0bed3c23148db98996f4925da8fe514
-  RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
+  RNScreens: 6a8a3c6b808aa48dca1780df7b73ea524f602c63
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 65286bb6a07edce5e4fe8c90774da977ae8fc009

--- a/Example/package.json
+++ b/Example/package.json
@@ -26,7 +26,7 @@
     "react-native-pager-view": "5.4.24",
     "react-native-reanimated": "link:../",
     "react-native-safe-area-context": "^4.6.3",
-    "react-native-screens": "github:software-mansion/react-native-screens#1d8ab85967e1285b7191c4f65d7e54ea77e0fd94",
+    "react-native-screens": "^3.23.0",
     "react-native-svg": "^13.9.0"
   },
   "devDependencies": {

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -5913,9 +5913,10 @@ react-native-safe-area-context@^4.6.3:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.6.3.tgz#f06cfea05b1c4b018aa9758667a109f619c62b55"
   integrity sha512-3CeZM9HFXkuqiU9HqhOQp1yxhXw6q99axPWrT+VJkITd67gnPSU03+U27Xk2/cr9XrLUnakM07kj7H0hdPnFiQ==
 
-"react-native-screens@github:software-mansion/react-native-screens#1d8ab85967e1285b7191c4f65d7e54ea77e0fd94":
-  version "3.22.1"
-  resolved "https://codeload.github.com/software-mansion/react-native-screens/tar.gz/1d8ab85967e1285b7191c4f65d7e54ea77e0fd94"
+react-native-screens@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.23.0.tgz#7afb9456df3aa2c4a7a19889a44687003b8fb2b4"
+  integrity sha512-SdYGv1/f2o43OVZlBtaHEIfyWa3EjqBWB3m/kH+G7m8tNIi98mh4t5bUL7ISBtaR4Zhrs1sU93Rq6BYoHECdgQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1139,7 +1139,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.22.0):
+  - RNScreens (3.23.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1147,8 +1147,8 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.22.0)
-  - RNScreens/common (3.22.0):
+    - RNScreens/common (= 3.23.0)
+  - RNScreens/common (3.23.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1428,7 +1428,7 @@ SPEC CHECKSUMS:
   React-perflogger: 3d501f34c8d4b10cb75f348e43591765788525ad
   React-RCTActionSheet: f5335572c979198c0c3daff67b07bd1ad8370c1d
   React-RCTAnimation: 5d0d31a4f9c49a70f93f32e4da098fb49b5ae0b3
-  React-RCTAppDelegate: e156b3ac068733bb003a78b3303aa5a6ad82f4a4
+  React-RCTAppDelegate: 7ab4f1e405d178036df67185560f13d9e0735d8d
   React-RCTBlob: 280d2605ba10b8f2282f1e8a849584368577251a
   React-RCTFabric: 9c4ff9a5bb3373146cff554d07f05956cd981658
   React-RCTImage: e15d22db53406401cdd1407ce51080a66a9c7ed4
@@ -1447,7 +1447,7 @@ SPEC CHECKSUMS:
   RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
   RNGestureHandler: d8224aad6d7081834ae6e6cf925397059485b69e
   RNReanimated: 2ed93fab1e7e2439219853ce9fb534fbeb9b8104
-  RNScreens: 9d61ea7595ba14c8ef38c010e1e918bcc51fc5c3
+  RNScreens: 95b62f9fb2aa427d7c1a2a2d127a72edb7450390
   RNSVG: a9204714b832d82b483b0cbaee9e675646426b8d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 65286bb6a07edce5e4fe8c90774da977ae8fc009

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -25,7 +25,7 @@
     "react-native-pager-view": "5.4.24",
     "react-native-reanimated": "link:../",
     "react-native-safe-area-context": "^4.6.3",
-    "react-native-screens": "^3.22.0",
+    "react-native-screens": "^3.23.0",
     "react-native-svg": "^13.9.0"
   },
   "devDependencies": {

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -5581,10 +5581,10 @@ react-native-safe-area-context@^4.6.3:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.6.3.tgz#f06cfea05b1c4b018aa9758667a109f619c62b55"
   integrity sha512-3CeZM9HFXkuqiU9HqhOQp1yxhXw6q99axPWrT+VJkITd67gnPSU03+U27Xk2/cr9XrLUnakM07kj7H0hdPnFiQ==
 
-react-native-screens@^3.22.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.22.0.tgz#7d892baf964fddb642b5eec71a09e2aeb501e578"
-  integrity sha512-csLypBSXIt/egh37YJmokETptZJCtZdoZBsZNLR9n31GesDyVogprT+MM22dEPDuxPxt/mFWq+lSpVwk7khuTw==
+react-native-screens@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.23.0.tgz#7afb9456df3aa2c4a7a19889a44687003b8fb2b4"
+  integrity sha512-SdYGv1/f2o43OVZlBtaHEIfyWa3EjqBWB3m/kH+G7m8tNIi98mh4t5bUL7ISBtaR4Zhrs1sU93Rq6BYoHECdgQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "react-native-pager-view": "5.4.24",
     "react-native-reanimated": "link:../",
     "react-native-safe-area-context": "^4.6.3",
-    "react-native-screens": "github:software-mansion/react-native-screens#1d8ab85967e1285b7191c4f65d7e54ea77e0fd94",
+    "react-native-screens": "^3.23.0",
     "react-native-svg": "^13.9.0",
     "react-native-web": "~0.18.12"
   },

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1464,9 +1464,10 @@ react-native-safe-area-context@^4.6.3:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.6.3.tgz#f06cfea05b1c4b018aa9758667a109f619c62b55"
   integrity sha512-3CeZM9HFXkuqiU9HqhOQp1yxhXw6q99axPWrT+VJkITd67gnPSU03+U27Xk2/cr9XrLUnakM07kj7H0hdPnFiQ==
 
-"react-native-screens@github:software-mansion/react-native-screens#1d8ab85967e1285b7191c4f65d7e54ea77e0fd94":
-  version "3.22.1"
-  resolved "https://codeload.github.com/software-mansion/react-native-screens/tar.gz/1d8ab85967e1285b7191c4f65d7e54ea77e0fd94"
+react-native-screens@^3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.23.0.tgz#7afb9456df3aa2c4a7a19889a44687003b8fb2b4"
+  integrity sha512-SdYGv1/f2o43OVZlBtaHEIfyWa3EjqBWB3m/kH+G7m8tNIi98mh4t5bUL7ISBtaR4Zhrs1sU93Rq6BYoHECdgQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Since https://github.com/software-mansion/react-native-screens/pull/1810 got merged and included in `3.23.0` release we can use the npm published pack again.

## Test plan

Yes