### PR TITLE
Made unneeded and empty JS reanimated methods throw errors

### DIFF
--- a/src/reanimated2/js-reanimated/JSReanimated.ts
+++ b/src/reanimated2/js-reanimated/JSReanimated.ts
@@ -55,12 +55,15 @@ export default class JSReanimated {
     _eventName: string,
     _emitterReactTag: number
   ): number {
-    // noop
-    return -1;
+    throw new Error(
+      '[Reanimated] registerEventHandler is not available in JSReanimated.'
+    );
   }
 
   unregisterEventHandler(_: number): void {
-    // noop
+    throw new Error(
+      '[Reanimated] unregisterEventHandler is not available in JSReanimated.'
+    );
   }
 
   enableLayoutAnimations() {


### PR DESCRIPTION
## Summary

`registerEventHandler` and `unregisterEventHandler` methods in JS Reanimated were empty so far, but used in `WorkletEventHandler`. Since https://github.com/software-mansion/react-native-reanimated/pull/5845 makes sure they are not used anymore, we can throw errors instead of keeping them empty.

Note: to be merged after https://github.com/software-mansion/react-native-reanimated/pull/5845 gets merged.

## Test plan

:shipit: 
