### PR TITLE
Fix existing transform on web

### DIFF
--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -60,7 +60,7 @@ function chooseAction(
 ) {
   switch (animationType) {
     case LayoutAnimationType.ENTERING:
-      setElementAnimation(element, animationConfig);
+      setElementAnimation(element, animationConfig, transform);
       break;
     case LayoutAnimationType.LAYOUT:
       transitionData.reversed = animationConfig.reversed;


### PR DESCRIPTION
## Summary

While fixing `entering` animations on web, I removed `handleEnteringAnimation` and used `setElementAnimation` instead. However, I didn't pass `transform` parameter, so it couldn't be applied.

## Test plan

Tested on mounting/unmounting example.