### PR TITLE
Use `[RCTUIManager viewForReactTag:]` instead of `viewRegistry` to avoid infinite loop in `[RCTComponentViewRegistry objectForKey:]`

### DIFF
--- a/apple/LayoutReanimation/REASwizzledUIManager.mm
+++ b/apple/LayoutReanimation/REASwizzledUIManager.mm
@@ -220,8 +220,8 @@ std::atomic<bool> hasPendingBlocks;
       CGSize contentSize = shadowView.layoutMetrics.frame.size;
 
       RCTExecuteOnMainQueue(^{
-        NSMutableDictionary<NSNumber *, REAUIView *> *viewRegistry = [self valueForKey:@"_viewRegistry"];
-        REAUIView *view = viewRegistry[reactTag];
+        RCTUIManager *uiManager = [self valueForKey:@"_uiManager"];
+        REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
         RCTAssert(view != nil, @"view (for ID %@) not found", reactTag);
 
         RCTRootView *rootView = (RCTRootView *)[view superview];
@@ -245,7 +245,7 @@ std::atomic<bool> hasPendingBlocks;
     for (NSNumber *reactTag in reactTags) {
       RCTFrameData frameData = frameDataArray[index++];
 
-      REAUIView *view = viewRegistry[reactTag];
+      REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
       CGRect frame = frameData.frame;
 
       UIUserInterfaceLayoutDirection layoutDirection = frameData.layoutDirection;
@@ -331,7 +331,7 @@ std::atomic<bool> hasPendingBlocks;
     index = 0;
     for (NSNumber *reactTag in reactTags) {
       RCTFrameData frameData = frameDataArray[index++];
-      REAUIView *view = viewRegistry[reactTag];
+      REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
       BOOL isNew = frameData.isNew;
       CGRect frame = frameData.frame;
 

--- a/apple/REANodesManager.mm
+++ b/apple/REANodesManager.mm
@@ -410,7 +410,7 @@ using namespace facebook::react;
 
 - (BOOL)isNativeViewMounted:(NSNumber *)viewTag
 {
-  REAUIView *view = _viewRegistry[viewTag];
+  REAUIView *view = [_uiManager viewForReactTag:(NSNumber *)viewTag];
   if (view.superview != nil) {
     return YES;
   }


### PR DESCRIPTION
## Summary

This PR fixes the following infinite loop:

![obraz](https://github.com/software-mansion/react-native-reanimated/assets/20516055/196f62a3-1e8b-411f-9d66-3e3946dc406f)

For details, see https://github.com/expo/expo/pull/28531.

## Test plan

1. Build Example app on iOS Paper on 0.74.0
2. Open Bokeh example
3. Go back
4. Reload the app by pressing <kbd>r</kbd> in Metro console
5. Repeat steps 2-4 several times
6. When the app hangs, press pause button in Xcode debugger
