### PR TITLE
Fix entering flickers in web LA

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -51,7 +51,9 @@ import {
   startWebLayoutAnimation,
   tryActivateLayoutTransition,
   configureWebLayoutAnimations,
+  hasReducedMotion,
 } from '../reanimated2/layoutReanimation/web';
+import type { CustomConfig } from '../reanimated2/layoutReanimation/web/config';
 
 const IS_WEB = isWeb();
 const IS_FABRIC = isFabric();
@@ -129,11 +131,16 @@ export function createAnimatedComponent(
 
       if (IS_WEB) {
         configureWebLayoutAnimations();
+
+        if (hasReducedMotion(this.props.entering as CustomConfig)) {
+          this._isFirstRender = false;
+          return;
+        }
+
         startWebLayoutAnimation(
           this.props,
           this._component as HTMLElement,
-          LayoutAnimationType.ENTERING,
-          !!(this._isFirstRender && this.props.entering)
+          LayoutAnimationType.ENTERING
         );
       }
 
@@ -148,6 +155,10 @@ export function createAnimatedComponent(
       this._sharedElementTransition?.unregisterTransition(this._viewTag);
 
       if (IS_WEB) {
+        if (hasReducedMotion(this.props.exiting as CustomConfig)) {
+          return;
+        }
+
         startWebLayoutAnimation(
           this.props,
           this._component as HTMLElement,
@@ -404,6 +415,10 @@ export function createAnimatedComponent(
 
       // Snapshot won't be undefined because it comes from getSnapshotBeforeUpdate method
       if (IS_WEB && snapshot !== null) {
+        if (hasReducedMotion(this.props.layout as CustomConfig)) {
+          return;
+        }
+
         tryActivateLayoutTransition(
           this.props,
           this._component as HTMLElement,
@@ -519,7 +534,11 @@ export function createAnimatedComponent(
       // Because of that we can encounter a situation in which component is visible for a short amount of time, and later on animation triggers.
       // I've tested that on various browsers and devices and it did not happen to me. To be sure that it won't happen to someone else,
       // I've decided to hide component at first render. Its visibility is reset in `componentDidMount`.
-      if (this._isFirstRender && IS_WEB && props.entering) {
+      if (
+        this._isFirstRender &&
+        IS_WEB &&
+        !hasReducedMotion(props.entering as CustomConfig)
+      ) {
         props.style = {
           ...(props.style ?? {}),
           visibility: 'hidden', // Hide component until `componentDidMount` triggers

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -154,11 +154,7 @@ export function createAnimatedComponent(
       this._InlinePropManager.detachInlineProps();
       this._sharedElementTransition?.unregisterTransition(this._viewTag);
 
-      if (IS_WEB) {
-        if (hasReducedMotion(this.props.exiting as CustomConfig)) {
-          return;
-        }
-
+      if (IS_WEB && !hasReducedMotion(this.props.exiting as CustomConfig)) {
         startWebLayoutAnimation(
           this.props,
           this._component as HTMLElement,
@@ -407,18 +403,18 @@ export function createAnimatedComponent(
       _prevState: Readonly<unknown>,
       // This type comes straight from React
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      snapshot?: any
+      snapshot: DOMRect | null
     ) {
       this._reattachNativeEvents(prevProps);
       this._attachAnimatedStyles();
       this._InlinePropManager.attachInlineProps(this, this._getViewInfo());
 
       // Snapshot won't be undefined because it comes from getSnapshotBeforeUpdate method
-      if (IS_WEB && snapshot !== null) {
-        if (hasReducedMotion(this.props.layout as CustomConfig)) {
-          return;
-        }
-
+      if (
+        IS_WEB &&
+        snapshot !== null &&
+        !hasReducedMotion(this.props.layout as CustomConfig)
+      ) {
         tryActivateLayoutTransition(
           this.props,
           this._component as HTMLElement,

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -52,7 +52,7 @@ function getDelayFromConfig(config: CustomConfig): number {
       config.delayV! / 1000;
 }
 
-function getReducedMotionFromConfig(config: CustomConfig) {
+export function getReducedMotionFromConfig(config: CustomConfig) {
   if (!config.reduceMotionV) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useReducedMotion();
@@ -130,7 +130,6 @@ export function getProcessedConfig(
     ),
     delay: getDelayFromConfig(config),
     easing: getEasingFromConfig(config),
-    reduceMotion: getReducedMotionFromConfig(config),
     callback: getCallbackFromConfig(config),
     reversed: getReversedFromConfig(config),
   };
@@ -240,6 +239,9 @@ export function handleExitingAnimation(
   const parent = element.offsetParent;
   const dummy = element.cloneNode() as HTMLElement;
 
+  element.style.animationName = '';
+  element.style.visibility = 'hidden';
+
   // After cloning the element, we want to move all children from original element to its clone. This is because original element
   // will be unmounted, therefore when this code executes in child component, parent will be either empty or removed soon.
   // Using element.cloneNode(true) doesn't solve the problem, because it creates copy of children and we won't be able to set their animations
@@ -253,7 +255,6 @@ export function handleExitingAnimation(
   parent?.appendChild(dummy);
 
   // We hide current element so only its copy with proper animation will be displayed
-  element.style.visibility = 'hidden';
 
   dummy.style.position = 'absolute';
   dummy.style.top = `${element.offsetTop}px`;

--- a/src/reanimated2/layoutReanimation/web/config.ts
+++ b/src/reanimated2/layoutReanimation/web/config.ts
@@ -50,7 +50,6 @@ export interface AnimationConfig {
   duration: number;
   delay: number;
   easing: string;
-  reduceMotion: boolean;
   callback: AnimationCallback;
   reversed: boolean;
 }

--- a/src/reanimated2/layoutReanimation/web/index.ts
+++ b/src/reanimated2/layoutReanimation/web/index.ts
@@ -3,6 +3,7 @@
 export {
   startWebLayoutAnimation,
   tryActivateLayoutTransition,
+  hasReducedMotion,
 } from './animationsManager';
 
 export { configureWebLayoutAnimations } from './domUtils';


### PR DESCRIPTION
## Summary

Sometimes entering animations flicker. This happens because we've recently merged [this PR](https://github.com/software-mansion/react-native-reanimated/pull/5278), which always sets component visibility of the component on its first render, even though now we are doing it inside `onanimationstart`.

## Test plan

Tested on example app on [LA] examples
