### PR TITLE
Fix `ShadowNodeWrapper` type

### DIFF
--- a/src/createAnimatedComponent/InlinePropManager.ts
+++ b/src/createAnimatedComponent/InlinePropManager.ts
@@ -13,11 +13,12 @@ import updateProps from '../reanimated2/UpdateProps';
 import { stopMapper, startMapper } from '../reanimated2/mappers';
 import { isSharedValue } from '../reanimated2/utils';
 import { shouldBeUseWeb } from '../reanimated2/PlatformChecker';
+import type { ShadowNodeWrapper } from '../reanimated2/commonTypes';
 
 export interface ViewInfo {
   viewTag: number | HTMLElement | null;
   viewName: string | null;
-  shadowNodeWrapper: object | null;
+  shadowNodeWrapper: ShadowNodeWrapper | null;
   viewConfig: ViewConfig;
 }
 

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -186,7 +186,9 @@ export enum InterfaceOrientation {
   ROTATION_270 = 270,
 }
 
-export type ShadowNodeWrapper = object;
+export type ShadowNodeWrapper = {
+  __hostObjectShadowNodeWrapper: never;
+};
 
 export enum KeyboardState {
   UNKNOWN = 0,

--- a/src/reanimated2/platformFunctions/scrollTo.web.ts
+++ b/src/reanimated2/platformFunctions/scrollTo.web.ts
@@ -14,6 +14,7 @@ export function scrollTo<T extends Component>(
   // This prevents crashes if ref has not been set yet
   if (element !== -1) {
     // By ScrollView we mean any scrollable component
-    (element as ScrollView)?.scrollTo({ x, y, animated });
+    const scrollView = element as HTMLElement as unknown as ScrollView;
+    scrollView?.scrollTo({ x, y, animated });
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR improves typing of `ShadowNodeWrapper` so it's no longer possible to confuse it with a regular `object`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
