### PR TITLE
Properly transpile async functions

### DIFF
--- a/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/__tests__/__snapshots__/plugin.test.ts.snap
@@ -335,6 +335,60 @@ new FadeIn().withCallback(function () {
 }());"
 `;
 
+exports[`babel plugin for async functions makes an async worklet factory 1`] = `
+"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+var _worklet_2720353136439_init_data = {
+  code: "async function foo(){await Promise.resolve();}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foo = function () {
+  var _e = [new global.Error(), 1, -27];
+  var foo = function () {
+    var _ref = (0, _asyncToGenerator2.default)(function* () {
+      yield Promise.resolve();
+    });
+    return function foo() {
+      return _ref.apply(this, arguments);
+    };
+  }();
+  foo.__closure = {};
+  foo.__workletHash = 2720353136439;
+  foo.__initData = _worklet_2720353136439_init_data;
+  foo.__stackDetails = _e;
+  return foo;
+}();"
+`;
+
+exports[`babel plugin for async functions makes an async worklet string 1`] = `
+"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+var _worklet_2720353136439_init_data = {
+  code: "async function foo(){await Promise.resolve();}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foo = function () {
+  var _e = [new global.Error(), 1, -27];
+  var foo = function () {
+    var _ref = (0, _asyncToGenerator2.default)(function* () {
+      yield Promise.resolve();
+    });
+    return function foo() {
+      return _ref.apply(this, arguments);
+    };
+  }();
+  foo.__closure = {};
+  foo.__workletHash = 2720353136439;
+  foo.__initData = _worklet_2720353136439_init_data;
+  foo.__stackDetails = _e;
+  return foo;
+}();"
+`;
+
 exports[`babel plugin for class worklets workletizes class field 1`] = `
 "var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -1722,4 +1722,34 @@ describe('babel plugin', () => {
       expect(code).toMatchSnapshot();
     });
   });
+
+  describe('for async functions', () => {
+    it('makes an async worklet factory', () => {
+      const input = html`<script>
+        async function foo() {
+          'worklet';
+          await Promise.resolve();
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+      expect(code).toContain('asyncToGenerator');
+      expect(code).toMatchSnapshot();
+    });
+
+    it('makes an async worklet string', () => {
+      const input = html`<script>
+        async function foo() {
+          'worklet';
+          await Promise.resolve();
+        }
+      </script>`;
+
+      const { code } = runPlugin(input);
+      expect(code).toContain(
+        `code: "async function foo(){await Promise.resolve();}"`
+      );
+      expect(code).toMatchSnapshot();
+    });
+  });
 });

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -95,7 +95,7 @@ var require_buildWorkletString = __commonJS({
       const expression = (0, types_1.isFunctionDeclaration)(draftExpression) ? draftExpression : draftExpression.expression;
       (0, assert_1.strict)("params" in expression, "'params' property is undefined in 'expression'");
       (0, assert_1.strict)((0, types_1.isBlockStatement)(expression.body), "[Reanimated] `expression.body` is not a `BlockStatement`");
-      const workletFunction = (0, types_1.functionExpression)((0, types_1.identifier)(name), expression.params, expression.body, expression.generator);
+      const workletFunction = (0, types_1.functionExpression)((0, types_1.identifier)(name), expression.params, expression.body, expression.generator, expression.async);
       const code = (0, generator_1.default)(workletFunction).code;
       (0, assert_1.strict)(inputMap, "[Reanimated] `inputMap` is undefined.");
       const includeSourceMap = !(0, utils_1.isRelease)();
@@ -332,7 +332,7 @@ var require_makeWorklet = __commonJS({
       const functionName = makeWorkletName(fun);
       const functionIdentifier = (0, types_1.identifier)(functionName);
       const clone = (0, types_1.cloneNode)(fun.node);
-      const funExpression = (0, types_1.isBlockStatement)(clone.body) ? (0, types_1.functionExpression)(null, clone.params, clone.body, clone.generator) : clone;
+      const funExpression = (0, types_1.isBlockStatement)(clone.body) ? (0, types_1.functionExpression)(null, clone.params, clone.body, clone.generator, clone.async) : clone;
       let [funString, sourceMapString] = (0, buildWorkletString_1.buildWorkletString)(transformed.ast, variables, functionName, transformed.map);
       (0, assert_1.strict)(funString, "[Reanimated] `funString` is undefined.");
       const workletHash = hash(funString);

--- a/plugin/src/buildWorkletString.ts
+++ b/plugin/src/buildWorkletString.ts
@@ -64,7 +64,8 @@ export function buildWorkletString(
     identifier(name),
     expression.params,
     expression.body,
-    expression.generator
+    expression.generator,
+    expression.async
   );
 
   const code = generate(workletFunction).code;

--- a/plugin/src/makeWorklet.ts
+++ b/plugin/src/makeWorklet.ts
@@ -104,7 +104,13 @@ export function makeWorklet(
 
   const clone = cloneNode(fun.node);
   const funExpression = isBlockStatement(clone.body)
-    ? functionExpression(null, clone.params, clone.body, clone.generator)
+    ? functionExpression(
+        null,
+        clone.params,
+        clone.body,
+        clone.generator,
+        clone.async
+      )
     : clone;
 
   let [funString, sourceMapString] = buildWorkletString(


### PR DESCRIPTION
## Summary

Inspired by #5565. Currently we don't respect if the workletized function is an async one. This PR fixes this.

Keep in mind that even with these change **async worklets will not work properly on the UI thread**. This is because Hermes doesn't support them out of the box and they need to be transformed into generators first (you can see that in the snapshots).

Properly transforming them so they are valid on UI thread should be considered a future, very low priority task, since it wasn't requested yet by our users.

## Test plan

Relevant tests were added to `plugin.test.ts`.

<details>
<summary>
To see the difference between JS and UI behavior
</summary>

```tsx
import { StyleSheet, View, Button } from 'react-native';

import React from 'react';

import { runOnUI } from 'react-native-reanimated';

export default function EmptyExample() {
  async function asyncWorklet() {
    'worklet';
    await Promise.resolve();
    console.log('Hello world!');
  }

  const runAsyncWorklet = runOnUI(asyncWorklet);

  return (
    <View style={styles.container}>
      <Button title="Run async worklet on UI" onPress={runAsyncWorklet} />
      <Button title="Run async worklet on JS" onPress={asyncWorklet} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

</details>