### PR TITLE
Add `overflow: hidden` in UpdatePropsPerfExample

### DIFF
--- a/app/src/examples/UpdatePropsPerfExample.tsx
+++ b/app/src/examples/UpdatePropsPerfExample.tsx
@@ -57,6 +57,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     flexDirection: 'column',
+    overflow: 'hidden',
   },
   bar: {
     width: 100,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR enables clipping in "Update props performance" to prevent bars from overlapping examples list:

https://github.com/software-mansion/react-native-reanimated/assets/20516055/1f6e7c64-08d3-43a8-a4f0-45dcde566994

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
