### PR TITLE
Add `window` availability check

### DIFF
--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -32,8 +32,17 @@ export function nativeShouldBeMock() {
   return isJest() || isChromeDebugger() || isWindows();
 }
 
+export function isWindowAvailable() {
+  // the window object is unavailable when building the server portion of a site that uses SSG
+  // this function shouldn't be used to conditionally render components
+  // https://www.joshwcomeau.com/react/the-perils-of-rehydration/
+  return typeof window !== 'undefined';
+}
+
 export function isReducedMotion() {
   return isWeb()
-    ? !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+    ? isWindowAvailable()
+      ? !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+      : false
     : global._REANIMATED_IS_REDUCED_MOTION ?? false;
 }

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -1,4 +1,9 @@
-import { isChromeDebugger, isJest, isWeb } from '../PlatformChecker';
+import {
+  isChromeDebugger,
+  isJest,
+  isWeb,
+  isWindowAvailable,
+} from '../PlatformChecker';
 import type {
   ShareableRef,
   ShareableSyncDataHolderRef,
@@ -78,6 +83,12 @@ export default class JSReanimated {
     _iosReferenceFrame: number,
     eventHandler: ShareableRef<(data: Value3D | ValueRotation) => void>
   ): number {
+    if (!isWindowAvailable()) {
+      // the window object is unavailable when building the server portion of a site that uses SSG
+      // this check is here to ensure that the server build won't fail
+      return -1;
+    }
+
     if (this.platform === undefined) {
       this.detectPlatform();
     }


### PR DESCRIPTION
## Summary

When SSG is used to generate a website the `window` object can't be accessed (in the server portion of the build). This PR adds an availability check for when `window` is used.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
