### PR TITLE
fix: lazily search for ReactFabric

### DIFF
--- a/src/reanimated2/fabricUtils.ts
+++ b/src/reanimated2/fabricUtils.ts
@@ -13,21 +13,21 @@ interface HostInstance {
 }
 
 let findHostInstance_DEPRECATED: (ref: React.Component) => HostInstance;
-if (isFabric()) {
-  try {
-    findHostInstance_DEPRECATED =
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('react-native/Libraries/Renderer/shims/ReactFabric').findHostInstance_DEPRECATED;
-  } catch (e) {
-    throw new Error(
-      '[Reanimated] Cannot import `findHostInstance_DEPRECATED`.'
-    );
-  }
-}
 
 export function getShadowNodeWrapperFromRef(
   ref: React.Component
 ): ShadowNodeWrapper {
+  if (!findHostInstance_DEPRECATED && isFabric()) {
+    try {
+      findHostInstance_DEPRECATED =
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('react-native/Libraries/Renderer/shims/ReactFabric').findHostInstance_DEPRECATED;
+    } catch (e) {
+      throw new Error(
+        '[Reanimated] Cannot import `findHostInstance_DEPRECATED`.'
+      );
+    }
+  }
   return findHostInstance_DEPRECATED(ref)._internalInstanceHandle.stateNode
     .node;
 }


### PR DESCRIPTION
## Summary

Quick PR fixing a problem that can be spotted in `Expensfiy` app where for some reason on new arch, this code was evaluated before the `nativeFabricUIManager` was added to global, making the code throw. Now it is requested only when used for the first time, making it more safe.

## Test plan

For some reason I could not reproduce it in the `FabricExample` in any way.
