### PR TITLE
Headers sufficiency check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ react-native-reanimated-tests.js
 # plugin
 !plugin/build
 plugin/types
+
+# headers-sufficiency-checker
+headers-sufficiency-check

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -77,9 +77,15 @@ add_library(
 
 # includes
 
+if(NOT DEFINED CHECK_HEADERS)
+  set(INCLUDE_MODE "PRIVATE")
+else()
+  set(INCLUDE_MODE "PUBLIC")
+endif()
+
 target_include_directories(
         ${PACKAGE_NAME}
-        PRIVATE
+        ${INCLUDE_MODE}
         "${COMMON_SRC_DIR}/cpp/AnimatedSensor"
         "${COMMON_SRC_DIR}/cpp/Fabric"
         "${COMMON_SRC_DIR}/cpp/hidden_headers"
@@ -95,7 +101,7 @@ target_include_directories(
 if(${REACT_NATIVE_MINOR_VERSION} GREATER_EQUAL 71)
     target_include_directories(
         ${PACKAGE_NAME}
-        PRIVATE
+        ${INCLUDE_MODE}
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
         "${REACT_NATIVE_DIR}/ReactCommon"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
@@ -107,7 +113,7 @@ else()
     file(GLOB LIBFBJNI_INCLUDE_DIR ${FBJNI_HEADERS_DIR})
     target_include_directories(
         ${PACKAGE_NAME}
-        PRIVATE
+        ${INCLUDE_MODE}
         "${LIBFBJNI_INCLUDE_DIR}"
         "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
         "${BUILD_DIR}/third-party-ndk/double-conversion"
@@ -223,7 +229,7 @@ if(${JS_RUNTIME} STREQUAL "hermes")
         # Bundled Hermes from module `com.facebook.react:hermes-engine` or project `:ReactAndroid:hermes-engine`
         target_include_directories(
             ${PACKAGE_NAME}
-            PRIVATE
+            ${INCLUDE_MODE}
             "${JS_RUNTIME_DIR}/API"
             "${JS_RUNTIME_DIR}/public"
         )
@@ -232,7 +238,7 @@ if(${JS_RUNTIME} STREQUAL "hermes")
         # From `hermes-engine` npm package
         target_include_directories(
             ${PACKAGE_NAME}
-            PRIVATE
+            ${INCLUDE_MODE}
             "${JS_RUNTIME_DIR}/android/include"
         )
         set(HERMES_LIB "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}/libhermes.so")
@@ -275,7 +281,7 @@ elseif(${JS_RUNTIME} STREQUAL "v8")
     string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_V8=1")
     target_include_directories(
             ${PACKAGE_NAME}
-            PRIVATE
+            ${INCLUDE_MODE}
             "${JS_RUNTIME_DIR}/src"
     )
     file (GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/*/jni/${ANDROID_ABI}")
@@ -335,3 +341,22 @@ endif()
 # when any of the following variables is not used in some build configuration.
 set (ignoreMe "${JS_RUNTIME_DIR}")
 set (ignoreMe "${BOOST_VERSION}")
+
+if(DEFINED CHECK_HEADERS)
+  file(GLOB_RECURSE HEADER_FILES CONFIGURE_DEPENDS "${COMMON_SRC_DIR}/**.h")
+  foreach(header ${HEADER_FILES})
+    get_filename_component(header_name ${header} NAME)
+    get_filename_component(directory ${header} DIRECTORY)
+    string(REPLACE ".h" ".cpp" CPP_FILE ${header_name})
+
+    # Copy header as cpp file for compilation
+    # configure_file(${header} ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE} COPYONLY)
+    file(WRITE ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE} "#include \"${header}\"\n")
+
+    add_library(${header_name}_test ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE})
+    target_link_directories(${header_name}_test PRIVATE ${directory})
+    target_link_libraries(${header_name}_test ${PACKAGE_NAME})
+
+    add_test(NAME ${header_name}_test COMMAND ${header_name}_test)
+  endforeach()
+endif()

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -349,8 +349,7 @@ if(DEFINED CHECK_HEADERS)
     get_filename_component(directory ${header} DIRECTORY)
     string(REPLACE ".h" ".cpp" CPP_FILE ${header_name})
 
-    # Copy header as cpp file for compilation
-    # configure_file(${header} ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE} COPYONLY)
+    # Create cpp file with include of the header
     file(WRITE ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE} "#include \"${header}\"\n")
 
     add_library(${header_name}_test ${CMAKE_BINARY_DIR}/headers_check/${CPP_FILE})

--- a/scripts/headers-sufficiency-check.sh
+++ b/scripts/headers-sufficiency-check.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR=$ROOT_DIR/headers-sufficiency-check
+
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+
+ANDROID_PREFAB_CMAKE_DIR=../android/.cxx/Debug/1e3q424l/prefab/x86_64/prefab/lib/x86_64-linux-android/cmake
+ANDROID_NDK_DIR=~/Library/Android/sdk/ndk/23.1.7779620
+
+cmake ../android \
+  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_DIR/build/cmake/android.toolchain.cmake \
+  -DANDROID_ABI=x86_64 \
+  -DANDROID_PLATFORM=android-31 \
+  -Dfbjni_DIR=$ANDROID_PREFAB_CMAKE_DIR/fbjni \
+  -DReactAndroid_DIR=$ANDROID_PREFAB_CMAKE_DIR/ReactAndroid \
+  -Dhermes-engine_DIR=$ANDROID_PREFAB_CMAKE_DIR/hermes-engine \
+  -DREACT_NATIVE_MINOR_VERSION=72 \
+  -DJS_RUNTIME=hermes \
+  -DREACT_NATIVE_DIR=../node_modules/react-native \
+  -DIS_NEW_ARCHITECTURE_ENABLED=1 \
+  -DHERMES_ENABLE_DEBUGGER=1 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCHECK_HEADERS=1
+
+make -j8


### PR DESCRIPTION
## Summary

Script for checking whether all headers in Common directory are self-sufficient, i.e. really includes whatever is needed by them.

Currently it needs to have android prefab extracted somewhere and path to it set as `ANDROID_PREFAB_CMAKE_DIR` in `scripts/headers-sufficiency-check.sh`. For testing purposes I've built android `FabricExample` app and taken prefab from one of downloaded dirs.

It also need to have Android NDK path set in the script.

What's needed is integration with CI pipelines.

## Test plan

None
