### PR TITLE
Remove `CellRendererComponent` from Animated.FlatList props

### DIFF
--- a/__typetests__/common/AnimatedComponentTest.tsx
+++ b/__typetests__/common/AnimatedComponentTest.tsx
@@ -23,6 +23,15 @@ function AnimatedComponentPropsTest() {
         <MyAnimatedScrollView style={RNStyle} />
         <Animated.FlatList
           style={RNStyle}
+          // @ts-expect-error
+          CellRendererComponent={() => {
+            return <View />;
+          }}
+          data={[]}
+          renderItem={() => <View />}
+        />
+        <Animated.FlatList
+          style={RNStyle}
           data={[]}
           renderItem={() => <View />}
         />

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -42,7 +42,7 @@ const createCellRendererComponent = (
 };
 
 interface ReanimatedFlatListPropsWithLayout<T>
-  extends Omit<AnimatedProps<FlatListProps<T>>, 'CellRendererComponent'> {
+  extends AnimatedProps<FlatListProps<T>> {
   /**
    * Lets you pass layout animation directly to the FlatList item.
    */
@@ -51,6 +51,10 @@ interface ReanimatedFlatListPropsWithLayout<T>
    * Lets you skip entering and exiting animations of FlatList items when on FlatList mount or unmount.
    */
   skipEnteringExitingAnimations?: boolean;
+  /**
+   * CellRendererComponent is not supported in Animated.FlatList
+   */
+  CellRendererComponent?: never;
 }
 
 export type FlatListPropsWithLayout<T> = ReanimatedFlatListPropsWithLayout<T>;

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -42,7 +42,7 @@ const createCellRendererComponent = (
 };
 
 interface ReanimatedFlatListPropsWithLayout<T>
-  extends AnimatedProps<FlatListProps<T>> {
+  extends Omit<AnimatedProps<FlatListProps<T>>, 'CellRendererComponent'> {
   /**
    * Lets you pass layout animation directly to the FlatList item.
    */

--- a/src/reanimated2/component/FlatList.tsx
+++ b/src/reanimated2/component/FlatList.tsx
@@ -52,7 +52,7 @@ interface ReanimatedFlatListPropsWithLayout<T>
    */
   skipEnteringExitingAnimations?: boolean;
   /**
-   * CellRendererComponent is not supported in Animated.FlatList
+   * Property `CellRendererComponent` is not supported in `Animated.FlatList`.
    */
   CellRendererComponent?: never;
 }


### PR DESCRIPTION
## Summary

Closes #5931 

In our implementation of Animated.FlatList we overwrite `CellRendererComponent` and providing it is not supported. Therefore I remove it from valid props

## Error message
Error message should contain the information "CellRendererComponent is not supported in Animated.FlatList"
Code:
<img width="717" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/0e59d647-26ac-4f2c-8082-333b9b3ecd67">

Error message:
<img width="717" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/e569fa48-9d90-48f6-a6ae-1bbdea698dc6">

## Test plan

Tests in `__typetests__/common/AnimatedComponentTest.tsx` added

