### PR TITLE
Fix compatibility with older rn-screens version

### DIFF
--- a/apple/LayoutReanimation/REASharedTransitionManager.m
+++ b/apple/LayoutReanimation/REASharedTransitionManager.m
@@ -341,7 +341,8 @@ static REASharedTransitionManager *_sharedTransitionManager;
     Class screenClass = [RNSScreen class];
     Class screenViewClass = [RNSScreenView class];
     BOOL allSelectorsAreAvailable = [RNSScreen instancesRespondToSelector:viewDidLayoutSubviewsSelector] &&
-        [RNSScreenView instancesRespondToSelector:notifyWillDisappearSelector];
+        [RNSScreenView instancesRespondToSelector:notifyWillDisappearSelector] &&
+        [RNSScreenView instancesRespondToSelector:@selector(isModal)]; // used by REAScreenHelper
 
     if (allSelectorsAreAvailable) {
       [REAUtils swizzleMethod:viewDidLayoutSubviewsSelector


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4992
This issue may happen when someone uses an older version of RN screens without the `isModal` method. This PR adds a check to detect if this selector exists. If not, the whole SET feature is disabled.

## Test plan

Try to compile the App with the newest Reaniamted and the old version of rn-screens.
