### PR TITLE
[LA Web] Add check for `HTMLElement` when looking for descendant with animation.

### DIFF
--- a/src/reanimated2/layoutReanimation/web/domUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/domUtils.ts
@@ -163,6 +163,8 @@ function findDescendantWithExitingAnimation(
   node: ReanimatedHTMLElement,
   root: Node
 ) {
+  // Node could be something else than HTMLElement, for example TextNode (treated as plain text, not as HTML object),
+  // therefore it won't have children prop and calling Array.from(node.children) will cause error.
   if (!(node instanceof HTMLElement)) {
     return;
   }

--- a/src/reanimated2/layoutReanimation/web/domUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/domUtils.ts
@@ -163,6 +163,10 @@ function findDescendantWithExitingAnimation(
   node: ReanimatedHTMLElement,
   root: Node
 ) {
+  if (!(node instanceof HTMLElement)) {
+    return;
+  }
+
   if (node.reanimatedDummy && node.removedAfterAnimation === undefined) {
     reattachElementToAncestor(node, root);
   }


### PR DESCRIPTION
## Summary

This issue was found in [Expensify](https://github.com/Expensify/App/issues/37463). `node.children` was undefined, because `node` wasn't `HTMLElement` - it was `plaintext`. This PR introduces new check - if `node` is not `HTMLElement`, we won't perform any action.

## Test plan

Tested on Expensify App 