### PR TITLE
fix: remove top level is_fabric check

### DIFF
--- a/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -57,7 +57,6 @@ import type { FlatList, FlatListProps } from 'react-native';
 import { addHTMLMutationObserver } from '../reanimated2/layoutReanimation/web/domUtils';
 
 const IS_WEB = isWeb();
-const IS_FABRIC = isFabric();
 
 if (IS_WEB) {
   configureWebLayoutAnimations();
@@ -268,7 +267,7 @@ export function createAnimatedComponent(
         if (this.props.animatedProps?.viewDescriptors) {
           this.props.animatedProps.viewDescriptors.remove(this._viewTag);
         }
-        if (IS_FABRIC) {
+        if (isFabric()) {
           removeFromPropsRegistry(this._viewTag);
         }
       }
@@ -359,7 +358,7 @@ export function createAnimatedComponent(
 
         viewConfig = hostInstance?.viewConfig;
 
-        if (IS_FABRIC) {
+        if (isFabric()) {
           shadowNodeWrapper = getShadowNodeWrapperFromRef(this);
         }
       }

--- a/src/reanimated2/PropsRegistry.ts
+++ b/src/reanimated2/PropsRegistry.ts
@@ -2,8 +2,6 @@
 import { isFabric } from './PlatformChecker';
 import { runOnUI } from './threads';
 
-const IS_FABRIC = isFabric();
-
 let VIEW_TAGS: number[] = [];
 
 export function removeFromPropsRegistry(viewTag: number) {
@@ -14,7 +12,7 @@ export function removeFromPropsRegistry(viewTag: number) {
 }
 
 function flush() {
-  if (__DEV__ && !IS_FABRIC) {
+  if (__DEV__ && !isFabric()) {
     throw new Error('[Reanimated] PropsRegistry is only available on Fabric.');
   }
   runOnUI(removeFromPropsRegistryOnUI)(VIEW_TAGS);

--- a/src/reanimated2/core.ts
+++ b/src/reanimated2/core.ts
@@ -29,7 +29,6 @@ export type { WorkletRuntime } from './runtimes';
 export { makeShareable, makeShareableCloneRecursive } from './shareables';
 export { makeMutable } from './mutables';
 
-const IS_FABRIC = isFabric();
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
 /**
@@ -56,7 +55,7 @@ if (SHOULD_BE_USE_WEB) {
 }
 
 export function getViewProp<T>(viewTag: number, propName: string): Promise<T> {
-  if (IS_FABRIC) {
+  if (isFabric()) {
     throw new Error(
       '[Reanimated] `getViewProp` is not supported on Fabric yet.'
     );

--- a/src/reanimated2/hook/useAnimatedRef.ts
+++ b/src/reanimated2/hook/useAnimatedRef.ts
@@ -11,7 +11,6 @@ import { Platform, findNodeHandle } from 'react-native';
 import type { ScrollView, FlatList } from 'react-native';
 import { isFabric, isWeb } from '../PlatformChecker';
 
-const IS_FABRIC = isFabric();
 const IS_WEB = isWeb();
 
 interface MaybeScrollableComponent extends Component {
@@ -25,15 +24,15 @@ interface MaybeScrollableComponent extends Component {
 }
 
 function getComponentOrScrollable(component: MaybeScrollableComponent) {
-  if (IS_FABRIC && component.getNativeScrollRef) {
+  if (isFabric() && component.getNativeScrollRef) {
     return component.getNativeScrollRef();
-  } else if (!IS_FABRIC && component.getScrollableNode) {
+  } else if (!isFabric() && component.getScrollableNode) {
     return component.getScrollableNode();
   }
   return component;
 }
 
-const getTagValueFunction = IS_FABRIC
+const getTagValueFunction = isFabric()
   ? getShadowNodeWrapperFromRef
   : findNodeHandle;
 
@@ -62,7 +61,7 @@ export function useAnimatedRef<
           : getTagValueFunction(getComponentOrScrollable(component));
         fun.current = component;
         // viewName is required only on iOS with Paper
-        if (Platform.OS === 'ios' && !IS_FABRIC) {
+        if (Platform.OS === 'ios' && !isFabric()) {
           viewName.value =
             (component as MaybeScrollableComponent)?.viewConfig
               ?.uiViewClassName || 'RCTView';


### PR DESCRIPTION
## Summary

PR removing top level check for `isFabric` since it should be evaluated after it is added to `global` which may not be done at that point.

## Test plan
