### PR TITLE
Fix `useAnimatedSensor` usage in docs and examples

### DIFF
--- a/app/src/examples/AnimatedSensorAccelerometerExample.tsx
+++ b/app/src/examples/AnimatedSensorAccelerometerExample.tsx
@@ -13,14 +13,14 @@ const OFFSET_X = 100; // in px
 const OFFSET_Y = 100; // in px
 
 export default function AnimatedSensorAccelerometerExample() {
-  const accelerometer = useAnimatedSensor(SensorType.ACCELEROMETER);
+  const { sensor } = useAnimatedSensor(SensorType.ACCELEROMETER);
 
   const xOffset = useSharedValue(-OFFSET_X);
   const yOffset = useSharedValue(0);
   const zOffset = useSharedValue(1);
 
   const animatedStyle = useAnimatedStyle(() => {
-    const { x, y, z } = accelerometer.sensor.value;
+    const { x, y, z } = sensor.value;
     xOffset.value = clamp(xOffset.value - x, -OFFSET_X * 2, OFFSET_X / 4);
     yOffset.value = clamp(yOffset.value - y, -OFFSET_Y, OFFSET_Y);
     zOffset.value = clamp(zOffset.value + z * 0.1, 0.5, 2);

--- a/app/src/examples/AnimatedSensorGravityExample.tsx
+++ b/app/src/examples/AnimatedSensorGravityExample.tsx
@@ -8,12 +8,12 @@ import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
 
 export default function AnimatedSensorGravityExample() {
-  const gravity = useAnimatedSensor(SensorType.GRAVITY);
+  const { sensor } = useAnimatedSensor(SensorType.GRAVITY);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
-      top: -gravity.sensor.value.y * 300,
-      left: gravity.sensor.value.x * 200,
+      top: -sensor.value.y * 300,
+      left: sensor.value.x * 200,
     };
   });
 

--- a/app/src/examples/AnimatedSensorGyroscopeExample.tsx
+++ b/app/src/examples/AnimatedSensorGyroscopeExample.tsx
@@ -14,14 +14,14 @@ const OFFSET_Y = 100; // in px
 const OFFSET_Z = 180; // in degrees
 
 export default function AnimatedSensorGyroscopeExample() {
-  const gyroscope = useAnimatedSensor(SensorType.GYROSCOPE);
+  const { sensor } = useAnimatedSensor(SensorType.GYROSCOPE);
 
   const xOffset = useSharedValue(-OFFSET_X);
   const yOffset = useSharedValue(0);
   const zOffset = useSharedValue(0);
 
   const animatedStyle = useAnimatedStyle(() => {
-    const { x, y, z } = gyroscope.sensor.value;
+    const { x, y, z } = sensor.value;
     // The x vs y here seems wrong but is the way to make it feel right to the user
     xOffset.value = clamp(xOffset.value + y, -OFFSET_X * 2, OFFSET_X / 4);
     yOffset.value = clamp(yOffset.value - x, -OFFSET_Y, OFFSET_Y);

--- a/app/src/examples/AnimatedSensorMagneticFieldExample.tsx
+++ b/app/src/examples/AnimatedSensorMagneticFieldExample.tsx
@@ -10,10 +10,10 @@ import React from 'react';
 const BOX_SIZE = 150;
 
 export default function AnimatedSensorMagneticFieldExample() {
-  const magneticField = useAnimatedSensor(SensorType.MAGNETIC_FIELD);
+  const { sensor } = useAnimatedSensor(SensorType.MAGNETIC_FIELD);
 
   const animatedStyle = useAnimatedStyle(() => {
-    const { x, y } = magneticField.sensor.value;
+    const { x, y } = sensor.value;
     const angle = (Math.atan2(y, x) * 180) / Math.PI;
     return {
       transform: [{ rotateZ: `${angle}deg` }, { translateY: BOX_SIZE / 2 }],

--- a/app/src/examples/AnimatedSensorRotationExample.tsx
+++ b/app/src/examples/AnimatedSensorRotationExample.tsx
@@ -8,10 +8,10 @@ import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
 
 export default function AnimatedSensorRotationExample() {
-  const rotation = useAnimatedSensor(SensorType.ROTATION);
+  const { sensor } = useAnimatedSensor(SensorType.ROTATION);
 
   const animatedStyle = useAnimatedStyle(() => {
-    const { pitch, roll, yaw } = rotation.sensor.value;
+    const { pitch, roll, yaw } = sensor.value;
     return {
       transform: [
         { perspective: 100 },

--- a/app/src/examples/CubesExample.tsx
+++ b/app/src/examples/CubesExample.tsx
@@ -201,7 +201,7 @@ const sidesColors = [
 ];
 
 function CubeWithEulerAngles() {
-  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+  const { sensor } = useAnimatedSensor(SensorType.ROTATION, {
     iosReferenceFrame: IOSReferenceFrame.XArbitraryZVertical,
     adjustToInterfaceOrientation: true,
   });
@@ -209,9 +209,9 @@ function CubeWithEulerAngles() {
   const sidesStyles = sidesRotations.map((rotation, i) =>
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useAnimatedStyle(() => {
-      const pitch = animatedSensor.sensor.value.pitch;
-      const roll = animatedSensor.sensor.value.roll;
-      const yaw = animatedSensor.sensor.value.yaw;
+      const pitch = sensor.value.pitch;
+      const roll = sensor.value.roll;
+      const yaw = sensor.value.yaw;
 
       const sideLength = 100;
       const origin = { x: 0, y: 0, z: -sideLength / 2 };
@@ -240,7 +240,7 @@ function CubeWithEulerAngles() {
 }
 
 function CubeWithQuaternions() {
-  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+  const { sensor } = useAnimatedSensor(SensorType.ROTATION, {
     adjustToInterfaceOrientation: true,
   });
 
@@ -252,7 +252,7 @@ function CubeWithQuaternions() {
 
       const q0 = eulerToQuaternion(-rotation[0], -rotation[1], rotation[2]);
 
-      const { qx, qy, qz, qw } = animatedSensor.sensor.value;
+      const { qx, qy, qz, qw } = sensor.value;
       const q1 = [-qx, qy, -qz, qw];
 
       const q = multiplyQuaternions(q0, q1);
@@ -279,12 +279,12 @@ function CubeWithQuaternions() {
 }
 
 export default function CubesExample() {
-  const animatedSensor = useAnimatedSensor(SensorType.ROTATION, {
+  const { sensor } = useAnimatedSensor(SensorType.ROTATION, {
     adjustToInterfaceOrientation: true,
   });
 
   const compassStyle = useAnimatedStyle(() => {
-    const yaw = animatedSensor.sensor.value.yaw;
+    const yaw = sensor.value.yaw;
 
     return {
       transform: [{ rotate: `${yaw}rad` }],
@@ -293,10 +293,7 @@ export default function CubesExample() {
 
   return (
     <View style={componentStyle.container}>
-      <Button
-        title={'log data'}
-        onPress={() => console.log(animatedSensor.sensor.value)}
-      />
+      <Button title="log data" onPress={() => console.log(sensor.value)} />
       <View style={componentStyle.cubesContainer}>
         <CubeWithQuaternions />
         <CubeWithEulerAngles />

--- a/app/src/examples/OldAnimatedSensorExample.tsx
+++ b/app/src/examples/OldAnimatedSensorExample.tsx
@@ -7,9 +7,9 @@ import Animated, {
 import { View, Button, StyleSheet } from 'react-native';
 
 export default function OldAnimatedSensorExample() {
-  const animatedSensor = useAnimatedSensor(SensorType.GRAVITY);
+  const { sensor } = useAnimatedSensor(SensorType.GRAVITY);
   const style = useAnimatedStyle(() => {
-    const { x, y } = animatedSensor.sensor.value;
+    const { x, y } = sensor.value;
     return {
       transform: [{ translateX: x * 5 }, { translateY: y * 5 }],
     };
@@ -17,10 +17,7 @@ export default function OldAnimatedSensorExample() {
 
   return (
     <View style={componentStyle.container}>
-      <Button
-        title={'log data'}
-        onPress={() => console.log(animatedSensor.sensor.value)}
-      />
+      <Button title="log data" onPress={() => console.log(sensor.value)} />
       <Animated.View style={componentStyle.rect}>
         <Animated.View style={[componentStyle.square, style]} />
       </Animated.View>

--- a/app/src/examples/VolumeExample.tsx
+++ b/app/src/examples/VolumeExample.tsx
@@ -54,13 +54,13 @@ export default function VolumeExample() {
   const x = useSharedValue(50);
   const vx = useSharedValue(0);
 
-  const animatedSensor = useAnimatedSensor(SensorType.GRAVITY);
+  const { sensor } = useAnimatedSensor(SensorType.GRAVITY);
 
   useFrameCallback(({ timeSincePreviousFrame: dt }) => {
     if (dt == null) {
       return;
     }
-    const ax = animatedSensor.sensor.value.x * 0.0001;
+    const ax = sensor.value.x * 0.0001;
     vx.value += ax * dt;
     x.value += vx.value * dt;
     x.value = Math.min(100, Math.max(0, x.value));
@@ -85,7 +85,7 @@ export default function VolumeExample() {
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
-      transform: [{ rotate: `${animatedSensor.sensor.value.x * 2}deg` }],
+      transform: [{ rotate: `${sensor.value.x * 2}deg` }],
     };
   });
 

--- a/docs/docs/device/useAnimatedSensor.mdx
+++ b/docs/docs/device/useAnimatedSensor.mdx
@@ -24,10 +24,10 @@ import { useAnimatedSensorPlayground } from '@site/src/components/InteractivePla
 import { useAnimatedSensor, SensorType } from 'react-native-reanimated';
 
 function App() {
-  const gyroscope = useAnimatedSensor(SensorType.GYROSCOPE);
+  const { sensor } = useAnimatedSensor(SensorType.GYROSCOPE);
 
   useDerivedValue(() => {
-    const { x, y, z } = gyroscope.sensor.value;
+    const { x, y, z } = sensor.value;
   });
 }
 ```
@@ -215,6 +215,8 @@ import AnimatedSensorSrc from '!!raw-loader!@site/src/examples/AnimatedSensor';
 - Most of the sensors operate in resolutions up to 100Hz.
 
 - You can read the sensor data on both [UI thread](/docs/fundamentals/glossary#ui-thread) and [JavaScript thread](/docs/fundamentals/glossary#javascript-thread).
+
+- Remember to use the destructuring pattern when calling `useAnimatedSensor`. Passing the whole returned object to a worklet may cause unexpected behavior.
 
 ## Platform compatibility
 

--- a/docs/src/examples/AnimatedSensor.jsx
+++ b/docs/src/examples/AnimatedSensor.jsx
@@ -9,15 +9,15 @@ import Animated, {
 
 export default function App() {
   // highlight-next-line
-  const gravity = useAnimatedSensor(SensorType.GRAVITY);
+  const { sensor } = useAnimatedSensor(SensorType.GRAVITY);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
       transform: [
         // highlight-next-line
-        { translateX: withSpring(gravity.sensor.value.x * 20) },
+        { translateX: withSpring(sensor.value.x * 20) },
         // highlight-next-line
-        { translateY: withSpring(gravity.sensor.value.y * 20) },
+        { translateY: withSpring(sensor.value.y * 20) },
       ],
     };
   });


### PR DESCRIPTION
## Summary

Currently `useAnimatedSensor` returns a stable ref which is also modified inside of `useAnimatedSensor`. This leads to issues when a user passes the whole return object of `useAnimatedSensor` to a worklet - the whole object gets frozen in `makeShareableCloneRecursive` and the hook stops working properly on re-render.

Currently in our documentation and examples we use it in this exact way - passing the whole object to a worklet. This was unnoticed until now since we never did any additional re-renders there.

There are two ways out of this problem.

1. Amend documentation and examples to show proper usage. Obviously it won't reach users fast. (Unless they get warnings from #5548).

2. Make it so `useAnimatedSensor` doesn't return a stable ref. I don't think we ever claimed it to be stable, but nevertheless this is potentially a breaking change since someone might rely on it being stable.

I prefer the first option since the latter is a breaking change but I'd like to hear you out.

## Test plan

🚀 
