### PR TITLE
Added some includes to make headers self sufficient

### DIFF
--- a/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
@@ -16,6 +16,7 @@
 #include <jsi/decorator.h>
 #include <jsi/jsi.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <thread>

--- a/Common/cpp/Tools/UIScheduler.h
+++ b/Common/cpp/Tools/UIScheduler.h
@@ -2,6 +2,7 @@
 
 #include <ReactCommon/CallInvoker.h>
 
+#include <atomic>
 #include <memory>
 
 #include "ThreadSafeQueue.h"

--- a/Common/cpp/hidden_headers/Logger.h
+++ b/Common/cpp/hidden_headers/Logger.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
+
 #include "./LoggerInterface.h"
 
 namespace reanimated {


### PR DESCRIPTION
## Summary

I've noticed that some headers did not have enough includes to be self-sufficient. I've alse make a quick test using this CMake helper code that compiles each header from Common directory:

```
file(GLOB_RECURSE HEADER_FILES CONFIGURE_DEPENDS "${COMMON_SRC_DIR}/**.h")
foreach(header ${HEADER_FILES})
  get_filename_component(header_name ${header} NAME)
  get_filename_component(directory ${header} DIRECTORY)
  string(REPLACE ".h" ".cpp" CPP_FILE ${header_name})

  # Copy header as cpp file for compilation
  configure_file(${header} ${CMAKE_BINARY_DIR}/destination_dir/${CPP_FILE} COPYONLY)

  add_library(${header_name}_test ${CMAKE_BINARY_DIR}/destination_dir/${CPP_FILE})
  target_link_directories(${header_name}_test PRIVATE ${directory})
  target_link_libraries(${header_name}_test ${PACKAGE_NAME})

  add_test(NAME ${header_name}_test COMMAND ${header_name}_test)
endforeach()
```

It may be a good idea to add this as a pipeline check, but I didn't want to spend much time at this now.

## Test plan

None
