### PR TITLE
Fix missing null check for lastValue in useAnimatedStyle.ts

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -68,7 +68,7 @@ function prepareAnimation(
     const animation = animatedProp;
 
     let value = animation.current;
-    if (lastValue !== undefined) {
+    if (lastValue !== undefined && lastValue !== null) {
       if (typeof lastValue === 'object') {
         if (lastValue.value !== undefined) {
           // previously it was a shared value


### PR DESCRIPTION
## Summary

When using the latest version of this library as part of my app i kept running into a scenario where `lastValue` in `useAnimatedStyle.ts` was `null`, therefore leading to a crash. The existing check only looked for `lastValue !== undefined`, I added an additional check for `null`.

Check out my attached screenshot from my devtools debugging session, where u can see above described scenario with `lastValue` being `null`.

Note that I did not manage to find the underlying reason for this (therefore i can also not tell you how to reproduce this), but the additional null check will avoid the app from crashing and everything else seems to work properly.

<img width="590" alt="Screenshot 2023-11-23 at 21 50 14" src="https://github.com/software-mansion/react-native-reanimated/assets/48987577/239eedf3-98a2-49b1-b76d-a434fc340e64">
