### PR TITLE
Fix JSISerializer for empty jsi::HostObject

### DIFF
--- a/Common/cpp/Tools/JSISerializer.cpp
+++ b/Common/cpp/Tools/JSISerializer.cpp
@@ -140,10 +140,10 @@ std::string JSISerializer::stringifyHostObject(jsi::HostObject &hostObject) {
 
   auto props = hostObject.getPropertyNames(rt_);
   auto propsCount = props.size();
-  auto lastKey = props.back().utf8(rt_);
 
   if (propsCount > 0) {
     ss << '{';
+    auto lastKey = props.back().utf8(rt_);
     for (const auto &key : props) {
       auto formattedKey = key.utf8(rt_);
       auto value = hostObject.get(rt_, key);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes a crash when passing a `jsi::HostObject` with no props to `_log` or `_toString` functions caused by accessing the last element of an empty list.

## Test plan

```ts
runOnUI(() => {
  'worklet';
  const x = makeShareableCloneOnUIRecursive(() => {
    'worklet';
    console.log(42);
  });
  _log(x);
})();
```
