### PR TITLE
Fix `this` context on Web

### DIFF
--- a/src/createAnimatedComponent/PropsFilter.tsx
+++ b/src/createAnimatedComponent/PropsFilter.tsx
@@ -24,8 +24,10 @@ export class PropsFilter {
   private _isFirstRender = true;
 
   public filterNonAnimatedProps(
-    inputProps: AnimatedComponentProps<InitialComponentProps>
+    component: React.Component<unknown, unknown>
   ): Record<string, unknown> {
+    const inputProps =
+      component.props as AnimatedComponentProps<InitialComponentProps>;
     const props: Record<string, unknown> = {};
     for (const key in inputProps) {
       const value = inputProps[key];
@@ -35,7 +37,7 @@ export class PropsFilter {
         const processedStyle: StyleProps = styles.map((style) => {
           if (style && style.viewDescriptors) {
             // this is how we recognize styles returned by useAnimatedStyle
-            style.viewsRef.add(this);
+            style.viewsRef.add(component);
             if (this._isFirstRender) {
               this._initialStyle = {
                 ...style.initial.value,
@@ -58,7 +60,7 @@ export class PropsFilter {
         if (animatedProp.initial !== undefined) {
           Object.keys(animatedProp.initial.value).forEach((key) => {
             props[key] = animatedProp.initial?.value[key];
-            animatedProp.viewsRef?.add(this);
+            animatedProp.viewsRef?.add(component);
           });
         }
       } else if (

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -443,7 +443,7 @@ export function createAnimatedComponent(
     });
 
     render() {
-      const props = this._PropsFilter.filterNonAnimatedProps(this.props);
+      const props = this._PropsFilter.filterNonAnimatedProps(this);
       this._PropsFilter.onRender();
 
       if (isJest()) {


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in https://github.com/software-mansion/react-native-reanimated/pull/5102. The `filterNonAnimatedProps` method stores `this` in some registries, after the relocation of this function to another class `this` no longer points to a component.

## Test plan

Run web example and run any animation
