### PR TITLE
Fix lint staged

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,3 @@ docs/*
 plugin/*
 eslintrc.js
 jest.config.js
-__typetests__/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,7 @@
 .eslintrc.js
 scripts/*.js
+docs/*
+plugin/*
+eslintrc.js
+jest.config.js
+__typetests__/*

--- a/package.json
+++ b/package.json
@@ -165,8 +165,8 @@
   },
   "lint-staged": {
     "*.(js|ts|tsx)": [
-      "eslint --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
-      "eslint --quiet --ext '.js,.ts,.tsx' src/ --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
+      "eslint",
+      "eslint --quiet --ext '.js,.ts,.tsx' src/",
       "prettier --write"
     ],
     "plugin/**/*.ts": "yarn lint:plugin",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
   "lint-staged": {
     "*.(js|ts|tsx)": [
       "eslint --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
-            "prettier --write"
+      "prettier --write"
     ],
     "plugin/**/*.ts": "yarn lint:plugin",
     "**/*.{h,cpp}": "yarn lint:cpp",

--- a/package.json
+++ b/package.json
@@ -165,8 +165,8 @@
   },
   "lint-staged": {
     "*.(js|ts|tsx)": [
-      "eslint --quiet --ext '.js,.ts,.tsx' src/ --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
-      "prettier --write"
+      "eslint --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
+            "prettier --write"
     ],
     "plugin/**/*.ts": "yarn lint:plugin",
     "**/*.{h,cpp}": "yarn lint:cpp",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
   },
   "lint-staged": {
     "*.(js|ts|tsx)": [
-      "eslint --ext '.js,.ts,.tsx' src/ --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
+      "eslint --quiet --ext '.js,.ts,.tsx' src/ --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
       "prettier --write"
     ],
     "plugin/**/*.ts": "yarn lint:plugin",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
   "lint-staged": {
     "*.(js|ts|tsx)": [
       "eslint --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
+      "eslint --quiet --ext '.js,.ts,.tsx' src/ --ignore-pattern docs --ignore-pattern plugin --ignore-pattern .eslintrc.js --ignore-pattern jest.config.js --ignore-pattern __typetests__",
       "prettier --write"
     ],
     "plugin/**/*.ts": "yarn lint:plugin",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
BEFORE:
* Lint-staged lints all files and prints all warnings and errors

NOW:
* Lint only staged files and shows both errors and warnings
* If the previous tasks success all files get lined, but only errors are printed
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->


Drawbacks:
Lint runs twice. It should not cause burdensome delays since the first lint runs only for the staged files, so if you stage <10 files it runs very fast.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
