### PR TITLE
Fix web layout animations during standard animation

### DIFF
--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -45,7 +45,7 @@ global._scheduleOnJS = () => {
   );
 };
 
-interface JSReanimatedComponent {
+export interface JSReanimatedComponent {
   previousStyle: StyleProps;
   setNativeProps?: (style: StyleProps) => void;
   style?: StyleProps;

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -55,9 +55,18 @@ export interface JSReanimatedComponent {
   };
 }
 
+export interface ReanimatedHTMLElement extends HTMLElement {
+  previousStyle: StyleProps;
+  setNativeProps?: (style: StyleProps) => void;
+  props: Record<string, string | number>;
+  _touchableNode: {
+    setAttribute: (key: string, props: unknown) => void;
+  };
+}
+
 export const _updatePropsJS = (
   updates: StyleProps | AnimatedStyle<any>,
-  viewRef: { _component?: JSReanimatedComponent },
+  viewRef: { _component?: JSReanimatedComponent | ReanimatedHTMLElement },
   isAnimatedProps?: boolean
 ): void => {
   if (viewRef._component) {
@@ -99,7 +108,7 @@ export const _updatePropsJS = (
 };
 
 const setNativeProps = (
-  component: JSReanimatedComponent,
+  component: JSReanimatedComponent | ReanimatedHTMLElement,
   newProps: StyleProps,
   isAnimatedProps?: boolean
 ): void => {

--- a/src/reanimated2/js-reanimated/index.ts
+++ b/src/reanimated2/js-reanimated/index.ts
@@ -45,7 +45,7 @@ global._scheduleOnJS = () => {
   );
 };
 
-export interface JSReanimatedComponent {
+interface JSReanimatedComponent {
   previousStyle: StyleProps;
   setNativeProps?: (style: StyleProps) => void;
   style?: StyleProps;

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -18,7 +18,7 @@ import { SequencedTransition } from './transition/Sequenced.web';
 import { FadingTransition } from './transition/Fading.web';
 import { useReducedMotion } from '../../../reanimated2/hook/useReducedMotion';
 import { _updatePropsJS } from '../../js-reanimated';
-import type { JSReanimatedComponent } from '../../js-reanimated';
+import type { ReanimatedHTMLElement } from '../../js-reanimated';
 
 export const WEB_ANIMATIONS_ID = 'ReanimatedWebAnimationsStyle';
 
@@ -438,10 +438,9 @@ export function startWebLayoutAnimation<
   // We don't care about layout transitions since they're created dynamically
   if (!(initialAnimationName in Animations) && !isLayoutTransition) {
     if (props.entering) {
-      // TODO TYPESCRIPT: Fix this
       _updatePropsJS(
         { visibility: 'initial' },
-        { _component: element as unknown as JSReanimatedComponent }
+        { _component: element as ReanimatedHTMLElement }
       );
     }
 
@@ -514,17 +513,15 @@ export function handleEnteringAnimation(
   // If `delay` === 0, value passed to `setTimeout` will be 0. However, `setTimeout` executes after given amount of time, not exactly after that time
   // Because of that, we have to immediately toggle on the component when the delay is 0.
   if (delay === 0) {
-    // TODO TYPESCRIPT: Fix this
     _updatePropsJS(
       { visibility: 'initial' },
-      { _component: element as unknown as JSReanimatedComponent }
+      { _component: element as ReanimatedHTMLElement }
     );
   } else {
     setTimeout(() => {
-      // TODO TYPESCRIPT: Fix this
       _updatePropsJS(
         { visibility: 'initial' },
-        { _component: element as unknown as JSReanimatedComponent }
+        { _component: element as ReanimatedHTMLElement }
       );
     }, delay * 1000);
   }

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -17,6 +17,8 @@ import { LinearTransition } from './transition/Linear.web';
 import { SequencedTransition } from './transition/Sequenced.web';
 import { FadingTransition } from './transition/Fading.web';
 import { useReducedMotion } from '../../../reanimated2/hook/useReducedMotion';
+import { _updatePropsJS } from '../../js-reanimated';
+import type { JSReanimatedComponent } from '../../js-reanimated';
 
 export const WEB_ANIMATIONS_ID = 'ReanimatedWebAnimationsStyle';
 
@@ -436,7 +438,11 @@ export function startWebLayoutAnimation<
   // We don't care about layout transitions since they're created dynamically
   if (!(initialAnimationName in Animations) && !isLayoutTransition) {
     if (props.entering) {
-      element.style.visibility = 'initial';
+      // TODO TYPESCRIPT: Fix this
+      _updatePropsJS(
+        { visibility: 'initial' },
+        { _component: element as unknown as JSReanimatedComponent }
+      );
     }
 
     console.warn(
@@ -508,10 +514,18 @@ export function handleEnteringAnimation(
   // If `delay` === 0, value passed to `setTimeout` will be 0. However, `setTimeout` executes after given amount of time, not exactly after that time
   // Because of that, we have to immediately toggle on the component when the delay is 0.
   if (delay === 0) {
-    element.style.visibility = 'initial';
+    // TODO TYPESCRIPT: Fix this
+    _updatePropsJS(
+      { visibility: 'initial' },
+      { _component: element as unknown as JSReanimatedComponent }
+    );
   } else {
     setTimeout(() => {
-      element.style.visibility = 'initial';
+      // TODO TYPESCRIPT: Fix this
+      _updatePropsJS(
+        { visibility: 'initial' },
+        { _component: element as unknown as JSReanimatedComponent }
+      );
     }, delay * 1000);
   }
 


### PR DESCRIPTION
## Summary

If a component has an entering animation and is simultaneously running a standard animation (e.g., withTiming), it is possible for the component to disappear. This issue arises because the standard animation utilizes `setNativeProps`, which stores the last applied style. As a result, any changes to the style made using the syntax `element.style.visibility = 'initial'`will be overridden by `setNativeProps`.

## Test plan

Run example

<details>
<summary>code</summary>

```js
import Animated, {
  useSharedValue,
  withTiming,
  useAnimatedStyle,
  FadeIn,
} from 'react-native-reanimated';
import { View, Button, StyleSheet } from 'react-native';
import React from 'react';

export default function AnimatedStyleUpdateExample() {
  const randomWidth = useSharedValue(10);

  const style = useAnimatedStyle(() => {
    return {
      width: withTiming(randomWidth.value),
    };
  });

  return (
    <View style={styles.container}>
      <Animated.View style={[styles.box, style]} entering={FadeIn} />
      <Button
        title="toggle"
        onPress={() => {
          randomWidth.value = Math.random() * 350;
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    flexDirection: 'column',
  },
  box: {
    width: 100,
    height: 80,
    backgroundColor: 'black',
    margin: 30,
  },
});

```

</details>
