### PR TITLE
[Web] Fix hiding component with `entering` on every render

### DIFF
--- a/src/createAnimatedComponent/utils.ts
+++ b/src/createAnimatedComponent/utils.ts
@@ -12,6 +12,10 @@ import type {
   ViewDescriptorsSet,
   ViewRefSet,
 } from '../reanimated2/ViewDescriptorsSet';
+import type { JSPropUpdater } from './JSPropUpdater';
+import type { InlinePropManager, ViewInfo } from './InlinePropManager';
+import type { SkipEnteringContext } from 'src/reanimated2/component/LayoutAnimationConfig';
+import type { PropsFilter } from './PropsFilter';
 
 export interface AnimatedProps extends Record<string, unknown> {
   viewDescriptors?: ViewDescriptorsSet;
@@ -41,6 +45,27 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
   sharedTransitionTag?: string;
   sharedTransitionStyle?: SharedTransition;
 };
+
+export interface ReanimatedComponentRef extends Component {
+  setNativeProps?: (props: Record<string, unknown>) => void;
+  getScrollableNode?: () => ReanimatedComponentRef;
+  getAnimatableRef?: () => ReanimatedComponentRef;
+}
+
+export interface AnimatedComponentClass {
+  _styles: StyleProps[] | null;
+  _animatedProps?: Partial<AnimatedComponentProps<AnimatedProps>>;
+  _viewTag: number;
+  _isFirstRender: boolean;
+  animatedStyle: { value: StyleProps };
+  _component: ReanimatedComponentRef | HTMLElement | null;
+  _sharedElementTransition: SharedTransition | null;
+  _JSPropUpdater: JSPropUpdater;
+  _InlinePropManager: InlinePropManager;
+  _PropsFilter: PropsFilter;
+  _viewInfo?: ViewInfo;
+  context: React.ContextType<typeof SkipEnteringContext>;
+}
 
 type NestedArray<T> = T | NestedArray<T>[];
 

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -35,18 +35,12 @@ function chooseConfig<ComponentProps extends Record<string, unknown>>(
 
 function checkUndefinedAnimationFail(
   initialAnimationName: string,
-  isLayoutTransition: boolean,
-  hasEnteringAnimation: boolean,
-  element: HTMLElement
+  isLayoutTransition: boolean
 ) {
   // This prevents crashes if we try to set animations that are not defined.
   // We don't care about layout transitions since they're created dynamically
   if (initialAnimationName in Animations || isLayoutTransition) {
     return false;
-  }
-
-  if (hasEnteringAnimation) {
-    makeElementVisible(element);
   }
 
   console.warn(
@@ -56,17 +50,9 @@ function checkUndefinedAnimationFail(
   return true;
 }
 
-function checkReduceMotionFail(
-  animationConfig: AnimationConfig,
-  hasEnteringAnimation: boolean,
-  element: HTMLElement
-) {
+function checkReduceMotionFail(animationConfig: AnimationConfig) {
   if (!animationConfig.reduceMotion) {
     return false;
-  }
-
-  if (hasEnteringAnimation) {
-    makeElementVisible(element);
   }
 
   return true;
@@ -105,6 +91,7 @@ export function startWebLayoutAnimation<
   props: Readonly<AnimatedComponentProps<ComponentProps>>,
   element: HTMLElement,
   animationType: LayoutAnimationType,
+  shouldMakeVisible = false,
   transitionData?: TransitionData
 ) {
   const config = chooseConfig(animationType, props);
@@ -112,16 +99,13 @@ export function startWebLayoutAnimation<
     return;
   }
 
-  const hasEnteringAnimation = props.entering !== undefined;
   const isLayoutTransition = animationType === LayoutAnimationType.LAYOUT;
   const initialAnimationName =
     typeof config === 'function' ? config.name : config.constructor.name;
 
   const shouldFail = checkUndefinedAnimationFail(
     initialAnimationName,
-    isLayoutTransition,
-    hasEnteringAnimation,
-    element
+    isLayoutTransition
   );
 
   if (shouldFail) {
@@ -141,8 +125,12 @@ export function startWebLayoutAnimation<
     initialAnimationName as AnimationNames
   );
 
-  if (checkReduceMotionFail(animationConfig, hasEnteringAnimation, element)) {
+  if (checkReduceMotionFail(animationConfig)) {
     return;
+  }
+
+  if (shouldMakeVisible) {
+    makeElementVisible(element);
   }
 
   chooseAction(
@@ -183,6 +171,7 @@ export function tryActivateLayoutTransition<
     props,
     element,
     LayoutAnimationType.LAYOUT,
+    false,
     transitionData
   );
 }

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -154,16 +154,10 @@ export function handleEnteringAnimation(
   // If `delay` === 0, value passed to `setTimeout` will be 0. However, `setTimeout` executes after given amount of time, not exactly after that time
   // Because of that, we have to immediately toggle on the component when the delay is 0.
   if (delay === 0) {
-    _updatePropsJS(
-      { visibility: 'initial' },
-      { _component: element as ReanimatedHTMLElement }
-    );
+    makeElementVisible(element);
   } else {
     setTimeout(() => {
-      _updatePropsJS(
-        { visibility: 'initial' },
-        { _component: element as ReanimatedHTMLElement }
-      );
+      makeElementVisible(element);
     }, delay * 1000);
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Some TS shenanigans as a necessary bonus.

<table>
<tr><td>BEFORE</td><td>AFTER</td></tr>
<tr><td>

https://github.com/software-mansion/react-native-reanimated/assets/40713406/d13c9186-f1e5-4e12-bbb1-704b1eac0c08

</td><td>

https://github.com/software-mansion/react-native-reanimated/assets/40713406/804fbcfb-f0f0-4b3f-9af3-c46617ffed18

</td></tr>
</table>




## Test plan

<details>

```tsx
import { StyleSheet, View, Button } from 'react-native';

import Animated, { FadeIn } from 'react-native-reanimated';

import React from 'react';

export default function EmptyExample() {
  const [shouldBeUseEntering, setShouldBeUseEntering] = React.useState(false);

  function handlePress() {
    setShouldBeUseEntering(!shouldBeUseEntering);
  }

  return (
    <View style={styles.container}>
      <Button title="ShouldBeUseEntering" onPress={handlePress} />
      <Animated.View
        style={styles.box}
        entering={shouldBeUseEntering ? FadeIn : undefined}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'blue',
  },
});
```

</details>

