### PR TITLE
align with new layoutWithAffectedShadowViews on react-native@0.73

### DIFF
--- a/apple/LayoutReanimation/REASwizzledUIManager.mm
+++ b/apple/LayoutReanimation/REASwizzledUIManager.mm
@@ -135,7 +135,12 @@
   }
 
   RCTUIManager *originalSelf = (RCTUIManager *)self;
+#if REACT_NATIVE_MINOR_VERSION >= 73
   NSPointerArray *affectedShadowViews = [NSPointerArray weakObjectsPointerArray];
+#endif // REACT_NATIVE_MINOR_VERSION >= 73
+#if REACT_NATIVE_MINOR_VERSION <= 72
+  NSHashTable<RCTShadowView *> *affectedShadowViews = [NSHashTable weakObjectsHashTable];
+#endif // REACT_NATIVE_MINOR_VERSION <= 72
   [rootShadowView layoutWithAffectedShadowViews:affectedShadowViews];
 
   if (!affectedShadowViews.count) {

--- a/apple/LayoutReanimation/REASwizzledUIManager.mm
+++ b/apple/LayoutReanimation/REASwizzledUIManager.mm
@@ -135,7 +135,7 @@
   }
 
   RCTUIManager *originalSelf = (RCTUIManager *)self;
-  NSHashTable<RCTShadowView *> *affectedShadowViews = [NSHashTable weakObjectsHashTable];
+  NSPointerArray *affectedShadowViews = [NSPointerArray weakObjectsPointerArray];
   [rootShadowView layoutWithAffectedShadowViews:affectedShadowViews];
 
   if (!affectedShadowViews.count) {


### PR DESCRIPTION
There is an open PR with changes for calculating onLayout on iOS on Paper: https://github.com/facebook/react-native/pull/40748

This PR aligns reanimated with these changes. 
