### PR TITLE
Hotfix accidental rename of `remove` to `delete`

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -244,7 +244,7 @@ export function createAnimatedComponent(
     _detachStyles() {
       if (IS_WEB && this._styles !== null) {
         for (const style of this._styles) {
-          style.viewsRef.delete(this);
+          style.viewsRef.remove(this);
         }
       } else if (this._viewTag !== -1 && this._styles !== null) {
         for (const style of this._styles) {


### PR DESCRIPTION
## Test plan

Tested in Web with

```tsx
import { Button } from 'react-native';

import Animated, { useAnimatedStyle } from 'react-native-reanimated';

import React from 'react';

export default function EmptyExample() {
  const [show, setShow] = React.useState(true);

  const animatedStyle = useAnimatedStyle(() => ({
    width: 100,
    height: 100,
    backgroundColor: 'red',
  }));
  return (
    <>
      <Button title="Toggle" onPress={() => setShow(!show)} />
      {show ? <Animated.View style={animatedStyle} /> : null}
    </>
  );
}
```
