### PR TITLE
Use TS in `jestUtils.ts`

### DIFF
--- a/src/createAnimatedComponent/commonTypes.ts
+++ b/src/createAnimatedComponent/commonTypes.ts
@@ -88,7 +88,7 @@ export interface IAnimatedComponentInternal {
   _animatedProps?: Partial<AnimatedComponentProps<AnimatedProps>>;
   _viewTag: number;
   _isFirstRender: boolean;
-  animatedStyle: { value: StyleProps };
+  jestAnimatedStyle: { value: StyleProps };
   _component: AnimatedComponentRef | HTMLElement | null;
   _sharedElementTransition: SharedTransition | null;
   _jsPropsUpdater: IJSPropsUpdater;

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -561,10 +561,10 @@ export function createAnimatedComponent(
     }
 
     render() {
-      const props = this._PropsFilter.filterNonAnimatedProps(this);
+      const filteredProps = this._PropsFilter.filterNonAnimatedProps(this);
 
       if (isJest()) {
-        props.jestAnimatedStyle = this.jestAnimatedStyle;
+        filteredProps.jestAnimatedStyle = this.jestAnimatedStyle;
       }
 
       // Layout animations on web are set inside `componentDidMount` method, which is called after first render.
@@ -574,11 +574,11 @@ export function createAnimatedComponent(
       if (
         this._isFirstRender &&
         IS_WEB &&
-        props.entering &&
-        !getReducedMotionFromConfig(props.entering as CustomConfig)
+        filteredProps.entering &&
+        !getReducedMotionFromConfig(filteredProps.entering as CustomConfig)
       ) {
-        props.style = {
-          ...(props.style ?? {}),
+        filteredProps.style = {
+          ...(filteredProps.style ?? {}),
           visibility: 'hidden', // Hide component until `componentDidMount` triggers
         };
       }
@@ -590,7 +590,7 @@ export function createAnimatedComponent(
 
       return (
         <Component
-          {...props}
+          {...filteredProps}
           // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
           // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
           ref={this._setComponentRef as (ref: Component) => void}

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -136,7 +136,7 @@ export function createAnimatedComponent(
     _animatedProps?: Partial<AnimatedComponentProps<AnimatedProps>>;
     _viewTag = -1;
     _isFirstRender = true;
-    animatedStyle: { value: StyleProps } = { value: {} };
+    jestAnimatedStyle: { value: StyleProps } = { value: {} };
     _component: AnimatedComponentRef | HTMLElement | null = null;
     _sharedElementTransition: SharedTransition | null = null;
     _jsPropsUpdater = new JSPropsUpdater();
@@ -150,7 +150,7 @@ export function createAnimatedComponent(
     constructor(props: AnimatedComponentProps<InitialComponentProps>) {
       super(props);
       if (isJest()) {
-        this.animatedStyle = { value: {} };
+        this.jestAnimatedStyle = { value: {} };
       }
     }
 
@@ -407,11 +407,11 @@ export function createAnimatedComponent(
            * We can't update props object directly because TestObject contains a copy of props - look at render function:
            * const props = this._filterNonAnimatedProps(this.props);
            */
-          this.animatedStyle.value = {
-            ...this.animatedStyle.value,
+          this.jestAnimatedStyle.value = {
+            ...this.jestAnimatedStyle.value,
             ...style.initial.value,
           };
-          style.animatedStyle.current = this.animatedStyle;
+          style.jestAnimatedStyle.current = this.jestAnimatedStyle;
         }
       });
 
@@ -564,7 +564,7 @@ export function createAnimatedComponent(
       const props = this._PropsFilter.filterNonAnimatedProps(this);
 
       if (isJest()) {
-        props.animatedStyle = this.animatedStyle;
+        props.jestAnimatedStyle = this.jestAnimatedStyle;
       }
 
       // Layout animations on web are set inside `componentDidMount` method, which is called after first render.

--- a/src/reanimated2/hook/commonTypes.ts
+++ b/src/reanimated2/hook/commonTypes.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { Component } from 'react';
+import type { Component, MutableRefObject } from 'react';
 import type { ShadowNodeWrapper } from '../commonTypes';
 import type {
   ImageStyle,
@@ -8,6 +8,8 @@ import type {
   ViewStyle,
   NativeScrollEvent,
 } from 'react-native';
+import type { ViewDescriptorsSet, ViewRefSet } from '../ViewDescriptorsSet';
+import type { AnimatedStyle } from '../helperTypes';
 
 export type DependencyList = Array<unknown> | undefined;
 
@@ -56,3 +58,20 @@ export type DefaultStyle = ViewStyle | ImageStyle | TextStyle;
 export type RNNativeScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
 
 export type ReanimatedScrollEvent = ReanimatedEvent<RNNativeScrollEvent>;
+
+export interface AnimatedStyleHandle<
+  Style extends DefaultStyle = DefaultStyle
+> {
+  viewDescriptors: ViewDescriptorsSet;
+  initial: {
+    value: AnimatedStyle<Style>;
+    updater: () => AnimatedStyle<Style>;
+  };
+  viewsRef: ViewRefSet<unknown>;
+}
+
+export interface JestAnimatedStyleHandle<
+  Style extends DefaultStyle = DefaultStyle
+> extends AnimatedStyleHandle<Style> {
+  jestAnimatedStyle: MutableRefObject<AnimatedStyle<Style>>;
+}

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -12,7 +12,13 @@ import {
   shallowEqual,
   validateAnimatedStyles,
 } from './utils';
-import type { DefaultStyle, DependencyList, Descriptor } from './commonTypes';
+import type {
+  AnimatedStyleHandle,
+  DefaultStyle,
+  DependencyList,
+  Descriptor,
+  JestAnimatedStyleHandle,
+} from './commonTypes';
 import type { ViewDescriptorsSet, ViewRefSet } from '../ViewDescriptorsSet';
 import { makeViewDescriptorsSet, useViewRefSet } from '../ViewDescriptorsSet';
 import { isJest, shouldBeUseWeb } from '../PlatformChecker';
@@ -409,7 +415,7 @@ export function useAnimatedStyle<Style extends DefaultStyle>(
   dependencies?: DependencyList | null,
   adapters?: WorkletFunction | WorkletFunction[],
   isAnimatedProps = false
-) {
+): AnimatedStyleHandle<Style> | JestAnimatedStyleHandle<Style> {
   const viewsRef: ViewRefSet<unknown> = useViewRefSet();
   const initRef = useRef<AnimationRef>();
   let inputs = Object.values(updater.__closure ?? {});
@@ -432,7 +438,7 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
     : [];
   const adaptersHash = adapters ? buildWorkletsHash(adaptersArray) : null;
   const animationsActive = useSharedValue<boolean>(true);
-  const animatedStyle: MutableRefObject<Style> = useRef<Style>({} as Style);
+  const jestAnimatedStyle: MutableRefObject<Style> = useRef<Style>({} as Style);
 
   // build dependencies
   if (!dependencies) {
@@ -489,7 +495,7 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
           remoteState,
           maybeViewRef,
           animationsActive,
-          animatedStyle,
+          jestAnimatedStyle,
           adaptersArray
         );
       };
@@ -522,7 +528,7 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
   checkSharedValueUsage(initial.value);
 
   if (isJest()) {
-    return { viewDescriptors, initial, viewsRef, animatedStyle };
+    return { viewDescriptors, initial, viewsRef, jestAnimatedStyle };
   } else {
     return { viewDescriptors, initial, viewsRef };
   }

--- a/src/reanimated2/jestUtils.ts
+++ b/src/reanimated2/jestUtils.ts
@@ -4,7 +4,7 @@
 import type {
   AnimatedComponentProps,
   InitialComponentProps,
-} from 'src/createAnimatedComponent/commonTypes';
+} from '../createAnimatedComponent/commonTypes';
 import { isJest } from './PlatformChecker';
 import type { DefaultStyle } from './hook/commonTypes';
 import type { StyleProp } from 'react-native';


### PR DESCRIPTION
## Summary

This file is cursed...

Hopefully not anymore.

I removed

```ts
const isAnimatedStyle = (style) => {
  return !!style.animatedStyle;
};

const getAnimatedStyleFromObject = (style) => {
  return style.animatedStyle.current.value;
};
```

in `jestUtils.ts` because it was dead code. This is due to how props are handled inside `createAnimatedComponent`

![Screenshot 2023-12-29 at 18 18 56](https://github.com/software-mansion/react-native-reanimated/assets/40713406/d2dce93d-7042-4ca3-8f2e-4263738ee7f5)


Because we pass `filteredProps` there will no longer be objects associated with `JestAnimatedStyleHandle` type there, since all Animated Props are filtered out.


## Test plan

CI & Jest tests
