### PR TITLE
Add reduceMotion to mock

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -3,7 +3,7 @@
 // @ts-nocheck
 'use strict';
 
-import { SensorType } from './commonTypes';
+import { ReduceMotion, SensorType } from './commonTypes';
 
 const NOOP = () => {
   // noop
@@ -47,6 +47,10 @@ class BaseAnimationMock {
   build() {
     return () => ({ initialValues: {}, animations: {} });
   }
+
+  reduceMotion(_: ReduceMotion) {
+    return this;
+  }
 }
 
 const ReanimatedV2 = {
@@ -58,6 +62,7 @@ const ReanimatedV2 = {
   useAnimatedRef: () => ({ current: null }),
   useAnimatedReaction: NOOP,
   useAnimatedProps: IMMEDIATE_CB_INVOCATION,
+  ReduceMotion: ReduceMotion,
   SensorType: SensorType,
   useAnimatedSensor: () => ({
     sensor: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

`reduceMotion` and the `ReduceMotion` enum were added in 3.5.

https://github.com/software-mansion/react-native-reanimated/releases/tag/3.5.0

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

`jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'))`

`FadeInUp.duration(500).reduceMotion(ReduceMotion.Never)`