### PR TITLE
Fix olympic example

### DIFF
--- a/app/src/examples/LayoutAnimations/OlympicAnimation.tsx
+++ b/app/src/examples/LayoutAnimations/OlympicAnimation.tsx
@@ -77,27 +77,27 @@ export default function OlympicAnimation() {
     from: {
       zIndex: 2,
       opacity: 1,
-      transform: [{ translateX: -13 }, { translateY: 0 }, { scale: 1 }],
+      transform: [{ translateX: 0 }, { translateY: 0 }, { scale: 1 }],
     },
     10: {
       opacity: 1,
-      transform: [{ translateX: 22 }, { translateY: 30 }, { scale: 1 }],
+      transform: [{ translateX: 35 }, { translateY: 30 }, { scale: 1 }],
     },
     20: {
       opacity: 1,
-      transform: [{ translateX: 57 }, { translateY: 0 }, { scale: 1 }],
+      transform: [{ translateX: 70 }, { translateY: 0 }, { scale: 1 }],
     },
     30: {
       opacity: 1,
-      transform: [{ translateX: 92 }, { translateY: 30 }, { scale: 1 }],
+      transform: [{ translateX: 105 }, { translateY: 30 }, { scale: 1 }],
     },
     40: {
       opacity: 1,
-      transform: [{ translateX: 127 }, { translateY: 0 }, { scale: 1 }],
+      transform: [{ translateX: 140 }, { translateY: 0 }, { scale: 1 }],
     },
     50: {
       opacity: 1,
-      transform: [{ translateX: 57 }, { translateY: 0 }, { scale: 1 }],
+      transform: [{ translateX: 70 }, { translateY: 0 }, { scale: 1 }],
     },
     60: {
       opacity: 0,
@@ -157,17 +157,18 @@ export default function OlympicAnimation() {
         <View>
           <Animated.View
             entering={blueRingAnimation}
-            exiting={blueRingExitAnimation}
-            style={{ transform: [{ translateX: -13 }] }}>
-            <Svg width={500} height={500}>
-              <Path
-                fill="none"
-                stroke="#2A5AA6"
-                strokeWidth={5}
-                strokeMiterlimit={10}
-                d="M106.9 180.7c6.3-14.9 23.4-21.9 38.3-15.6 14.9 6.3 21.9 23.4 15.6 38.3-6.3 14.9-23.4 21.9-38.3 15.6-10.8-4.6-17.9-15.2-17.9-26.9 0-3.9.8-7.8 2.3-11.4"
-              />
-            </Svg>
+            exiting={blueRingExitAnimation}>
+            <View style={{ transform: [{ translateX: -13 }] }}>
+              <Svg width={500} height={500}>
+                <Path
+                  fill="none"
+                  stroke="#2A5AA6"
+                  strokeWidth={5}
+                  strokeMiterlimit={10}
+                  d="M106.9 180.7c6.3-14.9 23.4-21.9 38.3-15.6 14.9 6.3 21.9 23.4 15.6 38.3-6.3 14.9-23.4 21.9-38.3 15.6-10.8-4.6-17.9-15.2-17.9-26.9 0-3.9.8-7.8 2.3-11.4"
+                />
+              </Svg>
+            </View>
           </Animated.View>
           <Animated.View
             entering={yellowRingAnimation}


### PR DESCRIPTION
## Summary
We had a warning in olympic example
>[Reanimated] Property "transform" of AnimatedComponent(View) may be overwritten with layout animation. Please create a wrapper with the layout animation you want to apply.

It was a correct warning, since we actually want to overwrite transform, yet I am getting rid of it with a wrapper

https://github.com/software-mansion/react-native-reanimated/assets/56199675/fe463d94-bb38-4dac-ab15-dfc44578d860


## Test plan
