### PR TITLE
Add clamp to mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -38,6 +38,7 @@ const Reanimated = {
 
   interpolate: NOOP,
   interpolateColor: NOOP,
+  clamp: NOOP,
   createAnimatedComponent: (Component) => Component,
   addWhitelistedUIProps: NOOP,
   addWhitelistedNativeProps: NOOP,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes error `TypeError: (0 , _reactNativeReanimated.clamp) is not a function`.

## Test plan

`jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'))`
