### PR TITLE
fix(android): Unable to update properties for view tag

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -344,6 +344,19 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   public void updateProps(int viewTag, Map<String, Object> props) {
+    // We need to check current view exist in UIManager or not
+    // Sometime, view can be replace, recycle, ... with wrong way (like FlashList)
+    // So before update, We need to check view tag exist in UIManager
+    try {
+        View view = mUIManager.resolveView(viewTag);
+        if(view == null) {
+          return;
+        }
+    } catch (Exception ex) {
+        Log.d("Reanimated-updateProps", "Skip update props cause viewTag not exist or have been removed!");
+        return;
+    }
+
     // TODO: update PropsNode to use this method instead of its own way of updating props
     boolean hasUIProps = false;
     boolean hasNativeProps = false;


### PR DESCRIPTION

## Summary
### Platform: Android

I catch this issue when use [FlashList](https://shopify.github.io/flash-list/) with large data and have animated update on each item.
One element can be update/replace/recycle, so view tag can be update/remove too
So, before update props, we check current view tag exist in UIManager or not.

Fix [#4505](https://github.com/software-mansion/react-native-reanimated/issues/4505)
Fix [#4231](https://github.com/software-mansion/react-native-reanimated/issues/4231)
Fix [#3860](https://github.com/software-mansion/react-native-reanimated/issues/3860)

## Test plan
Before:

https://github.com/software-mansion/react-native-reanimated/assets/43195241/8f24027e-01d1-4af0-9bf6-8f611a14c6fa

After:

https://github.com/software-mansion/react-native-reanimated/assets/43195241/ccf439b9-8c76-4448-ad83-aaeae91e032b


