### PR TITLE
Fix sensors on macOS

### DIFF
--- a/apple/sensor/ReanimatedSensor.m
+++ b/apple/sensor/ReanimatedSensor.m
@@ -218,7 +218,10 @@
 
 @implementation ReanimatedSensor
 
-- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+- (instancetype)init:(ReanimatedSensorType)sensorType
+             interval:(int)interval
+    iosReferenceFrame:(int)iosReferenceFrame
+               setter:(void (^)(double[], int))setter
 {
   self = [super init];
   return self;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Previously, the app crashed whenever `useAnimatedSensor` was called on macOS. This PR fix this issue by creating proper `init` method in `ReanimatedSensor.m`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Tested on macOS with sensor example.
