### PR TITLE
Use strict everywhere

### DIFF
--- a/src/Animated.ts
+++ b/src/Animated.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Extrapolate as _Extrapolate } from './reanimated2/interpolateColor';
 import type { SharedValue as _SharedValue } from './reanimated2/commonTypes';
 import type { DerivedValue as _DerivedValue } from './reanimated2/hook/useDerivedValue';

--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { configureProps as jsiConfigureProps } from './reanimated2/core';
 
 /**

--- a/src/animationBuilder.tsx
+++ b/src/animationBuilder.tsx
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   ILayoutAnimationBuilder,
   LayoutAnimationFunction,

--- a/src/createAnimatedComponent/JSPropUpdater.ts
+++ b/src/createAnimatedComponent/JSPropUpdater.ts
@@ -1,3 +1,4 @@
+'use strict';
 import {
   NativeEventEmitter,
   NativeModules,

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   Component,
   ComponentClass,

--- a/src/createAnimatedComponent/setAndForwardRef.ts
+++ b/src/createAnimatedComponent/setAndForwardRef.ts
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * imported from react-native
  */

--- a/src/createAnimatedComponent/utils.ts
+++ b/src/createAnimatedComponent/utils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Ref, Component } from 'react';
 import type {
   StyleProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 import * as Animated from './Animated';
 
 export * from './reanimated2';

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,2 +1,3 @@
+'use strict';
 export * from './reanimated2';
 export * as default from './Animated'; // If this line fails, you probably forgot some installation steps. Check out the installation guide here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started#installation 1) Make sure reanimated's babel plugin is installed in your babel.config.js (you should have 'react-native-reanimated/plugin' listed there - also see the above link for details) 2) Make sure you reset build cache after updating the config, run: yarn start --reset-cache

--- a/src/reanimated2/Bezier.ts
+++ b/src/reanimated2/Bezier.ts
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * https://github.com/gre/bezier-easing
  * BezierEasing - use bezier curve for transition easing function

--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * Copied from:
  * react-native/Libraries/StyleSheet/normalizeColor.js

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { Bezier } from './Bezier';
 
 /**

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { MeasuredDimensions, ShadowNodeWrapper } from './commonTypes';
 import {
   isChromeDebugger,

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { NativeModules } from 'react-native';
 import type {
   ShareableRef,

--- a/src/reanimated2/NativeReanimated/index.ts
+++ b/src/reanimated2/NativeReanimated/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 import reanimatedJS from '../js-reanimated';
 import { shouldBeUseWeb } from '../PlatformChecker';
 import { NativeReanimated } from './NativeReanimated';

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { Platform } from 'react-native';
 
 export function isJest(): boolean {

--- a/src/reanimated2/PropAdapters.ts
+++ b/src/reanimated2/PropAdapters.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { addWhitelistedNativeProps } from '../ConfigHelper';
 import type { __AdapterWorkletFunction } from './commonTypes';
 import type { AnimatedPropsAdapterFunction } from './helperTypes';

--- a/src/reanimated2/PropsRegistry.ts
+++ b/src/reanimated2/PropsRegistry.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { runOnUI } from './threads';
 
 let viewTags: number[] = [];

--- a/src/reanimated2/Sensor.ts
+++ b/src/reanimated2/Sensor.ts
@@ -1,3 +1,4 @@
+'use strict';
 import NativeReanimatedModule from './NativeReanimated';
 import type {
   SensorConfig,

--- a/src/reanimated2/SensorContainer.ts
+++ b/src/reanimated2/SensorContainer.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   SensorType,
   SensorConfig,

--- a/src/reanimated2/SetNativeProps.ts
+++ b/src/reanimated2/SetNativeProps.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { ShadowNodeWrapper, StyleProps } from './commonTypes';
 import {
   isChromeDebugger,

--- a/src/reanimated2/UpdateProps.ts
+++ b/src/reanimated2/UpdateProps.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { MutableRefObject } from 'react';
 import { processColorsInProps } from './Colors';
 import type { ShadowNodeWrapper, SharedValue, StyleProps } from './commonTypes';

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useRef } from 'react';
 import { makeMutable } from './core';
 import type { SharedValue } from './commonTypes';

--- a/src/reanimated2/WorkletEventHandler.ts
+++ b/src/reanimated2/WorkletEventHandler.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { NativeEvent } from './commonTypes';
 import NativeReanimatedModule from './NativeReanimated';
 import { registerEventHandler, unregisterEventHandler } from './core';

--- a/src/reanimated2/animation/commonTypes.ts
+++ b/src/reanimated2/animation/commonTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   StyleProps,
   AnimatableValue,

--- a/src/reanimated2/animation/decay.ts
+++ b/src/reanimated2/animation/decay.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation, getReduceMotionForAnimation } from './util';
 import type {
   Animation,

--- a/src/reanimated2/animation/delay.ts
+++ b/src/reanimated2/animation/delay.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation, getReduceMotionForAnimation } from './util';
 import type {
   Animation,

--- a/src/reanimated2/animation/index.ts
+++ b/src/reanimated2/animation/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 export type {
   HigherOrderAnimation,
   NextAnimation,

--- a/src/reanimated2/animation/repeat.ts
+++ b/src/reanimated2/animation/repeat.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation, getReduceMotionForAnimation } from './util';
 import type {
   Animation,

--- a/src/reanimated2/animation/sequence.ts
+++ b/src/reanimated2/animation/sequence.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation, getReduceMotionForAnimation } from './util';
 import type { NextAnimation, SequenceAnimation } from './commonTypes';
 import type {

--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation, getReduceMotionForAnimation } from './util';
 import type {
   Animation,

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   Animation,
   AnimatableValue,

--- a/src/reanimated2/animation/styleAnimation.ts
+++ b/src/reanimated2/animation/styleAnimation.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { defineAnimation } from './util';
 import type {
   Timestamp,

--- a/src/reanimated2/animation/timing.ts
+++ b/src/reanimated2/animation/timing.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { EasingFunction, EasingFunctionFactory } from '../Easing';
 import { Easing } from '../Easing';
 import { defineAnimation, getReduceMotionForAnimation } from './util';

--- a/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
+++ b/src/reanimated2/animation/transformationMatrix/matrixUtils.tsx
@@ -1,3 +1,4 @@
+'use strict';
 type FixedLengthArray<
   T,
   L extends number,

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { HigherOrderAnimation, StyleLayoutAnimation } from './commonTypes';
 import type { ParsedColorArray } from '../Colors';
 import {

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { ViewStyle, TextStyle } from 'react-native';
 
 export interface StyleProps extends ViewStyle, TextStyle {

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -1,3 +1,4 @@
+'use strict';
 import type { ForwardedRef } from 'react';
 import React, { Component, forwardRef } from 'react';
 import type { FlatListProps, LayoutChangeEvent } from 'react-native';

--- a/src/reanimated2/component/Image.ts
+++ b/src/reanimated2/component/Image.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { ImageProps } from 'react-native';
 import { Image } from 'react-native';
 import createAnimatedComponent from '../../createAnimatedComponent/createAnimatedComponent';

--- a/src/reanimated2/component/ScrollView.tsx
+++ b/src/reanimated2/component/ScrollView.tsx
@@ -1,3 +1,4 @@
+'use strict';
 import type { ForwardedRef, RefObject } from 'react';
 import React, { Component, forwardRef } from 'react';
 import type { ScrollViewProps } from 'react-native';

--- a/src/reanimated2/component/Text.ts
+++ b/src/reanimated2/component/Text.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { Component } from 'react';
 import type { TextProps } from 'react-native';
 import { Text } from 'react-native';

--- a/src/reanimated2/component/View.ts
+++ b/src/reanimated2/component/View.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { ViewProps } from 'react-native';
 import { View } from 'react-native';
 import createAnimatedComponent from '../../createAnimatedComponent/createAnimatedComponent';

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -1,3 +1,4 @@
+'use strict';
 import NativeReanimatedModule from './NativeReanimated';
 import { nativeShouldBeMock, isWeb } from './PlatformChecker';
 import type {

--- a/src/reanimated2/errors.ts
+++ b/src/reanimated2/errors.ts
@@ -1,3 +1,4 @@
+'use strict';
 type StackDetails = [Error, number, number];
 
 const _workletStackDetails = new Map<number, StackDetails>();

--- a/src/reanimated2/fabricUtils.ts
+++ b/src/reanimated2/fabricUtils.ts
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-disable camelcase */
 
 import type { ShadowNodeWrapper } from './commonTypes';

--- a/src/reanimated2/fabricUtils.web.ts
+++ b/src/reanimated2/fabricUtils.web.ts
@@ -1,3 +1,4 @@
+'use strict';
 export function getShadowNodeWrapperFromRef() {
   throw new Error(
     '[Reanimated] Trying to call `getShadowNodeWrapperFromRef` on web.'

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryJS.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { runOnUI } from '../core';
 import type { FrameInfo } from './FrameCallbackRegistryUI';
 import { prepareUIRegistry } from './FrameCallbackRegistryUI';

--- a/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
+++ b/src/reanimated2/frameCallback/FrameCallbackRegistryUI.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { runOnUIImmediately } from '../threads';
 
 type CallbackDetails = {

--- a/src/reanimated2/frameCallback/index.ts
+++ b/src/reanimated2/frameCallback/index.ts
@@ -1,1 +1,2 @@
+'use strict';
 export type { FrameInfo } from './FrameCallbackRegistryUI';

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-var */
+'use strict';
 import type {
   StyleProps,
   MeasuredDimensions,

--- a/src/reanimated2/helperTypes.ts
+++ b/src/reanimated2/helperTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 /*
 This file is a legacy remainder of manual types from react-native-reanimated.d.ts file. 
 I wasn't able to get rid of all of them from the code. 

--- a/src/reanimated2/hook/Hooks.ts
+++ b/src/reanimated2/hook/Hooks.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useCallback } from 'react';
 import { useAnimatedStyle } from './useAnimatedStyle';
 import type { DependencyList } from './commonTypes';

--- a/src/reanimated2/hook/commonTypes.ts
+++ b/src/reanimated2/hook/commonTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Component } from 'react';
 import type { __Context, ShadowNodeWrapper } from '../commonTypes';
 import type { ImageStyle, TextStyle, ViewStyle } from 'react-native';

--- a/src/reanimated2/hook/index.ts
+++ b/src/reanimated2/hook/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 export type { DependencyList, AnimatedRef } from './commonTypes';
 export {
   useAnimatedProps,

--- a/src/reanimated2/hook/useAnimatedGestureHandler.ts
+++ b/src/reanimated2/hook/useAnimatedGestureHandler.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { __Context, __WorkletFunction, NativeEvent } from '../commonTypes';
 import type { DependencyList } from './commonTypes';
 import { useEvent, useHandler } from './Hooks';

--- a/src/reanimated2/hook/useAnimatedKeyboard.ts
+++ b/src/reanimated2/hook/useAnimatedKeyboard.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect, useRef } from 'react';
 import {
   makeMutable,

--- a/src/reanimated2/hook/useAnimatedReaction.ts
+++ b/src/reanimated2/hook/useAnimatedReaction.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect } from 'react';
 import type { __BasicWorkletFunction, __WorkletFunction } from '../commonTypes';
 import { startMapper, stopMapper } from '../core';

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Component } from 'react';
 import { useRef } from 'react';
 import { useSharedValue } from './useSharedValue';

--- a/src/reanimated2/hook/useAnimatedScrollHandler.ts
+++ b/src/reanimated2/hook/useAnimatedScrollHandler.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { RefObject } from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import type { __Context, NativeEvent, __WorkletFunction } from '../commonTypes';

--- a/src/reanimated2/hook/useAnimatedSensor.ts
+++ b/src/reanimated2/hook/useAnimatedSensor.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect, useRef } from 'react';
 import { initializeSensor, registerSensor, unregisterSensor } from '../core';
 import type {

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { MutableRefObject } from 'react';
 import { useEffect, useRef } from 'react';
 

--- a/src/reanimated2/hook/useDerivedValue.ts
+++ b/src/reanimated2/hook/useDerivedValue.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect, useRef } from 'react';
 import { initialUpdaterRun } from '../animation';
 import type { __BasicWorkletFunction, SharedValue } from '../commonTypes';

--- a/src/reanimated2/hook/useFrameCallback.ts
+++ b/src/reanimated2/hook/useFrameCallback.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect, useRef } from 'react';
 import FrameCallbackRegistryJS from '../frameCallback/FrameCallbackRegistryJS';
 import type { FrameInfo } from '../frameCallback/FrameCallbackRegistryUI';

--- a/src/reanimated2/hook/useReducedMotion.ts
+++ b/src/reanimated2/hook/useReducedMotion.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { isReducedMotion } from '../PlatformChecker';
 
 const IS_REDUCED_MOTION = isReducedMotion();

--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { RefObject } from 'react';
 import { useEffect, useRef } from 'react';
 

--- a/src/reanimated2/hook/useSharedValue.ts
+++ b/src/reanimated2/hook/useSharedValue.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { useEffect, useRef } from 'react';
 import { cancelAnimation } from '../animation';
 import type { SharedValue } from '../commonTypes';

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { MutableRefObject } from 'react';
 import { useEffect, useRef } from 'react';
 import type {

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 import './publicGlobals';
 
 export {

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { reportFatalErrorOnJS } from './errors';
 import { isChromeDebugger, isJest, shouldBeUseWeb } from './PlatformChecker';
 import {

--- a/src/reanimated2/interpolateColor.ts
+++ b/src/reanimated2/interpolateColor.ts
@@ -1,3 +1,4 @@
+'use strict';
 import {
   hsvToColor,
   RGBtoHSV,

--- a/src/reanimated2/interpolation.ts
+++ b/src/reanimated2/interpolation.ts
@@ -1,3 +1,4 @@
+'use strict';
 export enum Extrapolation {
   IDENTITY = 'identity',
   CLAMP = 'clamp',

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+'use strict';
 
 import { isJest } from './PlatformChecker';
 

--- a/src/reanimated2/jestUtils.web.ts
+++ b/src/reanimated2/jestUtils.web.ts
@@ -1,3 +1,4 @@
+'use strict';
 /*
  * Stubbed for web, where we don't use this file;
  */

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -1,3 +1,4 @@
+'use strict';
 import {
   isChromeDebugger,
   isJest,

--- a/src/reanimated2/js-reanimated/MutableValue.ts
+++ b/src/reanimated2/js-reanimated/MutableValue.ts
@@ -1,3 +1,4 @@
+'use strict';
 export default class MutableValue<T> {
   static MUTABLE_ID = 1;
   _id: number;

--- a/src/reanimated2/js-reanimated/WebSensor.ts
+++ b/src/reanimated2/js-reanimated/WebSensor.ts
@@ -1,3 +1,4 @@
+'use strict';
 export declare class WebSensor {
   start: () => void;
   stop: () => void;

--- a/src/reanimated2/js-reanimated/commonTypes.ts
+++ b/src/reanimated2/js-reanimated/commonTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Timestamp, NestedObjectValues } from '../commonTypes';
 import type MutableValue from './MutableValue';
 

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 import JSReanimated from './JSReanimated';
 import type { StyleProps } from '../commonTypes';
 import type { AnimatedStyle } from '../helperTypes';

--- a/src/reanimated2/js-reanimated/react-native-web.d.ts
+++ b/src/reanimated2/js-reanimated/react-native-web.d.ts
@@ -1,2 +1,3 @@
+'use strict';
 declare module 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle';
 declare module 'react-native-web/dist/exports/StyleSheet/preprocess';

--- a/src/reanimated2/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withDelay } from '../../animation';
 import type {
   EntryExitAnimationFunction,

--- a/src/reanimated2/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withTiming, withSpring } from '../../animation';
 import type {
   AnimationFunction,

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { EasingFunction } from '../../Easing';
 import { Easing } from '../../Easing';
 import { withDelay, withSequence, withTiming } from '../../animation';

--- a/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/commonTypes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { TransformArrayItem } from '../../helperTypes';
 import type { EasingFunction } from '../../Easing';
 import type { StyleProps } from '../../commonTypes';

--- a/src/reanimated2/layoutReanimation/animationBuilder/index.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 export { BaseAnimationBuilder } from './BaseAnimationBuilder';
 export { ComplexAnimationBuilder } from './ComplexAnimationBuilder';
 export { Keyframe } from './Keyframe';

--- a/src/reanimated2/layoutReanimation/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/animationsManager.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withStyleAnimation } from '../animation/styleAnimation';
 import type { SharedValue } from '../commonTypes';
 import { makeUIMutable } from '../mutables';

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   IEntryExitAnimationBuilder,
   EntryExitAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   IEntryExitAnimationBuilder,
   EntryExitAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withSequence, withTiming } from '../../animation';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   EntryAnimationsValues,
   ExitAnimationsValues,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   IEntryExitAnimationBuilder,
   EntryExitAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   IEntryExitAnimationBuilder,
   EntryExitAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultAnimations/index.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 export * from './Flip';
 export * from './Stretch';
 export * from './Fade';

--- a/src/reanimated2/layoutReanimation/defaultTransitions/CurvedTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/CurvedTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   ILayoutAnimationBuilder,
   LayoutAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   ILayoutAnimationBuilder,
   LayoutAnimationsValues,

--- a/src/reanimated2/layoutReanimation/defaultTransitions/FadingTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/FadingTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withSequence, withTiming } from '../../animation';
 import type {
   ILayoutAnimationBuilder,

--- a/src/reanimated2/layoutReanimation/defaultTransitions/JumpingTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/JumpingTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type {
   ILayoutAnimationBuilder,
   LayoutAnimationFunction,

--- a/src/reanimated2/layoutReanimation/defaultTransitions/LinearTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/LinearTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type {

--- a/src/reanimated2/layoutReanimation/defaultTransitions/SequencedTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/SequencedTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withSequence, withTiming } from '../../animation';
 import type {
   ILayoutAnimationBuilder,

--- a/src/reanimated2/layoutReanimation/defaultTransitions/index.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 export * from './LinearTransition';
 export * from './FadingTransition';
 export * from './SequencedTransition';

--- a/src/reanimated2/layoutReanimation/index.ts
+++ b/src/reanimated2/layoutReanimation/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 import './animationsManager';
 export * from './animationBuilder';
 export * from './defaultAnimations';

--- a/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { runOnUIImmediately } from '../../threads';
 import type { ProgressAnimation } from '../animationBuilder/commonTypes';
 import { registerEventHandler, unregisterEventHandler } from '../../core';

--- a/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/SharedTransition.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { withTiming } from '../../animation';
 import type {
   SharedTransitionAnimationsFunction,

--- a/src/reanimated2/layoutReanimation/sharedTransitions/index.ts
+++ b/src/reanimated2/layoutReanimation/sharedTransitions/index.ts
@@ -1,2 +1,3 @@
+'use strict';
 export * from './SharedTransition';
 export * from './ProgressTransitionManager';

--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { SharedValue } from './commonTypes';
 import { isJest } from './PlatformChecker';
 import { runOnUI } from './threads';

--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -1,6 +1,8 @@
 /* eslint-disable node/no-callback-literal */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+'use strict';
+
 import { SensorType } from './commonTypes';
 
 const NOOP = () => {

--- a/src/reanimated2/mutables.ts
+++ b/src/reanimated2/mutables.ts
@@ -1,3 +1,4 @@
+'use strict';
 import NativeReanimatedModule from './NativeReanimated';
 import type { SharedValue, ShareableSyncDataHolderRef } from './commonTypes';
 import {

--- a/src/reanimated2/platform-specific/RNRenderer.ts
+++ b/src/reanimated2/platform-specific/RNRenderer.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
+'use strict';
 export { default as RNRenderer } from 'react-native/Libraries/Renderer/shims/ReactNative';

--- a/src/reanimated2/platform-specific/RNRenderer.web.ts
+++ b/src/reanimated2/platform-specific/RNRenderer.web.ts
@@ -1,2 +1,3 @@
+'use strict';
 // RNRender is not used for web. An export is still defined to eliminate warnings from bundlers such as esbuild.
 module.exports = null;

--- a/src/reanimated2/platform-specific/checkCppVersion.ts
+++ b/src/reanimated2/platform-specific/checkCppVersion.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { jsVersion } from './jsVersion';
 
 export function checkCppVersion() {

--- a/src/reanimated2/platform-specific/checkVersion.web.ts
+++ b/src/reanimated2/platform-specific/checkVersion.web.ts
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-disable @typescript-eslint/no-empty-function */
 /**
  * Checks that native and js versions of reanimated match.

--- a/src/reanimated2/platform-specific/jsVersion.ts
+++ b/src/reanimated2/platform-specific/jsVersion.ts
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * We hardcode the version of Reanimated here in order to compare it
  * with the version used to build the native part of the library in runtime.

--- a/src/reanimated2/pluginUtils.ts
+++ b/src/reanimated2/pluginUtils.ts
@@ -1,3 +1,4 @@
+'use strict';
 export function getUseOfValueInStyleWarning() {
   return (
     "It looks like you might be using shared value's .value inside reanimated inline style. " +

--- a/src/reanimated2/publicGlobals.ts
+++ b/src/reanimated2/publicGlobals.ts
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-disable no-var */
 export {};
 

--- a/src/reanimated2/runtimes.ts
+++ b/src/reanimated2/runtimes.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { __ComplexWorkletFunction } from './commonTypes';
 import { setupCallGuard, setupConsole } from './initializers';
 import NativeReanimatedModule from './NativeReanimated';

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -1,3 +1,4 @@
+'use strict';
 import NativeReanimatedModule from './NativeReanimated';
 import type {
   ShareableRef,

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -1,3 +1,4 @@
+'use strict';
 import NativeReanimatedModule from './NativeReanimated';
 import { isJest, shouldBeUseWeb } from './PlatformChecker';
 import type { WorkletFunction } from './commonTypes';

--- a/src/reanimated2/utils.ts
+++ b/src/reanimated2/utils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Component } from 'react';
 import { measure } from './NativeMethods';
 import type { AnimatedRef } from './hook/commonTypes';

--- a/src/reanimated2/valueSetter.ts
+++ b/src/reanimated2/valueSetter.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { AnimationObject, AnimatableValue } from './commonTypes';
 import type { Descriptor } from './hook/commonTypes';
 

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { shouldBeUseWeb } from './PlatformChecker';
 
 const IS_NATIVE = !shouldBeUseWeb();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I'm not sure if we need this pull request, but it only took me 
```bash
#!/bin/bash
for file in $(find . -type f \( -name "*.ts" -o -name "*.d.ts" \))
do
  sed -i '' -e $'1i\\\n'"'use strict';"$'\n' "$file"
done
```
to make it.

It would help us in the past when @bartlomiejbloniarz ran into issues when `Object.freeze` froze his object and he couldn't modify it - and without `use strict` this is a silent fail.

## Test plan

Many clicks in Example app.
