### PR TITLE
Capture exiting element snapshot only right before hiding it to preve…

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -49,7 +49,6 @@ import {
   tryActivateLayoutTransition,
   configureWebLayoutAnimations,
   getReducedMotionFromConfig,
-  saveSnapshot,
 } from '../reanimated2/layoutReanimation/web';
 import { updateLayoutAnimations } from '../reanimated2/UpdateLayoutAnimations';
 import type { CustomConfig } from '../reanimated2/layoutReanimation/web/config';
@@ -165,10 +164,6 @@ export function createAnimatedComponent(
       }
 
       if (IS_WEB) {
-        if (this.props.exiting) {
-          saveSnapshot(this._component as HTMLElement);
-        }
-
         if (
           !this.props.entering ||
           getReducedMotionFromConfig(this.props.entering as CustomConfig)
@@ -470,10 +465,6 @@ export function createAnimatedComponent(
       this._reattachNativeEvents(prevProps);
       this._attachAnimatedStyles();
       this._InlinePropManager.attachInlineProps(this, this._getViewInfo());
-
-      if (IS_WEB && this.props.exiting) {
-        saveSnapshot(this._component as HTMLElement);
-      }
 
       // Snapshot won't be undefined because it comes from getSnapshotBeforeUpdate method
       if (

--- a/src/createAnimatedComponent/utils.ts
+++ b/src/createAnimatedComponent/utils.ts
@@ -33,3 +33,20 @@ export const has = <K extends string>(
   }
   return false;
 };
+
+type DisposableCallback<T extends (...args: any[]) => any> = {
+  (...args: Parameters<T>): ReturnType<T>;
+  dispose: () => void;
+};
+export function disposableCallback<T extends (...args: any[]) => any>(
+  callback: T
+) {
+  let disposed = false;
+  const wrapped = ((...args: Parameters<T>) =>
+    callback(...args)) as DisposableCallback<T>;
+  wrapped.dispose = () => {
+    disposed = true;
+  };
+
+  return wrapped;
+}

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -133,7 +133,8 @@ export function startWebLayoutAnimation<
   props: Readonly<AnimatedComponentProps<ComponentProps>>,
   element: HTMLElement,
   animationType: LayoutAnimationType,
-  transitionData?: TransitionData
+  transitionData?: TransitionData,
+  onAnimationEnd?: (finished: boolean) => void
 ) {
   const maybeAnimationConfigWithTransform = tryGetAnimationConfigWithTransform(
     props,
@@ -145,7 +146,13 @@ export function startWebLayoutAnimation<
 
     chooseAction(
       animationType,
-      animationConfig,
+      {
+        ...animationConfig,
+        callback: (finished) => {
+          animationConfig.callback?.(finished);
+          onAnimationEnd?.(finished);
+        },
+      },
       element,
       transitionData as TransitionData,
       transform

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -127,6 +127,10 @@ export function getProcessedConfig(
   };
 }
 
+export function saveSnapshot(element: HTMLElement) {
+  snapshots.set(element, element.getBoundingClientRect());
+}
+
 export function setElementAnimation(
   element: HTMLElement,
   animationConfig: AnimationConfig,
@@ -218,7 +222,7 @@ export function handleExitingAnimation(
   const dummy = element.cloneNode() as ReanimatedHTMLElement;
   dummy.reanimatedDummy = true;
 
-  const snapshot = element.getBoundingClientRect();
+  const snapshot = snapshots.get(element) ?? element.getBoundingClientRect();
 
   element.style.animationName = '';
   // We hide current element so only its copy with proper animation will be displayed

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -127,10 +127,6 @@ export function getProcessedConfig(
   };
 }
 
-export function saveSnapshot(element: HTMLElement) {
-  snapshots.set(element, element.getBoundingClientRect());
-}
-
 export function setElementAnimation(
   element: HTMLElement,
   animationConfig: AnimationConfig,
@@ -222,6 +218,8 @@ export function handleExitingAnimation(
   const dummy = element.cloneNode() as ReanimatedHTMLElement;
   dummy.reanimatedDummy = true;
 
+  const snapshot = element.getBoundingClientRect();
+
   element.style.animationName = '';
   // We hide current element so only its copy with proper animation will be displayed
   element.style.visibility = 'hidden';
@@ -238,7 +236,6 @@ export function handleExitingAnimation(
   setElementAnimation(dummy, animationConfig);
   parent?.appendChild(dummy);
 
-  const snapshot = snapshots.get(element)!;
   snapshots.set(dummy, snapshot);
 
   setDummyPosition(dummy, snapshot);

--- a/src/reanimated2/layoutReanimation/web/index.ts
+++ b/src/reanimated2/layoutReanimation/web/index.ts
@@ -5,6 +5,6 @@ export {
   tryActivateLayoutTransition,
 } from './animationsManager';
 
-export { getReducedMotionFromConfig, saveSnapshot } from './componentUtils';
+export { getReducedMotionFromConfig } from './componentUtils';
 
 export { configureWebLayoutAnimations } from './domUtils';

--- a/src/reanimated2/layoutReanimation/web/index.ts
+++ b/src/reanimated2/layoutReanimation/web/index.ts
@@ -5,6 +5,6 @@ export {
   tryActivateLayoutTransition,
 } from './animationsManager';
 
-export { getReducedMotionFromConfig } from './componentUtils';
+export { getReducedMotionFromConfig, saveSnapshot } from './componentUtils';
 
 export { configureWebLayoutAnimations } from './domUtils';


### PR DESCRIPTION
…nt enforcing (browser) layout on each render

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Current implementation of saving snapshot on each component update causes browser to re-layout elements with defined 'exiting' animations. This is caused by .getBoundingClientRect() called in each componentDidUpdate.

Moreover, component might not necessarily update, but its bounding client rect might have changed due to ancestor (of some level) layout change, that did not cause element to render (e.g. due to memo).

Getting component "snapshot" (boundingClientRect) right before hiding element seems to be enough, and has no significant performance overhead.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Motivation: performance optimization, removing unnecessary overhead.

## Test plan

I will provide repo for tests later.

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
