### PR TITLE
Fix layout transitions crashes on web

### DIFF
--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -84,8 +84,6 @@ function chooseAction(
       handleEnteringAnimation(element, animationConfig);
       break;
     case LayoutAnimationType.LAYOUT:
-      // `transitionData` is cast as defined because it is a result of calculations made inside componentDidUpdate method.
-      // We can reach this piece of code only from componentDidUpdate, therefore this parameter will be defined.
       transitionData.reversed = animationConfig.reversed;
 
       handleLayoutTransition(

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -86,12 +86,7 @@ function chooseAction(
     case LayoutAnimationType.LAYOUT:
       // `transitionData` is cast as defined because it is a result of calculations made inside componentDidUpdate method.
       // We can reach this piece of code only from componentDidUpdate, therefore this parameter will be defined.
-
-      // @ts-ignore This property exists in SequencedTransition
-      (transitionData as TransitionData).reversed = config.reversed
-        ? // @ts-ignore This property exists in SequencedTransition
-          config.reversed
-        : false;
+      transitionData.reversed = animationConfig.reversed;
 
       handleLayoutTransition(
         element,

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -84,6 +84,10 @@ function getCallbackFromConfig(config: CustomConfig): AnimationCallback {
   return config.callbackV !== undefined ? config.callbackV! : null;
 }
 
+function getReversedFromConfig(config: CustomConfig) {
+  return !!config.reversed;
+}
+
 export function getProcessedConfig(
   animationName: string,
   config: CustomConfig,
@@ -101,6 +105,7 @@ export function getProcessedConfig(
     easing: getEasingFromConfig(config),
     reduceMotion: getReducedMotionFromConfig(config),
     callback: getCallbackFromConfig(config),
+    reversed: getReversedFromConfig(config),
   };
 }
 

--- a/src/reanimated2/layoutReanimation/web/config.ts
+++ b/src/reanimated2/layoutReanimation/web/config.ts
@@ -50,6 +50,7 @@ export interface AnimationConfig {
   easing: string;
   reduceMotion: boolean;
   callback: AnimationCallback;
+  reversed: boolean;
 }
 
 export interface CustomConfig {
@@ -59,6 +60,7 @@ export interface CustomConfig {
   randomizeDelay?: boolean;
   reduceMotionV?: ReduceMotion;
   callbackV?: AnimationCallback;
+  reversed?: boolean;
 }
 
 export enum TransitionType {


### PR DESCRIPTION
## Summary

While refactoring `animationsManager` file I've moved most of the logic to new functions. Turns out that VSCode tricked me and left syntax highlighting on a variable that wasn't present in `chooseAction` (namely `config`). This caused crashes while starting layout transition.

## Test plan

Verified that layout transitions work on [LA] examples in our example app