### PR TITLE
Add option to autoworkletize function on user request

### DIFF
--- a/plugin/.eslintrc.js
+++ b/plugin/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
   ],
   rules: {
     'curly': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   ignorePatterns: ['**/*.d.ts','jestUtils.ts']};

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -813,7 +813,7 @@ var require_autoworkletization = __commonJS({
   "lib/autoworkletization.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.processCalleesAutoworkletizableCallbacks = exports2.processIfAutoworkletizableCallback = void 0;
+    exports2.processCalleesAutoworkletizableCallbacks = exports2.processIfAutoworkletizableCallback = exports2.processIfRequestedWorkletization = void 0;
     var types_12 = require("@babel/types");
     var types_2 = require_types();
     var assert_1 = require("assert");
@@ -840,6 +840,27 @@ var require_autoworkletization = __commonJS({
       "useAnimatedGestureHandler",
       "useAnimatedScrollHandler"
     ]);
+    function processIfRequestedWorkletization(path, state) {
+      var _a;
+      if (!state.opts.autoworkletizationRequests || !state.filename || !path.isFunctionDeclaration()) {
+        return false;
+      }
+      const functionName = (_a = path.node.id) === null || _a === void 0 ? void 0 : _a.name;
+      if (!functionName) {
+        return false;
+      }
+      const filename = Object.keys(state.opts.autoworkletizationRequests).find((key) => state.filename.includes(key));
+      if (!filename) {
+        return false;
+      }
+      const requests = state.opts.autoworkletizationRequests[filename];
+      if (requests.includes(functionName)) {
+        (0, workletSubstitution_12.processWorklet)(path, state);
+        return true;
+      }
+      return false;
+    }
+    exports2.processIfRequestedWorkletization = processIfRequestedWorkletization;
     function processIfAutoworkletizableCallback(path, state) {
       if ((0, gestureHandlerAutoworkletization_1.isGestureHandlerEventCallback)(path) || (0, layoutAnimationAutoworkletization_1.isLayoutAnimationCallback)(path)) {
         (0, workletSubstitution_12.processWorklet)(path, state);
@@ -1042,7 +1063,7 @@ module.exports = function() {
       [types_1.WorkletizableFunction]: {
         enter(path, state) {
           runWithTaggedExceptions(() => {
-            (0, workletSubstitution_1.processIfWithWorkletDirective)(path, state) || (0, autoworkletization_1.processIfAutoworkletizableCallback)(path, state);
+            (0, workletSubstitution_1.processIfWithWorkletDirective)(path, state) || (0, autoworkletization_1.processIfAutoworkletizableCallback)(path, state) || (0, autoworkletization_1.processIfRequestedWorkletization)(path, state);
           });
         }
       },

--- a/plugin/src/autoworkletization.ts
+++ b/plugin/src/autoworkletization.ts
@@ -32,6 +32,36 @@ const objectHooks = new Set([
   'useAnimatedScrollHandler',
 ]);
 
+export function processIfRequestedWorkletization(
+  path: NodePath<WorkletizableFunction>,
+  state: ReanimatedPluginPass
+): boolean {
+  if (
+    !state.opts.autoworkletizationRequests ||
+    !state.filename ||
+    !path.isFunctionDeclaration()
+  ) {
+    return false;
+  }
+  const functionName = path.node.id?.name;
+  if (!functionName) {
+    return false;
+  }
+  const filename = Object.keys(state.opts.autoworkletizationRequests).find(
+    (key) => state.filename!.includes(key)
+  );
+  if (!filename) {
+    return false;
+  }
+  const requests = state.opts.autoworkletizationRequests[filename];
+  if (requests.includes(functionName)) {
+    processWorklet(path, state);
+    return true;
+  }
+
+  return false;
+}
+
 /**
  *
  * @returns `true` if the function was workletized, `false` otherwise.

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -3,6 +3,7 @@ import type { CallExpression } from '@babel/types';
 import {
   processIfAutoworkletizableCallback,
   processCalleesAutoworkletizableCallbacks,
+  processIfRequestedWorkletization,
 } from './autoworkletization';
 import { WorkletizableFunction } from './types';
 import type { ReanimatedPluginPass } from './types';
@@ -46,7 +47,8 @@ module.exports = function (): PluginItem {
         ) {
           runWithTaggedExceptions(() => {
             processIfWithWorkletDirective(path, state) ||
-              processIfAutoworkletizableCallback(path, state);
+              processIfAutoworkletizableCallback(path, state) ||
+              processIfRequestedWorkletization(path, state);
           });
         },
       },

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -13,6 +13,7 @@ export interface ReanimatedPluginOptions {
   omitNativeOnlyData?: boolean;
   globals?: string[];
   substituteWebPlatformChecks?: boolean;
+  autoworkletizationRequests?: Record<string, string[]>;
 }
 
 export interface ReanimatedPluginPass {


### PR DESCRIPTION
## Summary

This is a feature that will allow the user to workletize specific functions requested by the user, without the need to add `worklet` directive in them. It's done through new Babel plugin option - `autoworkletizationRequests`. This property is an object of the following structure:

```js
{
  nameOfTheFileWithFunctionsToWorkletize1: [
    'functionToWorkletizeInThatFile1',
    'functionToWorkletizeInThatFile2',
    'functionToWorkletizeInThatFile3',
  ],
  nameOfAnotherFileWithFunctionsToWorkletize2: [
    'anotherFunction',
  ],
}
```

Listed functions in given files will become autoworkletized.

## Example usage

For a file:

```js
// file.js
function autoworkletizeMe() {
  'worklet';
  console.log('Thank you for autoworkletizing me!');
}
```

Add this to your `babel.config.js`:

```js
plugins: [
      'react-native-reanimated/plugin',
      {
        autoworkletizationRequests: {
          file: ['autoworkletizeMe'],
        },
      },
    ]
```

## Notes

### What will get autoworkletized

Currently only function declarations will get autoworkletized, namely:

```js
function foo(){}; // OK
const foo = function foo(){}; // OK
const foo = function (){}; // NOT OK
const foo = () => {}; // NOT OK
const obj = {
  foo(){}; // NOT OK
}
```

This will probably change in the future to support more cases, but as a PoC I stay with function declarations only.

### How to make requests

At the moment try to use the longer possible path for the filename, e.g.
if you have a file

`src/something/else/other/file.js`

use as much of the path as possible (keeping in mind building your dist files etc.) so you don't accidentally workletize functions with the same names in the same files. Excess autoworkletization is not harmful to your code, but might unnecessarily inflate its size in the bundle.

## Test plan

Perform the steps in [Example usage](#example-usage), follow with
`yarn babel file.js --compact=false -o file.out.js`
and see in the output file that it got autoworkletized.

Relevant unit tests for plugin will be added later on.

If you want to help test this solution in your project, you can install Reanimated from this tarball
[react-native-reanimated-3.7.0-20240215104724.tgz](https://github.com/software-mansion/react-native-reanimated/files/14295724/react-native-reanimated-3.7.0-20240215104724.tgz)
with (e.g.) `yarn add ./react-native-reanimated-3.7.0-20240215104724.tgz`