### PR TITLE
Fix incomplete UI runtime initialization

### DIFF
--- a/Common/cpp/NativeModules/NativeReanimatedModule.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.cpp
@@ -166,7 +166,11 @@ jsi::Value NativeReanimatedModule::createWorkletRuntime(
     const jsi::Value &name,
     const jsi::Value &initializer) {
   auto workletRuntime = std::make_shared<WorkletRuntime>(
-      rt, jsQueue_, jsScheduler_, name.asString(rt).utf8(rt), valueUnpackerCode_);
+      rt,
+      jsQueue_,
+      jsScheduler_,
+      name.asString(rt).utf8(rt),
+      valueUnpackerCode_);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
       rt, initializer, "[Reanimated] Initializer must be a worklet.");
   workletRuntime->runGuarded(initializerShareable);

--- a/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -36,13 +36,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       const std::shared_ptr<CallInvoker> &jsInvoker,
       const std::shared_ptr<MessageQueueThread> &jsQueue,
       const std::shared_ptr<UIScheduler> &uiScheduler,
-      const PlatformDepMethodsHolder &platformDepMethodsHolder);
+      const PlatformDepMethodsHolder &platformDepMethodsHolder,
+      const std::string &valueUnpackerCode);
 
   ~NativeReanimatedModule();
