### PR TITLE
Sort include paths in CMakeLists.txt

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -80,16 +80,15 @@ add_library(
 target_include_directories(
         ${PACKAGE_NAME}
         PRIVATE
-        "${COMMON_SRC_DIR}/cpp/Tools"
-        "${COMMON_SRC_DIR}/cpp/SpecTools"
-        "${COMMON_SRC_DIR}/cpp/NativeModules"
-        "${COMMON_SRC_DIR}/cpp/SharedItems"
-        "${COMMON_SRC_DIR}/cpp/ReanimatedRuntime"
-        "${COMMON_SRC_DIR}/cpp/Registries"
-        "${COMMON_SRC_DIR}/cpp/LayoutAnimations"
         "${COMMON_SRC_DIR}/cpp/AnimatedSensor"
         "${COMMON_SRC_DIR}/cpp/Fabric"
         "${COMMON_SRC_DIR}/cpp/hidden_headers"
+        "${COMMON_SRC_DIR}/cpp/LayoutAnimations"
+        "${COMMON_SRC_DIR}/cpp/NativeModules"
+        "${COMMON_SRC_DIR}/cpp/ReanimatedRuntime"
+        "${COMMON_SRC_DIR}/cpp/Registries"
+        "${COMMON_SRC_DIR}/cpp/SharedItems"
+        "${COMMON_SRC_DIR}/cpp/Tools"
         "${SRC_DIR}/main/cpp"
 )
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR sorts paths in `target_include_directories` as well as removes `"${COMMON_SRC_DIR}/cpp/SpecTools"` which no longer exists.

## Test plan

Check if CI is green.
