### PR TITLE
fix: don't use deprecated onCatalystInstanceDestroy API

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -109,13 +109,13 @@ public class NodesManager implements EventDispatcherListener {
     return mAnimationManager;
   }
 
-  public void onCatalystInstanceDestroy() {
+  public void onInvalidate() {
     if (mAnimationManager != null) {
-      mAnimationManager.onCatalystInstanceDestroy();
+      mAnimationManager.onInvalidate();
     }
 
     if (mNativeProxy != null) {
-      mNativeProxy.onCatalystInstanceDestroy();
+      mNativeProxy.onInvalidate();
       mNativeProxy = null;
     }
   }

--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -109,13 +109,13 @@ public class NodesManager implements EventDispatcherListener {
     return mAnimationManager;
   }
 
-  public void onInvalidate() {
+  public void invalidate() {
     if (mAnimationManager != null) {
-      mAnimationManager.onInvalidate();
+      mAnimationManager.invalidate();
     }
 
     if (mNativeProxy != null) {
-      mNativeProxy.onInvalidate();
+      mNativeProxy.invalidate();
       mNativeProxy = null;
     }
   }

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -116,11 +116,11 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     if (mNodesManager != null) {
-      mNodesManager.onCatalystInstanceDestroy();
+      mNodesManager.onInvalidate();
     }
   }
 }

--- a/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -120,7 +120,7 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
     super.invalidate();
 
     if (mNodesManager != null) {
-      mNodesManager.onInvalidate();
+      mNodesManager.invalidate();
     }
   }
 }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -67,7 +67,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     mSharedTransitionManager = new SharedTransitionManager(this);
   }
 
-  public void onCatalystInstanceDestroy() {
+  public void onInvalidate() {
     isCatalystInstanceDestroyed = true;
     mNativeMethodsHolder = null;
     mContext = null;

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -44,7 +44,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
   private HashSet<Integer> mAncestorsToRemove = new HashSet<>();
   private HashMap<Integer, Runnable> mCallbacks = new HashMap<>();
   private ReanimatedNativeHierarchyManager mReanimatedNativeHierarchyManager;
-  private boolean isCatalystInstanceDestroyed;
+  private boolean isInvalidated;
   private SharedTransitionManager mSharedTransitionManager;
 
   public void setReanimatedNativeHierarchyManager(
@@ -63,12 +63,12 @@ public class AnimationsManager implements ViewHierarchyObserver {
   public AnimationsManager(ReactContext context, UIManagerModule uiManagerModule) {
     mContext = context;
     mUIManager = uiManagerModule;
-    isCatalystInstanceDestroyed = false;
+    isInvalidated = false;
     mSharedTransitionManager = new SharedTransitionManager(this);
   }
 
   public void invalidate() {
-    isCatalystInstanceDestroyed = true;
+    isInvalidated = true;
     mNativeMethodsHolder = null;
     mContext = null;
     mUIManager = null;
@@ -80,7 +80,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
 
   @Override
   public void onViewRemoval(View view, ViewGroup parent, Runnable callback) {
-    if (isCatalystInstanceDestroyed) {
+    if (isInvalidated) {
       return;
     }
     Integer tag = view.getId();
@@ -93,7 +93,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
 
   @Override
   public void onViewCreate(View view, ViewGroup parent, Snapshot after) {
-    if (isCatalystInstanceDestroyed) {
+    if (isInvalidated) {
       return;
     }
     maybeRegisterSharedView(view);
@@ -118,7 +118,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
 
   @Override
   public void onViewUpdate(View view, Snapshot before, Snapshot after) {
-    if (isCatalystInstanceDestroyed) {
+    if (isInvalidated) {
       return;
     }
     int tag = view.getId();

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -67,7 +67,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     mSharedTransitionManager = new SharedTransitionManager(this);
   }
 
-  public void onInvalidate() {
+  public void invalidate() {
     isCatalystInstanceDestroyed = true;
     mNativeMethodsHolder = null;
     mContext = null;

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -226,7 +226,7 @@ public abstract class NativeProxyCommon {
 
   protected abstract HybridData getHybridData();
 
-  public void onCatalystInstanceDestroy() {
+  public void onInvalidate() {
     mAndroidUIScheduler.deactivate();
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -226,7 +226,7 @@ public abstract class NativeProxyCommon {
 
   protected abstract HybridData getHybridData();
 
-  public void onInvalidate() {
+  public void invalidate() {
     mAndroidUIScheduler.deactivate();
   }
 


### PR DESCRIPTION
## Summary

PR moving from deprecated method `onCatalystInstanceDestroy` to `invalidate` as suggested by the core.

## Test plan
