### PR TITLE
Fix keyframe error 'Property '_this' doesn't exist'

### DIFF
--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -241,9 +241,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
                   ? keyframePoints[0].easing
                   : Easing.linear,
               })
-            : withSequence.apply(
-                this,
-                keyframePoints.map((keyframePoint: KeyframePoint) =>
+            : withSequence(
+                ...keyframePoints.map((keyframePoint: KeyframePoint) =>
                   withTiming(keyframePoint.value, {
                     duration: keyframePoint.duration,
                     easing: keyframePoint.easing


### PR DESCRIPTION
## Summary

After analyzing the code it seems that `apply` doesn't serve any purpose in Keyframe. I noticed it here because it was causing problems when `processNestedWorklets` option was enabled, but this will be a subject of a separate investigation.

## Testplan

Check that `KeyframeAnimation` and `OlympicAnimation` Examples are working properly.
