### PR TITLE
Fix `remoteState` in `useAnimatedStyle`

### DIFF
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -2,7 +2,7 @@
 import type { MutableRefObject } from 'react';
 import { useEffect, useRef } from 'react';
 
-import { startMapper, stopMapper } from '../core';
+import { makeShareable, startMapper, stopMapper } from '../core';
 import updateProps, { updatePropsJestWrapper } from '../UpdateProps';
 import { initialUpdaterRun } from '../animation';
 import { useSharedValue } from './useSharedValue';
@@ -460,12 +460,12 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
         value: initialStyle,
         updater,
       },
-      remoteState: {
+      remoteState: makeShareable({
         last: initialStyle,
         animations: {},
         isAnimationCancelled: false,
         isAnimationRunning: false,
-      },
+      }),
       viewDescriptors: makeViewDescriptorsSet(),
     };
   }

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -329,8 +329,12 @@ export function makeShareableCloneOnUIRecursive<T>(
   return cloneRecursive(value);
 }
 
-export function makeShareable<T extends object>(value: T): T {
-  if (SHOULD_BE_USE_WEB) {
+function makeShareableJS<T extends object>(value: T): T {
+  return value;
+}
+
+function makeShareableNative<T extends object>(value: T): T {
+  if (shareableMappingCache.get(value)) {
     return value;
   }
   const handle = makeShareableCloneRecursive({
@@ -342,3 +346,12 @@ export function makeShareable<T extends object>(value: T): T {
   shareableMappingCache.set(value, handle);
   return value;
 }
+
+/**
+ * This function creates a value on UI with persistent state - changes to it on the UI
+ * thread will be seen by all worklets. Use it when you want to create a value
+ * that is read and written only on the UI thread.
+ */
+export const makeShareable = SHOULD_BE_USE_WEB
+  ? makeShareableJS
+  : makeShareableNative;


### PR DESCRIPTION
## Summary

When we merged #5518 we weren't aware that the mechanism of `ShareableHandles` (objects with `__init` worklet property) are memoized on UI thread with the use of `std::unique_ptr` and a map. Because of that `remoteState` currently resets to its initial state after `dependencies` change. This happens, because:

- worklet is stateful during one call of `runOnUI`,
- `startMapper` calls `runOnUI` exactly once,
- worklet has access to its state and can change it (and access changed state) as long as the mapper runs,
- when `dependencies` change, mapper is stopped and started again, so another `runOnUI` is called and previous state is lost
- worklet starts with initial instead 

## Test plan

<details>
<summary>
Test code
</summary>

```tsx
import React from 'react';
import { StyleSheet, View, Button } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withTiming,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const [render, setRender] = React.useState(0);
  const [deps, setDeps] = React.useState(0);
  const sv = useSharedValue(100);

  const animatedStyle = useAnimatedStyle(() => ({ width: sv.value }), [deps]);

  function handleRerender() {
    console.log('Rerendering');
    setRender((prev) => prev + 1);
  }

  function handleChangeDeps() {
    console.log('Changing deps & Re-rendering');
    setDeps((prev) => prev + 1);
  }

  function handleAnimate() {
    sv.value = withTiming(Math.random() * 100 + 50, { duration: 1000 });
  }

  return (
    <View style={styles.container}>
      <Button title="Rerender" onPress={handleRerender} />
      <Button title="Animate" onPress={handleAnimate} />
      <Button title="Change deps" onPress={handleChangeDeps} />
      <Animated.View style={[styles.box, animatedStyle]} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  box: {
    height: 100,
    backgroundColor: 'red',
  },
});
```

</details>

Add this to `useAnimatedStyle`:

```diff
diff --git a/src/reanimated2/hook/useAnimatedStyle.ts b/src/reanimated2/hook/useAnimatedStyle.ts
index d6d015572..18dd46d17 100644
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -505,6 +505,7 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
     } else {
       fun = () => {
         'worklet';
+        console.log(remoteState.last);
         styleUpdater(
           shareableViewDescriptors,
           updaterFn,
```



|Before|After|
|--|--|
|![Screenshot 2024-02-07 at 18 20 03](https://github.com/software-mansion/react-native-reanimated/assets/40713406/47e0c24f-e1f2-49d6-8afb-f3c45cffa0e8)|![Screenshot 2024-02-07 at 18 21 15](https://github.com/software-mansion/react-native-reanimated/assets/40713406/e9f27133-3923-4c3f-a4a9-a80eecc535a0)|



