### PR TITLE
Fix: Build RN 0.73.1 with New Architecture and Proguard enabled

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,2 +1,3 @@
 -keep class com.swmansion.reanimated.** { *; }
 -keep class com.facebook.react.turbomodule.** { *; }
+-keep class com.facebook.react.fabric.** { *; }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Keep fabric class to prevent crashes in react-native 0.73+ with new architecture and proguard.

Fixes #5514 

Related #5472, https://github.com/facebook/react-native/pull/41657

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

- Clone `gh repo clone ahmetbicer/mBinding-proguard-repro`
- add `-keep class com.facebook.react.fabric.** { *; }` in your app proguard-rules.pro or reanimated node_modules folder
- Run `yarn react-native run-android --mode Release`
- Build and Open without crash 🎉 

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
