### PR TITLE
Make forceUpdate optional

### DIFF
--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -32,7 +32,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
           descriptors.push(item);
         }
         return descriptors;
-      });
+      }, false);
     },
 
     remove: (viewTag: number) => {
@@ -45,7 +45,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
           descriptors.splice(index, 1);
         }
         return descriptors;
-      });
+      }, false);
     },
   };
   return data;

--- a/src/reanimated2/commonTypes.ts
+++ b/src/reanimated2/commonTypes.ts
@@ -12,7 +12,7 @@ export interface SharedValue<Value> {
   value: Value;
   addListener: (listenerID: number, listener: (value: any) => void) => void;
   removeListener: (listenerID: number) => void;
-  modify: (modifier?: (value: any) => any) => void;
+  modify: (modifier?: (value: any) => any, forceUpdate?: boolean) => void;
 }
 
 // The below type is used for HostObjects returned by the JSI API that don't have

--- a/src/reanimated2/mutables.ts
+++ b/src/reanimated2/mutables.ts
@@ -49,8 +49,12 @@ export function makeUIMutable<T>(
     get _value(): T {
       return value;
     },
-    modify: (modifier?: (value: T) => T) => {
-      valueSetter(self, modifier !== undefined ? modifier(value) : value, true);
+    modify: (modifier?: (value: T) => T, forceUpdate = true) => {
+      valueSetter(
+        self,
+        modifier !== undefined ? modifier(value) : value,
+        forceUpdate
+      );
     },
     addListener: (id: number, listener: (newValue: T) => void) => {
       listeners.set(id, listener);
@@ -120,16 +124,16 @@ export function makeMutable<T>(
       }
       return value;
     },
-    modify: (modifier?: (value: T) => T) => {
+    modify: (modifier?: (value: T) => T, forceUpdate = true) => {
       if (!SHOULD_BE_USE_WEB) {
         runOnUI(() => {
-          mutable.modify(modifier);
+          mutable.modify(modifier, forceUpdate);
         })();
       } else {
         valueSetter(
           mutable,
           modifier !== undefined ? modifier(mutable.value) : mutable.value,
-          true
+          forceUpdate
         );
       }
     },


### PR DESCRIPTION
## Summary

The modifications made in PR https://github.com/software-mansion/react-native-reanimated/pull/5306 cause the `_updateDataSynchronously` method to be called after every `modify()` call. However, this method is slow for larger objects because it involves copying the entire structure. This PR includes an additional option to skip force updates if desired.

| before | after |
| --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/52f3c996-6d4c-4441-9085-2f488886ebff" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/a48ebd44-22fd-4c7b-ae4f-37e6ca4496d6" /> |
