### PR TITLE
Add missing binding to `shareableMappingCache`

### DIFF
--- a/src/reanimated2/shareableMappingCache.ts
+++ b/src/reanimated2/shareableMappingCache.ts
@@ -40,5 +40,5 @@ export const shareableMappingCache = SHOULD_BE_USE_WEB
       set(shareable: object, shareableRef?: ShareableRef): void {
         cache!.set(shareable, shareableRef || shareableMappingFlag);
       },
-      get: cache!.get,
+      get: cache!.get.bind(cache),
     };


### PR DESCRIPTION
I knew I forgot something in #5530.

Fixes `TypeError: WeakMap.prototype.get can only be called on a WeakMap, js engine: hermes`