### PR TITLE
Fixed boost download link

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -567,7 +567,7 @@ if (REACT_NATIVE_MINOR_VERSION < 71) {
     task downloadBoost(dependsOn: resolveBoost, type: Download) {
         def transformedVersion = BOOST_VERSION.replace("_", ".")
         def artifactLocalName = "boost_${BOOST_VERSION}.tar.gz"
-        def srcUrl = "https://boostorg.jfrog.io/artifactory/main/release/${transformedVersion}/source/${artifactLocalName}"
+        def srcUrl = "https://archives.boost.io/release/${transformedVersion}/source/${artifactLocalName}"
         if (REACT_NATIVE_MINOR_VERSION < 69) {
             srcUrl = "https://github.com/react-native-community/boost-for-react-native/releases/download/v${transformedVersion}-0/${artifactLocalName}"
         }


### PR DESCRIPTION
Synced the link with React Native.
Commit : https://github.com/facebook/react-native/commit/7e721f09ad3dafed9f490f433b2ac613786c27b2

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Synced the boost download link with React Native boost download link
Commit in RN: https://github.com/facebook/react-native/commit/7e721f09ad3dafed9f490f433b2ac613786c27b2
This is already released in v0.73.2

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Build the base App
