### PR TITLE
Adding playground to withDecay subpage

### DIFF
--- a/docs/docs/animations/withDecay.mdx
+++ b/docs/docs/animations/withDecay.mdx
@@ -62,6 +62,10 @@ enum ReduceMotion {
 
 The decay animation configuration.
 
+import { useDecayPlayground } from '@site/src/components/InteractivePlayground';
+
+<InteractivePlayground usePlayground={useDecayPlayground} />
+
 Available properties:
 
 | Name                          | Type               | Default               | Description                                                                                                                                                                                                             |

--- a/docs/src/components/InteractivePlayground/index.tsx
+++ b/docs/src/components/InteractivePlayground/index.tsx
@@ -12,6 +12,7 @@ import useSpringPlayground from './useSpringPlayground';
 import useTimingPlayground from './useTimingPlayground';
 import useInterpolateColorPlayground from './useInterpolateColorPlayground';
 import useAnimatedSensorPlayground from './useAnimatedSensorPlayground';
+import useDecayPlayground from './useDecayPlayground';
 
 import Reset from '@site/static/img/reset.svg';
 import ResetDark from '@site/static/img/reset-dark.svg';
@@ -31,6 +32,7 @@ export {
   useTimingPlayground,
   useInterpolateColorPlayground,
   useAnimatedSensorPlayground,
+  useDecayPlayground,
 };
 
 interface InteractivePlaygroundProps {

--- a/docs/src/components/InteractivePlayground/useDecayPlayground/Example.tsx
+++ b/docs/src/components/InteractivePlayground/useDecayPlayground/Example.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  cancelAnimation,
+  WithDecayConfig,
+  withDecay,
+} from 'react-native-reanimated';
+
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+
+interface Props {
+  options: Omit<WithDecayConfig, 'rubberBandFactor'> & {
+    rubberBandFactor: number;
+  };
+}
+
+export default function App({ options }: Props) {
+  const offset = useSharedValue(0);
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateX: offset.value }],
+    };
+  });
+
+  useEffect(() => {
+    cancelAnimation(offset);
+    offset.value = 0;
+  }, [options]);
+
+  const pan = Gesture.Pan()
+    .onChange((event) => {
+      offset.value += event.changeX;
+    })
+    .onFinalize((event) => {
+      offset.value = withDecay({
+        velocity: event.velocityX,
+        ...(options as WithDecayConfig),
+      });
+    });
+
+  return (
+    <GestureHandlerRootView style={styles.container}>
+      <View style={styles.wrapper}>
+        <GestureDetector gesture={pan}>
+          <Animated.View style={[styles.box, animatedStyles]} />
+        </GestureDetector>
+      </View>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    marginTop: 64,
+    marginBottom: 34,
+  },
+  wrapper: {
+    flex: 1,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  box: {
+    height: 100,
+    width: 100,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    cursor: 'grab',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/docs/src/components/InteractivePlayground/useDecayPlayground/index.tsx
+++ b/docs/src/components/InteractivePlayground/useDecayPlayground/index.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import Example from './Example';
+
+import {
+  Range,
+  CheckboxOption,
+  SelectOption,
+  formatReduceMotion,
+  DoubleRange,
+} from '..';
+import { ReduceMotion, WithDecayConfig } from 'react-native-reanimated';
+
+const defaultConfig: Omit<WithDecayConfig, 'rubberBandFactor'> & {
+  rubberBandFactor: number;
+} = {
+  deceleration: 0.998,
+  clamp: [-300, 300],
+  velocityFactor: 1,
+  rubberBandEffect: true,
+  rubberBandFactor: 0.6,
+  reduceMotion: ReduceMotion.System,
+};
+
+export default function useDecayPlayground() {
+  const [deceleration, setDeceleration] = useState(defaultConfig.deceleration);
+  const [clampMin, setClampMin] = useState(defaultConfig.clamp[0]);
+  const [clampMax, setClampMax] = useState(defaultConfig.clamp[1]);
+  const [velocityFactor, setVelocityFactor] = useState(
+    defaultConfig.velocityFactor
+  );
+  const [rubberBandEffect, setRubberBandEffect] = useState(
+    defaultConfig.rubberBandEffect
+  );
+  const [rubberBandFactor, setRubberBandFactor] = useState(
+    defaultConfig.rubberBandFactor
+  );
+  const [reduceMotion, setReduceMotion] = useState(defaultConfig.reduceMotion);
+
+  const resetOptions = () => {
+    setDeceleration(() => defaultConfig.deceleration);
+    setClampMin(() => defaultConfig.clamp[0]);
+    setClampMax(() => defaultConfig.clamp[1]);
+    setVelocityFactor(() => defaultConfig.velocityFactor);
+    setRubberBandEffect(() => defaultConfig.rubberBandEffect);
+    setReduceMotion(() => defaultConfig.reduceMotion);
+  };
+
+  const code = `
+    withDecay({
+      velocity: event.velocityX,
+      deceleration: ${deceleration},
+      clamp: [${clampMin}, ${clampMax}],
+      velocityFactor: ${velocityFactor},
+      rubberBandEffect: ${rubberBandEffect},
+      ${rubberBandEffect ? '' : '// '}rubberBandFactor: ${rubberBandFactor},
+      reduceMotion: ${formatReduceMotion(reduceMotion)},
+    })
+  `;
+
+  const controls = (
+    <>
+      {/* Needed state-controlled Tabs and `TabItem` components from "@theme/Tabs" so I hacked them around with classes ;) */}
+      <Range
+        label="Deceleration"
+        min={0.9}
+        max={1}
+        step={0.001}
+        value={deceleration}
+        onChange={setDeceleration}
+      />
+      <DoubleRange
+        label="Clamp limits"
+        min={defaultConfig.clamp[0]}
+        max={defaultConfig.clamp[1]}
+        step={1}
+        value={[clampMin, clampMax]}
+        onChange={[setClampMin, setClampMax]}
+      />
+      <Range
+        label="Velocity factor"
+        min={0.1}
+        max={2}
+        step={0.1}
+        value={velocityFactor}
+        onChange={setVelocityFactor}
+      />
+      <CheckboxOption
+        label="Rubber band effect"
+        value={rubberBandEffect}
+        onChange={setRubberBandEffect}
+      />
+      <Range
+        label="Rubber band factor"
+        min={0.1}
+        max={1}
+        step={0.1}
+        value={rubberBandFactor}
+        onChange={setRubberBandFactor}
+      />
+      <SelectOption
+        label="Reduce motion"
+        value={reduceMotion}
+        onChange={(option) => setReduceMotion(option as ReduceMotion)}
+        options={[ReduceMotion.System, ReduceMotion.Always, ReduceMotion.Never]}
+      />
+    </>
+  );
+
+  return {
+    example: Example,
+    props: {
+      options: {
+        deceleration,
+        clamp: [clampMin, clampMax],
+        velocityFactor,
+        rubberBandEffect,
+        rubberBandFactor,
+        reduceMotion,
+      },
+    },
+    controls,
+    code,
+    resetOptions,
+    additionalComponents: {},
+  };
+}


### PR DESCRIPTION
## Summary
This PR includes a playground to withDecay subpage.

## Preview
withDecay Playground
<img width="994" alt="Zrzut ekranu 2024-04-26 o 12 23 33" src="https://github.com/software-mansion/react-native-reanimated/assets/80314375/cd1c69a2-4309-48ae-a0f3-8319a1cae87a">

## Test plan
Command to change current working dictionary:
> cd docs

Command to download libraries:
> yarn

Command to preview feature:
> yarn start