### PR TITLE
Allow nullables in useAnimatedRef scrollable node getters

### DIFF
--- a/src/reanimated2/fabricUtils.ts
+++ b/src/reanimated2/fabricUtils.ts
@@ -10,9 +10,7 @@ interface HostInstance {
   };
 }
 
-let findHostInstance_DEPRECATED: (
-  ref: React.Component | undefined | null
-) => HostInstance;
+let findHostInstance_DEPRECATED: (ref: React.Component) => HostInstance;
 if (global._IS_FABRIC) {
   try {
     findHostInstance_DEPRECATED =
@@ -26,7 +24,7 @@ if (global._IS_FABRIC) {
 }
 
 export function getShadowNodeWrapperFromRef(
-  ref: React.Component | undefined | null
+  ref: React.Component
 ): ShadowNodeWrapper {
   return findHostInstance_DEPRECATED(ref)._internalInstanceHandle.stateNode
     .node;

--- a/src/reanimated2/fabricUtils.ts
+++ b/src/reanimated2/fabricUtils.ts
@@ -10,10 +10,13 @@ interface HostInstance {
   };
 }
 
-let findHostInstance_DEPRECATED: (ref: React.Component) => HostInstance;
+let findHostInstance_DEPRECATED: (
+  ref: React.Component | undefined | null
+) => HostInstance;
 if (global._IS_FABRIC) {
   try {
     findHostInstance_DEPRECATED =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('react-native/Libraries/Renderer/shims/ReactFabric').findHostInstance_DEPRECATED;
   } catch (e) {
     throw new Error(
@@ -23,7 +26,7 @@ if (global._IS_FABRIC) {
 }
 
 export function getShadowNodeWrapperFromRef(
-  ref: React.Component
+  ref: React.Component | undefined | null
 ): ShadowNodeWrapper {
   return findHostInstance_DEPRECATED(ref)._internalInstanceHandle.stateNode
     .node;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -42,7 +42,12 @@ export function useAnimatedRef<
     const fun: AnimatedRef<T> = <AnimatedRef<T>>((component) => {
       // enters when ref is set by attaching to a component
       if (component) {
-        tag.value = getTagValueFunction(getComponentOrScrollable(component));
+        // On Fabric we use getNativeScrollRef which can return undefined
+        // but on Paper getTagValueFunction is 'findNodeHandle' which cannot
+        // get undefined. It's hard to solve this in TypeScript so we can just
+        // use !.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        tag.value = getTagValueFunction(getComponentOrScrollable(component)!);
         fun.current = component;
       }
       return tag.value;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -8,7 +8,6 @@ import {
   makeShareableCloneRecursive,
   registerShareableMapping,
 } from '../shareables';
-import { findNodeHandle } from 'react-native';
 
 type Nullable<T> = T | undefined | null;
 interface MaybeScrollableComponent extends Component {
@@ -27,9 +26,11 @@ function getComponentOrScrollable(
   return component;
 }
 
-const getTagValueFunction = global._IS_FABRIC
-  ? getShadowNodeWrapperFromRef
-  : findNodeHandle;
+// const getTagValueFunction = global._IS_FABRIC
+//   ? getShadowNodeWrapperFromRef
+//   : findNodeHandle;
+
+const getTagValueFunction = getShadowNodeWrapperFromRef;
 
 export function useAnimatedRef<
   T extends MaybeScrollableComponent

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 import { useSharedValue } from './useSharedValue';
 import type { AnimatedRef } from './commonTypes';
 import type { ShadowNodeWrapper } from '../commonTypes';
-import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import {
   makeShareableCloneRecursive,
   registerShareableMapping,
@@ -27,9 +26,11 @@ function getComponentOrScrollable(
   return component;
 }
 
-const getTagValueFunction = global._IS_FABRIC
-  ? getShadowNodeWrapperFromRef
-  : findNodeHandle;
+// const getTagValueFunction = global._IS_FABRIC
+//   ? getShadowNodeWrapperFromRef
+//   : findNodeHandle;
+
+const getTagValueFunction = findNodeHandle;
 
 export function useAnimatedRef<
   T extends MaybeScrollableComponent

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -41,10 +41,9 @@ export function useAnimatedRef<
     const fun: AnimatedRef<T> = <AnimatedRef<T>>((component) => {
       // enters when ref is set by attaching to a component
       if (component) {
-        // On Fabric we use getNativeScrollRef which can return undefined
-        // but on Paper getTagValueFunction is 'findNodeHandle' which cannot
-        // get undefined. It's hard to solve this in TypeScript so we can just
-        // use !.
+        // On Fabric we use `getNativeScrollRef` which can return undefined but
+        // on Paper getTagValueFunction is `findNodeHandle` which cannot get
+        // undefined as an argument. It's hard to solve this in TypeScript so we can just use !.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         tag.value = getTagValueFunction(getComponentOrScrollable(component)!);
         fun.current = component;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -3,12 +3,12 @@ import { useRef } from 'react';
 import { useSharedValue } from './useSharedValue';
 import type { AnimatedRef } from './commonTypes';
 import type { ShadowNodeWrapper } from '../commonTypes';
+import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import {
   makeShareableCloneRecursive,
   registerShareableMapping,
 } from '../shareables';
 import { findNodeHandle } from 'react-native';
-import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import type { FlatList, ScrollView, SectionList } from 'react-native';
 interface MaybeScrollableComponent extends Component {
   getNativeScrollRef?: FlatList['getNativeScrollRef'];

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -8,6 +8,7 @@ import {
   registerShareableMapping,
 } from '../shareables';
 import { findNodeHandle } from 'react-native';
+import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 
 type Nullable<T> = T | undefined | null;
 interface MaybeScrollableComponent extends Component {
@@ -26,11 +27,9 @@ function getComponentOrScrollable(
   return component;
 }
 
-// const getTagValueFunction = global._IS_FABRIC
-//   ? getShadowNodeWrapperFromRef
-//   : findNodeHandle;
-
-const getTagValueFunction = findNodeHandle;
+const getTagValueFunction = global._IS_FABRIC
+  ? getShadowNodeWrapperFromRef
+  : findNodeHandle;
 
 export function useAnimatedRef<
   T extends MaybeScrollableComponent

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -9,13 +9,11 @@ import {
   registerShareableMapping,
 } from '../shareables';
 import { findNodeHandle } from 'react-native';
-import type { FlatList, ScrollView, SectionList } from 'react-native';
 interface MaybeScrollableComponent extends Component {
-  getNativeScrollRef?: FlatList['getNativeScrollRef'];
-  getScrollableNode?:
-    | FlatList['getScrollableNode']
-    | ScrollView['getScrollableNode']
-    | SectionList['getScrollableNode'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getNativeScrollRef?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getScrollableNode?: any;
 }
 
 function getComponentOrScrollable(component: MaybeScrollableComponent) {

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -8,6 +8,7 @@ import {
   makeShareableCloneRecursive,
   registerShareableMapping,
 } from '../shareables';
+import { findNodeHandle } from 'react-native';
 
 type Nullable<T> = T | undefined | null;
 interface MaybeScrollableComponent extends Component {
@@ -26,11 +27,9 @@ function getComponentOrScrollable(
   return component;
 }
 
-// const getTagValueFunction = global._IS_FABRIC
-//   ? getShadowNodeWrapperFromRef
-//   : findNodeHandle;
-
-const getTagValueFunction = getShadowNodeWrapperFromRef;
+const getTagValueFunction = global._IS_FABRIC
+  ? getShadowNodeWrapperFromRef
+  : findNodeHandle;
 
 export function useAnimatedRef<
   T extends MaybeScrollableComponent

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -10,14 +10,15 @@ import {
 } from '../shareables';
 import { findNodeHandle } from 'react-native';
 
+type Nullable<T> = T | undefined | null;
 interface MaybeScrollableComponent extends Component {
-  getNativeScrollRef?: () => MaybeScrollableComponent;
-  getScrollableNode?: () => MaybeScrollableComponent;
+  getNativeScrollRef?: () => Nullable<MaybeScrollableComponent>;
+  getScrollableNode?: () => Nullable<MaybeScrollableComponent>;
 }
 
 function getComponentOrScrollable(
   component: MaybeScrollableComponent
-): MaybeScrollableComponent {
+): Nullable<MaybeScrollableComponent> {
   if (global._IS_FABRIC && component.getNativeScrollRef) {
     return component.getNativeScrollRef();
   } else if (!global._IS_FABRIC && component.getScrollableNode) {

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -10,15 +10,20 @@ import {
 import { findNodeHandle } from 'react-native';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 
-type Nullable<T> = T | undefined | null;
+import type {
+  FlatList, // here
+  ScrollView, // here
+  SectionList, // here
+} from 'react-native';
 interface MaybeScrollableComponent extends Component {
-  getNativeScrollRef?: () => Nullable<MaybeScrollableComponent>;
-  getScrollableNode?: () => Nullable<MaybeScrollableComponent>;
+  getNativeScrollRef?: FlatList['getNativeScrollRef'];
+  getScrollableNode?:
+    | FlatList['getScrollableNode']
+    | ScrollView['getScrollableNode']
+    | SectionList['getScrollableNode'];
 }
 
-function getComponentOrScrollable(
-  component: MaybeScrollableComponent
-): Nullable<MaybeScrollableComponent> {
+function getComponentOrScrollable(component: MaybeScrollableComponent) {
   if (global._IS_FABRIC && component.getNativeScrollRef) {
     return component.getNativeScrollRef();
   } else if (!global._IS_FABRIC && component.getScrollableNode) {
@@ -41,11 +46,7 @@ export function useAnimatedRef<
     const fun: AnimatedRef<T> = <AnimatedRef<T>>((component) => {
       // enters when ref is set by attaching to a component
       if (component) {
-        // On Fabric we use `getNativeScrollRef` which can return undefined but
-        // on Paper getTagValueFunction is `findNodeHandle` which cannot get
-        // undefined as an argument. It's hard to solve this in TypeScript so we can just use !.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        tag.value = getTagValueFunction(getComponentOrScrollable(component)!);
+        tag.value = getTagValueFunction(getComponentOrScrollable(component));
         fun.current = component;
       }
       return tag.value;

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -9,12 +9,7 @@ import {
 } from '../shareables';
 import { findNodeHandle } from 'react-native';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
-
-import type {
-  FlatList, // here
-  ScrollView, // here
-  SectionList, // here
-} from 'react-native';
+import type { FlatList, ScrollView, SectionList } from 'react-native';
 interface MaybeScrollableComponent extends Component {
   getNativeScrollRef?: FlatList['getNativeScrollRef'];
   getScrollableNode?:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

~~In types of `react-native` we can see that `getNativeScrollRef` and `getScrollableNode` could return `null` or `undefined`. This PR makes this acknowledged in `useAnimatedRef`.~~

Since #4873 cast new light on how these types should be I checked how are those methods typed in `react-native` and seeing it we decided simply to use `any` since it seems like the only safe option currently.

<details>
<summary>pic rel</summary>

![Screenshot 2023-08-04 at 09 59 24](https://github.com/software-mansion/react-native-reanimated/assets/40713406/4f87d69d-77f9-41c2-8a99-5614ca348f9a)

</details>


## Test plan

CI
