### PR TITLE
Make `useEvent` return a different reference if event handler should be reattached

### DIFF
--- a/app/src/examples/MemoExample.tsx
+++ b/app/src/examples/MemoExample.tsx
@@ -1,0 +1,85 @@
+import React, { memo } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import type {
+  AnimatedStyle,
+  EventHandlerProcessed,
+} from 'react-native-reanimated';
+
+const MemoizedComponent = memo<{
+  scrollHandler: EventHandlerProcessed<NativeSyntheticEvent<NativeScrollEvent>>;
+  animatedBoxStyle: AnimatedStyle;
+}>(({ scrollHandler, animatedBoxStyle }) => (
+  <>
+    <Animated.View style={[styles.box, animatedBoxStyle]} />
+    <Animated.ScrollView
+      onScroll={scrollHandler}
+      horizontal={true}
+      style={styles.list}>
+      {[...Array(10).keys()].map((i: number) => (
+        <View
+          key={i}
+          style={[
+            styles.element,
+            {
+              backgroundColor: `hsl(${i * 10}, 50%, 50%)`,
+            },
+          ]}
+        />
+      ))}
+    </Animated.ScrollView>
+  </>
+));
+
+export default function App() {
+  const [counter, setCounter] = React.useState(0);
+
+  const width = useSharedValue(100);
+  const backgroundColor = useSharedValue('hsl(0, 50%, 50%)');
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    console.log(counter);
+    width.value = 100 + event.contentOffset.x / 5;
+    backgroundColor.value = `hsl(${event.contentOffset.x / 10}, 50%, 50%)`;
+  });
+  const animatedBoxStyle = useAnimatedStyle(() => ({
+    width: width.value,
+    backgroundColor: backgroundColor.value,
+  }));
+
+  return (
+    <View style={styles.container}>
+      <MemoizedComponent
+        scrollHandler={scrollHandler}
+        animatedBoxStyle={animatedBoxStyle}
+      />
+      <Button title="Re-render" onPress={() => setCounter((s) => s + 1)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    backgroundColor: 'white',
+  },
+  list: {
+    maxHeight: 120,
+  },
+  box: {
+    height: 100,
+    backgroundColor: 'red',
+    alignSelf: 'center',
+    margin: 30,
+  },
+  element: {
+    width: 100,
+    height: 100,
+    margin: 10,
+  },
+});

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -117,6 +117,7 @@ import NestedLayoutAnimationConfig from './LayoutAnimations/NestedLayoutAnimatio
 import WithClampExample from './WithClampExample';
 import WorkletFactoryCrash from './WorkletFactoryCrashExample';
 import HabitsExample from './LayoutAnimations/HabitsExample';
+import MemoExample from './MemoExample';
 
 interface Example {
   icon?: string;
@@ -151,6 +152,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🟨',
     title: 'JS props',
     screen: JSPropsExample,
+  },
+  MemoExample: {
+    icon: '🧠',
+    title: 'Memo',
+    screen: MemoExample,
   },
 
   // About

