### PR TITLE
Mark `create-expo-app` as latest

### DIFF
--- a/docs/docs/fundamentals/getting-started.mdx
+++ b/docs/docs/fundamentals/getting-started.mdx
@@ -22,7 +22,7 @@ If you don't have an existing project, you can create a new Expo app using a tem
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
 
-    npx create-expo-app my-app -e with-reanimated
+    npx create-expo-app@latest my-app -e with-reanimated
 
   </TabItem>
   <TabItem value="yarn" label="YARN">


### PR DESCRIPTION
It seems like npx sometimes uses an old cached version of the `create-expo-app` cli 

This PR adds the `latest` modifier to make sure that the invoked command have the `-e` command available