### PR TITLE
Extract keyframe key construction to a function

### DIFF
--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -287,7 +287,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
   };
 }
 
-function keyframeKey(index: number, transformProp: string) {
+function makeKeyframeKey(index: number, transformProp: string) {
   return `${index}_transform:${transformProp}`;
 }
 

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -85,7 +85,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         }
         initialValues.transform.forEach((transformStyle, index) => {
           Object.keys(transformStyle).forEach((transformProp: string) => {
-            parsedKeyframes[keyframeKey(index, transformProp)] = [];
+            parsedKeyframes[makeKeyframeKey(index, transformProp)] = [];
           });
         });
       } else {
@@ -163,7 +163,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
               (transformStyle: { [key: string]: any }, index) => {
                 Object.keys(transformStyle).forEach((transformProp: string) => {
                   addKeyPointWith(
-                    keyframeKey(index, transformProp),
+                    makeKeyframeKey(index, transformProp),
                     transformStyle[transformProp]
                   );
                 });
@@ -270,7 +270,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
           initialValues[key].forEach(
             (transformProp: Record<string, number | string>, index: number) => {
               Object.keys(transformProp).forEach((transformPropKey: string) => {
-                addAnimation(keyframeKey(index, transformPropKey));
+                addAnimation(makeKeyframeKey(index, transformPropKey));
               });
             }
           );

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -85,8 +85,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         }
         initialValues.transform.forEach((transformStyle, index) => {
           Object.keys(transformStyle).forEach((transformProp: string) => {
-            parsedKeyframes[index.toString() + '_transform:' + transformProp] =
-              [];
+            parsedKeyframes[keyframeKey(index, transformProp)] = [];
           });
         });
       } else {
@@ -164,7 +163,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
               (transformStyle: { [key: string]: any }, index) => {
                 Object.keys(transformStyle).forEach((transformProp: string) => {
                   addKeyPointWith(
-                    index.toString() + '_transform:' + transformProp,
+                    keyframeKey(index, transformProp),
                     transformStyle[transformProp]
                   );
                 });
@@ -271,9 +270,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
           initialValues[key].forEach(
             (transformProp: Record<string, number | string>, index: number) => {
               Object.keys(transformProp).forEach((transformPropKey: string) => {
-                addAnimation(
-                  index.toString() + '_transform:' + transformPropKey
-                );
+                addAnimation(keyframeKey(index, transformPropKey));
               });
             }
           );
@@ -288,6 +285,10 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       };
     };
   };
+}
+
+function keyframeKey(index: number, transformProp: string) {
+  return `${index.toString()}_transform:${transformProp}`;
 }
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -288,7 +288,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
 }
 
 function keyframeKey(index: number, transformProp: string) {
-  return `${index.toString()}_transform:${transformProp}`;
+  return `${index}_transform:${transformProp}`;
 }
 
 // TODO TYPESCRIPT This is a temporary type to get rid of .d.ts file.


### PR DESCRIPTION
## Summary
This PR uses string interpolation to construct keyframe keys in `Keyframe.ts` as requested it [PR comment](https://github.com/software-mansion/react-native-reanimated/pull/5363#discussion_r1390286269). Additionally it extracts it to a helper function
