### PR TITLE
Point metro resolver for react-native to lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "main": "lib/module/index",
   "module": "lib/module/index",
-  "react-native": "src/index",
+  "react-native": "lib/module/index",
   "source": "src/index",
   "types": "lib/typescript/index",
   "files": [


### PR DESCRIPTION
react-native-builder-bob uses standard directories for "main", "module" and "react-native" in package.json. These expect precompilation before release.
"react-native" usually points to the source directory. 
Since in the case of react-native-reanimated sometimes typescript is not transpiled correctly (see #5789 and https://github.com/facebook/react-native/issues/39296#issuecomment-1707525728) and react-native uses javascript anyways, it should be safe to point "react-native" to the compiled javascript sources instead of the typescript sources (which are referenced in "source" anyways).

## Summary

Fixes #5789 