-
-  void installValueUnpacker(
-      jsi::Runtime &rt,
-      const jsi::Value &valueUnpackerCode) override;
 
   jsi::Value makeShareableClone(
       jsi::Runtime &rt,

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -6,16 +6,6 @@
 
 namespace reanimated {
 
-static jsi::Value SPEC_PREFIX(installValueUnpacker)(
-    jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const jsi::Value *args,
-    size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->installValueUnpacker(rt, std::move(args[0]));
-  return jsi::Value::undefined();
-}
-
 // SharedValue
 
 static jsi::Value SPEC_PREFIX(makeShareableClone)(
@@ -198,9 +188,6 @@ static jsi::Value SPEC_PREFIX(setShouldAnimateExiting)(
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
-  methodMap_["installValueUnpacker"] =
-      MethodMetadata{1, SPEC_PREFIX(installValueUnpacker)};
-
   methodMap_["makeShareableClone"] =
       MethodMetadata{2, SPEC_PREFIX(makeShareableClone)};
 

--- a/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
+++ b/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
@@ -22,10 +22,6 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
   explicit NativeReanimatedModuleSpec(std::shared_ptr<CallInvoker> jsInvoker);
 
  public:
-  virtual void installValueUnpacker(
-      jsi::Runtime &rt,
-      const jsi::Value &valueUnpackerCode) = 0;
-
   // SharedValue
   virtual jsi::Value makeShareableClone(
       jsi::Runtime &rt,

--- a/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
@@ -17,10 +17,12 @@ WorkletRuntime::WorkletRuntime(
   WorkletRuntimeCollector::install(rt);
   WorkletRuntimeDecorator::decorate(rt, name, jsScheduler);
 
-  auto codeBuffer = std::make_shared<const jsi::StringBuffer>("(" + valueUnpackerCode + "\n)");
-  auto valueUnpacker = rt.evaluateJavaScript(codeBuffer, "WorkletRuntime::WorkletRuntime")
-                                       .asObject(rt)
-                                       .asFunction(rt);
+  auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
+      "(" + valueUnpackerCode + "\n)");
+  auto valueUnpacker =
+      rt.evaluateJavaScript(codeBuffer, "WorkletRuntime::WorkletRuntime")
+          .asObject(rt)
+          .asFunction(rt);
   rt.global().setProperty(rt, "__valueUnpacker", valueUnpacker);
 }
 

--- a/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
+++ b/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
@@ -10,21 +10,17 @@ WorkletRuntime::WorkletRuntime(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<MessageQueueThread> &jsQueue,
     const std::shared_ptr<JSScheduler> &jsScheduler,
-    const std::string &name)
+    const std::string &name,
+    const std::string &valueUnpackerCode)
     : runtime_(ReanimatedRuntime::make(rnRuntime, jsQueue, name)), name_(name) {
   jsi::Runtime &rt = *runtime_;
   WorkletRuntimeCollector::install(rt);
   WorkletRuntimeDecorator::decorate(rt, name, jsScheduler);
-}
 
-void WorkletRuntime::installValueUnpacker(
-    const std::string &valueUnpackerCode) {
-  jsi::Runtime &rt = *runtime_;
-  auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
-      "(" + valueUnpackerCode + "\n)");
-  auto valueUnpacker = rt.evaluateJavaScript(codeBuffer, "installValueUnpacker")
-                           .asObject(rt)
-                           .asFunction(rt);
+  auto codeBuffer = std::make_shared<const jsi::StringBuffer>("(" + valueUnpackerCode + "\n)");
+  auto valueUnpacker = rt.evaluateJavaScript(codeBuffer, "WorkletRuntime::WorkletRuntime")
+                                       .asObject(rt)
+                                       .asFunction(rt);
   rt.global().setProperty(rt, "__valueUnpacker", valueUnpacker);
 }
 

--- a/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
+++ b/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
@@ -25,9 +25,8 @@ class WorkletRuntime : public jsi::HostObject,
       jsi::Runtime &rnRuntime,
       const std::shared_ptr<MessageQueueThread> &jsQueue,
       const std::shared_ptr<JSScheduler> &jsScheduler,
-      const std::string &name);
-
-  void installValueUnpacker(const std::string &valueUnpackerCode);
+      const std::string &name,
+      const std::string &valueUnpackerCode);
 
   jsi::Runtime &getJSIRuntime() const {
     return *runtime_;

--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -19,7 +19,7 @@ public class NativeProxy extends NativeProxyCommon {
     @SuppressWarnings("unused")
     private final HybridData mHybridData;
 
-    public NativeProxy(ReactApplicationContext context) {
+    public NativeProxy(ReactApplicationContext context, String valueUnpackerCode) {
         super(context);
         ReactFeatureFlagsWrapper.enableMountHooks();
         CallInvokerHolderImpl holder =
@@ -39,6 +39,7 @@ public class NativeProxy extends NativeProxyCommon {
                         mAndroidUIScheduler,
                         LayoutAnimations,
                         messageQueueThread,
+                        valueUnpackerCode,
                         fabricUIManager);
         prepareLayoutAnimations(LayoutAnimations);
         installJSIBindings();

--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -54,6 +54,7 @@ public class NativeProxy extends NativeProxyCommon {
             AndroidUIScheduler androidUIScheduler,
             LayoutAnimations LayoutAnimations,
             MessageQueueThread messageQueueThread,
+            String valueUnpackerCode,
             FabricUIManager fabricUIManager);
 
     public native boolean isAnyHandlerWaitingForEvent(String eventName, int emitterReactTag);

--- a/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -39,8 +39,8 @@ public class NativeProxy extends NativeProxyCommon {
                         mAndroidUIScheduler,
                         LayoutAnimations,
                         messageQueueThread,
-                        valueUnpackerCode,
-                        fabricUIManager);
+                        fabricUIManager,
+                        valueUnpackerCode);
         prepareLayoutAnimations(LayoutAnimations);
         installJSIBindings();
         if (BuildConfig.DEBUG) {
@@ -54,8 +54,8 @@ public class NativeProxy extends NativeProxyCommon {
             AndroidUIScheduler androidUIScheduler,
             LayoutAnimations LayoutAnimations,
             MessageQueueThread messageQueueThread,
-            String valueUnpackerCode,
-            FabricUIManager fabricUIManager);
+            FabricUIManager fabricUIManager,
+            String valueUnpackerCode);
 
     public native boolean isAnyHandlerWaitingForEvent(String eventName, int emitterReactTag);
 

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -37,13 +37,11 @@ NativeProxy::NativeProxy(
     const std::shared_ptr<UIScheduler> &uiScheduler,
     jni::global_ref<LayoutAnimations::javaobject> layoutAnimations,
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
-    const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
-    ,
     jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-        fabricUIManager
+        fabricUIManager,
 #endif
-    )
+    const std::string &valueUnpackerCode)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       nativeReanimatedModule_(std::make_shared<NativeReanimatedModule>(
@@ -88,13 +86,11 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
     jni::alias_ref<AndroidUIScheduler::javaobject> androidUiScheduler,
     jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations,
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
-    const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
-    ,
     jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-        fabricUIManager
+        fabricUIManager,
 #endif
-) {
+    const std::string &valueUnpackerCode) {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
   auto uiScheduler = androidUiScheduler->cthis()->getUIScheduler();
   return makeCxxInstance(
@@ -104,12 +100,10 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
       uiScheduler,
       make_global(layoutAnimations),
       messageQueueThread,
-      valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
-      ,
-      fabricUIManager
+      fabricUIManager,
 #endif
-      /**/);
+      valueUnpackerCode);
 }
 
 #ifndef NDEBUG

--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -36,7 +36,8 @@ NativeProxy::NativeProxy(
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
     const std::shared_ptr<UIScheduler> &uiScheduler,
     jni::global_ref<LayoutAnimations::javaobject> layoutAnimations,
-    jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread
+    jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
+    const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
     ,
     jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
@@ -50,7 +51,8 @@ NativeProxy::NativeProxy(
           jsCallInvoker,
           std::make_shared<JMessageQueueThread>(messageQueueThread),
           uiScheduler,
-          getPlatformDependentMethods())),
+          getPlatformDependentMethods(),
+          valueUnpackerCode)),
       layoutAnimations_(std::move(layoutAnimations)) {
 #ifdef RCT_NEW_ARCH_ENABLED
   const auto &uiManager =
@@ -85,7 +87,8 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
         jsCallInvokerHolder,
     jni::alias_ref<AndroidUIScheduler::javaobject> androidUiScheduler,
     jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations,
-    jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread
+    jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
+    const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
     ,
     jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
@@ -100,7 +103,8 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
       jsCallInvoker,
       uiScheduler,
       make_global(layoutAnimations),
-      messageQueueThread
+      messageQueueThread,
+      valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
       ,
       fabricUIManager

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -155,13 +155,11 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       jni::alias_ref<AndroidUIScheduler::javaobject> androidUiScheduler,
       jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations,
       jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
-      const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
-      ,
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-          fabricUIManager
+          fabricUIManager,
 #endif
-      /**/);
+      const std::string &valueUnpackerCode);
   static void registerNatives();
 
   ~NativeProxy();
