### PR TITLE
Fix FlatList item generic types

### DIFF
--- a/__typetests__/common.tsx
+++ b/__typetests__/common.tsx
@@ -120,6 +120,16 @@ function AnimatedFlatListTest() {
       />
     );
   }
+
+  function AnimatedFlatListTestGenericParameter() {
+    return (
+      <>
+        <Animated.FlatList<string> data={['a', 'b']} renderItem={() => null} />
+        {/* @ts-expect-error Properly detects wrong generic type */}
+        <Animated.FlatList<string> data={[1, 2]} renderItem={() => null} />
+      </>
+    );
+  }
 }
 
 function MakeMutableTest() {

--- a/__typetests__/common.tsx
+++ b/__typetests__/common.tsx
@@ -121,12 +121,21 @@ function AnimatedFlatListTest() {
     );
   }
 
-  function AnimatedFlatListTestGenericParameter() {
+  function AnimatedFlatListTestGenericParameterPresence() {
     return (
       <>
         <Animated.FlatList<string> data={['a', 'b']} renderItem={() => null} />
         {/* @ts-expect-error Properly detects wrong generic type */}
         <Animated.FlatList<string> data={[1, 2]} renderItem={() => null} />
+      </>
+    );
+  }
+
+  function AnimatedFlatListTestGenericParameterDefaultsToAny() {
+    return (
+      <>
+        {/* @ts-expect-error Disable TypeScript item type inference */}
+        <Animated.FlatList renderItem={({ item }) => item.absurdProperty} />
       </>
     );
   }

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -1,5 +1,4 @@
 'use strict';
-import type { ForwardedRef } from 'react';
 import React, { forwardRef } from 'react';
 import type {
   FlatListProps,
@@ -64,7 +63,7 @@ interface AnimatedFlatListComplement<T> extends FlatList<T> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const FlatListForwardRefRender = function <Item>(
   props: ReanimatedFlatListPropsWithLayout<Item>,
-  ref: ForwardedRef<FlatList>
+  ref: React.ForwardedRef<FlatList>
 ) {
   const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
     props;
@@ -109,7 +108,7 @@ export const ReanimatedFlatList = forwardRef(FlatListForwardRefRender) as <
   ItemT = any
 >(
   props: ReanimatedFlatListPropsWithLayout<ItemT> & {
-    ref?: ForwardedRef<FlatList>;
+    ref?: React.ForwardedRef<FlatList>;
   }
 ) => React.ReactElement;
 

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -60,19 +60,16 @@ interface AnimatedFlatListComplement<T> extends FlatList<T> {
   getNode(): FlatList<T>;
 }
 
-export const ReanimatedFlatList = forwardRef(
-  (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    props: ReanimatedFlatListPropsWithLayout<any>,
-    ref: ForwardedRef<FlatList>
-  ) => {
+// We need explicit any here, because this is the exact same type that is used in React Native types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const FlatListForwardRefRender = <ItemT = any>(props: ReanimatedFlatListPropsWithLayout<ItemT>, ref: ForwardedRef<FlatList>) => {
     const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
       props;
 
     // Set default scrollEventThrottle, because user expects
     // to have continuous scroll events and
     // react-native defaults it to 50 for FlatLists.
-    // We set it to 1 so we have peace until
+    // We set it to 1, so we have peace until
     // there are 960 fps screens.
     if (!('scrollEventThrottle' in restProps)) {
       restProps.scrollEventThrottle = 1;
@@ -83,7 +80,8 @@ export const ReanimatedFlatList = forwardRef(
       []
     );
 
-    const animatedFlatList = (
+  const animatedFlatList = (
+    // @ts-expect-error We Can't easily make the result of createAnimatedComponent generic
       <AnimatedFlatList
         ref={ref}
         {...restProps}
@@ -101,7 +99,12 @@ export const ReanimatedFlatList = forwardRef(
       </LayoutAnimationConfig>
     );
   }
-);
+
+// We need explicit any here, because this is the exact same type that is used in React Native types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ReanimatedFlatList = forwardRef(FlatListForwardRefRender) as <ItemT = any>(props: ReanimatedFlatListPropsWithLayout<ItemT> & {
+  ref?: ForwardedRef<FlatList>
+}) => React.ReactElement;
 
 export type ReanimatedFlatList<T> = typeof AnimatedFlatList &
   AnimatedFlatListComplement<T>;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -62,49 +62,56 @@ interface AnimatedFlatListComplement<T> extends FlatList<T> {
 
 // We need explicit any here, because this is the exact same type that is used in React Native types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const FlatListForwardRefRender = <ItemT = any>(props: ReanimatedFlatListPropsWithLayout<ItemT>, ref: ForwardedRef<FlatList>) => {
-    const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
-      props;
+const FlatListForwardRefRender = <ItemT = any,>(
+  props: ReanimatedFlatListPropsWithLayout<ItemT>,
+  ref: ForwardedRef<FlatList>
+) => {
+  const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
+    props;
 
-    // Set default scrollEventThrottle, because user expects
-    // to have continuous scroll events and
-    // react-native defaults it to 50 for FlatLists.
-    // We set it to 1, so we have peace until
-    // there are 960 fps screens.
-    if (!('scrollEventThrottle' in restProps)) {
-      restProps.scrollEventThrottle = 1;
-    }
+  // Set default scrollEventThrottle, because user expects
+  // to have continuous scroll events and
+  // react-native defaults it to 50 for FlatLists.
+  // We set it to 1, so we have peace until
+  // there are 960 fps screens.
+  if (!('scrollEventThrottle' in restProps)) {
+    restProps.scrollEventThrottle = 1;
+  }
 
-    const CellRendererComponent = React.useMemo(
-      () => createCellRendererComponent(itemLayoutAnimation),
-      []
-    );
+  const CellRendererComponent = React.useMemo(
+    () => createCellRendererComponent(itemLayoutAnimation),
+    []
+  );
 
   const animatedFlatList = (
     // @ts-expect-error We Can't easily make the result of createAnimatedComponent generic
-      <AnimatedFlatList
-        ref={ref}
-        {...restProps}
-        CellRendererComponent={CellRendererComponent}
-      />
-    );
+    <AnimatedFlatList
+      ref={ref}
+      {...restProps}
+      CellRendererComponent={CellRendererComponent}
+    />
+  );
 
-    if (skipEnteringExitingAnimations === undefined) {
-      return animatedFlatList;
-    }
-
-    return (
-      <LayoutAnimationConfig skipEntering skipExiting>
-        {animatedFlatList}
-      </LayoutAnimationConfig>
-    );
+  if (skipEnteringExitingAnimations === undefined) {
+    return animatedFlatList;
   }
+
+  return (
+    <LayoutAnimationConfig skipEntering skipExiting>
+      {animatedFlatList}
+    </LayoutAnimationConfig>
+  );
+};
 
 // We need explicit any here, because this is the exact same type that is used in React Native types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const ReanimatedFlatList = forwardRef(FlatListForwardRefRender) as <ItemT = any>(props: ReanimatedFlatListPropsWithLayout<ItemT> & {
-  ref?: ForwardedRef<FlatList>
-}) => React.ReactElement;
+export const ReanimatedFlatList = forwardRef(FlatListForwardRefRender) as <
+  ItemT = any
+>(
+  props: ReanimatedFlatListPropsWithLayout<ItemT> & {
+    ref?: ForwardedRef<FlatList>;
+  }
+) => React.ReactElement;
 
 export type ReanimatedFlatList<T> = typeof AnimatedFlatList &
   AnimatedFlatListComplement<T>;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -62,10 +62,10 @@ interface AnimatedFlatListComplement<T> extends FlatList<T> {
 
 // We need explicit any here, because this is the exact same type that is used in React Native types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const FlatListForwardRefRender = <ItemT = any,>(
-  props: ReanimatedFlatListPropsWithLayout<ItemT>,
+const FlatListForwardRefRender = function <Item>(
+  props: ReanimatedFlatListPropsWithLayout<Item>,
   ref: ForwardedRef<FlatList>
-) => {
+) {
   const { itemLayoutAnimation, skipEnteringExitingAnimations, ...restProps } =
     props;
 
@@ -84,7 +84,7 @@ const FlatListForwardRefRender = <ItemT = any,>(
   );
 
   const animatedFlatList = (
-    // @ts-expect-error We Can't easily make the result of createAnimatedComponent generic
+    // @ts-expect-error In its current type state, createAnimatedComponent cannot create generic components.
     <AnimatedFlatList
       ref={ref}
       {...restProps}
@@ -103,9 +103,9 @@ const FlatListForwardRefRender = <ItemT = any,>(
   );
 };
 
-// We need explicit any here, because this is the exact same type that is used in React Native types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ReanimatedFlatList = forwardRef(FlatListForwardRefRender) as <
+  // We need explicit any here, because this is the exact same type that is used in React Native types.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ItemT = any
 >(
   props: ReanimatedFlatListPropsWithLayout<ItemT> & {

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -59,9 +59,9 @@ interface AnimatedFlatListComplement<T> extends FlatList<T> {
   getNode(): FlatList<T>;
 }
 
-// We need explicit any here, because this is the exact same type that is used in React Native types
+// We need explicit any here, because this is the exact same type that is used in React Native types.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const FlatListForwardRefRender = function <Item>(
+const FlatListForwardRefRender = function <Item = any>(
   props: ReanimatedFlatListPropsWithLayout<Item>,
   ref: React.ForwardedRef<FlatList>
 ) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I think I ran into a typescript types regression, where the `Animated.FlatList` type was no longer generic. It always used the any type and I couldn't provide a custom item type myself anymore. I found it while upgrading from Reanimated v2 to v3. I think I managed to patch the generated .d.ts file properly locally and this is what did the trick for me.

If this isn't matching your code style or requirements, I'm happy to work with you on making this work.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Probably makes sense to see if it breaks anything in the example app but other than that 🤷 
