### PR TITLE
Bump Gesture Handler version in documentation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.5",
     "react-native": "^0.71.4",
-    "react-native-gesture-handler": "^2.13.2",
+    "react-native-gesture-handler": "^2.16.0",
     "react-native-reanimated": "^3.9.0-nightly-20240320-d6dab8f65",
     "react-native-svg": "^13.14.0",
     "react-native-web": "^0.18.12",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -10344,10 +10344,10 @@ react-native-codegen@^0.71.5:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-gesture-handler@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.13.2.tgz#06813c250922db258ce4ee255f757e7ef32a3ae0"
-  integrity sha512-EADHg1cFunvu47lyzlqCJQluQxUIGZwDpdq2GEBXxFmH8AWTI2ofurio5doWnFR+dLVEjaLAzI/dU2xQjP0/pA==
+react-native-gesture-handler@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.16.0.tgz#45a00b5988e74ebc58f130c8d1443319c8e678db"
+  integrity sha512-1hFkx7RIfeJSyTQQ0Nkv4icFVZ5+XjQkd47OgZMBFzoB7ecL+nFSz8KLi3OCWOhq+nbHpSPlSG5VF3CQNCJpWA==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
## Summary

This PR upgrades `react-native-gesture-handler` version in documentation. 

## Test plan

Run docs
