### PR TITLE
Remove debug flag when `PRODUCTION` flag is not set

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -18,7 +18,7 @@ boost_compiler_flags = '-Wno-documentation'
 fabric_flags = fabric_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
 example_flag = config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 version_flag = '-DREANIMATED_VERSION=' + reanimated_package_json["version"]
-debug_flag = is_release ? '-DNDEBUG' : '-DDEBUG'
+debug_flag = is_release ? '-DNDEBUG' : ''
 
 Pod::Spec.new do |s|
   


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

[React Native sets only `NDEBUG` flag](https://github.com/facebook/react-native/blob/41af21b42dd51868ade23402774a61c8acca8d7c/packages/react-native/scripts/cocoapods/new_architecture.rb#L46) when building in release mode, without adding `DEBUG` flag. When building the app in release mode without installing pods with `PRODUCTION=1`, Reanimated will use [different implementations of containers](https://github.com/facebook/react-native/blob/41af21b42dd51868ade23402774a61c8acca8d7c/packages/react-native/ReactCommon/butter/butter.h#L64-L73) than the RN, resulting in crashes that don't really make sense.

This PR removes the `DEBUG` flag from Reanimated, so it will use the same implementation as React Native.

## Test plan

Build the `FabricExample` app in Release mode.
