### PR TITLE
Use stable version of CLI

### DIFF
--- a/.github/workflows/build-monorepo-action.yml
+++ b/.github/workflows/build-monorepo-action.yml
@@ -30,10 +30,10 @@ jobs:
         run: mkdir -p monorepo/packages
       - name: Create RootApp
         working-directory: monorepo
-        run: npx react-native@next init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native init RootApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Create PackageApp
         working-directory: monorepo/packages
-        run: npx react-native@next init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
+        run: npx react-native init PackageApp --skip-install ${{ env.REACT_NATIVE_TEMPLATE }}
       - name: Setup monorepo
         working-directory: monorepo
         run: |


### PR DESCRIPTION
## Summary

We should use stable version of CLI for nightly jobs. Now our CLI on main fails - https://github.com/software-mansion/react-native-reanimated/actions/workflows/build-monorepo-nightly.yml
