### PR TITLE
Fix production build

### DIFF
--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -188,7 +188,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   [[self.moduleRegistry moduleForName:"EventDispatcher"] addDispatchObserver:self];
 }
 
-#ifndef NDEBUG
 - (void)setReaSurfacePresenter
 {
   if (reaSurface == nil) {
@@ -198,7 +197,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   }
   reaSurface.reaModule = self;
 }
-#endif // NDEBUG
 
 #else // RCT_NEW_ARCH_ENABLED
 


### PR DESCRIPTION
## Summary

This PR fixes production build for iOS. In https://github.com/software-mansion/react-native-reanimated/pull/5901 I called `setReaSurfacePresenter` method but this one was defined only on debug build.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/5912

## Test plan

Run production build for iOS
