### PR TITLE
Notify users to run `setNativeProps` on the UI runtime

### DIFF
--- a/src/reanimated2/SetNativeProps.ts
+++ b/src/reanimated2/SetNativeProps.ts
@@ -28,7 +28,7 @@ if (isWeb()) {
     'worklet';
     if (!_WORKLET) {
       console.warn(
-        '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
+        '[Reanimated] setNativeProps() can only be used on the UI runtime.'
       );
       return;
     }
@@ -42,7 +42,7 @@ if (isWeb()) {
     'worklet';
     if (!_WORKLET) {
       console.warn(
-        '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
+        '[Reanimated] setNativeProps() can only be used on the UI runtime.'
       );
       return;
     }
@@ -55,17 +55,17 @@ if (isWeb()) {
 } else if (isChromeDebugger()) {
   setNativeProps = () => {
     console.warn(
-      '[Reanimated] `setNativeProps` is not supported with Chrome Debugger.'
+      '[Reanimated] setNativeProps() is not supported with Chrome Debugger.'
     );
   };
 } else if (isJest()) {
   setNativeProps = () => {
-    console.warn('[Reanimated] `setNativeProps` is not supported with Jest.');
+    console.warn('[Reanimated] setNativeProps() is not supported with Jest.');
   };
 } else {
   setNativeProps = () => {
     console.warn(
-      '[Reanimated] `setNativeProps` is not supported on this configuration.'
+      '[Reanimated] setNativeProps() is not supported on this configuration.'
     );
   };
 }

--- a/src/reanimated2/SetNativeProps.ts
+++ b/src/reanimated2/SetNativeProps.ts
@@ -28,7 +28,7 @@ if (isWeb()) {
     'worklet';
     if (!_WORKLET) {
       throw new Error(
-        '[Reanimated] `setNativeProps` can only be used on the UI runtime. Please call the function with `runOnUI` or run it in a worklet instead.'
+        '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
       );
     }
     const shadowNodeWrapper = (animatedRef as any)() as ShadowNodeWrapper;
@@ -41,7 +41,7 @@ if (isWeb()) {
     'worklet';
     if (!_WORKLET) {
       throw new Error(
-        '[Reanimated] `setNativeProps` can only be used on the UI runtime. Please call the function with `runOnUI` or run it in a worklet instead.'
+        '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
       );
     }
     const tag = (animatedRef as any)() as number;

--- a/src/reanimated2/SetNativeProps.ts
+++ b/src/reanimated2/SetNativeProps.ts
@@ -27,9 +27,10 @@ if (isWeb()) {
   setNativeProps = (animatedRef, updates) => {
     'worklet';
     if (!_WORKLET) {
-      throw new Error(
+      console.warn(
         '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
       );
+      return;
     }
     const shadowNodeWrapper = (animatedRef as any)() as ShadowNodeWrapper;
     processColorsInProps(updates);
@@ -40,9 +41,10 @@ if (isWeb()) {
   setNativeProps = (animatedRef, updates) => {
     'worklet';
     if (!_WORKLET) {
-      throw new Error(
+      console.warn(
         '[Reanimated] `setNativeProps` can only be used on the UI runtime.'
       );
+      return;
     }
     const tag = (animatedRef as any)() as number;
     const name = (animatedRef as any).viewName.value;
@@ -53,17 +55,17 @@ if (isWeb()) {
 } else if (isChromeDebugger()) {
   setNativeProps = () => {
     console.warn(
-      '[Reanimated] setNativeProps() is not supported with Chrome Debugger.'
+      '[Reanimated] `setNativeProps` is not supported with Chrome Debugger.'
     );
   };
 } else if (isJest()) {
   setNativeProps = () => {
-    console.warn('[Reanimated] setNativeProps() is not supported with Jest.');
+    console.warn('[Reanimated] `setNativeProps` is not supported with Jest.');
   };
 } else {
   setNativeProps = () => {
     console.warn(
-      '[Reanimated] setNativeProps() is not supported on this configuration.'
+      '[Reanimated] `setNativeProps` is not supported on this configuration.'
     );
   };
 }

--- a/src/reanimated2/SetNativeProps.ts
+++ b/src/reanimated2/SetNativeProps.ts
@@ -26,6 +26,11 @@ if (isWeb()) {
 } else if (IS_NATIVE && global._IS_FABRIC) {
   setNativeProps = (animatedRef, updates) => {
     'worklet';
+    if (!_WORKLET) {
+      throw new Error(
+        '[Reanimated] `setNativeProps` can only be used on the UI runtime. Please call the function with `runOnUI` or run it in a worklet instead.'
+      );
+    }
     const shadowNodeWrapper = (animatedRef as any)() as ShadowNodeWrapper;
     processColorsInProps(updates);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -34,6 +39,11 @@ if (isWeb()) {
 } else if (IS_NATIVE) {
   setNativeProps = (animatedRef, updates) => {
     'worklet';
+    if (!_WORKLET) {
+      throw new Error(
+        '[Reanimated] `setNativeProps` can only be used on the UI runtime. Please call the function with `runOnUI` or run it in a worklet instead.'
+      );
+    }
     const tag = (animatedRef as any)() as number;
     const name = (animatedRef as any).viewName.value;
     processColorsInProps(updates);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds a check whether the user calls `setNativeProps` on the UI runtime. Currently, running `setNativeProps` from JS thread results in a non-relevant runtime crash.

## Test plan

```jsx
import React from 'react';
import Animated, {
  runOnUI,
  setNativeProps,
  useAnimatedRef,
} from 'react-native-reanimated';
import { Button, StyleSheet, View } from 'react-native';

export default function Example() {
  const animatedRef = useAnimatedRef<TextInput>();

  const handlePress = () => {
    // runOnUI(() => {
    setNativeProps(animatedRef, { backgroundColor: 'blue' });
    // })();
  };

  return (
    <View style={styles.container}>
      <Animated.View ref={animatedRef} style={styles.box} />
      <Button title="set native prop" onPress={handlePress} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: { width: 100, height: 100, backgroundColor: 'red' },
});

```
