### PR TITLE
Fix plugin sometimes not workletizing `ObjectMethod`

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Check Example App bundling
         working-directory: Example
-        run: yarn && yarn react-native bundle --reset-cache --entry-file='App.tsx' --dev=true --platform='ios' > /dev/null
+        run: yarn && yarn react-native bundle --reset-cache --entry-file='App.tsx' --bundle-output='/dev/null' --dev=true --platform='ios'

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -49,3 +49,7 @@ jobs:
         run: git diff
       - name: Test
         run: yarn jest plugin
+
+      - name: Check Example App bundling
+        working-directory: Example
+        run: yarn && yarn react-native bundle --reset-cache --entry-file='App.tsx' --dev=true --platform='ios' > /dev/null

--- a/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/__tests__/__snapshots__/plugin.test.ts.snap
@@ -1826,20 +1826,20 @@ var foo = function () {
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets embedded in runOnJS in runOnUI 1`] = `
-"var _worklet_16739363980177_init_data = {
-  code: "function anonymous(){const{runOnJS}=this.__closure;console.log('Hello from UI thread');runOnJS(function(){'worklet';console.log('Hello from JS thread');})();}",
-  location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
-};
-var _worklet_13427774179957_init_data = {
+"var _worklet_13427774179957_init_data = {
   code: "function anonymous(){console.log('Hello from JS thread');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\"",
   version: "x.y.z"
 };
