### PR TITLE
Clear PropKeysManagedByAnimated register

### DIFF
--- a/apple/REANodesManager.mm
+++ b/apple/REANodesManager.mm
@@ -431,16 +431,16 @@ using namespace facebook::react;
 {
   // adapted from RCTPropsAnimatedNode.m
   RCTSurfacePresenter *surfacePresenter = _bridge.surfacePresenter ?: _surfacePresenter;
-  // `synchronouslyUpdateViewOnUIThread` does not flush props like `backgroundColor` etc.
-  // so that's why we need to call `finalizeUpdates` here.
   RCTComponentViewRegistry *componentViewRegistry = surfacePresenter.mountingManager.componentViewRegistry;
   REAUIView<RCTComponentViewProtocol> *componentView =
       [componentViewRegistry findComponentViewWithTag:[viewTag integerValue]];
 
-  NSSet<NSString *> *rnAnimatedProps = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
+  NSSet<NSString *> *propKeysManagedByAnimated = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
   [surfacePresenter synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
-  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:rnAnimatedProps];
+  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:propKeysManagedByAnimated];
 
+  // `synchronouslyUpdateViewOnUIThread` does not flush props like `backgroundColor` etc.
+  // so that's why we need to call `finalizeUpdates` here.
   [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
 }
 

--- a/apple/REANodesManager.mm
+++ b/apple/REANodesManager.mm
@@ -431,13 +431,16 @@ using namespace facebook::react;
 {
   // adapted from RCTPropsAnimatedNode.m
   RCTSurfacePresenter *surfacePresenter = _bridge.surfacePresenter ?: _surfacePresenter;
-  [surfacePresenter synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
-
   // `synchronouslyUpdateViewOnUIThread` does not flush props like `backgroundColor` etc.
   // so that's why we need to call `finalizeUpdates` here.
   RCTComponentViewRegistry *componentViewRegistry = surfacePresenter.mountingManager.componentViewRegistry;
   REAUIView<RCTComponentViewProtocol> *componentView =
       [componentViewRegistry findComponentViewWithTag:[viewTag integerValue]];
+
+  NSSet<NSString *> *rnAnimatedProps = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
+  [surfacePresenter synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
+  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:rnAnimatedProps];
+
   [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
 }
 


### PR DESCRIPTION
## Summary

The `synchronouslyUpdateViewOnUIThread` method adds all received props to the `propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN` registry. If some style prop is added to this registry, then it is unable to animate it from the commit hook. This PR prevents to addition of props managed by Reanimated to the `propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN` registry. A similar solution exists in the RN codebase: https://github.com/facebook/react-native/blob/850349b1d274f0cc2595eee2f6bb361a958bb2e2/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm#L308-L310

Related PR:
- https://github.com/facebook/react-native/commit/b2c022ec54f094f84407151bb2756e1cb7202bc4
- https://github.com/facebook/react-native/commit/c642afd97d2f0ce7657405d72538cecaefadc036

## Test plan
Run "Animate stack color" example on iOS/Fabric
