### PR TITLE
Fix MacOSExample unable to bundle

### DIFF
--- a/MacOSExample/babel.config.js
+++ b/MacOSExample/babel.config.js
@@ -10,6 +10,6 @@ module.exports = {
         },
       },
     ],
-    [['../plugin', {processNestedWorklets: true}]],
+    ['../plugin', {processNestedWorklets: true}],
   ],
 };


### PR DESCRIPTION
## Summary

This PR resolves the following error when trying to bundle MacOSExample:

![Screenshot 2024-02-04 at 12 29 26](https://github.com/software-mansion/react-native-reanimated/assets/20516055/59365926-7fe4-4a9c-aad2-73c45d460113)

## Test plan
