### PR TITLE
Fix assigning RN `ViewStyle.style` type to Animated components `style`

### DIFF
--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -40,13 +40,11 @@ import Animated, {
   createAnimatedPropAdapter,
   useAnimatedProps,
   useAnimatedRef,
-} from '..';
-import {
   dispatchCommand,
   measure,
   scrollTo,
   setGestureState,
-} from '../src/reanimated2/NativeMethods';
+} from '..';
 
 class Path extends React.Component<{ fill?: string }> {
   render() {

--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -2,8 +2,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState, useCallback, forwardRef, useRef } from 'react';
-import type { FlatListProps, ViewProps, ImageProps } from 'react-native';
-import { StyleSheet, Button, View, Image } from 'react-native';
+import type {
+  FlatListProps,
+  ViewProps,
+  ImageProps,
+  ViewStyle,
+} from 'react-native';
+import { StyleSheet, Button, View, Image, ScrollView } from 'react-native';
 import type {
   PanGestureHandlerGestureEvent,
   PinchGestureHandlerGestureEvent,
@@ -784,7 +789,7 @@ function testPartialAnimatedProps() {
     const plainRef = useRef<Animated.View>();
     // @ts-expect-error should only work for Animated refs?
     dispatchCommand(plainRef, 'command', [1, 2, 3]);
-    // @ts-expect-error args are not optional
+    // it should work without arguments
     dispatchCommand(animatedRef, 'command');
   }
 
@@ -833,4 +838,31 @@ function testPartialAnimatedProps() {
       }}
     />;
   }
+}
+
+declare const RNStyle: ViewStyle;
+// test style prop of Animated components
+function testStyleProps() {
+  const MyAnimatedView = Animated.createAnimatedComponent(View);
+  const MyAnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
+  const MyAnimatedFlatList = Animated.createAnimatedComponent(FlatList);
+
+  return (
+    <View>
+      <Animated.View style={RNStyle} />
+      <MyAnimatedView style={RNStyle} />
+      <Animated.ScrollView style={RNStyle} />
+      <MyAnimatedScrollView style={RNStyle} />
+      <Animated.FlatList
+        style={RNStyle}
+        data={[]}
+        renderItem={() => <View />}
+      />
+      <MyAnimatedFlatList
+        style={RNStyle}
+        data={[]}
+        renderItem={() => <View />}
+      />
+    </View>
+  );
 }

--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -775,7 +775,7 @@ function testPartialAnimatedProps() {
     const animatedRef = useAnimatedRef<Animated.View>();
     measure(animatedRef);
     const plainRef = useRef<Animated.View>();
-    // @ts-expect-error should only work for Animated refs?
+    // @ts-expect-error should only work for Animated refs
     measure(plainRef);
   }
 
