### PR TITLE
docs: typo in useAnimatedProps.mdx

### DIFF
--- a/docs/docs/core/useAnimatedProps.mdx
+++ b/docs/docs/core/useAnimatedProps.mdx
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # useAnimatedProps
 
-`useAnimatedStyle` lets you create an animated props object which can be animated using [shared values](/docs/fundamentals/glossary#shared-value). This object is used to animate properties of third-party components.
+`useAnimatedProps` lets you create an animated props object which can be animated using [shared values](/docs/fundamentals/glossary#shared-value). This object is used to animate properties of third-party components.
 
 For animating style use [`useAnimatedStyle`](/docs/core/useAnimatedStyle) instead.
 


### PR DESCRIPTION
Fixed small typo in [useAnimatedProps doc](https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedProps)

Should be `useAnimatedProps` instead of `useAnimatedStyle` I guess

![image](https://github.com/Roka20012/react-native-reanimated/assets/32239452/df10e59d-3c47-41d7-9aa9-eacbb713f080)