### PR TITLE
Extract worklet logic from value unpacker

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -1,5 +1,7 @@
 #include "Shareables.h"
 
+#include <sstream>
+
 using namespace facebook;
 
 namespace reanimated {
@@ -218,15 +220,80 @@ jsi::Value ShareableHostFunction::toJSValue(jsi::Runtime &rt) {
       rt, jsi::PropNameID::forUtf8(rt, name_), paramCount_, hostFunction_);
 }
 
+static inline jsi::Object getWorkletsCache(jsi::Runtime &rt) {
+  constexpr auto key = "__workletsCache";
+  auto value = rt.global().getProperty(rt, key);
+  if (value.isUndefined()) {
+    value = rt.global().getPropertyAsFunction(rt, "Map").callAsConstructor(rt);
+    rt.global().setProperty(rt, key, value);
+  }
+  return value.asObject(rt);
+}
+
 jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
+  const auto obj = ShareableObject::toJSValue(rt).asObject(rt);
+
+  const auto workletHash = obj.getProperty(rt, "__workletHash");
   assert(
-      std::any_of(
-          data_.cbegin(),
-          data_.cend(),
-          [](const auto &item) { return item.first == "__workletHash"; }) &&
-      "ShareableWorklet doesn't have `__workletHash` property");
-  jsi::Value obj = ShareableObject::toJSValue(rt);
-  return getValueUnpacker(rt).call(rt, obj);
+      !workletHash.isUndefined() &&
+      "[Reanimated] `__workletHash` property not found");
+
+  const auto workletsCache = getWorkletsCache(rt);
+  auto workletFun = workletsCache.getPropertyAsFunction(rt, "get").callWithThis(
+      rt, workletsCache, obj);
+  if (workletFun.isUndefined()) {
+    const auto initData = obj.getPropertyAsObject(rt, "__initData");
+
+    const auto code = initData.getProperty(rt, "code");
+    std::stringstream ss;
+    ss << '(' << code.asString(rt).utf8(rt) << "\n)";
+    const auto wrappedCode = jsi::String::createFromUtf8(rt, ss.str());
+
+    const auto location = initData.getProperty(rt, "location");
+    const auto sourceMap = initData.getProperty(rt, "sourceMap");
+
+    const auto evalWithSourceMap =
+        rt.global().getProperty(rt, "evalWithSourceMap");
+    if (!evalWithSourceMap.isUndefined()) {
+      // if the runtime (hermes only for now) supports loading source maps
+      // we want to use the proper filename for the location as it guarantees
+      // that debugger understands and loads the source code of the file where
+      // the worklet is defined.
+      // TODO: call HermesRuntime::evaluateJavaScriptWithSourceMap directly
+      workletFun = evalWithSourceMap.asObject(rt).asFunction(rt).call(
+          rt, wrappedCode, location, sourceMap);
+    } else {
+      const auto evalWithSourceUrl =
+          rt.global().getProperty(rt, "evalWithSourceUrl");
+      if (!evalWithSourceUrl.isUndefined()) {
+        // if the runtime doesn't support loading source maps, in dev mode we
+        // can pass source url when evaluating the worklet. Now, instead of
+        // using the actual file location we use worklet hash, as it the allows
+        // us to properly symbolicate traces (see errors.ts for details)
+        // TODO: call jsi::Runtime::evaluateJavaScript directly
+        std::stringstream sourceURL;
+        sourceURL << "worklet_"
+                  << static_cast<uint64_t>(workletHash.asNumber());
+        workletFun = evalWithSourceUrl.asObject(rt).asFunction(rt).call(
+            rt, wrappedCode, sourceURL.str());
+      } else {
+        // in release we use the regular eval to save on JSI calls
+        // TODO: call jsi::Runtime::evaluateJavaScript directly
+        workletFun =
+            rt.global().getPropertyAsFunction(rt, "eval").call(rt, wrappedCode);
+      }
+    }
+
+    workletsCache.getPropertyAsFunction(rt, "set").callWithThis(
+        rt, workletsCache, workletHash, workletFun);
+  }
+
+  auto functionInstance = workletFun.asObject(rt)
+                              .getPropertyAsFunction(rt, "bind")
+                              .callWithThis(rt, workletFun.asObject(rt), obj);
+  obj.setProperty(rt, "_recur", functionInstance);
+
+  return functionInstance;
 }
 
 jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {

--- a/src/reanimated2/globals.d.ts
+++ b/src/reanimated2/globals.d.ts
@@ -92,7 +92,6 @@ declare global {
   var console: Console;
   var __frameTimestamp: number | undefined;
   var __flushAnimationFrame: (timestamp: number) => void;
-  var __workletsCache: Map<string, any>;
   var __handleCache: WeakMap<object, any>;
   var __callMicrotasks: () => void;
   var __mapperRegistry: MapperRegistry;

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -5,50 +5,12 @@ import type { WorkletFunction } from './commonTypes';
 
 function valueUnpacker(objectToUnpack: any, category?: string): any {
   'worklet';
-  let workletsCache = global.__workletsCache;
   let handleCache = global.__handleCache;
-  if (workletsCache === undefined) {
+  if (handleCache === undefined) {
     // init
-    workletsCache = global.__workletsCache = new Map();
     handleCache = global.__handleCache = new WeakMap();
   }
-  const workletHash = objectToUnpack.__workletHash;
-  if (workletHash !== undefined) {
-    let workletFun = workletsCache.get(workletHash);
-    if (workletFun === undefined) {
-      const initData = objectToUnpack.__initData;
-      if (global.evalWithSourceMap) {
-        // if the runtime (hermes only for now) supports loading source maps
-        // we want to use the proper filename for the location as it guarantees
-        // that debugger understands and loads the source code of the file where
-        // the worklet is defined.
-        workletFun = global.evalWithSourceMap(
-          '(' + initData.code + '\n)',
-          initData.location,
-          initData.sourceMap
-        ) as (...args: any[]) => any;
-      } else if (global.evalWithSourceUrl) {
-        // if the runtime doesn't support loading source maps, in dev mode we
-        // can pass source url when evaluating the worklet. Now, instead of using
-        // the actual file location we use worklet hash, as it the allows us to
-        // properly symbolicate traces (see errors.ts for details)
-        workletFun = global.evalWithSourceUrl(
-          '(' + initData.code + '\n)',
-          `worklet_${workletHash}`
-        ) as (...args: any[]) => any;
-      } else {
-        // in release we use the regular eval to save on JSI calls
-        // eslint-disable-next-line no-eval
-        workletFun = eval('(' + initData.code + '\n)') as (
-          ...args: any[]
-        ) => any;
-      }
-      workletsCache.set(workletHash, workletFun);
-    }
-    const functionInstance = workletFun.bind(objectToUnpack);
-    objectToUnpack._recur = functionInstance;
-    return functionInstance;
-  } else if (objectToUnpack.__init) {
+  if (objectToUnpack.__init) {
     let value = handleCache.get(objectToUnpack);
     if (value === undefined) {
       value = objectToUnpack.__init();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR moves the logic behind creation of worklets from JS `valueUnpacker` directly into C++ `ShareableWorklet::toJSValue`.

It's a step towards removing `valueUnpacker` which has been causing some problems recently (see #5660).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
