### PR TITLE
feat: suggest useComposedScrollHandler hook

### DIFF
--- a/app/src/examples/ComposedScrollHandler/index.tsx
+++ b/app/src/examples/ComposedScrollHandler/index.tsx
@@ -1,0 +1,54 @@
+import Animated, {
+  AnimatedScrollViewProps,
+  useAnimatedScrollHandler,
+} from 'react-native-reanimated';
+import { StyleSheet, Text } from 'react-native';
+
+import React from 'react';
+import { useComposedScrollHandler } from '../../../../src/reanimated2/hook/composeAnimatedScrollHandler';
+
+export default function ComposedAnimatedScrollHandlerExample() {
+  const externalScrollHandler = useAnimatedScrollHandler((event) => {
+    console.log('External handler', event.contentOffset.y);
+  });
+
+  return (
+    <CustomScrollView
+      onScroll={externalScrollHandler}
+      style={styles.scrollView}>
+      {[...Array(100)].map((_, i) => (
+        <Text key={i} style={styles.text}>
+          {i}
+        </Text>
+      ))}
+    </CustomScrollView>
+  );
+}
+
+function CustomScrollView(props: AnimatedScrollViewProps) {
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    console.log('Internal handler', event.contentOffset.y);
+  });
+
+  const composedScrollHandler = useComposedScrollHandler([
+    scrollHandler,
+    props.onScroll, // <- I don't know how to correctly type this
+  ]);
+
+  return (
+    <Animated.ScrollView {...props} onScroll={composedScrollHandler}>
+      {props.children}
+    </Animated.ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+    width: '100%',
+  },
+  text: {
+    fontSize: 50,
+    textAlign: 'center',
+  },
+});

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -124,6 +124,7 @@ import HabitsExample from './LayoutAnimations/HabitsExample';
 import MemoExample from './MemoExample';
 import PerformanceMonitorExample from './PerfomanceMonitorExample';
 import ScreenTransitionExample from './ScreenTransitionExample';
+import ComposedScrollHandler from './ComposedScrollHandler';
 
 interface Example {
   icon?: string;
@@ -340,6 +341,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🗣',
     title: 'useFrameCallback',
     screen: FrameCallbackExample,
+  },
+  ComposedScrollHandler: {
+    icon: '🔀',
+    title: 'useComposedScrollHandler',
+    screen: ComposedScrollHandler,
   },
   ScrollViewExample: {
     icon: '📜',

--- a/src/reanimated2/hook/composeAnimatedScrollHandler.ts
+++ b/src/reanimated2/hook/composeAnimatedScrollHandler.ts
@@ -1,0 +1,28 @@
+import type {ScrollHandlerInternal, ScrollHandlerProcessed} from "./useAnimatedScrollHandler";
+import {useEvent, useHandler} from "./index";
+import type {RNNativeScrollEvent} from "./commonTypes";
+
+
+
+export function useComposedScrollHandler<Context extends Record<string, unknown>>(
+    handlerList: Array<ScrollHandlerProcessed<Context> | undefined>, // <- I don't know how to correctly type this
+){
+
+    /**
+     * unknown casting seems legitimate. See {@link useHandler} override
+     */
+    const internalHandlerList = handlerList as unknown as Array<ScrollHandlerInternal>;
+
+    const {doDependenciesDiffer} = useHandler({}, internalHandlerList);
+
+    const allWorklets = internalHandlerList.flatMap(handler => handler.workletEventHandler?.worklet ? handler.workletEventHandler?.worklet : []);
+
+    return useEvent<RNNativeScrollEvent, Context>(
+        (event) => {
+            'worklet';
+            allWorklets.forEach(it => it(event));
+        },
+        ['onScroll', 'onScrollBeginDrag', 'onScrollEndDrag', 'onMomentumScrollBegin', 'onMomentumScrollEnd'],
+        doDependenciesDiffer,
+    );
+}


### PR DESCRIPTION
The goal of this hook is to be able to compose multiple scrollHandler, and therefore "hide" the fact that a custom scrollView already use a scrollHandler.

## why

Let's say I want to create a Fancy ScrollView that use `useAnimatedScrollHandler` internally to do some animation, on the background color for example.
I want to expose this new component to the team and let them use their own animations (in addition to mines) using `reanimated` primitives.

Maybe I missed something in the documentation, but as of today it seems that there is no **easy** way to do it.
We have to provide a custom API for our `FancyScrollView` to handle `onScroll`, `onMomentumScrollEnd` etc ...
This is not ideal because now the implementation details of our FancyScrollView have somehow leaked outside our component.


## Existing discussion

https://github.com/software-mansion/react-native-reanimated/discussions/3611

## Status
This is still a work in progress, I would really appreciate some feedback on this:
- Would it actually make sense to add this API in reanimated ? (Or should it be an external lib ?)
- Is this the right way to do it ?
- How to type the handlerList params properly ?

