### PR TITLE
fix: copy state in reanimated commit hook

### DIFF
--- a/Common/cpp/Fabric/ShadowTreeCloner.cpp
+++ b/Common/cpp/Fabric/ShadowTreeCloner.cpp
@@ -53,6 +53,7 @@ ShadowNode::Unshared cloneShadowTreeWithNewProps(
     newChildNode = parentNode.clone({
         ShadowNodeFragment::propsPlaceholder(),
         std::make_shared<ShadowNode::ListOfShared>(children),
+        parentNode.getState()
     });
   }
 

--- a/Common/cpp/Fabric/ShadowTreeCloner.cpp
+++ b/Common/cpp/Fabric/ShadowTreeCloner.cpp
@@ -26,7 +26,7 @@ ShadowNode::Unshared cloneShadowTreeWithNewProps(
   const auto props = source->getComponentDescriptor().cloneProps(
       propsParserContext, source->getProps(), std::move(rawProps));
 
-  auto newChildNode = source->clone({/* .props = */ props});
+  auto newChildNode = source->clone({/* .props = */ props, ShadowNodeFragment::childrenPlaceholder(), source->getState()});
 
   for (auto it = ancestors.rbegin(); it != ancestors.rend(); ++it) {
     auto &parentNode = it->first.get();


### PR DESCRIPTION
## Summary

Fix for the issue: https://github.com/Expensify/App/issues/40048 which root cause of seems to be the not copied state of `ScrollView` when this code is not added. I'll try to provide a simple repro when I get some time to do it.

## Test plan
