### PR TITLE
Add information about type of `toValue` to our documentation

### DIFF
--- a/docs/docs/animations/shared/animationToValue.mdx
+++ b/docs/docs/animations/shared/animationToValue.mdx
@@ -1,0 +1,16 @@
+The value on which the animation will come at rest. Supported categories:
+
+- **numbers** - number can be a either a number or a string
+- **suffixed numbers** - strings being a number with a unit, like `"5.5%"`, `"90deg"` or even `"3bananas`". Just make sure there is no space between number and suffix, also suffix should consist of basic english letters only.
+- **colors**
+  - Hexadecimal integer - e.g. `0xff1234`,
+  - RGB (Red, Green, Blue) - e.g. `"rgb(100, 50, 0)"`,
+  - RGBA (Red, Green, Blue, Alpha) - e.g. `"rgba(255, 105, 180, 0)`",
+  - RGB Hexadecimal - e.g. `"#53575E"`,
+  - HSL (Hue, Saturation, Lightness) - e.g.`"hsl(0, 50%, 50%)"`,
+  - Named colors - e.g. `"dodgerblue"`.
+- **objects** - object with properties that will be animated separately,
+- **array** - array of numbers, each value will be animated separately.
+- **transformation matrix** - an array consisting of exactly 16 numerical values is by default animated as a transformation matrix. The numbers in the matrix aren't animated separately. Instead, the array gets decomposed into 3 basic transformations - rotation, scale, and translation – which are then animated separately.
+
+Please mind, that `toValue` and the animated shared value have to share the same category (e.g. you can't animate `width` from `100px` to `50%`).

--- a/docs/docs/animations/withSpring.mdx
+++ b/docs/docs/animations/withSpring.mdx
@@ -59,7 +59,7 @@ enum ReduceMotion {
 
 #### `toValue`
 
-The value at which the animation will come to rest.
+<AnimationToValue />
 
 #### `config` <Optional />
 

--- a/docs/docs/animations/withSpring.mdx
+++ b/docs/docs/animations/withSpring.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 2
 ---
 
+import AnimationToValue from './shared/animationToValue.mdx';
+
 # withSpring
 
 `withSpring` lets you create spring-based animations.

--- a/docs/docs/animations/withTiming.mdx
+++ b/docs/docs/animations/withTiming.mdx
@@ -54,6 +54,26 @@ enum ReduceMotion {
 #### `toValue`
 
 The value on which the animation will come at rest.
+There are many possible types for `toValue`, currently the following kinds of values are supported:
+
+* **colors** - we support wide range of color formats:
+  * hex numbers - `0xff1234`
+  * rgb - `rgb(100,50,0)`
+  * rgba - `rgba(255,105,180,0)`
+  * hsl - `hsl(0, 50%, 50%)`
+  * hex strings - `#53575E`
+  * css color names - `dodgerblue`
+* **numbers**
+* **suffixed numbers** - strings being a number with a unit, like `"100%"` or `"90deg"`
+* **objects** - object with properties that will be animated separately
+* **array** - array of values, each value will be animated separately.
+* **transformation matrix** - each array of exactly 16 numerical values is by default 
+animated as a transformation matrix. It means that we don't apply the animation to each value separately.
+Instead we decompose the transformation matrix into matrices of 3 basic transformations - rotation, scale and translation.
+Then we animate each of these 3 transforms separately.
+
+Please mind, that `toValue` and the animated shared value should share the same category
+(for example you can't animate width from 100px to 50%)
 
 #### `config` <Optional />
 

--- a/docs/docs/animations/withTiming.mdx
+++ b/docs/docs/animations/withTiming.mdx
@@ -56,21 +56,21 @@ enum ReduceMotion {
 The value on which the animation will come at rest.
 There are many possible types for `toValue`, currently the following kinds of values are supported:
 
-* **colors** - we support wide range of color formats:
-  * hex numbers - `0xff1234`
-  * rgb - `rgb(100,50,0)`
-  * rgba - `rgba(255,105,180,0)`
-  * hsl - `hsl(0, 50%, 50%)`
-  * hex strings - `#53575E`
-  * css color names - `dodgerblue`
-* **numbers**
-* **suffixed numbers** - strings being a number with a unit, like `"100%"` or `"90deg"`
-* **objects** - object with properties that will be animated separately
-* **array** - array of values, each value will be animated separately.
-* **transformation matrix** - each array of exactly 16 numerical values is by default 
-animated as a transformation matrix. It means that we don't apply the animation to each value separately.
-Instead we decompose the transformation matrix into matrices of 3 basic transformations - rotation, scale and translation.
-Then we animate each of these 3 transforms separately.
+- **colors** - we support wide range of color formats:
+  - hex numbers - `0xff1234`
+  - rgb - `rgb(100,50,0)`
+  - rgba - `rgba(255,105,180,0)`
+  - hsl - `hsl(0, 50%, 50%)`
+  - hex strings - `#53575E`
+  - css color names - `dodgerblue`
+- **numbers**
+- **suffixed numbers** - strings being a number with a unit, like `"100%"` or `"90deg"`
+- **objects** - object with properties that will be animated separately
+- **array** - array of values, each value will be animated separately.
+- **transformation matrix** - each array of exactly 16 numerical values is by default
+  animated as a transformation matrix. It means that we don't apply the animation to each value separately.
+  Instead we decompose the transformation matrix into matrices of 3 basic transformations - rotation, scale and translation.
+  Then we animate each of these 3 transforms separately.
 
 Please mind, that `toValue` and the animated shared value should share the same category
 (for example you can't animate width from 100px to 50%)

--- a/docs/docs/animations/withTiming.mdx
+++ b/docs/docs/animations/withTiming.mdx
@@ -53,27 +53,22 @@ enum ReduceMotion {
 
 #### `toValue`
 
-The value on which the animation will come at rest.
-There are many possible types for `toValue`, currently the following kinds of values are supported:
+The value on which the animation will come at rest. Supported categories:
 
-- **colors** - we support wide range of color formats:
-  - hex numbers - `0xff1234`
-  - rgb - `rgb(100,50,0)`
-  - rgba - `rgba(255,105,180,0)`
-  - hsl - `hsl(0, 50%, 50%)`
-  - hex strings - `#53575E`
-  - css color names - `dodgerblue`
+- **colors**
+  - RGB (Red, Green, Blue) - e.g. `rgb(100, 50, 0)`,
+  - RGBA (Red, Green, Blue, Alpha) - e.g. `rgba(255, 105, 180, 0)`,
+  - RGB Hexadecimal - e.g. `#53575E`,
+  - Hexadecimal integer literal - e.g. `0xff1234`,
+  - HSL (Hue, Saturation, Lightness) - e.g.`hsl(0, 50%, 50%)`,
+  - Named colors - e.g. `dodgerblue`.
 - **numbers**
 - **suffixed numbers** - strings being a number with a unit, like `"100%"` or `"90deg"`
-- **objects** - object with properties that will be animated separately
+- **objects** - object with properties that will be animated separately,
 - **array** - array of values, each value will be animated separately.
-- **transformation matrix** - each array of exactly 16 numerical values is by default
-  animated as a transformation matrix. It means that we don't apply the animation to each value separately.
-  Instead we decompose the transformation matrix into matrices of 3 basic transformations - rotation, scale and translation.
-  Then we animate each of these 3 transforms separately.
+- **transformation matrix** - an array consisting of exactly 16 numerical values is by default animated as a transformation matrix. The numbers in the matrix aren't animated separately. Instead, the array gets decomposed into 3 basic transformations - rotation, scale, and translation – which are then animated separately.
 
-Please mind, that `toValue` and the animated shared value should share the same category
-(for example you can't animate width from 100px to 50%)
+Please mind, that `toValue` and the animated shared value have to share the same category (e.g. you can't animate `width` from `100px` to `50%`).
 
 #### `config` <Optional />
 

--- a/docs/docs/animations/withTiming.mdx
+++ b/docs/docs/animations/withTiming.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import AnimationToValue from './shared/animationToValue.mdx';
+
 # withTiming
 
 `withTiming` lets you create an animation based on duration and [easing](https://easings.net/).
@@ -53,22 +55,7 @@ enum ReduceMotion {
 
 #### `toValue`
 
-The value on which the animation will come at rest. Supported categories:
-
-- **numbers** - number can be a either a number or a string
-- **suffixed numbers** - strings being a number with a unit, like `"5.5%"`, `"90deg"` or even `"3bananas`". Just make sure there is no space between number and suffix, also suffix should consist of basic english letters only.
-- **colors**
-  - Hexadecimal integer - e.g. `0xff1234`,
-  - RGB (Red, Green, Blue) - e.g. `"rgb(100, 50, 0)"`,
-  - RGBA (Red, Green, Blue, Alpha) - e.g. `"rgba(255, 105, 180, 0)`",
-  - RGB Hexadecimal - e.g. `"#53575E"`,
-  - HSL (Hue, Saturation, Lightness) - e.g.`"hsl(0, 50%, 50%)"`,
-  - Named colors - e.g. `"dodgerblue"`.
-- **objects** - object with properties that will be animated separately,
-- **array** - array of numbers, each value will be animated separately.
-- **transformation matrix** - an array consisting of exactly 16 numerical values is by default animated as a transformation matrix. The numbers in the matrix aren't animated separately. Instead, the array gets decomposed into 3 basic transformations - rotation, scale, and translation – which are then animated separately.
-
-Please mind, that `toValue` and the animated shared value have to share the same category (e.g. you can't animate `width` from `100px` to `50%`).
+<AnimationToValue />
 
 #### `config` <Optional />
 

--- a/docs/docs/animations/withTiming.mdx
+++ b/docs/docs/animations/withTiming.mdx
@@ -55,17 +55,17 @@ enum ReduceMotion {
 
 The value on which the animation will come at rest. Supported categories:
 
+- **numbers** - number can be a either a number or a string
+- **suffixed numbers** - strings being a number with a unit, like `"5.5%"`, `"90deg"` or even `"3bananas`". Just make sure there is no space between number and suffix, also suffix should consist of basic english letters only.
 - **colors**
-  - RGB (Red, Green, Blue) - e.g. `rgb(100, 50, 0)`,
-  - RGBA (Red, Green, Blue, Alpha) - e.g. `rgba(255, 105, 180, 0)`,
-  - RGB Hexadecimal - e.g. `#53575E`,
-  - Hexadecimal integer literal - e.g. `0xff1234`,
-  - HSL (Hue, Saturation, Lightness) - e.g.`hsl(0, 50%, 50%)`,
-  - Named colors - e.g. `dodgerblue`.
-- **numbers**
-- **suffixed numbers** - strings being a number with a unit, like `"100%"` or `"90deg"`
+  - Hexadecimal integer - e.g. `0xff1234`,
+  - RGB (Red, Green, Blue) - e.g. `"rgb(100, 50, 0)"`,
+  - RGBA (Red, Green, Blue, Alpha) - e.g. `"rgba(255, 105, 180, 0)`",
+  - RGB Hexadecimal - e.g. `"#53575E"`,
+  - HSL (Hue, Saturation, Lightness) - e.g.`"hsl(0, 50%, 50%)"`,
+  - Named colors - e.g. `"dodgerblue"`.
 - **objects** - object with properties that will be animated separately,
-- **array** - array of values, each value will be animated separately.
+- **array** - array of numbers, each value will be animated separately.
 - **transformation matrix** - an array consisting of exactly 16 numerical values is by default animated as a transformation matrix. The numbers in the matrix aren't animated separately. Instead, the array gets decomposed into 3 basic transformations - rotation, scale, and translation – which are then animated separately.
 
 Please mind, that `toValue` and the animated shared value have to share the same category (e.g. you can't animate `width` from `100px` to `50%`).


### PR DESCRIPTION
## Summary
Our documentation is missing information about type of `toValue`

> [!Note]
> The information added in this PR should be included in our documentation 3 times, on pages `withTiming`, `withSpring` and `withDecay`. I will copy-paste it once the text is accepted

<img width="905" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/ac72fb8d-6d28-4854-8b40-bedb6364fb5d">
