### PR TITLE
Fix crash on reload in `ShareableRemoteFunction`

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -208,7 +208,7 @@ jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
 
 jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
   if (&rt == runtime_) {
-    return jsi::Value(rt, function_);
+    return jsi::Value(rt, *function_);
   } else {
 #ifdef DEBUG
     return getValueUnpacker(rt).call(

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -233,13 +233,17 @@ class ShareableRemoteFunction
       public std::enable_shared_from_this<ShareableRemoteFunction> {
  private:
   jsi::Runtime *runtime_;
-  jsi::Function function_;
+  std::unique_ptr<jsi::Value> function_;
 
  public:
   ShareableRemoteFunction(jsi::Runtime &rt, jsi::Function &&function)
       : Shareable(RemoteFunctionType),
         runtime_(&rt),
-        function_(std::move(function)) {}
+        function_(std::make_unique<jsi::Value>(rt, std::move(function))) {}
+
+  ~ShareableRemoteFunction() {
+    cleanupIfRuntimeExists(runtime_, function_);
+  }
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes a crash that occurs during a reload of the app. `ShareableRemoteFunction` holds a reference to a remote function in `function_` field. When `ShareableRemoteFunction` is deallocated, `function_` also gets deallocated. If the runtime has already been terminated, the assert in `~jsi::Pointer` will fail.

![Zrzut ekranu 2023-08-31 o 10 48 42](https://github.com/software-mansion/react-native-reanimated/assets/20516055/3685ce3c-639d-42c5-84da-a4f238d2cf19)

## Test plan

Tested on VisionCameraExample.
