### PR TITLE
Fix `LayoutAnimationConfig`

### DIFF
--- a/src/reanimated2/component/LayoutAnimationConfig.tsx
+++ b/src/reanimated2/component/LayoutAnimationConfig.tsx
@@ -1,5 +1,11 @@
 'use strict';
-import { Children, Component, createContext, useEffect, useRef } from 'react';
+import React, {
+  Children,
+  Component,
+  createContext,
+  useEffect,
+  useRef,
+} from 'react';
 import type { ReactNode } from 'react';
 import { setShouldAnimateExitingForTag } from '../core';
 import { findNodeHandle } from 'react-native';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds missing `import React from 'react'` to `LayoutAnimationConfig`. Without it the docs would fail.

## Test plan

