### PR TITLE
Fix easing in Keyframe

### DIFF
--- a/src/animationBuilder.tsx
+++ b/src/animationBuilder.tsx
@@ -85,9 +85,9 @@ export function maybeBuild(
 
   if (isAnimationBuilder(layoutAnimationOrBuilder)) {
     const animationFactory = layoutAnimationOrBuilder.build();
-    const layoutAnimation = animationFactory(mockTargetValues);
 
     if (__DEV__ && style) {
+      const layoutAnimation = animationFactory(mockTargetValues);
       maybeReportOverwrittenProperties(
         layoutAnimation.animations,
         style,
@@ -95,7 +95,7 @@ export function maybeBuild(
       );
     }
 
-    return layoutAnimationOrBuilder.build();
+    return animationFactory;
   } else {
     return layoutAnimationOrBuilder;
   }

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -146,7 +146,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         }
         const keyframe: KeyframeProps = this.definitions[keyPoint];
         const easing = keyframe.easing;
-
+        delete keyframe.easing;
         const addKeyPointWith = (key: string, value: string | number) =>
           addKeyPoint({
             key,
@@ -154,7 +154,6 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
             currentKeyPoint: parseInt(keyPoint),
             easing,
           });
-
         Object.keys(keyframe).forEach((key: string) => {
           if (key === 'transform') {
             if (!Array.isArray(keyframe.transform)) {
@@ -172,9 +171,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
               });
             });
           } else {
-            if (key !== 'easing') {
-              addKeyPointWith(key, keyframe[key]);
-            }
+            addKeyPointWith(key, keyframe[key]);
           }
         });
       });

--- a/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/src/reanimated2/layoutReanimation/animationBuilder/Keyframe.ts
@@ -146,7 +146,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         }
         const keyframe: KeyframeProps = this.definitions[keyPoint];
         const easing = keyframe.easing;
-        delete keyframe.easing;
+
         const addKeyPointWith = (key: string, value: string | number) =>
           addKeyPoint({
             key,
@@ -154,6 +154,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
             currentKeyPoint: parseInt(keyPoint),
             easing,
           });
+
         Object.keys(keyframe).forEach((key: string) => {
           if (key === 'transform') {
             if (!Array.isArray(keyframe.transform)) {
@@ -171,7 +172,9 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
               });
             });
           } else {
-            addKeyPointWith(key, keyframe[key]);
+            if (key !== 'easing') {
+              addKeyPointWith(key, keyframe[key]);
+            }
           }
         });
       });


### PR DESCRIPTION
## Summary
Due to a bug, we drop easing in keyframe animation and it doesn't influence the actual animation at all. The goal of this PR is to fix it.

## Test plan
Use example `KeyframeAnimation.tsx` from our example app. Try changing easing (I suggest changing it to `easing: Easing.bounce`). Without this change can't observe any bounces.
