### PR TITLE
add missing easing method to BaseAnimationMock

### DIFF
--- a/src/reanimated2/mock.ts
+++ b/src/reanimated2/mock.ts
@@ -44,6 +44,10 @@ class BaseAnimationMock {
     return this;
   }
 
+  easing(_: (t: number) => number) {
+    return this;
+  }
+
   build() {
     return () => ({ initialValues: {}, animations: {} });
   }


### PR DESCRIPTION
## Summary

This pr is a fix for #5379 which is related to missing easing method in BaseAnimationMock class.
