### PR TITLE
Fix default Magnetic Sensor interval causing a security exception

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -17,6 +17,7 @@ public class ReanimatedSensor {
   Sensor sensor;
   ReanimatedSensorType sensorType;
   int interval;
+  public static final int MINIMAL_UNPRIVILEGED_INTERVAL = 8;
 
   ReanimatedSensor(
       WeakReference<ReactApplicationContext> reactContext,
@@ -29,11 +30,7 @@ public class ReanimatedSensor {
     sensorManager =
         (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
     this.sensorType = sensorType;
-    if (interval == -1) {
-      this.interval = SensorManager.SENSOR_DELAY_UI;
-    } else {
-      this.interval = interval;
-    }
+    this.interval = Math.max(interval, MINIMAL_UNPRIVILEGED_INTERVAL);
   }
 
   boolean initialize() {

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -31,7 +31,7 @@ public class ReanimatedSensor {
         (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
     this.sensorType = sensorType;
     if (interval == -1) {
-      this.interval = MINIMAL_UNPRIVILEGED_SAMPLING_RATE;
+      this.interval = DEFAULT_INTERVAL;
     } else {
       this.interval = interval;
     }

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -17,7 +17,7 @@ public class ReanimatedSensor {
   Sensor sensor;
   ReanimatedSensorType sensorType;
   int interval;
-  private static final int MINIMAL_UNPRIVILEGED_SAMPLING_RATE = 8;
+  private static final int DEFAULT_INTERVAL = 8;
 
   ReanimatedSensor(
       WeakReference<ReactApplicationContext> reactContext,

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -17,7 +17,7 @@ public class ReanimatedSensor {
   Sensor sensor;
   ReanimatedSensorType sensorType;
   int interval;
-  public static final int MINIMAL_UNPRIVILEGED_INTERVAL = 8;
+  private static final int MINIMAL_UNPRIVILEGED_SAMPLING_RATE = 8;
 
   ReanimatedSensor(
       WeakReference<ReactApplicationContext> reactContext,
@@ -30,7 +30,7 @@ public class ReanimatedSensor {
     sensorManager =
         (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
     this.sensorType = sensorType;
-    this.interval = Math.max(interval, MINIMAL_UNPRIVILEGED_INTERVAL);
+    this.interval = Math.max(interval, MINIMAL_UNPRIVILEGED_SAMPLING_RATE);
   }
 
   boolean initialize() {

--- a/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
+++ b/android/src/main/java/com/swmansion/reanimated/sensor/ReanimatedSensor.java
@@ -30,7 +30,11 @@ public class ReanimatedSensor {
     sensorManager =
         (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
     this.sensorType = sensorType;
-    this.interval = Math.max(interval, MINIMAL_UNPRIVILEGED_SAMPLING_RATE);
+    if (interval == -1) {
+      this.interval = MINIMAL_UNPRIVILEGED_SAMPLING_RATE;
+    } else {
+      this.interval = interval;
+    }
   }
 
   boolean initialize() {


### PR DESCRIPTION
## Summary

Currently default magnetic sampling interval equals 2ms, which triggers a `HIGH_SAMPLE_RATE` security exception.
This fix defaults the probing interval to 8ms.

Note: `'auto'` setting defaults to `-1`, which is then replaced by `2`.

## Test plan

Download a new emulator on Android Studio - I'm using `Pixel 8 UpsideDownCake`
Launch the magnetic sensor example before, and after applying this patch.