### PR TITLE
Replace `systemUptime` calls with `CACurrentMediaTime()` to comply with Apple privacy requirements

### DIFF
--- a/Example/ios/MBFingerTipWindow.m
+++ b/Example/ios/MBFingerTipWindow.m
@@ -282,7 +282,7 @@
 {
     self.fingerTipRemovalScheduled = NO;
 
-    NSTimeInterval now = [[NSProcessInfo processInfo] systemUptime];
+    NSTimeInterval now = CACurrentMediaTime() * 1000;
     const CGFloat REMOVAL_DELAY = 0.2;
 
     for (MBFingerTipView *touchView in [self.overlayWindow subviews])

--- a/apple/sensor/ReanimatedSensor.m
+++ b/apple/sensor/ReanimatedSensor.m
@@ -48,7 +48,7 @@
   [_motionManager
       startGyroUpdatesToQueue:[NSOperationQueue mainQueue]
                   withHandler:^(CMGyroData *sensorData, NSError *error) {
-                    double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                    double currentTime = CACurrentMediaTime() * 1000;
                     if (currentTime - self->_lastTimestamp < self->_interval) {
                       return;
                     }
@@ -69,7 +69,7 @@
   [_motionManager startAccelerometerUpdates];
   [_motionManager startAccelerometerUpdatesToQueue:[NSOperationQueue mainQueue]
                                        withHandler:^(CMAccelerometerData *sensorData, NSError *error) {
-                                         double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                                         double currentTime = CACurrentMediaTime() * 1000;
                                          if (currentTime - self->_lastTimestamp < self->_interval) {
                                            return;
                                          }
@@ -96,7 +96,7 @@
   [_motionManager
       startDeviceMotionUpdatesToQueue:[NSOperationQueue mainQueue]
                           withHandler:^(CMDeviceMotion *sensorData, NSError *error) {
-                            double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                            double currentTime = CACurrentMediaTime() * 1000;
                             if (currentTime - self->_lastTimestamp < self->_interval) {
                               return;
                             }
@@ -121,7 +121,7 @@
   [_motionManager
       startMagnetometerUpdatesToQueue:[NSOperationQueue mainQueue]
                           withHandler:^(CMMagnetometerData *sensorData, NSError *error) {
-                            double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                            double currentTime = CACurrentMediaTime() * 1000;
                             if (currentTime - self->_lastTimestamp < self->_interval) {
                               return;
                             }
@@ -157,7 +157,7 @@
   [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:(1 << _referenceFrame)
                                                       toQueue:[NSOperationQueue mainQueue]
                                                   withHandler:^(CMDeviceMotion *sensorData, NSError *error) {
-                                                    double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                                                    double currentTime = CACurrentMediaTime() * 1000;
                                                     if (currentTime - self->_lastTimestamp < self->_interval) {
                                                       return;
                                                     }


### PR DESCRIPTION
## Summary

Closes #5801.

This PR replaces all `[[NSProcessInfo processInfo] systemUptime]` calls with `CACurrentMediaTime() * 1000`.

## Test plan

Check if `useAnimatedSensor` with interval works properly.
