### PR TITLE
Add shareable BigInt

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -92,6 +92,10 @@ jsi::Value makeShareableClone(
     shareable = std::make_shared<ShareableScalar>(value.getBool());
   } else if (value.isNumber()) {
     shareable = std::make_shared<ShareableScalar>(value.getNumber());
+#if REACT_NATIVE_MINOR_VERSION >= 71
+  } else if (value.isBigInt()) {
+    shareable = std::make_shared<ShareableBigInt>(rt, value.getBigInt(rt));
+#endif
   } else if (value.isSymbol()) {
     // TODO: this is only a placeholder implementation, here we replace symbols
     // with strings in order to make certain objects to be captured. There isn't
@@ -299,6 +303,12 @@ jsi::Value ShareableSynchronizedDataHolder::toJSValue(jsi::Runtime &rt) {
 
 jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {
   return jsi::String::createFromUtf8(rt, data_);
+}
+
+jsi::Value ShareableBigInt::toJSValue(jsi::Runtime &rt) {
+  return rt.global()
+      .getPropertyAsFunction(rt, "BigInt")
+      .call(rt, jsi::String::createFromAscii(rt, string_));
 }
 
 jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -305,11 +305,13 @@ jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {
   return jsi::String::createFromUtf8(rt, data_);
 }
 
+#if REACT_NATIVE_MINOR_VERSION >= 71
 jsi::Value ShareableBigInt::toJSValue(jsi::Runtime &rt) {
   return rt.global()
       .getPropertyAsFunction(rt, "BigInt")
       .call(rt, jsi::String::createFromAscii(rt, string_));
 }
+#endif
 
 jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {
   switch (valueType_) {

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -309,7 +309,7 @@ jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {
 jsi::Value ShareableBigInt::toJSValue(jsi::Runtime &rt) {
   return rt.global()
       .getPropertyAsFunction(rt, "BigInt")
-      .call(rt, jsi::String::createFromAscii(rt, string_));
+      .call(rt, jsi::String::createFromUtf8(rt, string_));
 }
 #endif
 

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -74,7 +74,7 @@ class Shareable {
     BooleanType,
     NumberType,
     // SymbolType, TODO
-    // BigIntType, TODO
+    BigIntType,
     StringType,
     ObjectType,
     ArrayType,
@@ -336,6 +336,19 @@ class ShareableString : public Shareable {
  protected:
   std::string data_;
 };
+
+#if REACT_NATIVE_MINOR_VERSION >= 71
+class ShareableBigInt : public Shareable {
+ public:
+  explicit ShareableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint)
+      : Shareable(BigIntType), string_(bigint.toString(rt).utf8(rt)) {}
+
+  jsi::Value toJSValue(jsi::Runtime &rt) override;
+
+ protected:
+  const std::string string_;
+};
+#endif
 
 class ShareableScalar : public Shareable {
  public:

--- a/app/src/examples/ShareablesExample.tsx
+++ b/app/src/examples/ShareablesExample.tsx
@@ -8,6 +8,7 @@ export default function ShareablesExample() {
     <View style={styles.container}>
       <CyclicObjectDemo />
       <InaccessibleObjectDemo />
+      <BigIntDemo />
       <ArrayBufferDemo />
       <TypedArrayDemo />
       <BigIntTypedArrayDemo />
@@ -39,6 +40,18 @@ function InaccessibleObjectDemo() {
   };
 
   return <Button title="Inaccessible object" onPress={handlePress} />;
+}
+
+function BigIntDemo() {
+  const handlePress = () => {
+    const bigint = BigInt('1234567890');
+    runOnUI(() => {
+      console.log(bigint === BigInt('1234567890'));
+      console.log(typeof bigint === 'bigint');
+    })();
+  };
+
+  return <Button title="BigInt" onPress={handlePress} />;
 }
 
 function ArrayBufferDemo() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds support for passing instances of `BigInt` to worklet runtimes.

## Test plan

ShareablesExample &rarr; BigIntDemo

```ts
const bigint = BigInt('1234567890');
runOnUI(() => {
  console.log(typeof bigint === 'bigint');
  console.log(bigint === BigInt('1234567890'));
})();
```
