### PR TITLE
Run CI only if it's needed

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,6 +15,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/android-build.yml
+      - android/**
+      - Common/**
+      - Example/package.json
+      - Example/android/**
+      - FabricExample/package.json
+      - FabricExample/android/**
 
 jobs:
   build:

--- a/.github/workflows/build-on-windows-nightly.yml
+++ b/.github/workflows/build-on-windows-nightly.yml
@@ -1,17 +1,11 @@
-name: Test build on Windows
+name: Test build on Windows nightly
 on:
   pull_request:
     paths:
-      - '.github/workflows/build-on-windows.yml'
-      - 'android/**'
-      - 'Common/**'
-      - package.json
-  merge_group:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+      - .github/workflows/build-on-windows-nightly.yml
+  schedule:
+    - cron: '37 19 * * *'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-v8-nightly.yml
+++ b/.github/workflows/build-v8-nightly.yml
@@ -1,21 +1,11 @@
-name: Test V8 on Android
+name: Test V8 on Android nightly
 on:
   pull_request:
     paths:
-      - '.github/workflows/build-v8.yml'
-      - 'android/**'
-      - 'Common/**'
-      - 'FabricExample/package.json'
-      - 'Example/package.json'
-  merge_group:
-    branches:
-      - main
-  push:
-    branches:
-      - main
-
-env:
-  REACT_NATIVE_VERSION: "0.71.6"
+      - .github/workflows/build-v8-nightly.yml
+  schedule:
+    - cron: '37 19 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -29,7 +19,7 @@ jobs:
         with:
           path: 'reanimated_repo'
       - name: Create React Native app
-        run: npx react-native init app --version ${{ env.REACT_NATIVE_VERSION }}
+        run: npx react-native init app
       - name: Install dependencies
         working-directory: app
         run: yarn add github:software-mansion/react-native-reanimated#${{ github.ref }} react-native-v8 v8-android-jit

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -17,6 +17,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/ios-build.yml
+      - RNReanimated.podspec
+      - scripts/reanimated_utils.rb
+      - ios/**
+      - Common/**
+      - Example/package.json
+      - Example/ios/**
+      - FabricExample/package.json
+      - FabricExample/ios/**
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      docs/**
 
 jobs:
   publish:

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -1,14 +1,6 @@
 name: Test TypeScript and Lint
 on:
   pull_request:
-    paths:
-      - '.github/workflows/static-example-apps-checks.yml'
-      - 'app/**'
-      - 'Example/**'
-      - 'FabricExample/**'
-      - 'WebExample/**'
-      - 'TVOSExample/**'
-      - '*'
   merge_group:
     branches:
       - main

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -1,10 +1,6 @@
 name: Test TypeScript and Lint
 on:
   pull_request:
-    paths:
-      - '.github/workflows/static-root-checks.yml'
-      - 'src/**'
-      - '*'
   merge_group:
     branches:
       - main

--- a/.github/workflows/tvos-build.yml
+++ b/.github/workflows/tvos-build.yml
@@ -14,6 +14,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/tvos-build.yml'
+      - 'RNReanimated.podspec'
+      - 'ios/**'
+      - 'Common/**'
+      - 'TVOSExample/package.json'
+      - 'TVOSExample/ios/**'
 
 jobs:
   build:

--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/validate-java.yml'
+      - 'android/src/main/java/**'
+      - 'android/build.gradle'
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/validate-plugin.yml'
+      - 'plugin/**'
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ comes to gesture based interactions.
 [![Check static framework nightly build](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-static-framework-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-static-framework-nightly.yml)
 [![Check React Native nightly build](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-react-native-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-react-native-nightly.yml)
 [![Check Expo dev-client nightly build](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-expo-dev-client-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/check-expo-dev-client-nightly.yml)
+[![Test V8 on Android nightly](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-v8-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-v8-nightly.yml)
+[![Test build on Windows nightly](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-on-windows-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-on-windows-nightly.yml)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

This PR aims to reduce unnecessary triggering of CI by implementing a limitation. Additionally, it moves the 'Build V8' and 'Build on Windows' processes to nightly actions.

## Test plan

Merge this PR 🎉
