### PR TITLE
Improve spring config verification

### DIFF
--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -19,7 +19,7 @@ import {
   underDampedSpringCalculations,
   criticallyDampedSpringCalculations,
   isAnimationTerminatingCalculation,
-  isConfigValid,
+  checkIfConfigIsValid,
 } from './springUtils';
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
@@ -58,7 +58,7 @@ export const withSpring = ((
       skipAnimation: false,
     };
 
-    config.skipAnimation = !isConfigValid(config);
+    config.skipAnimation = !checkIfConfigIsValid(config);
 
     if (config.duration === 0) {
       config.skipAnimation = true;
@@ -80,13 +80,9 @@ export const withSpring = ((
       }
 
       if (config.skipAnimation) {
-        // If we use duration we want to wait the provided time before stopping
-        if (config.useDuration) return false;
-        else {
-          animation.current = toValue;
-          animation.lastTimestamp = 0;
-          return true;
-        }
+        animation.current = toValue;
+        animation.lastTimestamp = 0;
+        return true;
       }
       const { lastTimestamp, velocity } = animation;
 

--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -19,7 +19,7 @@ import {
   underDampedSpringCalculations,
   criticallyDampedSpringCalculations,
   isAnimationTerminatingCalculation,
-  validateConfig,
+  isConfigValid,
 } from './springUtils';
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.
@@ -58,7 +58,7 @@ export const withSpring = ((
       skipAnimation: false,
     };
 
-    config.skipAnimation = validateConfig(config);
+    config.skipAnimation = !isConfigValid(config);
 
     if (config.duration === 0) {
       config.skipAnimation = true;

--- a/src/reanimated2/animation/spring.ts
+++ b/src/reanimated2/animation/spring.ts
@@ -80,7 +80,7 @@ export const withSpring = ((
       }
 
       if (config.skipAnimation) {
-        // We don't animate wrong config
+        // If we use duration we want to wait the provided time before stopping
         if (config.useDuration) return false;
         else {
           animation.current = toValue;

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -122,7 +122,7 @@ function bisectRoot({
 
 export function initialCalculations(
   mass = 0,
-  config: Record<keyof SpringConfig, any> & SpringConfigInner
+  config: DefaultSpringConfig & SpringConfigInner
 ): {
   zeta: number;
   omega0: number;
@@ -157,7 +157,7 @@ export function initialCalculations(
 
 export function calculateNewMassToMatchDuration(
   x0: number,
-  config: Record<keyof SpringConfig, any> & SpringConfigInner,
+  config: DefaultSpringConfig & SpringConfigInner,
   v0: number
 ) {
   'worklet';

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -60,7 +60,7 @@ export interface InnerSpringAnimation
 }
 export function isConfigValid(config: DefaultSpringConfig): boolean {
   'worklet';
-  let errorMessage: string | null = null;
+  let errorMessage = '';
 
   (
     [
@@ -74,26 +74,19 @@ export function isConfigValid(config: DefaultSpringConfig): boolean {
   ).forEach((prop) => {
     const value = config[prop];
     if (value <= 0) {
-      if (errorMessage === null) {
-        errorMessage = '';
-      }
       errorMessage += `, ${prop} must be grater than zero but got ${value}`;
     }
   });
 
   if (config.duration < 0) {
-    if (errorMessage === null) {
-      errorMessage = '';
-    }
-
     errorMessage += `, duration can't be negative, got ${config.duration}`;
   }
 
-  if (errorMessage !== null) {
+  if (errorMessage !== '') {
     console.warn('[Reanimated] Invalid spring config' + errorMessage);
   }
 
-  return errorMessage === null;
+  return errorMessage === '';
 }
 
 function bisectRoot({

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -58,7 +58,7 @@ export interface InnerSpringAnimation
   toValue: number;
   current: number;
 }
-export function isConfigValid(config: DefaultSpringConfig): boolean {
+export function checkIfConfigIsValid(config: DefaultSpringConfig): boolean {
   'worklet';
   let errorMessage = '';
   (

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -58,11 +58,10 @@ export interface InnerSpringAnimation
   toValue: number;
   current: number;
 }
-
 export function validateConfig(config: DefaultSpringConfig): boolean {
   'worklet';
   let errorLog = '[Reanimated] Invalid spring config, ';
-  let invalidConfig = false;
+  let configIsInvalid = false;
 
   (
     [
@@ -75,21 +74,21 @@ export function validateConfig(config: DefaultSpringConfig): boolean {
     ] as const
   ).forEach((property) => {
     if (config[property] <= 0) {
-      invalidConfig = true;
-      errorLog += `${property} must be grater than zero, `;
+      configIsInvalid = true;
+      errorLog += `${property} must be grater than zero but got ${config[property]}, `;
     }
   });
 
   if (config.duration < 0) {
-    invalidConfig = true;
-    errorLog += "duration can't be negative";
+    configIsInvalid = true;
+    errorLog += `duration can't be negative, got ${config.duration}, `;
   }
 
-  if (invalidConfig) {
+  if (configIsInvalid) {
     console.warn(errorLog);
   }
 
-  return invalidConfig;
+  return configIsInvalid;
 }
 
 function bisectRoot({

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -93,7 +93,7 @@ export function isConfigValid(config: DefaultSpringConfig): boolean {
     console.warn('[Reanimated] Invalid spring config' + errorMessage);
   }
 
-  return errorMessage !== null;
+  return errorMessage === null;
 }
 
 function bisectRoot({

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -58,10 +58,10 @@ export interface InnerSpringAnimation
   toValue: number;
   current: number;
 }
-export function validateConfig(config: DefaultSpringConfig): boolean {
+export function isConfigValid(config: DefaultSpringConfig): boolean {
   'worklet';
-  let errorLog = '[Reanimated] Invalid spring config, ';
-  let configIsInvalid = false;
+  let errorLog = '[Reanimated] Invalid spring config';
+  let configIsValid = true;
 
   (
     [
@@ -72,23 +72,24 @@ export function validateConfig(config: DefaultSpringConfig): boolean {
       'restSpeedThreshold',
       'mass',
     ] as const
-  ).forEach((property) => {
-    if (config[property] <= 0) {
-      configIsInvalid = true;
-      errorLog += `${property} must be grater than zero but got ${config[property]}, `;
+  ).forEach((prop) => {
+    const value = config[prop];
+    if (value <= 0) {
+      configIsValid = false;
+      errorLog += `, ${prop} must be grater than zero but got ${value}`;
     }
   });
 
   if (config.duration < 0) {
-    configIsInvalid = true;
-    errorLog += `duration can't be negative, got ${config.duration}, `;
+    configIsValid = false;
+    errorLog += `, duration can't be negative, got ${config.duration}`;
   }
 
-  if (configIsInvalid) {
+  if (configIsValid) {
     console.warn(errorLog);
   }
 
-  return configIsInvalid;
+  return configIsValid;
 }
 
 function bisectRoot({

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -61,7 +61,6 @@ export interface InnerSpringAnimation
 export function isConfigValid(config: DefaultSpringConfig): boolean {
   'worklet';
   let errorMessage = '';
-
   (
     [
       'stiffness',

--- a/src/reanimated2/animation/springUtils.ts
+++ b/src/reanimated2/animation/springUtils.ts
@@ -60,8 +60,7 @@ export interface InnerSpringAnimation
 }
 export function isConfigValid(config: DefaultSpringConfig): boolean {
   'worklet';
-  let errorLog = '[Reanimated] Invalid spring config';
-  let configIsValid = true;
+  let errorMessage: string | null = null;
 
   (
     [
@@ -75,21 +74,26 @@ export function isConfigValid(config: DefaultSpringConfig): boolean {
   ).forEach((prop) => {
     const value = config[prop];
     if (value <= 0) {
-      configIsValid = false;
-      errorLog += `, ${prop} must be grater than zero but got ${value}`;
+      if (errorMessage === null) {
+        errorMessage = '';
+      }
+      errorMessage += `, ${prop} must be grater than zero but got ${value}`;
     }
   });
 
   if (config.duration < 0) {
-    configIsValid = false;
-    errorLog += `, duration can't be negative, got ${config.duration}`;
+    if (errorMessage === null) {
+      errorMessage = '';
+    }
+
+    errorMessage += `, duration can't be negative, got ${config.duration}`;
   }
 
-  if (configIsValid) {
-    console.warn(errorLog);
+  if (errorMessage !== null) {
+    console.warn('[Reanimated] Invalid spring config' + errorMessage);
   }
 
-  return configIsValid;
+  return errorMessage !== null;
 }
 
 function bisectRoot({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Each time a spring animation is triggered we check if provided config is valid. When it isn't we skip animation and change the animated view to its final position after waiting the time passed as `duration` (which may be zero)

This change fixes the following bug:
* Warning when spring used with zero duration (which should be a valid usage)
* No warning for negative mass

Additional benefits are:
* Invalid config warning informs what exactly is wrong
* Types are both more accurate and less verobse

Behaviour when duration is zero:

https://github.com/software-mansion/react-native-reanimated/assets/56199675/c16caa2a-9df0-4ba0-9890-4fe81b5b090d


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
