### PR TITLE
Update `sideEffects` in package.json to `true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,8 +185,5 @@
       "typescript"
     ]
   },
-  "sideEffects": [
-    "./lib/reanimated2/core",
-    "./lib/index"
-  ]
+  "sideEffects": true
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I've proposed a change in the package.json of [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated/blob/main/package.json#L188) regarding the sideEffects property. Currently, it specifies two directories:

```
"sideEffects: [
    "./lib/reanimated2/core",
    "./lib/index"
  ]
```

However, this configuration seems to be inaccurate for the following reasons:

- **React Native Usage**: In React Native environments, the TypeScript files from the src folder are primarily used for bundling.
- **Presence of Side Effects in src**: Numerous files in the src folder, such as src/reanimated2/layoutReanimation/animationsManager.ts, contain side effects.

The current setup leads to issues when using bundlers like esbuild, where files with side effects may be inadvertently omitted.

To address this, I've set the sideEffects field to true in package.json. This change aims to ensure that bundling processes correctly include necessary files. 

However, if there's a more precise way to specify the side effects, I'm open to suggestions and feedback in the pull request comments!

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

- Make a metro build with the updated `package.json` and check if all tests are passing.

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
