### PR TITLE
Enable defines module

### DIFF
--- a/RNReanimated.podspec
+++ b/RNReanimated.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
+    "DEFINES_MODULE" => "YES",
     "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
     "FRAMEWORK_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR enables `DEFINES_MODULE` in order to fix the following error during `pod install` when using Reanimated in VisionCameraExample app which has Swift sources:

![swift](https://github.com/software-mansion/react-native-reanimated/assets/20516055/b55f8f3e-f76b-4fd8-89e3-13abec00bf80)

Copied from https://github.com/margelo/react-native-worklets-core/blob/main/react-native-worklets-core.podspec#L37

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
