### PR TITLE
fix(android): delete native instance of Scheduler on deactivate

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/Scheduler.java
+++ b/android/src/main/java/com/swmansion/reanimated/Scheduler.java
@@ -47,5 +47,6 @@ public class Scheduler {
 
   public void deactivate() {
     mActive.set(false);
+    mHybridData.resetNative();
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

We found a leak that `Scheduler` was holding mContext after the activity has been closed, and found out `mHybridData` was holding a native JNI global reference to the Scheduler instance, preventing GC.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
