### PR TITLE
Add missing plugin config to example apps

### DIFF
--- a/FabricExample/babel.config.js
+++ b/FabricExample/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['../plugin'],
+  plugins: [['../plugin', {processNestedWorklets: true}]],
 };

--- a/MacOSExample/babel.config.js
+++ b/MacOSExample/babel.config.js
@@ -10,6 +10,6 @@ module.exports = {
         },
       },
     ],
-    '../plugin',
+    [['../plugin', {processNestedWorklets: true}]],
   ],
 };

--- a/TVOSExample/babel.config.js
+++ b/TVOSExample/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['../plugin'],
+  plugins: [['../plugin', {processNestedWorklets: true}]],
 };


### PR DESCRIPTION
## Summary

Our example app tests nested worklets, specifically the `WorkletExample` that includes the `ThrowErrorNestedWorkletDemo`. This test requires additional plugin configuration. Previously, this configuration was only present in the Example app. This PR adds this config to rest of our example apps.

## Test plan

Run example:
<img width="438" alt="Screenshot 2024-01-15 at 15 05 31" src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/51f39d24-d3ce-4836-a9cc-1238f3090958">
