### PR TITLE
Fix race condition when ShareableHandle is accessed on multiple threads

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -251,8 +251,8 @@ jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
     auto value = std::make_unique<jsi::Value>(getValueUnpacker(rt).call(
         rt, initObj, jsi::String::createFromAscii(rt, "Handle")));
 
-    std::unique_lock<std::mutex> lock(initializationMutex_, std::try_to_lock);
-    if (lock.owns_lock() && remoteValue_ == nullptr) {
+    std::unique_lock<std::mutex> lock(initializationMutex_);
+    if (remoteValue_ == nullptr) {
       remoteValue_ = std::move(value);
       remoteRuntime_ = &rt;
     }

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -252,7 +252,7 @@ jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
         rt, initObj, jsi::String::createFromAscii(rt, "Handle")));
 
     std::unique_lock<std::mutex> lock(initializationMutex_, std::try_to_lock);
-    if (lock.owns_lock()) {
+    if (lock.owns_lock() && remoteValue_ == nullptr) {
       remoteValue_ = std::move(value);
       remoteRuntime_ = &rt;
     }

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -248,9 +248,6 @@ jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
 jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
   if (remoteValue_ == nullptr) {
     auto initObj = initializer_->getJSValue(rt);
-    if (remoteValue_ != nullptr) {
-      jsi::String::createFromAscii(rt, "Handle");
-    }
     remoteValue_ = std::make_unique<jsi::Value>(getValueUnpacker(rt).call(
         rt, initObj, jsi::String::createFromAscii(rt, "Handle")));
     remoteRuntime_ = &rt;

--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -226,7 +226,8 @@ jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
           [](const auto &item) { return item.first == "__workletHash"; }) &&
       "ShareableWorklet doesn't have `__workletHash` property");
   jsi::Value obj = ShareableObject::toJSValue(rt);
-  return getValueUnpacker(rt).call(rt, obj);
+  return getValueUnpacker(rt).call(
+      rt, obj, jsi::String::createFromAscii(rt, "Worklet"));
 }
 
 jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
@@ -245,13 +246,14 @@ jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
 }
 
 jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
