### PR TITLE
Hotfix: allow transform to be a string in useAnimatedStyle

### DIFF
--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -33,6 +33,7 @@ type TransformsStyle = Pick<RNTransformsStyle, 'transform'>;
 
 type TransformStyleTypes = TransformsStyle['transform'] extends
   | readonly (infer T)[]
+  | string
   | undefined
   ? T
   : never;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

A few months back RN [added in its types](https://github.com/facebook/react-native/issues/37543) that `transform` could be a `string` - but it's missing in RN `0.72.3` and causes some errors when current version of `react-native-reanimated` is used with RN `0.71`. This PR hotfixes that, allowing `transform` to be a string.

Keep in mind that it's definitely not the final form of how `useAnimatedStyle` types should look like - it will be refactored in the future.

## Test plan


<details>
<summary> This snippet yields errors on `0.71.12` without this change </summary>

```TSX
function Foo() {
  const sv = useSharedValue(0);
  const otherSv = useSharedValue(0);

  const width = 200;

  // error here, transform being inferred to `never`
  const animatedStyle = useAnimatedStyle(() => {
    return {
      width: '200%',
      alignItems: 'center',
      opacity: interpolate(sv.value, [0, 1], [0, 1], Extrapolation.CLAMP),
      transform: [
        {
          translateX: interpolate(
            sv.value,
            [0, 1],
            [0, 100],
            Extrapolation.CLAMP,
          ),
        },
        {
          translateY: sv.value + otherSv.value,
        },
      ],
    };
  }, [width]);

  return <Animated.View style={animatedStyle} />;
}
```
