### PR TITLE
Fix exporting enums as types and type of global in PlatformChecker

### DIFF
--- a/app/src/examples/DragAndSnapExample.tsx
+++ b/app/src/examples/DragAndSnapExample.tsx
@@ -6,7 +6,7 @@ import Animated, {
   useAnimatedStyle,
   useAnimatedGestureHandler,
   interpolate,
-  Extrapolate,
+  Extrapolation,
 } from 'react-native-reanimated';
 import {
   PanGestureHandler,
@@ -42,10 +42,10 @@ export default function DragAndSnapExample() {
 
   const stylez = useAnimatedStyle(() => {
     const H = Math.round(
-      interpolate(translation.x.value, [0, 300], [0, 360], Extrapolate.CLAMP)
+      interpolate(translation.x.value, [0, 300], [0, 360], Extrapolation.CLAMP)
     );
     const S = Math.round(
-      interpolate(translation.y.value, [0, 500], [100, 50], Extrapolate.CLAMP)
+      interpolate(translation.y.value, [0, 500], [100, 50], Extrapolation.CLAMP)
     );
     const backgroundColor = `hsl(${H},${S}%,50%)`;
     return {

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -1,11 +1,13 @@
 'use strict';
 import { Platform } from 'react-native';
 
+// This type is necessary since some libraries tend to do a lib check
+// and this file causes type errors on `global` access.
+type localGlobal = typeof globalThis & Record<string, unknown>;
+
 export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }
-
-type localGlobal = typeof globalThis & Record<string, unknown>;
 
 export function isChromeDebugger(): boolean {
   return (

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -5,8 +5,13 @@ export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }
 
+type localGlobal = typeof globalThis & Record<string, unknown>;
+
 export function isChromeDebugger(): boolean {
-  return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
+  return (
+    !(global as localGlobal).nativeCallSyncHook ||
+    !!(global as localGlobal).__REMOTEDEV__
+  );
 }
 
 export function isWeb(): boolean {
@@ -41,5 +46,5 @@ export function isReducedMotion() {
     ? isWindowAvailable()
       ? !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
       : false
-    : global._REANIMATED_IS_REDUCED_MOTION ?? false;
+    : (global as localGlobal)._REANIMATED_IS_REDUCED_MOTION ?? false;
 }

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -3,7 +3,7 @@ import { Platform } from 'react-native';
 
 // This type is necessary since some libraries tend to do a lib check
 // and this file causes type errors on `global` access.
-type localGlobal = typeof globalThis & Record<string, unknown>;
+type localGlobal = typeof global & Record<string, unknown>;
 
 export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
@@ -40,13 +40,15 @@ export function isWindowAvailable() {
   // the window object is unavailable when building the server portion of a site that uses SSG
   // this function shouldn't be used to conditionally render components
   // https://www.joshwcomeau.com/react/the-perils-of-rehydration/
-  return typeof window !== 'undefined';
+  return typeof (global as localGlobal).window !== 'undefined';
 }
 
 export function isReducedMotion() {
   return isWeb()
     ? isWindowAvailable()
-      ? !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+      ? !(global as localGlobal).window.matchMedia(
+          '(prefers-reduced-motion: no-preference)'
+        ).matches
       : false
     : (global as localGlobal)._REANIMATED_IS_REDUCED_MOTION ?? false;
 }

--- a/src/reanimated2/PlatformChecker.ts
+++ b/src/reanimated2/PlatformChecker.ts
@@ -40,15 +40,15 @@ export function isWindowAvailable() {
   // the window object is unavailable when building the server portion of a site that uses SSG
   // this function shouldn't be used to conditionally render components
   // https://www.joshwcomeau.com/react/the-perils-of-rehydration/
-  return typeof (global as localGlobal).window !== 'undefined';
+  // @ts-ignore Fallback if `window` is undefined.
+  return typeof window !== 'undefined';
 }
 
 export function isReducedMotion() {
   return isWeb()
     ? isWindowAvailable()
-      ? !(global as localGlobal).window.matchMedia(
-          '(prefers-reduced-motion: no-preference)'
-        ).matches
+      ? // @ts-ignore Fallback if `window` is undefined.
+        !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
       : false
     : (global as localGlobal)._REANIMATED_IS_REDUCED_MOTION ?? false;
 }

--- a/src/reanimated2/hook/useAnimatedScrollHandler.ts
+++ b/src/reanimated2/hook/useAnimatedScrollHandler.ts
@@ -34,7 +34,7 @@ export interface ScrollHandlers<TContext extends __Context> {
 type OnScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
-export type useAnimatedScrollHandler = <
+type useAnimatedScrollHandlerType = <
   TContext extends __Context = Record<string, never>
 >(
   handlers: ScrollHandlers<TContext> | ScrollHandler<TContext>,
@@ -101,4 +101,4 @@ export const useAnimatedScrollHandler = function <TContext extends __Context>(
     // TODO TYPESCRIPT This temporary cast is to get rid of .d.ts file.
   ) as any;
   // TODO TYPESCRIPT This temporary cast is to get rid of .d.ts file.
-} as unknown as useAnimatedScrollHandler;
+} as unknown as useAnimatedScrollHandlerType;

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -66,21 +66,17 @@ export {
   withRepeat,
   withSequence,
 } from './animation';
-export type {
-  Extrapolation,
-  ExtrapolationConfig,
-  ExtrapolationType,
-} from './interpolation';
-export { interpolate, clamp } from './interpolation';
+export type { ExtrapolationConfig, ExtrapolationType } from './interpolation';
+export { Extrapolation, interpolate, clamp } from './interpolation';
 export type {
   InterpolationOptions,
-  ColorSpace,
   InterpolateConfig,
   InterpolateRGB,
   InterpolateHSV,
 } from './interpolateColor';
 export {
   Extrapolate,
+  ColorSpace,
   interpolateColor,
   useInterpolateConfig,
 } from './interpolateColor';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes regression that occurred in #5074.

Later on we also have to rethink if we want to promote `Extrapolate` or `Extrapolation` since both are exactly the same and we only use the former.

## Test plan

I actually made `Extrapolation` used in our examples so such mistake in the future would be caught on CI (only regarding `Extrapolation` sadly).

> [!Note]
> I recommend using this
> ```json
> "editor.tokenColorCustomizations": {
>    "textMateRules": [
>      {
>        "scope": "entity.name.type.enum",
>        "settings": {
>          "foreground": "#a3e577"
>        }
>      },
>      {
>        "scope": "entity.name.type.class",
>        "settings": {
>          "foreground": "#e8b55e"
>        }
>      }
>    ]
>  }
>```
> In your VSCode settings so Classes, Enums and Types are not in the same color.

