### PR TITLE
Remove dummy element on animation cancel

### DIFF
--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -290,4 +290,10 @@ export function handleExitingAnimation(
     // Given that this function overrides onAnimationEnd, it won't be null
     originalOnAnimationEnd?.call(this, event);
   };
+
+  dummy.addEventListener('animationcancel', () => {
+    if (parent?.contains(dummy)) {
+      parent.removeChild(dummy);
+    }
+  });
 }


### PR DESCRIPTION
## Summary

In exiting animation, we create a dummy - clone of the original element that will be removed. When animation ends, we remove dummy from parent. The problem is, if something cancels animation, our dummy component won't be removed. 

I've stumbled upon this problem while working on custom keyframes.

## Test plan

Tested on example app. Mostly on Keyframe animation example (on branch with custom keyframes implementation).