### PR TITLE
Ignore events with null payload on Android

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -372,7 +372,7 @@ void NativeProxy::handleEvent(
     jni::alias_ref<react::WritableMap> event) {
   // handles RCTEvents from RNGestureHandler
   if (event.get() == nullptr) {
-    // Ignore events with empty payload.
+    // Ignore events with null payload.
     return;
   }
   // TODO: convert event directly to jsi::Value without JSON serialization

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -371,6 +371,10 @@ void NativeProxy::handleEvent(
     jint emitterReactTag,
     jni::alias_ref<react::WritableMap> event) {
   // handles RCTEvents from RNGestureHandler
+  if (event.get() == nullptr) {
+    // Ignore events with empty payload.
+    return;
+  }
   // TODO: convert event directly to jsi::Value without JSON serialization
   std::string eventAsString;
   try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR eliminates a crash on Android that occurs when Reanimated tries to handle an event with `null` payload.

## Test plan

`EventHandler.java`

```diff
   @Override
   public void receiveEvent(int emitterReactTag, String eventName, @Nullable WritableMap event) {
     String resolvedEventName = mCustomEventNamesResolver.resolveCustomEventName(eventName);
-    receiveEvent(resolvedEventName, emitterReactTag, event);
+    receiveEvent(resolvedEventName, emitterReactTag, null);
   }
