### PR TITLE
Mock REAInitializer for backward compatibility

### DIFF
--- a/ios/native/REAInitializer.h
+++ b/ios/native/REAInitializer.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 namespace reanimated {
 
+[[deprecated(
+    "REAInitializer method is no longer required, you can just remove invocation.")]] void
+REAInitializer(RCTBridge *bridge);
+
 #if REACT_NATIVE_MINOR_VERSION <= 71
 [[deprecated(
     "REAJSIExecutorRuntimeInstaller method is no longer required, you can just remove invocation.")]] JSIExecutor::

--- a/ios/native/REAInitializer.mm
+++ b/ios/native/REAInitializer.mm
@@ -4,6 +4,11 @@
 
 namespace reanimated {
 
+void REAInitializer(RCTBridge *bridge)
+{
+  // do nothing, just for backward compatibility
+}
+
 #if REACT_NATIVE_MINOR_VERSION <= 71
 
 JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4631

In https://github.com/software-mansion/react-native-reanimated/pull/4619 I removed REAInitializer because it is no longer needed. However, some brownfield apps still use it. This PR adds a mock for REAInitializer to ensure backward compatibility.

## Test plan

CI
