### PR TITLE
Fix Fast Refresh with useDerivedValue

### DIFF
--- a/src/reanimated2/hook/useDerivedValue.ts
+++ b/src/reanimated2/hook/useDerivedValue.ts
@@ -6,6 +6,7 @@ import { makeMutable, startMapper, stopMapper } from '../core';
 import type { DependencyList } from './commonTypes';
 import { shouldBeUseWeb } from '../PlatformChecker';
 
+// @refresh reset
 export type DerivedValue<Value> = Readonly<SharedValue<Value>>;
 
 // @ts-expect-error This overload is required by our API.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Closes #1964

According to documentation https://reactnative.dev/docs/fast-refresh adding comment `// @refresh reset` anywhere in a file forces the state to be reset on Fast Refresh, which is handy since we have some calculations that should be done only on mount.

This PR doesn't change any behaviour in RELEASE mode at all.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan
<details>
<summary>Tested on this example: </summary>

```jsx
import * as React from 'react'
import { Text, View, StyleSheet, Pressable } from 'react-native'
import Animated, { useSharedValue, useDerivedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated'

/**
 * Inside of App, try commenting out the extraState prop that is passed to to <Shape />
 *
 * Once you comment it out, and save with Fast Refresh, the derived value no longer updates when you press on the box.
 *
 * Updating the scoped variables around a derived value seems to break the mutation of a shared value
 */

function Shape({ extraState, pressed }) {
  const opacity = useDerivedValue(() => (pressed.value ? 0.5 : 1))

  const style = useAnimatedStyle(() => ({
    opacity: withTiming(opacity.value)
  }))

  return <Animated.View style={[styles.shape, style]} />
}

export default function App() {
  const pressed = useSharedValue(false)
  const [pressedState, setPressed] = React.useState(false)

  const onPressIn = () => {
    pressed.value = true
    setPressed(true)
  }
  const onPressOut = () => {
    pressed.value = false
    setPressed(false)
  }

  return (
    <Pressable onPressIn={onPressIn} onPressOut={onPressOut} style={styles.container}>
      <Shape
        pressed={pressed}
        // comment extraState in/out, and then save. Notice that doing this breaks the press in/out interaction
        extraState={pressedState}
      />
    </Pressable>
  )
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: 'cyan',
    padding: 8
  },
  shape: {
    height: 200,
    width: 200,
    backgroundColor: 'black',
    borderRadius: 16
  }
})
```

</details>