### PR TITLE
fix: prevent error due to undefined right operand of  "in" check in animationBuilder

### DIFF
--- a/src/animationBuilder.tsx
+++ b/src/animationBuilder.tsx
@@ -35,7 +35,7 @@ function getCommonProperties(
     : [componentStyle];
 
   componentStyleFlat = componentStyleFlat.map((style) =>
-    'initial' in style
+    style && 'initial' in style
       ? style.initial.value // Include properties of animated style
       : style
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
There's currently an error when a style in an array is `undefined`: 
 `ERROR  TypeError: right operand of 'in' is not an object`

```tsx

function App() {
  return <Animated.View entering={FadeIn} style={[{ flex: 1, backgroundColor: 'red' }, undefined]} />
}

```

not sure why this isn't a TS error?

![Screenshot 2024-03-11 at 10 21 28 AM](https://github.com/software-mansion/react-native-reanimated/assets/6730148/0aff5125-5b39-455d-bb3c-68a19ad10cbe)





## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
