### PR TITLE
Add missing env to MacOSExample

### DIFF
--- a/MacOSExample/ios/Podfile
+++ b/MacOSExample/ios/Podfile
@@ -1,6 +1,8 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
+ENV['REANIMATED_EXAMPLE_APP_NAME'] = 'MacOSExample-ios'
+
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 

--- a/MacOSExample/macos/Podfile
+++ b/MacOSExample/macos/Podfile
@@ -1,6 +1,8 @@
 require_relative '../node_modules/react-native-macos/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
+ENV['REANIMATED_EXAMPLE_APP_NAME'] = 'MacOSExample-macos'
+
 prepare_react_native_project!
 
 target 'MacOSExample-macOS' do


### PR DESCRIPTION
## Summary

This PR adds missing env `REANIMATED_EXAMPLE_APP_NAME` to MacOSExample app, because we have some logic based on this env, for example check for multiple instances etc.

## Test plan

`cd MacOSExample/macos && pod install`
