### PR TITLE
Work in progress on library/annotate mode

### DIFF
--- a/plugin/src/makeWorklet.ts
+++ b/plugin/src/makeWorklet.ts
@@ -15,6 +15,8 @@ import {
   assignmentExpression,
   blockStatement,
   cloneNode,
+  directive,
+  directiveLiteral,
   expressionStatement,
   functionExpression,
   identifier,
@@ -46,6 +48,8 @@ import { isRelease } from './utils';
 
 const REAL_VERSION = require('../../package.json').version;
 const MOCK_VERSION = 'x.y.z';
+
+export const WORKLET_DIRECTIVE = directive(directiveLiteral('worklet'));
 
 export function makeWorklet(
   fun: NodePath<WorkletizableFunction>,

--- a/plugin/src/processIfWorkletNode.ts
+++ b/plugin/src/processIfWorkletNode.ts
@@ -4,7 +4,7 @@ import type { BlockStatement } from '@babel/types';
 import { processIfWorkletFunction } from './processIfWorkletFunction';
 import type { ExplicitWorklet, ReanimatedPluginPass } from './types';
 
-function hasWorkletDirective(directives: BlockStatement['directives']) {
+export function hasWorkletDirective(directives: BlockStatement['directives']) {
   return (
     directives &&
     directives.length > 0 &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This pull request is a work in progress attempt to tune the existing babel plugin to only inject `"worklet"` directives when building a library using reanimated.

The rational behind this work comes from https://github.com/software-mansion/react-native-reanimated/discussions/4979

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
