### PR TITLE
Add `useLayoutWorklet` hook

### DIFF
--- a/app/src/examples/EmptyExample.tsx
+++ b/app/src/examples/EmptyExample.tsx
@@ -1,11 +1,29 @@
-import { Text, StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Button } from 'react-native';
 
+import Animated, { useLayoutWorklet } from 'react-native-reanimated';
 import React from 'react';
 
+function noop() {}
+
 export default function EmptyExample() {
+  const [width, setWidth] = React.useState(100);
+
+  const onLayoutWorklet = useLayoutWorklet((layout) => {
+    console.log(_WORKLET, layout);
+  });
+
   return (
     <View style={styles.container}>
-      <Text>Hello world!</Text>
+      <Animated.View
+        style={[styles.box, { width }]}
+        onLayout={noop}
+        // @ts-expect-error TODO
+        thisCanBeAnything={onLayoutWorklet}
+      />
+      <Button
+        title="change width"
+        onPress={() => setWidth(Math.random() * 300)}
+      />
     </View>
   );
 }
@@ -15,5 +33,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  box: {
+    height: 100,
+    backgroundColor: 'red',
   },
 });

--- a/plugin/build/plugin.js
+++ b/plugin/build/plugin.js
@@ -831,6 +831,7 @@ var require_autoworkletization = __commonJS({
       ["createAnimatedPropAdapter", [0]],
       ["useDerivedValue", [0]],
       ["useAnimatedScrollHandler", [0]],
+      ["useLayoutWorklet", [0]],
       ["useAnimatedReaction", [0, 1]],
       ["useWorkletCallback", [0]],
       ["withTiming", [2]],
@@ -863,7 +864,7 @@ var require_autoworkletization = __commonJS({
         (0, assert_1.strict)(!Array.isArray(maybeWorklet), "[Reanimated] `workletToProcess` is an array.");
         if (maybeWorklet.isObjectExpression()) {
           processObjectHook(maybeWorklet, state);
-        } else if (name === "useAnimatedScrollHandler") {
+        } else if (name === "useAnimatedScrollHandler" || name === "useLayoutWorklet") {
           if ((0, types_2.isWorkletizableFunctionType)(maybeWorklet)) {
             (0, workletSubstitution_12.processWorklet)(maybeWorklet, state);
           }

--- a/plugin/src/autoworkletization.ts
+++ b/plugin/src/autoworkletization.ts
@@ -15,6 +15,7 @@ const functionArgsToWorkletize = new Map([
   ['createAnimatedPropAdapter', [0]],
   ['useDerivedValue', [0]],
   ['useAnimatedScrollHandler', [0]],
+  ['useLayoutWorklet', [0]],
   ['useAnimatedReaction', [0, 1]],
   ['useWorkletCallback', [0]],
   // animations' callbacks
@@ -77,7 +78,10 @@ export function processCalleesAutoworkletizableCallbacks(
       processObjectHook(maybeWorklet, state);
       // useAnimatedScrollHandler can take a function as an argument instead of an ObjectExpression
       // but useAnimatedGestureHandler can't
-    } else if (name === 'useAnimatedScrollHandler') {
+    } else if (
+      name === 'useAnimatedScrollHandler' ||
+      name === 'useLayoutWorklet'
+    ) {
       if (isWorkletizableFunctionType(maybeWorklet)) {
         processWorklet(maybeWorklet, state);
       }

--- a/src/reanimated2/hook/index.ts
+++ b/src/reanimated2/hook/index.ts
@@ -39,3 +39,4 @@ export type {
 export { useEvent } from './useEvent';
 export type { UseHandlerContext } from './useHandler';
 export { useHandler } from './useHandler';
+export { useLayoutWorklet } from './useLayoutWorklet';

--- a/src/reanimated2/hook/useLayoutWorklet.ts
+++ b/src/reanimated2/hook/useLayoutWorklet.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import type { WorkletFunction } from '../commonTypes';
+import { useEvent } from './useEvent';
+
+interface Layout {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// @ts-expect-error This overload is required by our API.
+export function useLayoutWorklet(worklet: (layout: Layout) => void);
+
+export function useLayoutWorklet(worklet: WorkletFunction) {
+  return useEvent(
+    (event: { layout: Layout }) => {
+      'worklet';
+      worklet(event.layout);
+    },
+    ['topLayout'],
+    true
+  );
+}

--- a/src/reanimated2/index.ts
+++ b/src/reanimated2/index.ts
@@ -47,6 +47,7 @@ export {
   useFrameCallback,
   useAnimatedKeyboard,
   useScrollViewOffset,
+  useLayoutWorklet,
 } from './hook';
 export type {
   DelayAnimation,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This PR introduces `useLayoutWorklet` hook which lets you run custom JS code on the UI runtime when the layout of an animated component changes.

`useLayoutWorklet` was designed to replace `measure` function (imperative API) which needs to be explicitly called on each animation frame when needed.

https://github.com/software-mansion/react-native-reanimated/assets/20516055/b7ec12df-ea65-4c27-8507-6ef084c7f45b

## Test plan

See EmptyExample.tsx