### PR TITLE
Fix calculating keyboard height

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
@@ -1,7 +1,5 @@
 package com.swmansion.reanimated.keyboard;
 
-import android.view.KeyCharacterMap;
-import android.view.KeyEvent;
 import androidx.core.view.WindowInsetsCompat;
 import com.facebook.react.uimanager.PixelUtil;
 
@@ -23,9 +21,7 @@ public class Keyboard {
   public void updateHeight(WindowInsetsCompat insets) {
     int contentBottomInset = insets.getInsets(CONTENT_TYPE_MASK).bottom;
     int systemBarBottomInset = insets.getInsets(SYSTEM_BAR_TYPE_MASK).bottom;
-    boolean hasNavigationBar = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME);
-    int keyboardHeightDip =
-        hasNavigationBar ? contentBottomInset - systemBarBottomInset : contentBottomInset;
+    int keyboardHeightDip = contentBottomInset - systemBarBottomInset;
     int keyboardHeight = (int) PixelUtil.toDIPFromPixel(Math.max(0, keyboardHeightDip));
     if (keyboardHeight == 0 && mState == KeyboardState.OPEN) {
       /*
@@ -35,7 +31,7 @@ public class Keyboard {
       */
       return;
     }
-    mHeight = (int) PixelUtil.toDIPFromPixel(keyboardHeightDip);
+    mHeight = keyboardHeight;
   }
 
   public void onAnimationStart() {

--- a/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -9,7 +9,6 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.swmansion.reanimated.BuildConfig;
 import java.lang.ref.WeakReference;
 
 public class WindowsInsetsManager {
@@ -58,24 +57,19 @@ public class WindowsInsetsManager {
   }
 
   private WindowInsetsCompat onApplyWindowInsetsListener(View view, WindowInsetsCompat insets) {
+    WindowInsetsCompat defaultInsets = ViewCompat.onApplyWindowInsets(view, insets);
     if (mKeyboard.getState() == KeyboardState.OPEN) {
       mKeyboard.updateHeight(insets);
       mNotifyAboutKeyboardChange.call();
     }
-    setWindowInsets(insets);
-    return insets;
+    setWindowInsets(defaultInsets);
+    return defaultInsets;
   }
 
   private void setWindowInsets(WindowInsetsCompat insets) {
-    int paddingBottom = 0;
-    boolean isOldPaperImplementation =
-        !BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && BuildConfig.REACT_NATIVE_MINOR_VERSION < 70;
-    if (isOldPaperImplementation) {
-      int navigationBarTypeMask = WindowInsetsCompat.Type.navigationBars();
-      paddingBottom = insets.getInsets(navigationBarTypeMask).bottom;
-    }
     int systemBarsTypeMask = WindowInsetsCompat.Type.systemBars();
     int paddingTop = insets.getInsets(systemBarsTypeMask).top;
+    int paddingBottom = insets.getInsets(systemBarsTypeMask).bottom;
     updateInsets(paddingTop, paddingBottom);
   }
 

--- a/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -89,7 +89,7 @@ public class WindowsInsetsManager {
     FrameLayout.LayoutParams params =
         new FrameLayout.LayoutParams(matchParentFlag, matchParentFlag);
     if (mIsStatusBarTranslucent) {
-      params.setMargins(0, 0, 0, 0);
+      params.setMargins(0, 0, 0, paddingBottom);
     } else {
       params.setMargins(0, paddingTop, 0, paddingBottom);
     }


### PR DESCRIPTION
## Summary

Should fix: #5811

Keyboard height seems to be improperly calculated. Based on my investigation it seems that ` WindowInsetsCompat.Type.ime()` includes height of the keyboard + bottom navigation. What Reanimated does currently is checking if navigation bar is visible (`KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_HOME);`) and then subtracts the bottom inset `int keyboardHeight = DiphasNavigationBar ? contentBottomInset - systemBarBottomInset : contentBottomInset;`. But to my understanding `hasNavigationBar` is always true, thus when keyboard is hidden keyboard height becomes `-contentBottomInset`. So I changed the navigation height to be `Math.max(0, keyboardHeightDip)`

Additionally in WindowInsetsManager.java I applied default paddings and added padding bottom which should help correctly position element from the bottom. 

### Remarks
- on older androids < 11, hidden status bar rolls back to adjustPan keyboard behavior
- flag `isStatusBarTranslucentAndroid` doesn't seems to do anything when screen has native header (`headerShown: true`)

### Examples before vs after 

*Adding useAnimatedKeyboard breaks the layout*
|Before|After|
|-|-|
|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/bb3bec01-7e57-451f-8d43-2271739402eb" />|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/46eff754-5eea-41d0-9ffe-20657cdc4e0c" />|

*After closing the keyboard there is unexpected gap (negative height)*
|Before|After|
|-|-|
|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/284d0be5-5cb2-439a-b0f3-5881525f0ec6" />|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/5e6ebf04-6d53-4284-8ad0-d079fbe242bd" />|

*When StatusBar is hidden keyboard nor working properly on Android 10 - not fixed but not a regression*
|Before|After|
|-|-|
|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/75041b95-7db9-4a12-89f5-a68ab5006ea9" />|<video src="https://github.com/software-mansion/react-native-reanimated/assets/11800297/608ac6e6-9dcc-40bc-8f41-d6132e21b006" />|

## Test plan

<details>
<summary>Example showing the problem</summary>

```jsx
import React, { useEffect, useState } from 'react';
import Animated, {
  useAnimatedKeyboard,
  useAnimatedReaction,
  useAnimatedStyle,
} from 'react-native-reanimated';
import {
  Platform,
  StatusBar,
  StyleSheet,
  TextInput,
  View,
  Text,
  Button,
} from 'react-native';

export default function EmptyExample() {
  const [statusBarHidden, setStatusBarHidden] = useState(false);
  const keyboard = useAnimatedKeyboard();

  const animatedStyles = useAnimatedStyle(() => ({
    transform: [{ translateY: -keyboard.height.value }],
  }));

  useAnimatedReaction(
    () => {
      return keyboard.height.value;
    },
    (currentValue) => console.log(currentValue)
  );

  useEffect(() => {
    StatusBar.setHidden(statusBarHidden);
  }, [statusBarHidden]);

  return (
    <Animated.View
      style={[
        styles.container,
        animatedStyles,
        { justifyContent: 'flex-end', borderWidth: 5, borderColor: '#ff0' },
      ]}>
      <Button
        title="Toggle StatusBar"
        onPress={() => setStatusBarHidden((hidden) => !hidden)}
      />
      <Button
        title="Show Warning"
        onPress={() => console.warn('WARNING!!!!')}
      />
      <View
        style={[
          styles.center,
          {
            height: 200,
            backgroundColor: '#f0f',
            borderWidth: 5,
            borderColor: '#0ff',
          },
        ]}>
        <Text>{`Android ${Platform.constants['Release']}`}</Text>
        <TextInput placeholder="Test" />
      </View>
    </Animated.View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1 },
  center: { justifyContent: 'center', alignItems: 'center' },
});

```

</details>