### PR TITLE
Reduce file createAnimatedComponent - part3

### DIFF
--- a/src/createAnimatedComponent/PropsFilter.tsx
+++ b/src/createAnimatedComponent/PropsFilter.tsx
@@ -1,0 +1,93 @@
+'use strict';
+
+import type { StyleProps, SharedValue } from '../reanimated2';
+import { isSharedValue } from '../reanimated2';
+import { isChromeDebugger } from '../reanimated2/PlatformChecker';
+import WorkletEventHandler from '../reanimated2/WorkletEventHandler';
+import { initialUpdaterRun } from '../reanimated2/animation';
+import { hasInlineStyles, getInlineStyle } from './InlinePropManager';
+import type {
+  AnimatedComponentProps,
+  AnimatedProps,
+  InitialComponentProps,
+} from './utils';
+import { flattenArray, has } from './utils';
+import { StyleSheet } from 'react-native';
+
+function dummyListener() {
+  // empty listener we use to assign to listener properties for which animated
+  // event is used.
+}
+
+export class PropsFilter {
+  initialStyle = {};
+  _isFirstRender = true;
+
+  public filterNonAnimatedProps(
+    inputProps: AnimatedComponentProps<InitialComponentProps>
+  ): Record<string, unknown> {
+    const props: Record<string, unknown> = {};
+    for (const key in inputProps) {
+      const value = inputProps[key];
+      if (key === 'style') {
+        const styleProp = inputProps.style;
+        const styles = flattenArray<StyleProps>(styleProp ?? []);
+        const processedStyle: StyleProps = styles.map((style) => {
+          if (style && style.viewDescriptors) {
+            // this is how we recognize styles returned by useAnimatedStyle
+            style.viewsRef.add(this);
+            if (this._isFirstRender) {
+              this.initialStyle = {
+                ...style.initial.value,
+                ...this.initialStyle,
+                ...initialUpdaterRun<StyleProps>(style.initial.updater),
+              };
+            }
+            return this.initialStyle;
+          } else if (hasInlineStyles(style)) {
+            return getInlineStyle(style, this._isFirstRender);
+          } else {
+            return style;
+          }
+        });
+        props[key] = StyleSheet.flatten(processedStyle);
+      } else if (key === 'animatedProps') {
+        const animatedProp = inputProps.animatedProps as Partial<
+          AnimatedComponentProps<AnimatedProps>
+        >;
+        if (animatedProp.initial !== undefined) {
+          Object.keys(animatedProp.initial.value).forEach((key) => {
+            props[key] = animatedProp.initial?.value[key];
+            animatedProp.viewsRef?.add(this);
+          });
+        }
+      } else if (
+        has('current', value) &&
+        value.current instanceof WorkletEventHandler
+      ) {
+        if (value.current.eventNames.length > 0) {
+          value.current.eventNames.forEach((eventName) => {
+            props[eventName] = has('listeners', value.current)
+              ? (value.current.listeners as Record<string, unknown>)[eventName]
+              : dummyListener;
+          });
+        } else {
+          props[key] = dummyListener;
+        }
+      } else if (isSharedValue(value)) {
+        if (this._isFirstRender) {
+          props[key] = (value as SharedValue<any>).value;
+        }
+      } else if (key !== 'onGestureHandlerStateChange' || !isChromeDebugger()) {
+        props[key] = value;
+      }
+    }
+    return props;
+  }
+
+  public setNotAFirstRender() {
+    if (this._isFirstRender) {
+      this._isFirstRender = false;
+    }
+  }
+}

--- a/src/createAnimatedComponent/PropsFilter.tsx
+++ b/src/createAnimatedComponent/PropsFilter.tsx
@@ -20,8 +20,8 @@ function dummyListener() {
 }
 
 export class PropsFilter {
-  initialStyle = {};
-  _isFirstRender = true;
+  private _initialStyle = {};
+  private _isFirstRender = true;
 
   public filterNonAnimatedProps(
     inputProps: AnimatedComponentProps<InitialComponentProps>
@@ -37,13 +37,13 @@ export class PropsFilter {
             // this is how we recognize styles returned by useAnimatedStyle
             style.viewsRef.add(this);
             if (this._isFirstRender) {
-              this.initialStyle = {
+              this._initialStyle = {
                 ...style.initial.value,
-                ...this.initialStyle,
+                ...this._initialStyle,
                 ...initialUpdaterRun<StyleProps>(style.initial.updater),
               };
             }
-            return this.initialStyle;
+            return this._initialStyle;
           } else if (hasInlineStyles(style)) {
             return getInlineStyle(style, this._isFirstRender);
           } else {
@@ -85,7 +85,7 @@ export class PropsFilter {
     return props;
   }
 
-  public setNotAFirstRender() {
+  public onRender() {
     if (this._isFirstRender) {
       this._isFirstRender = false;
     }

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -98,7 +98,7 @@ export function createAnimatedComponent(
     _sharedElementTransition: SharedTransition | null = null;
     _JSPropUpdater = new JSPropUpdater();
     _InlinePropManager = new InlinePropManager();
-    _propsFilter = new PropsFilter();
+    _PropsFilter = new PropsFilter();
     static displayName: string;
 
     constructor(props: AnimatedComponentProps<InitialComponentProps>) {
@@ -443,8 +443,8 @@ export function createAnimatedComponent(
     });
 
     render() {
-      const props = this._propsFilter.filterNonAnimatedProps(this.props);
-      this._propsFilter.setNotAFirstRender();
+      const props = this._PropsFilter.filterNonAnimatedProps(this.props);
+      this._PropsFilter.onRender();
 
       if (isJest()) {
         props.animatedStyle = this.animatedStyle;

--- a/src/createAnimatedComponent/utils.ts
+++ b/src/createAnimatedComponent/utils.ts
@@ -44,6 +44,11 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
 
 type NestedArray<T> = T | NestedArray<T>[];
 
+export interface InitialComponentProps extends Record<string, unknown> {
+  ref?: Ref<Component>;
+  collapsable?: boolean;
+}
+
 export function flattenArray<T>(array: NestedArray<T>): T[] {
   if (!Array.isArray(array)) {
     return [array];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
File `createAnimatedComponent.tsx` contains our most important logic. It is already very big and since in the future we want to support ${\textcolor{teal}{\textsf{inline Styles}}}$ this file may grow a lot. Thats why we should make it clear and easy to rid - for example by splitting it across many small files.

This refactor will be made in smaller parts.

### Part 1 [LINK](https://github.com/software-mansion/react-native-reanimated/pull/5053)
* Create folder 📁 `createAnimatedComponent` 
* Move all files used only in `createAnimatedComponent.tsx` into that folder. Move `createAnimatedComponent.tsx` as well.
* Extract all util function into separate file.
### Part 2 ([LINK](https://github.com/software-mansion/react-native-reanimated/pull/5003))
* Create class `inlinePropUpdater.tsx` which handles logic related with inline styles.
### Part 3 ($\textcolor{green}{\textsf{This PR}}$)
This is not fixed yet, but I suggest we should:
* Move function `_filterNonAnimatedProps` away (70 lines of code)

## Test plan

Run the app, nothing explodes 🤯 
<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
