### PR TITLE
Fix "Trying to access property `__remoteFunction`" for inaccessible objects

### DIFF
--- a/app/src/examples/ShareablesExample.tsx
+++ b/app/src/examples/ShareablesExample.tsx
@@ -35,6 +35,8 @@ function InaccessibleObjectDemo() {
     const x = new Set();
     runOnUI(() => {
       console.log(x);
+      console.log(x instanceof Set); // returns false
+      console.log(x.has(42)); // should throw error
     })();
   };
 

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -62,10 +62,14 @@ const INACCESSIBLE_OBJECT = {
       {},
       {
         get: (_: any, prop: string | symbol) => {
-          if (prop === '_isReanimatedSharedValue') {
+          if (
+            prop === '_isReanimatedSharedValue' ||
+            prop === '__remoteFunction'
+          ) {
             // not very happy about this check here, but we need to allow for
             // "inaccessible" objects to be tested with isSharedValue check
-            // as it is being used in the mappers when extracing inputs recursively.
+            // as it is being used in the mappers when extracting inputs recursively
+            // as well as with isRemoteFunction when cloning objects recursively.
             // Apparently we can't check if a key exists there as HostObjects always
             // return true for such tests, so the only possibility for us is to
             // actually access that key and see if it is set to true. We therefore


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the message of the following error that appears when using an object that couldn't been cloned to the UI runtime, for example instances of `Map` or `Set`.

| Before | After |
|:-:|:-:|
| <img width="507" alt="Zrzut ekranu 2023-10-16 o 11 32 38" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/0193ebdf-a75c-48d7-a4a2-1318676185be"> | <img width="507" alt="Zrzut ekranu 2023-10-16 o 11 32 45" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/4f012976-1691-4436-9a2f-c717a4e3bd15"> |

## Test plan

```ts
const x = new Set();
runOnUI(() => {
  console.log(x.has(42));
})();
```
