### PR TITLE
Android reloads

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -227,7 +227,6 @@ public abstract class NativeProxyCommon {
 
   public void onCatalystInstanceDestroy() {
     mAndroidUIScheduler.deactivate();
-    getHybridData().resetNative();
   }
 
   public void prepareLayoutAnimations(LayoutAnimations layoutAnimations) {


### PR DESCRIPTION
## Summary

The purpose of this PR is to address crashes on Android that occur after the application is reloaded. The application can be reloaded in debug mode by pressing the `r` key in the Metro console, or in release mode after an over-the-air update.
The main cause of the crashes after reload is the reference to deallocated native parts of the hybrid object, specifically NativeProxy.

https://github.com/software-mansion/react-native-reanimated/assets/36106620/6c2ba48e-6344-4acc-9de0-d0b25629a7cc

To resolve this issue, the PR removes the call to `getHybridData().resetNative()`, which invokes the destructor of the native part of the hybrid object. The problem arises because the Java part of object can still be used by the React Native runtime. The simplest way to prevent crashes is to avoid manually calling the destructor and letting React Native handle it.

**However**, React Native doesn't always clean up all objects properly. The `onCatalystInstanceDestroy` method is not called for every created instance of Native Module, which can potentially result in memory leaks after the application is reloaded. An attempt was made to fix these memory leaks in a separate branch ([found here](https://github.com/software-mansion/react-native-reanimated/tree/%40piaskowyk/android-reload-fix)), but it proved difficult to prevent React Native from using the module after the native parts of the hybrid objects were destructed. 😕

Fixes https://github.com/software-mansion/react-native-reanimated/issues/4786
Related to: https://github.com/software-mansion/react-native-reanimated/pull/5198
