### PR TITLE
Fix mapper getting stuck on an error in worklet

### DIFF
--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -85,17 +85,20 @@ function createMapperRegistry() {
     if (processingMappers) {
       return;
     }
-    processingMappers = true;
-    if (mappers.size !== sortedMappers.length) {
-      updateMappersOrder();
-    }
-    for (const mapper of sortedMappers) {
-      if (mapper.dirty) {
-        mapper.dirty = false;
-        mapper.worklet();
+    try {
+      processingMappers = true;
+      if (mappers.size !== sortedMappers.length) {
+        updateMappersOrder();
       }
+      for (const mapper of sortedMappers) {
+        if (mapper.dirty) {
+          mapper.dirty = false;
+          mapper.worklet();
+        }
+      }
+    } finally {
+      processingMappers = false;
     }
-    processingMappers = false;
   }
 
   function maybeRequestUpdates() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently, in `mapperRun` function, when we set `processingMappers` to `true` and then a breaking worklet is called in
```TSX
      for (const mapper of sortedMappers) {
        if (mapper.dirty) {
          mapper.dirty = false;
          mapper.worklet();
        }
      }
```
      
We get stuck in `processingMappers` always set to `true` and mappers are never run again without reloading the app. This PR fixes it.

## Test plan

Animations here break after first button press without this PR.
<details>
<summary>
Snippet
</summary>

```TSX
import { StyleSheet, View, Button } from 'react-native';

import React from 'react';

import Animated, {
  useSharedValue,
  useAnimatedStyle,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const sv = useSharedValue(100);

  const animatedStyle = useAnimatedStyle(() => {
    if (sv.value === 110) {
      throw new Error('Break animations');
    }
    return {
      width: sv.value,
    };
  });

  function handleAnimate() {
    sv.value += 10;
  }

  return (
    <View style={styles.container}>
      <Animated.View style={[styles.box, animatedStyle]} />
      <Button title="Animate" onPress={handleAnimate} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    height: 100,
    backgroundColor: 'red',
  },
});
```
</details>
