### PR TITLE
docs: Change installation url in "Failed to create a worklet" error

### DIFF
--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -21,7 +21,7 @@ All of them are supposed to work correctly only within the same minor version. T
 
 **Problem:** This usually happens when Reanimated is not properly installed, e.g. forgetting to include the Reanimated Babel plugin in `babel.config.js`.
 
-**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation#babel-plugin for more information.
+**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation for more information.
 
 ### Native part of Reanimated doesn't seem to be initialized
 

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -21,7 +21,7 @@ All of them are supposed to work correctly only within the same minor version. T
 
 **Problem:** This usually happens when Reanimated is not properly installed, e.g. forgetting to include the Reanimated Babel plugin in `babel.config.js`.
 
-**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation for more information.
+**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#step-2-add-reanimateds-babel-plugin for more information.
 
 ### Native part of Reanimated doesn't seem to be initialized
 


### PR DESCRIPTION
## Summary

The link in the "Failed to create a worklet" error had an old installation link that gave a 404 code. The link has been replaced with a new one.

