### PR TITLE
Add eslint rule for consistent `import type`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   rules: {
     'import/no-unresolved': 'error',
+    'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
     'react/jsx-uses-vars': 'error',
     'react/jsx-uses-react': 'error',
     'no-use-before-define': 'off',

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -7,14 +7,14 @@ import {
   toGammaSpace,
   toLinearSpace,
 } from '../Colors';
-import {
-  type SharedValue,
-  type AnimatableValue,
-  type Animation,
-  type AnimationObject,
-  type Timestamp,
-  type AnimatableValueObject,
-  ReduceMotion,
+import { ReduceMotion } from '../commonTypes';
+import type {
+  SharedValue,
+  AnimatableValue,
+  Animation,
+  AnimationObject,
+  Timestamp,
+  AnimatableValueObject,
 } from '../commonTypes';
 import NativeReanimatedModule from '../NativeReanimated';
 import type {


### PR DESCRIPTION
## Summary
This PR adds an eslint rule that forces `import type` to always have the `type` specifier on the top level.

![Screenshot 2023-08-21 at 17 27 17](https://github.com/software-mansion/react-native-reanimated/assets/56109050/a328f3fd-23d4-47bb-a374-24316d7f1cdf)

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
