### PR TITLE
Improve entry exit animation types

### DIFF
--- a/src/animationBuilder.tsx
+++ b/src/animationBuilder.tsx
@@ -12,6 +12,7 @@ const mockTargetValues: LayoutAnimationsValues = {
   targetHeight: 0,
   targetGlobalOriginX: 0,
   targetGlobalOriginY: 0,
+  targetBorderRadius: 0,
   windowWidth: 0,
   windowHeight: 0,
   currentOriginX: 0,
@@ -20,6 +21,7 @@ const mockTargetValues: LayoutAnimationsValues = {
   currentHeight: 0,
   currentGlobalOriginX: 0,
   currentGlobalOriginY: 0,
+  currentBorderRadius: 0,
 };
 
 export function maybeBuild(

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -2,6 +2,28 @@ import type { ExtractArrayItemType } from '../../helperTypes';
 import type { EasingFunction } from '../../Easing';
 import type { StyleProps } from '../../commonTypes';
 
+export type LayoutAnimationsOptions =
+  | 'originX'
+  | 'originY'
+  | 'width'
+  | 'height'
+  | 'borderRadius'
+  | 'globalOriginX'
+  | 'globalOriginY';
+
+type CurrentLayoutAnimationsValues = {
+  [K in LayoutAnimationsOptions as `current${Capitalize<string & K>}`]: number;
+};
+
+type TargetLayoutAnimationsValues = {
+  [K in LayoutAnimationsOptions as `target${Capitalize<string & K>}`]: number;
+};
+
+interface WindowDimensions {
+  windowWidth: number;
+  windowHeight: number;
+}
+
 export interface KeyframeProps extends StyleProps {
   easing?: EasingFunction;
   [key: string]: any;
@@ -14,28 +36,13 @@ export type LayoutAnimation = {
 };
 
 export type AnimationFunction = (a?: any, b?: any, c?: any) => any; // this is just a temporary mock
+export interface EntryAnimationsValues
+  extends TargetLayoutAnimationsValues,
+    WindowDimensions {}
 
-export interface EntryAnimationsValues {
-  targetOriginX: number;
-  targetOriginY: number;
-  targetWidth: number;
-  targetHeight: number;
-  targetGlobalOriginX: number;
-  targetGlobalOriginY: number;
-  windowWidth: number;
-  windowHeight: number;
-}
-
-export interface ExitAnimationsValues {
-  currentOriginX: number;
-  currentOriginY: number;
-  currentWidth: number;
-  currentHeight: number;
-  currentGlobalOriginX: number;
-  currentGlobalOriginY: number;
-  windowWidth: number;
-  windowHeight: number;
-}
+export interface ExitAnimationsValues
+  extends CurrentLayoutAnimationsValues,
+    WindowDimensions {}
 
 export type EntryExitAnimationFunction =
   | ((targetValues: EntryAnimationsValues) => LayoutAnimation)
@@ -44,23 +51,10 @@ export type EntryExitAnimationFunction =
 
 export type AnimationConfigFunction<T> = (targetValues: T) => LayoutAnimation;
 
-export interface LayoutAnimationsValues {
-  [key: string]: number | number[];
-  currentOriginX: number;
-  currentOriginY: number;
-  currentWidth: number;
-  currentHeight: number;
-  currentGlobalOriginX: number;
-  currentGlobalOriginY: number;
-  targetOriginX: number;
-  targetOriginY: number;
-  targetWidth: number;
-  targetHeight: number;
-  targetGlobalOriginX: number;
-  targetGlobalOriginY: number;
-  windowWidth: number;
-  windowHeight: number;
-}
+export interface LayoutAnimationsValues
+  extends CurrentLayoutAnimationsValues,
+    TargetLayoutAnimationsValues,
+    WindowDimensions {}
 
 export interface SharedTransitionAnimationsValues
   extends LayoutAnimationsValues {

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -35,13 +35,12 @@ export type LayoutAnimation = {
 };
 
 export type AnimationFunction = (a?: any, b?: any, c?: any) => any; // this is just a temporary mock
-export interface EntryAnimationsValues
-  extends TargetLayoutAnimationsValues,
-    WindowDimensions {}
 
-export interface ExitAnimationsValues
-  extends CurrentLayoutAnimationsValues,
-    WindowDimensions {}
+export type EntryAnimationsValues = TargetLayoutAnimationsValues &
+  WindowDimensions;
+
+export type ExitAnimationsValues = CurrentLayoutAnimationsValues &
+  WindowDimensions;
 
 export type EntryExitAnimationFunction =
   | ((targetValues: EntryAnimationsValues) => LayoutAnimation)
@@ -50,10 +49,9 @@ export type EntryExitAnimationFunction =
 
 export type AnimationConfigFunction<T> = (targetValues: T) => LayoutAnimation;
 
-export interface LayoutAnimationsValues
-  extends CurrentLayoutAnimationsValues,
-    TargetLayoutAnimationsValues,
-    WindowDimensions {}
+export type LayoutAnimationsValues = CurrentLayoutAnimationsValues &
+  TargetLayoutAnimationsValues &
+  WindowDimensions;
 
 export interface SharedTransitionAnimationsValues
   extends LayoutAnimationsValues {

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -26,7 +26,6 @@ interface WindowDimensions {
 
 export interface KeyframeProps extends StyleProps {
   easing?: EasingFunction;
-  [key: string]: any;
 }
 
 export type LayoutAnimation = {

--- a/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
@@ -212,8 +212,8 @@ export class SharedTransition {
           const currentPropertyName = `current${PropertyName}` as const;
           const targetPropertyName = `target${PropertyName}` as const;
 
-          const currentValue: number = values[currentPropertyName];
-          const targetValue: number = values[targetPropertyName];
+          const currentValue = values[currentPropertyName];
+          const targetValue = values[targetPropertyName];
 
           newStyles[propertyName] =
             progress * (targetValue - currentValue) + currentValue;

--- a/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
@@ -22,7 +22,7 @@ const SUPPORTED_PROPS = [
   'originY',
   'transform',
   'borderRadius',
-] as Array<LayoutAnimationsOptions | 'transform'>;
+] as const;
 
 type AnimationFactory = (
   values: SharedTransitionAnimationsValues
@@ -140,7 +140,7 @@ export class SharedTransition {
       if (animationFactory) {
         animations = animationFactory(values);
         for (const key in animations) {
-          if (!(SUPPORTED_PROPS as string[]).includes(key)) {
+          if (!(SUPPORTED_PROPS as readonly string[]).includes(key)) {
             throw new Error(
               `[Reanimated] The prop '${key}' is not supported yet.`
             );

--- a/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
@@ -4,6 +4,7 @@ import type {
   SharedTransitionAnimationsValues,
   CustomProgressAnimation,
   ProgressAnimation,
+  LayoutAnimationsOptions,
 } from '../animationBuilder/commonTypes';
 import {
   LayoutAnimationType,
@@ -14,14 +15,14 @@ import { ReduceMotion } from '../../commonTypes';
 import { configureLayoutAnimations } from '../../core';
 import { ProgressTransitionManager } from './ProgressTransitionManager';
 
-const supportedProps = [
+const SUPPORTED_PROPS = [
   'width',
   'height',
   'originX',
   'originY',
   'transform',
   'borderRadius',
-];
+] as Array<LayoutAnimationsOptions | 'transform'>;
 
 type AnimationFactory = (
   values: SharedTransitionAnimationsValues
@@ -139,14 +140,14 @@ export class SharedTransition {
       if (animationFactory) {
         animations = animationFactory(values);
         for (const key in animations) {
-          if (!supportedProps.includes(key)) {
+          if (!(SUPPORTED_PROPS as string[]).includes(key)) {
             throw new Error(
               `[Reanimated] The prop '${key}' is not supported yet.`
             );
           }
         }
       } else {
-        for (const propName of supportedProps) {
+        for (const propName of SUPPORTED_PROPS) {
           if (propName === 'transform') {
             const matrix = values.targetTransformMatrix;
             animations.transformMatrix = withTiming(matrix, {
@@ -154,8 +155,12 @@ export class SharedTransition {
               duration: transitionDuration,
             });
           } else {
-            const keyToTargetValue =
-              'target' + propName.charAt(0).toUpperCase() + propName.slice(1);
+            const capitalizedPropName = `${propName
+              .charAt(0)
+              .toUpperCase()}${propName.slice(
+              1
+            )}` as Capitalize<LayoutAnimationsOptions>;
+            const keyToTargetValue = `target${capitalizedPropName}` as const;
             animations[propName] = withTiming(values[keyToTargetValue], {
               reduceMotion,
               duration: transitionDuration,
@@ -168,8 +173,9 @@ export class SharedTransition {
         if (propName === 'transform') {
           initialValues.transformMatrix = values.currentTransformMatrix;
         } else {
-          const keyToCurrentValue =
-            'current' + propName.charAt(0).toUpperCase() + propName.slice(1);
+          const capitalizedPropName = (propName.charAt(0).toUpperCase() +
+            propName.slice(1)) as Capitalize<LayoutAnimationsOptions>;
+          const keyToCurrentValue = `current${capitalizedPropName}` as const;
           initialValues[propName] = values[keyToCurrentValue];
         }
       }
@@ -186,7 +192,7 @@ export class SharedTransition {
     this._progressAnimation = (viewTag, values, progress) => {
       'worklet';
       const newStyles: { [key: string]: number | number[] } = {};
-      for (const propertyName of supportedProps) {
+      for (const propertyName of SUPPORTED_PROPS) {
         if (propertyName === 'transform') {
           // this is not the perfect solution, but at this moment it just interpolates the whole
           // matrix instead of interpolating scale, translate, rotate, etc. separately
@@ -201,10 +207,14 @@ export class SharedTransition {
           newStyles.transformMatrix = newMatrix;
         } else {
           // PropertyName == propertyName with capitalized fist letter, (width -> Width)
-          const PropertyName =
-            propertyName.charAt(0).toUpperCase() + propertyName.slice(1);
-          const currentValue = values['current' + PropertyName] as number;
-          const targetValue = values['target' + PropertyName] as number;
+          const PropertyName = (propertyName.charAt(0).toUpperCase() +
+            propertyName.slice(1)) as Capitalize<LayoutAnimationsOptions>;
+          const currentPropertyName = `current${PropertyName}` as const;
+          const targetPropertyName = `target${PropertyName}` as const;
+
+          const currentValue: number = values[currentPropertyName];
+          const targetValue: number = values[targetPropertyName];
+
           newStyles[propertyName] =
             progress * (targetValue - currentValue) + currentValue;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

1. Use typescript regex types to generate object with `current` and `target` prefixes based on a single source of truth
   - This may be a good change, since we consider supporting more animation properties.
3. Extract common properties from similar types to reduce boiler-plate code, use inheritance instead of copy-pasting them
4. Get rid of `[key: string]: number | number[];` 🥳 
5. Remove lots of type casts in `SharedTransition.ts` 🥳 


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan
`yarn type:check` & `yarn type:check-api`

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
