### PR TITLE
Fix worklet directive in `HSVtoRGB`

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -498,7 +498,7 @@ export function RGBtoHSV(r: number, g: number, b: number): HSV {
  * @returns \{r: red (0-255), g: green (0-255), b: blue (0-255)\}
  */
 function HSVtoRGB(h: number, s: number, v: number): RGB {
-  ('worklet');
+  'worklet';
   let r, g, b;
 
   const i = Math.floor(h * 6);


### PR DESCRIPTION
## Summary

This PR fixes syntax of `'worklet'` directive in HSVtoRGB function. Introduced accidentally here: https://github.com/software-mansion/react-native-reanimated/pull/5482

![Screenshot 2024-02-08 at 12 44 38](https://github.com/software-mansion/react-native-reanimated/assets/36106620/899c6f7a-323e-465f-ad19-c03d347defb3)

## Test plan

Open Color Interpolate example
