### PR TITLE
Extract initializer logic from value unpacker

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -248,7 +248,8 @@ static inline jsi::Object getHandleCache(jsi::Runtime &rt) {
   constexpr auto key = "__handleCache";
   auto value = rt.global().getProperty(rt, key);
   if (value.isUndefined()) {
-    value = rt.global().getPropertyAsFunction(rt, "WeakMap").callAsConstructor(rt);
+    value =
+        rt.global().getPropertyAsFunction(rt, "WeakMap").callAsConstructor(rt);
     rt.global().setProperty(rt, key, value);
   }
   return value.asObject(rt);
@@ -258,14 +259,20 @@ jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
   if (initializer_ != nullptr) {
     auto initializerValue = initializer_->getJSValue(rt);
     auto handleCache = getHandleCache(rt);
-    auto remoteValue = handleCache.getPropertyAsFunction(rt, "get").callWithThis(rt, handleCache, initializerValue);
+    auto remoteValue =
+        handleCache.getPropertyAsFunction(rt, "get").callWithThis(
+            rt, handleCache, initializerValue);
     if (remoteValue.isUndefined()) {
-      remoteValue = initializerValue.asObject(rt).getPropertyAsFunction(rt, "__init").call(rt);
-      handleCache.getPropertyAsFunction(rt, "set").callWithThis(rt, handleCache, initializerValue, remoteValue);
+      remoteValue = initializerValue.asObject(rt)
+                        .getPropertyAsFunction(rt, "__init")
+                        .call(rt);
+      handleCache.getPropertyAsFunction(rt, "set").callWithThis(
+          rt, handleCache, initializerValue, remoteValue);
     }
     remoteValue_ = std::make_unique<jsi::Value>(std::move(remoteValue));
     remoteRuntime_ = &rt;
-    initializer_ = nullptr; // we can release ref to initializer since __init should be called at most once
+    initializer_ = nullptr; // we can release ref to initializer since __init
+                            // should be called at most once
   }
   return jsi::Value(rt, *remoteValue_);
 }

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -48,13 +48,6 @@ function valueUnpacker(objectToUnpack: any, category?: string): any {
     const functionInstance = workletFun.bind(objectToUnpack);
     objectToUnpack._recur = functionInstance;
     return functionInstance;
-  } else if (objectToUnpack.__init) {
-    let value = handleCache.get(objectToUnpack);
-    if (value === undefined) {
-      value = objectToUnpack.__init();
-      handleCache.set(objectToUnpack, value);
-    }
-    return value;
   } else if (category === 'RemoteFunction') {
     const fun = () => {
       throw new Error(`[Reanimated] Tried to synchronously call a non-worklet function on the UI thread.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR moves the logic behind creation of remote function wrappers from JS `valueUnpacker` directly into C++ `ShareableHandle::toJSValue`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
