### PR TITLE
Update docs regarding event handlers' reusability

### DIFF
--- a/docs/docs/advanced/useEvent.mdx
+++ b/docs/docs/advanced/useEvent.mdx
@@ -31,7 +31,7 @@ Value indicating whether handler should be rebuilt.
 
 ### Returns
 
-The hook returns event handler that will be invoked when native event is dispatched. That handler should be connected to only one component.
+The hook returns event handler that will be invoked when native event is dispatched. That handler may be connected to multiple components and will be invoked for each one's specific events.
 
 ## Example
 

--- a/docs/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/docs/docs/scroll/useAnimatedScrollHandler.mdx
@@ -68,7 +68,7 @@ The handler should be passed under `onScroll` parameter regardless of whether it
 
 ### Remarks
 
-The hook returns a handler that is not supposed to be passed to multiple components. You need a separate handler for each scrollable container.
+- The hook returns a handler that may be passed to multiple components. In such situation, the handler will invoke for the given events each time any of the components dispatches them.
 
 ## Example
 

--- a/docs/docs/scroll/useScrollViewOffset.mdx
+++ b/docs/docs/scroll/useScrollViewOffset.mdx
@@ -48,10 +48,6 @@ An optional shared value to be updated with the scroll offset. If not provided a
 
 `useScrollViewOffset` returns a [shared value](/docs/fundamentals/glossary#shared-value) which holds the current offset of the `ScrollView`.
 
-### Remarks
-
-The `animatedRef` passed to the hook mustn't be changed dynamically.
-
 ## Example
 
 import ScrollViewOffset from '@site/src/examples/ScrollViewOffset';


### PR DESCRIPTION
## Summary

After some updates, our event handlers can now be used for multiple components, thus the change.

NOTE: this PR can be merged ONLY after https://github.com/software-mansion/react-native-reanimated/pull/5909 because of some yarn issues (`yarn.lock` file will be added to changes afterwards).

## Test plan

:shipit: 
