### PR TITLE
Run only plugin tests in validate plugin workflow

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -49,4 +49,4 @@ jobs:
         if: failure() && steps.diff.outcome == 'failure'
         run: git diff
       - name: Test
-        run: yarn jest
+        run: yarn jest plugin


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Previously, validate plugin workflow would run all unit tests in the library, including those for `useAnimatedStyle` etc. which are also run in another job. However, the expected behavior is to run only unit tests related to Reanimated Babel plugin from `__tests__/plugin.test.ts`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
