### PR TITLE
Update compatibility table for 0.73

### DIFF
--- a/docs/docs/guides/compatibility.mdx
+++ b/docs/docs/guides/compatibility.mdx
@@ -9,17 +9,18 @@ sidebar_label: Compatibility
 
 <div className="compatibility">
 
-|                                      | 0.63            | 0.64            | 0.65            | 0.66         | 0.67         | 0.68            | 0.69            | 0.70            | 0.71            | 0.72            |
-| ------------------------------------ | --------------- | --------------- | --------------- | ------------ | ------------ | --------------- | --------------- | --------------- | --------------- | --------------- |
-| <Version version="3.4.x - 3.5.x"/>   | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    |
-| <Version version="3.1.x - 3.3.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    |
-| <Version version="3.0.x"/>           | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> |
-| <Spacer/>                            |                 |                 |                 |              |              |                 |                 |                 |                 |                 |
-| <Version version="2.14.x - 2.17.x"/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> |
-| <Version version="2.11.x - 2.13.x"/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> |
-| <Version version="2.10.x"/>          | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> | <NotSupported/> |
-| <Version version="2.5.x - 2.9.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> |
-| <Version version="2.3.x - 2.4.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> |
+|                                      | 0.63            | 0.64            | 0.65            | 0.66         | 0.67         | 0.68            | 0.69            | 0.70            | 0.71            | 0.72            | 0.73            |
+| ------------------------------------ | --------------- | --------------- | --------------- | ------------ | ------------ | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
+| <Version version="3.6.x"/>           | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    |
+| <Version version="3.5.x"/>           | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> |
+| <Version version="3.3.x – 3.4.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> |
+| <Version version="3.0.x – 3.2.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> |
+| <Spacer/>                            |                 |                 |                 |              |              |                 |                 |                 |                 |                 |                 |
+| <Version version="2.14.x – 2.17.x"/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> |
+| <Version version="2.11.x – 2.13.x"/> | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> | <NotSupported/> |
+| <Version version="2.10.x"/>          | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <Supported/>    | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> |
+| <Version version="2.5.x – 2.9.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <Supported/>    | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> |
+| <Version version="2.3.x – 2.4.x"/>   | <Supported/>    | <Supported/>    | <Supported/>    | <Supported/> | <Supported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> |
 
 </div>
 
@@ -33,9 +34,10 @@ To use Reanimated with [the experimental New Architecture](https://reactnative.d
 
 <div className="compatibility">
 
-|                                    | 0.63            | 0.64            | 0.65            | 0.66            | 0.67            | 0.68            | 0.69            | 0.70            | 0.71            | 0.72            |
-| ---------------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
-| <Version version="3.1.x - 3.5.x"/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/>    |
-| <Version version="3.0.x"/>         | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/>    | <NotSupported/> |
+|                                    | 0.63            | 0.64            | 0.65            | 0.66            | 0.67            | 0.68            | 0.69            | 0.70            | 0.71            | 0.72            | 0.73            |
+| ---------------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
+| <Version version="3.6.x"/>         | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/>    | <Supported/>    |
+| <Version version="3.1.x – 3.5.x"/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/>    | <NotSupported/> |
+| <Version version="3.0.x"/>         | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <NotSupported/> | <Supported/>    | <NotSupported/> | <NotSupported/> |
 
 </div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds RN 0.73 to the compatibility table as well as updates some cells with correct information.

## Test plan

<img width="1492" alt="Zrzut ekranu 2023-11-27 o 11 15 00" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/a1d6561a-2e22-4b65-9f3d-0a0112d874d6">

<img width="1492" alt="Zrzut ekranu 2023-11-27 o 11 15 28" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/b37e6baa-ad1a-41b5-bf63-281b418690c0">
