### PR TITLE
Fix inverted `FlatList`

### DIFF
--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -23,7 +23,6 @@ const createCellRendererComponent = (
   itemLayoutAnimation?: ILayoutAnimationBuilder
 ) => {
   const CellRendererComponent = (props: CellRendererComponentProps) => {
-    console.log(itemLayoutAnimation);
     return (
       <AnimatedView
         // TODO TYPESCRIPT This is temporary cast is to get rid of .d.ts file.

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -2,7 +2,7 @@
 import type { ForwardedRef } from 'react';
 import React, { Component, forwardRef } from 'react';
 import type { FlatListProps, LayoutChangeEvent } from 'react-native';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList } from 'react-native';
 import { AnimatedView } from './View';
 import { createAnimatedComponent } from '../../createAnimatedComponent';
 import type { ILayoutAnimationBuilder } from '../layoutReanimation/animationBuilder/commonTypes';
@@ -12,25 +12,21 @@ import { LayoutAnimationConfig } from './LayoutAnimationConfig';
 
 const AnimatedFlatList = createAnimatedComponent(FlatList as any) as any;
 
-interface AnimatedFlatListProps {
+interface CellRendererProps {
   onLayout: (event: LayoutChangeEvent) => void;
   // implicit `children` prop has been removed in @types/react^18.0.0
   children: React.ReactNode;
-  inverted?: boolean;
-  horizontal?: boolean;
+  style?: StyleProps;
 }
 
-const createCellRenderer = (
-  itemLayoutAnimation?: ILayoutAnimationBuilder,
-  cellStyle?: StyleProps
-) => {
-  const cellRenderer = (props: AnimatedFlatListProps) => {
+const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
+  const cellRenderer = (props: CellRendererProps) => {
     return (
       <AnimatedView
         // TODO TYPESCRIPT This is temporary cast is to get rid of .d.ts file.
         layout={itemLayoutAnimation as any}
         onLayout={props.onLayout}
-        style={cellStyle}>
+        style={props.style}>
         {props.children}
       </AnimatedView>
     );
@@ -63,12 +59,6 @@ export const ReanimatedFlatList = forwardRef(
     const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
       props;
 
-    const cellStyle = restProps?.inverted
-      ? restProps?.horizontal
-        ? styles.horizontallyInverted
-        : styles.verticallyInverted
-      : undefined;
-
     // Set default scrollEventThrottle, because user expects
     // to have continuous scroll events and
     // react-native defaults it to 50 for FlatLists.
@@ -79,8 +69,8 @@ export const ReanimatedFlatList = forwardRef(
     }
 
     const cellRenderer = React.useMemo(
-      () => createCellRenderer(itemLayoutAnimation, cellStyle),
-      [cellStyle]
+      () => createCellRenderer(itemLayoutAnimation),
+      []
     );
 
     const animatedFlatList = (
@@ -102,11 +92,6 @@ export const ReanimatedFlatList = forwardRef(
     );
   }
 ) as unknown as ReanimatedFlatList<any>;
-
-const styles = StyleSheet.create({
-  verticallyInverted: { transform: [{ scaleY: -1 }] },
-  horizontallyInverted: { transform: [{ scaleX: -1 }] },
-});
 
 export type ReanimatedFlatList<T> = typeof ReanimatedFlatListClass<T> &
   FlatList<T>;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -12,15 +12,18 @@ import { LayoutAnimationConfig } from './LayoutAnimationConfig';
 
 const AnimatedFlatList = createAnimatedComponent(FlatList as any) as any;
 
-interface CellRendererProps {
+interface CellRendererComponentProps {
   onLayout: (event: LayoutChangeEvent) => void;
   // implicit `children` prop has been removed in @types/react^18.0.0
   children: React.ReactNode;
   style?: StyleProps;
 }
 
-const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
-  const cellRenderer = (props: CellRendererProps) => {
+const createCellRendererComponent = (
+  itemLayoutAnimation?: ILayoutAnimationBuilder
+) => {
+  const CellRendererComponent = (props: CellRendererComponentProps) => {
+    console.log(itemLayoutAnimation);
     return (
       <AnimatedView
         // TODO TYPESCRIPT This is temporary cast is to get rid of .d.ts file.
@@ -32,7 +35,7 @@ const createCellRenderer = (itemLayoutAnimation?: ILayoutAnimationBuilder) => {
     );
   };
 
-  return cellRenderer;
+  return CellRendererComponent;
 };
 
 interface ReanimatedFlatListPropsWithLayout<T> extends FlatListProps<T> {
@@ -68,8 +71,8 @@ export const ReanimatedFlatList = forwardRef(
       restProps.scrollEventThrottle = 1;
     }
 
-    const cellRenderer = React.useMemo(
-      () => createCellRenderer(itemLayoutAnimation),
+    const CellRendererComponent = React.useMemo(
+      () => createCellRendererComponent(itemLayoutAnimation),
       []
     );
 
@@ -77,7 +80,7 @@ export const ReanimatedFlatList = forwardRef(
       <AnimatedFlatList
         ref={ref}
         {...restProps}
-        CellRendererComponent={cellRenderer}
+        CellRendererComponent={CellRendererComponent}
       />
     );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR changes how reanimated treats inverted `FlatLists`. In #3765 our implementation was changed to mimic the react-native behavior by assigning a special style that reverts the cell inversion (inverted FlatList flips the entire view and then flips back every cell). In react-native@0.72.4 the inversion style was [changed](https://github.com/facebook/react-native/pull/38073) on android due to some performance issues. That change combined with our implementation was causing the cell to remain inverted on android (since both styles were being applied). This PR changes our implementation to instead allow the `CellRendererComponent` to receive a style prop, making react solely responsible for the cell inversion.


## Test plan
Check whether the Inverted FlatList Example behaves properly on android.
I tested the example on all rn versions from rn@0.69