### PR TITLE
Improve mockedRequestAnimationFrame generated types.

### DIFF
--- a/src/reanimated2/mockedRequestAnimationFrame.ts
+++ b/src/reanimated2/mockedRequestAnimationFrame.ts
@@ -4,6 +4,6 @@
 // by React Native for test purposes.
 export function mockedRequestAnimationFrame(
   callback: (timestamp: number) => void
-) {
+): ReturnType<typeof setTimeout> {
   return setTimeout(() => callback(performance.now()), 0);
 }


### PR DESCRIPTION
## Summary

Applying this change makes build process avoid including `/// <reference types="node" />` annotation in generated output.
In effect developers using package won't automatically have node types imported into their codebase.

**Before**

<img width="849" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/109506928/bbb7159f-d7c2-40ef-a86d-bb0251706126">

**After**

<img width="992" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/109506928/a4f7bc5e-d0c4-432e-8efd-5c879493af32">

