### PR TITLE
[PoC] Use lazy closures in worklets

### DIFF
--- a/app/src/examples/WorkletFactoryCrashExample.tsx
+++ b/app/src/examples/WorkletFactoryCrashExample.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { Button, StyleSheet, View, Text } from 'react-native';
+import { runOnUI } from 'react-native-reanimated';
 
 export default function App() {
   function handleOnPress() {
@@ -9,6 +10,7 @@ export default function App() {
       // @ts-expect-error
       unexistingVariable;
     }
+    runOnUI(badWorklet)();
   }
 
   return (

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -375,7 +375,9 @@ var require_makeWorklet = __commonJS({
         (0, types_1.variableDeclaration)("const", [
           (0, types_1.variableDeclarator)(functionIdentifier, funExpression)
         ]),
-        (0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__closure"), false), (0, types_1.objectExpression)(variables.map((variable) => (0, types_1.objectProperty)((0, types_1.identifier)(variable.name), variable, false, true))))),
+        (0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__closure"), false), (0, types_1.arrowFunctionExpression)([], (0, types_1.blockStatement)([
+          (0, types_1.returnStatement)((0, types_1.objectExpression)(variables.map((variable) => (0, types_1.objectProperty)((0, types_1.identifier)(variable.name), variable, false, true))))
+        ])))),
         (0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__workletHash"), false), (0, types_1.numericLiteral)(workletHash)))
       ];
       if (shouldIncludeInitData) {

--- a/plugin/src/makeWorklet.ts
+++ b/plugin/src/makeWorklet.ts
@@ -12,6 +12,7 @@ import type {
 } from '@babel/types';
 import {
   arrayExpression,
+  arrowFunctionExpression,
   assignmentExpression,
   blockStatement,
   cloneNode,
@@ -211,10 +212,22 @@ export function makeWorklet(
       assignmentExpression(
         '=',
         memberExpression(functionIdentifier, identifier('__closure'), false),
-        objectExpression(
-          variables.map((variable) =>
-            objectProperty(identifier(variable.name), variable, false, true)
-          )
+        arrowFunctionExpression(
+          [],
+          blockStatement([
+            returnStatement(
+              objectExpression(
+                variables.map((variable) =>
+                  objectProperty(
+                    identifier(variable.name),
+                    variable,
+                    false,
+                    true
+                  )
+                )
+              )
+            ),
+          ])
         )
       )
     ),

--- a/src/reanimated2/hook/useAnimatedReaction.ts
+++ b/src/reanimated2/hook/useAnimatedReaction.ts
@@ -31,7 +31,11 @@ export function useAnimatedReaction<PreparedResult>(
 ) {
   const previous = useSharedValue<PreparedResult | null>(null, true);
 
-  let inputs = Object.values(prepare.__closure ?? {});
+  let inputs = Object.values(
+    typeof prepare.__closure === 'function'
+      ? prepare.__closure()
+      : prepare.__closure ?? {}
+  );
 
   if (shouldBeUseWeb()) {
     if (!inputs.length && dependencies?.length) {
@@ -42,8 +46,16 @@ export function useAnimatedReaction<PreparedResult>(
 
   if (dependencies === undefined) {
     dependencies = [
-      ...Object.values(prepare.__closure ?? {}),
-      ...Object.values(react.__closure ?? {}),
+      ...Object.values(
+        typeof prepare.__closure() === 'function'
+          ? prepare.__closure()
+          : prepare.__closure ?? {}
+      ),
+      ...Object.values(
+        typeof react.__closure() === 'function'
+          ? react.__closure()
+          : react.__closure ?? {}
+      ),
       prepare.__workletHash,
       react.__workletHash,
     ];

--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -412,7 +412,11 @@ export function useAnimatedStyle<Style extends DefaultStyle>(
 ) {
   const viewsRef: ViewRefSet<unknown> = useViewRefSet();
   const initRef = useRef<AnimationRef>();
-  let inputs = Object.values(updater.__closure ?? {});
+  let inputs = Object.values(
+    typeof updater.__closure === 'function'
+      ? updater.__closure()
+      : updater.__closure ?? {}
+  );
   if (SHOULD_BE_USE_WEB) {
     if (!inputs.length && dependencies?.length) {
       // let web work without a Babel/SWC plugin

--- a/src/reanimated2/hook/useDerivedValue.ts
+++ b/src/reanimated2/hook/useDerivedValue.ts
@@ -27,7 +27,11 @@ export function useDerivedValue<Value>(
   dependencies?: DependencyList
 ): DerivedValue<Value> {
   const initRef = useRef<SharedValue<Value> | null>(null);
-  let inputs = Object.values(updater.__closure ?? {});
+  let inputs = Object.values(
+    typeof updater.__closure === 'function'
+      ? updater.__closure()
+      : updater.__closure ?? {}
+  );
   if (shouldBeUseWeb()) {
     if (!inputs.length && dependencies?.length) {
       // let web work without a Babel/SWC plugin

--- a/src/reanimated2/hook/utils.ts
+++ b/src/reanimated2/hook/utils.ts
@@ -26,7 +26,10 @@ export function buildDependencies(
     dependencies = handlersList.map((handler) => {
       return {
         workletHash: handler.__workletHash,
-        closure: handler.__closure,
+        closure:
+          typeof handler.__closure === 'function'
+            ? handler.__closure()
+            : handler.__closure,
       };
     });
   } else {

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -161,6 +161,10 @@ export function makeShareableCloneRecursive<T>(
         toAdapt = {};
         if (value.__workletHash !== undefined) {
           // we are converting a worklet
+          value.__closure =
+            typeof value.__closure === 'function'
+              ? value.__closure()
+              : value.__closure;
           if (__DEV__) {
             const babelVersion = value.__initData.version;
             if (babelVersion !== undefined && babelVersion !== jsVersion) {
@@ -328,9 +332,17 @@ export function makeShareableCloneOnUIRecursive<T>(
           value.map(cloneRecursive)
         ) as FlatShareableRef<T>;
       }
+      // if (value.__closure && typeof value.__closure === 'function') {
+      //   value.__closure = value.__closure();
+      // }
       const toAdapt: Record<string, FlatShareableRef<T>> = {};
       for (const [key, element] of Object.entries(value)) {
-        toAdapt[key] = cloneRecursive<T>(element);
+        if (key === '__closure' && typeof element === 'function') {
+          value.__closure = value.__closure();
+          toAdapt[key] = cloneRecursive(value.__closure);
+        } else {
+          toAdapt[key] = cloneRecursive<T>(element);
+        }
       }
       return _makeShareableClone(toAdapt) as FlatShareableRef<T>;
     }

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -83,7 +83,10 @@ if (__DEV__ && !shouldBeUseWeb()) {
   if (!('__workletHash' in valueUnpacker)) {
     throw new Error('[Reanimated] `valueUnpacker` is not a worklet');
   }
-  const closure = (valueUnpacker as ValueUnpacker).__closure;
+  const closure =
+    typeof (valueUnpacker as ValueUnpacker).__closure === 'function'
+      ? (valueUnpacker as ValueUnpacker).__closure()
+      : (valueUnpacker as ValueUnpacker).__closure;
   if (closure === undefined) {
     throw new Error('[Reanimated] `valueUnpacker` closure is undefined');
   }


### PR DESCRIPTION
## Summary

This PR was motivated by #5365. Fixes #5365.

As you can read there, currently a variable used in a worklet but defined after it will cause it to be undefined in a worklet. Example:

```ts
function foo(){
  'worklet'
  console.log(bar);
}

const bar = 1;

runOnUI(foo)();
```

Will print `undefined`.

This PR moves unpacking of a worklet's closure from its worklet factory to the actual usage of a worklet.

Instead of having (removed irrelevant lines):

```ts
var foo = function () {
  var foo = function foo() {
    console.log(bar);
  };
  foo.__closure = {
    bar: bar
  };
  return foo;
}();
```

we will get:

```ts
var foo = function () {
  var foo = function foo() {
    console.log(bar);
  };
  foo.__closure = function () {
    return {
      bar: bar
    };
  };
  return foo;
}();
```



Don't mind all the `typeof ... ?` currently as it was a fail-safe for test-purposes. With current implementation all of Reanimated seems to be working properly.

## Test plan

Test all of Reanimated 🤯 