### PR TITLE
Remove unused methods from `ThreadSafeQueue`

### DIFF
--- a/Common/cpp/Tools/ThreadSafeQueue.h
+++ b/Common/cpp/Tools/ThreadSafeQueue.h
@@ -20,25 +20,9 @@ class ThreadSafeQueue {
     while (queue_.empty()) {
       cond_.wait(mlock);
     }
-    auto item = queue_.front();
+    const auto item = queue_.front();
     queue_.pop();
     return item;
-  }
-
-  void pop(T &item) {
-    std::unique_lock<std::mutex> mlock(mutex_);
-    while (queue_.empty()) {
-      cond_.wait(mlock);
-    }
-    item = queue_.front();
-    queue_.pop();
-  }
-
-  void push(const T &item) {
-    std::unique_lock<std::mutex> mlock(mutex_);
-    queue_.push(item);
-    mlock.unlock();
-    cond_.notify_one();
   }
 
   void push(T &&item) {
@@ -48,9 +32,9 @@ class ThreadSafeQueue {
     cond_.notify_one();
   }
 
-  size_t getSize() {
+  bool empty() const {
     std::unique_lock<std::mutex> mlock(mutex_);
-    const size_t res = queue_.size();
+    const auto res = queue_.empty();
     mlock.unlock();
     cond_.notify_one();
     return res;
@@ -58,8 +42,8 @@ class ThreadSafeQueue {
 
  private:
   std::queue<T> queue_;
-  std::mutex mutex_;
-  std::condition_variable cond_;
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cond_;
 };
 
 } // namespace reanimated

--- a/Common/cpp/Tools/UIScheduler.cpp
+++ b/Common/cpp/Tools/UIScheduler.cpp
@@ -11,7 +11,7 @@ void UIScheduler::scheduleOnUI(std::function<void()> job) {
 
 void UIScheduler::triggerUI() {
   scheduledOnUI_ = false;
-  while (uiJobs_.getSize()) {
+  while (!uiJobs_.empty()) {
     const auto job = uiJobs_.pop();
     job();
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR introduces the following improvements to `ThreadSafeQueue`:
* Removes unused methods
* Converts `getSize` method into `empty`
* Mark mutex and conditional variable as `mutable`
* Mark `empty` method as `const`

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
