### PR TITLE
Fix event dispatcher broken on ios with expo-dev-client

### DIFF
--- a/ios/RCTEventDispatcher+Reanimated.m
+++ b/ios/RCTEventDispatcher+Reanimated.m
@@ -11,9 +11,14 @@
 - (void)reanimated_sendEvent:(id<RCTEvent>)event
 {
   // Pass the event to Reanimated
+  static __weak RCTBridge *bridge;
   static __weak REAModule *reaModule;
+  if (bridge != self.bridge) {
+    bridge = self.bridge;
+    reaModule = nil;
+  }
   if (reaModule == nil) {
-    reaModule = [[self bridge] moduleForName:@"ReanimatedModule"];
+    reaModule = [bridge moduleForName:@"ReanimatedModule"];
   }
   [reaModule eventDispatcherWillDispatchEvent:event];
 


### PR DESCRIPTION
## Summary

@hirbod reported an issue with reanimated 3.4 + expo-dev-client on ios that `useEvent` is broken. this happens because of the setup of expo-dev-client and would like to propose and discuss solution in this pr.

### expo-dev-client setup

expo-dev-client will create multiple bridges:
  - app bridge: the target app
  - expo-dev-menu: the customized dev menu is also a react native app.
  - expo-dev-launcher: the default start ui that for user to choose a target app is also a react native app.

### the error startup flow

when clicking the app in ios springboard, i.e. not starting the app through deep linking, the default startup ui will launch expo-dev-launcher first. the initialize flow will be
  1. `RCTEventDispatcher+Reanimated +load`
  2. create a bridge for expo-dev-launcher
  3. even expo-dev-launcher doesn't use reanimated now, as long as other code in expo-dev-launcher sends an event. it will call the swizzled `RCTEventDispatcher.sendEvent:` and cache the `REAModule` to the one belong to expo-dev-launcher: https://github.com/software-mansion/react-native-reanimated/blob/f55e831b1e45566f3f28707344e983ade62021e6/ios/RCTEventDispatcher%2BReanimated.m#L11-L19
  4. on expo-dev-launcher ui, user selects an app to start. the app bridge is then created (and not deallocating the expo-dev-launcher's bridge). now we have two bridges and two `REAModule`s.
  5. when the app receives events through `useEvent`, it will send events to expo-dev-launcher's `REAModule`, which is wrong target.
 
### proposing solution

in the swizzled `RCTEventDispatcher.sendEvent:`, if the bridge instance is changed, we should update the cached `REAModule`.

## Test plan

based on the repro where @hirbod and @keith-kurak provided: https://github.com/keith-kurak/test-reanimated-dev-client-issue

To reproduce:

> 1. Build a development build on iOS simulator (eas build --profile development --platform simulator)
>
NOTE(kudo): could also use `npx expo run:ios`, but after launching the app, please stop the app and launch from ios springboard instead.

> 2. Run the repro project locally ( npx expo start ). This repro is a blank SDK 49 project + an example from the reanimated docs
> 
> 3. Try to move the red shade/ drawer. The ball should also move, but doesn't (the ball moves on reanimated 3.3.x and as a standalone build.)
