### PR TITLE
Extract remote function logic from value unpacker

### DIFF
--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -256,12 +256,14 @@ class ShareableRemoteFunction
       public std::enable_shared_from_this<ShareableRemoteFunction> {
  private:
   jsi::Runtime *runtime_;
+  const std::string name_;
   std::unique_ptr<jsi::Value> function_;
 
  public:
   ShareableRemoteFunction(jsi::Runtime &rt, jsi::Function &&function)
       : Shareable(RemoteFunctionType),
         runtime_(&rt),
+        name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
         function_(std::make_unique<jsi::Value>(rt, std::move(function))) {}
 
   ~ShareableRemoteFunction() {

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -55,13 +55,6 @@ function valueUnpacker(objectToUnpack: any, category?: string): any {
       handleCache.set(objectToUnpack, value);
     }
     return value;
-  } else if (category === 'RemoteFunction') {
-    const fun = () => {
-      throw new Error(`[Reanimated] Tried to synchronously call a non-worklet function on the UI thread.
-See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#tried-to-synchronously-call-a-non-worklet-function-on-the-ui-thread\` for more details.`);
-    };
-    fun.__remoteFunction = objectToUnpack;
-    return fun;
   } else {
     throw new Error('[Reanimated] Data type not recognized by value unpacker.');
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Remote functions from RN runtime passed or captured into worklets cannot be directly called in the UI runtime, instead they need to be wrapped with `runOnJS` to schedule an async call.

For better developer experience, when the function is called directly without `runOnJS`, we throw an error with developer-friendly actionable message. This behavior this is implemented in `valueUnpacker`, a utility function used when converting C++ shareable into JS value.

However, this function is implemented in JS and thus we need to pass its source code through multiple layers of native code which is cumbersome. Also, `valueUnpacker` has been causing some problems recently (see #5660).

This PR moves the logic behind creation of remote function wrappers from JS `valueUnpacker` directly into C++ `ShareableRemoteFunction::toJSValue`.

Additionally, I made a change to include the function name to the error message so it's easier for the developer to find out which function is causing troubles:

<img width="492" alt="Screenshot 2024-02-19 at 14 03 08" src="https://github.com/software-mansion/react-native-reanimated/assets/20516055/2b38ac7c-f5e0-45d0-bc43-06075bf9005e">

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
