### PR TITLE
Assert shareable type

### DIFF
--- a/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
@@ -26,7 +26,8 @@ jsi::Value AnimatedSensorModule::registerSensor(
     const jsi::Value &sensorDataHandler) {
   SensorType sensorType = static_cast<SensorType>(sensorTypeValue.asNumber());
 
-  auto shareableHandler = extractShareableOrThrow(rt, sensorDataHandler);
+  auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
+      rt, sensorDataHandler, "sensor event handler must be a worklet");
 
   int sensorId = platformRegisterSensorFunction_(
       sensorType,

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -196,10 +196,8 @@ NativeReanimatedModule::~NativeReanimatedModule() {
 void NativeReanimatedModule::scheduleOnUI(
     jsi::Runtime &rt,
     const jsi::Value &worklet) {
-  auto shareableWorklet = extractShareableOrThrow(rt, worklet);
-  assert(
-      shareableWorklet->valueType() == Shareable::WorkletType &&
-      "only worklets can be scheduled to run on UI");
+  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+      rt, worklet, "only worklets can be scheduled to run on UI");
   runtimeManager_->uiScheduler_->scheduleOnUI([=] {
     jsi::Runtime &rt = *runtimeHelper->uiRuntime();
     auto workletValue = shareableWorklet->getJSValue(rt);
@@ -735,7 +733,8 @@ jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
     jsi::Runtime &rt,
     const jsi::Value &handlerWorklet,
     const jsi::Value &isStatusBarTranslucent) {
-  auto shareableHandler = extractShareableOrThrow(rt, handlerWorklet);
+  auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
+      rt, handlerWorklet, "keyboard event handler must be a worklet");
   return subscribeForKeyboardEventsFunction(
       [=](int keyboardState, int height) {
         jsi::Runtime &rt = *runtimeHelper->uiRuntime();

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -215,7 +215,8 @@ void NativeReanimatedModule::scheduleOnJS(
       "Incompatible object passed to scheduleOnJS. It is only allowed to schedule worklets or functions defined on the React Native JS runtime this way.");
   auto shareableArgs = argsValue.isUndefined()
       ? nullptr
-      : extractShareableOrThrow(rt, argsValue);
+      : extractShareableOrThrow<ShareableArray>(
+            rt, argsValue, "args must be an array");
   auto jsRuntime = this->runtimeHelper->rnRuntime();
   runtimeManager_->jsScheduler_->scheduleOnJS([=] {
     jsi::Runtime &rt = *jsRuntime;
@@ -331,7 +332,8 @@ jsi::Value NativeReanimatedModule::registerEventHandler(
 
   uint64_t newRegistrationId = EVENT_HANDLER_ID++;
   auto eventName = eventHash.asString(rt).utf8(rt);
-  auto handlerShareable = extractShareableOrThrow(rt, worklet);
+  auto handlerShareable = extractShareableOrThrow<ShareableWorklet>(
+      rt, worklet, "event handler must be a worklet");
 
   runtimeManager_->uiScheduler_->scheduleOnUI([=] {
     jsi::Runtime &rt = *runtimeHelper->uiRuntime();
@@ -418,7 +420,8 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimation(
       viewTag.asNumber(),
       static_cast<LayoutAnimationType>(type.asNumber()),
       sharedTransitionTag.asString(rt).utf8(rt),
-      extractShareableOrThrow(rt, config));
+      extractShareableOrThrow<ShareableObject>(
+          rt, config, "layout animation config must be an object"));
   return jsi::Value::undefined();
 }
 

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -139,7 +139,7 @@ std::shared_ptr<T> extractShareableOrThrow(
   auto res = std::dynamic_pointer_cast<T>(
       extractShareableOrThrow(rt, shareableRef, errorMessage));
   if (!res) {
-    throw new std::runtime_error(
+    throw std::runtime_error(
         errorMessage != nullptr
             ? errorMessage
             : "provided shareable object is of an incompatible type");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR replaces a few occurrences of `extractShareableOrThrow` with `extractShareableOrThrow<T>` which asserts the type of the shareable along with a proper error message.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
