### PR TITLE
Move `setNativeProps` and `getRelativeCoords` to `platformFunctions`

### DIFF
--- a/src/createAnimatedComponent/InlinePropManager.ts
+++ b/src/createAnimatedComponent/InlinePropManager.ts
@@ -11,7 +11,7 @@ import type { ViewConfig } from '../ConfigHelper';
 import { adaptViewConfig } from '../ConfigHelper';
 import updateProps from '../reanimated2/UpdateProps';
 import { stopMapper, startMapper } from '../reanimated2/mappers';
-import { isSharedValue } from '../reanimated2/utils';
+import { isSharedValue } from '../reanimated2/isSharedValue';
 import { shouldBeUseWeb } from '../reanimated2/PlatformChecker';
 import type { ShadowNodeWrapper } from '../reanimated2/commonTypes';
 

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -96,8 +96,8 @@ export {
   dispatchCommand,
   scrollTo,
   setGestureState,
+  setNativeProps,
 } from './platformFunctions';
-export { setNativeProps } from './SetNativeProps';
 export type { ParsedColorArray } from './Colors';
 export { isColor, processColor, convertToRGBA } from './Colors';
 export { createAnimatedPropAdapter } from './PropAdapters';

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -91,12 +91,14 @@ export type {
   EasingFactoryFn,
 } from './Easing';
 export { Easing } from './Easing';
+export type { ComponentCoords } from './platformFunctions';
 export {
   measure,
   dispatchCommand,
   scrollTo,
   setGestureState,
   setNativeProps,
+  getRelativeCoords,
 } from './platformFunctions';
 export type { ParsedColorArray } from './Colors';
 export { isColor, processColor, convertToRGBA } from './Colors';
@@ -216,8 +218,7 @@ export {
   SharedTransition,
   SharedTransitionType,
 } from './layoutReanimation';
