### PR TITLE
Add check for undefined style in LA Web

### DIFF
--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -108,7 +108,7 @@ export function extractTransformFromStyle(style: StyleProps) {
 
   // Only last transform should be considered
   for (let i = style.length - 1; i >= 0; --i) {
-    if (style[i].transform) {
+    if (style[i]?.transform) {
       return style[i].transform;
     }
   }


### PR DESCRIPTION
## Summary

Web layout animations crash if someone passes style prop which is an array that contains undefined. 

## Test plan

Tested on [this code](https://github.com/software-mansion/react-native-reanimated/issues/5429#issuecomment-1834260349).