### PR TITLE
fix Maximum call stack size exceeded

### DIFF
--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -254,9 +254,11 @@ type RemoteFunction<T> = {
   __remoteFunction: FlatShareableRef<T>;
 };
 
-function isRemoteFunction<T>(value: object): value is RemoteFunction<T> {
+function isRemoteFunction<T>(value: {
+  __remoteFunction?: unknown;
+}): value is RemoteFunction<T> {
   'worklet';
-  return '__remoteFunction' in value;
+  return !!value.__remoteFunction;
 }
 
 export function makeShareableCloneOnUIRecursive<T>(

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -196,6 +196,8 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
     | WorkletFunction<Args, ReturnValue>
 ): (...args: Args) => void {
   'worklet';
+  type FunWorklet = Extract<typeof fun, WorkletFunction<Args, ReturnValue>>;
+  type FunDevRemote = Extract<typeof fun, DevRemoteFunction<Args, ReturnValue>>;
   if (!IS_NATIVE || !_WORKLET) {
     // if we are already on the JS thread, we just schedule the worklet on the JS queue
     return (...args) =>
@@ -205,7 +207,7 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
           : (fun as () => ReturnValue)
       );
   }
-  if (fun.__workletHash) {
+  if ((fun as FunWorklet).__workletHash) {
     // If `fun` is a worklet, we schedule a call of a remote function `runWorkletOnJS`
     // and pass the worklet as a first argument followed by original arguments.
 
@@ -215,12 +217,12 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
         ...args
       );
   }
-  if (fun.__remoteFunction) {
+  if ((fun as FunDevRemote).__remoteFunction) {
     // In development mode the function provided as `fun` throws an error message
     // such that when someone accidentally calls it directly on the UI runtime, they
     // see that they should use `runOnJS` instead. To facilitate that we put the
     // reference to the original remote function in the `__functionInDEV` property.
-    fun = fun.__remoteFunction;
+    fun = (fun as FunDevRemote).__remoteFunction;
   }
   return (...args) => {
     _scheduleOnJS(

--- a/src/reanimated2/threads.ts
+++ b/src/reanimated2/threads.ts
@@ -205,7 +205,7 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
           : (fun as () => ReturnValue)
       );
   }
-  if ('__workletHash' in fun) {
+  if (fun.__workletHash) {
     // If `fun` is a worklet, we schedule a call of a remote function `runWorkletOnJS`
     // and pass the worklet as a first argument followed by original arguments.
 
@@ -215,7 +215,7 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
         ...args
       );
   }
-  if ('__remoteFunction' in fun) {
+  if (fun.__remoteFunction) {
     // In development mode the function provided as `fun` throws an error message
     // such that when someone accidentally calls it directly on the UI runtime, they
     // see that they should use `runOnJS` instead. To facilitate that we put the

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -1,5 +1,6 @@
 'use strict';
 import { shouldBeUseWeb } from './PlatformChecker';
+import type { WorkletFunction } from './commonTypes';
 
 const IS_NATIVE = !shouldBeUseWeb();
 
@@ -67,18 +68,21 @@ See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshoo
   }
 }
 
+type ValueUnpacker = WorkletFunction<
+  [objectToUnpack: any, category?: string],
+  any
+>;
+
 if (__DEV__ && IS_NATIVE) {
-  if (!('__workletHash' in valueUnpacker)) {
+  if (!(valueUnpacker as ValueUnpacker).__workletHash) {
     throw new Error('[Reanimated] `valueUnpacker` is not a worklet');
   }
-  // @ts-ignore TODO TYPESCRIPT
-  const closure = valueUnpacker.__closure;
+  const closure = (valueUnpacker as ValueUnpacker).__closure;
   if (closure !== undefined && Object.keys(closure).length !== 0) {
     throw new Error('[Reanimated] `valueUnpacker` must have empty closure');
   }
 }
 
 export function getValueUnpackerCode() {
-  // @ts-ignore TODO TYPESCRIPT
-  return valueUnpacker.__initData.code as string;
+  return (valueUnpacker as ValueUnpacker).__initData.code;
 }

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -74,7 +74,7 @@ type ValueUnpacker = WorkletFunction<
 >;
 
 if (__DEV__ && IS_NATIVE) {
-  if (!(valueUnpacker as ValueUnpacker).__workletHash) {
+  if (!('__workletHash' in valueUnpacker)) {
     throw new Error('[Reanimated] `valueUnpacker` is not a worklet');
   }
   const closure = (valueUnpacker as ValueUnpacker).__closure;


### PR DESCRIPTION
fixes 

- https://github.com/software-mansion/react-native-reanimated/issues/5067 
- https://github.com/software-mansion/react-native-reanimated/issues/5075
- https://github.com/software-mansion/react-native-reanimated/issues/5069
- https://github.com/software-mansion/react-native-reanimated/issues/5091

quoting @tjzel explanation just for reference
> The problem is with Cpp HostObjects, they always return true for in operator in JS and now we have more situations where those can be used as worklets. Therefore the only proper check is actually checking if value is truthy.

_had to skip git hooks due to typing errors_

PR that created this error:
#4794 
