### PR TITLE
Fix `useScrollViewOffset` using animated ref before its initialization

### DIFF
--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -52,9 +52,8 @@ export function useScrollViewOffset(
     // for more information about this cast.
   ) as unknown as EventHandlerInternal<ReanimatedScrollEvent>;
 
-  const component = animatedRef.current;
-
   useEffect(() => {
+    const component = animatedRef.current;
     const viewTag = IS_WEB ? component : findNodeHandle(component);
 
     eventHandler.workletEventHandler.registerForEvents(viewTag as number);
@@ -62,7 +61,11 @@ export function useScrollViewOffset(
     return () => {
       eventHandler.workletEventHandler?.unregisterFromEvents();
     };
-  }, [component, eventHandler]);
+    // React here has a problem with `animatedRef.current` since a Ref .current
+    // field shouldn't be used as a dependency. However, in this case we have
+    // to do it this way.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animatedRef, animatedRef.current, eventHandler]);
 
   return offsetRef.current;
 }


### PR DESCRIPTION
## Summary

Fixing regression I introduced in #5743 by making the line

`const component = animatedRef.current` 

outside of `useEfect`.

## Test plan

Check `Article progress` example.
