### PR TITLE
Pull hotfix into reanimated2

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -129,6 +129,7 @@ declare module 'react-native-reanimated' {
     export type TransformStyleTypes = TransformsStyle['transform'] extends
       | readonly (infer T)[]
       | undefined
+      | string
       ? T
       : never;
     export type AdaptTransforms<T> = {


### PR DESCRIPTION
- https://github.com/software-mansion/react-native-reanimated/pull/4881

This is a copy of the above PR, against Reanimated2 branch

Summary
A few months back RN https://github.com/facebook/react-native/issues/37543 that transform could be a string - but it's missing in RN 0.72.3 and causes some errors when current version of react-native-reanimated is used with RN 0.71. This PR hotfixes that, allowing transform to be a string.

Keep in mind that it's definitely not the final form of how useAnimatedStyle types should look like - it will be refactored in the future.

Test plan
This snippet yields errors on `0.71.12` without this change