### PR TITLE
Add default implementations for blocks from AnimationsManager on iOS

### DIFF
--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -79,14 +79,18 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     _reaSwizzledUIManager = [[REASwizzledUIManager alloc] initWithUIManager:uiManager withAnimationManager:self];
 
     _startAnimationForTag = ^(NSNumber *tag, LayoutAnimationType type, NSDictionary *yogaValues) {
+      // default implementation, this block will be replaced by a setter
     };
     _hasAnimationForTag = ^(NSNumber *tag, LayoutAnimationType type) {
+      // default implementation, this block will be replaced by a setter
       return NO;
     };
     _clearAnimationConfigForTag = ^(NSNumber *tag) {
+      // default implementation, this block will be replaced by a setter
     };
 #ifdef DEBUG
     _checkDuplicateSharedTag = ^(UIView *view, NSNumber *viewTag) {
+      // default implementation, this block will be replaced by a setter
     };
 #endif
   }

--- a/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/LayoutReanimation/REAAnimationsManager.m
@@ -77,6 +77,18 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     }
     _sharedTransitionManager = [[REASharedTransitionManager alloc] initWithAnimationsManager:self];
     _reaSwizzledUIManager = [[REASwizzledUIManager alloc] initWithUIManager:uiManager withAnimationManager:self];
+
+    _startAnimationForTag = ^(NSNumber *tag, LayoutAnimationType type, NSDictionary *yogaValues) {
+    };
+    _hasAnimationForTag = ^(NSNumber *tag, LayoutAnimationType type) {
+      return NO;
+    };
+    _clearAnimationConfigForTag = ^(NSNumber *tag) {
+    };
+#ifdef DEBUG
+    _checkDuplicateSharedTag = ^(UIView *view, NSNumber *viewTag) {
+    };
+#endif
   }
   return self;
 }


### PR DESCRIPTION
## Summary

This PR adds default instances for uninitialized blocks in AnimationManager on iOS. It helps avoid null exceptions in two cases:
- When reloading during Layout Animations and Shared Transitions.
- When someone has installed Reanimated but doesn't import anything from it. In this situation, these blocks will not be set, but due to swizzling in Screens, there is a possibility of calling some of these blocks.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4836
Fixes:
<img width="500" alt="Screenshot 2023-06-26 at 21 26 52" src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/5bc60a08-da8b-4b14-8762-bbd1ab9a45ec">

## Test plan

1. Run Example -> open [LA] Entering and Exiting with Layout -> click toggle -> press R in console
2. Run example from https://github.com/software-mansion/react-native-reanimated/issues/4836#issuecomment-1659917226
