### PR TITLE
Expose `makeShareableCloneRecursive`

### DIFF
--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -45,7 +45,7 @@ import Animated, {
   scrollTo,
   setGestureState,
   isSharedValue,
-  makeShareableCloneRecursive
+  makeShareableCloneRecursive,
 } from '..';
 
 class Path extends React.Component<{ fill?: string }> {

--- a/__typetests__/react-native-reanimated-tests.tsx
+++ b/__typetests__/react-native-reanimated-tests.tsx
@@ -44,6 +44,7 @@ import Animated, {
   measure,
   scrollTo,
   setGestureState,
+  makeShareableCloneRecursive,
 } from '..';
 import type { AnimatedStyle } from '..';
 
@@ -219,6 +220,13 @@ function MakeMutableTest() {
   const mut2 = makeMutable(true);
 
   return <Animated.View style={styles.container} />;
+}
+
+// makeShareableCloneRecursive
+function MakeShareableCloneRecursiveTest() {
+  const mut = makeShareableCloneRecursive(0);
+  const mut2 = makeShareableCloneRecursive(true);
+  const mut3 = makeShareableCloneRecursive({ foo: 'bar' });
 }
 
 /**

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -24,7 +24,7 @@ export { startMapper, stopMapper } from './mappers';
 export { runOnJS, runOnUI } from './threads';
 export { createWorkletRuntime } from './runtimes';
 export type { WorkletRuntime } from './runtimes';
-export { makeShareable } from './shareables';
+export { makeShareable, makeShareableCloneRecursive } from './shareables';
 export { makeMutable, makeRemote } from './mutables';
 
 /**

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -6,6 +6,7 @@ export {
   createWorkletRuntime,
   WorkletRuntime,
   makeMutable,
+  makeShareableCloneRecursive,
   isReanimated3,
   isConfigured,
   enableLayoutAnimations,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds `makeShareableCloneRecursive` to the public API.

Example use case:

```ts
const runtime = createWorkletRuntime('foo');
const worklet = () => {
  'worklet';
  console.log(42);
};
someJSIBindingFromThirdPartyLibrary(runtime, makeShareableCloneRecursive(worklet));
```

We need to call `makeShareableCloneRecursive` here so that the argument is an instance of `std::shared_ptr<ShareableWorklet>` and not just a `jsi::Function`. Also, we need the whole worklet closure to be shareable.

An alternative would be to expose a new function `makeShareableWorklet`.

## Test plan

See typetests.
