### PR TITLE
[Example] Fix counter being editable

### DIFF
--- a/app/src/examples/CounterExample.tsx
+++ b/app/src/examples/CounterExample.tsx
@@ -35,7 +35,11 @@ export default function CounterExample() {
       <View style={styles.buttons}>
         <Button onPress={handleToggle} title="Toggle" />
       </View>
-      <AnimatedTextInput animatedProps={animatedProps} style={styles.text} />
+      <AnimatedTextInput
+        animatedProps={animatedProps}
+        style={styles.text}
+        editable={false}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

Currently the counter is editable - meaning, the user can put in some value from keyboard - which doesn't make a lot of sense.

## Test plan

🔢 
