### PR TITLE
Fix android layout animation z-index bug

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -649,7 +649,9 @@ public class AnimationsManager implements ViewHierarchyObserver {
       mReanimatedNativeHierarchyManager.publicDropView(view);
     }
 
-    if (parent != null) {
+    // this removal might be redundant, however we decided to keep it for now to avoid introducing
+    // breaking changes
+    if (parent != null && parent.indexOfChild(view) != -1) {
       parent.removeView(view);
     }
   }


### PR DESCRIPTION
## Summary
This PR fixes the bug that was causing z-index to behave incorrectly on Android after a layout animation was triggered. The issue was that sometimes our layout animation implementation was causing `removeView` to be called more than once for the same view. This is not a problem on plain Android, since there is a conditional check there for removal. However, react-native's implementation of `ReactViewGroup` does not check if the view is a part of this `ViewGroup` when handling removal. 

![Screenshot 2024-03-08 at 11 17 45](https://github.com/software-mansion/react-native-reanimated/assets/56109050/e4035cf3-abfa-4259-b543-e3169786ad04)

![Screenshot 2024-03-08 at 11 12 28](https://github.com/software-mansion/react-native-reanimated/assets/56109050/9425828e-3c3f-420b-88e4-5d2f93a66b3b)
The handler code decreases the counter, that maintains the number of views that have 'z-index' defined by the user. Calling `removeView` too many times causes the counter to go into negative numbers, causing react to disable custom z-index order, even when there are views with user defined z-index.

We decided to add an additional check when calling the `removeView` function in `AnimationsManager.java`. There is a possibility we could remove it altogether, but as of now this is not certain and requires further investigation.

closes #5715

## Test plan

Check if the repro from #5715 works properly
