### PR TITLE
Add support for cloning `Error`

### DIFF
--- a/app/src/examples/ShareablesExample.tsx
+++ b/app/src/examples/ShareablesExample.tsx
@@ -162,7 +162,6 @@ function DataViewDemo() {
 
 function ErrorDemo() {
   const handlePress = () => {
-    // const e = new Error('error message');
     const e = new Error('error message');
     console.log(_WORKLET ? 'UI' : 'RN', e instanceof Error);
     console.log(_WORKLET ? 'UI' : 'RN', String(e));

--- a/app/src/examples/ShareablesExample.tsx
+++ b/app/src/examples/ShareablesExample.tsx
@@ -13,6 +13,7 @@ export default function ShareablesExample() {
       <TypedArrayDemo />
       <BigIntTypedArrayDemo />
       <DataViewDemo />
+      <ErrorDemo />
     </View>
   );
 }
@@ -157,6 +158,23 @@ function DataViewDemo() {
   };
 
   return <Button title="DataView" onPress={handlePress} />;
+}
+
+function ErrorDemo() {
+  const handlePress = () => {
+    // const e = new Error('error message');
+    const e = new Error('error message');
+    console.log(_WORKLET ? 'UI' : 'RN', e instanceof Error);
+    console.log(_WORKLET ? 'UI' : 'RN', String(e));
+    console.log(_WORKLET ? 'UI' : 'RN', e.stack?.length);
+    runOnUI(() => {
+      console.log(_WORKLET ? 'UI' : 'RN', e instanceof Error);
+      console.log(_WORKLET ? 'UI' : 'RN', String(e));
+      console.log(_WORKLET ? 'UI' : 'RN', e.stack?.length);
+    })();
+  };
+
+  return <Button title="Error" onPress={handlePress} />;
 }
 
 const styles = StyleSheet.create({

--- a/src/reanimated2/shareables.ts
+++ b/src/reanimated2/shareables.ts
@@ -202,6 +202,20 @@ Offending code was: \`${getWorkletCode(value)}\``);
         });
         shareableMappingCache.set(value, handle);
         return handle as ShareableRef<T>;
+      } else if (value instanceof Error) {
+        const { name, message, stack } = value;
+        const handle = makeShareableCloneRecursive({
+          __init: () => {
+            'worklet';
+            const error = new Error();
+            error.name = name;
+            error.message = message;
+            error.stack = stack;
+            return error;
+          },
+        });
+        shareableMappingCache.set(value, handle);
+        return handle as ShareableRef<T>;
       } else if (value instanceof ArrayBuffer) {
         toAdapt = value;
       } else if (ArrayBuffer.isView(value)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds support for cloning JS `Error` instances from RN runtime to UI runtime (or any worklet runtime).

The copied error inherits the original name, message as well as stack trace.

Initially, I also wanted to implement cloning in the opposite direction (UI &rarr; RN) but currently `makeShareableCloneOnUIRecursive` does not support initializers and most likely will be subject to change as we plan to unify the implementation of cloning across the runtimes.

## Test plan

ShareableExample.tsx