-  if (initializer_ != nullptr) {
+  if (remoteValue_ == nullptr) {
     auto initObj = initializer_->getJSValue(rt);
-    remoteValue_ =
-        std::make_unique<jsi::Value>(getValueUnpacker(rt).call(rt, initObj));
+    if (remoteValue_ != nullptr) {
+      jsi::String::createFromAscii(rt, "Handle");
+    }
+    remoteValue_ = std::make_unique<jsi::Value>(getValueUnpacker(rt).call(
+        rt, initObj, jsi::String::createFromAscii(rt, "Handle")));
     remoteRuntime_ = &rt;
-    initializer_ = nullptr; // we can release ref to initializer as this
-    // method should be called at most once
   }
   return jsi::Value(rt, *remoteValue_);
 }

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -277,14 +277,14 @@ class ShareableHandle : public Shareable {
   // initialized in parallel on multiple threads. However this is not a problem,
   // since the final value is taken from a cache on the runtime which guarantees
   // sequential access.
-  std::shared_ptr<ShareableObject> initializer_;
+  std::unique_ptr<ShareableObject> initializer_;
   std::unique_ptr<jsi::Value> remoteValue_ = nullptr;
   jsi::Runtime *remoteRuntime_;
 
  public:
   ShareableHandle(jsi::Runtime &rt, const jsi::Object &initializerObject)
       : Shareable(HandleType),
-        initializer_(std::make_shared<ShareableObject>(rt, initializerObject)) {
+        initializer_(std::make_unique<ShareableObject>(rt, initializerObject)) {
   }
 
   ~ShareableHandle() {

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -279,7 +279,7 @@ class ShareableHandle : public Shareable {
   // sequential access.
   std::unique_ptr<ShareableObject> initializer_;
   std::unique_ptr<jsi::Value> remoteValue_;
-  std::mutex initializationMutex_;
+  mutable std::mutex initializationMutex_;
   jsi::Runtime *remoteRuntime_;
 
  public:

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -279,6 +279,7 @@ class ShareableHandle : public Shareable {
   // sequential access.
   std::unique_ptr<ShareableObject> initializer_;
   std::unique_ptr<jsi::Value> remoteValue_;
+  std::mutex initializationMutex_;
   jsi::Runtime *remoteRuntime_;
 
  public:

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -278,7 +278,7 @@ class ShareableHandle : public Shareable {
   // since the final value is taken from a cache on the runtime which guarantees
   // sequential access.
   std::unique_ptr<ShareableObject> initializer_;
-  std::unique_ptr<jsi::Value> remoteValue_ = nullptr;
+  std::unique_ptr<jsi::Value> remoteValue_;
   jsi::Runtime *remoteRuntime_;
 
  public:

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -273,14 +273,18 @@ class ShareableRemoteFunction
 
 class ShareableHandle : public Shareable {
  private:
-  std::unique_ptr<ShareableObject> initializer_;
-  std::unique_ptr<jsi::Value> remoteValue_;
+  // We don't release the initializer since the handle can get
+  // initialized in parallel on multiple threads. However this is not a problem,
+  // since the final value is taken from a cache on the runtime which guarantees
+  // sequential access.
+  std::shared_ptr<ShareableObject> initializer_;
+  std::unique_ptr<jsi::Value> remoteValue_ = nullptr;
   jsi::Runtime *remoteRuntime_;
 
  public:
   ShareableHandle(jsi::Runtime &rt, const jsi::Object &initializerObject)
       : Shareable(HandleType),
-        initializer_(std::make_unique<ShareableObject>(rt, initializerObject)) {
+        initializer_(std::make_shared<ShareableObject>(rt, initializerObject)) {
   }
 
   ~ShareableHandle() {

--- a/src/reanimated2/valueUnpacker.ts
+++ b/src/reanimated2/valueUnpacker.ts
@@ -48,7 +48,7 @@ function valueUnpacker(objectToUnpack: any, category?: string): any {
     const functionInstance = workletFun.bind(objectToUnpack);
     objectToUnpack._recur = functionInstance;
     return functionInstance;
-  } else if (objectToUnpack.__init) {
+  } else if (objectToUnpack.__init !== undefined) {
     let value = handleCache.get(objectToUnpack);
     if (value === undefined) {
       value = objectToUnpack.__init();
@@ -63,7 +63,11 @@ See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshoo
     fun.__remoteFunction = objectToUnpack;
     return fun;
   } else {
-    throw new Error('[Reanimated] Data type not recognized by value unpacker.');
+    throw new Error(
+      `[Reanimated] Data type in category "${category}" not recognized by value unpacker: "${_toString(
+        objectToUnpack
+      )}".`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #5660, a regression introduced in #4300.

The aforementioned race condition happens this way:

1. An object using a `ShareableHandle` underneath (e.g. a shared value) is created.
2. This object is accessed on UI thread.
3. The initializer of this `ShareableHandle` get called on the UI thread.
4. At the same time, JS thread schedules an operation on this object (e.g. setting a value of shared value).
5. Access on UI thread forces the initialization. The condition of the if clause resolves to true and UI thread tries to access the runtime.
![Screenshot 2024-03-04 at 13 00 07](https://github.com/software-mansion/react-native-reanimated/assets/40713406/6c124599-3d60-4211-a1a9-3ccedd88f687)
6. However, access from JS thread has locked the runtime and causes the UI runtime to wait.
7. Then, JS thread enters the same if clause body and initializes the whole shareable.
8. After initializing and releasing the runtime, UI thread gets unblocked.
9. However, now `initializer_` has been nulled and causes memory access issues.

It's difficult to change the whole flow of locking to prevent such scenarios. Therefore we won't null the `initializer_` object anymore. However, this won't fix the problem of potential double initialization. Luckily, the code of `valueUnpacker` already prevents that with its shareable handle cache and the fact that runtime operations must be sequential. 

## Test plan

Run the following race condition reproduction made - you should re-run the app several times (probably up to 20ish) since it's most likely to happen when the app starts. It's also more likely to happen on Android simulators (at least for me).

<details>
<summary>
Test code
</summary>

```tsx
import {useSharedValue} from 'react-native-reanimated';
import {useEffect, useState} from 'react';

const value = 666666;

const Screen = () => {
  const sv = useSharedValue(value);
  useSharedValue(1);
  useSharedValue(2);
  useSharedValue(3);
  sv.value = value;

  useEffect(() => {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars
    const currentValue = sv.value;
  }, [sv]);

  return null;
};
const ReanimatedCrashReproduction = () => {
  const [render, setRender] = useState(false);

  useEffect(() => {
    const interval = setInterval(() => setRender(r => !r), 500);
    return () => clearInterval(interval);
  }, []);

  return render ? <Screen /> : null;
};

export default ReanimatedCrashReproduction;
```

</summary>

You can do the following to see that double initialization happens still, but all is well 🚰.

![Screenshot 2024-03-06 at 10 06 50](https://github.com/software-mansion/react-native-reanimated/assets/40713406/6517cd3a-eea0-45ef-bd18-a15215272f13)

Big thanks to @piaskowyk for the debugging help 🚀 
