### PR TITLE
Update `useAnimatedGestureHandler` in docs

### DIFF
--- a/docs/docs/api/hooks/useAnimatedGestureHandler.md
+++ b/docs/docs/api/hooks/useAnimatedGestureHandler.md
@@ -61,6 +61,8 @@ const App = () => {
 The hook returns a handler object that can be attached to one of the gesture handler components provided by the `react-native-gesture-handler` library.
 The handler should be passed under `onGestureEvent` parameter regardless of what gesture states we are interested in processing.
 
+Note: Since version `2.10.0` of `react-native-gesture-handler`, to use this hook on web, you have to pass returned handler object to both `onGestureEvent` and `onHandlerStateChange` parameters.
+
 ## Example
 
 In the below example we use [`PanGestureHandler`](https://docs.swmansion.com/react-native-gesture-handler/docs/gesture-handlers/api/pan-gh/) to register for pan gesture events performed on the rendered View.

--- a/docs/docs/api/hooks/useAnimatedGestureHandler.md
+++ b/docs/docs/api/hooks/useAnimatedGestureHandler.md
@@ -61,7 +61,7 @@ const App = () => {
 The hook returns a handler object that can be attached to one of the gesture handler components provided by the `react-native-gesture-handler` library.
 The handler should be passed under `onGestureEvent` parameter regardless of what gesture states we are interested in processing.
 
-Note: Since version `2.10.0` of `react-native-gesture-handler`, to use this hook on web, you have to pass returned handler object to both `onGestureEvent` and `onHandlerStateChange` parameters.
+Note: Since version 2.10.0 of `react-native-gesture-handler`, to use this hook on web, you have to pass returned handler object to both `onGestureEvent` and `onHandlerStateChange` parameters.
 
 ## Example
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Since `2.10.0` gesture handler enables new web implementation by default. Because of that `useAnimatedGestureHandler` doesn't work unless both `onGestureEvent` and `onHandlerStateChange` props are defined. This PR updates docs entry for `useAnimatedGestureHandler` so that people will be aware of that change.
