### PR TITLE
Replace old shadow nodes in PropsRegistry with new ones

### DIFF
--- a/Common/cpp/Fabric/PropsRegistry.cpp
+++ b/Common/cpp/Fabric/PropsRegistry.cpp
@@ -18,7 +18,6 @@ void PropsRegistry::update(
     // returns `ShadowNodeFamily const &` which is non-owning
     map_[tag] = std::make_pair(shadowNode, props);
   } else {
-    // no need to update `.first` because ShadowNodeFamily doesn't change
     // merge new props with old props
     it->second.second.update(props);
 

--- a/Common/cpp/Fabric/PropsRegistry.cpp
+++ b/Common/cpp/Fabric/PropsRegistry.cpp
@@ -21,6 +21,12 @@ void PropsRegistry::update(
     // no need to update `.first` because ShadowNodeFamily doesn't change
     // merge new props with old props
     it->second.second.update(props);
+
+    // Update ShadowNode stored in the map in case it was replaced
+    // in order to allow old ShadowNode to be deallocated
+    if (it->second.first != shadowNode) {
+      it->second.first = shadowNode;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

I found out that many shadow nodes are stored in `PropsRegistry` even if newer versions were passed to `update` method. This PR replaces old `ShadowNode` with new one if needed.

## Test plan

None
