### PR TITLE
Fix some typos

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -10,7 +10,8 @@
     "barfoo",
     "devs",
     "lightspeed",
-    "easings"
+    "easings",
+    "snapshotting"
   ],
   "ignorePaths": ["node_modules", "docs/src/components/Testimonials"],
   "useGitignore": true

--- a/cspell.json
+++ b/cspell.json
@@ -8,12 +8,10 @@
     "workletizes",
     "workletized",
     "barfoo",
-    "devs"
+    "devs",
+    "lightspeed",
+    "easings"
   ],
-  "ignorePaths": [
-    "node_modules",
-    "docs/src/components/Testimonials"
-  ],
+  "ignorePaths": ["node_modules", "docs/src/components/Testimonials"],
   "useGitignore": true
 }
-

--- a/src/reanimated2/layoutReanimation/web/animationsManager.ts
+++ b/src/reanimated2/layoutReanimation/web/animationsManager.ts
@@ -48,7 +48,7 @@ function checkUndefinedAnimationFail(
   }
 
   console.warn(
-    "[Reanimated] Couldn't load entering/exiting animation. Current version supports only predefined animations with modifiers: duration, delay, easing, randomizeDelay, wtihCallback, reducedMotion."
+    "[Reanimated] Couldn't load entering/exiting animation. Current version supports only predefined animations with modifiers: duration, delay, easing, randomizeDelay, withCallback, reducedMotion."
   );
 
   return true;

--- a/src/reanimated2/layoutReanimation/web/componentUtils.ts
+++ b/src/reanimated2/layoutReanimation/web/componentUtils.ts
@@ -276,7 +276,7 @@ export function handleExitingAnimation(
 
   const scrollOffsets = getElementScrollValue(element);
 
-  // Scroll does not trigger snapshoting, therefore if we start exiting animation after
+  // Scroll does not trigger snapshotting, therefore if we start exiting animation after
   // scrolling through parent component, dummy will end up in wrong place. In order to fix that
   // we keep last known scroll position in snapshot and then adjust dummy position based on
   // last known scroll offset and current scroll offset

--- a/src/reanimated2/layoutReanimation/web/createAnimation.ts
+++ b/src/reanimated2/layoutReanimation/web/createAnimation.ts
@@ -14,7 +14,7 @@ import { FadingTransition } from './transition/Fading.web';
 import { insertWebAnimation } from './domUtils';
 
 // Translate values are passed as numbers. However, if `translate` property receives number, it will not automatically
-// convert it to `px`. Therefore if we want to keep exisitng transform we have to add 'px' suffix to each of translate values
+// convert it to `px`. Therefore if we want to keep existing transform we have to add 'px' suffix to each of translate values
 // that are present inside transform.
 function addPxToTranslate(
   existingTransform: NonNullable<TransformsStyle['transform']>
@@ -43,7 +43,7 @@ function addPxToTranslate(
   return newTransform;
 }
 
-// In order to keep exisitng transform throughout animation, we have to add it to each of keyframe step.
+// In order to keep existing transform throughout animation, we have to add it to each of keyframe step.
 function addExistingTransform(
   newAnimationData: AnimationData,
   newTransform: ReanimatedWebTransformProperties[]


### PR DESCRIPTION
## Summary

#5888 introduced spell checker on our CI and it turns out that there are some typos in web LA codebase. This PR aims to remove them. 

Also I've decided to add "lightspeed", "easings" and "snapshotting" into correct words list, let me know if I should replace them with something else.

Here you can find that these forms are actually correct:

- [snapshotting](https://www.verbix.com/webverbix/english/snapshot)
- [easings](https://www.verbix.com/webverbix/english/snapshot)
- [lightspeed](https://en.wiktionary.org/wiki/lightspeed)

## Test plan

Check that CI passes.