### PR TITLE
Fix `runOnJS` crash in release mode again

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -69,9 +69,9 @@ jsi::Value makeShareableClone(
       shareable =
           std::make_shared<ShareableArrayBuffer>(rt, object.getArrayBuffer(rt));
     } else if (object.isHostObject(rt)) {
-      assert(
-          !object.isHostObject<ShareableJSRef>(rt) &&
-          "[Reanimated] Provided value is already an instance of ShareableJSRef.");
+      if (object.isHostObject<ShareableJSRef>(rt)) {
+        return object;
+      }
       shareable =
           std::make_shared<ShareableHostObject>(rt, object.getHostObject(rt));
     } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes a crash described in https://github.com/software-mansion/react-native-reanimated/issues/4613#issuecomment-1741018643.

Turns out that the condition in assert is always true in debug mode but there's an optimization for RemoteFunction in release mode which breaks it.

## Test plan

See repro in #4617.
