### PR TITLE
Fix typo in `useAnimatedSensor` docs

### DIFF
--- a/docs/docs/device/useAnimatedSensor.mdx
+++ b/docs/docs/device/useAnimatedSensor.mdx
@@ -218,7 +218,7 @@ import AnimatedSensorSrc from '!!raw-loader!@site/src/examples/AnimatedSensor';
 
 ## Platform compatibility
 
-<div className="compatibility">
+<div className="platform-compatibility">
 
 | Android | iOS | Web |
 | ------- | --- | --- |


### PR DESCRIPTION
## Summary

By mistake I've used a wrong css class to style platform compatibility table in the last section of `useAnimatedSensor` docs 

Before
<img width="869" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/39658211/cf6d06fb-a753-4a08-8745-960ec3e42c2f">


After

<img width="876" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/39658211/45223307-f2ba-4bc7-9591-98183972ff00">


## Test plan

😉 
