### PR TITLE
docs(README-Fabric): updated next tag to nightly

### DIFF
--- a/README-Fabric.md
+++ b/README-Fabric.md
@@ -1,9 +1,0 @@
-# React Native Reanimated – Fabric version
-
-To use this library with your Fabric application, you have to:
-
-1. Add `react-native-reanimated@nightly`
-2. on iOS
-   - Install pods using `RCT_NEW_ARCH_ENABLED=1 pod install` – this is the same command you run to prepare a Fabric build but you also need to run it after a new native library gets added.
-3. on Android
-   - There are no additional steps required so long as your app is configured to build with Fabric – this is typically configured by setting `newArchEnabled=true` in `gradle.properties` file in your project.

--- a/README-Fabric.md
+++ b/README-Fabric.md
@@ -2,7 +2,7 @@
 
 To use this library with your Fabric application, you have to:
 
-1. Add `react-native-reanimated@next`
+1. Add `react-native-reanimated@nightly`
 2. on iOS
    - Install pods using `RCT_NEW_ARCH_ENABLED=1 pod install` – this is the same command you run to prepare a Fabric build but you also need to run it after a new native library gets added.
 3. on Android


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Updates the Fabric documentation to install `react-native-reanimated@nightly` since the `next` tag isn't available anymore.

## Test plan
n/a