### PR TITLE
Fix web layout animations manager not handling `string` transform

### DIFF
--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -85,6 +85,10 @@ function addPxToTranslate(
 ) {
   type RNTransformProp = (typeof existingTransform)[number];
 
+  if (typeof existingTransform === 'string') {
+    throw new Error('[Reanimated] String transform is unsupported.');
+  }
+
   const newTransform = existingTransform.map(
     (transformProp: RNTransformProp) => {
       const newTransformProp: ReanimatedWebTransformProperties = {};


### PR DESCRIPTION
In newer version of React Native `transform` prop can be a `string`.