### PR TITLE
Change gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .DS_Store
 
 # Xcode
-build/
+apple/build
+ios/build
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -21,6 +22,7 @@ DerivedData
 project.xcworkspace
 
 # Android/IJ
+android/build
 *.iml
 .idea
 .gradle
@@ -56,5 +58,5 @@ react-native-reanimated-tests.js
 *.settings**
 
 # plugin
-!plugin/build/plugin.js
+plugin/build/plugin.js.map
 plugin/types


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR changes the main `.gitignore` file to ignore `plugin.js.map` instead of ignoring all `build/` folders and treating `plugin.js` as an exception. The previous version was causing husky to throw an error when changes to `plugin.js` were committed.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
