### PR TITLE
Fix scrollTo crash

### DIFF
--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -8,6 +8,7 @@ import {
 
 import type { AnimatedRef } from './hook/commonTypes';
 import type { Component } from 'react';
+import type { ScrollView } from '../Animated';
 
 const IS_NATIVE = !shouldBeUseWeb();
 
@@ -145,10 +146,13 @@ export let scrollTo: <T extends Component>(
 
 if (isWeb()) {
   scrollTo = (animatedRef, x, y, animated) => {
-    'worklet';
-    const element = (animatedRef as any)() as HTMLElement; // TODO: fix typing of animated refs on web
-    // @ts-ignore same call as in react-native-web
-    element.scrollTo({ x, y, animated });
+    const element = animatedRef();
+
+    // This prevents crashes if ref has not been set yet
+    if (element !== -1) {
+      // By ScrollView we mean any scrollable component
+      (element as ScrollView)?.scrollTo({ x, y, animated });
+    }
   };
 } else if (IS_NATIVE && global._IS_FABRIC) {
   scrollTo = (animatedRef, x, y, animated) => {

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -8,7 +8,7 @@ import {
 
 import type { AnimatedRef } from './hook/commonTypes';
 import type { Component } from 'react';
-import type { ScrollView } from '../Animated';
+import type { ScrollView } from 'react-native';
 
 const IS_NATIVE = !shouldBeUseWeb();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds check whether `animatedRef` has been set or not. If ref is not defined, calling `element.scrollTo` results in crash, because `element` is set to `-1`.

Fixes #4424 

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Tested on snack from [issue](https://github.com/software-mansion/react-native-reanimated/issues/4424)
