### PR TITLE
Use `useMemo` in `useViewRefSet`

### DIFF
--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { useRef } from 'react';
+import { useMemo } from 'react';
 import { makeMutable } from './core';
 import type { SharedValue } from './commonTypes';
 import type { Descriptor } from './hook/commonTypes';
@@ -64,22 +64,18 @@ function useViewRefSetNative() {
 }
 
 function useViewRefSetJS<T>(): ViewRefSet<T> {
-  const ref = useRef<ViewRefSet<T> | null>(null);
-  if (ref.current === null) {
-    const data: ViewRefSet<T> = {
-      items: new Set(),
-
+  const viewRefSet = useMemo(
+    () => ({
+      items: new Set<T>(),
       add: (item: T) => {
-        if (data.items.has(item)) return;
-        data.items.add(item);
+        viewRefSet.items.add(item);
       },
-
       remove: (item: T) => {
-        data.items.delete(item);
+        viewRefSet.items.delete(item);
       },
-    };
-    ref.current = data;
-  }
+    }),
+    []
+  );
 
-  return ref.current;
+  return viewRefSet;
 }

--- a/src/reanimated2/ViewDescriptorsSet.ts
+++ b/src/reanimated2/ViewDescriptorsSet.ts
@@ -64,7 +64,7 @@ function useViewRefSetNative() {
 }
 
 function useViewRefSetJS<T>(): ViewRefSet<T> {
-  const viewRefSet = useMemo(
+  const viewRefSet = useMemo<ViewRefSet<T>>(
     () => ({
       items: new Set<T>(),
       add: (item: T) => {


### PR DESCRIPTION
## Summary

This PR is a part of #5731.

## Test plan

Use the following and see that no exceptions are thrown in WebExample (this change doesn't affect Native).

<details>
<summary>
testing diff
</summary>

```patch
diff --git a/src/reanimated2/hook/useAnimatedStyle.ts b/src/reanimated2/hook/useAnimatedStyle.ts
index 6b74e82cb..49d631944 100644
--- a/src/reanimated2/hook/useAnimatedStyle.ts
+++ b/src/reanimated2/hook/useAnimatedStyle.ts
@@ -424,6 +424,12 @@ export function useAnimatedStyle<Style extends DefaultStyle>(
   isAnimatedProps = false
 ): AnimatedStyleHandle<Style> | JestAnimatedStyleHandle<Style> {
   const viewsRef: ViewRefSet<unknown> | undefined = useViewRefSet();
+  const viewsRefRef = useRef(viewsRef);
+  if (viewsRefRef.current !== viewsRef) {
+    throw new Error('TEST FAILED');
+  } else {
+    console.log('TEST PASSED');
+  }
   const animatedUpdaterData = useRef<AnimatedUpdaterData>();
   let inputs = Object.values(updater.__closure ?? {});
   if (SHOULD_BE_USE_WEB) {
```

</details>
