### PR TITLE
Expose `libreanimated` to be consumed via prefab

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -482,6 +482,7 @@ task printVersions {
 task createNativeDepsDirectories() {
     downloadsDir.mkdirs()
     thirdPartyNdkDir.mkdirs()
+    prefabHeadersDir.mkdirs()
 }
 
 def resolveTaskFactory(String taskName, String artifactLocalName, File reactNativeAndroidDownloadDir, File reanimatedDownloadDir) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -167,6 +167,8 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeThirdParty = new File("$reactNativeRootDir/ReactAndroid/src/main/jni/third-party")
 def reactNativeAndroidDownloadDir = new File("$reactNativeRootDir/ReactAndroid/build/downloads")
 
+def prefabHeadersDir = project.file("$buildDir/prefab-headers/reanimated")
+
 def JS_RUNTIME = {
     // Override JS runtime with environment variable
     if (System.getenv("JS_RUNTIME")) {
@@ -246,11 +248,18 @@ android {
         ndkVersion rootProject.ext.ndkVersion
     }
 
-    if (REACT_NATIVE_MINOR_VERSION >= 71) {
-        buildFeatures {
-            prefab true
+    buildFeatures {
+        prefab true
+        prefabPublishing true
+    }
+
+    prefab {
+        reanimated {
+            headers prefabHeadersDir.absolutePath
+            libraryName "libreanimated"
         }
     }
+
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 16)
         targetSdkVersion safeExtGet("targetSdkVersion", 30)
@@ -445,6 +454,13 @@ def assertLatestReactNativeWithNewArchitecture = task assertLatestReactNativeWit
             "\n[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + REANIMATED_VERSION + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
         )
     }
+}
+
+task prepareHeadersForPrefab(type: Copy) {
+    from("$projectDir/src/main/cpp")
+    from("$projectDir/../Common/cpp")
+    include("**/*.h")
+    into(prefabHeadersDir)
 }
 
 tasks.preBuild {
@@ -904,6 +920,8 @@ afterEvaluate {
         nativeBuildDependsOn(extractAARHeaders)
         nativeBuildDependsOn(extractSOFiles)
     }
+
+    preBuild.dependsOn(prepareHeadersForPrefab)
 
     tasks.forEach({ task ->
         if (task.name.contains("JniLibFolders")) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -457,8 +457,15 @@ def assertLatestReactNativeWithNewArchitecture = task assertLatestReactNativeWit
 
 task prepareHeadersForPrefab(type: Copy) {
     from("$projectDir/src/main/cpp")
-    from("$projectDir/../Common/cpp")
-    include("**/*.h")
+    from("$projectDir/../Common/cpp/AnimatedSensor")
+    from("$projectDir/../Common/cpp/Fabric")
+    from("$projectDir/../Common/cpp/LayoutAnimations")
+    from("$projectDir/../Common/cpp/NativeModules")
+    from("$projectDir/../Common/cpp/ReanimatedRuntime")
+    from("$projectDir/../Common/cpp/Registries")
+    from("$projectDir/../Common/cpp/SharedItems")
+    from("$projectDir/../Common/cpp/Tools")
+    include("*.h")
     into(prefabHeadersDir)
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -256,7 +256,6 @@ android {
     prefab {
         reanimated {
             headers prefabHeadersDir.absolutePath
-            libraryName "libreanimated"
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR exposes `libreanimated.so` along with necessary headers as a prefab on Android so it can be easily consumed by other third-party libraries (e.g. VisionCamera) without a need to manually specify paths to node_modules.

```gradle
android {
  buildFeatures {
    prefab true
  }
}
```

```cmake
find_package(react-native-reanimated REQUIRED CONFIG)

target_link_libraries(${PACKAGE_NAME} react-native-reanimated::reanimated)
```

> [!NOTE]  
> For now, we expose all header files, but this is subject to change as ultimately we want to expose only headers from public C++ API.

> [!NOTE]  
> When using `com.android.tools.build:gradle:7.3.1` the following error may occur. Please upgrade to 7.4.2 or newer.

```
Usage: prefab [OPTIONS] PACKAGE_PATH...

Error: Invalid value for "PACKAGE_PATH": Directory "/Users/tomekzaw/(...)/node_modules/react-native-reanimated/android/build/intermediates/prefab_package_configuration/debug/prefab" is not readable.
```

## Changes

1. We need to set `prefabPublishing true` in order to enable exposing libraries as prefabs.
2. We need `prefabHeadersDir` because `headers` accepts only one path. So we copy all headers from `src/main/cpp` and `Common/cpp/**` directly to `prefabHeadersDir` in `prepareHeadersForPrefab` task.
3. We need to list all directories in `Common/cpp` because in our codebase we use `#include "SomeHeader.h"` without any directory prefix so `SomeHeader.h` needs to be directly in `prefabHeadersDir`.
4. We need to call `prefabHeadersDir.mkdirs()` because otherwise Gradle Sync fails due to non-existent path.
5. We need `preBuild.dependsOn(prepareHeadersForPrefab)` so that the headers are already copied before CMake starts building other parts that depend on it.

## Test plan

🧨 
