### PR TITLE
Fix `measure` crash on web

### DIFF
--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -21,6 +21,9 @@ if (isWeb()) {
     const element = (animatedRef as any)();
 
     if (element === -1) {
+      console.warn(
+        `[Reanimated] The view with tag ${element} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+      );
       return null;
     }
 

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -18,8 +18,13 @@ export let measure: <T extends Component>(
 
 if (isWeb()) {
   measure = (animatedRef) => {
-    const element = (animatedRef as any)() as HTMLElement; // TODO: fix typing of animated refs on web
-    const viewportOffset = element.getBoundingClientRect();
+    const element = (animatedRef as any)();
+
+    if (element === -1) {
+      return null;
+    }
+
+    const viewportOffset = (element as HTMLElement).getBoundingClientRect();
     return {
       width: element.offsetWidth,
       height: element.offsetHeight,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

While going through our example app I stumbled upon crash in "Article progress" example. Turns out that sometimes we try to call `getBoundingClientRect` on element that has not been rendered yet. This PR fixes this problem.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Tested on "Article progress" example.