+var _worklet_12029053563916_init_data = {
+  code: "function anonymous(){const{runOnJS,_worklet_13427774179957_init_data}=this.__closure;console.log('Hello from UI thread');runOnJS(function(){const _e=[new global.Error(),1,-27];const anonymous=function(){console.log('Hello from JS thread');};anonymous.__closure={};anonymous.__workletHash=13427774179957;anonymous.__initData=_worklet_13427774179957_init_data;anonymous.__stackDetails=_e;return anonymous;}())();}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
 runOnUI(function () {
-  var _e = [new global.Error(), -2, -27];
+  var _e = [new global.Error(), -3, -27];
   var anonymous = function anonymous() {
     console.log('Hello from UI thread');
     runOnJS(function () {
@@ -1855,24 +1855,25 @@ runOnUI(function () {
     }())();
   };
   anonymous.__closure = {
-    runOnJS: runOnJS
+    runOnJS: runOnJS,
+    _worklet_13427774179957_init_data: _worklet_13427774179957_init_data
   };
-  anonymous.__workletHash = 16739363980177;
-  anonymous.__initData = _worklet_16739363980177_init_data;
+  anonymous.__workletHash = 12029053563916;
+  anonymous.__initData = _worklet_12029053563916_init_data;
   anonymous.__stackDetails = _e;
   return anonymous;
 }())();"
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets embedded in runOnUI in runOnJS in runOnUI 1`] = `
-"var _worklet_15024386663586_init_data = {
-  code: "function anonymous(){const{runOnJS,runOnUI}=this.__closure;console.log('Hello from UI thread');runOnJS(function(){'worklet';console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();})();}",
+"var _worklet_15780567630262_init_data = {
+  code: "function anonymous(){const{runOnUI}=this.__closure;console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\"",
   version: "x.y.z"
 };
-var _worklet_15780567630262_init_data = {
-  code: "function anonymous(){const{runOnUI}=this.__closure;console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();}",
+var _worklet_10673554115844_init_data = {
+  code: "function anonymous(){const{runOnJS,runOnUI,_worklet_15780567630262_init_data}=this.__closure;console.log('Hello from UI thread');runOnJS(function(){const _e=[new global.Error(),-2,-27];const anonymous=function(){console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();};anonymous.__closure={runOnUI:runOnUI};anonymous.__workletHash=15780567630262;anonymous.__initData=_worklet_15780567630262_init_data;anonymous.__stackDetails=_e;return anonymous;}())();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\"",
   version: "x.y.z"
@@ -1884,7 +1885,7 @@ var _worklet_12364489264272_init_data = {
   version: "x.y.z"
 };
 runOnUI(function () {
-  var _e = [new global.Error(), -3, -27];
+  var _e = [new global.Error(), -4, -27];
   var anonymous = function anonymous() {
     console.log('Hello from UI thread');
     runOnJS(function () {
@@ -1914,10 +1915,11 @@ runOnUI(function () {
   };
   anonymous.__closure = {
     runOnJS: runOnJS,
-    runOnUI: runOnUI
+    runOnUI: runOnUI,
+    _worklet_15780567630262_init_data: _worklet_15780567630262_init_data
   };
-  anonymous.__workletHash = 15024386663586;
-  anonymous.__initData = _worklet_15024386663586_init_data;
+  anonymous.__workletHash = 10673554115844;
+  anonymous.__initData = _worklet_10673554115844_init_data;
   anonymous.__stackDetails = _e;
   return anonymous;
 }())();"
@@ -2021,13 +2023,7 @@ var foo = function () {
 `;
 
 exports[`babel plugin for worklet nesting transpiles worklets with functions defined on UI thread to run them on JS 1`] = `
-"var _worklet_4484193487608_init_data = {
-  code: "function anonymous(){const{runOnJS}=this.__closure;const a=function(){'worklet';console.log('Good morning from JS thread!');};const b=function(){'worklet';console.log('Good afternoon from JS thread');};const func=Math.random()<0.5?a:b;runOnJS(func)();}",
-  location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
-};
-var _worklet_2310082662475_init_data = {
+"var _worklet_2310082662475_init_data = {
   code: "function anonymous(){console.log('Good morning from JS thread!');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\"",
@@ -2039,8 +2035,14 @@ var _worklet_9108102051728_init_data = {
   sourceMap: "\\"mock source map\\"",
   version: "x.y.z"
 };
+var _worklet_7385395288732_init_data = {
+  code: "function anonymous(){const{_worklet_2310082662475_init_data,_worklet_9108102051728_init_data,runOnJS}=this.__closure;const a=function(){const _e=[new global.Error(),1,-27];const anonymous=function(){console.log('Good morning from JS thread!');};anonymous.__closure={};anonymous.__workletHash=2310082662475;anonymous.__initData=_worklet_2310082662475_init_data;anonymous.__stackDetails=_e;return anonymous;}();const b=function(){const _e=[new global.Error(),1,-27];const anonymous=function(){console.log('Good afternoon from JS thread');};anonymous.__closure={};anonymous.__workletHash=9108102051728;anonymous.__initData=_worklet_9108102051728_init_data;anonymous.__stackDetails=_e;return anonymous;}();const func=Math.random()<0.5?a:b;runOnJS(func)();}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
 runOnUI(function () {
-  var _e = [new global.Error(), -2, -27];
+  var _e = [new global.Error(), -4, -27];
   var anonymous = function anonymous() {
     var a = function () {
       var _e = [new global.Error(), 1, -27];
@@ -2068,10 +2070,12 @@ runOnUI(function () {
     runOnJS(func)();
   };
   anonymous.__closure = {
+    _worklet_2310082662475_init_data: _worklet_2310082662475_init_data,
+    _worklet_9108102051728_init_data: _worklet_9108102051728_init_data,
     runOnJS: runOnJS
   };
-  anonymous.__workletHash = 4484193487608;
-  anonymous.__initData = _worklet_4484193487608_init_data;
+  anonymous.__workletHash = 7385395288732;
+  anonymous.__initData = _worklet_7385395288732_init_data;
   anonymous.__stackDetails = _e;
   return anonymous;
 }())();"

--- a/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/__tests__/__snapshots__/plugin.test.ts.snap
@@ -804,6 +804,28 @@ var foo = function () {
 }();"
 `;
 
+exports[`babel plugin for explicit worklets workletizes ObjectMethod 1`] = `
+"var _worklet_16974800582491_init_data = {
+  code: "function bar(x){return x+2;}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foo = {
+  bar: function () {
+    var _e = [new global.Error(), 1, -27];
+    var bar = function bar(x) {
+      return x + 2;
+    };
+    bar.__closure = {};
+    bar.__workletHash = 16974800582491;
+    bar.__initData = _worklet_16974800582491_init_data;
+    bar.__stackDetails = _e;
+    return bar;
+  }()
+};"
+`;
+
 exports[`babel plugin for explicit worklets workletizes named FunctionExpression 1`] = `
 "var _worklet_4679479961836_init_data = {
   code: "function foo(x){return x+2;}",

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -362,6 +362,21 @@ describe('babel plugin', () => {
       expect(code).not.toContain("'worklet';");
       expect(code).toMatchSnapshot();
     });
+
+    it('workletizes ObjectMethod', () => {
+      const input = html`<script>
+        const foo = {
+          bar(x) {
+            'worklet';
+            return x + 2;
+          },
+        };
+      </script>`;
+
+      const { code } = runPlugin(input);
+      expect(code).toHaveWorkletData();
+      expect(code).toMatchSnapshot();
+    });
   });
 
   describe('for class worklets', () => {

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -25,6 +25,21 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// lib/types.js
+var require_types = __commonJS({
+  "lib/types.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.isWorkletizableFunctionType = exports2.WorkletizableFunction = exports2.ExplicitWorklet = void 0;
+    exports2.ExplicitWorklet = "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression";
+    exports2.WorkletizableFunction = "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod";
+    function isWorkletizableFunctionType(path) {
+      return path.isFunctionDeclaration() || path.isFunctionExpression() || path.isArrowFunctionExpression() || path.isObjectMethod();
+    }
+    exports2.isWorkletizableFunctionType = isWorkletizableFunctionType;
+  }
+});
+
 // lib/utils.js
 var require_utils = __commonJS({
   "lib/utils.js"(exports2) {
@@ -83,19 +98,19 @@ var require_buildWorkletString = __commonJS({
     exports2.buildWorkletString = void 0;
     var core_1 = require("@babel/core");
     var generator_1 = __importDefault(require("@babel/generator"));
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     var assert_1 = require("assert");
     var convertSourceMap = __importStar(require("convert-source-map"));
     var fs = __importStar(require("fs"));
     var utils_1 = require_utils();
     var MOCK_SOURCE_MAP = "mock source map";
     function buildWorkletString(fun, closureVariables, name, inputMap) {
-      const draftExpression = fun.program.body.find((obj) => (0, types_1.isFunctionDeclaration)(obj)) || fun.program.body.find((obj) => (0, types_1.isExpressionStatement)(obj)) || void 0;
+      const draftExpression = fun.program.body.find((obj) => (0, types_12.isFunctionDeclaration)(obj)) || fun.program.body.find((obj) => (0, types_12.isExpressionStatement)(obj)) || void 0;
       (0, assert_1.strict)(draftExpression, "[Reanimated] `draftExpression` is undefined.");
-      const expression = (0, types_1.isFunctionDeclaration)(draftExpression) ? draftExpression : draftExpression.expression;
+      const expression = (0, types_12.isFunctionDeclaration)(draftExpression) ? draftExpression : draftExpression.expression;
       (0, assert_1.strict)("params" in expression, "'params' property is undefined in 'expression'");
-      (0, assert_1.strict)((0, types_1.isBlockStatement)(expression.body), "[Reanimated] `expression.body` is not a `BlockStatement`");
-      const workletFunction = (0, types_1.functionExpression)((0, types_1.identifier)(name), expression.params, expression.body, expression.generator, expression.async);
+      (0, assert_1.strict)((0, types_12.isBlockStatement)(expression.body), "[Reanimated] `expression.body` is not a `BlockStatement`");
+      const workletFunction = (0, types_12.functionExpression)((0, types_12.identifier)(name), expression.params, expression.body, expression.generator, expression.async);
       const code = (0, generator_1.default)(workletFunction).code;
       (0, assert_1.strict)(inputMap, "[Reanimated] `inputMap` is undefined.");
       const includeSourceMap = !(0, utils_1.isRelease)();
@@ -132,27 +147,27 @@ var require_buildWorkletString = __commonJS({
       return process.env.REANIMATED_JEST_SHOULD_MOCK_SOURCE_MAP === "1";
     }
     function prependClosure(path, closureVariables, closureDeclaration) {
-      if (closureVariables.length === 0 || !(0, types_1.isProgram)(path.parent)) {
+      if (closureVariables.length === 0 || !(0, types_12.isProgram)(path.parent)) {
         return;
       }
-      if (!(0, types_1.isExpression)(path.node.body)) {
+      if (!(0, types_12.isExpression)(path.node.body)) {
         path.node.body.body.unshift(closureDeclaration);
       }
     }
     function prependRecursiveDeclaration(path) {
       var _a;
-      if ((0, types_1.isProgram)(path.parent) && !(0, types_1.isArrowFunctionExpression)(path.node) && !(0, types_1.isObjectMethod)(path.node) && path.node.id && path.scope.parent) {
+      if ((0, types_12.isProgram)(path.parent) && !(0, types_12.isArrowFunctionExpression)(path.node) && !(0, types_12.isObjectMethod)(path.node) && path.node.id && path.scope.parent) {
         const hasRecursiveCalls = ((_a = path.scope.parent.bindings[path.node.id.name]) === null || _a === void 0 ? void 0 : _a.references) > 0;
         if (hasRecursiveCalls) {
-          path.node.body.body.unshift((0, types_1.variableDeclaration)("const", [
-            (0, types_1.variableDeclarator)((0, types_1.identifier)(path.node.id.name), (0, types_1.memberExpression)((0, types_1.thisExpression)(), (0, types_1.identifier)("_recur")))
+          path.node.body.body.unshift((0, types_12.variableDeclaration)("const", [
+            (0, types_12.variableDeclarator)((0, types_12.identifier)(path.node.id.name), (0, types_12.memberExpression)((0, types_12.thisExpression)(), (0, types_12.identifier)("_recur")))
           ]));
         }
       }
     }
     function prependClosureVariablesIfNecessary(closureVariables) {
-      const closureDeclaration = (0, types_1.variableDeclaration)("const", [
-        (0, types_1.variableDeclarator)((0, types_1.objectPattern)(closureVariables.map((variable) => (0, types_1.objectProperty)((0, types_1.identifier)(variable.name), (0, types_1.identifier)(variable.name), false, true))), (0, types_1.memberExpression)((0, types_1.thisExpression)(), (0, types_1.identifier)("__closure")))
+      const closureDeclaration = (0, types_12.variableDeclaration)("const", [
+        (0, types_12.variableDeclarator)((0, types_12.objectPattern)(closureVariables.map((variable) => (0, types_12.objectProperty)((0, types_12.identifier)(variable.name), (0, types_12.identifier)(variable.name), false, true))), (0, types_12.memberExpression)((0, types_12.thisExpression)(), (0, types_12.identifier)("__closure")))
       ]);
       return {
         visitor: {
@@ -287,10 +302,10 @@ var require_makeWorklet = __commonJS({
       return mod && mod.__esModule ? mod : { "default": mod };
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.makeWorklet = void 0;
+    exports2.makeWorkletFactory = void 0;
     var core_1 = require("@babel/core");
     var generator_1 = __importDefault(require("@babel/generator"));
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     var assert_1 = require("assert");
     var path_1 = require("path");
     var buildWorkletString_1 = require_buildWorkletString();
@@ -298,14 +313,14 @@ var require_makeWorklet = __commonJS({
     var utils_1 = require_utils();
     var REAL_VERSION = require("../../package.json").version;
     var MOCK_VERSION = "x.y.z";
-    function makeWorklet(fun, state) {
+    function makeWorkletFactory(fun, state) {
       removeWorkletDirective(fun);
       (0, assert_1.strict)(state.file.opts.filename, "[Reanimated] `state.file.opts.filename` is undefined.");
       const codeObject = (0, generator_1.default)(fun.node, {
         sourceMaps: true,
         sourceFileName: state.file.opts.filename
       });
-      codeObject.code = "(" + ((0, types_1.isObjectMethod)(fun) ? "function " : "") + codeObject.code + "\n)";
+      codeObject.code = "(" + ((0, types_12.isObjectMethod)(fun) ? "function " : "") + codeObject.code + "\n)";
       const transformed = (0, core_1.transformSync)(codeObject.code, {
         filename: state.file.opts.filename,
         presets: [require.resolve("@babel/preset-typescript")],
@@ -328,9 +343,9 @@ var require_makeWorklet = __commonJS({
       (0, assert_1.strict)(transformed.ast, "[Reanimated] `transformed.ast` is undefined.");
       const variables = makeArrayFromCapturedBindings(transformed.ast, fun);
       const functionName = makeWorkletName(fun);
-      const functionIdentifier = (0, types_1.identifier)(functionName);
-      const clone = (0, types_1.cloneNode)(fun.node);
-      const funExpression = (0, types_1.isBlockStatement)(clone.body) ? (0, types_1.functionExpression)(null, clone.params, clone.body, clone.generator, clone.async) : clone;
+      const functionIdentifier = (0, types_12.identifier)(functionName);
+      const clone = (0, types_12.cloneNode)(fun.node);
+      const funExpression = (0, types_12.isBlockStatement)(clone.body) ? (0, types_12.functionExpression)(null, clone.params, clone.body, clone.generator, clone.async) : clone;
       let [funString, sourceMapString] = (0, buildWorkletString_1.buildWorkletString)(transformed.ast, variables, functionName, transformed.map);
       (0, assert_1.strict)(funString, "[Reanimated] `funString` is undefined.");
       const workletHash = hash(funString);
@@ -338,12 +353,12 @@ var require_makeWorklet = __commonJS({
       if (variables.length > 0) {
         lineOffset -= variables.length + 2;
       }
-      const pathForStringDefinitions = fun.parentPath.isProgram() ? fun : fun.findParent((path) => (0, types_1.isProgram)(path.parentPath));
+      const pathForStringDefinitions = fun.parentPath.isProgram() ? fun : fun.findParent((path) => (0, types_12.isProgram)(path.parentPath));
       (0, assert_1.strict)(pathForStringDefinitions, "[Reanimated] `pathForStringDefinitions` is null.");
       (0, assert_1.strict)(pathForStringDefinitions.parentPath, "[Reanimated] `pathForStringDefinitions.parentPath` is null.");
       const initDataId = pathForStringDefinitions.parentPath.scope.generateUidIdentifier(`worklet_${workletHash}_init_data`);
-      const initDataObjectExpression = (0, types_1.objectExpression)([
-        (0, types_1.objectProperty)((0, types_1.identifier)("code"), (0, types_1.stringLiteral)(funString))
+      const initDataObjectExpression = (0, types_12.objectExpression)([
+        (0, types_12.objectProperty)((0, types_12.identifier)("code"), (0, types_12.stringLiteral)(funString))
       ]);
       const shouldInjectLocation = !(0, utils_1.isRelease)();
       if (shouldInjectLocation) {
@@ -352,48 +367,48 @@ var require_makeWorklet = __commonJS({
           location = (0, path_1.relative)(state.cwd, location);
           sourceMapString = sourceMapString === null || sourceMapString === void 0 ? void 0 : sourceMapString.replace(state.file.opts.filename, location);
         }
-        initDataObjectExpression.properties.push((0, types_1.objectProperty)((0, types_1.identifier)("location"), (0, types_1.stringLiteral)(location)));
+        initDataObjectExpression.properties.push((0, types_12.objectProperty)((0, types_12.identifier)("location"), (0, types_12.stringLiteral)(location)));
       }
       if (sourceMapString) {
-        initDataObjectExpression.properties.push((0, types_1.objectProperty)((0, types_1.identifier)("sourceMap"), (0, types_1.stringLiteral)(sourceMapString)));
+        initDataObjectExpression.properties.push((0, types_12.objectProperty)((0, types_12.identifier)("sourceMap"), (0, types_12.stringLiteral)(sourceMapString)));
       }
       const shouldInjectVersion = !(0, utils_1.isRelease)();
       if (shouldInjectVersion) {
-        initDataObjectExpression.properties.push((0, types_1.objectProperty)((0, types_1.identifier)("version"), (0, types_1.stringLiteral)(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION)));
+        initDataObjectExpression.properties.push((0, types_12.objectProperty)((0, types_12.identifier)("version"), (0, types_12.stringLiteral)(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION)));
       }
       const shouldIncludeInitData = !state.opts.omitNativeOnlyData;
       if (shouldIncludeInitData) {
-        pathForStringDefinitions.insertBefore((0, types_1.variableDeclaration)("const", [
-          (0, types_1.variableDeclarator)(initDataId, initDataObjectExpression)
+        pathForStringDefinitions.insertBefore((0, types_12.variableDeclaration)("const", [
+          (0, types_12.variableDeclarator)(initDataId, initDataObjectExpression)
         ]));
       }
-      (0, assert_1.strict)(!(0, types_1.isFunctionDeclaration)(funExpression), "[Reanimated] `funExpression` is a `FunctionDeclaration`.");
-      (0, assert_1.strict)(!(0, types_1.isObjectMethod)(funExpression), "[Reanimated] `funExpression` is an `ObjectMethod`.");
+      (0, assert_1.strict)(!(0, types_12.isFunctionDeclaration)(funExpression), "[Reanimated] `funExpression` is a `FunctionDeclaration`.");
+      (0, assert_1.strict)(!(0, types_12.isObjectMethod)(funExpression), "[Reanimated] `funExpression` is an `ObjectMethod`.");
       const statements = [
-        (0, types_1.variableDeclaration)("const", [
-          (0, types_1.variableDeclarator)(functionIdentifier, funExpression)
+        (0, types_12.variableDeclaration)("const", [
+          (0, types_12.variableDeclarator)(functionIdentifier, funExpression)
         ]),
-        (0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__closure"), false), (0, types_1.objectExpression)(variables.map((variable) => (0, types_1.objectProperty)((0, types_1.identifier)(variable.name), variable, false, true))))),
-        (0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__workletHash"), false), (0, types_1.numericLiteral)(workletHash)))
+        (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)(functionIdentifier, (0, types_12.identifier)("__closure"), false), (0, types_12.objectExpression)(variables.map((variable) => (0, types_12.objectProperty)((0, types_12.identifier)(variable.name), variable, false, true))))),
+        (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)(functionIdentifier, (0, types_12.identifier)("__workletHash"), false), (0, types_12.numericLiteral)(workletHash)))
       ];
       if (shouldIncludeInitData) {
-        statements.push((0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__initData"), false), initDataId)));
+        statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)(functionIdentifier, (0, types_12.identifier)("__initData"), false), initDataId)));
       }
       if (!(0, utils_1.isRelease)()) {
-        statements.unshift((0, types_1.variableDeclaration)("const", [
-          (0, types_1.variableDeclarator)((0, types_1.identifier)("_e"), (0, types_1.arrayExpression)([
-            (0, types_1.newExpression)((0, types_1.memberExpression)((0, types_1.identifier)("global"), (0, types_1.identifier)("Error")), []),
-            (0, types_1.numericLiteral)(lineOffset),
-            (0, types_1.numericLiteral)(-27)
+        statements.unshift((0, types_12.variableDeclaration)("const", [
+          (0, types_12.variableDeclarator)((0, types_12.identifier)("_e"), (0, types_12.arrayExpression)([
+            (0, types_12.newExpression)((0, types_12.memberExpression)((0, types_12.identifier)("global"), (0, types_12.identifier)("Error")), []),
+            (0, types_12.numericLiteral)(lineOffset),
+            (0, types_12.numericLiteral)(-27)
           ]))
         ]));
-        statements.push((0, types_1.expressionStatement)((0, types_1.assignmentExpression)("=", (0, types_1.memberExpression)(functionIdentifier, (0, types_1.identifier)("__stackDetails"), false), (0, types_1.identifier)("_e"))));
+        statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)(functionIdentifier, (0, types_12.identifier)("__stackDetails"), false), (0, types_12.identifier)("_e"))));
       }
-      statements.push((0, types_1.returnStatement)(functionIdentifier));
-      const newFun = (0, types_1.functionExpression)(void 0, [], (0, types_1.blockStatement)(statements));
+      statements.push((0, types_12.returnStatement)(functionIdentifier));
+      const newFun = (0, types_12.functionExpression)(void 0, [], (0, types_12.blockStatement)(statements));
       return newFun;
     }
-    exports2.makeWorklet = makeWorklet;
+    exports2.makeWorkletFactory = makeWorkletFactory;
     function removeWorkletDirective(fun) {
       fun.traverse({
         DirectiveLiteral(path) {
@@ -418,13 +433,13 @@ var require_makeWorklet = __commonJS({
       return (hash1 >>> 0) * 4096 + (hash2 >>> 0);
     }
     function makeWorkletName(fun) {
-      if ((0, types_1.isObjectMethod)(fun.node) && (0, types_1.isIdentifier)(fun.node.key)) {
+      if ((0, types_12.isObjectMethod)(fun.node) && (0, types_12.isIdentifier)(fun.node.key)) {
         return fun.node.key.name;
       }
-      if ((0, types_1.isFunctionDeclaration)(fun.node) && (0, types_1.isIdentifier)(fun.node.id)) {
+      if ((0, types_12.isFunctionDeclaration)(fun.node) && (0, types_12.isIdentifier)(fun.node.id)) {
         return fun.node.id.name;
       }
-      if ((0, types_1.isFunctionExpression)(fun.node) && (0, types_1.isIdentifier)(fun.node.id)) {
+      if ((0, types_12.isFunctionExpression)(fun.node) && (0, types_12.isIdentifier)(fun.node.id)) {
         return fun.node.id.name;
       }
       return "anonymous";
@@ -445,10 +460,10 @@ var require_makeWorklet = __commonJS({
             return;
           }
           const parentNode = path.parent;
-          if ((0, types_1.isMemberExpression)(parentNode) && parentNode.property === path.node && !parentNode.computed) {
+          if ((0, types_12.isMemberExpression)(parentNode) && parentNode.property === path.node && !parentNode.computed) {
             return;
           }
-          if ((0, types_1.isObjectProperty)(parentNode) && (0, types_1.isObjectExpression)(path.parentPath.parent) && path.node !== parentNode.value) {
+          if ((0, types_12.isObjectProperty)(parentNode) && (0, types_12.isObjectExpression)(path.parentPath.parent) && path.node !== parentNode.value) {
             return;
           }
           let currentScope = path.scope;
@@ -480,43 +495,23 @@ var require_makeWorklet = __commonJS({
   }
 });
 
-// lib/processWorkletObjectMethod.js
-var require_processWorkletObjectMethod = __commonJS({
-  "lib/processWorkletObjectMethod.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processWorkletObjectMethod = void 0;
-    var types_1 = require("@babel/types");
-    var makeWorklet_1 = require_makeWorklet();
-    function processWorkletObjectMethod(path, state) {
-      if (!(0, types_1.isFunctionParent)(path)) {
-        return;
-      }
-      const newFun = (0, makeWorklet_1.makeWorklet)(path, state);
-      const replacement = (0, types_1.objectProperty)((0, types_1.identifier)((0, types_1.isIdentifier)(path.node.key) ? path.node.key.name : ""), (0, types_1.callExpression)(newFun, []));
-      path.replaceWith(replacement);
-    }
-    exports2.processWorkletObjectMethod = processWorkletObjectMethod;
-  }
-});
-
 // lib/processIfWorkletFunction.js
 var require_processIfWorkletFunction = __commonJS({
   "lib/processIfWorkletFunction.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processIfWorkletFunction = void 0;
-    var types_1 = require("@babel/types");
+    exports2.makeWorkletFactoryCall = void 0;
+    var types_12 = require("@babel/types");
     var makeWorklet_1 = require_makeWorklet();
-    function processIfWorkletFunction(path, state) {
-      if (path.isFunctionDeclaration() || path.isFunctionExpression() || path.isArrowFunctionExpression()) {
-        processWorkletFunction(path, state);
-      }
+    function makeWorkletFactoryCall(path, state) {
+      const workletFactory = (0, makeWorklet_1.makeWorkletFactory)(path, state);
+      const workletFactoryCall = (0, types_12.callExpression)(workletFactory, []);
+      addStackTraceDataToWorkletFactory(path, workletFactoryCall);
+      const replacement = workletFactoryCall;
+      return replacement;
     }
-    exports2.processIfWorkletFunction = processIfWorkletFunction;
-    function processWorkletFunction(path, state) {
-      const workletFactory = (0, makeWorklet_1.makeWorklet)(path, state);
-      const workletFactoryCall = (0, types_1.callExpression)(workletFactory, []);
+    exports2.makeWorkletFactoryCall = makeWorkletFactoryCall;
+    function addStackTraceDataToWorkletFactory(path, workletFactoryCall) {
       const originalWorkletLocation = path.node.loc;
       if (originalWorkletLocation) {
         workletFactoryCall.callee.loc = {
@@ -524,12 +519,66 @@ var require_processIfWorkletFunction = __commonJS({
           end: originalWorkletLocation.start
         };
       }
-      const needDeclaration = (0, types_1.isScopable)(path.parent) || (0, types_1.isExportNamedDeclaration)(path.parent);
-      const replacement = "id" in path.node && path.node.id && needDeclaration ? (0, types_1.variableDeclaration)("const", [
-        (0, types_1.variableDeclarator)(path.node.id, workletFactoryCall)
+    }
+  }
+});
+
+// lib/processIfWorkletNode.js
+var require_processIfWorkletNode = __commonJS({
+  "lib/processIfWorkletNode.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.maybeSubstituteFunctionDeclarationWithVariableDeclaration = exports2.substituteObjectMethodWithObjectProperty = exports2.processWorklet = exports2.processIfWithWorkletDirective = void 0;
+    var types_12 = require("@babel/types");
+    var processIfWorkletFunction_1 = require_processIfWorkletFunction();
+    var types_2 = require_types();
+    function processIfWithWorkletDirective(path, state) {
+      if (!(0, types_12.isBlockStatement)(path.node.body)) {
+        return;
+      }
+      if (!hasWorkletDirective(path.node.body.directives)) {
+        return;
+      }
+      processWorklet(path, state);
+    }
+    exports2.processIfWithWorkletDirective = processIfWithWorkletDirective;
+    function processWorklet(path, state) {
+      if (state.opts.processNestedWorklets) {
+        path.traverse({
+          [types_2.WorkletizableFunction](subPath, passedState) {
+            processIfWithWorkletDirective(subPath, passedState);
+          }
+        }, state);
+      }
+      const workletFactoryCall = (0, processIfWorkletFunction_1.makeWorkletFactoryCall)(path, state);
+      substituteWithWorkletFactoryCall(path, workletFactoryCall);
+    }
+    exports2.processWorklet = processWorklet;
+    function hasWorkletDirective(directives) {
+      return directives.some((directive) => (0, types_12.isDirectiveLiteral)(directive.value) && directive.value.value === "worklet");
+    }
+    function substituteWithWorkletFactoryCall(path, workletFactoryCall) {
+      if (path.isObjectMethod()) {
+        substituteObjectMethodWithObjectProperty(path, workletFactoryCall);
+      } else if (path.isFunctionDeclaration()) {
+        maybeSubstituteFunctionDeclarationWithVariableDeclaration(path, workletFactoryCall);
+      } else {
+        path.replaceWith(workletFactoryCall);
+      }
+    }
+    function substituteObjectMethodWithObjectProperty(path, workletFactoryCall) {
+      const replacement = (0, types_12.objectProperty)(path.node.key, workletFactoryCall);
+      path.replaceWith(replacement);
+    }
+    exports2.substituteObjectMethodWithObjectProperty = substituteObjectMethodWithObjectProperty;
+    function maybeSubstituteFunctionDeclarationWithVariableDeclaration(path, workletFactoryCall) {
+      const needDeclaration = (0, types_12.isScopable)(path.parent) || (0, types_12.isExportNamedDeclaration)(path.parent);
+      const replacement = "id" in path.node && path.node.id && needDeclaration ? (0, types_12.variableDeclaration)("const", [
+        (0, types_12.variableDeclarator)(path.node.id, workletFactoryCall)
       ]) : workletFactoryCall;
       path.replaceWith(replacement);
     }
+    exports2.maybeSubstituteFunctionDeclarationWithVariableDeclaration = maybeSubstituteFunctionDeclarationWithVariableDeclaration;
   }
 });
 
@@ -538,11 +587,11 @@ var require_processForCalleesWorklets = __commonJS({
   "lib/processForCalleesWorklets.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processForCalleesWorklets = void 0;
-    var types_1 = require("@babel/types");
-    var processWorkletObjectMethod_1 = require_processWorkletObjectMethod();
-    var processIfWorkletFunction_1 = require_processIfWorkletFunction();
+    exports2.autoworkletizeCalleesWorklets = void 0;
+    var types_12 = require("@babel/types");
+    var types_2 = require_types();
     var assert_1 = require("assert");
+    var processIfWorkletNode_12 = require_processIfWorkletNode();
     var functionArgsToWorkletize = /* @__PURE__ */ new Map([
       ["useFrameCallback", [0]],
       ["useAnimatedStyle", [0]],
@@ -563,19 +612,21 @@ var require_processForCalleesWorklets = __commonJS({
       "useAnimatedGestureHandler",
       "useAnimatedScrollHandler"
     ]);
-    function processForCalleesWorklets(path, state) {
-      const callee = (0, types_1.isSequenceExpression)(path.node.callee) ? path.node.callee.expressions[path.node.callee.expressions.length - 1] : path.node.callee;
+    function autoworkletizeCalleesWorklets(path, state) {
+      const callee = (0, types_12.isSequenceExpression)(path.node.callee) ? path.node.callee.expressions[path.node.callee.expressions.length - 1] : path.node.callee;
       const name = "name" in callee ? callee.name : "property" in callee && "name" in callee.property ? callee.property.name : void 0;
       if (name === void 0) {
         return;
       }
       if (objectHooks.has(name)) {
-        const workletToProcess = path.get("arguments.0");
-        (0, assert_1.strict)(!Array.isArray(workletToProcess), "[Reanimated] `workletToProcess` is an array.");
-        if (workletToProcess.isObjectExpression()) {
-          processObjectHook(workletToProcess, state);
+        const maybeWorklet = path.get("arguments.0");
+        (0, assert_1.strict)(!Array.isArray(maybeWorklet), "[Reanimated] `workletToProcess` is an array.");
+        if (maybeWorklet.isObjectExpression()) {
+          processObjectHook(maybeWorklet, state);
         } else if (name === "useAnimatedScrollHandler") {
-          (0, processIfWorkletFunction_1.processIfWorkletFunction)(workletToProcess, state);
+          if ((0, types_2.isWorkletizableFunctionType)(maybeWorklet)) {
+            (0, processIfWorkletNode_12.processWorklet)(maybeWorklet, state);
+          }
         }
       } else {
         const indices = functionArgsToWorkletize.get(name);
@@ -585,65 +636,34 @@ var require_processForCalleesWorklets = __commonJS({
         processArguments(path, indices, state);
       }
     }
-    exports2.processForCalleesWorklets = processForCalleesWorklets;
+    exports2.autoworkletizeCalleesWorklets = autoworkletizeCalleesWorklets;
     function processObjectHook(path, state) {
       const properties = path.get("properties");
       for (const property of properties) {
         if (property.isObjectMethod()) {
-          (0, processWorkletObjectMethod_1.processWorkletObjectMethod)(property, state);
+          (0, processIfWorkletNode_12.processWorklet)(property, state);
         } else if (property.isObjectProperty()) {
           const value = property.get("value");
-          (0, processIfWorkletFunction_1.processIfWorkletFunction)(value, state);
+          if ((0, types_2.isWorkletizableFunctionType)(value)) {
+            (0, processIfWorkletNode_12.processWorklet)(value, state);
+          }
         } else {
-          throw new Error(`[Reanimated] '${property.type}' as to-be workletized arguments is not supported for object hooks.`);
+          throw new Error(`[Reanimated] '${property.type}' as to-be workletized argument is not supported for object hooks.`);
         }
       }
     }
     function processArguments(path, indices, state) {
       const argumentsArray = path.get("arguments");
       indices.forEach((index) => {
-        const argumentToWorkletize = argumentsArray[index];
-        if (!argumentToWorkletize) {
+        const maybeWorklet = argumentsArray[index];
+        if (!maybeWorklet) {
           return;
         }
-        (0, processIfWorkletFunction_1.processIfWorkletFunction)(argumentToWorkletize, state);
-      });
-    }
-  }
-});
-
-// lib/processIfWorkletNode.js
-var require_processIfWorkletNode = __commonJS({
-  "lib/processIfWorkletNode.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processIfWorkletNode = void 0;
-    var types_1 = require("@babel/types");
-    var processIfWorkletFunction_1 = require_processIfWorkletFunction();
-    function hasWorkletDirective(directives) {
-      return directives && directives.length > 0 && directives.some((directive) => (0, types_1.isDirectiveLiteral)(directive.value) && directive.value.value === "worklet");
-    }
-    function processIfWorkletNode(fun, state) {
-      let shouldBeProcessed = false;
-      fun.traverse({
-        DirectiveLiteral(path) {
-          const value = path.node.value;
-          if (value === "worklet" && (0, types_1.isBlockStatement)(fun.node.body)) {
-            const parent = path.getFunctionParent();
-            if (parent === fun) {
-              const directives = fun.node.body.directives;
-              shouldBeProcessed = hasWorkletDirective(directives);
-            } else if (state.opts.processNestedWorklets && ((parent === null || parent === void 0 ? void 0 : parent.isFunctionDeclaration()) || (parent === null || parent === void 0 ? void 0 : parent.isFunctionExpression()) || (parent === null || parent === void 0 ? void 0 : parent.isArrowFunctionExpression()))) {
-              processIfWorkletNode(parent, state);
-            }
-          }
+        if ((0, types_2.isWorkletizableFunctionType)(maybeWorklet)) {
+          (0, processIfWorkletNode_12.processWorklet)(maybeWorklet, state);
         }
       });
-      if (shouldBeProcessed) {
-        (0, processIfWorkletFunction_1.processIfWorkletFunction)(fun, state);
-      }
     }
-    exports2.processIfWorkletNode = processIfWorkletNode;
   }
 });
 
@@ -653,28 +673,28 @@ var require_processInlineStylesWarning = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.processInlineStylesWarning = void 0;
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     var utils_1 = require_utils();
     var assert_1 = require("assert");
     function generateInlineStylesWarning(path) {
-      return (0, types_1.callExpression)((0, types_1.arrowFunctionExpression)([], (0, types_1.blockStatement)([
-        (0, types_1.expressionStatement)((0, types_1.callExpression)((0, types_1.memberExpression)((0, types_1.identifier)("console"), (0, types_1.identifier)("warn")), [
-          (0, types_1.callExpression)((0, types_1.memberExpression)((0, types_1.callExpression)((0, types_1.identifier)("require"), [
-            (0, types_1.stringLiteral)("react-native-reanimated")
-          ]), (0, types_1.identifier)("getUseOfValueInStyleWarning")), [])
+      return (0, types_12.callExpression)((0, types_12.arrowFunctionExpression)([], (0, types_12.blockStatement)([
+        (0, types_12.expressionStatement)((0, types_12.callExpression)((0, types_12.memberExpression)((0, types_12.identifier)("console"), (0, types_12.identifier)("warn")), [
+          (0, types_12.callExpression)((0, types_12.memberExpression)((0, types_12.callExpression)((0, types_12.identifier)("require"), [
+            (0, types_12.stringLiteral)("react-native-reanimated")
+          ]), (0, types_12.identifier)("getUseOfValueInStyleWarning")), [])
         ])),
-        (0, types_1.returnStatement)(path.node)
+        (0, types_12.returnStatement)(path.node)
       ])), []);
     }
     function processPropertyValueForInlineStylesWarning(path) {
-      if (path.isMemberExpression() && (0, types_1.isIdentifier)(path.node.property)) {
+      if (path.isMemberExpression() && (0, types_12.isIdentifier)(path.node.property)) {
         if (path.node.property.name === "value") {
           path.replaceWith(generateInlineStylesWarning(path));
         }
       }
     }
     function processTransformPropertyForInlineStylesWarning(path) {
-      if ((0, types_1.isArrayExpression)(path.node)) {
+      if ((0, types_12.isArrayExpression)(path.node)) {
         const elements = path.get("elements");
         (0, assert_1.strict)(Array.isArray(elements), "[Reanimated] `elements` should be an array.");
         for (const element of elements) {
@@ -689,7 +709,7 @@ var require_processInlineStylesWarning = __commonJS({
       for (const property of properties) {
         if (property.isObjectProperty()) {
           const value = property.get("value");
-          if ((0, types_1.isIdentifier)(property.node.key) && property.node.key.name === "transform") {
+          if ((0, types_12.isIdentifier)(property.node.key) && property.node.key.name === "transform") {
             processTransformPropertyForInlineStylesWarning(value);
           } else {
             processPropertyValueForInlineStylesWarning(value);
@@ -707,7 +727,7 @@ var require_processInlineStylesWarning = __commonJS({
       if (path.node.name.name !== "style") {
         return;
       }
-      if (!(0, types_1.isJSXExpressionContainer)(path.node.value)) {
+      if (!(0, types_12.isJSXExpressionContainer)(path.node.value)) {
         return;
       }
       const expression = path.get("value").get("expression");
@@ -734,7 +754,7 @@ var require_isGestureHandlerEventCallback = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.isGestureHandlerEventCallback = void 0;
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     var gestureHandlerGestureObjects = /* @__PURE__ */ new Set([
       "Tap",
       "Pan",
@@ -763,23 +783,23 @@ var require_isGestureHandlerEventCallback = __commonJS({
       "onTouchesCancelled"
     ]);
     function isGestureHandlerEventCallback(path) {
-      return (0, types_1.isCallExpression)(path.parent) && (0, types_1.isExpression)(path.parent.callee) && isGestureObjectEventCallbackMethod(path.parent.callee);
+      return (0, types_12.isCallExpression)(path.parent) && (0, types_12.isExpression)(path.parent.callee) && isGestureObjectEventCallbackMethod(path.parent.callee);
     }
     exports2.isGestureHandlerEventCallback = isGestureHandlerEventCallback;
     function isGestureObjectEventCallbackMethod(exp) {
-      return (0, types_1.isMemberExpression)(exp) && (0, types_1.isIdentifier)(exp.property) && gestureHandlerBuilderMethods.has(exp.property.name) && containsGestureObject(exp.object);
+      return (0, types_12.isMemberExpression)(exp) && (0, types_12.isIdentifier)(exp.property) && gestureHandlerBuilderMethods.has(exp.property.name) && containsGestureObject(exp.object);
     }
     function containsGestureObject(exp) {
       if (isGestureObject(exp)) {
         return true;
       }
-      if ((0, types_1.isCallExpression)(exp) && (0, types_1.isMemberExpression)(exp.callee) && containsGestureObject(exp.callee.object)) {
+      if ((0, types_12.isCallExpression)(exp) && (0, types_12.isMemberExpression)(exp.callee) && containsGestureObject(exp.callee.object)) {
         return true;
       }
       return false;
     }
     function isGestureObject(exp) {
-      return (0, types_1.isCallExpression)(exp) && (0, types_1.isMemberExpression)(exp.callee) && (0, types_1.isIdentifier)(exp.callee.object) && exp.callee.object.name === "Gesture" && (0, types_1.isIdentifier)(exp.callee.property) && gestureHandlerGestureObjects.has(exp.callee.property.name);
+      return (0, types_12.isCallExpression)(exp) && (0, types_12.isMemberExpression)(exp.callee) && (0, types_12.isIdentifier)(exp.callee.object) && exp.callee.object.name === "Gesture" && (0, types_12.isIdentifier)(exp.callee.property) && gestureHandlerGestureObjects.has(exp.callee.property.name);
     }
   }
 });
@@ -790,7 +810,7 @@ var require_isLayoutAnimationCallback = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.isLayoutAnimationCallback = void 0;
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     var EntryExitAnimations = /* @__PURE__ */ new Set([
       "BounceIn",
       "BounceInDown",
@@ -922,19 +942,19 @@ var require_isLayoutAnimationCallback = __commonJS({
     ]);
     var LayoutAnimationsCallbacks = /* @__PURE__ */ new Set(["withCallback"]);
     function isLayoutAnimationCallback(path) {
-      return (0, types_1.isCallExpression)(path.parent) && (0, types_1.isExpression)(path.parent.callee) && isLayoutAnimationCallbackMethod(path.parent.callee);
+      return (0, types_12.isCallExpression)(path.parent) && (0, types_12.isExpression)(path.parent.callee) && isLayoutAnimationCallbackMethod(path.parent.callee);
     }
     exports2.isLayoutAnimationCallback = isLayoutAnimationCallback;
     function isLayoutAnimationCallbackMethod(exp) {
-      return (0, types_1.isMemberExpression)(exp) && (0, types_1.isIdentifier)(exp.property) && LayoutAnimationsCallbacks.has(exp.property.name) && isLayoutAnimationsChainableOrNewOperator(exp.object);
+      return (0, types_12.isMemberExpression)(exp) && (0, types_12.isIdentifier)(exp.property) && LayoutAnimationsCallbacks.has(exp.property.name) && isLayoutAnimationsChainableOrNewOperator(exp.object);
     }
     function isLayoutAnimationsChainableOrNewOperator(exp) {
-      if ((0, types_1.isIdentifier)(exp) && LayoutAnimations.has(exp.name)) {
+      if ((0, types_12.isIdentifier)(exp) && LayoutAnimations.has(exp.name)) {
         return true;
-      } else if ((0, types_1.isNewExpression)(exp) && (0, types_1.isIdentifier)(exp.callee) && LayoutAnimations.has(exp.callee.name)) {
+      } else if ((0, types_12.isNewExpression)(exp) && (0, types_12.isIdentifier)(exp.callee) && LayoutAnimations.has(exp.callee.name)) {
         return true;
       }
-      if ((0, types_1.isCallExpression)(exp) && (0, types_1.isMemberExpression)(exp.callee) && (0, types_1.isIdentifier)(exp.callee.property) && LayoutAnimationsChainableMethods.has(exp.callee.property.name) && isLayoutAnimationsChainableOrNewOperator(exp.callee.object)) {
+      if ((0, types_12.isCallExpression)(exp) && (0, types_12.isMemberExpression)(exp.callee) && (0, types_12.isIdentifier)(exp.callee.property) && LayoutAnimationsChainableMethods.has(exp.callee.property.name) && isLayoutAnimationsChainableOrNewOperator(exp.callee.object)) {
         return true;
       }
       return false;
@@ -947,16 +967,16 @@ var require_processIfCallback = __commonJS({
   "lib/processIfCallback.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processIfCallback = void 0;
+    exports2.processIfAutoworkletizableCallback = void 0;
     var isGestureHandlerEventCallback_1 = require_isGestureHandlerEventCallback();
-    var processIfWorkletFunction_1 = require_processIfWorkletFunction();
     var isLayoutAnimationCallback_1 = require_isLayoutAnimationCallback();
-    function processIfCallback(path, state) {
+    var processIfWorkletNode_12 = require_processIfWorkletNode();
+    function processIfAutoworkletizableCallback(path, state) {
       if ((0, isGestureHandlerEventCallback_1.isGestureHandlerEventCallback)(path) || (0, isLayoutAnimationCallback_1.isLayoutAnimationCallback)(path)) {
-        (0, processIfWorkletFunction_1.processIfWorkletFunction)(path, state);
+        (0, processIfWorkletNode_12.processWorklet)(path, state);
       }
     }
-    exports2.processIfCallback = processIfCallback;
+    exports2.processIfAutoworkletizableCallback = processIfAutoworkletizableCallback;
   }
 });
 
@@ -984,13 +1004,13 @@ var require_substituteWebCallExpression = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.substituteWebCallExpression = void 0;
-    var types_1 = require("@babel/types");
+    var types_12 = require("@babel/types");
     function substituteWebCallExpression(path) {
       const callee = path.node.callee;
-      if ((0, types_1.isIdentifier)(callee)) {
+      if ((0, types_12.isIdentifier)(callee)) {
         const name = callee.name;
         if (name === "isWeb" || name === "shouldBeUseWeb") {
-          path.replaceWith((0, types_1.booleanLiteral)(true));
+          path.replaceWith((0, types_12.booleanLiteral)(true));
         }
       }
     }
@@ -1001,6 +1021,7 @@ var require_substituteWebCallExpression = __commonJS({
 // lib/plugin.js
 Object.defineProperty(exports, "__esModule", { value: true });
 var processForCalleesWorklets_1 = require_processForCalleesWorklets();
+var types_1 = require_types();
 var processIfWorkletNode_1 = require_processIfWorkletNode();
 var processInlineStylesWarning_1 = require_processInlineStylesWarning();
 var processIfCallback_1 = require_processIfCallback();
@@ -1026,18 +1047,18 @@ module.exports = function() {
       CallExpression: {
         enter(path, state) {
           runWithTaggedExceptions(() => {
-            (0, processForCalleesWorklets_1.processForCalleesWorklets)(path, state);
+            (0, processForCalleesWorklets_1.autoworkletizeCalleesWorklets)(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               (0, substituteWebCallExpression_1.substituteWebCallExpression)(path);
             }
           });
         }
       },
-      "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression": {
+      [types_1.WorkletizableFunction]: {
         enter(path, state) {
           runWithTaggedExceptions(() => {
-            (0, processIfWorkletNode_1.processIfWorkletNode)(path, state);
-            (0, processIfCallback_1.processIfCallback)(path, state);
+            (0, processIfWorkletNode_1.processIfWithWorkletDirective)(path, state);
+            (0, processIfCallback_1.processIfAutoworkletizableCallback)(path, state);
           });
         }
       },

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -30,8 +30,7 @@ var require_types = __commonJS({
   "lib/types.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.isWorkletizableFunctionType = exports2.WorkletizableFunction = exports2.ExplicitWorklet = void 0;
-    exports2.ExplicitWorklet = "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression";
+    exports2.isWorkletizableFunctionType = exports2.WorkletizableFunction = void 0;
     exports2.WorkletizableFunction = "FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod";
     function isWorkletizableFunctionType(path) {
       return path.isFunctionDeclaration() || path.isFunctionExpression() || path.isArrowFunctionExpression() || path.isObjectMethod();
@@ -588,7 +587,7 @@ var require_processForCalleesWorklets = __commonJS({
   "lib/processForCalleesWorklets.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.autoworkletizeCalleesWorklets = void 0;
+    exports2.processCalleesAutoworkletizableCallbacks = void 0;
     var types_12 = require("@babel/types");
     var types_2 = require_types();
     var assert_1 = require("assert");
@@ -613,7 +612,7 @@ var require_processForCalleesWorklets = __commonJS({
       "useAnimatedGestureHandler",
       "useAnimatedScrollHandler"
     ]);
-    function autoworkletizeCalleesWorklets(path, state) {
+    function processCalleesAutoworkletizableCallbacks(path, state) {
       const callee = (0, types_12.isSequenceExpression)(path.node.callee) ? path.node.callee.expressions[path.node.callee.expressions.length - 1] : path.node.callee;
       const name = "name" in callee ? callee.name : "property" in callee && "name" in callee.property ? callee.property.name : void 0;
       if (name === void 0) {
@@ -637,7 +636,7 @@ var require_processForCalleesWorklets = __commonJS({
         processArguments(path, indices, state);
       }
     }
-    exports2.autoworkletizeCalleesWorklets = autoworkletizeCalleesWorklets;
+    exports2.processCalleesAutoworkletizableCallbacks = processCalleesAutoworkletizableCallbacks;
     function processObjectHook(path, state) {
       const properties = path.get("properties");
       for (const property of properties) {
@@ -1050,7 +1049,7 @@ module.exports = function() {
       CallExpression: {
         enter(path, state) {
           runWithTaggedExceptions(() => {
-            (0, processForCalleesWorklets_1.autoworkletizeCalleesWorklets)(path, state);
+            (0, processForCalleesWorklets_1.processCalleesAutoworkletizableCallbacks)(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               (0, substituteWebCallExpression_1.substituteWebCallExpression)(path);
             }

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -534,12 +534,13 @@ var require_processIfWorkletNode = __commonJS({
     var types_2 = require_types();
     function processIfWithWorkletDirective(path, state) {
       if (!(0, types_12.isBlockStatement)(path.node.body)) {
-        return;
+        return false;
       }
       if (!hasWorkletDirective(path.node.body.directives)) {
-        return;
+        return false;
       }
       processWorklet(path, state);
+      return true;
     }
     exports2.processIfWithWorkletDirective = processIfWithWorkletDirective;
     function processWorklet(path, state) {
@@ -974,7 +975,9 @@ var require_processIfCallback = __commonJS({
     function processIfAutoworkletizableCallback(path, state) {
       if ((0, isGestureHandlerEventCallback_1.isGestureHandlerEventCallback)(path) || (0, isLayoutAnimationCallback_1.isLayoutAnimationCallback)(path)) {
         (0, processIfWorkletNode_12.processWorklet)(path, state);
+        return true;
       }
+      return false;
     }
     exports2.processIfAutoworkletizableCallback = processIfAutoworkletizableCallback;
   }
@@ -1057,8 +1060,7 @@ module.exports = function() {
       [types_1.WorkletizableFunction]: {
         enter(path, state) {
           runWithTaggedExceptions(() => {
-            (0, processIfWorkletNode_1.processIfWithWorkletDirective)(path, state);
-            (0, processIfCallback_1.processIfAutoworkletizableCallback)(path, state);
+            (0, processIfWorkletNode_1.processIfWithWorkletDirective)(path, state) || (0, processIfCallback_1.processIfAutoworkletizableCallback)(path, state);
           });
         }
       },

--- a/plugin/src/isGestureHandlerEventCallback.ts
+++ b/plugin/src/isGestureHandlerEventCallback.ts
@@ -6,7 +6,7 @@ import {
   isMemberExpression,
   isExpression,
 } from '@babel/types';
-import type { ExplicitWorklet } from './types';
+import type { WorkletizableFunction } from './types';
 
 const gestureHandlerGestureObjects = new Set([
   'Tap',
@@ -84,7 +84,9 @@ const gestureHandlerBuilderMethods = new Set([
     arguments: [fun3]
   )
   */
-export function isGestureHandlerEventCallback(path: NodePath<ExplicitWorklet>) {
+export function isGestureHandlerEventCallback(
+  path: NodePath<WorkletizableFunction>
+): boolean {
   return (
     isCallExpression(path.parent) &&
     isExpression(path.parent.callee) &&
@@ -92,7 +94,7 @@ export function isGestureHandlerEventCallback(path: NodePath<ExplicitWorklet>) {
   );
 }
 
-function isGestureObjectEventCallbackMethod(exp: Expression) {
+function isGestureObjectEventCallbackMethod(exp: Expression): boolean {
   // Checks if node matches the pattern `Gesture.Foo()[*].onBar`
   // where `[*]` represents any number of method calls.
   return (
@@ -103,7 +105,7 @@ function isGestureObjectEventCallbackMethod(exp: Expression) {
   );
 }
 
-function containsGestureObject(exp: Expression) {
+function containsGestureObject(exp: Expression): boolean {
   // Checks if node matches the pattern `Gesture.Foo()[*]`
   // where `[*]` represents any number of chained method calls, like `.something(42)`.
 
@@ -124,7 +126,7 @@ function containsGestureObject(exp: Expression) {
   return false;
 }
 
-function isGestureObject(exp: Expression) {
+function isGestureObject(exp: Expression): boolean {
   // Checks if node matches `Gesture.Tap()` or similar.
   /*
   node: CallExpression(

--- a/plugin/src/isLayoutAnimationCallback.ts
+++ b/plugin/src/isLayoutAnimationCallback.ts
@@ -1,10 +1,5 @@
 import type { NodePath } from '@babel/core';
-import type {
-  FunctionDeclaration,
-  FunctionExpression,
-  ArrowFunctionExpression,
-  Expression,
-} from '@babel/types';
+import type { Expression } from '@babel/types';
 import {
   isIdentifier,
   isCallExpression,
@@ -12,6 +7,7 @@ import {
   isExpression,
   isNewExpression,
 } from '@babel/types';
+import type { WorkletizableFunction } from './types';
 
 const EntryExitAnimations = new Set([
   'BounceIn',
@@ -152,10 +148,8 @@ const LayoutAnimationsChainableMethods = new Set([
 const LayoutAnimationsCallbacks = new Set(['withCallback']);
 
 export function isLayoutAnimationCallback(
-  path: NodePath<
-    FunctionDeclaration | FunctionExpression | ArrowFunctionExpression
-  >
-) {
+  path: NodePath<WorkletizableFunction>
+): boolean {
   return (
     isCallExpression(path.parent) &&
     isExpression(path.parent.callee) &&
@@ -163,7 +157,7 @@ export function isLayoutAnimationCallback(
   );
 }
 
-function isLayoutAnimationCallbackMethod(exp: Expression) {
+function isLayoutAnimationCallbackMethod(exp: Expression): boolean {
   return (
     isMemberExpression(exp) &&
     isIdentifier(exp.property) &&
@@ -172,7 +166,7 @@ function isLayoutAnimationCallbackMethod(exp: Expression) {
   );
 }
 
-function isLayoutAnimationsChainableOrNewOperator(exp: Expression) {
+function isLayoutAnimationsChainableOrNewOperator(exp: Expression): boolean {
   if (isIdentifier(exp) && LayoutAnimations.has(exp.name)) {
     return true;
   } else if (

--- a/plugin/src/makeWorklet.ts
+++ b/plugin/src/makeWorklet.ts
@@ -47,7 +47,7 @@ import { isRelease } from './utils';
 const REAL_VERSION = require('../../package.json').version;
 const MOCK_VERSION = 'x.y.z';
 
-export function makeWorklet(
+export function makeWorkletFactory(
   fun: NodePath<WorkletizableFunction>,
   state: ReanimatedPluginPass
 ): FunctionExpression {
@@ -287,7 +287,7 @@ export function makeWorklet(
   return newFun;
 }
 
-function removeWorkletDirective(fun: NodePath<WorkletizableFunction>) {
+function removeWorkletDirective(fun: NodePath<WorkletizableFunction>): void {
   fun.traverse({
     DirectiveLiteral(path) {
       if (path.node.value === 'worklet' && path.getFunctionParent() === fun) {
@@ -297,13 +297,13 @@ function removeWorkletDirective(fun: NodePath<WorkletizableFunction>) {
   });
 }
 
-function shouldMockVersion() {
+function shouldMockVersion(): boolean {
   // We don't want to pollute tests with current version number so we mock it
   // for all tests (except one)
   return process.env.REANIMATED_JEST_SHOULD_MOCK_VERSION === '1';
 }
 
-function hash(str: string) {
+function hash(str: string): number {
   let i = str.length;
   let hash1 = 5381;
   let hash2 = 52711;
@@ -320,7 +320,7 @@ function hash(str: string) {
   return (hash1 >>> 0) * 4096 + (hash2 >>> 0);
 }
 
-function makeWorkletName(fun: NodePath<WorkletizableFunction>) {
+function makeWorkletName(fun: NodePath<WorkletizableFunction>): string {
   if (isObjectMethod(fun.node) && isIdentifier(fun.node.key)) {
     return fun.node.key.name;
   }
@@ -336,7 +336,7 @@ function makeWorkletName(fun: NodePath<WorkletizableFunction>) {
 function makeArrayFromCapturedBindings(
   ast: BabelFile,
   fun: NodePath<WorkletizableFunction>
-) {
+): Identifier[] {
   const closure = new Map<string, Identifier>();
   const isLocationAssignedMap = new Map<string, boolean>();
 

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -1,10 +1,11 @@
 import type { PluginItem, NodePath } from '@babel/core';
 import type { CallExpression } from '@babel/types';
-import { processForCalleesWorklets } from './processForCalleesWorklets';
-import type { ExplicitWorklet, ReanimatedPluginPass } from './types';
-import { processIfWorkletNode } from './processIfWorkletNode';
+import { autoworkletizeCalleesWorklets } from './processForCalleesWorklets';
+import { WorkletizableFunction } from './types';
+import type { ReanimatedPluginPass } from './types';
+import { processIfWithWorkletDirective } from './processIfWorkletNode';
 import { processInlineStylesWarning } from './processInlineStylesWarning';
-import { processIfCallback } from './processIfCallback';
+import { processIfAutoworkletizableCallback } from './processIfCallback';
 import { addCustomGlobals } from './addCustomGlobals';
 import { initializeGlobals } from './globals';
 import { substituteWebCallExpression } from './substituteWebCallExpression';
@@ -29,18 +30,21 @@ module.exports = function (): PluginItem {
       CallExpression: {
         enter(path: NodePath<CallExpression>, state: ReanimatedPluginPass) {
           runWithTaggedExceptions(() => {
-            processForCalleesWorklets(path, state);
+            autoworkletizeCalleesWorklets(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               substituteWebCallExpression(path);
             }
           });
         },
       },
-      'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression': {
-        enter(path: NodePath<ExplicitWorklet>, state: ReanimatedPluginPass) {
+      [WorkletizableFunction]: {
+        enter(
+          path: NodePath<WorkletizableFunction>,
+          state: ReanimatedPluginPass
+        ) {
           runWithTaggedExceptions(() => {
-            processIfWorkletNode(path, state);
-            processIfCallback(path, state);
+            processIfWithWorkletDirective(path, state);
+            processIfAutoworkletizableCallback(path, state);
           });
         },
       },

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -43,8 +43,8 @@ module.exports = function (): PluginItem {
           state: ReanimatedPluginPass
         ) {
           runWithTaggedExceptions(() => {
-            processIfWithWorkletDirective(path, state);
-            processIfAutoworkletizableCallback(path, state);
+            processIfWithWorkletDirective(path, state) ||
+              processIfAutoworkletizableCallback(path, state);
           });
         },
       },

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -1,6 +1,6 @@
 import type { PluginItem, NodePath } from '@babel/core';
 import type { CallExpression } from '@babel/types';
-import { autoworkletizeCalleesWorklets } from './processForCalleesWorklets';
+import { processCalleesAutoworkletizableCallbacks } from './processForCalleesWorklets';
 import { WorkletizableFunction } from './types';
 import type { ReanimatedPluginPass } from './types';
 import { processIfWithWorkletDirective } from './processIfWorkletNode';
@@ -30,7 +30,7 @@ module.exports = function (): PluginItem {
       CallExpression: {
         enter(path: NodePath<CallExpression>, state: ReanimatedPluginPass) {
           runWithTaggedExceptions(() => {
-            autoworkletizeCalleesWorklets(path, state);
+            processCalleesAutoworkletizableCallbacks(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               substituteWebCallExpression(path);
             }

--- a/plugin/src/processForCalleesWorklets.ts
+++ b/plugin/src/processForCalleesWorklets.ts
@@ -1,10 +1,10 @@
 import type { NodePath } from '@babel/core';
 import type { CallExpression, ObjectExpression } from '@babel/types';
 import { isSequenceExpression } from '@babel/types';
+import { isWorkletizableFunctionType } from './types';
 import type { ReanimatedPluginPass } from './types';
-import { processWorkletObjectMethod } from './processWorkletObjectMethod';
-import { processIfWorkletFunction } from './processIfWorkletFunction';
 import { strict as assert } from 'assert';
+import { processWorklet } from './processIfWorkletNode';
 
 const functionArgsToWorkletize = new Map([
   ['useFrameCallback', [0]],
@@ -30,10 +30,10 @@ const objectHooks = new Set([
   'useAnimatedScrollHandler',
 ]);
 
-export function processForCalleesWorklets(
+export function autoworkletizeCalleesWorklets(
   path: NodePath<CallExpression>,
   state: ReanimatedPluginPass
-) {
+): void {
   const callee = isSequenceExpression(path.node.callee)
     ? path.node.callee.expressions[path.node.callee.expressions.length - 1]
     : path.node.callee;
@@ -51,17 +51,19 @@ export function processForCalleesWorklets(
   }
 
   if (objectHooks.has(name)) {
-    const workletToProcess = path.get('arguments.0');
+    const maybeWorklet = path.get('arguments.0');
     assert(
-      !Array.isArray(workletToProcess),
+      !Array.isArray(maybeWorklet),
       '[Reanimated] `workletToProcess` is an array.'
     );
-    if (workletToProcess.isObjectExpression()) {
-      processObjectHook(workletToProcess, state);
+    if (maybeWorklet.isObjectExpression()) {
+      processObjectHook(maybeWorklet, state);
       // useAnimatedScrollHandler can take a function as an argument instead of an ObjectExpression
       // but useAnimatedGestureHandler can't
     } else if (name === 'useAnimatedScrollHandler') {
-      processIfWorkletFunction(workletToProcess, state);
+      if (isWorkletizableFunctionType(maybeWorklet)) {
+        processWorklet(maybeWorklet, state);
+      }
     }
   } else {
     const indices = functionArgsToWorkletize.get(name);
@@ -75,17 +77,19 @@ export function processForCalleesWorklets(
 function processObjectHook(
   path: NodePath<ObjectExpression>,
   state: ReanimatedPluginPass
-) {
+): void {
   const properties = path.get('properties');
   for (const property of properties) {
     if (property.isObjectMethod()) {
-      processWorkletObjectMethod(property, state);
+      processWorklet(property, state);
     } else if (property.isObjectProperty()) {
       const value = property.get('value');
-      processIfWorkletFunction(value, state);
+      if (isWorkletizableFunctionType(value)) {
+        processWorklet(value, state);
+      }
     } else {
       throw new Error(
-        `[Reanimated] '${property.type}' as to-be workletized arguments is not supported for object hooks.`
+        `[Reanimated] '${property.type}' as to-be workletized argument is not supported for object hooks.`
       );
     }
   }
@@ -95,14 +99,16 @@ function processArguments(
   path: NodePath<CallExpression>,
   indices: number[],
   state: ReanimatedPluginPass
-) {
+): void {
   const argumentsArray = path.get('arguments');
   indices.forEach((index) => {
-    const argumentToWorkletize = argumentsArray[index];
-    if (!argumentToWorkletize) {
+    const maybeWorklet = argumentsArray[index];
+    if (!maybeWorklet) {
       // workletizable argument doesn't always have to be specified
       return;
     }
-    processIfWorkletFunction(argumentToWorkletize, state);
+    if (isWorkletizableFunctionType(maybeWorklet)) {
+      processWorklet(maybeWorklet, state);
+    }
   });
 }

--- a/plugin/src/processForCalleesWorklets.ts
+++ b/plugin/src/processForCalleesWorklets.ts
@@ -30,7 +30,7 @@ const objectHooks = new Set([
   'useAnimatedScrollHandler',
 ]);
 
-export function autoworkletizeCalleesWorklets(
+export function processCalleesAutoworkletizableCallbacks(
   path: NodePath<CallExpression>,
   state: ReanimatedPluginPass
 ): void {

--- a/plugin/src/processIfCallback.ts
+++ b/plugin/src/processIfCallback.ts
@@ -1,14 +1,14 @@
 import type { NodePath } from '@babel/core';
 import { isGestureHandlerEventCallback } from './isGestureHandlerEventCallback';
-import { processIfWorkletFunction } from './processIfWorkletFunction';
 import { isLayoutAnimationCallback } from './isLayoutAnimationCallback';
-import type { ExplicitWorklet, ReanimatedPluginPass } from './types';
+import type { ReanimatedPluginPass, WorkletizableFunction } from './types';
+import { processWorklet } from './processIfWorkletNode';
 
-export function processIfCallback(
-  path: NodePath<ExplicitWorklet>,
+export function processIfAutoworkletizableCallback(
+  path: NodePath<WorkletizableFunction>,
   state: ReanimatedPluginPass
-) {
+): void {
   if (isGestureHandlerEventCallback(path) || isLayoutAnimationCallback(path)) {
-    processIfWorkletFunction(path, state);
+    processWorklet(path, state);
   }
 }

--- a/plugin/src/processIfCallback.ts
+++ b/plugin/src/processIfCallback.ts
@@ -4,11 +4,17 @@ import { isLayoutAnimationCallback } from './isLayoutAnimationCallback';
 import type { ReanimatedPluginPass, WorkletizableFunction } from './types';
 import { processWorklet } from './processIfWorkletNode';
 
+/**
+ *
+ * @returns `true` if the function was workletized, `false` otherwise.
+ */
 export function processIfAutoworkletizableCallback(
   path: NodePath<WorkletizableFunction>,
   state: ReanimatedPluginPass
-): void {
+): boolean {
   if (isGestureHandlerEventCallback(path) || isLayoutAnimationCallback(path)) {
     processWorklet(path, state);
+    return true;
   }
+  return false;
 }

--- a/plugin/src/processIfWorkletFunction.ts
+++ b/plugin/src/processIfWorkletFunction.ts
@@ -1,40 +1,25 @@
 import type { NodePath } from '@babel/core';
-import {
-  callExpression,
-  isScopable,
-  isExportNamedDeclaration,
-  variableDeclaration,
-  variableDeclarator,
-} from '@babel/types';
-import type { ExplicitWorklet, ReanimatedPluginPass } from './types';
-import { makeWorklet } from './makeWorklet';
+import { callExpression } from '@babel/types';
+import type { CallExpression } from '@babel/types';
+import type { ReanimatedPluginPass, WorkletizableFunction } from './types';
+import { makeWorkletFactory } from './makeWorklet';
 
-/**
- * Replaces `FunctionDeclaration`, `FunctionExpression` or `ArrowFunctionExpression`
- * with a workletized version of itself.
- */
-export function processIfWorkletFunction(
-  path: NodePath,
+export function makeWorkletFactoryCall(
+  path: NodePath<WorkletizableFunction>,
   state: ReanimatedPluginPass
-) {
-  if (
-    path.isFunctionDeclaration() ||
-    path.isFunctionExpression() ||
-    path.isArrowFunctionExpression()
-  ) {
-    processWorkletFunction(path, state);
-  }
-}
-
-function processWorkletFunction(
-  path: NodePath<ExplicitWorklet>,
-  state: ReanimatedPluginPass
-) {
-  const workletFactory = makeWorklet(path, state);
+): CallExpression {
+  const workletFactory = makeWorkletFactory(path, state);
 
   const workletFactoryCall = callExpression(workletFactory, []);
 
-  /* 
+  addStackTraceDataToWorkletFactory(path, workletFactoryCall);
+
+  const replacement = workletFactoryCall;
+
+  return replacement;
+}
+
+/* 
   If for some reason the code of the worklet is so bad that it
   causes the worklet factory to crash, eg.:
 
@@ -50,6 +35,10 @@ function processWorkletFunction(
   crashing on the factory leads to its end on the stack trace - the closing bracket. It's more
   approachable this way, when it points to the start of the original function.
   */
+function addStackTraceDataToWorkletFactory(
+  path: NodePath<WorkletizableFunction>,
+  workletFactoryCall: CallExpression
+): void {
   const originalWorkletLocation = path.node.loc;
   if (originalWorkletLocation) {
     workletFactoryCall.callee.loc = {
@@ -57,21 +46,4 @@ function processWorkletFunction(
       end: originalWorkletLocation.start,
     };
   }
-
-  // we check if function needs to be assigned to variable declaration.
-  // This is needed if function definition directly in a scope. Some other ways
-  // where function definition can be used is for example with variable declaration:
-  // const ggg = function foo() { }
-  // ^ in such a case we don't need to define variable for the function
-  const needDeclaration =
-    isScopable(path.parent) || isExportNamedDeclaration(path.parent);
-
-  const replacement =
-    'id' in path.node && path.node.id && needDeclaration
-      ? variableDeclaration('const', [
-          variableDeclarator(path.node.id, workletFactoryCall),
-        ])
-      : workletFactoryCall;
-
-  path.replaceWith(replacement);
 }

--- a/plugin/src/processIfWorkletNode.ts
+++ b/plugin/src/processIfWorkletNode.ts
@@ -1,52 +1,123 @@
 import type { NodePath } from '@babel/core';
-import { isBlockStatement, isDirectiveLiteral } from '@babel/types';
-import type { BlockStatement } from '@babel/types';
-import { processIfWorkletFunction } from './processIfWorkletFunction';
-import type { ExplicitWorklet, ReanimatedPluginPass } from './types';
+import {
+  isBlockStatement,
+  isDirectiveLiteral,
+  objectProperty,
+  variableDeclaration,
+  variableDeclarator,
+  isScopable,
+  isExportNamedDeclaration,
+} from '@babel/types';
+import type {
+  Directive,
+  ObjectMethod,
+  CallExpression,
+  FunctionDeclaration,
+} from '@babel/types';
+import { makeWorkletFactoryCall } from './processIfWorkletFunction';
+import type { ReanimatedPluginPass } from './types';
+import { WorkletizableFunction } from './types';
 
-function hasWorkletDirective(directives: BlockStatement['directives']) {
-  return (
-    directives &&
-    directives.length > 0 &&
-    directives.some(
-      (directive) =>
-        isDirectiveLiteral(directive.value) &&
-        directive.value.value === 'worklet'
-    )
+export function processIfWithWorkletDirective(
+  path: NodePath<WorkletizableFunction>,
+  state: ReanimatedPluginPass
+): void {
+  if (!isBlockStatement(path.node.body)) {
+    // If the function body is not a block statement we can safely assume that it's not a worklet
+    // since it's the case of an arrow function with immediate return
+    // eg. `const foo = () => 1;`
+    return;
+  }
+  if (!hasWorkletDirective(path.node.body.directives)) {
+    return;
+  }
+  processWorklet(path, state);
+}
+
+/**
+ * Replaces
+ * - `FunctionDeclaration`,
+ * - `FunctionExpression`,
+ * - `ArrowFunctionExpression`
+ * - `ObjectMethod`
+ *
+ * with a workletized version of itself.
+ */
+export function processWorklet(
+  path: NodePath<WorkletizableFunction>,
+  state: ReanimatedPluginPass
+): void {
+  if (state.opts.processNestedWorklets) {
+    path.traverse(
+      {
+        // @ts-expect-error TypeScript doesn't like this syntax here.
+        [WorkletizableFunction](
+          subPath: NodePath<WorkletizableFunction>,
+          passedState: ReanimatedPluginPass
+        ): void {
+          processIfWithWorkletDirective(subPath, passedState);
+        },
+      },
+      state
+    );
+  }
+
+  const workletFactoryCall = makeWorkletFactoryCall(path, state);
+
+  substituteWithWorkletFactoryCall(path, workletFactoryCall);
+}
+
+function hasWorkletDirective(directives: Directive[]): boolean {
+  return directives.some(
+    (directive) =>
+      isDirectiveLiteral(directive.value) && directive.value.value === 'worklet'
   );
 }
 
-export function processIfWorkletNode(
-  fun: NodePath<ExplicitWorklet>,
-  state: ReanimatedPluginPass
-) {
-  let shouldBeProcessed = false;
-  fun.traverse({
-    DirectiveLiteral(path) {
-      const value = path.node.value;
-      if (value === 'worklet' && isBlockStatement(fun.node.body)) {
-        const parent = path.getFunctionParent();
-        if (parent === fun) {
-          // make sure "worklet" is listed among directives for the fun
-          // this is necessary as because of some bug, babel will attempt to
-          // process replaced function if it is nested inside another function
-          const directives = fun.node.body.directives;
-
-          shouldBeProcessed = hasWorkletDirective(directives);
-        } else if (
-          state.opts.processNestedWorklets &&
-          // use better function for that once proper merges come to life
-          (parent?.isFunctionDeclaration() ||
-            parent?.isFunctionExpression() ||
-            parent?.isArrowFunctionExpression())
-        ) {
-          processIfWorkletNode(parent, state);
-        }
-      }
-    },
-  });
-
-  if (shouldBeProcessed) {
-    processIfWorkletFunction(fun, state);
+function substituteWithWorkletFactoryCall(
+  path: NodePath<WorkletizableFunction>,
+  workletFactoryCall: CallExpression
+): void {
+  if (path.isObjectMethod()) {
+    substituteObjectMethodWithObjectProperty(path, workletFactoryCall);
+  } else if (path.isFunctionDeclaration()) {
+    maybeSubstituteFunctionDeclarationWithVariableDeclaration(
+      path,
+      workletFactoryCall
+    );
+  } else {
+    path.replaceWith(workletFactoryCall);
   }
+}
+
+export function substituteObjectMethodWithObjectProperty(
+  path: NodePath<ObjectMethod>,
+  workletFactoryCall: CallExpression
+): void {
+  const replacement = objectProperty(path.node.key, workletFactoryCall);
+  path.replaceWith(replacement);
+}
+
+export function maybeSubstituteFunctionDeclarationWithVariableDeclaration(
+  path: NodePath<FunctionDeclaration>,
+  workletFactoryCall: CallExpression
+): void {
+  // We check if function needs to be assigned to variable declaration.
+  // This is needed if function definition directly in a scope. Some other ways
+  // where function definition can be used is for example with variable declaration:
+  //
+  // const bar = function foo() {'worklet' ...};
+  //
+  // In such a case we don't need to define variable for the function.
+  const needDeclaration =
+    isScopable(path.parent) || isExportNamedDeclaration(path.parent);
+
+  const replacement =
+    'id' in path.node && path.node.id && needDeclaration
+      ? variableDeclaration('const', [
+          variableDeclarator(path.node.id, workletFactoryCall),
+        ])
+      : workletFactoryCall;
+
+  path.replaceWith(replacement);
 }

--- a/plugin/src/processIfWorkletNode.ts
+++ b/plugin/src/processIfWorkletNode.ts
@@ -18,20 +18,25 @@ import { makeWorkletFactoryCall } from './processIfWorkletFunction';
 import type { ReanimatedPluginPass } from './types';
 import { WorkletizableFunction } from './types';
 
+/**
+ *
+ * @returns `true` if the function was workletized, `false` otherwise.
+ */
 export function processIfWithWorkletDirective(
   path: NodePath<WorkletizableFunction>,
   state: ReanimatedPluginPass
-): void {
+): boolean {
   if (!isBlockStatement(path.node.body)) {
     // If the function body is not a block statement we can safely assume that it's not a worklet
     // since it's the case of an arrow function with immediate return
     // eg. `const foo = () => 1;`
-    return;
+    return false;
   }
   if (!hasWorkletDirective(path.node.body.directives)) {
-    return;
+    return false;
   }
   processWorklet(path, state);
+  return true;
 }
 
 /**

--- a/plugin/src/processWorkletObjectMethod.ts
+++ b/plugin/src/processWorkletObjectMethod.ts
@@ -8,19 +8,19 @@ import {
   callExpression,
 } from '@babel/types';
 import type { ReanimatedPluginPass } from './types';
-import { makeWorklet } from './makeWorklet';
+import { makeWorkletFactory } from './makeWorklet';
 
 export function processWorkletObjectMethod(
   path: NodePath<ObjectMethod>,
   state: ReanimatedPluginPass
-) {
+): void {
   // Replaces ObjectMethod with a workletized version of itself.
 
   if (!isFunctionParent(path)) {
     return;
   }
 
-  const newFun = makeWorklet(path, state);
+  const newFun = makeWorkletFactory(path, state);
 
   const replacement = objectProperty(
     identifier(isIdentifier(path.node.key) ? path.node.key.name : ''),

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,4 +1,4 @@
-import type { BabelFile } from '@babel/core';
+import type { BabelFile, NodePath } from '@babel/core';
 import type {
   FunctionDeclaration,
   FunctionExpression,
@@ -26,9 +26,25 @@ export interface ReanimatedPluginPass {
   [key: string]: unknown;
 }
 
-export type ExplicitWorklet =
+export const ExplicitWorklet =
+  'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression';
+
+export type WorkletizableFunction =
   | FunctionDeclaration
   | FunctionExpression
-  | ArrowFunctionExpression;
+  | ArrowFunctionExpression
+  | ObjectMethod;
 
-export type WorkletizableFunction = ExplicitWorklet | ObjectMethod;
+export const WorkletizableFunction =
+  'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod';
+
+export function isWorkletizableFunctionType(
+  path: NodePath
+): path is NodePath<WorkletizableFunction> {
+  return (
+    path.isFunctionDeclaration() ||
+    path.isFunctionExpression() ||
+    path.isArrowFunctionExpression() ||
+    path.isObjectMethod()
+  );
+}

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -26,9 +26,6 @@ export interface ReanimatedPluginPass {
   [key: string]: unknown;
 }
 
-export const ExplicitWorklet =
-  'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression';
-
 export type WorkletizableFunction =
   | FunctionDeclaration
   | FunctionExpression


### PR DESCRIPTION
## Summary

Fixes #5555.

Currently, when transforming functions with a `'worklet'` directive we are only looking for:

1. FunctionDeclaration
```ts
function foo(){'worklet'}
```

2. FunctionExpression
```ts
const foo = function (){'worklet'}}
```

3. ArrowFunctionExpression
```ts
const foo = () => {'worklet'};
```

And not taking into consideration ObjectMethod:

4.
```ts
const foo = {
  bar() {'worklet'}
}
```

This PR fixes that and does a slight refactor of the upper control flow and renames some functions.

This wasn't an issue before because plugins used in Expo and React Native used to transform ObjectMethods to ObjectProperties:

```ts
const foo {
  bar: function() {'worklet'}
}
```

But it's no longer always the case.

## Test plan

Added a step to the CI if our App is actually bundling properly and added a test.

## Note

I'm considering changing the names of relevant files afterwards, but in this PR it would just be too messy I think.
