### PR TITLE
Sync tabs in docs/getting-started

### DIFF
--- a/docs/docs/fundamentals/getting-started.mdx
+++ b/docs/docs/fundamentals/getting-started.mdx
@@ -19,7 +19,7 @@ With Reanimated, you can easily create smooth animations and interactions that r
 
 If you don't have an existing project, you can create a new Expo app using a template:
 
-<Tabs>
+<Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
 
     npx create-expo-app my-app -e with-reanimated
@@ -42,7 +42,7 @@ It takes three steps to add Reanimated to a project:
 
 Install `react-native-reanimated` package from npm:
 
-<Tabs>
+<Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
 
     npx expo install react-native-reanimated
@@ -93,7 +93,7 @@ To learn more about the plugin head onto to [Reanimated babel plugin](/docs/fund
 
 ### Step 3: Clear cache (recommended)
 
-<Tabs>
+<Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
 
     npx expo start -c
@@ -131,7 +131,7 @@ For building apps that target web using [react-native-web](https://www.npmjs.com
 
 To use Reanimated on the web all you need to do is to install and add [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from) Babel plugin to your `babel.config.js`.
 
-<Tabs>
+<Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
 
     npx expo install @babel/plugin-proposal-export-namespace-from


### PR DESCRIPTION
### Before
You need to click each tab one by one if you use a certain package manager.


https://github.com/software-mansion/react-native-reanimated/assets/39658211/74a75188-4480-4983-9e96-7e18a79001b7



### After
Your choice in tabs syncs after a selection 



https://github.com/software-mansion/react-native-reanimated/assets/39658211/a98c8301-79aa-4a37-82a6-c1cd7bf51dc2



Requested in https://twitter.com/samrithshankar/status/1689513343504257029?s=20