--- a/src/createAnimatedComponent/PropsFilter.tsx
+++ b/src/createAnimatedComponent/PropsFilter.tsx
@@ -65,13 +65,15 @@ export class PropsFilter implements IPropsFilter {
           });
         }
       } else if (
-        has('current', value) &&
-        value.current instanceof WorkletEventHandler
+        has('workletEventHandler', value) &&
+        value.workletEventHandler instanceof WorkletEventHandler
       ) {
-        if (value.current.eventNames.length > 0) {
-          value.current.eventNames.forEach((eventName) => {
-            props[eventName] = has('listeners', value.current)
-              ? (value.current.listeners as Record<string, unknown>)[eventName]
+        if (value.workletEventHandler.eventNames.length > 0) {
+          value.workletEventHandler.eventNames.forEach((eventName) => {
+            props[eventName] = has('listeners', value.workletEventHandler)
+              ? (
+                  value.workletEventHandler.listeners as Record<string, unknown>
+                )[eventName]
               : dummyListener;
           });
         } else {

--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -231,15 +231,15 @@ export function createAnimatedComponent(
       for (const key in this.props) {
         const prop = this.props[key];
         if (
-          has('current', prop) &&
-          prop.current instanceof WorkletEventHandler
+          has('workletEventHandler', prop) &&
+          prop.workletEventHandler instanceof WorkletEventHandler
         ) {
           if (viewTag === null) {
             viewTag = IS_WEB
               ? this._component
               : findNodeHandle(options?.setNativeProps ? this : node);
           }
-          prop.current.registerForEvents(viewTag as number, key);
+          prop.workletEventHandler.registerForEvents(viewTag as number, key);
         }
       }
     }
@@ -248,10 +248,10 @@ export function createAnimatedComponent(
       for (const key in this.props) {
         const prop = this.props[key];
         if (
-          has('current', prop) &&
-          prop.current instanceof WorkletEventHandler
+          has('workletEventHandler', prop) &&
+          prop.workletEventHandler instanceof WorkletEventHandler
         ) {
-          prop.current.unregisterFromEvents();
+          prop.workletEventHandler.unregisterFromEvents();
         }
       }
     }
@@ -280,11 +280,11 @@ export function createAnimatedComponent(
       for (const key in prevProps) {
         const prop = this.props[key];
         if (
-          has('current', prop) &&
-          prop.current instanceof WorkletEventHandler &&
-          prop.current.reattachNeeded
+          has('workletEventHandler', prop) &&
+          prop.workletEventHandler instanceof WorkletEventHandler &&
+          prop.workletEventHandler.reattachNeeded
         ) {
-          prop.current.unregisterFromEvents();
+          prop.workletEventHandler.unregisterFromEvents();
         }
       }
 
@@ -293,9 +293,9 @@ export function createAnimatedComponent(
       for (const key in this.props) {
         const prop = this.props[key];
         if (
-          has('current', prop) &&
-          prop.current instanceof WorkletEventHandler &&
-          prop.current.reattachNeeded
+          has('workletEventHandler', prop) &&
+          prop.workletEventHandler instanceof WorkletEventHandler &&
+          prop.workletEventHandler.reattachNeeded
         ) {
           if (viewTag === null) {
             const node = this._getEventViewRef() as AnimatedComponentRef;
@@ -304,8 +304,8 @@ export function createAnimatedComponent(
               ? this._component
               : findNodeHandle(options?.setNativeProps ? this : node);
           }
-          prop.current.registerForEvents(viewTag as number, key);
-          prop.current.reattachNeeded = false;
+          prop.workletEventHandler.registerForEvents(viewTag as number, key);
+          prop.workletEventHandler.reattachNeeded = false;
         }
       }
     }

--- a/src/reanimated2/hook/useEvent.ts
+++ b/src/reanimated2/hook/useEvent.ts
@@ -1,5 +1,4 @@
 'use strict';
-import type { MutableRefObject } from 'react';
 import { useRef } from 'react';
 import WorkletEventHandler from '../WorkletEventHandler';
 import type { ReanimatedEvent } from './commonTypes';
@@ -17,9 +16,9 @@ export type EventHandlerProcessed<
   Context extends Record<string, unknown> = never
 > = (event: Event, context?: Context) => void;
 
-export type EventHandlerInternal<Event extends object> = MutableRefObject<
-  WorkletEventHandler<Event>
->;
+export type EventHandlerInternal<Event extends object> = {
+  workletEventHandler: WorkletEventHandler<Event>;
+};
 
 /**
  * Lets you run a function whenever a specified native event occurs.
@@ -49,13 +48,16 @@ export function useEvent<Event extends object, Context = never>(
   eventNames: string[] = [],
   rebuild = false
 ): EventHandlerInternal<Event> {
-  const initRef = useRef<WorkletEventHandler<Event> | null>(null);
+  const initRef = useRef<EventHandlerInternal<Event>>(null!);
   if (initRef.current === null) {
-    initRef.current = new WorkletEventHandler<Event>(handler, eventNames);
+    initRef.current = {
+      workletEventHandler: new WorkletEventHandler<Event>(handler, eventNames),
+    };
   } else if (rebuild) {
-    initRef.current.updateWorklet(handler);
+    const workletEventHandler = initRef.current.workletEventHandler;
+    workletEventHandler.updateWorklet(handler);
+    initRef.current = { workletEventHandler };
   }
 
-  // We cast it since we don't want to expose initial null value outside.
-  return initRef as EventHandlerInternal<Event>;
+  return initRef.current;
 }

--- a/src/reanimated2/hook/useEvent.ts
+++ b/src/reanimated2/hook/useEvent.ts
@@ -50,9 +50,11 @@ export function useEvent<Event extends object, Context = never>(
 ): EventHandlerInternal<Event> {
   const initRef = useRef<EventHandlerInternal<Event>>(null!);
   if (initRef.current === null) {
-    initRef.current = {
-      workletEventHandler: new WorkletEventHandler<Event>(handler, eventNames),
-    };
+    const workletEventHandler = new WorkletEventHandler<Event>(
+      handler,
+      eventNames
+    );
+    initRef.current = { workletEventHandler };
   } else if (rebuild) {
     const workletEventHandler = initRef.current.workletEventHandler;
     workletEventHandler.updateWorklet(handler);

--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -57,12 +57,13 @@ export function useScrollViewOffset(
       ? animatedRef.current
       : findNodeHandle(animatedRef.current);
 
-    eventHandler.current?.registerForEvents(viewTag as number);
+    eventHandler.workletEventHandler.registerForEvents(viewTag as number);
 
     return () => {
-      eventHandler.current?.unregisterFromEvents();
+      eventHandler.workletEventHandler?.unregisterFromEvents();
     };
-  }, [animatedRef.current]);
+    // TODO dependencies
+  }, [animatedRef.current, eventHandler]);
 
   return offsetRef.current;
 }

--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -52,18 +52,17 @@ export function useScrollViewOffset(
     // for more information about this cast.
   ) as unknown as EventHandlerInternal<ReanimatedScrollEvent>;
 
+  const component = animatedRef.current;
+
   useEffect(() => {
-    const viewTag = IS_WEB
-      ? animatedRef.current
-      : findNodeHandle(animatedRef.current);
+    const viewTag = IS_WEB ? component : findNodeHandle(component);
 
     eventHandler.workletEventHandler.registerForEvents(viewTag as number);
 
     return () => {
       eventHandler.workletEventHandler?.unregisterFromEvents();
     };
-    // TODO dependencies
-  }, [animatedRef.current, eventHandler]);
+  }, [component, eventHandler]);
 
   return offsetRef.current;
 }


### PR DESCRIPTION
## Summary

Currently Reanimated relies on reattaching event handlers on render. However, we give any notice to React that it should occur, because `useEvent` always returns the same reference.

With these changes, the reference for a given handler will change if it had to be rebuild and components using `memo` will get re-rendered.

Fixes #5364 

## Test plan

See added `MemoExample.tsx`.
