### PR TITLE
Improve TS in src [0/6] - Allow non-null assertion and remove some eslint directives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,5 +60,6 @@ module.exports = {
       { fixMixedExportsWithInlineTypeSpecifier: false },
     ],
     'tsdoc/syntax': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
 };

--- a/src/createAnimatedComponent/InlinePropManager.ts
+++ b/src/createAnimatedComponent/InlinePropManager.ts
@@ -153,11 +153,8 @@ export class InlinePropManager implements IInlinePropManager {
         }
 
         this._inlinePropsViewDescriptors.add({
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           tag: viewTag as number,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           name: viewName!,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           shadowNodeWrapper: shadowNodeWrapper!,
         });
       }

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -286,10 +286,8 @@ export function createAnimatedComponent(
 
     _updateFromNative(props: StyleProps) {
       if (options?.setNativeProps) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         options.setNativeProps(this._component as AnimatedComponentRef, props);
       } else {
-        // eslint-disable-next-line no-unused-expressions
         (this._component as AnimatedComponentRef)?.setNativeProps?.(props);
       }
     }
@@ -418,11 +416,8 @@ export function createAnimatedComponent(
       // attach animatedProps property
       if (this.props.animatedProps?.viewDescriptors) {
         this.props.animatedProps.viewDescriptors.add({
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           tag: viewTag as number,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           name: viewName!,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           shadowNodeWrapper: shadowNodeWrapper!,
         });
       }

--- a/src/reanimated2/PropAdapters.ts
+++ b/src/reanimated2/PropAdapters.ts
@@ -14,7 +14,6 @@ export const createAnimatedPropAdapter = ((
   nativeProps?: string[]
 ): __AdapterWorkletFunction => {
   const nativePropsToAdd: { [key: string]: boolean } = {};
-  // eslint-disable-next-line no-unused-expressions
   nativeProps?.forEach((prop) => {
     nativePropsToAdd[prop] = true;
   });

--- a/src/reanimated2/UpdateProps.ts
+++ b/src/reanimated2/UpdateProps.ts
@@ -29,7 +29,6 @@ if (shouldBeUseWeb()) {
   updateProps = (viewDescriptors, updates) => {
     'worklet';
     processColorsInProps(updates);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     global.UpdatePropsManager!.update(viewDescriptors, updates);
   };
 }
@@ -78,7 +77,6 @@ const createUpdatePropsManager = isFabric()
           });
         },
         flush() {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           _updatePropsFabric!(operations);
           operations.length = 0;
         },
@@ -109,7 +107,6 @@ const createUpdatePropsManager = isFabric()
           });
         },
         flush() {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           _updatePropsPaper!(operations);
           operations.length = 0;
         },