@@ -785,7 +785,7 @@ function testPartialAnimatedProps() {
     // TODO I don't know how to fix it at the moment
     dispatchCommand(animatedRef, 'command', [1, 2, 3]);
     const plainRef = useRef<Animated.View>();
-    // @ts-expect-error should only work for Animated refs?
+    // @ts-expect-error should only work for Animated refs
     dispatchCommand(plainRef, 'command', [1, 2, 3]);
     // it should work without arguments
     dispatchCommand(animatedRef, 'command');

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format:common": "find Common/ -iname *.h -o -iname *.cpp | xargs clang-format -i",
     "find-unused-code:js": "yarn ts-prune --ignore \"index|.web.\" --error  ",
     "type:check": "yarn tsc --noEmit && cd plugin && yarn type:check && cd ..",
-    "type:check-api": "yarn tsc --noEmit --target es6 --module ESNext --jsx react-native --skipLibCheck true --allowSyntheticDefaultImports true --moduleResolution node --esModuleInterop true --strict true --forceConsistentCasingInFileNames true --resolveJsonModule true app/src/App.tsx",
+    "type:check-api": "yarn tsc --noEmit --target es6 --module ESNext --jsx react-native --skipLibCheck true --allowSyntheticDefaultImports true --moduleResolution node --esModuleInterop true --strict true --forceConsistentCasingInFileNames true --resolveJsonModule true app/src/App.tsx __typetests__/react-native-reanimated-tests.tsx",
     "prepare": "yarn plugin && bob build && husky install && yarn app",
     "circular_dependency_check": "yarn madge --extensions js,ts,tsx --circular src lib",
     "setup": "yarn && cd Example && yarn && cd ios && pod install --verbose && cd ../..",

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -45,14 +45,18 @@ export type ExtractArrayType<Arr> = Arr extends readonly (infer Element)[]
   : never;
 
 /**
- * @deprecated Please use `TransformArrayElementsType` type instead.
+ * @deprecated Please use `TransformArrayType` type instead.
  */
 export type TransformStyleTypes = ExtractArrayType<TransformStyle>;
 
 export type TransformArrayType = TransformStyleTypes;
 
+// Note: why is `readonly` here? For safety.
+// In TS ReadonlyArray is a supertype of Array,
+// therefore Array can be assigned to ReadonlyArray but
+// ReadonlyArray cannot be assigned to Array.
 export type AnimatedTransform =
-  | (TransformArrayType | SharedValue<TransformArrayType>)[]
+  | readonly (TransformArrayType | SharedValue<TransformArrayType>)[]
   | TransformStyle;
 
 /**

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -12,19 +12,18 @@ import type {
   StyleProp,
   TransformsStyle as RNTransformsStyle,
 } from 'react-native';
+import type { AnimatableValue, SharedValue } from './commonTypes';
+import type { BaseAnimationBuilder } from './layoutReanimation/animationBuilder/BaseAnimationBuilder';
 import type {
-  AnimatableValue,
-  BaseAnimationBuilder,
   EntryExitAnimationFunction,
   LayoutAnimationFunction,
-  SharedValue,
-} from '.';
+} from './layoutReanimation/animationBuilder/commonTypes';
 import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 import type { SharedTransition } from './layoutReanimation/sharedTransitions';
 import type { DependencyList } from './hook/commonTypes';
 
 /**
- * @deprecated
+ * @deprecated This type is no longer relevant.
  */
 export type Adaptable<T> =
   | T
@@ -32,32 +31,32 @@ export type Adaptable<T> =
   | SharedValue<T>;
 
 /**
- * @deprecated
+ * @deprecated This type is no longer relevant.
  */
 export type AdaptTransforms<T> = {
   [P in keyof T]: Adaptable<T[P]>;
 };
 
-type TransformStyle = RNTransformsStyle['transform'];
+type RNTransformType = RNTransformsStyle['transform'];
 
-export type ExtractArrayType<Arr> = Arr extends readonly (infer Element)[]
-  ? Element
+export type ExtractArrayItemType<Arr> = Arr extends readonly (infer Item)[]
+  ? Item
   : never;
 
 /**
- * @deprecated Please use `TransformArrayType` type instead.
+ * @deprecated Please use `TransformArrayItemType` type instead.
  */
-export type TransformStyleTypes = ExtractArrayType<TransformStyle>;
+export type TransformStyleTypes = ExtractArrayItemType<RNTransformType>;
 
-export type TransformArrayType = TransformStyleTypes;
+export type TransformArrayItemType = TransformStyleTypes;
 
 // Note: why is `readonly` here? For safety.
-// In TS ReadonlyArray is a supertype of Array,
-// therefore Array can be assigned to ReadonlyArray but
-// ReadonlyArray cannot be assigned to Array.
+// In TS `ReadonlyArray` is a supertype of `Array`,
+// therefore `Array` can be assigned to `ReadonlyArray` but
+// `ReadonlyArray` cannot be assigned to `Array`.
 export type AnimatedTransform =
-  | readonly (TransformArrayType | SharedValue<TransformArrayType>)[]
-  | TransformStyle;
+  | readonly (TransformArrayItemType | SharedValue<TransformArrayItemType>)[]
+  | RNTransformType;
 
 /**
  * @deprecated Please use `AnimatedStyle` type instead.

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -40,7 +40,10 @@ export type TransformStyleTypes = TransformsStyle['transform'] extends
   | undefined
   ? T
   : never;
-export type AnimatedTransform = AdaptTransforms<TransformStyleTypes>[];
+
+export type AnimatedTransform =
+  | AdaptTransforms<TransformStyleTypes>[]
+  | TransformsStyle['transform'];
 
 /**
  * @deprecated Please use `AnimatedStyle` type instead.

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -23,27 +23,37 @@ import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Ke
 import type { SharedTransition } from './layoutReanimation/sharedTransitions';
 import type { DependencyList } from './hook/commonTypes';
 
+/**
+ * @deprecated
+ */
 export type Adaptable<T> =
   | T
   | ReadonlyArray<T | ReadonlyArray<T>>
   | SharedValue<T>;
 
+/**
+ * @deprecated
+ */
 export type AdaptTransforms<T> = {
   [P in keyof T]: Adaptable<T[P]>;
 };
 
-type TransformsStyle = Pick<RNTransformsStyle, 'transform'>;
+type TransformStyle = RNTransformsStyle['transform'];
 
-export type TransformStyleTypes = TransformsStyle['transform'] extends
-  | readonly (infer T)[]
-  | string
-  | undefined
-  ? T
+export type ExtractArrayType<Arr> = Arr extends readonly (infer Element)[]
+  ? Element
   : never;
 
+/**
+ * @deprecated Please use `TransformArrayElementsType` type instead.
+ */
+export type TransformStyleTypes = ExtractArrayType<TransformStyle>;
+
+export type TransformArrayType = TransformStyleTypes;
+
 export type AnimatedTransform =
-  | AdaptTransforms<TransformStyleTypes>[]
-  | TransformsStyle['transform'];
+  | (TransformArrayType | SharedValue<TransformArrayType>)[]
+  | TransformStyle;
 
 /**
  * @deprecated Please use `AnimatedStyle` type instead.

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -39,23 +39,23 @@ export type AdaptTransforms<T> = {
 
 type RNTransformType = RNTransformsStyle['transform'];
 
-export type ExtractArrayItemType<Arr> = Arr extends readonly (infer Item)[]
+export type ExtractArrayItem<Arr> = Arr extends readonly (infer Item)[]
   ? Item
   : never;
 
 /**
- * @deprecated Please use `TransformArrayItemType` type instead.
+ * @deprecated Please use `TransformArrayItem` type instead.
  */
-export type TransformStyleTypes = ExtractArrayItemType<RNTransformType>;
+export type TransformStyleTypes = ExtractArrayItem<RNTransformType>;
 
-export type TransformArrayItemType = TransformStyleTypes;
+export type TransformArrayItem = TransformStyleTypes;
 
 // Note: why is `readonly` here? For safety.
 // In TS `ReadonlyArray` is a supertype of `Array`,
 // therefore `Array` can be assigned to `ReadonlyArray` but
 // `ReadonlyArray` cannot be assigned to `Array`.
 export type AnimatedTransform =
-  | readonly (TransformArrayItemType | SharedValue<TransformArrayItemType>)[]
+  | readonly (TransformArrayItem | SharedValue<TransformArrayItem>)[]
   | RNTransformType;
 
 /**

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -23,7 +23,7 @@ export type {
   AnimatedProps,
   AnimatedTransform,
   TransformStyleTypes,
-  TransformArrayType,
+  TransformArrayItemType,
   AnimateStyle,
   AnimatedStyle,
   StylesOrDefault,

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -23,6 +23,7 @@ export type {
   AnimatedProps,
   AnimatedTransform,
   TransformStyleTypes,
+  TransformArrayType,
   AnimateStyle,
   AnimatedStyle,
   StylesOrDefault,

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -23,7 +23,7 @@ export type {
   AnimatedProps,
   AnimatedTransform,
   TransformStyleTypes,
-  TransformArrayItemType,
+  TransformArrayItem,
   AnimateStyle,
   AnimatedStyle,
   StylesOrDefault,

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -8,6 +8,7 @@ import type {
   KeyframeProps,
 } from './commonTypes';
 import type { TransformProperty, StyleProps } from '../../commonTypes';
+import { ExtractArrayType } from '../../helperTypes';
 interface KeyframePoint {
   duration: number;
   value: number | string;
@@ -197,8 +198,10 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     return () => {
       'worklet';
       const animations: StyleProps & {
-        transform?: Exclude<StyleProps, string>;
-      } = {};
+        transform?: ExtractArrayType<StyleProps['transform']>[];
+      } = {
+        transform: [],
+      };
 
       /* 
             For each style property, an animations sequence is created that corresponds with its key points.
@@ -230,10 +233,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
               )
         );
         if (key.includes('transform')) {
-          if (!('transform' in animations)) {
-            animations.transform = [];
-          }
-          animations.transform?.push(<TransformProperty>{
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          animations.transform!.push(<TransformProperty>{
             [key.split(':')[1]]: animation,
           });
         } else {
@@ -255,6 +256,11 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
           addAnimation(key);
         }
       });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (animations.transform!.length === 0) {
+        //
+        delete animations.transform;
+      }
       return {
         animations: animations,
         initialValues: initialValues,

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -72,8 +72,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       Initialize parsedKeyframes for properties provided in initial keyframe
     */
     Object.keys(initialValues).forEach((styleProp: string) => {
-      if (styleProp === 'transform') {
-        initialValues[styleProp]?.forEach((transformStyle, index) => {
+      if (styleProp === 'transform' && Array.isArray(initialValues.transform)) {
+        initialValues.transform.forEach((transformStyle, index) => {
           Object.keys(transformStyle).forEach((transformProp: string) => {
             parsedKeyframes[index.toString() + '_transform:' + transformProp] =
               [];
@@ -144,8 +144,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
             easing,
           });
         Object.keys(keyframe).forEach((key: string) => {
-          if (key === 'transform') {
-            keyframe[key]?.forEach(
+          if (key === 'transform' && Array.isArray(keyframe.transform)) {
+            keyframe.transform.forEach(
               (transformStyle: { [key: string]: any }, index) => {
                 Object.keys(transformStyle).forEach((transformProp: string) => {
                   addKeyPointWith(
@@ -196,7 +196,9 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
 
     return () => {
       'worklet';
-      const animations: StyleProps = {};
+      const animations: StyleProps & {
+        transform?: Exclude<StyleProps, string>;
+      } = {};
 
       /* 
             For each style property, an animations sequence is created that corresponds with its key points.

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -74,7 +74,9 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     */
     Object.keys(initialValues).forEach((styleProp: string) => {
       if (styleProp === 'transform') {
-        if (!Array.isArray(initialValues.transform)) return;
+        if (!Array.isArray(initialValues.transform)) {
+          return;
+        }
         initialValues.transform.forEach((transformStyle, index) => {
           Object.keys(transformStyle).forEach((transformProp: string) => {
             parsedKeyframes[index.toString() + '_transform:' + transformProp] =
@@ -147,7 +149,9 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
           });
         Object.keys(keyframe).forEach((key: string) => {
           if (key === 'transform') {
-            if (!Array.isArray(keyframe.transform)) return;
+            if (!Array.isArray(keyframe.transform)) {
+              return;
+            }
             keyframe.transform.forEach(
               (transformStyle: { [key: string]: any }, index) => {
                 Object.keys(transformStyle).forEach((transformProp: string) => {
@@ -208,7 +212,9 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       const addAnimation = (key: string) => {
         const keyframePoints = keyframes[key];
         // in case if property was only passed as initial value
-        if (keyframePoints.length === 0) return;
+        if (keyframePoints.length === 0) {
+          return;
+        }
         const animation = delayFunction(
           delay,
           keyframePoints.length === 1

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -1,3 +1,4 @@
+import type { ExtractArrayItemType } from '../../helperTypes';
 import type { EasingFunction } from '../../Easing';
 import type { StyleProps } from '../../commonTypes';
 
@@ -152,3 +153,7 @@ export enum SharedTransitionType {
 export type EntryExitAnimationsValues =
   | EntryAnimationsValues
   | ExitAnimationsValues;
+
+export type StylePropsWithArrayTransform = StyleProps & {
+  transform?: ExtractArrayItemType<StyleProps['transform']>[];
+};

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -1,4 +1,4 @@
-import type { ExtractArrayItemType } from '../../helperTypes';
+import type { ExtractArrayItem } from '../../helperTypes';
 import type { EasingFunction } from '../../Easing';
 import type { StyleProps } from '../../commonTypes';
 
@@ -155,5 +155,5 @@ export type EntryExitAnimationsValues =
   | ExitAnimationsValues;
 
 export type StylePropsWithArrayTransform = StyleProps & {
-  transform?: ExtractArrayItemType<StyleProps['transform']>[];
+  transform?: ExtractArrayItem<StyleProps['transform']>[];
 };

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -68,13 +68,18 @@ export class EntryExitTransition
       'worklet';
       const enteringValues = enteringAnimation(values);
       const exitingValues = exitingAnimation(values);
-      const animations: StyleProps = {
+      const animations: StyleProps & {
+        transform?: Exclude<StyleProps, string>;
+      } = {
         transform: [],
       };
 
       for (const prop of Object.keys(exitingValues.animations)) {
-        if (prop === 'transform') {
-          exitingValues.animations[prop]?.forEach((value, index) => {
+        if (
+          prop === 'transform' &&
+          Array.isArray(exitingValues.animations.transform)
+        ) {
+          exitingValues.animations.transform?.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
               animations.transform?.push({
                 [transformProp]: delayFunction(
@@ -118,8 +123,11 @@ export class EntryExitTransition
         }
       }
       for (const prop of Object.keys(enteringValues.animations)) {
-        if (prop === 'transform') {
-          enteringValues.animations[prop]?.forEach((value, index) => {
+        if (
+          prop === 'transform' &&
+          Array.isArray(enteringValues.animations.transform)
+        ) {
+          enteringValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
               animations.transform?.push({
                 [transformProp]: delayFunction(
@@ -154,9 +162,14 @@ export class EntryExitTransition
       }
 
       const mergedTransform = (
-        exitingValues.initialValues.transform ?? []
+        Array.isArray(exitingValues.initialValues.transform)
+          ? exitingValues.initialValues.transform
+          : []
       ).concat(
-        (enteringValues.animations.transform ?? []).map((value) => {
+        (Array.isArray(enteringValues.animations.transform)
+          ? enteringValues.animations.transform
+          : []
+        ).map((value) => {
           const objectKeys = Object.keys(value);
           if (objectKeys?.length < 1) {
             console.error(

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -11,6 +11,7 @@ import type {
   TransformProperty,
   AnimationObject,
 } from '../../commonTypes';
+import { ExtractArrayType } from '../../helperTypes';
 
 export class EntryExitTransition
   extends BaseAnimationBuilder
@@ -69,7 +70,7 @@ export class EntryExitTransition
       const enteringValues = enteringAnimation(values);
       const exitingValues = exitingAnimation(values);
       const animations: StyleProps & {
-        transform?: Exclude<StyleProps, string>;
+        transform: ExtractArrayType<StyleProps['transform']>[];
       } = {
         transform: [],
       };
@@ -81,7 +82,7 @@ export class EntryExitTransition
         ) {
           exitingValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              animations.transform?.push({
+              animations.transform.push({
                 [transformProp]: delayFunction(
                   delay,
                   withSequence(
@@ -129,7 +130,7 @@ export class EntryExitTransition
         ) {
           enteringValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              animations.transform?.push({
+              animations.transform.push({
                 [transformProp]: delayFunction(
                   delay + exitingDuration,
                   withSequence(

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -79,7 +79,7 @@ export class EntryExitTransition
           prop === 'transform' &&
           Array.isArray(exitingValues.animations.transform)
         ) {
-          exitingValues.animations.transform?.forEach((value, index) => {
+          exitingValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
               animations.transform?.push({
                 [transformProp]: delayFunction(

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -70,10 +70,10 @@ export class EntryExitTransition
       };
 
       for (const prop of Object.keys(exitingValues.animations)) {
-        if (
-          prop === 'transform' &&
-          Array.isArray(exitingValues.animations.transform)
-        ) {
+        if (prop === 'transform') {
+          if (!Array.isArray(exitingValues.animations.transform)) {
+            continue;
+          }
           exitingValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -119,10 +119,10 @@ export class EntryExitTransition
         }
       }
       for (const prop of Object.keys(enteringValues.animations)) {
-        if (
-          prop === 'transform' &&
-          Array.isArray(enteringValues.animations.transform)
-        ) {
+        if (prop === 'transform') {
+          if (!Array.isArray(enteringValues.animations.transform)) {
+            continue;
+          }
           enteringValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -2,16 +2,12 @@ import type {
   ILayoutAnimationBuilder,
   LayoutAnimationsValues,
   LayoutAnimationFunction,
+  StylePropsWithArrayTransform,
 } from '../animationBuilder/commonTypes';
 import { BaseAnimationBuilder } from '../animationBuilder';
 import { withSequence, withTiming } from '../../animation';
 import { FadeIn, FadeOut } from '../defaultAnimations/Fade';
-import type {
-  StyleProps,
-  TransformProperty,
-  AnimationObject,
-} from '../../commonTypes';
-import { ExtractArrayType } from '../../helperTypes';
+import type { TransformProperty, AnimationObject } from '../../commonTypes';
 
 export class EntryExitTransition
   extends BaseAnimationBuilder
@@ -69,9 +65,7 @@ export class EntryExitTransition
       'worklet';
       const enteringValues = enteringAnimation(values);
       const exitingValues = exitingAnimation(values);
-      const animations: StyleProps & {
-        transform: ExtractArrayType<StyleProps['transform']>[];
-      } = {
+      const animations: StylePropsWithArrayTransform = {
         transform: [],
       };
 
@@ -82,7 +76,8 @@ export class EntryExitTransition
         ) {
           exitingValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              animations.transform.push({
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              animations.transform!.push({
                 [transformProp]: delayFunction(
                   delay,
                   withSequence(
@@ -130,7 +125,8 @@ export class EntryExitTransition
         ) {
           enteringValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              animations.transform.push({
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              animations.transform!.push({
                 [transformProp]: delayFunction(
                   delay + exitingDuration,
                   withSequence(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This is a continuation of #4881 - our utility type `AnimatedTransform` allowed `string` as transforms but only as an array of strings. This PR only fixes non-functional assignment of a potential string to `transform` in style.

## Test plan

Before, the following code yielded errors:

```TSX
import React from 'react';
import type { ViewStyle } from 'react-native';
import Animated from 'react-native-reanimated';

declare const style: ViewStyle;

function App() {
  return <Animated.View style={style} /> // `style.transform` could be a string, but it's not accepted
}
```


