### PR TITLE
Remove unnecessary space when serializing jsi::HostObject with no props

### DIFF
--- a/Common/cpp/Tools/JSISerializer.cpp
+++ b/Common/cpp/Tools/JSISerializer.cpp
@@ -135,14 +135,14 @@ std::string JSISerializer::stringifyHostObject(jsi::HostObject &hostObject) {
   }
 
   std::stringstream ss;
-  ss << "[jsi::HostObject(" << hostObjClassName << ") ";
+  ss << "[jsi::HostObject(" << hostObjClassName << ")";
   std::free(hostObjClassName);
 
   auto props = hostObject.getPropertyNames(rt_);
   auto propsCount = props.size();
 
   if (propsCount > 0) {
-    ss << '{';
+    ss << " {";
     auto lastKey = props.back().utf8(rt_);
     for (const auto &key : props) {
       auto formattedKey = key.utf8(rt_);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Before: `[jsi::HostObject(reanimated::ShareableJSRef) ]`

After: `[jsi::HostObject(reanimated::ShareableJSRef)]`

## Test plan

```ts
runOnUI(() => {
  'worklet';
  const x = makeShareableCloneOnUIRecursive(() => {
    'worklet';
    console.log(42);
  });
  _log(x);
})();
```
