### PR TITLE
Remove redundant `object is object` type guard in `isPlainJSObject`

### DIFF
--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -31,7 +31,7 @@ function isHostObject(value: NonNullable<object>) {
   return MAGIC_KEY in value;
 }
 
-function isPlainJSObject(object: object): object is object {
+function isPlainJSObject(object: object) {
   return Object.getPrototypeOf(object) === Object.prototype;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

No need to use type guard `object is object` since the argument is already of type `object`.

## Test plan

Check if TypeScript CIs pass.