### PR TITLE
Fix keyframes crash

### DIFF
--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -288,6 +288,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
 }
 
 function makeKeyframeKey(index: number, transformProp: string) {
+  'worklet';
   return `${index}_transform:${transformProp}`;
 }
 


### PR DESCRIPTION
## Summary

[Recent changes](https://github.com/software-mansion/react-native-reanimated/pull/5376) in Keyframe.ts introduced crashes on iOS and Android, because of calling non-worklet function from UI thread.

## Test plan

Tested on Olympic example.
