### PR TITLE
Add `jestUtils` to mocks

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -17,6 +17,11 @@ import {
   ColorSpace,
   Extrapolation,
   SharedTransitionType,
+  withReanimatedTimer,
+  advanceAnimationByTime,
+  advanceAnimationByFrame,
+  setUpTests,
+  getAnimatedStyle,
 } from './reanimated2';
 import {
   View as ViewRN,
@@ -391,7 +396,13 @@ const pluginUtils = {
   // getUseOfValueInStyleWarning: ADD ME IF NEEDED
 };
 
-// const jestUtils = ADD ME IF NEEDED
+const jestUtils = {
+  withReanimatedTimer,
+  advanceAnimationByTime,
+  advanceAnimationByFrame,
+  setUpTests,
+  getAnimatedStyle,
+};
 
 const LayoutAnimationConfig = {
   // LayoutAnimationConfig: ADD ME IF NEEDED
@@ -431,6 +442,7 @@ const Reanimated = {
   ...isSharedValue,
   ...commonTypes,
   ...pluginUtils,
+  ...jestUtils,
   ...LayoutAnimationConfig,
   ...mappers,
 };


### PR DESCRIPTION
## Summary

Currently we don't reexport jest specific function (especially `setUpTests`) in our mock. This is due to fact that our recommended way of initializing Reanimated for testing is to do that in `jest-setup.js` file.

However, doing it just before the test suite (with `beforeAll` jest function) is just as good, if even not better considering test separation. This cannot be done if Reanimated is already mocked.

## Test plan

Add Reanimated to a new RN app, mock Reanimated and see that `setUpTests` cannot be used in `beforeAll`. Do it using Reanimated built from this PR and see that it works.
