### PR TITLE
tests: add missing mock function

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -150,7 +150,7 @@ const platformFunctions = {
     pageY: 0,
   }),
   // dispatchCommand: ADD ME IF NEEDED
-  // scrollTo: ADD ME IF NEEDED
+  scrollTo: NOOP,
   // setGestureState: ADD ME IF NEEDED
   // setNativeProps: ADD ME IF NEEDED
   // getRelativeCoords: ADD ME IF NEEDED


### PR DESCRIPTION

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
This PR adds a missing mock, to avoid the error  `TypeError: (0 , _reactnativereanimated.scrollTo) is not a function` when executing tests on jest.

