### PR TITLE
Fix `useHandler` context issue

### DIFF
--- a/src/reanimated2/hook/useHandler.ts
+++ b/src/reanimated2/hook/useHandler.ts
@@ -4,6 +4,7 @@ import type { WorkletFunction } from '../commonTypes';
 import { isWeb, isJest } from '../PlatformChecker';
 import type { DependencyList, ReanimatedEvent } from './commonTypes';
 import { areDependenciesEqual, buildDependencies } from './utils';
+import { makeShareable } from '../shareables';
 
 interface GeneralHandler<
   Event extends object,
@@ -64,8 +65,9 @@ export function useHandler<
 ): UseHandlerContext<Context> {
   const initRef = useRef<ContextWithDependencies<Context> | null>(null);
   if (initRef.current === null) {
+    const context = makeShareable({} as Context);
     initRef.current = {
-      context: {} as Context,
+      context,
       savedDependencies: [],
     };
   }


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in #5518. `useHandler` works by maintaining a `context` object that can be accessed and modified in event handlers (e.g. within `useAnimatedGestureHandler`). Removing `makeRemote` call there made it so that any changes to the `context` object were not visible in event handlers, rendering the `context` object useless. In this PR I wrapped the context object with `makeShareable`, which works basically in the same way as `makeRemote` did.

## Test plan

Check whether the `[SET] Modals` example behaves properly (i.e. if the modal closing gestures are captured correctly).