--- a/src/reanimated2/hook/useDerivedValue.ts
+++ b/src/reanimated2/hook/useDerivedValue.ts
@@ -46,8 +46,7 @@ export function useDerivedValue<Value>(
     initRef.current = makeMutable(initialUpdaterRun(updater));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const sharedValue: SharedValue<Value> = initRef.current!;
+  const sharedValue: SharedValue<Value> = initRef.current;
 
   useEffect(() => {
     const fun = () => {

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -42,8 +42,10 @@ export function areDependenciesEqual(
   prevDeps: DependencyList
 ) {
   function is(x: number, y: number) {
-    // eslint-disable-next-line no-self-compare
-    return (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
+    return (
+      (x === y && (x !== 0 || 1 / x === 1 / y)) ||
+      (Number.isNaN(x) && Number.isNaN(y))
+    );
   }
   const objectIs: (nextDeps: unknown, prevDeps: unknown) => boolean =
     typeof Object.is === 'function' ? Object.is : is;
@@ -83,8 +85,9 @@ export function isAnimated(prop: unknown) {
 // This function works because `Object.keys`
 // return empty array of primitives and on arrays
 // it returns array of its indices.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function shallowEqual(a: any, b: any) {
+export function shallowEqual<
+  T extends Record<string | number | symbol, unknown>
+>(a: T, b: T) {
   'worklet';
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -159,16 +159,14 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
             if (!Array.isArray(keyframe.transform)) {
               return;
             }
-            keyframe.transform.forEach(
-              (transformStyle: { [key: string]: any }, index) => {
-                Object.keys(transformStyle).forEach((transformProp: string) => {
-                  addKeyPointWith(
-                    makeKeyframeKey(index, transformProp),
-                    transformStyle[transformProp]
-                  );
-                });
-              }
-            );
+            keyframe.transform.forEach((transformStyle, index) => {
+              Object.keys(transformStyle).forEach((transformProp: string) => {
+                addKeyPointWith(
+                  makeKeyframeKey(index, transformProp),
+                  transformStyle[transformProp as keyof typeof transformStyle]
+                );
+              });
+            });
           } else {
             addKeyPointWith(key, keyframe[key]);
           }
@@ -256,7 +254,6 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
           if (!('transform' in animations)) {
             animations.transform = [];
           }
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           animations.transform!.push(<TransformArrayItem>{
             [key.split(':')[1]]: animation,
           });

--- a/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/src/reanimated2/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -78,7 +78,6 @@ export class EntryExitTransition
           }
           exitingValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               animations.transform!.push({
                 [transformProp]: delayFunction(
                   delay,
@@ -135,16 +134,13 @@ export class EntryExitTransition
           }
           enteringValues.animations.transform.forEach((value, index) => {
             for (const transformProp of Object.keys(value)) {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               animations.transform!.push({
                 [transformProp]: delayFunction(
                   delay + exitingDuration,
                   withSequence(
                     withTiming(
                       enteringValues.initialValues.transform
-                        ? // TODO TYPESCRIPT
-                          // @ts-ignore Read similar comment above.
-                          enteringValues.initialValues.transform[index][
+                        ? enteringValues.initialValues.transform[index][
                             transformProp as keyof TransformArrayItem
                           ]
                         : 0,
@@ -175,8 +171,6 @@ export class EntryExitTransition
           ? exitingValues.initialValues.transform
           : []
       ).concat(
-        // TODO TYPESCRIPT
-        // @ts-ignore Read similar comment above.
         (Array.isArray(enteringValues.animations.transform)
           ? enteringValues.animations.transform
           : []

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -17,20 +17,16 @@ import { _updatePropsJS } from '../../js-reanimated';
 import type { ReanimatedHTMLElement } from '../../js-reanimated';
 import { ReduceMotion } from '../../commonTypes';
 import type { StyleProps } from '../../commonTypes';
-import { useReducedMotion } from '../../hook/useReducedMotion';
+import { isReducedMotion } from '../../PlatformChecker';
 import { LayoutAnimationType } from '../animationBuilder/commonTypes';
 
-const snapshots = new WeakMap();
+const snapshots = new WeakMap<HTMLElement, DOMRect>();
 
 function getEasingFromConfig(config: CustomConfig): string {
-  const easingName = (
-    config.easingV !== undefined &&
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    config.easingV!.name in WebEasings
-      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        config.easingV!.name
-      : 'linear'
-  ) as WebEasingsNames;
+  const easingName =
+    config.easingV && config.easingV.name in WebEasings
+      ? (config.easingV.name as WebEasingsNames)
+      : 'linear';
 
   return `cubic-bezier(${WebEasings[easingName].toString()})`;
 }
@@ -50,14 +46,12 @@ function getDelayFromConfig(config: CustomConfig): number {
 
   return shouldRandomizeDelay
     ? getRandomDelay(config.delayV)
-    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      config.delayV! / 1000;
+    : config.delayV / 1000;
 }
 
 export function getReducedMotionFromConfig(config: CustomConfig) {
   if (!config.reduceMotionV) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useReducedMotion();
+    return isReducedMotion();
   }
 
   switch (config.reduceMotionV) {
@@ -66,8 +60,7 @@ export function getReducedMotionFromConfig(config: CustomConfig) {
     case ReduceMotion.Always:
       return true;
     default:
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      return useReducedMotion();
+      return isReducedMotion();
   }
 }
 
@@ -81,14 +74,12 @@ function getDurationFromConfig(
     : Animations[animationName].duration;
 
   return config.durationV !== undefined
-    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      config.durationV! / 1000
+    ? config.durationV / 1000
     : defaultDuration;
 }
 
 function getCallbackFromConfig(config: CustomConfig): AnimationCallback {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return config.callbackV !== undefined ? config.callbackV! : null;
+  return config.callbackV !== undefined ? config.callbackV : null;
 }
 
 function getReversedFromConfig(config: CustomConfig) {
@@ -261,7 +252,7 @@ export function handleExitingAnimation(
   setElementAnimation(dummy, animationConfig);
   parent?.appendChild(dummy);
 
-  const snapshot = snapshots.get(element);
+  const snapshot = snapshots.get(element)!;
 
   dummy.style.position = 'absolute';
   dummy.style.top = `${snapshot.top}px`;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Non-null assertions are considered to be a bad practice - however this is in regard to pure TypeScript code. This is not the case in Reanimated, since we have to deal with multiple platforms and multiple threads. Therefore sometimes we know that a value is defined, without a need for unnecessary checks for `undefined` or `null` - and non-null assertions are very handy there, since they are very short.

Also, using `?` operator instead of TS `!` could lead to unexpected behavior that could be hard to understand. Consider the following example:

```TS
function dispatchCommandPaper<T extends Component>(
  animatedRef: AnimatedRef<T>,
  commandName: string,
  args: Array<unknown> = []
) {
  'worklet';
  if (!_WORKLET) {
    return;
  }

  const viewTag = animatedRef() as number;
  // TS error - _dispatchCommandPaper is not defined
  _dispatchCommandPaper(viewTag, commandName, args);
}
```

We get a TS error even though we are sure that `_dispatchCommandPaper` is defined - `dispatchCommandPaper` is only used on Paper and `_dispatchCommandPaper` is injected there. However, if we changed it to:

```TS
_dispatchCommandPaper?(viewTag, commandName, args);
```

And something would go so wrong that `_dispatchCommandPaper` would actually be undefined this function would silently fail instead of throwing with a meaningful stacktrace.

## Test plan

TS tests are sufficient for this.

Co-authored by: @marmor157.