### PR TITLE
Detect V8 engine in AboutExample

### DIFF
--- a/app/src/examples/AboutExample.tsx
+++ b/app/src/examples/AboutExample.tsx
@@ -23,7 +23,18 @@ function getMode() {
 }
 
 function getRuntime() {
-  return 'HermesInternal' in global ? 'Hermes' : 'JSC'; // TODO: V8
+  if ('HermesInternal' in global) {
+    const version =
+      // @ts-ignore this is fine
+      global.HermesInternal?.getRuntimeProperties?.()['OSS Release Version'];
+    return `Hermes (${version})`;
+  }
+  if ('_v8runtime' in global) {
+    // @ts-ignore this is fine
+    const version = global._v8runtime().version;
+    return `V8 (${version})`;
+  }
+  return 'JSC';
 }
 
 function getArchitecture() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Previously, `getRuntime()` function in `AboutExample.tsx` would only check if Hermes is enabled, otherwise it would return "JSC". This PR extends the implementation by checking if the current JS engine is V8.

## Test plan

AboutExample.tsx
