### PR TITLE
feat: Create stack animation repro

### DIFF
--- a/app/src/examples/LayoutAnimations/StackedLayoutAnimationExample.tsx
+++ b/app/src/examples/LayoutAnimations/StackedLayoutAnimationExample.tsx
@@ -1,0 +1,94 @@
+import Animated, {
+  useAnimatedStyle,
+  SlideInDown,
+  ZoomOut,
+  useDerivedValue,
+  withSpring,
+  interpolate,
+} from 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
+
+import React, { useEffect, useState } from 'react';
+
+interface Item {
+  color: string;
+}
+
+function getRandomColor(): string {
+  return '#' + Math.floor(Math.random() * 16777215).toString(16);
+}
+
+const Entering = SlideInDown.springify().mass(1).stiffness(1000).damping(500);
+const Exiting = ZoomOut.springify().mass(1).stiffness(1000).damping(500);
+
+function ItemComponent({ item, index }: { item: Item; index: number }) {
+  const rotation = useDerivedValue(() => withSpring(index * 15), [index]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      zIndex: -index,
+      backgroundColor: item.color,
+      transform: [
+        {
+          translateX: interpolate(rotation.value, [0, 100], [0, 100]),
+        },
+        {
+          translateY: interpolate(rotation.value, [0, 100], [0, -30]),
+        },
+        {
+          scale: interpolate(rotation.value, [0, 100], [1, 0.7]),
+        },
+        {
+          rotate: `${rotation.value}deg`,
+        },
+      ],
+    };
+  }, [rotation, index, item]);
+
+  return (
+    <Animated.View
+      entering={Entering}
+      exiting={Exiting}
+      style={[styles.item, animatedStyle]}
+    />
+  );
+}
+
+export default function StackedLayoutAnimationExample() {
+  const [items, setItems] = useState<Item[]>([
+    { color: 'red' },
+    { color: 'green' },
+  ]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setItems((i) => [{ color: getRandomColor() }, ...i]);
+    }, 1500);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {items.map((item, index) => {
+        if (index > 2) {
+          return null;
+        }
+        return <ItemComponent key={item.color} item={item} index={index} />;
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  item: {
+    width: 100,
+    height: 150,
+    borderRadius: 15,
+    position: 'absolute',
+  },
+});

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -97,6 +97,7 @@ import SetNativePropsExample from './SetNativePropsExample';
 import ShareablesExample from './ShareablesExample';
 import SharedStyleExample from './SharedStyleExample';
 import SpringLayoutAnimation from './LayoutAnimations/SpringLayoutAnimation';
+import StackedLayoutAnimationExample from './LayoutAnimations/StackedLayoutAnimationExample';
 import SvgExample from './SvgExample';
 import SwipeableList from './LayoutAnimations/SwipeableList';
 import SwipeableListExample from './SwipeableListExample';
@@ -577,6 +578,10 @@ export const EXAMPLES: Record<string, Example> = {
   SwipeableList: {
     title: '[LA] Swipeable list',
     screen: SwipeableList,
+  },
+  StackedLayoutAnimationExample: {
+    title: '[LA] Stacked LayoutAnimation',
+    screen: StackedLayoutAnimationExample,
   },
   Modal: {
     title: '[LA] Modal',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Created a neat lil Stack animation that uses Layout Animations to animate items in and out of a Stack.


https://github.com/software-mansion/react-native-reanimated/assets/15199031/ac1b9fee-d177-46db-825d-bc28ab5b232a



<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

This is purely an example that showcases a current bug, but the test plan here is to just verify that all three parts of the animation are running:

1. The top element slides in from the bottom
2. The two elements behind animate/rotate smoothly to the right (this is currently not happening for the first render!)
3. The last element has an `exiting` animation of zoom out (this is currently not running!)

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
