### PR TITLE
Update paths in iOS/tvOS/macOS workflows

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,7 +21,7 @@ on:
       - .github/workflows/ios-build.yml
       - RNReanimated.podspec
       - scripts/reanimated_utils.rb
-      - ios/**
+      - apple/**
       - Common/**
       - Example/package.json
       - Example/ios/**

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -2,19 +2,29 @@ name: Test macOS build
 on:
   pull_request:
     paths:
-      - '.github/workflows/macos-build.yml'
-      - 'RNReanimated.podspec'
-      - 'apple/**'
-      - 'Common/**'
-      - 'MacOSExample/package.json'
-      - 'MacOSExample/ios/**'
-      - 'MacOSExample/macos/**'
+      - .github/workflows/macos-build.yml
+      - RNReanimated.podspec
+      - scripts/reanimated_utils.rb
+      - apple/**
+      - Common/**
+      - MacOSExample/package.json
+      - MacOSExample/ios/**
+      - MacOSExample/macos/**
   merge_group:
     branches:
       - main
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/macos-build.yml
+      - RNReanimated.podspec
+      - scripts/reanimated_utils.rb
+      - apple/**
+      - Common/**
+      - MacOSExample/package.json
+      - MacOSExample/ios/**
+      - MacOSExample/macos/**
 
 jobs:
   build:

--- a/.github/workflows/tvos-build.yml
+++ b/.github/workflows/tvos-build.yml
@@ -17,7 +17,7 @@ on:
     paths:
       - '.github/workflows/tvos-build.yml'
       - 'RNReanimated.podspec'
-      - 'ios/**'
+      - 'apple/**'
       - 'Common/**'
       - 'TVOSExample/package.json'
       - 'TVOSExample/ios/**'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I've noticed that MacOSExample CIs are started even for JS-only PRs because `on.push.paths` was not specified.

Additionally, I fixed paths in iOS and tvOS workflows (`ios` &rarr; `apple`).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
