### PR TITLE
Fix color in the swm color palette

### DIFF
--- a/docs/src/css/colors.css
+++ b/docs/src/css/colors.css
@@ -41,7 +41,7 @@
   --swm-blue-dark-120: #126893;
   --swm-blue-dark-100: #00a9f0;
   --swm-blue-dark-80: #6fcef5;
-  --swm-blue-dark-60: #00a9f0;
+  --swm-blue-dark-60: #a8dbf0;
   --swm-blue-dark-40: #d7f0fa;
 
   --swm-green-light-100: #57b495;


### PR DESCRIPTION
There was a typo in Figma design file that propagated a wrong color across different projects/documentations.