### PR TITLE
Fixed usage reanimated_version name on reanimated_utils file

### DIFF
--- a/scripts/reanimated_utils.rb
+++ b/scripts/reanimated_utils.rb
@@ -78,7 +78,7 @@ def assert_latest_react_native_with_new_architecture(config, reanimated_package_
   react_native_minor_version = config[:react_native_minor_version]
   fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
   if fabric_enabled && reanimated_major_version == 3 && react_native_minor_version < 72
-    raise "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + reanimated-version + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
+    raise "[Reanimated] Outdated version of React Native for New Architecture. Reanimated " + reanimated_version + " supports the New Architecture on React Native 0.72.0+. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#outdated-version-of-react-native-for-new-architecture for more information."
   end
 end
 


### PR DESCRIPTION
## Summary
When I tried to activate NEW_ARCH within the project while having React Native version 0.71.12 installed, I encountered the following error during the pod-install step for the Reanimated library:

"Invalid RNReanimated.podspec file: undefined local variable or method `reanimated' for Pod:Module
Did you mean? reanimated_version."

This pull request contains a solution to this error.

## Test plan

You can install the latest version of Reanimated in a project with a React Native version lower than 0.72 by running the following command: RCT_NEW_ARCH_ENABLED=1 pod install.