### PR TITLE
Improve reduced motion warning

### DIFF
--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -145,11 +145,11 @@ See [the compatibility table](compatibility) for a full list of supported versio
 
 **Problem:** This warning is displayed to avoid confusion that could arise when Reduced motion is enabled.
 
-**Solution:** This warning is only displayed in development mode, but if you wish to disable it you can add the following line to your project's root file.
+**Solution:** Do nothing, this warning is safe to ignore as it is only displayed in development mode to avoid confusion. If you wish to disable it, you can add the following line to your project's root file:
 
 ```js
 LogBox.ignoreLogs([
-  '[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/accessibility.',
+  '[Reanimated] Reduced motion setting is enabled on this device.',
 ]);
 ```
 

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -141,7 +141,7 @@ See [the compatibility table](compatibility) for a full list of supported versio
 
 ## Warnings
 
-### Reduced motion setting is enabled on this device. Some animations will be disabled by default.
+### Reduced motion setting is enabled on this device.
 
 **Problem:** This warning is displayed to avoid confusion that could arise when Reduced motion is enabled.
 

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -139,6 +139,22 @@ See [Multiple versions of Reanimated were detected](#multiple-versions-of-reanim
 **Solution:** Please upgrade to a newer version of React Native or downgrade to an older version of Reanimated.
 See [the compatibility table](compatibility) for a full list of supported versions of React Native.
 
+## Warnings
+
+### Reduced motion setting is enabled on this device. Some animations will be disabled by default.
+
+**Problem:** This warning is displayed to avoid confusion that could arise when Reduced motion is enabled.
+
+**Solution:** This warning is only displayed in development mode, but if you wish to disable it you can add the following line to your project's root file.
+
+```js
+LogBox.ignoreLogs([
+  '[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/accessibility.',
+]);
+```
+
+See [the accessibility overview](accessibility) to learn more about Reduced Motion.
+
 ## Threading issues
 
 ### Tried to synchronously call a non-worklet function on the UI thread

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -38,7 +38,7 @@ const IS_REDUCED_MOTION = isReducedMotion();
 
 if (__DEV__ && IS_REDUCED_MOTION) {
   console.warn(
-    `[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/accessibility.`
+    `[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#reduced-motion-setting-is-enabled-on-this-device.`
   );
 }
 

--- a/src/reanimated2/animation/util.ts
+++ b/src/reanimated2/animation/util.ts
@@ -38,7 +38,7 @@ const IS_REDUCED_MOTION = isReducedMotion();
 
 if (__DEV__ && IS_REDUCED_MOTION) {
   console.warn(
-    `[Reanimated] Reduced motion setting is enabled on this device. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/accessibility.`
+    `[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/accessibility.`
   );
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR extends the reduced motion warning to inform that it is only displayed in development mode and adds a note in docs that explains why the warning is displayed and how it can be disabled. 

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
