### PR TITLE
Reorder checks in `getInlinePropsUpdate` and remove `transform`-specific syntax

### DIFF
--- a/src/ConfigHelper.ts
+++ b/src/ConfigHelper.ts
@@ -83,6 +83,7 @@ let NATIVE_THREAD_PROPS_WHITELIST: Record<string, boolean> = {
   fontSize: true,
   lineHeight: true,
   textShadowRadius: true,
+  textShadowOffset: true,
   letterSpacing: true,
   aspectRatio: true,
   columnGap: true, // iOS only

--- a/src/createAnimatedComponent/InlinePropManager.ts
+++ b/src/createAnimatedComponent/InlinePropManager.ts
@@ -35,16 +35,18 @@ function inlinePropsHasChanged(
   return false;
 }
 
-function getInlinePropsUpdate(inlineProps: Record<string, any>) {
+function getInlinePropsUpdate(inlineProps: Record<string, unknown>) {
   'worklet';
-  const update: Record<string, any> = {};
+  const update: Record<string, unknown> = {};
   for (const [key, styleValue] of Object.entries(inlineProps)) {
-    if (key === 'transform') {
-      update[key] = styleValue.map((transform: Record<string, any>) => {
-        return getInlinePropsUpdate(transform);
-      });
-    } else if (isSharedValue(styleValue)) {
+    if (isSharedValue(styleValue)) {
       update[key] = styleValue.value;
+    } else if (Array.isArray(styleValue)) {
+      update[key] = styleValue.map((item) => {
+        return getInlinePropsUpdate(item);
+      });
+    } else if (typeof styleValue === 'object') {
+      update[key] = getInlinePropsUpdate(styleValue as Record<string, unknown>);
     } else {
       update[key] = styleValue;
     }


### PR DESCRIPTION
This PR makes the behavior of `useAnimatedStyle` and InlineStyles API consistent. Because of wrong order of checks in `getInlinePropsUpdate` potential Shared Values were treated as arrays and threw errors - this didn't happen for the same usage of Shared Value with `useAnimatedStyle`.

```TSX
export default function App() {
  const sv = useSharedValue([{ translateX: 50 }, { translateY: 50 }]);
  const handlePress = () => {
    sv.value = [{ translateX: 100 }, { translateY: 100 }];
  };
  const animatedStyle = useAnimatedStyle(() => {
    return {
      transform: sv.value,
    };
  });
  return (
    <View style={styles.container}>
      <Button title="Press me" onPress={handlePress} />
      {/* This works. */}
      <Animated.View style={[styles.box, animatedStyle]} />
      {/* This doesn't. */}
      <Animated.View style={[styles.box, { transform: sv }]} />
    </View>
  );
}
```

## Test plan

With these changes this snippet works:

<details>
<summary>
code
</summary>

```TSX
import { StyleSheet, View, Button } from 'react-native';
import Animated, { useSharedValue } from 'react-native-reanimated';

import React from 'react';

function TransformSharedValue() {
  const sv = useSharedValue([{ translateX: 100 }, { rotate: '30deg' }]);
  function handlePress() {
    sv.value = [{ translateX: 200 }, { rotate: '60deg' }];
  }
  return (
    <>
      <Animated.View style={[styles.box, { transform: sv }]} />
      <Button title="Press me" onPress={handlePress} />
    </>
  );
}

function TextShadowOffsetSharedValue() {
  const sv = useSharedValue({ width: 5, height: 5 });
  function handlePress() {
    sv.value = { width: 10, height: 10 };
  }
  return (
    <>
      <Animated.Text
        ref={null}
        style={[
          styles.text,
          { textShadowColor: 'black', textShadowRadius: 10 },
          { textShadowOffset: sv },
        ]}>
        Serious text
      </Animated.Text>
      <Button title="Press me" onPress={handlePress} />
    </>
  );
}

export default function Example() {
  return (
    <View style={styles.container}>
      <TransformSharedValue />
      <TextShadowOffsetSharedValue />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'red',
  },
  text: {
    width: 100,
    height: 100,
  },
});
```
</details>
