### PR TITLE
fix useAnimatedKeyboard when keyboard type changes

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -57,6 +57,16 @@ public class ReanimatedKeyboardEventListener {
     ViewCompat.setOnApplyWindowInsetsListener(
         rootView,
         (v, insets) -> {
+          if (state == KeyboardState.OPEN) {
+            int keyboardHeight = (int)
+                    PixelUtil.toDIPFromPixel(
+                            Math.max(
+                                    0,
+                                    insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                                            - insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom));
+
+            updateKeyboard(keyboardHeight);
+          }
           int paddingBottom = 0;
           if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
               && BuildConfig.REACT_NATIVE_MINOR_VERSION < 70) {

--- a/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -58,12 +58,13 @@ public class ReanimatedKeyboardEventListener {
         rootView,
         (v, insets) -> {
           if (state == KeyboardState.OPEN) {
-            int keyboardHeight = (int)
+            int keyboardHeight =
+                (int)
                     PixelUtil.toDIPFromPixel(
-                            Math.max(
-                                    0,
-                                    insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-                                            - insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom));
+                        Math.max(
+                            0,
+                            insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                                - insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom));
 
             updateKeyboard(keyboardHeight);
           }


### PR DESCRIPTION
## Summary

FIxes #5208 

For some reasons i don't understand, android's WindowInsetsAnimationCompat.Callback don't run any animations when keyboard height changes (maybe because there is no animation 🤔). It only works when keyboard opens/closes. I personally had a problem with emoji keyboard. User opens text keyboard, then goes into emoji (same problem in gboard gif/stickers) and keyboard gets bigger, but app doesn't. setOnApplyWindowInsetsListener on the other hand knows about new keyboard's height and in my commit i just send this update without any animation to updateKeyboard.

## Test plan

I've tested this on my samsung a71 with android 13 (one ui 5.1). Needs testing on 
1. <11 android without keyboard animation support
2. other os
3. other keyboards
