### PR TITLE
[LA Web] Fix animations in production bundle

### DIFF
--- a/src/createAnimatedComponent/commonTypes.ts
+++ b/src/createAnimatedComponent/commonTypes.ts
@@ -54,8 +54,8 @@ export interface IJSPropsUpdater {
   ): void;
 }
 
-type LayoutAnimationStaticContext = {
-  className: string;
+export type LayoutAnimationStaticContext = {
+  presetName: string;
 };
 
 export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {

--- a/src/createAnimatedComponent/commonTypes.ts
+++ b/src/createAnimatedComponent/commonTypes.ts
@@ -54,25 +54,35 @@ export interface IJSPropsUpdater {
   ): void;
 }
 
+type LayoutAnimationStaticContext = {
+  className: string;
+};
+
 export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
   forwardedRef?: Ref<Component>;
   style?: NestedArray<StyleProps>;
   animatedProps?: Partial<AnimatedComponentProps<AnimatedProps>>;
   animatedStyle?: StyleProps;
-  layout?:
+  layout?: (
     | BaseAnimationBuilder
     | ILayoutAnimationBuilder
-    | typeof BaseAnimationBuilder;
-  entering?:
+    | typeof BaseAnimationBuilder
+  ) &
+    LayoutAnimationStaticContext;
+  entering?: (
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
     | EntryExitAnimationFunction
-    | Keyframe;
-  exiting?:
+    | Keyframe
+  ) &
+    LayoutAnimationStaticContext;
+  exiting?: (
     | BaseAnimationBuilder
     | typeof BaseAnimationBuilder
     | EntryExitAnimationFunction
-    | Keyframe;
+    | Keyframe
+  ) &
+    LayoutAnimationStaticContext;
   sharedTransitionTag?: string;
   sharedTransitionStyle?: SharedTransition;
 };

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
@@ -19,7 +19,7 @@ export class BounceIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceIn';
+  static presetName = 'BounceIn';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -81,7 +81,7 @@ export class BounceInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceInDown';
+  static presetName = 'BounceInDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -147,7 +147,7 @@ export class BounceInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceInUp';
+  static presetName = 'BounceInUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -209,7 +209,7 @@ export class BounceInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceInLeft';
+  static presetName = 'BounceInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -271,7 +271,7 @@ export class BounceInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceInRight';
+  static presetName = 'BounceInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -333,7 +333,7 @@ export class BounceOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceOut';
+  static presetName = 'BounceOut';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -395,7 +395,7 @@ export class BounceOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceOutDown';
+  static presetName = 'BounceOutDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -459,7 +459,7 @@ export class BounceOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceOutUp';
+  static presetName = 'BounceOutUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -523,7 +523,7 @@ export class BounceOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceOutLeft';
+  static presetName = 'BounceOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -587,7 +587,7 @@ export class BounceOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'BounceOutRight';
+  static presetName = 'BounceOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Bounce.ts
@@ -19,6 +19,8 @@ export class BounceIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceIn';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -79,6 +81,8 @@ export class BounceInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceInDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -143,6 +147,8 @@ export class BounceInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceInUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -203,6 +209,8 @@ export class BounceInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -263,6 +271,8 @@ export class BounceInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -323,6 +333,8 @@ export class BounceOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceOut';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -383,6 +395,8 @@ export class BounceOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceOutDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -445,6 +459,8 @@ export class BounceOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceOutUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -507,6 +523,8 @@ export class BounceOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -569,6 +587,8 @@ export class BounceOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'BounceOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
@@ -17,6 +17,7 @@ export class FadeIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeIn';
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -57,6 +58,8 @@ export class FadeInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -101,6 +104,8 @@ export class FadeInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -145,6 +150,8 @@ export class FadeInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeInUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -189,6 +196,8 @@ export class FadeInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeInDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -233,6 +242,8 @@ export class FadeOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeOut';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -273,6 +284,8 @@ export class FadeOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -317,6 +330,8 @@ export class FadeOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -360,6 +375,8 @@ export class FadeOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeOutUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -404,6 +421,8 @@ export class FadeOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FadeOutDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Fade.ts
@@ -17,7 +17,7 @@ export class FadeIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeIn';
+  static presetName = 'FadeIn';
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -58,7 +58,7 @@ export class FadeInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeInRight';
+  static presetName = 'FadeInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -104,7 +104,7 @@ export class FadeInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeInLeft';
+  static presetName = 'FadeInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -150,7 +150,7 @@ export class FadeInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeInUp';
+  static presetName = 'FadeInUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -196,7 +196,7 @@ export class FadeInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeInDown';
+  static presetName = 'FadeInDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -242,7 +242,7 @@ export class FadeOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeOut';
+  static presetName = 'FadeOut';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -284,7 +284,7 @@ export class FadeOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeOutRight';
+  static presetName = 'FadeOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -330,7 +330,7 @@ export class FadeOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeOutLeft';
+  static presetName = 'FadeOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -375,7 +375,7 @@ export class FadeOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeOutUp';
+  static presetName = 'FadeOutUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -421,7 +421,7 @@ export class FadeOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FadeOutDown';
+  static presetName = 'FadeOutDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -22,7 +22,7 @@ export class FlipInXUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'FlipInXUp';
+  static presetName = 'FlipInXUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -72,7 +72,7 @@ export class FlipInYLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'FlipInYLeft';
+  static presetName = 'FlipInYLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -122,7 +122,7 @@ export class FlipInXDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'FlipInXDown';
+  static presetName = 'FlipInXDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -172,7 +172,7 @@ export class FlipInYRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'FlipInYRight';
+  static presetName = 'FlipInYRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -222,7 +222,7 @@ export class FlipInEasyX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FlipInEasyX';
+  static presetName = 'FlipInEasyX';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -267,7 +267,7 @@ export class FlipInEasyY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FlipInEasyY';
+  static presetName = 'FlipInEasyY';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -312,7 +312,7 @@ export class FlipOutXUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'FlipOutXUp';
+  static presetName = 'FlipOutXUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -367,7 +367,7 @@ export class FlipOutYLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'FlipOutYLeft';
+  static presetName = 'FlipOutYLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -422,7 +422,7 @@ export class FlipOutXDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'FlipOutXDown';
+  static presetName = 'FlipOutXDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -477,7 +477,7 @@ export class FlipOutYRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'FlipOutYRight';
+  static presetName = 'FlipOutYRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -532,7 +532,7 @@ export class FlipOutEasyX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FlipOutEasyX';
+  static presetName = 'FlipOutEasyX';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -577,7 +577,7 @@ export class FlipOutEasyY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'FlipOutEasyY';
+  static presetName = 'FlipOutEasyY';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Flip.ts
@@ -22,6 +22,8 @@ export class FlipInXUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'FlipInXUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -70,6 +72,8 @@ export class FlipInYLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'FlipInYLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -118,6 +122,8 @@ export class FlipInXDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'FlipInXDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -166,6 +172,8 @@ export class FlipInYRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'FlipInYRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -214,6 +222,8 @@ export class FlipInEasyX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FlipInEasyX';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -257,6 +267,8 @@ export class FlipInEasyY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FlipInEasyY';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -300,6 +312,8 @@ export class FlipOutXUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'FlipOutXUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -353,6 +367,8 @@ export class FlipOutYLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'FlipOutYLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -406,6 +422,8 @@ export class FlipOutXDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'FlipOutXDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -459,6 +477,8 @@ export class FlipOutYRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'FlipOutYRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -512,6 +532,8 @@ export class FlipOutEasyX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FlipOutEasyX';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -555,6 +577,8 @@ export class FlipOutEasyY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'FlipOutEasyY';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -19,7 +19,7 @@ export class LightSpeedInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'LightSpeedInRight';
+  static presetName = 'LightSpeedInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -81,7 +81,7 @@ export class LightSpeedInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'LightSpeedInLeft';
+  static presetName = 'LightSpeedInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -143,7 +143,7 @@ export class LightSpeedOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'LightSpeedOutRight';
+  static presetName = 'LightSpeedOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -197,7 +197,7 @@ export class LightSpeedOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'LightSpeedOutLeft';
+  static presetName = 'LightSpeedOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -19,6 +19,8 @@ export class LightSpeedInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'LightSpeedInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -79,6 +81,8 @@ export class LightSpeedInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'LightSpeedInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -139,6 +143,8 @@ export class LightSpeedOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'LightSpeedOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -191,6 +197,8 @@ export class LightSpeedOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'LightSpeedOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -17,6 +17,8 @@ export class PinwheelIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'PinwheelIn';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -73,6 +75,8 @@ export class PinwheelOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'PinwheelOut';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -17,7 +17,7 @@ export class PinwheelIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'PinwheelIn';
+  static presetName = 'PinwheelIn';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -75,7 +75,7 @@ export class PinwheelOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'PinwheelOut';
+  static presetName = 'PinwheelOut';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -18,6 +18,8 @@ export class RollInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'RollInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -64,6 +66,8 @@ export class RollInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'RollInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -107,6 +111,8 @@ export class RollOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'RollOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -155,6 +161,8 @@ export class RollOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'RollOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -18,7 +18,7 @@ export class RollInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'RollInLeft';
+  static presetName = 'RollInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -66,7 +66,7 @@ export class RollInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'RollInRight';
+  static presetName = 'RollInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -111,7 +111,7 @@ export class RollOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'RollOutLeft';
+  static presetName = 'RollOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -161,7 +161,7 @@ export class RollOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'RollOutRight';
+  static presetName = 'RollOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
@@ -20,6 +20,8 @@ export class RotateInDownLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'RotateInDownLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -70,6 +72,8 @@ export class RotateInDownRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'RotateInDownRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -120,6 +124,8 @@ export class RotateInUpLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'RotateInUpLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -170,6 +176,8 @@ export class RotateInUpRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'RotateInUpRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -220,6 +228,8 @@ export class RotateOutDownLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'RotateOutDownLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -282,6 +292,8 @@ export class RotateOutDownRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'RotateOutDownRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -344,6 +356,8 @@ export class RotateOutUpLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'RotateOutUpLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -406,6 +420,8 @@ export class RotateOutUpRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'RotateOutUpRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Rotate.ts
@@ -20,7 +20,7 @@ export class RotateInDownLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'RotateInDownLeft';
+  static presetName = 'RotateInDownLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -72,7 +72,7 @@ export class RotateInDownRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'RotateInDownRight';
+  static presetName = 'RotateInDownRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -124,7 +124,7 @@ export class RotateInUpLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'RotateInUpLeft';
+  static presetName = 'RotateInUpLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -176,7 +176,7 @@ export class RotateInUpRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'RotateInUpRight';
+  static presetName = 'RotateInUpRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -228,7 +228,7 @@ export class RotateOutDownLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'RotateOutDownLeft';
+  static presetName = 'RotateOutDownLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -292,7 +292,7 @@ export class RotateOutDownRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'RotateOutDownRight';
+  static presetName = 'RotateOutDownRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -356,7 +356,7 @@ export class RotateOutUpLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'RotateOutUpLeft';
+  static presetName = 'RotateOutUpLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -420,7 +420,7 @@ export class RotateOutUpRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'RotateOutUpRight';
+  static presetName = 'RotateOutUpRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
@@ -20,6 +20,8 @@ export class SlideInRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'SlideInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -63,6 +65,8 @@ export class SlideInLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'SlideInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -106,6 +110,8 @@ export class SlideOutRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'SlideOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -155,6 +161,8 @@ export class SlideOutLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'SlideOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -204,6 +212,8 @@ export class SlideInUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'SlideInUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -247,6 +257,8 @@ export class SlideInDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'SlideInDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -290,6 +302,8 @@ export class SlideOutUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'SlideOutUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -336,6 +350,8 @@ export class SlideOutDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'SlideOutDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Slide.ts
@@ -20,7 +20,7 @@ export class SlideInRight
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'SlideInRight';
+  static presetName = 'SlideInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -65,7 +65,7 @@ export class SlideInLeft
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'SlideInLeft';
+  static presetName = 'SlideInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -110,7 +110,7 @@ export class SlideOutRight
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'SlideOutRight';
+  static presetName = 'SlideOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -161,7 +161,7 @@ export class SlideOutLeft
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'SlideOutLeft';
+  static presetName = 'SlideOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -212,7 +212,7 @@ export class SlideInUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'SlideInUp';
+  static presetName = 'SlideInUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -257,7 +257,7 @@ export class SlideInDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'SlideInDown';
+  static presetName = 'SlideInDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -302,7 +302,7 @@ export class SlideOutUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'SlideOutUp';
+  static presetName = 'SlideOutUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -350,7 +350,7 @@ export class SlideOutDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'SlideOutDown';
+  static presetName = 'SlideOutDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
@@ -17,6 +17,8 @@ export class StretchInX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'StretchInX';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -57,6 +59,8 @@ export class StretchInY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'StretchInY';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -97,6 +101,8 @@ export class StretchOutX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'StretchOutX';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -137,6 +143,8 @@ export class StretchOutY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'StretchOutY';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Stretch.ts
@@ -17,7 +17,7 @@ export class StretchInX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'StretchInX';
+  static presetName = 'StretchInX';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -59,7 +59,7 @@ export class StretchInY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'StretchInY';
+  static presetName = 'StretchInY';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -101,7 +101,7 @@ export class StretchOutX
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'StretchOutX';
+  static presetName = 'StretchOutX';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -143,7 +143,7 @@ export class StretchOutY
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'StretchOutY';
+  static presetName = 'StretchOutY';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
@@ -23,6 +23,8 @@ export class ZoomIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomIn';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -63,6 +65,8 @@ export class ZoomInRotate
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomInRotate';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -107,6 +111,8 @@ export class ZoomInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomInLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -150,6 +156,8 @@ export class ZoomInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomInRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -193,6 +201,8 @@ export class ZoomInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomInUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -236,6 +246,8 @@ export class ZoomInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomInDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -279,6 +291,8 @@ export class ZoomInEasyUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'ZoomInEasyUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -322,6 +336,8 @@ export class ZoomInEasyDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
+  static className = 'ZoomInEasyDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -365,6 +381,8 @@ export class ZoomOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOut';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -405,6 +423,8 @@ export class ZoomOutRotate
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOutRotate';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -449,6 +469,8 @@ export class ZoomOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOutLeft';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -497,6 +519,8 @@ export class ZoomOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOutRight';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -545,6 +569,8 @@ export class ZoomOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOutUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -593,6 +619,8 @@ export class ZoomOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
+  static className = 'ZoomOutDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -641,6 +669,8 @@ export class ZoomOutEasyUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'ZoomOutEasyUp';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {
@@ -689,6 +719,8 @@ export class ZoomOutEasyDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
+  static className = 'ZoomOutEasyDown';
+
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
   ): InstanceType<T> {

--- a/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts
@@ -23,7 +23,7 @@ export class ZoomIn
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomIn';
+  static presetName = 'ZoomIn';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -65,7 +65,7 @@ export class ZoomInRotate
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomInRotate';
+  static presetName = 'ZoomInRotate';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -111,7 +111,7 @@ export class ZoomInLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomInLeft';
+  static presetName = 'ZoomInLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -156,7 +156,7 @@ export class ZoomInRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomInRight';
+  static presetName = 'ZoomInRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -201,7 +201,7 @@ export class ZoomInUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomInUp';
+  static presetName = 'ZoomInUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -246,7 +246,7 @@ export class ZoomInDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomInDown';
+  static presetName = 'ZoomInDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -291,7 +291,7 @@ export class ZoomInEasyUp
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'ZoomInEasyUp';
+  static presetName = 'ZoomInEasyUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -336,7 +336,7 @@ export class ZoomInEasyDown
   extends ComplexAnimationBuilder
   implements IEntryAnimationBuilder
 {
-  static className = 'ZoomInEasyDown';
+  static presetName = 'ZoomInEasyDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -381,7 +381,7 @@ export class ZoomOut
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOut';
+  static presetName = 'ZoomOut';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -423,7 +423,7 @@ export class ZoomOutRotate
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOutRotate';
+  static presetName = 'ZoomOutRotate';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -469,7 +469,7 @@ export class ZoomOutLeft
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOutLeft';
+  static presetName = 'ZoomOutLeft';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -519,7 +519,7 @@ export class ZoomOutRight
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOutRight';
+  static presetName = 'ZoomOutRight';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -569,7 +569,7 @@ export class ZoomOutUp
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOutUp';
+  static presetName = 'ZoomOutUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -619,7 +619,7 @@ export class ZoomOutDown
   extends ComplexAnimationBuilder
   implements IEntryExitAnimationBuilder
 {
-  static className = 'ZoomOutDown';
+  static presetName = 'ZoomOutDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -669,7 +669,7 @@ export class ZoomOutEasyUp
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'ZoomOutEasyUp';
+  static presetName = 'ZoomOutEasyUp';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T
@@ -719,7 +719,7 @@ export class ZoomOutEasyDown
   extends ComplexAnimationBuilder
   implements IExitAnimationBuilder
 {
-  static className = 'ZoomOutEasyDown';
+  static presetName = 'ZoomOutEasyDown';
 
   static createInstance<T extends typeof BaseAnimationBuilder>(
     this: T

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -89,13 +89,15 @@ function tryGetAnimationConfigWithTransform<
     return null;
   }
 
+  type ConstructorWithStaticContext = {
+    className: string;
+  } & typeof config.constructor;
+
   const isLayoutTransition = animationType === LayoutAnimationType.LAYOUT;
   const initialAnimationName =
     typeof config === 'function'
-      ? // @ts-expect-error ignore for now
-        config.className
-      : // @ts-expect-error ignore for now
-        config.constructor.className;
+      ? config.className
+      : (config.constructor as ConstructorWithStaticContext).className;
 
   const shouldFail = checkUndefinedAnimationFail(
     initialAnimationName,

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -2,7 +2,10 @@
 
 import type { AnimationConfig, AnimationNames, CustomConfig } from './config';
 import { Animations } from './config';
-import type { AnimatedComponentProps } from '../../../createAnimatedComponent/commonTypes';
+import type {
+  AnimatedComponentProps,
+  LayoutAnimationStaticContext,
+} from '../../../createAnimatedComponent/commonTypes';
 import { LayoutAnimationType } from '../animationBuilder/commonTypes';
 import type { StyleProps } from '../../commonTypes';
 import { createAnimationWithExistingTransform } from './createAnimation';
@@ -89,15 +92,14 @@ function tryGetAnimationConfigWithTransform<
     return null;
   }
 
-  type ConstructorWithStaticContext = {
-    className: string;
-  } & typeof config.constructor;
+  type ConstructorWithStaticContext = LayoutAnimationStaticContext &
+    typeof config.constructor;
 
   const isLayoutTransition = animationType === LayoutAnimationType.LAYOUT;
   const initialAnimationName =
     typeof config === 'function'
-      ? config.className
-      : (config.constructor as ConstructorWithStaticContext).className;
+      ? config.presetName
+      : (config.constructor as ConstructorWithStaticContext).presetName;
 
   const shouldFail = checkUndefinedAnimationFail(
     initialAnimationName,

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -91,7 +91,11 @@ function tryGetAnimationConfigWithTransform<
 
   const isLayoutTransition = animationType === LayoutAnimationType.LAYOUT;
   const initialAnimationName =
-    typeof config === 'function' ? config.name : config.constructor.name;
+    typeof config === 'function'
+      ? // @ts-expect-error ignore for now
+        config.className
+      : // @ts-expect-error ignore for now
+        config.constructor.className;
 
   const shouldFail = checkUndefinedAnimationFail(
     initialAnimationName,


### PR DESCRIPTION
## Summary

As pointed in #5561, layout animations don't work with production bundle. It is caused by fragile method of obtaining animation name, i.e. using `config.name` if config is function. During bundling, name of this function may change (in linked issue to `c`, in my case to `r`), so instead of animation user will see warning that reanimated couldn't load animation. 

This PR adds static field `className` to animations builders in order to provide access to animation name, even if config name gets changed during bundling.  

## Test plan

1.  Create new app (`npx create-expo-app`)
2. Install Reanimated from package (`npm pack` -> `yarn add <path_to_package>`) 
3. `npx expo export -p web`
4. `npx serve dist --single`

I used reanimated from local package to make sure that `expo export` works correctly.

<details>
<summary> Tested on the following code </summary>

```jsx
import Animated, { FadeOut, FadeOutRight } from "react-native-reanimated";
import { View, Button } from "react-native";
import { useState } from "react";

export default function AnimatedStyleUpdateExample(props) {
  const [show, setShow] = useState(true);

  return (
    <View
      style={{
        flex: 1,
        alignItems: "center",
        justifyContent: "center",
        flexDirection: "column",
      }}
    >
      {show && (
        <Animated.View
          style={[{ width: 100, height: 80, backgroundColor: "black" }]}
          exiting={FadeOut}
        />
      )}

      <Button
        title="toggle"
        onPress={() => {
          setShow((prev) => !prev);
        }}
      />
    </View>
  );
}

```

</details>