### PR TITLE
Fix article progress example on android

### DIFF
--- a/app/src/examples/ArticleProgressExample.tsx
+++ b/app/src/examples/ArticleProgressExample.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 import Animated, {
   measure,
@@ -11,16 +11,12 @@ export default function ArticleProgressExample() {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>();
   const textRef = useAnimatedRef<Animated.Text>();
   const scrollHandler = useScrollViewOffset(scrollViewRef);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   const progressBarAnimatedStyle = useAnimatedStyle(() => {
-    if (!mounted) {
+    if (!textRef.current || !scrollViewRef.current) {
       return {};
     }
+
     const measuredText = measure(textRef);
     if (measuredText === null) {
       return { width: 0 };

--- a/app/src/examples/ArticleProgressExample.tsx
+++ b/app/src/examples/ArticleProgressExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 import Animated, {
   measure,
@@ -11,8 +11,16 @@ export default function ArticleProgressExample() {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>();
   const textRef = useAnimatedRef<Animated.Text>();
   const scrollHandler = useScrollViewOffset(scrollViewRef);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const progressBarAnimatedStyle = useAnimatedStyle(() => {
+    if (!mounted) {
+      return {};
+    }
     const measuredText = measure(textRef);
     if (measuredText === null) {
       return { width: 0 };

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -75,7 +75,7 @@ if (isWeb()) {
       return null;
     } else if (measured.x === -1234567) {
       console.warn(
-        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please make sure the view is currently rendered.`
+        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please ensure that the view has been rendered.`
       );
       return null;
     } else if (isNaN(measured.x)) {

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -75,7 +75,7 @@ if (isWeb()) {
       return null;
     } else if (measured.x === -1234567) {
       console.warn(
-        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please ensure that the view has been rendered.`
+        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please make sure the view is currently rendered.`
       );
       return null;
     } else if (isNaN(measured.x)) {

--- a/src/reanimated2/NativeMethods.ts
+++ b/src/reanimated2/NativeMethods.ts
@@ -75,7 +75,7 @@ if (isWeb()) {
       return null;
     } else if (measured.x === -1234567) {
       console.warn(
-        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response.`
+        `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please make sure the view is currently rendered.`
       );
       return null;
     } else if (isNaN(measured.x)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

An error is thrown when you measure en element that is not mounted yet. So I create a boolean flag which I set when component is ready to avoid this error.

Probably we also should improve error log.

Current error log:
> `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response.`

New error log:
> `[Reanimated] The view with tag ${viewTag} returned an invalid measurement response. Please make sure the view is currently rendered.`

Both logs are not perfect, since in our example our measured element is a Text component, not a View one, however adding component type to log is not easy.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
