### PR TITLE
Added optimization to shouldSkipCommit mechanism

### DIFF
--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -31,8 +31,8 @@ class PropsRegistry {
 
   bool shouldReanimatedSkipCommit() {
 #if REACT_NATIVE_MINOR_VERSION >= 73
-    // In RN 0.73 we have a mount hook will properly set this flag after
-    // non-Reanimated commit
+    // In RN 0.73+ we have a mount hook that will properly set this flag
+    // after a non-Reanimated commit.
     return shouldReanimatedSkipCommit_;
 #else
     return shouldReanimatedSkipCommit_.exchange(false);

--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -33,6 +33,10 @@ class PropsRegistry {
     return letMeIn_.exchange(false);
   }
 
+  void resetSkipCommitFlag() {
+    letMeIn_ = false;
+  }
+
  private:
   std::unordered_map<Tag, std::pair<ShadowNode::Shared, folly::dynamic>> map_;
 

--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -26,15 +26,15 @@ class PropsRegistry {
   void remove(const Tag tag);
 
   void pleaseSkipCommit() {
-    letMeIn_ = true;
+    shouldReanimatedSkipCommit_ = true;
   }
 
   bool shouldSkipCommit() {
-    return letMeIn_.exchange(false);
+    return shouldReanimatedSkipCommit_.exchange(false);
   }
 
   void resetSkipCommitFlag() {
-    letMeIn_ = false;
+    shouldReanimatedSkipCommit_ = false;
   }
 
  private:
@@ -42,7 +42,7 @@ class PropsRegistry {
 
   mutable std::mutex mutex_; // Protects `map_`.
 
-  std::atomic<bool> letMeIn_;
+  std::atomic<bool> shouldReanimatedSkipCommit_;
 };
 
 } // namespace reanimated

--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -31,7 +31,7 @@ class PropsRegistry {
 
   bool shouldReanimatedSkipCommit() {
 #if REACT_NATIVE_MINOR_VERSION >= 73
-    // In RN 0.73+ we have a mount hook that will properly set this flag
+    // In RN 0.73+ we have a mount hook that will properly unset this flag
     // after a non-Reanimated commit.
     return shouldReanimatedSkipCommit_;
 #else
@@ -39,9 +39,11 @@ class PropsRegistry {
 #endif
   }
 
+#if REACT_NATIVE_MINOR_VERSION >= 73
   void resetReanimatedSkipCommitFlag() {
     shouldReanimatedSkipCommit_ = false;
   }
+#endif
 
  private:
   std::unordered_map<Tag, std::pair<ShadowNode::Shared, folly::dynamic>> map_;

--- a/Common/cpp/Fabric/PropsRegistry.h
+++ b/Common/cpp/Fabric/PropsRegistry.h
@@ -25,15 +25,21 @@ class PropsRegistry {
 
   void remove(const Tag tag);
 
-  void pleaseSkipCommit() {
+  void pleaseSkipReanimatedCommit() {
     shouldReanimatedSkipCommit_ = true;
   }
 
-  bool shouldSkipCommit() {
+  bool shouldReanimatedSkipCommit() {
+#if REACT_NATIVE_MINOR_VERSION >= 73
+    // In RN 0.73 we have a mount hook will properly set this flag after
+    // non-Reanimated commit
+    return shouldReanimatedSkipCommit_;
+#else
     return shouldReanimatedSkipCommit_.exchange(false);
+#endif
   }
 
-  void resetSkipCommitFlag() {
+  void resetReanimatedSkipCommitFlag() {
     shouldReanimatedSkipCommit_ = false;
   }
 

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -61,7 +61,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
   // since the ShadowTree to be committed by Reanimated may not include the new
   // changes from React Native yet and all changes of animated props will be
   // applied in ReanimatedCommitHook by iterating over PropsRegistry.
-  propsRegistry_->pleaseSkipCommit();
+  propsRegistry_->pleaseSkipReanimatedCommit();
 
   return std::static_pointer_cast<RootShadowNode>(rootNode);
 }

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -57,8 +57,8 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     });
   }
 
-  // request Reanimated to skip one commit so that React Native can mount the
-  // changes instead of failing 1024 times and crashing the app
+  // If the commit comes from React Native then skip one commit from Reanimated
+  // since the tree is already outdated and we have necessary updates.
   propsRegistry_->pleaseSkipCommit();
 
   return std::static_pointer_cast<RootShadowNode>(rootNode);

--- a/Common/cpp/Fabric/ReanimatedCommitHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedCommitHook.cpp
@@ -58,7 +58,9 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
   }
 
   // If the commit comes from React Native then skip one commit from Reanimated
-  // since the tree is already outdated and we have necessary updates.
+  // since the ShadowTree to be committed by Reanimated may not include the new
+  // changes from React Native yet and all changes of animated props will be
+  // applied in ReanimatedCommitHook by iterating over PropsRegistry.
   propsRegistry_->pleaseSkipCommit();
 
   return std::static_pointer_cast<RootShadowNode>(rootNode);

--- a/Common/cpp/Fabric/ReanimatedMountHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedMountHook.cpp
@@ -1,0 +1,31 @@
+#if defined(RCT_NEW_ARCH_ENABLED) && REACT_NATIVE_MINOR_VERSION >= 73
+
+#include "ReanimatedMountHook.h"
+#include "ReanimatedCommitMarker.h"
+
+namespace reanimated {
+
+ReanimatedMountHook::ReanimatedMountHook(
+    const std::shared_ptr<PropsRegistry> &propsRegistry,
+    const std::shared_ptr<UIManager> &uiManager)
+    : propsRegistry_(propsRegistry), uiManager_(uiManager) {
+  uiManager_->registerMountHook(*this);
+}
+
+ReanimatedMountHook::~ReanimatedMountHook() noexcept {
+  uiManager_->unregisterMountHook(*this);
+}
+
+void ReanimatedMountHook::shadowTreeDidMount(
+    RootShadowNode::Shared const &,
+    double) noexcept {
+  // When commit from React Native has finished, we reset the skip commit flag
+  // in order to allow Reanimated to commit its tree
+  if (!ReanimatedCommitMarker::isReanimatedCommit()) {
+    propsRegistry_->resetSkipCommitFlag();
+  }
+}
+
+} // namespace reanimated
+
+#endif // defined(RCT_NEW_ARCH_ENABLED) && REACT_NATIVE_MINOR_VERSION >= 73

--- a/Common/cpp/Fabric/ReanimatedMountHook.cpp
+++ b/Common/cpp/Fabric/ReanimatedMountHook.cpp
@@ -22,7 +22,7 @@ void ReanimatedMountHook::shadowTreeDidMount(
   // When commit from React Native has finished, we reset the skip commit flag
   // in order to allow Reanimated to commit its tree
   if (!ReanimatedCommitMarker::isReanimatedCommit()) {
-    propsRegistry_->resetSkipCommitFlag();
+    propsRegistry_->resetReanimatedSkipCommitFlag();
   }
 }
 

--- a/Common/cpp/Fabric/ReanimatedMountHook.h
+++ b/Common/cpp/Fabric/ReanimatedMountHook.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifdef RCT_NEW_ARCH_ENABLED &&REACT_NATIVE_MINOR_VERSION >= 73
+
+#include "PropsRegistry.h"
+
+#include <react/renderer/uimanager/UIManagerMountHook.h>
+
+#include <memory>
+
+namespace reanimated {
+
+using namespace facebook::react;
+
+class ReanimatedMountHook : public UIManagerMountHook {
+ public:
+  ReanimatedMountHook(
+      const std::shared_ptr<PropsRegistry> &propsRegistry,
+      const std::shared_ptr<UIManager> &uiManager);
+  ~ReanimatedMountHook() noexcept override;
+
+  void shadowTreeDidMount(
+      RootShadowNode::Shared const &rootShadowNode,
+      double mountTime) noexcept override;
+
+ private:
+  std::shared_ptr<PropsRegistry> propsRegistry_;
+
+  std::shared_ptr<UIManager> uiManager_;
+};
+
+} // namespace reanimated
+
+#endif // RCT_NEW_ARCH_ENABLED && REACT_NATIVE_MINOR_VERSION >= 73

--- a/Common/cpp/Fabric/ReanimatedMountHook.h
+++ b/Common/cpp/Fabric/ReanimatedMountHook.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef RCT_NEW_ARCH_ENABLED &&REACT_NATIVE_MINOR_VERSION >= 73
+#if defined(RCT_NEW_ARCH_ENABLED) && REACT_NATIVE_MINOR_VERSION >= 73
 
 #include "PropsRegistry.h"
 
@@ -31,4 +31,4 @@ class ReanimatedMountHook : public UIManagerMountHook {
 
 } // namespace reanimated
 
-#endif // RCT_NEW_ARCH_ENABLED && REACT_NATIVE_MINOR_VERSION >= 73
+#endif // defined(RCT_NEW_ARCH_ENABLED) &&REACT_NATIVE_MINOR_VERSION >= 73

--- a/Common/cpp/Fabric/ReanimatedMountHook.h
+++ b/Common/cpp/Fabric/ReanimatedMountHook.h
@@ -24,11 +24,10 @@ class ReanimatedMountHook : public UIManagerMountHook {
       double mountTime) noexcept override;
 
  private:
-  std::shared_ptr<PropsRegistry> propsRegistry_;
-
-  std::shared_ptr<UIManager> uiManager_;
+  const std::shared_ptr<PropsRegistry> propsRegistry_;
+  const std::shared_ptr<UIManager> uiManager_;
 };
 
 } // namespace reanimated
 
-#endif // defined(RCT_NEW_ARCH_ENABLED) &&REACT_NATIVE_MINOR_VERSION >= 73
+#endif // defined(RCT_NEW_ARCH_ENABLED) && REACT_NATIVE_MINOR_VERSION >= 73

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -610,7 +610,7 @@ void NativeReanimatedModule::performOperations() {
     return;
   }
 
-  if (propsRegistry_->shouldSkipCommit()) {
+  if (propsRegistry_->shouldReanimatedSkipCommit()) {
     // It may happen that `performOperations` is called on the UI thread
     // while React Native tries to commit a new tree on the JS thread.
     // In this case, we should skip the commit here and let React Native do it.

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -50,7 +50,7 @@ NativeProxy::NativeProxy(
       std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager_);
 #if REACT_NATIVE_MINOR_VERSION >= 73
   mountHook_ =
-      std::make_shared < ReanimatedMountHook(propsRegistry_, uiManager_);
+      std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_);
 #endif
 #endif
 }

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -16,11 +16,6 @@
 #include "PlatformDepMethodsHolder.h"
 #include "ReanimatedRuntime.h"
 
-#ifdef RCT_NEW_ARCH_ENABLED
-#include "FabricUtils.h"
-#include "ReanimatedCommitHook.h"
-#endif
-
 namespace reanimated {
 
 using namespace facebook;
@@ -53,6 +48,10 @@ NativeProxy::NativeProxy(
   uiManager_ = binding->getScheduler()->getUIManager();
   commitHook_ =
       std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager_);
+#if REACT_NATIVE_MINOR_VERSION >= 73
+  mountHook_ =
+      std::make_shared < ReanimatedMountHook(propsRegistry_, uiManager_);
+#endif
 #endif
 }
 

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -27,6 +27,10 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #include "PropsRegistry.h"
 #include "ReanimatedCommitHook.h"
+
+#if REACT_NATIVE_MINOR_VERSION >= 73
+#include "ReanimatedMountHook.h"
+#endif
 #endif
 
 namespace reanimated {
@@ -180,6 +184,10 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   std::shared_ptr<PropsRegistry> propsRegistry_;
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
+
+#if REACT_NATIVE_MINOR_VERSION >= 73
+  std::shared_ptr<ReanimatedMountHook> mountHook_;
+#endif
 
   // removed temporary, new event listener mechanism need fix on the RN side
   // std::shared_ptr<facebook::react::Scheduler> reactScheduler_;

--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -15,6 +15,10 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNReanimated/REAInitializerRCTFabricSurface.h>
 #import <RNReanimated/ReanimatedCommitHook.h>
+
+#if REACT_NATIVE_MINOR_VERSION >= 73
+#import <RNReanimated/ReanimatedMountHook.h>
+#endif
 #endif
 
 #import <RNReanimated/REAModule.h>
@@ -50,6 +54,9 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
   __weak RCTSurfacePresenter *_surfacePresenter;
   std::shared_ptr<PropsRegistry> propsRegistry_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
+#if REACT_NATIVE_MINOR_VERSION >= 73
+  std::shared_ptr<ReanimatedMountHook> mountHook_;
+#endif
   std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule_;
 #else
   NSMutableArray<AnimatedOperation> *_operations;
@@ -108,6 +115,9 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   react_native_assert(uiManager.get() != nil);
   propsRegistry_ = std::make_shared<PropsRegistry>();
   commitHook_ = std::make_shared<ReanimatedCommitHook>(propsRegistry_, uiManager);
+#if REACT_NATIVE_MINOR_VERSION >= 73
+  mountHook_ = std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager);
+#endif
   [self setUpNativeReanimatedModule:uiManager];
 }
 


### PR DESCRIPTION
## Summary

React Native 0.73 introduces concept of mount hooks. Such hook is useful to notify Reanimated that shadowTree commit coming from React Native has finished so that Reanimated can commit its own changes.

The solution has shown about 15% performance gain in number of successful commits per second.

## Test plan

None
