### PR TITLE
Add documentation that event handlers cannot be used with more than one component.

### DIFF
--- a/docs/docs/advanced/useEvent.mdx
+++ b/docs/docs/advanced/useEvent.mdx
@@ -31,7 +31,7 @@ Value indicating whether handler should be rebuilt.
 
 ### Returns
 
-The hook returns event handler that will be invoked when native event is dispatched.
+The hook returns event handler that will be invoked when native event is dispatched. That handler should be connected to only one component.
 
 ## Example
 

--- a/docs/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/docs/docs/scroll/useAnimatedScrollHandler.mdx
@@ -36,7 +36,7 @@ Optional array of values which changes cause this hook to receive updated values
 
 Example:
 
-```js {11}
+````js {11}
 const App = () => {
   const [state, setState] = useState(0);
   const sv = useSharedValue(0);
@@ -52,7 +52,7 @@ const App = () => {
   //...
   return <></>;
 };
-```
+```ś
 
 `dependencies` here may be:
 
@@ -65,6 +65,7 @@ const App = () => {
 The hook returns a handler object that can be hooked into a scrollable container.
 Note that in order for the handler to be properly triggered, you should use containers that are wrapped with `Animated` (e.g. `Animated.ScrollView` and not just `ScrollView`).
 The handler should be passed under `onScroll` parameter regardless of whether it is configured to receive only scroll or also momentum or drag events.
+Handlers are not supposed to be passed to multiple components, you need a separate handler for each scrollable container.
 
 ## Example
 
@@ -104,7 +105,7 @@ function ScrollExample() {
     </View>
   );
 }
-```
+````
 
 If we are interested in receiving drag or momentum events instead of passing a single worklet object we can pass an object of worklets.
 Below for convenience, we only show how the `scrollHandler` should be defined in such a case.

--- a/docs/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/docs/docs/scroll/useAnimatedScrollHandler.mdx
@@ -36,7 +36,7 @@ Optional array of values which changes cause this hook to receive updated values
 
 Example:
 
-````js {11}
+```js {11}
 const App = () => {
   const [state, setState] = useState(0);
   const sv = useSharedValue(0);
@@ -105,7 +105,7 @@ function ScrollExample() {
     </View>
   );
 }
-````
+```
 
 If we are interested in receiving drag or momentum events instead of passing a single worklet object we can pass an object of worklets.
 Below for convenience, we only show how the `scrollHandler` should be defined in such a case.

--- a/docs/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/docs/docs/scroll/useAnimatedScrollHandler.mdx
@@ -65,7 +65,10 @@ const App = () => {
 The hook returns a handler object that can be hooked into a scrollable container.
 Note that in order for the handler to be properly triggered, you should use containers that are wrapped with `Animated` (e.g. `Animated.ScrollView` and not just `ScrollView`).
 The handler should be passed under `onScroll` parameter regardless of whether it is configured to receive only scroll or also momentum or drag events.
-Handlers are not supposed to be passed to multiple components, you need a separate handler for each scrollable container.
+
+### Remarks
+
+The hook returns a handler that is not supposed to be passed to multiple components. You need a separate handler for each scrollable container.
 
 ## Example
 

--- a/docs/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/docs/docs/scroll/useAnimatedScrollHandler.mdx
@@ -52,7 +52,7 @@ const App = () => {
   //...
   return <></>;
 };
-```ś
+```
 
 `dependencies` here may be:
 

--- a/docs/docs/scroll/useScrollViewOffset.mdx
+++ b/docs/docs/scroll/useScrollViewOffset.mdx
@@ -38,8 +38,7 @@ function useScrollViewOffset(
 
 #### `animatedRef`
 
-An [animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component and
-mustn't be changed dynamically.
+An [animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
 
 #### `initialRef` <Optional/>
 
@@ -48,6 +47,10 @@ An optional shared value to be updated with the scroll offset. If not provided a
 ### Returns
 
 `useScrollViewOffset` returns a [shared value](/docs/fundamentals/glossary#shared-value) which holds the current offset of the `ScrollView`.
+
+### Remarks
+
+The `animatedRef` passed to the hook mustn't be changed dynamically.
 
 ## Example
 

--- a/docs/docs/scroll/useScrollViewOffset.mdx
+++ b/docs/docs/scroll/useScrollViewOffset.mdx
@@ -38,7 +38,8 @@ function useScrollViewOffset(
 
 #### `animatedRef`
 
-An [animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
+An [animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component and
+mustn't be changed dynamically.
 
 #### `initialRef` <Optional/>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In this comment https://github.com/software-mansion/react-native-reanimated/issues/5345#issuecomment-1859198802:

>Unfortunately, with current implementation handlers provided by **useAnimatedScrollHandler** or any other handlers that are an instance of WorkletEventHandler, that being: **useScrollViewOffset**, **useEvent** and **useAnimatedGestureHandler** (last one deprecated) are supposed to be passed to only one component. This is because their class instances keep the data of the latest component only. Passing them to multiple components leads to undefined behavior.

we mention that event handlers cannot be used with more than one component. This should be documented.

|Handler|Screenshot|Where in docs|
|--|--|--|
|useAnimatedScrollHandler|<img width="561" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/9557a8bb-93ca-4f86-92f0-3f1aab95454e">|Section "remarks"|
|useScrollViewOffset|<img width="645" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/231b76af-b311-4b12-9b62-239d7f225774">|Section "remarks"|
|useEvent|<img width="618" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/042503c7-94a9-47ca-933c-98b1f4ef3240">|Section "returns"|
|useAnimatedGestureHandler| Deprecated ❌| No documentation ❌|


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