-export type { ComponentCoords } from './utils';
-export { getRelativeCoords, isSharedValue } from './utils';
+export { isSharedValue } from './isSharedValue';
 export type {
   StyleProps,
   SharedValue,

--- a/src/reanimated2/initializers.ts
+++ b/src/reanimated2/initializers.ts
@@ -7,7 +7,7 @@ import {
   callMicrotasks,
   runOnUIImmediately,
 } from './threads';
-import { mockedRequestAnimationFrame } from './utils';
+import { mockedRequestAnimationFrame } from './mockedRequestAnimationFrame';
 
 const IS_JEST = isJest();
 const IS_NATIVE = !shouldBeUseWeb();

--- a/src/reanimated2/isSharedValue.ts
+++ b/src/reanimated2/isSharedValue.ts
@@ -1,0 +1,7 @@
+'use strict';
+import type { SharedValue } from './commonTypes';
+
+export function isSharedValue<T>(value: any): value is SharedValue<T> {
+  'worklet';
+  return value?._isReanimatedSharedValue === true;
+}

--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -15,7 +15,7 @@ import { SensorType } from '../commonTypes';
 import type { WorkletRuntime } from '../runtimes';
 import type { WebSensor } from './WebSensor';
 
-import { mockedRequestAnimationFrame } from '../utils';
+import { mockedRequestAnimationFrame } from '../mockedRequestAnimationFrame';
 
 // In Node.js environments (like when static rendering with Expo Router)
 // requestAnimationFrame is unavailable, so we use our mock.

--- a/src/reanimated2/mappers.ts
+++ b/src/reanimated2/mappers.ts
@@ -2,7 +2,7 @@
 import type { SharedValue } from './commonTypes';
 import { isJest } from './PlatformChecker';
 import { runOnUI } from './threads';
-import { isSharedValue } from './utils';
+import { isSharedValue } from './isSharedValue';
 
 const IS_JEST = isJest();
 

--- a/src/reanimated2/mockedRequestAnimationFrame.ts
+++ b/src/reanimated2/mockedRequestAnimationFrame.ts
@@ -1,0 +1,9 @@
+'use strict';
+
+// This is Jest implementation of `requestAnimationFrame` that is required
+// by React Native for test purposes.
+export function mockedRequestAnimationFrame(
+  callback: (timestamp: number) => void
+) {
+  return setTimeout(() => callback(performance.now()), 0);
+}

--- a/src/reanimated2/platformFunctions/getRelativeCoords.ts
+++ b/src/reanimated2/platformFunctions/getRelativeCoords.ts
@@ -1,8 +1,7 @@
 'use strict';
 import type { Component } from 'react';
-import { measure } from './platformFunctions';
-import type { AnimatedRef } from './hook/commonTypes';
-import type { SharedValue } from './commonTypes';
+import { measure } from './measure';
+import type { AnimatedRef } from '../hook/commonTypes';
 
 export interface ComponentCoords {
   x: number;
@@ -27,9 +26,4 @@ export function getRelativeCoords(
     x: absoluteX - parentCoords.x,
     y: absoluteY - parentCoords.y,
   };
-}
-
-export function isSharedValue<T>(value: any): value is SharedValue<T> {
-  'worklet';
-  return value?._isReanimatedSharedValue === true;
 }

--- a/src/reanimated2/platformFunctions/index.ts
+++ b/src/reanimated2/platformFunctions/index.ts
@@ -1,4 +1,6 @@
+'use strict';
 export { dispatchCommand } from './dispatchCommand';
 export { measure } from './measure';
 export { scrollTo } from './scrollTo';
 export { setGestureState } from './setGestureState';
+export { setNativeProps } from './setNativeProps';

--- a/src/reanimated2/platformFunctions/index.ts
+++ b/src/reanimated2/platformFunctions/index.ts
@@ -4,3 +4,5 @@ export { measure } from './measure';
 export { scrollTo } from './scrollTo';
 export { setGestureState } from './setGestureState';
 export { setNativeProps } from './setNativeProps';
+export { getRelativeCoords } from './getRelativeCoords';
+export type { ComponentCoords } from './getRelativeCoords';

--- a/src/reanimated2/platformFunctions/setNativeProps.ts
+++ b/src/reanimated2/platformFunctions/setNativeProps.ts
@@ -1,10 +1,10 @@
 'use strict';
-import type { ShadowNodeWrapper, StyleProps } from './commonTypes';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from './PlatformChecker';
+import type { ShadowNodeWrapper, StyleProps } from '../commonTypes';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 
-import type { AnimatedRef } from './hook/commonTypes';
+import type { AnimatedRef } from '../hook/commonTypes';
 import type { Component } from 'react';
-import { processColorsInProps } from './Colors';
+import { processColorsInProps } from '../Colors';
 
 const IS_NATIVE = !shouldBeUseWeb();
 

--- a/src/reanimated2/platformFunctions/setNativeProps.web.ts
+++ b/src/reanimated2/platformFunctions/setNativeProps.web.ts
@@ -1,7 +1,7 @@
 'use strict';
-import { _updatePropsJS } from './js-reanimated';
-import type { StyleProps } from './commonTypes';
-import type { AnimatedRef } from './hook/commonTypes';
+import { _updatePropsJS } from '../js-reanimated';
+import type { StyleProps } from '../commonTypes';
+import type { AnimatedRef } from '../hook/commonTypes';
 import type { Component } from 'react';
 
 export function setNativeProps<T extends Component>(

--- a/src/reanimated2/utils.ts
+++ b/src/reanimated2/utils.ts
@@ -33,11 +33,3 @@ export function isSharedValue<T>(value: any): value is SharedValue<T> {
   'worklet';
   return value?._isReanimatedSharedValue === true;
 }
-
-// This is Jest implementation of `requestAnimationFrame` that is required
-// by React Native for test purposes.
-export function mockedRequestAnimationFrame(
-  callback: (timestamp: number) => void
-) {
-  return setTimeout(() => callback(performance.now()), 0);
-}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR moves `setNativeProps` (and `getRelativeCoords`) function to `platformFunctions` directory as well as updates imports and removes circular dependencies by splitting `utils.ts` with mostly unrelated functions (which was the root cause of the issue) into separate files.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
