### PR TITLE
Add missing HostObject serialization in `makeShareableCloneOnUIRecursive`

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -66,6 +66,9 @@ jsi::Value makeShareableClone(
         shareable = std::make_shared<ShareableArray>(rt, object.asArray(rt));
       }
     } else if (object.isHostObject(rt)) {
+      if (object.isHostObject<ShareableJSRef>(rt)) {
+        return object;
+      }
       shareable =
           std::make_shared<ShareableHostObject>(rt, object.getHostObject(rt));
     } else {

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -109,6 +109,8 @@ std::shared_ptr<Shareable> extractShareableOrThrow(
     if (object.isHostObject<ShareableJSRef>(rt)) {
       return object.getHostObject<ShareableJSRef>(rt)->value();
     }
+    throw std::runtime_error(
+        "[Reanimated] Attempted to extract from a HostObject that wasn't converted to a Shareable.");
   } else if (maybeShareableValue.isUndefined()) {
     return Shareable::undefined();
   }

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -66,9 +66,9 @@ jsi::Value makeShareableClone(
         shareable = std::make_shared<ShareableArray>(rt, object.asArray(rt));
       }
     } else if (object.isHostObject(rt)) {
-      if (object.isHostObject<ShareableJSRef>(rt)) {
-        return object;
-      }
+      assert(
+          !object.isHostObject<ShareableJSRef>(rt) &&
+          "[Reanimated] Provided value is already an instance of ShareableJSRef.");
       shareable =
           std::make_shared<ShareableHostObject>(rt, object.getHostObject(rt));
     } else {

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1429,7 +1429,7 @@ SPEC CHECKSUMS:
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: f9bf9719258926aea9ecb8a2aa2595d3ff9a6022
-  React-RCTAppDelegate: 18d2a523f986aa3e073c68b52cc0d4cd494a9d94
+  React-RCTAppDelegate: dcb6303ebc89ef21497aad78e974ed886431cfae
   React-RCTBlob: c4f1e69a6ef739aa42586b876d637dab4e3b5bed
   React-RCTFabric: 125e7d77057cb62f94e79ac977fd68be042a3bc5
   React-RCTImage: e5798f01aba248416c02a506cf5e6dfcba827638

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -1429,7 +1429,7 @@ SPEC CHECKSUMS:
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: f9bf9719258926aea9ecb8a2aa2595d3ff9a6022
-  React-RCTAppDelegate: 2191e9b272d62a2e2828e8dd7ea0100763351f6e
+  React-RCTAppDelegate: 18d2a523f986aa3e073c68b52cc0d4cd494a9d94
   React-RCTBlob: c4f1e69a6ef739aa42586b876d637dab4e3b5bed
   React-RCTFabric: 125e7d77057cb62f94e79ac977fd68be042a3bc5
   React-RCTImage: e5798f01aba248416c02a506cf5e6dfcba827638

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -273,9 +273,14 @@ export function makeShareableCloneOnUIRecursive<T>(
       typeof value === 'function'
     ) {
       if (isHostObject(value)) {
+        // We call `_makeShareableClone` because provided HostObject
+        // might not be a Shareable.
         return _makeShareableClone(value) as FlatShareableRef<T>;
       }
       if (isRemoteFunction<T>(value)) {
+        // RemoteFunctions are created by us therefore they are
+        // a Shareable out of the box and there is no need to
+        // call `_makeShareableClone`.
         return value.__remoteFunction;
       }
       if (Array.isArray(value)) {

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -273,7 +273,7 @@ export function makeShareableCloneOnUIRecursive<T>(
       typeof value === 'function'
     ) {
       if (isHostObject(value)) {
-        return value as FlatShareableRef<T>;
+        return _makeShareableClone(value) as FlatShareableRef<T>;
       }
       if (isRemoteFunction<T>(value)) {
         return value.__remoteFunction;

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -273,8 +273,8 @@ export function makeShareableCloneOnUIRecursive<T>(
       typeof value === 'function'
     ) {
       if (isHostObject(value)) {
-        // We call `_makeShareableClone` because provided HostObject
-        // might not be a Shareable.
+        // We call `_makeShareableClone` to wrap the provided HostObject
+        // inside ShareableJSRef.
         return _makeShareableClone(value) as FlatShareableRef<T>;
       }
       if (isRemoteFunction<T>(value)) {

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -275,7 +275,9 @@ export function makeShareableCloneOnUIRecursive<T>(
       if (isHostObject(value)) {
         // We call `_makeShareableClone` because provided HostObject
         // might not be a Shareable.
-        return _makeShareableClone(value) as FlatShareableRef<T>;
+        return _makeShareableClone(
+          _makeShareableClone(value)
+        ) as FlatShareableRef<T>;
       }
       if (isRemoteFunction<T>(value)) {
         // RemoteFunctions are created by us therefore they are

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -275,9 +275,7 @@ export function makeShareableCloneOnUIRecursive<T>(
       if (isHostObject(value)) {
         // We call `_makeShareableClone` because provided HostObject
         // might not be a Shareable.
-        return _makeShareableClone(
-          _makeShareableClone(value)
-        ) as FlatShareableRef<T>;
+        return _makeShareableClone(value) as FlatShareableRef<T>;
       }
       if (isRemoteFunction<T>(value)) {
         // RemoteFunctions are created by us therefore they are


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

#4617 Changed the logic of `makeShareableCloneOnUIRecursive`, detecting if the object is a `HostObject` and skipping its serialization, on the assumption that it's already good to go. This caused crashes in `extractShareableOrThrow` due to how `isHostObject<T>` function works - it not only checks if the object is a `HostObject` but also if it's of type `T`.

<img width="631" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/40713406/64879db2-fdbb-4d8c-89f3-a37d97535d4f">

Therefore, given a `HostObject` from `react-native`, in this case `ShadowNodeWrapper` on Fabric, it wasn't converted to our `Shareable` type and failed the second check in `extractShareableOrThrow`.

Big thanks to @piaskowyk who debugged the most of it 🥳 

## Test plan

See that without the change in `makeShareableCloneOnUIRecursive` the new error is thrown.

## Note

I have added some (seemingly) unnecessary `HostObject` creation elision, please check if it's relevant to the problem or maybe should be deleted or expanded.
