### PR TITLE
feat: Support `jsi::NativeState` in Shareables

### DIFF
--- a/Common/cpp/SharedItems/Shareables.cpp
+++ b/Common/cpp/SharedItems/Shareables.cpp
@@ -198,6 +198,9 @@ ShareableObject::ShareableObject(jsi::Runtime &rt, const jsi::Object &object)
     auto value = extractShareableOrThrow(rt, object.getProperty(rt, key));
     data_.emplace_back(key.utf8(rt), value);
   }
+  if (object.hasNativeState(rt)) {
+    nativeState_ = object.getNativeState(rt);
+  }
 }
 
 jsi::Value ShareableObject::toJSValue(jsi::Runtime &rt) {
@@ -205,6 +208,9 @@ jsi::Value ShareableObject::toJSValue(jsi::Runtime &rt) {
   for (size_t i = 0, size = data_.size(); i < size; i++) {
     obj.setProperty(
         rt, data_[i].first.c_str(), data_[i].second->getJSValue(rt));
+  }
+  if (nativeState_ != nullptr) {
+    obj.setNativeState(rt, nativeState_);
   }
   return obj;
 }

--- a/Common/cpp/SharedItems/Shareables.h
+++ b/Common/cpp/SharedItems/Shareables.h
@@ -186,6 +186,9 @@ class ShareableObject : public Shareable {
 
  protected:
   std::vector<std::pair<std::string, std::shared_ptr<Shareable>>> data_;
+
+ private:
+  std::shared_ptr<jni::NativeState> nativeState_ = nullptr;
 };
 
 class ShareableHostObject : public Shareable {


### PR DESCRIPTION

## Summary

Allows Shared Objects to also retain their `NativeState` when copied between runtimes.

Assuming this object:

```cpp
jsi::Object obj;
obj.setProperty(runtime, "name", jsi::String::forUtf8(runtime, "Marc"));

std::shared_ptr<User> user = std::make_shared<User>("Marc");
obj.setNativeState(user);
```

..gets sent to JS, if it will be used in a Worklet runtime it will only contain the `"name"` property, and it's native state field will be null.

With this PR, `jsi::NativeState` also gets copied over to the JS object if it is shared between runtimes, which is safe to do because it is a `shared_ptr` already.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Try to use an object with Native State (e.g. VisionCamera v4 tests) in a Worklet runtime.
