### PR TITLE
Added CI that removes comments from PR description

### DIFF
--- a/.github/workflows/format-pull-request-description.yml
+++ b/.github/workflows/format-pull-request-description.yml
@@ -1,0 +1,20 @@
+name: Format Pull Request Description
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  format-pull-request-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove comments from PR description
+        uses: actions/checkout@v3
+      - name: Update PR Description
+        uses: software-mansion-labs/pr-description@main
+        with:
+          content: ""
+          regex: "<!-- .* -->\n"
+          regexFlags: img
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-pull-request-description.yml
+++ b/.github/workflows/format-pull-request-description.yml
@@ -9,8 +9,6 @@ jobs:
   format-pull-request-description:
     runs-on: ubuntu-latest
     steps:
-      - name: Remove comments from PR description
-        uses: actions/checkout@v3
       - name: Update PR Description
         uses: software-mansion-labs/pr-description@main
         with:


### PR DESCRIPTION
## Summary

The PR template description includes some comments.
![image](https://github.com/software-mansion/react-native-reanimated/assets/36106620/b5411523-ca89-4444-b4a4-ca9c6729bf1d)
It makes it difficult to read PR descriptions
![image](https://github.com/software-mansion/react-native-reanimated/assets/36106620/bf536b37-36eb-4bf1-a1d6-9ac8a438cd14)
This PR introduces a CI action that will run upon PR creation and remove the comments from the PR description.

`software-mansion-labs/pr-description` this is a fork of `nefrob/pr-description` with some adjustments.

## Test plan

Open a new PR and see if contains comments.

🍪