### PR TITLE
Fix overloads in createAnimatedComponent

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -87,15 +87,7 @@ type Options<P> = {
  * @see https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent
  */
 
-/**
- * @deprecated Please use `Animated.FlatList` component instead of calling `Animated.createAnimatedComponent(FlatList)` manually.
- */
-// @ts-ignore This is required to create this overload, since type of createAnimatedComponent is incorrect and doesn't include typeof FlatList
-export function createAnimatedComponent(
-  component: typeof FlatList<unknown>,
-  options?: Options<any>
-): ComponentClass<AnimateProps<FlatListProps<unknown>>>;
-
+// Don't change the order of overloads, since such a change breaks current behavior
 export function createAnimatedComponent<P extends object>(
   component: FunctionComponent<P>,
   options?: Options<P>
@@ -105,6 +97,22 @@ export function createAnimatedComponent<P extends object>(
   component: ComponentClass<P>,
   options?: Options<P>
 ): ComponentClass<AnimateProps<P>>;
+
+export function createAnimatedComponent<P extends object>(
+  // Actually ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P> but we need this overload too
+  // since some external components (like FastImage) are typed just as ComponentType
+  component: ComponentType<P>,
+  options?: Options<P>
+): FunctionComponent<AnimateProps<P>> | ComponentClass<AnimateProps<P>>;
+
+/**
+ * @deprecated Please use `Animated.FlatList` component instead of calling `Animated.createAnimatedComponent(FlatList)` manually.
+ */
+// @ts-ignore This is required to create this overload, since type of createAnimatedComponent is incorrect and doesn't include typeof FlatList
+export function createAnimatedComponent(
+  component: typeof FlatList<unknown>,
+  options?: Options<any>
+): ComponentClass<AnimateProps<FlatListProps<unknown>>>;
 
 export function createAnimatedComponent(
   Component: ComponentType<InitialComponentProps>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

1. Move the overload with type deprecation to be the last one. It means that if user provides invalid type which isn't covered by any overload he will not get the warning about FlatList deprecation. This warning was very confusing if user wasn't using FlatList at all
2. Add overload of `ComponentType`. Since `ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>` we have assume that it is enough to have two overloads (ComponentClass & FunctionComponent), but it isn't

|BEFORE|AFTER|
|--|--|
|Error for FastImage and deprecation for FastImage ❌ | Deprecation for FlatList only 😎|
|<img width="528" alt="Screenshot 2023-12-12 at 13 16 37" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/04a318ec-cf43-43a0-bf0a-5ad372265453">|<img width="528" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/9229ddd9-5a92-4c5f-9864-b2ae85550b8b">|
|<img width="773" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/f59aaf14-4865-4c62-acc1-16b6ef49d62a">||
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
