### PR TITLE
Fix crash due to `JNIEnv:CallLongMethod` on Android

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -370,6 +370,10 @@ void NativeProxy::unsubscribeFromKeyboardEvents(int listenerId) {
 }
 
 double NativeProxy::getCurrentTime() {
+  if (javaPart_.get() == nullptr) {
+      // This can happen when NativeProxy is destroyed
+      return 0;
+  }
   static const auto method = getJniMethod<jlong()>("getCurrentTime");
   jlong output = method(javaPart_.get());
   return static_cast<double>(output);


### PR DESCRIPTION
## Summary

Fixes #4786, #4426 

### Known Issue
Several users are complaining about a specific crash brought by `react-native-reanimated` where native crashes of `libreanimatd.so` are summarized from Google Play Console, Google Analytics for FireBase, Microsoft AppCenter etc.
```
[libreanimated.so] _JNIEnv::CallLongMethod(_jobject*, _jmethodID*, ...) SIGABRT
JNI DETECTED ERROR IN APPLICATION: obj == null
```

### Stack Trace & Logs
One of the stack trace could be like: 
```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 32195 >>> com.myapp.packagename <<<

backtrace:
  #00  pc 0x000000000008abe8  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164)
  #01  pc 0x00000000006f365c  /apex/com.android.art/lib64/libart.so (art::Runtime::Abort(char const*)+596)
  #02  pc 0x0000000000016ea8  /apex/com.android.art/lib64/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_3::__invoke(char const*)+80)
  #03  pc 0x0000000000016450  /apex/com.android.art/lib64/libbase.so (android::base::LogMessage::~LogMessage()+352)
  #04  pc 0x00000000004660d0  /apex/com.android.art/lib64/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+1612)
  #05  pc 0x00000000005eb090  /apex/com.android.art/lib64/libart.so (art::JNI<false>::CallLongMethodV(_JNIEnv*, _jobject*, _jmethodID*, std::__va_list)+496)
  #06  pc 0x00000000000aaa10  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (_JNIEnv::CallLongMethod(_jobject*, _jmethodID*, ...)+116)
  #07  pc 0x00000000000a65a0  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (reanimated::NativeProxy::getCurrentTime()+68)
  #08  pc 0x00000000000a3094  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (reanimated::NativeProxy::handleEvent(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)+308)
  #09  pc 0x00000000000a8b50  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (std::__ndk1::__function::__func<std::__ndk1::function<void (facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)> reanimated::NativeProxy::bindThis<void, facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap> >(void (reanimated::NativeProxy::*)(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>))::'lambda'(facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&), std::__ndk1::allocator<std::__ndk1::function<void (facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)> reanimated::NativeProxy::bindThis<void, facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap> >(void (reanimated::NativeProxy::*)(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>))::'lambda'(facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&)>, void (facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)>::operator()(facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&)+76)
  #10  pc 0x00000000000b0694  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (facebook::jni::detail::MethodWrapper<void (reanimated::EventHandler::*)(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>), &(reanimated::EventHandler::receiveEvent(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)), reanimated::EventHandler, void, facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap> >::dispatch(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<reanimated::EventHandler, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&)+96)
  #11  pc 0x00000000000b05c8  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (facebook::jni::detail::FunctionWrapper<void (*)(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<reanimated::EventHandler, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&), facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<reanimated::EventHandler, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*, void, facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap> >::call(_JNIEnv*, _jobject*, _jstring*, int, facebook::jni::detail::JTypeFor<facebook::react::WritableMap, facebook::jni::JObject, void>::_javaobject*, void (*)(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<reanimated::EventHandler, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<facebook::jni::JString>&&, int&&, facebook::jni::alias_ref<facebook::react::WritableMap>&&))+96)
  #12  pc 0x00000000000b0540  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/lib/arm64/libreanimated.so (facebook::jni::detail::MethodWrapper<void (reanimated::EventHandler::*)(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>), &(reanimated::EventHandler::receiveEvent(facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap>)), reanimated::EventHandler, void, facebook::jni::alias_ref<facebook::jni::JString>, int, facebook::jni::alias_ref<facebook::react::WritableMap> >::call(_JNIEnv*, _jobject*, _jstring*, int, facebook::jni::detail::JTypeFor<facebook::react::WritableMap, facebook::jni::JObject, void>::_javaobject*)+36)
  #13  pc 0x000000000006c880  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.odex (art_jni_trampoline+144)
  #14  pc 0x000000000020a2b0  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #15  pc 0x00000000019acff4  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.reanimated.nativeProxy.EventHandler.receiveEvent+12)
  #16  pc 0x000000000020b074  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  #17  pc 0x00000000019b9d02  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (cw.c.c+30)
  #18  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #19  pc 0x00000000019a7010  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.reanimated.NodesManager.handleEvent+4)
  #20  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #21  pc 0x00000000019a71d0  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.reanimated.NodesManager.onEventDispatch+12)
  #22  pc 0x000000000202ee54  /memfd:jit-cache (com.facebook.react.uimanager.events.e.f+468)
  #23  pc 0x000000000020b0d4  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
  #24  pc 0x00000000019af70c  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.rnscreens.i.z1+344)
  #25  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #26  pc 0x00000000019af978  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.rnscreens.i.C1+80)
  #27  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #28  pc 0x00000000019aface  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.rnscreens.i.G1+2)
  #29  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #30  pc 0x00000000019b0280  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.rnscreens.k.G1)
  #31  pc 0x000000000020a254  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  #32  pc 0x00000000019afe2e  /data/app/~~g0lD1ldAJYWclsA4l0VB8Q==/com.myapp.packagename-1xgYia0DBo5rfymB6KVKQA==/oat/arm64/base.vdex (com.swmansion.rnscreens.k$b$a.onAnimationEnd+22)
  #33  pc 0x0000000000caa034  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.animation.Animation.dispatchAnimationEnd+84)
  #34  pc 0x0000000000396550  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat ([DEDUPED]+64)
  #35  pc 0x0000000000ac7114  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Handler.dispatchMessage+84)
  #36  pc 0x0000000000acb1c8  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loopOnce+1032)
  #37  pc 0x0000000000acac8c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loop+1148)
  #38  pc 0x00000000007d51f8  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.app.ActivityThread.main+1480)
  #39  pc 0x0000000000458600  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+576)
  #40  pc 0x000000000048b39c  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+1560)
  #41  pc 0x000000000048ad5c  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+48)
  #42  pc 0x00000000002f0148  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+120)
  #43  pc 0x0000000000a328f0  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+144)
  #44  pc 0x0000000000a3d794  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.ZygoteInit.main+3604)
  #45  pc 0x0000000000458600  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+576)
  #46  pc 0x0000000000589dfc  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+912)
  #47  pc 0x0000000000606de4  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+160)
  #48  pc 0x00000000000bfad0  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+120)
  #49  pc 0x00000000000cbdf8  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+852)
  #50  pc 0x0000000000002568  /system/bin/app_process64 (main+1300)
  #51  pc 0x0000000000083198  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+96)
```
### Investigation
After re-mapping the obfuscated classes & methods, I found it was high likely the crash originated from `react-native-screens`:
```
com.swmansion.rnscreens.ScreenStackFragment.ScreensCoordinatorLayout#onAnimationEnd()
com.swmansion.rnscreens.ScreenFragment#onViewAnimationEnd()
com.swmansion.reanimated.NodesManager#handleEvent(Event)
com.swmansion.reanimated.nativeProxy.EventHandler#receiveEvent(String, int, WritableMap)
...
NativeProxy::handleEvent(jni::alias_ref<JString>, jint, jni::alias_ref<react::WritableMap>)
NativeProxy::getCurrentTime()
```

### Hypothesis 
Since the `onAnimatedEnd()` method might also be invoked when `Fragment#onDestory()`, it is also likely that when invoking the `NativeProxy::getCurrentTime()`, the corresponding `javaPart` is invalid.
Additionally, if we do inject a `nullptr` into `NativeProxy::getCurrentTime()`, the crash will generate a pretty similar stack trace.

### Fix Plan
Accordingly, I have tried to simply patch the code via adding a null-check into `NativeProxy::getCurrentTime()` and early-terminate if possible.
Thankfully, it did eliminate the crash and since then, we did not observe this crash from analytical platforms anymore.
Hopefully it could help to resolve other users' problems as well. 

## Test plan

Snippet that forces the crash:
```cpp
double NativeProxy::getCurrentTime() {
  static const auto method = getJniMethod<jlong()>("getCurrentTime");
  // inject a nullptr into the method()
  jlong output = method(nullptr);
  return static_cast<double>(output);
}
```
