### PR TITLE
Update first sentence tense in getting-started.mdx

### DIFF
--- a/docs/docs/fundamentals/getting-started.mdx
+++ b/docs/docs/fundamentals/getting-started.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Getting started
 
-The _Fundamentals_ section is designed to help you gain a strong foundation on the core concepts of Reanimated and give you the confidence to explore more advanced use cases on your own. This section is packed with interactive examples, code snippets and explanations. Are you ready? Let's dive in!
+The goal of the _Fundamentals_ section is to help you gain a strong foundation on the core concepts of Reanimated and give you the confidence to explore more advanced use cases on your own. This section is packed with interactive examples, code snippets and explanations. Are you ready? Let's dive in!
 
 ## What is React Native Reanimated?
 

--- a/docs/docs/fundamentals/getting-started.mdx
+++ b/docs/docs/fundamentals/getting-started.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Getting started
 
-The _Fundamentals_ section was designed to help you gain a strong foundation on the core concepts of Reanimated and give you the confidence to explore more advanced use cases on your own. This section is packed with interactive examples, code snippets and explanations. Are you ready? Let's dive in!
+The _Fundamentals_ section is designed to help you gain a strong foundation on the core concepts of Reanimated and give you the confidence to explore more advanced use cases on your own. This section is packed with interactive examples, code snippets and explanations. Are you ready? Let's dive in!
 
 ## What is React Native Reanimated?
 


### PR DESCRIPTION
Having "was" confused me, and I went back to the fundamentals header, thinking I missed something. This makes it more clear I am in the right spot, and I don't need to go search for a "fundaments section".

To me, it currently reads "now that you have a strong understanding from the fundamentals section, here is a new sections with ..."

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
