### PR TITLE
Prevent multiple registration of worklet event handlers

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -305,7 +305,6 @@ export function createAnimatedComponent(
               : findNodeHandle(options?.setNativeProps ? this : node);
           }
           prop.current.registerForEvents(viewTag as number, key);
-          prop.current.reattachNeeded = false;
         }
       }
     }

--- a/src/reanimated2/WorkletEventHandler.ts
+++ b/src/reanimated2/WorkletEventHandler.ts
@@ -23,23 +23,20 @@ function jsListener<Event extends object>(
 export default class WorkletEventHandler<Event extends object> {
   worklet: (event: ReanimatedEvent<Event>) => void;
   eventNames: string[];
-  reattachNeeded: boolean;
+  reattachNeeded: boolean = false;
+  isRegistered: boolean = false;
   listeners:
     | Record<string, (event: ReanimatedEvent<ReanimatedEvent<Event>>) => void>
-    | Record<string, (event: JSEvent<Event>) => void>;
+    | Record<string, (event: JSEvent<Event>) => void> = {};
 
-  viewTag: number | undefined;
-  registrations: number[];
+  viewTag: number | undefined = undefined;
+  registrations: number[] = [];
   constructor(
     worklet: (event: ReanimatedEvent<Event>) => void,
     eventNames: string[] = []
   ) {
     this.worklet = worklet;
     this.eventNames = eventNames;
-    this.reattachNeeded = false;
-    this.listeners = {};
-    this.viewTag = undefined;
-    this.registrations = [];
 
     if (SHOULD_BE_USE_WEB) {
       this.listeners = eventNames.reduce(
@@ -61,6 +58,12 @@ export default class WorkletEventHandler<Event extends object> {
   }
 
   registerForEvents(viewTag: number, fallbackEventName?: string): void {
+    if (this.isRegistered) {
+      console.warn(
+        "[Reanimated] Seems like you tried to register an event handler that's already registered. Maybe you tried to pass it to multiple components? Please make sure that every event handler from Reanimated is used only in one component."
+      );
+      return;
+    }
     this.viewTag = viewTag;
     this.registrations = this.eventNames.map((eventName) =>
       registerEventHandler(this.worklet, eventName, viewTag)
@@ -70,14 +73,13 @@ export default class WorkletEventHandler<Event extends object> {
         registerEventHandler(this.worklet, fallbackEventName, viewTag)
       );
     }
-  }
-
-  registerForEventByName(eventName: string) {
-    this.registrations.push(registerEventHandler(this.worklet, eventName));
+    this.reattachNeeded = false;
+    this.isRegistered = true;
   }
 
   unregisterFromEvents(): void {
     this.registrations.forEach((id) => unregisterEventHandler(id));
     this.registrations = [];
+    this.isRegistered = false;
   }
 }


### PR DESCRIPTION
## Summary

Currently `WorkletEventHandler` can only be attached to a single component - however, we don't check for that and it can lead to issues when using Reanimated. This PR adds QoL warning if the handler is attached to multiple components.

## Test plan

TBD