@@ -268,13 +266,11 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       const std::shared_ptr<UIScheduler> &uiScheduler,
       jni::global_ref<LayoutAnimations::javaobject> layoutAnimations,
       jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
-      const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
-      ,
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-          fabricUIManager
+          fabricUIManager,
 #endif
-      /**/);
+      const std::string &valueUnpackerCode);
 };
 
 } // namespace reanimated

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -154,7 +154,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
           jsCallInvokerHolder,
       jni::alias_ref<AndroidUIScheduler::javaobject> androidUiScheduler,
       jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations,
-      jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread
+      jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
+      const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
       ,
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
@@ -266,7 +267,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
       const std::shared_ptr<UIScheduler> &uiScheduler,
       jni::global_ref<LayoutAnimations::javaobject> layoutAnimations,
-      jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread
+      jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
+      const std::string &valueUnpackerCode
 #ifdef RCT_NEW_ARCH_ENABLED
       ,
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -120,9 +120,9 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
-  public void initWithContext(ReactApplicationContext reactApplicationContext) {
+  public void initWithContext(ReactApplicationContext reactApplicationContext, String valueUnpackerCode) {
     mReactApplicationContext = reactApplicationContext;
-    mNativeProxy = new NativeProxy(reactApplicationContext);
+    mNativeProxy = new NativeProxy(reactApplicationContext, valueUnpackerCode);
     mAnimationManager.setAndroidUIScheduler(getNativeProxy().getAndroidUIScheduler());
     compatibility = new ReaCompatibility(reactApplicationContext);
     compatibility.registerFabricEventListener(this);

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -120,7 +120,8 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
-  public void initWithContext(ReactApplicationContext reactApplicationContext, String valueUnpackerCode) {
+  public void initWithContext(
+      ReactApplicationContext reactApplicationContext, String valueUnpackerCode) {
     mReactApplicationContext = reactApplicationContext;
     mNativeProxy = new NativeProxy(reactApplicationContext, valueUnpackerCode);
     mAnimationManager.setAndroidUIScheduler(getNativeProxy().getAndroidUIScheduler());

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -91,13 +91,13 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public void installTurboModule() {
+  public void installTurboModule(String valueUnpackerCode) {
     // When debugging in chrome the JS context is not available.
     // https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25
     Utils.isChromeDebugger = getReactApplicationContext().getJavaScriptContextHolder().get() == 0;
 
     if (!Utils.isChromeDebugger) {
-      this.getNodesManager().initWithContext(getReactApplicationContext());
+      this.getNodesManager().initWithContext(getReactApplicationContext(), valueUnpackerCode);
     } else {
       Log.w(
           "[REANIMATED]",

--- a/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -19,7 +19,7 @@ public class NativeProxy extends NativeProxyCommon {
     @SuppressWarnings("unused")
     private final HybridData mHybridData;
 
-    public NativeProxy(ReactApplicationContext context) {
+    public NativeProxy(ReactApplicationContext context, String valueUnpackerCode) {
         super(context);
         CallInvokerHolderImpl holder =
                 (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
@@ -31,7 +31,8 @@ public class NativeProxy extends NativeProxyCommon {
                         holder,
                         mAndroidUIScheduler,
                         LayoutAnimations,
-                        messageQueueThread);
+                        messageQueueThread,
+                        valueUnpackerCode);
         prepareLayoutAnimations(LayoutAnimations);
         installJSIBindings();
         if (BuildConfig.DEBUG) {
@@ -44,7 +45,8 @@ public class NativeProxy extends NativeProxyCommon {
             CallInvokerHolderImpl jsCallInvokerHolder,
             AndroidUIScheduler androidUIScheduler,
             LayoutAnimations LayoutAnimations,
-            MessageQueueThread messageQueueThread);
+            MessageQueueThread messageQueueThread,
+            String valueUnpackerCode);
 
     public native boolean isAnyHandlerWaitingForEvent(String eventName, int emitterReactTag);
 

--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -257,14 +257,14 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   }
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule:(nonnull NSString *)valueUnpackerCode)
 {
   facebook::jsi::Runtime *jsiRuntime = [self.bridge respondsToSelector:@selector(runtime)]
       ? reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime)
       : nullptr;
 
   if (jsiRuntime) {
-    auto nativeReanimatedModule = reanimated::createReanimatedModule(self.bridge, self.bridge.jsCallInvoker);
+    auto nativeReanimatedModule = reanimated::createReanimatedModule(self.bridge, self.bridge.jsCallInvoker, std::string([valueUnpackerCode UTF8String]));
 
     jsi::Runtime &rnRuntime = *jsiRuntime;
     WorkletRuntimeCollector::install(rnRuntime);

--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -257,14 +257,15 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   }
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule:(nonnull NSString *)valueUnpackerCode)
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)valueUnpackerCode)
 {
   facebook::jsi::Runtime *jsiRuntime = [self.bridge respondsToSelector:@selector(runtime)]
       ? reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime)
       : nullptr;
 
   if (jsiRuntime) {
-    auto nativeReanimatedModule = reanimated::createReanimatedModule(self.bridge, self.bridge.jsCallInvoker, std::string([valueUnpackerCode UTF8String]));
+    auto nativeReanimatedModule = reanimated::createReanimatedModule(
+        self.bridge, self.bridge.jsCallInvoker, std::string([valueUnpackerCode UTF8String]));
 
     jsi::Runtime &rnRuntime = *jsiRuntime;
     WorkletRuntimeCollector::install(rnRuntime);

--- a/apple/native/NativeProxy.h
+++ b/apple/native/NativeProxy.h
@@ -8,7 +8,8 @@ namespace reanimated {
 
 std::shared_ptr<reanimated::NativeReanimatedModule> createReanimatedModule(
     RCTBridge *bridge,
-    const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker);
+    const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
+    const std::string &valueUnpackerCode);
 
 }
 

--- a/apple/native/NativeProxy.mm
+++ b/apple/native/NativeProxy.mm
@@ -288,8 +288,8 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
       maybeFlushUIUpdatesQueueFunction,
   };
 
-  auto nativeReanimatedModule =
-      std::make_shared<NativeReanimatedModule>(rnRuntime, jsInvoker, jsQueue, uiScheduler, platformDepMethodsHolder, valueUnpackerCode);
+  auto nativeReanimatedModule = std::make_shared<NativeReanimatedModule>(
+      rnRuntime, jsInvoker, jsQueue, uiScheduler, platformDepMethodsHolder, valueUnpackerCode);
 
   [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler

--- a/apple/native/NativeProxy.mm
+++ b/apple/native/NativeProxy.mm
@@ -96,7 +96,8 @@ static NSSet *convertProps(jsi::Runtime &rt, const jsi::Value &props)
 
 std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     RCTBridge *bridge,
-    const std::shared_ptr<CallInvoker> &jsInvoker)
+    const std::shared_ptr<CallInvoker> &jsInvoker,
+    const std::string &valueUnpackerCode)
 {
   REAModule *reaModule = [bridge moduleForClass:[REAModule class]];
 
@@ -288,7 +289,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   };
 
   auto nativeReanimatedModule =
-      std::make_shared<NativeReanimatedModule>(rnRuntime, jsInvoker, jsQueue, uiScheduler, platformDepMethodsHolder);
+      std::make_shared<NativeReanimatedModule>(rnRuntime, jsInvoker, jsQueue, uiScheduler, platformDepMethodsHolder, valueUnpackerCode);
 
   [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler

--- a/src/reanimated2/NativeReanimated/NativeReanimated.ts
+++ b/src/reanimated2/NativeReanimated/NativeReanimated.ts
@@ -17,7 +17,6 @@ import { getValueUnpackerCode } from '../valueUnpacker';
 
 // this is the type of `__reanimatedModuleProxy` which is injected using JSI
 export interface NativeReanimatedModule {
-  installValueUnpacker(valueUnpackerCode: string): void;
   makeShareableClone<T>(
     value: T,
     shouldPersistRemote: boolean
@@ -92,7 +91,8 @@ export class NativeReanimated {
     }
     if (global.__reanimatedModuleProxy === undefined) {
       const { ReanimatedModule } = NativeModules;
-      ReanimatedModule?.installTurboModule();
+      const valueUnpackerCode = getValueUnpackerCode();
+      ReanimatedModule?.installTurboModule(valueUnpackerCode);
     }
     if (global.__reanimatedModuleProxy === undefined) {
       throw new Error(
@@ -103,9 +103,7 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     if (__DEV__) {
       checkCppVersion();
     }
-
     this.InnerNativeModule = global.__reanimatedModuleProxy;
-    this.InnerNativeModule.installValueUnpacker(getValueUnpackerCode());
   }
 
   makeShareableClone<T>(value: T, shouldPersistRemote: boolean) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #5421, fixes #5331.

This PR removes `installValueUnpacker` method which was called on the JS thread during the creation of `NativeReanimatedModule` but operated directly on the UI runtime. Because of this, UI runtime was already used from JS thread so any use from the UI runtime (e.g. Reanimated event handlers) would cause a crash due to a failed check in `ReanimatedReentrancyCheck::before`. Note that the check also occurred in release mode due to improperly set `NDEBUG` flag.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
