### PR TITLE
fix: docs withSpring playground missing comma

### DIFF
--- a/docs/src/components/InteractivePlayground/useSpringPlayground/index.tsx
+++ b/docs/src/components/InteractivePlayground/useSpringPlayground/index.tsx
@@ -53,9 +53,9 @@ export default function useSpringPlayground() {
       ${
         isPhysicsBased
           ? `mass: ${mass},
-      damping: ${damping}`
+      damping: ${damping},`
           : `duration: ${duration},
-      dampingRatio: ${dampingRatio}`
+      dampingRatio: ${dampingRatio},`
       }
       stiffness: ${stiffness},
       overshootClamping: ${overshootClamping},


### PR DESCRIPTION
withSpring docs config section (https://docs.swmansion.com/react-native-reanimated/docs/animations/withSpring#config-) missing comma in the playground after `dampingRatio` and `damping `

![image](https://github.com/software-mansion/react-native-reanimated/assets/28902144/9936eefa-813e-4463-85b4-a7c9b9b1cc8a)
![image](https://github.com/software-mansion/react-native-reanimated/assets/28902144/af58945f-7884-4512-b6f0-83de1451497c)

