### PR TITLE
Update CI deps

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -37,7 +37,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build-next-example.yml
+++ b/.github/workflows/build-next-example.yml
@@ -17,7 +17,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Reanimated node_modules
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build-npm-package-action.yml
+++ b/.github/workflows/build-npm-package-action.yml
@@ -25,25 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Clear annotations
         run: scripts/clear-annotations.sh
 
       - name: Set up JDK 11
+        if: ${{ inputs.ref == 'Reanimated2' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
 
       - name: Install NDK
+        if: ${{ inputs.ref == 'Reanimated2' }}
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
@@ -83,7 +85,7 @@ jobs:
       - run: echo "PACKAGE_NAME=$(ls -l | egrep -o "react-native-reanimated-(.*)(=?\.tgz)")" >> $GITHUB_ENV
 
       - name: Upload npm package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}
           path: '*.tgz'
@@ -94,7 +96,7 @@ jobs:
 
       - name: Upload Android build folder
         if: ${{ inputs.upload_binaries }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-build-output
           path: android-build-output.zip

--- a/.github/workflows/build-v8-nightly.yml
+++ b/.github/workflows/build-v8-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'reanimated_repo'
       - name: Create React Native app

--- a/.github/workflows/check-TS-react-native.yml
+++ b/.github/workflows/check-TS-react-native.yml
@@ -20,9 +20,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
       - name: Clear annotations

--- a/.github/workflows/check-expo-dev-client-nightly.yml
+++ b/.github/workflows/check-expo-dev-client-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out reanimated repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'reanimated_repo'
       - name: Create Expo app
@@ -61,7 +61,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out reanimated repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'reanimated_repo'
       - name: Create Expo app

--- a/.github/workflows/close-when-stale.yml
+++ b/.github/workflows/close-when-stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable

--- a/.github/workflows/detect-broken-urls-nightly.yml
+++ b/.github/workflows/detect-broken-urls-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn add node-fetch@2
       - name: Validate urls

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -17,11 +17,10 @@ jobs:
       WORKING_DIRECTORY: docs
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
           cache: 'yarn'
       - name: Clear annotations
         run: scripts/clear-annotations.sh

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -41,7 +41,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore Reanimated node_modules from cache
         uses: actions/cache@v3

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -37,7 +37,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore Reanimated node_modules from cache
         uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate awesome content
         run: >-

--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -14,7 +14,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -20,11 +20,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
           cache: 'yarn'
       - name: Clear annotations
         run: scripts/clear-annotations.sh

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -16,11 +16,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
           cache: 'yarn'
       - name: Clear annotations
         run: scripts/clear-annotations.sh

--- a/.github/workflows/tvos-build.yml
+++ b/.github/workflows/tvos-build.yml
@@ -33,7 +33,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore Reanimated node_modules from cache
         uses: actions/cache@v3

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/validate-ios.yml
+++ b/.github/workflows/validate-ios.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository == 'software-mansion/react-native-reanimated'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Lint iOS
         run: yarn lint:ios

--- a/.github/workflows/validate-java.yml
+++ b/.github/workflows/validate-java.yml
@@ -24,11 +24,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
           cache: 'yarn'
       - name: Clear annotations
         run: scripts/clear-annotations.sh

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -22,11 +22,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
           cache: 'yarn'
       - name: Clear annotations
         run: scripts/clear-annotations.sh


### PR DESCRIPTION
## Summary

This PR updated CI dependencies to get rid off following warnings:
![Screenshot 2024-01-25 at 14 20 52](https://github.com/software-mansion/react-native-reanimated/assets/36106620/605453c0-2765-416d-b455-4a235e352468)

Contains update for:
- actions/checkout
- actions/setup-node
- actions/upload-artifact

I also removed node version specification where it isn't necessary.

## Test plan

See at CI output