### PR TITLE
Inject `_updateDataSynchronously` to worklet runtime

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -83,15 +83,6 @@ NativeReanimatedModule::NativeReanimatedModule(
         this->requestAnimationFrame(rt, callback);
       };
 
-  auto updateDataSynchronously =
-      [this](
-          jsi::Runtime &rt,
-          const jsi::Value &synchronizedDataHolderRef,
-          const jsi::Value &newData) {
-        return this->updateDataSynchronously(
-            rt, synchronizedDataHolderRef, newData);
-      };
-
 #ifdef RCT_NEW_ARCH_ENABLED
   auto updateProps = [this](jsi::Runtime &rt, const jsi::Value &operations) {
     this->updateProps(rt, operations);

--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -130,7 +130,6 @@ NativeReanimatedModule::NativeReanimatedModule(
       platformDepMethodsHolder.dispatchCommandFunction,
 #endif
       requestAnimationFrame,
-      updateDataSynchronously,
       platformDepMethodsHolder.getCurrentTime,
       platformDepMethodsHolder.setGestureStateFunction,
       platformDepMethodsHolder.progressLayoutAnimation,
@@ -196,9 +195,7 @@ void NativeReanimatedModule::updateDataSynchronously(
     jsi::Runtime &rt,
     const jsi::Value &synchronizedDataHolderRef,
     const jsi::Value &newData) {
-  auto dataHolder = extractShareableOrThrow<ShareableSynchronizedDataHolder>(
-      rt, synchronizedDataHolderRef);
-  dataHolder->set(rt, newData);
+  reanimated::updateDataSynchronously(rt, synchronizedDataHolderRef, newData);
 }
 
 jsi::Value NativeReanimatedModule::getDataSynchronously(

--- a/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
+++ b/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
@@ -103,6 +103,16 @@ void WorkletRuntimeDecorator::decorate(
           }
         });
       });
+
+  jsi_utils::installJsiFunction(
+      rt,
+      "_updateDataSynchronously",
+      [](jsi::Runtime &rt,
+         const jsi::Value &synchronizedDataHolderRef,
+         const jsi::Value &newData) {
+        return reanimated::updateDataSynchronously(
+            rt, synchronizedDataHolderRef, newData);
+      });
 }
 
 } // namespace reanimated

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -103,6 +103,15 @@ jsi::Value makeShareableClone(
   return ShareableJSRef::newHostObject(rt, shareable);
 }
 
+void updateDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef,
+    const jsi::Value &newData) {
+  auto dataHolder = extractShareableOrThrow<ShareableSynchronizedDataHolder>(
+      rt, synchronizedDataHolderRef);
+  dataHolder->set(rt, newData);
+}
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -147,6 +147,11 @@ jsi::Value makeShareableClone(
     const jsi::Value &value,
     const jsi::Value &shouldRetainRemote);
 
+void updateDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef,
+    const jsi::Value &newData);
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/Common/cpp/Tools/UIRuntimeDecorator.cpp
+++ b/Common/cpp/Tools/UIRuntimeDecorator.cpp
@@ -14,7 +14,6 @@ void UIRuntimeDecorator::decorate(
     const MeasureFunction measure,
     const DispatchCommandFunction dispatchCommand,
     const RequestAnimationFrameFunction requestAnimationFrame,
-    const UpdateDataSynchronouslyFunction updateDataSynchronously,
     const TimeProviderFunction getCurrentTime,
     const SetGestureStateFunction setGestureState,
     const ProgressLayoutAnimationFunction progressLayoutAnimation,
@@ -49,8 +48,6 @@ void UIRuntimeDecorator::decorate(
 
   jsi_utils::installJsiFunction(
       uiRuntime, "requestAnimationFrame", requestAnimationFrame);
-  jsi_utils::installJsiFunction(
-      uiRuntime, "_updateDataSynchronously", updateDataSynchronously);
 
   auto performanceNow = [getCurrentTime](
                             jsi::Runtime &,

--- a/Common/cpp/Tools/UIRuntimeDecorator.h
+++ b/Common/cpp/Tools/UIRuntimeDecorator.h
@@ -10,8 +10,6 @@ namespace reanimated {
 
 using RequestAnimationFrameFunction =
     std::function<void(jsi::Runtime &, const jsi::Value &)>;
-using UpdateDataSynchronouslyFunction =
-    std::function<void(jsi::Runtime &, const jsi::Value &, const jsi::Value &)>;
 
 class UIRuntimeDecorator {
  public:
@@ -26,7 +24,6 @@ class UIRuntimeDecorator {
       const MeasureFunction measure,
       const DispatchCommandFunction dispatchCommand,
       const RequestAnimationFrameFunction requestAnimationFrame,
-      const UpdateDataSynchronouslyFunction updateDataSynchronously,
       const TimeProviderFunction getCurrentTime,
       const SetGestureStateFunction setGestureState,
       const ProgressLayoutAnimationFunction progressLayoutAnimation,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Previously, we would inject `_updateDataSynchronously` only to the UI runtime so it was not available in a regular worklet runtime. However, VisionCamera needs to use synchronous shared values in its context so I moved `_updateDataSynchronously` from `UIRuntimeDecorator` to `WorkletRuntimeDecorator`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

```ts
const mutable = makeMutable(false);
const runtime = createWorkletRuntime('foo', () => {
  'worklet';
  mutable.value = true;
});
```
