### PR TITLE
Remove return type from function components

### DIFF
--- a/app/src/examples/AnimatedKeyboardExample.tsx
+++ b/app/src/examples/AnimatedKeyboardExample.tsx
@@ -16,12 +16,12 @@ import React from 'react';
 
 const BOX_SIZE = 50;
 
-function NestedView(): React.ReactElement {
+function NestedView() {
   useAnimatedKeyboard();
   return <View style={styles.nestedView} />;
 }
 
-export default function AnimatedKeyboardExample(): React.ReactElement {
+export default function AnimatedKeyboardExample() {
   const keyboard = useAnimatedKeyboard();
   const OPENING = KeyboardState.OPENING;
   const style = useAnimatedStyle(() => {

--- a/app/src/examples/AnimatedStyleUpdateExample.tsx
+++ b/app/src/examples/AnimatedStyleUpdateExample.tsx
@@ -7,7 +7,7 @@ import Animated, {
 import { View, Button, StyleSheet } from 'react-native';
 import React from 'react';
 
-export default function AnimatedStyleUpdateExample(): React.ReactElement {
+export default function AnimatedStyleUpdateExample() {
   const randomWidth = useSharedValue(10);
 
   const config = {

--- a/app/src/examples/AnimatedTabBarExample.tsx
+++ b/app/src/examples/AnimatedTabBarExample.tsx
@@ -238,7 +238,7 @@ const tabBarStyles = StyleSheet.create({
   },
 });
 
-export default function AnimatedTabBarExample(): React.ReactElement {
+export default function AnimatedTabBarExample() {
   return (
     <View style={tabBarStyles.container}>
       <View style={tabBarStyles.dummyPusher} />

--- a/app/src/examples/ChatHeadsExample.tsx
+++ b/app/src/examples/ChatHeadsExample.tsx
@@ -157,7 +157,7 @@ function Followers({
   );
 }
 
-export default function ChatHeadsExample(): React.ReactElement {
+export default function ChatHeadsExample() {
   return (
     <View style={styles.container}>
       <ChatHeads>

--- a/app/src/examples/CustomHandler/AnimatedText.tsx
+++ b/app/src/examples/CustomHandler/AnimatedText.tsx
@@ -18,7 +18,7 @@ export function AnimatedText({
 }: {
   style?: StyleProp<Animated.AnimateStyle<StyleProp<TextStyle>>>;
   text: Animated.SharedValue<string>;
-}): React.ReactElement {
+}) {
   const animatedProps = useAnimatedProps(() => {
     return { text: text.value } as unknown as TextInputProps;
   });

--- a/app/src/examples/CustomHandler/PagerExample.tsx
+++ b/app/src/examples/CustomHandler/PagerExample.tsx
@@ -25,7 +25,7 @@ const SLIDES = [
   { color: 'pink', key: 5 },
 ];
 
-export default function PagerExample(): React.ReactElement {
+export default function PagerExample() {
   const scrollPosition = useSharedValue(0);
   const scrollState = useSharedValue<PageScrollState>('idle');
   const currentPage = useSharedValue(0);

--- a/app/src/examples/CustomHandler/Pagination.tsx
+++ b/app/src/examples/CustomHandler/Pagination.tsx
@@ -12,7 +12,7 @@ function PaginationElement({
 }: {
   position: Animated.SharedValue<number>;
   slideIndex: number;
-}): React.ReactElement {
+}) {
   const inputRange = [slideIndex - 1, slideIndex, slideIndex + 1];
   const dotAnimatedStyle = useAnimatedStyle(() => {
     const width = interpolate(
@@ -49,7 +49,7 @@ export function Pagination({
 }: {
   numberOfSlides: number;
   position: Animated.SharedValue<number>;
-}): React.ReactElement {
+}) {
   return (
     <View style={styles.pagination}>
       {Array(numberOfSlides)

--- a/app/src/examples/DragAndSnapExample.tsx
+++ b/app/src/examples/DragAndSnapExample.tsx
@@ -13,7 +13,7 @@ import {
   PanGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';
 
-export default function DragAndSnapExample(): React.ReactElement {
+export default function DragAndSnapExample() {
   const translation = {
     x: useSharedValue(0),
     y: useSharedValue(0),

--- a/app/src/examples/ExtrapolationExample.tsx
+++ b/app/src/examples/ExtrapolationExample.tsx
@@ -14,7 +14,7 @@ import {
   PanGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';
 
-export default function ExtrapolationExample(): React.ReactElement {
+export default function ExtrapolationExample() {
   const translation = {
     x: useSharedValue(50),
     y: useSharedValue(0),

--- a/app/src/examples/IPodExample.tsx
+++ b/app/src/examples/IPodExample.tsx
@@ -40,7 +40,7 @@ const BIG_BALL_SIZE = 200;
 const SMALL_BALL_SIZE = 50;
 const INNER_BALL_SIZE = BIG_BALL_SIZE - SMALL_BALL_SIZE * 2;
 
-export default function IPodExample(): React.ReactElement {
+export default function IPodExample() {
   const position = useSharedValue(0);
   const animatedRef = useAnimatedRef<Animated.ScrollView>();
 

--- a/app/src/examples/LayoutAnimations/AnimatedList.tsx
+++ b/app/src/examples/LayoutAnimations/AnimatedList.tsx
@@ -62,7 +62,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <Animated.View
       entering={LightSpeedInLeft}
@@ -75,7 +75,7 @@ function Participant({
   );
 }
 
-export default function AnimatedListExample(): React.ReactElement {
+export default function AnimatedListExample() {
   const [inputValue, setInputValue] = useState('');
   const [participantList, setParticipantList] = useState<EventParticipant[]>(
     []

--- a/app/src/examples/LayoutAnimations/Carousel.tsx
+++ b/app/src/examples/LayoutAnimations/Carousel.tsx
@@ -59,7 +59,7 @@ function AnimatedView({ pokemon }: { pokemon: Pokemon }) {
   );
 }
 
-export default function Carousel(): React.ReactElement {
+export default function Carousel() {
   const [currentIndex, incrementIndex] = useState(0);
   return (
     <View style={styles.columnReverse}>

--- a/app/src/examples/LayoutAnimations/CustomLayout.tsx
+++ b/app/src/examples/LayoutAnimations/CustomLayout.tsx
@@ -53,7 +53,7 @@ function Box({ label, state }: { label: string; state: boolean }) {
   );
 }
 
-export default function CustomLayoutAnimationScreen(): React.ReactElement {
+export default function CustomLayoutAnimationScreen() {
   const [state, setState] = useState(true);
   return (
     <View style={styles.marginTop}>

--- a/app/src/examples/LayoutAnimations/DefaultAnimations.tsx
+++ b/app/src/examples/LayoutAnimations/DefaultAnimations.tsx
@@ -125,7 +125,7 @@ const AnimatedBlock = ({
   );
 };
 
-export default function DefaultAnimations(): React.ReactElement {
+export default function DefaultAnimations() {
   return (
     <ScrollView style={styles.container}>
       <Text style={styles.groupText}>Fade in</Text>

--- a/app/src/examples/LayoutAnimations/KeyframeAnimation.tsx
+++ b/app/src/examples/LayoutAnimations/KeyframeAnimation.tsx
@@ -2,7 +2,7 @@ import Animated, { Easing, Keyframe } from 'react-native-reanimated';
 import { Button, View, StyleSheet } from 'react-native';
 import React, { useState } from 'react';
 
-export default function KeyframeAnimation(): React.ReactElement {
+export default function KeyframeAnimation() {
   const [show, setShow] = useState(false);
   const enteringAnimation = new Keyframe({
     from: {

--- a/app/src/examples/LayoutAnimations/Modal.tsx
+++ b/app/src/examples/LayoutAnimations/Modal.tsx
@@ -76,7 +76,7 @@ function AnimatedView() {
   );
 }
 
-export default function Modal(): React.ReactElement {
+export default function Modal() {
   const [show, setShow] = useState(true);
   return (
     <View style={styles.container}>

--- a/app/src/examples/LayoutAnimations/ModalNewAPI.tsx
+++ b/app/src/examples/LayoutAnimations/ModalNewAPI.tsx
@@ -67,7 +67,7 @@ function AnimatedView() {
   );
 }
 
-export default function ModalNewAPI(): React.ReactElement {
+export default function ModalNewAPI() {
   const [show, setShow] = useState(false);
   return (
     <View style={styles.reverse}>

--- a/app/src/examples/LayoutAnimations/MountingUnmounting.tsx
+++ b/app/src/examples/LayoutAnimations/MountingUnmounting.tsx
@@ -40,7 +40,7 @@ function SWMLogo() {
   );
 }
 
-export default function MountingUnmounting(): React.ReactElement {
+export default function MountingUnmounting() {
   const [show, setShow] = useState(false);
   return (
     <View style={styles.columnReverse}>

--- a/app/src/examples/LayoutAnimations/OlympicAnimation.tsx
+++ b/app/src/examples/LayoutAnimations/OlympicAnimation.tsx
@@ -3,7 +3,7 @@ import { Button, View, StyleSheet } from 'react-native';
 import React, { useState } from 'react';
 import Svg, { Path } from 'react-native-svg';
 
-export default function OlympicAnimation(): React.ReactElement {
+export default function OlympicAnimation() {
   const [show, setShow] = useState(true);
 
   const blueRingAnimation = new Keyframe({

--- a/app/src/examples/LayoutAnimations/ReactionsCounterExample.tsx
+++ b/app/src/examples/LayoutAnimations/ReactionsCounterExample.tsx
@@ -126,7 +126,7 @@ type ButtonProps = {
   children: string;
 };
 
-function Button({ onPress, children }: ButtonProps): React.ReactElement {
+function Button({ onPress, children }: ButtonProps) {
   return (
     <TouchableOpacity onPress={onPress}>
       <View style={styles.button}>
@@ -136,7 +136,7 @@ function Button({ onPress, children }: ButtonProps): React.ReactElement {
   );
 }
 
-export default function ReactionsCounterExample(): React.ReactElement {
+export default function ReactionsCounterExample() {
   const [others, setOthers] = React.useState(3);
   const [you, setYou] = React.useState(false);
 

--- a/app/src/examples/LayoutAnimations/SpringLayoutAnimation.tsx
+++ b/app/src/examples/LayoutAnimations/SpringLayoutAnimation.tsx
@@ -21,7 +21,7 @@ function Box({ label, state }: { label: string; state: boolean }) {
   );
 }
 
-export default function SpringLayoutAnimation(): React.ReactElement {
+export default function SpringLayoutAnimation() {
   const [state, setState] = useState(true);
   return (
     <View style={styles.marginTop}>

--- a/app/src/examples/LightBoxExample.tsx
+++ b/app/src/examples/LightBoxExample.tsx
@@ -237,7 +237,7 @@ const images: ExampleImage[] = Array.from({ length: 30 }, (_, index) => {
   };
 });
 
-export default function LightBoxExample(): React.ReactElement {
+export default function LightBoxExample() {
   const [activeImage, setActiveImage] = useState<ActiveExampleImage | null>(
     null
   );

--- a/app/src/examples/LiquidSwipe/Button.tsx
+++ b/app/src/examples/LiquidSwipe/Button.tsx
@@ -14,10 +14,7 @@ type ButtonProps = {
   y: Animated.SharedValue<number>;
 };
 
-export default function Button({
-  progress,
-  y,
-}: ButtonProps): React.ReactElement {
+export default function Button({ progress, y }: ButtonProps) {
   const style = useAnimatedStyle(() => {
     return {
       opacity: interpolate(progress.value, [0, 0.1], [1, 0], Extrapolate.CLAMP),

--- a/app/src/examples/LiquidSwipe/LiquidSwipe.tsx
+++ b/app/src/examples/LiquidSwipe/LiquidSwipe.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function LiquidSwipe(): React.ReactElement {
+export default function LiquidSwipe() {
   const isBack = useSharedValue(0);
   const centerY = useSharedValue(initialWaveCenter);
   const progress = useSharedValue(0);

--- a/app/src/examples/OldMeasureExample.tsx
+++ b/app/src/examples/OldMeasureExample.tsx
@@ -53,7 +53,7 @@ function createSharedVariables() {
   };
 }
 
-export default function OldMeasureExample(): React.ReactElement {
+export default function OldMeasureExample() {
   const { heights, contentHeights } = createSharedVariables();
 
   return (

--- a/app/src/examples/PendulumExample.tsx
+++ b/app/src/examples/PendulumExample.tsx
@@ -46,7 +46,7 @@ function InputField({ fieldName, value, setValue }: FieldDefinition) {
   );
 }
 
-export default function SpringExample(): React.ReactElement {
+export default function SpringExample() {
   const pendulumSwing = useSharedValue(0);
   const offset = useSharedValue({ x: 0, y: 0 });
   const [useConfigWithDuration, setUseConfigWithDuration] = useState(true);

--- a/app/src/examples/PinExample.tsx
+++ b/app/src/examples/PinExample.tsx
@@ -21,7 +21,7 @@ const range = [0, 9999];
 
 const dotSize = 40;
 
-export default function PinExample(): React.ReactElement {
+export default function PinExample() {
   const progress = useSharedValue(0);
   const number = useDerivedValue(() => {
     const val = range[0] + Math.round(progress.value * (range[1] - range[0]));

--- a/app/src/examples/ScrollEventExample.tsx
+++ b/app/src/examples/ScrollEventExample.tsx
@@ -10,7 +10,7 @@ import { useHeaderHeight } from '@react-navigation/elements';
 
 const size = 40;
 
-export default function ScrollEventExample(): React.ReactElement {
+export default function ScrollEventExample() {
   const transY = useSharedValue(0);
   const isScrolling = useSharedValue(false);
   const headerHeight = useHeaderHeight();

--- a/app/src/examples/ScrollableViewExample.tsx
+++ b/app/src/examples/ScrollableViewExample.tsx
@@ -137,7 +137,7 @@ function Box({ color }: { color: string }) {
   return <View style={[{ backgroundColor: color }, styles.box]} />;
 }
 
-export default function ScrollableViewExample(): React.ReactElement {
+export default function ScrollableViewExample() {
   const headerHeight = useHeaderHeight();
 
   const height =

--- a/app/src/examples/SwipeableListExample.tsx
+++ b/app/src/examples/SwipeableListExample.tsx
@@ -55,7 +55,7 @@ const data: Data[] = [
   },
 ];
 
-export default function SwipeableListExample(): React.ReactElement {
+export default function SwipeableListExample() {
   function onRemove() {
     Alert.alert('Removed');
   }

--- a/docs/docs/layout-animations/custom-animations.mdx
+++ b/docs/docs/layout-animations/custom-animations.mdx
@@ -228,7 +228,7 @@ function Box({ label, state }: { label: string, state: boolean }) {
   );
 }
 
-export function CustomLayoutTransitionExample(): React.ReactElement {
+export function CustomLayoutTransitionExample() {
   const [state, setState] = useState(true);
   return (
     <View style={{ marginTop: 30 }}>

--- a/docs/docs/layout-animations/keyframe-animations.mdx
+++ b/docs/docs/layout-animations/keyframe-animations.mdx
@@ -139,7 +139,7 @@ Allows to execute code when keyframe animation ends.
 ## Example
 
 ```js
-export function KeyframeAnimation(): React.ReactElement {
+export function KeyframeAnimation() {
   const [show, setShow] = useState(false);
 
   const enteringAnimation = new Keyframe({

--- a/docs/versioned_docs/version-2.x/api/LayoutAnimations/CustomAnimations.md
+++ b/docs/versioned_docs/version-2.x/api/LayoutAnimations/CustomAnimations.md
@@ -224,7 +224,7 @@ function Box({ label, state }: { label: string, state: boolean }) {
   );
 }
 
-export function CustomLayoutTransitionExample(): React.ReactElement {
+export function CustomLayoutTransitionExample() {
   const [state, setState] = useState(true);
   return (
     <View style={{ marginTop: 30 }}>

--- a/docs/versioned_docs/version-2.x/api/LayoutAnimations/KeyframeAnimations.md
+++ b/docs/versioned_docs/version-2.x/api/LayoutAnimations/KeyframeAnimations.md
@@ -139,7 +139,7 @@ Allows to execute code when keyframe animation ends.
 ## Example
 
 ```js
-export function KeyframeAnimation(): React.ReactElement {
+export function KeyframeAnimation() {
   const [show, setShow] = useState(false);
 
   const enteringAnimation = new Keyframe({

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_fullCode.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_fullCode.md
@@ -6,7 +6,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <View
       style={[styles.participantView]}>
@@ -16,7 +16,7 @@ function Participant({
   );
 }
 
-export default function AnimatedListExample(): React.ReactElement {
+export default function AnimatedListExample() {
   const [inputValue, setInputValue] = useState('');
   const [participantList, setParticipantList] = useState<EventParticipant[]>(
     []

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_participantInternals.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_participantInternals.md
@@ -6,7 +6,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <View
       style={[styles.participantView]}>

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step1.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step1.md
@@ -7,7 +7,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <Animated.View
       style={[styles.participantView]}>

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step2.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step2.md
@@ -7,7 +7,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <Animated.View
       entering={LightSpeedInLeft}

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step3.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step3.md
@@ -10,7 +10,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <Animated.View
       entering={LightSpeedInLeft}

--- a/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step4.md
+++ b/docs/versioned_docs/version-2.x/tutorials/LayoutAnimations/_step4.md
@@ -11,7 +11,7 @@ function Participant({
 }: {
   name: string;
   onRemove: () => void;
-}): React.ReactElement {
+}) {
   return (
     <Animated.View
       entering={LightSpeedInLeft}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

There's no need to explicitly define return type for React function components.

## Test plan

See if CI is green.
