### PR TITLE
Fix "Test docs build" on CI

### DIFF
--- a/docs/static/examples/Marquee.js
+++ b/docs/static/examples/Marquee.js
@@ -56,9 +56,8 @@ const ChildrenScroller = ({
   }, [reverse]);
 
   useFrameCallback((i) => {
-    offset.value +=
-      (coeff.value * ((i.timeSincePreviousFrame ?? 1) * childrenWidth)) /
-      duration;
+    // prettier-ignore
+    offset.value += (coeff.value * ((i.timeSincePreviousFrame ?? 1) * childrenWidth)) / duration;
     offset.value = offset.value % childrenWidth;
   }, true);
 


### PR DESCRIPTION
For some reason docusarus build on CI adds a semi-colon in an incorrect place making the code from Marquee example not compile. It works on local and main but breaks on `Test build docs` CI.


This PR adds a `prettier-ignore` to prevent breaking the line in between division making it impossible for javascript interpreter to put `;` in an incorrect place.

### Before

![image](https://github.com/software-mansion/react-native-reanimated/assets/39658211/97f27f05-45a2-47db-9ba9-69dc11457484)

https://github.com/software-mansion/react-native-reanimated/actions/runs/8751612886/job/24017576211?pr=5914


### After 

CI ✅ 
