### PR TITLE
Finish clamped spring animation

### DIFF
--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -78,6 +78,10 @@ export const withSpring = ((
     ): boolean {
       const { toValue, startTimestamp, current } = animation;
 
+      if (current === toValue) {
+        return true;
+      }
+
       const timeFromStart = now - startTimestamp;
 
       if (config.useDuration && timeFromStart >= config.duration) {
@@ -85,7 +89,7 @@ export const withSpring = ((
 
         // clear lastTimestamp to avoid using stale value by the next spring animation that starts after this one
         animation.lastTimestamp = 0;
-        return true;
+        return false;
       }
 
       if (config.configIsInvalid) {
@@ -94,7 +98,7 @@ export const withSpring = ((
         else {
           animation.current = toValue;
           animation.lastTimestamp = 0;
-          return true;
+          return false;
         }
       }
       const { lastTimestamp, velocity } = animation;
@@ -139,7 +143,7 @@ export const withSpring = ((
         animation.current = toValue;
         // clear lastTimestamp to avoid using stale value by the next spring animation that starts after this one
         animation.lastTimestamp = 0;
-        return true;
+        return false;
       }
 
       return false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Disclaimer:
I'm unsure if this is a bug in the spring implementation or should be addressed elsewhere in the code, but it does happen only with `withSpring`, and kinda randomly, I could not reproduce it with `withTiming`.

While developing the screen transition animation, I noticed that the animation would stop near the end and then we unmount the screen, but it would never just finish completely. After some investigation, realized that the reason for that is the `restDisplacementThreshold` flag in the spring animation. 

When I tried to log the values in both my `useAnimatedStyle` and `springOnFrame` callback, I realized that useAnimatedStyle is never called with the end values.

```
 LOG  0
 LOG  0.054379944363520116
 LOG  0.17171456096392557
 LOG  0.3075683139784404
 LOG  0.4390611486117857
 LOG  0.5557570807744285
 LOG  0.6541357679058646
 LOG  0.7342995250647393
 LOG  0.798059955279234
 LOG  0.8478644812657916
 LOG  0.8862253751352963
 LOG  0.9154425173610802
 LOG  0.93749238762078
 LOG  0.9540066834990276
 LOG  0.966295548106543
 LOG  0.9753897143466889
 LOG  0.982087551556752
 LOG  0.9869998817539096
 LOG  0.990589401501771
 LOG  0.9932037270600896
 LOG  springIsNotInMove current: 0.9951022153102753, toValue: 1
 ```
 
 Notice there is no log after last `springIsNotInMove` - since `useAnimatedStyle` was not called with the ending `toValue = 1`.
 
 This happens since even if we assign `toValue` to the animation, the frame is never called again since we return `true` from the frame and the animation runner code thinks that it's finished and we don't really need to call it again, but that's not true - we do need to call all the mappers again with the resulting values.
 


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
