### PR TITLE
Prevent iOS bridgeless initialization from getting the wrong bridge

### DIFF
--- a/apple/REAModule.mm
+++ b/apple/REAModule.mm
@@ -281,7 +281,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
 {
   if (_isBridgeless) {
 #if REACT_NATIVE_MINOR_VERSION >= 74 && defined(RCT_NEW_ARCH_ENABLED)
-    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)[RCTBridge currentBridge];
+    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
     auto &rnRuntime = *(jsi::Runtime *)cxxBridge.runtime;
     auto executorFunction = ([executor = _runtimeExecutor](std::function<void(jsi::Runtime & runtime)> &&callback) {
       // Convert to Objective-C block so it can be captured properly.


### PR DESCRIPTION
## Summary

As I pointed out [here](https://github.com/software-mansion/react-native-reanimated/pull/5901#discussion_r1567743828), using `[RCTBridge currentBridge]` may lead to the wrong bridge in apps that have multiple React instances, as is the case for expo-dev-client.

https://github.com/software-mansion/react-native-reanimated/blob/7e1a19ed8190763456e96939eec71c2528c1eed4/apple/REAModule.mm#L284

Fixes #5497 

Instead of using `[RCTBridge currentBridge]` we can just call `self.bridge` and ensure the correct bridge is always used 

## Test plan

Run FabricExample app on iOS 
