### PR TITLE
Add macos platform to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -78,6 +78,7 @@ body:
       options:
         - Android
         - iOS
+        - macOS
         - Web
     validations:
       required: true


### PR DESCRIPTION
## Summary
This PR adds macOS as new platform option in issue template.

## Test plan
n/a
