### PR TITLE
Add react-hooks eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier',
     'plugin:import/typescript',
+    'plugin:react-hooks/recommended',
   ],
   plugins: ['react', 'react-native', 'import', 'jest', '@typescript-eslint'],
   env: {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-plugin-no-inline-styles": "^1.0.5",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-standard": "^5.0.0",
     "husky": "^7.0.4",
     "jest": "^29.0.0",

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -51,7 +51,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   return data;
 }
 
-export function makeViewsRefSet<T>(): ViewRefSet<T> {
+export function useViewRefSet<T>(): ViewRefSet<T> {
   const ref = useRef<ViewRefSet<T> | null>(null);
   if (ref.current === null) {
     const data: ViewRefSet<T> = {

--- a/src/reanimated2/component/ScrollView.tsx
+++ b/src/reanimated2/component/ScrollView.tsx
@@ -32,11 +32,13 @@ const AnimatedScrollViewComponent = createAnimatedComponent(
 export const AnimatedScrollView: AnimatedScrollView = forwardRef(
   (props: AnimatedScrollViewProps, ref: ForwardedRef<AnimatedScrollView>) => {
     const { scrollViewOffset, ...restProps } = props;
-    const animatedRef = (
+    const animatedRef = // eslint-disable-next-line react-hooks/rules-of-hooks
+    (
       ref === null ? useAnimatedRef<ScrollView>() : ref
     ) as AnimatedRef<AnimatedScrollView>;
 
     if (scrollViewOffset) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       useScrollViewOffset(animatedRef, scrollViewOffset);
     }
 

--- a/src/reanimated2/component/ScrollView.tsx
+++ b/src/reanimated2/component/ScrollView.tsx
@@ -32,9 +32,11 @@ const AnimatedScrollViewComponent = createAnimatedComponent(
 export const AnimatedScrollView: AnimatedScrollView = forwardRef(
   (props: AnimatedScrollViewProps, ref: ForwardedRef<AnimatedScrollView>) => {
     const { scrollViewOffset, ...restProps } = props;
-    const animatedRef = // eslint-disable-next-line react-hooks/rules-of-hooks
-    (
-      ref === null ? useAnimatedRef<ScrollView>() : ref
+    const animatedRef = (
+      ref === null
+        ? // eslint-disable-next-line react-hooks/rules-of-hooks
+          useAnimatedRef<ScrollView>()
+        : ref
     ) as AnimatedRef<AnimatedScrollView>;
 
     if (scrollViewOffset) {

--- a/src/reanimated2/hook/useAnimatedGestureHandler.ts
+++ b/src/reanimated2/hook/useAnimatedGestureHandler.ts
@@ -141,6 +141,7 @@ export function useAnimatedGestureHandler<
     return handler;
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useEvent<Event>(
     handler,
     ['onGestureHandlerStateChange', 'onGestureHandlerEvent'],

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -14,7 +14,7 @@ import {
 } from './utils';
 import type { DefaultStyle, DependencyList, Descriptor } from './commonTypes';
 import type { ViewDescriptorsSet, ViewRefSet } from '../ViewDescriptorsSet';
-import { makeViewDescriptorsSet, makeViewsRefSet } from '../ViewDescriptorsSet';
+import { makeViewDescriptorsSet, useViewRefSet } from '../ViewDescriptorsSet';
 import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 import type {
   AnimationObject,
@@ -402,7 +402,7 @@ export function useAnimatedStyle<Style extends DefaultStyle>(
   adapters?: WorkletFunction | WorkletFunction[],
   isAnimatedProps = false
 ) {
-  const viewsRef: ViewRefSet<unknown> = makeViewsRefSet();
+  const viewsRef: ViewRefSet<unknown> = useViewRefSet();
   const initRef = useRef<AnimationRef>();
   let inputs = Object.values(updater.__closure ?? {});
   if (SHOULD_BE_USE_WEB) {

--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -25,6 +25,7 @@ export function useScrollViewOffset(
   initialRef?: SharedValue<number>
 ): SharedValue<number> {
   const offsetRef = useRef(
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     initialRef !== undefined ? initialRef : useSharedValue(0)
   );
 

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -51,6 +51,7 @@ function getDelayFromConfig(config: CustomConfig): number {
 
 function getReducedMotionFromConfig(config: CustomConfig) {
   if (!config.reduceMotionV) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     return useReducedMotion();
   }
 
@@ -60,6 +61,7 @@ function getReducedMotionFromConfig(config: CustomConfig) {
     case ReduceMotion.Always:
       return true;
     default:
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       return useReducedMotion();
   }
 }


### PR DESCRIPTION
## Summary

I added _react-hooks_ eslint plugin to repo. It is a rule that checks integrity of used hooks, as well as their dependencies and general standards of their implementation and use. I have stumbled upon a custom hook that doesn't start with _"use"_ - which has been changed. There are some conditional hook calls in the repo - I have temporarily disabled eslint errors regarding them and await any ideas on what to do there.

## Test plan

Delete any of the _"eslint-disable..."_ comments added in [this commit](https://github.com/software-mansion/react-native-reanimated/commit/00c37e8c0d4fe2529cbca68b9d87ec2a7ce0c35a).  To see the dependencies' fixes and suggestions change dependencies [in this line](https://github.com/software-mansion/react-native-reanimated/blob/c11b671b5dd58b0b18df941727d9d8336d9227e6/app/src/examples/MatrixTransform.tsx#L46) to: `[matrix2, currentTransformIndex]`.
