### PR TITLE
Change troubleshooting docs section Id

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -438,7 +438,7 @@ def assertLatestReactNativeWithNewArchitecture = task assertLatestReactNativeWit
     onlyIf { IS_NEW_ARCHITECTURE_ENABLED && REANIMATED_MAJOR_VERSION == 3 && REACT_NATIVE_MINOR_VERSION < 72 }
     doFirst {
         throw new GradleException(
-            "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + REANIMATED_VERSION + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
+            "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + REANIMATED_VERSION + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
         )
     }
 }

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-id: Troubleshooting
+id: troubleshooting
 title: Troubleshooting
 sidebar_label: Troubleshooting
 ---

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -43,8 +43,8 @@ All of them are supposed to work correctly only within the same minor version. T
 
 **Solution:**
 
-1. Part of your code might be transpiled with an outdated version of Reanimated Babel plugin. See [Mismatch between JavaScript code version and Reanimated Babel plugin version](https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#mismatch-between-javascript-code-version-and-reanimated-babel-plugin-version).
-2. You use release bundle with debug build of the app. This is not supported. See [Using dev bundle in release app build is not supported](https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#using-dev-bundle-in-a-release-app-build-is-not-supported) for more information.
+1. Part of your code might be transpiled with an outdated version of Reanimated Babel plugin. See [Mismatch between JavaScript code version and Reanimated Babel plugin version](https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#mismatch-between-javascript-code-version-and-reanimated-babel-plugin-version).
+2. You use release bundle with debug build of the app. This is not supported. See [Using dev bundle in release app build is not supported](https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#using-dev-bundle-in-a-release-app-build-is-not-supported) for more information.
 
 ### Mismatch between JavaScript code version and Reanimated Babel plugin version
 

--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -68,7 +68,7 @@ def assert_no_multiple_instances(react_native_info)
       location['/package.json'] = ''
       parsed_location += "- " + location + "\n"
     end
-    raise "[Reanimated] Multiple versions of Reanimated were detected (iOS). See https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#multiple-versions-of-reanimated-were-detected/ for more information.\n\nConflict between: \n" + parsed_location
+    raise "[Reanimated] Multiple versions of Reanimated were detected (iOS). See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#multiple-versions-of-reanimated-were-detected/ for more information.\n\nConflict between: \n" + parsed_location
   end
 end
 
@@ -78,7 +78,7 @@ def assert_latest_react_native_with_new_architecture(config, reanimated_package_
   react_native_minor_version = config[:react_native_minor_version]
   fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
   if fabric_enabled && reanimated_major_version == 3 && react_native_minor_version < 72
-    raise "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + reanimated-version + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/Troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
+    raise "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + reanimated-version + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
   end
 end
 


### PR DESCRIPTION
## Summary

This PR fixes URL form for troubleshooting docs section. From 
```
react-native-reanimated/docs/guides/Troubleshooting
```
to
```
react-native-reanimated/docs/guides/troubleshooting
```
Because in many places in source code we uses `react-native-reanimated/docs/guides/troubleshooting` form.

Inspired by https://github.com/software-mansion/react-native-reanimated/pull/5131

## Test plan

Check documentation build
