### PR TITLE
Fix platform events for bridgeless

### DIFF
--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -131,7 +131,11 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)handleJavaScriptDidLoadNotification:(NSNotification *)notification
 {
-  _surfacePresenter = self.bridge.surfacePresenter;
+  [self attachReactEventListener];
+}
+
+- (void)attachReactEventListener
+{
   RCTScheduler *scheduler = [_surfacePresenter scheduler];
   __weak __typeof__(self) weakSelf = self;
   _surfacePresenter.runtimeExecutor(^(jsi::Runtime &runtime) {
@@ -289,6 +293,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
     });
     auto nativeReanimatedModule = reanimated::createReanimatedModuleBridgeless(
         _moduleRegistry, rnRuntime, std::string([valueUnpackerCode UTF8String]), executorFunction);
+    [self attachReactEventListener];
     [self commonInit:nativeReanimatedModule withRnRuntime:rnRuntime];
 #else // REACT_NATIVE_MINOR_VERSION >= 74 && defined(RCT_NEW_ARCH_ENABLED)
     [NSException raise:@"Missing bridge" format:@"[Reanimated] Failed to obtain the bridge."];


### PR DESCRIPTION
## Summary

This PR adds missing registration for platform events such as scroll events on Bridgeless mode. In the previous PR (https://github.com/software-mansion/react-native-reanimated/pull/5901) I checked support for Gesture Handler events, I forgot about platform events

## Test plan

| before | after |
| --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/0d83f08a-16d4-4669-bfea-a630ded6451f" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/2819b8b8-8c0a-4160-80d1-c5488ea9b0a5" /> |