### PR TITLE
Better reanimated shadow tree commit detection

### DIFF
--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -25,16 +25,6 @@ class PropsRegistry {
 
   void remove(const Tag tag);
 
-  void setLastReanimatedRoot(
-      RootShadowNode::Shared const &lastReanimatedRoot) noexcept {
-    lastReanimatedRoot_.store(lastReanimatedRoot.get());
-  }
-
-  bool isLastReanimatedRoot(
-      RootShadowNode::Shared const &newRootShadowNode) const noexcept {
-    return newRootShadowNode.get() == lastReanimatedRoot_.load();
-  }
-
   void pleaseSkipCommit() {
     letMeIn_ = true;
   }
@@ -47,8 +37,6 @@ class PropsRegistry {
   std::unordered_map<Tag, std::pair<ShadowNode::Shared, folly::dynamic>> map_;
 
   mutable std::mutex mutex_; // Protects `map_`.
-
-  std::atomic<const RootShadowNode *> lastReanimatedRoot_;
 
   std::atomic<bool> letMeIn_;
 };

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -24,7 +24,8 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
     RootShadowNode::Unshared const &newRootShadowNode) const noexcept {
-  if (propsRegistry_->isLastReanimatedRoot(newRootShadowNode)) {
+#endif
+  if (ReanimatedCommitMarker::isReanimatedCommit()) {
     // ShadowTree commited by Reanimated, no need to apply updates from
     // PropsRegistry
     return newRootShadowNode;

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -3,6 +3,7 @@
 #include <react/renderer/core/ComponentDescriptor.h>
 
 #include "ReanimatedCommitHook.h"
+#include "ReanimatedCommitMarker.h"
 #include "ShadowTreeCloner.h"
 
 using namespace facebook::react;

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -24,7 +24,6 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
     RootShadowNode::Unshared const &newRootShadowNode) const noexcept {
-#endif
   if (ReanimatedCommitMarker::isReanimatedCommit()) {
     // ShadowTree commited by Reanimated, no need to apply updates from
     // PropsRegistry

--- a/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
@@ -1,10 +1,13 @@
 #include "ReanimatedCommitMarker.h"
 
+#include <react/debug/react_native_assert.h>
+
 namespace reanimated {
 
 thread_local bool ReanimatedCommitMarker::reanimatedCommitFlag_{false};
 
 ReanimatedCommitMarker::ReanimatedCommitMarker() {
+  react_native_assert(reanimatedCommitFlag_ != true);
   reanimatedCommitFlag_ = true;
 }
 

--- a/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
@@ -1,0 +1,19 @@
+#include "ReanimatedCommitMarker.h"
+
+namespace reanimated {
+
+thread_local bool ReanimatedCommitMarker::reanimatedCommitFlag_{false};
+
+ReanimatedCommitMarker::ReanimatedCommitMarker() {
+  reanimatedCommitFlag_ = true;
+}
+
+ReanimatedCommitMarker::~ReanimatedCommitMarker() {
+  reanimatedCommitFlag_ = false;
+}
+
+bool ReanimatedCommitMarker::isReanimatedCommit() {
+  return reanimatedCommitFlag_;
+}
+
+} // namespace reanimated

--- a/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitMarker.cpp
@@ -1,3 +1,5 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
 #include "ReanimatedCommitMarker.h"
 
 #include <react/debug/react_native_assert.h>
@@ -20,3 +22,5 @@ bool ReanimatedCommitMarker::isReanimatedCommit() {
 }
 
 } // namespace reanimated
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/Common/cpp/Fabric/ReanimatedCommitMarker.h
+++ b/Common/cpp/Fabric/ReanimatedCommitMarker.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifdef RCT_NEW_ARCH_ENABLED
+
+namespace reanimated {
+
+// This class is used to mark shadow tree commit as coming from Reanimated.
+// During the life of this object, isReanimatedCommit() will return true, false
+// otherwise. isReanimatedCommit() value change is restricted to the thread that
+// created the object.
+class ReanimatedCommitMarker {
+ public:
+  ReanimatedCommitMarker();
+  ~ReanimatedCommitMarker();
+
+  static bool isReanimatedCommit();
+
+ private:
+  static thread_local bool reanimatedCommitFlag_;
+};
+
+} // namespace reanimated
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -14,6 +14,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #include "FabricUtils.h"
 #include "PropsRegistry.h"
+#include "ReanimatedCommitMarker.h"
 #include "ShadowTreeCloner.h"
 #endif
 
@@ -621,6 +622,10 @@ void NativeReanimatedModule::performOperations() {
   const auto &shadowTreeRegistry = uiManager_->getShadowTreeRegistry();
 
   shadowTreeRegistry.visit(surfaceId_, [&](ShadowTree const &shadowTree) {
+    // Mark the commit as Reanimated commit so that we can distinguish it
+    // in ReanimatedCommitHook.
+    ReanimatedCommitMarker commitMarker;
+
     shadowTree.commit(
         [&](RootShadowNode const &oldRootShadowNode) {
           auto rootNode =
@@ -645,9 +650,6 @@ void NativeReanimatedModule::performOperations() {
           }
 
           auto newRoot = std::static_pointer_cast<RootShadowNode>(rootNode);
-
-          // skip ReanimatedCommitHook for this ShadowTree
-          propsRegistry_->setLastReanimatedRoot(newRoot);
 
           return newRoot;
         },


### PR DESCRIPTION
## Summary

Proposed solution is more bullet proof solution for detecting whether currently committed shadow tree comes from reanimated.

Here are the main issues with current implementation:
- if there's another commit hook that is executed before `reanimated` one, then `propsRegistry_->isLastReanimatedRoot(newRootShadowNode)` may not work if the commit hook creates a copy of committed tree
- when `stateReconciliation` is enabled via commit options then new tree root is created and again above detection does not work.

It uses concept of `thread_local` c++ variable which has instance for each thread and RAII to ensure that the appropriate flag is set to `true` on entering commit section and reset to `false` after commit from reanimated on UI thread.

## Test plan

- enable state reconciliation for commit from `reanimated` and check whether the code goes into `isReanimatedCommit` `if` body in `ReanimatedCommitHook`

or

- create a custom commit hook and register it before `ReanimatedCommitHook` and perform same check as above