### PR TITLE
Unify `Extrapolation` and `Extrapolate`.

### DIFF
--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -75,6 +75,9 @@ export type {
   InterpolateHSV,
 } from './interpolateColor';
 export {
+  /**
+   * @deprecated Please use `Extrapolation` instead of `Extrapolate`
+   */
   Extrapolate,
   ColorSpace,
   interpolateColor,

--- a/src/reanimated2/interpolateColor.ts
+++ b/src/reanimated2/interpolateColor.ts
@@ -10,15 +10,18 @@ import {
   opacity,
 } from './Colors';
 import { makeMutable } from './core';
-import { interpolate } from './interpolation';
+import { Extrapolation, interpolate } from './interpolation';
 import type { SharedValue } from './commonTypes';
 import { useSharedValue } from './hook/useSharedValue';
 
+/**
+ * @deprecated Please use Extrapolation instead
+ */
 export const Extrapolate = {
   EXTEND: 'extend',
   CLAMP: 'clamp',
   IDENTITY: 'identity',
-};
+} as const;
 
 export type InterpolationOptions = {
   gamma?: number;
@@ -61,15 +64,20 @@ const interpolateColorsHSV = (
       }
     }
     h =
-      (interpolate(value, correctedInputRange, correctedH, Extrapolate.CLAMP) +
+      (interpolate(
+        value,
+        correctedInputRange,
+        correctedH,
+        Extrapolation.CLAMP
+      ) +
         1) %
       1;
   } else {
-    h = interpolate(value, inputRange, colors.h, Extrapolate.CLAMP);
+    h = interpolate(value, inputRange, colors.h, Extrapolation.CLAMP);
   }
-  const s = interpolate(value, inputRange, colors.s, Extrapolate.CLAMP);
-  const v = interpolate(value, inputRange, colors.v, Extrapolate.CLAMP);
-  const a = interpolate(value, inputRange, colors.a, Extrapolate.CLAMP);
+  const s = interpolate(value, inputRange, colors.s, Extrapolation.CLAMP);
+  const v = interpolate(value, inputRange, colors.v, Extrapolation.CLAMP);
+  const a = interpolate(value, inputRange, colors.a, Extrapolation.CLAMP);
   return hsvToColor(h, s, v, a);
 };
 
@@ -97,10 +105,10 @@ const interpolateColorsRGB = (
     outputG = toLinearSpace(outputG, gamma);
     outputB = toLinearSpace(outputB, gamma);
   }
-  const r = interpolate(value, inputRange, outputR, Extrapolate.CLAMP);
-  const g = interpolate(value, inputRange, outputG, Extrapolate.CLAMP);
-  const b = interpolate(value, inputRange, outputB, Extrapolate.CLAMP);
-  const a = interpolate(value, inputRange, colors.a, Extrapolate.CLAMP);
+  const r = interpolate(value, inputRange, outputR, Extrapolation.CLAMP);
+  const g = interpolate(value, inputRange, outputG, Extrapolation.CLAMP);
+  const b = interpolate(value, inputRange, outputB, Extrapolation.CLAMP);
+  const a = interpolate(value, inputRange, colors.a, Extrapolation.CLAMP);
   if (gamma === 1) {
     return rgbaColor(r, g, b, a);
   }

--- a/src/reanimated2/interpolation.ts
+++ b/src/reanimated2/interpolation.ts
@@ -1,4 +1,7 @@
 'use strict';
+
+import type { Extrapolate } from '.';
+
 export enum Extrapolation {
   IDENTITY = 'identity',
   CLAMP = 'clamp',
@@ -22,10 +25,12 @@ interface RequiredExtrapolationConfig {
   extrapolateRight: Extrapolation;
 }
 
+type extrapolateValues = (typeof Extrapolate)[keyof typeof Extrapolate];
+
 export type ExtrapolationType =
   | ExtrapolationConfig
   | Extrapolation
-  | string
+  | extrapolateValues
   | undefined;
 
 function getVal(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
We have duplicate code as follows:
<table>
<tr><td>Extrapolate</td><td>Extrapolation</td></tr>

<tr><td>
Was valid in reanimated v1 

[LINK](https://docs.swmansion.com/react-native-reanimated/docs/1.x/nodes/interpolate/#interpolate)
</td>
<td>
Valid option according to our docs, 

[LINK](https://docs.swmansion.com/react-native-reanimated/docs/utilities/interpolate/#extrapolation-type-object--string)
</td></tr>

<tr><td>

```javascript
export const Extrapolate = {
  EXTEND: 'extend',
  CLAMP: 'clamp',
  IDENTITY: 'identity',
}
```
</td><td>

```javascript
export enum Extrapolation {
  IDENTITY = 'identity',
  CLAMP = 'clamp',
  EXTEND = 'extend',
}
```
</td></tr>

</table>
## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
