### PR TITLE
Fix crashes when reloading app quickly on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -189,6 +189,14 @@ class ReaLayoutAnimator extends LayoutAnimationController {
   }
 
   public boolean isLayoutAnimationEnabled() {
+    // In case the user rapidly reloads the app, there is a possibility that the active instance may not be available.
+    // However, the code will still attempt to trigger the layout animation of views that are going to be dropped.
+    // This is required as without it, the `mAnimationsManager.isLayoutAnimationEnabled` 
+    // would crash when trying to get the uiManager from the context.
+    if (!mContext.hasActiveReactInstance()) {
+      return false;
+    }
+    
     maybeInit();
     return mAnimationsManager.isLayoutAnimationEnabled();
   }

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -189,14 +189,16 @@ class ReaLayoutAnimator extends LayoutAnimationController {
   }
 
   public boolean isLayoutAnimationEnabled() {
-    // In case the user rapidly reloads the app, there is a possibility that the active instance may not be available.
-    // However, the code will still attempt to trigger the layout animation of views that are going to be dropped.
-    // This is required as without it, the `mAnimationsManager.isLayoutAnimationEnabled` 
+    // In case the user rapidly reloads the app, there is a possibility that the active instance may
+    // not be available.
+    // However, the code will still attempt to trigger the layout animation of views that are going
+    // to be dropped.
+    // This is required as without it, the `mAnimationsManager.isLayoutAnimationEnabled`
     // would crash when trying to get the uiManager from the context.
     if (!mContext.hasActiveReactInstance()) {
       return false;
     }
-    
+
     maybeInit();
     return mAnimationsManager.isLayoutAnimationEnabled();
   }


### PR DESCRIPTION
## Summary

Fixes:
https://github.com/software-mansion/react-native-reanimated/assets/9578601/949756a7-fb89-4bbd-89a6-52d1ba759083

Stack trace:
```
FATAL EXCEPTION: main
Process: com.lukaszkosmaty.myapp, PID: 17336
java.lang.AssertionError
	at com.swmansion.reanimated.NodesManager.<init>(NodesManager.java:157)
	at com.swmansion.reanimated.ReanimatedModule.getNodesManager(ReanimatedModule.java:133)
	at com.swmansion.reanimated.layoutReanimation.ReaLayoutAnimator.maybeInit(ReanimatedNativeHierarchyManager.java:47)
	at com.swmansion.reanimated.layoutReanimation.ReaLayoutAnimator.isLayoutAnimationEnabled(ReanimatedNativeHierarchyManager.java:193)
	at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.isLayoutAnimationDisabled(ReanimatedNativeHierarchyManager.java:269)
	at com.swmansion.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.dropView(ReanimatedNativeHierarchyManager.java:416)
	at com.facebook.react.uimanager.NativeViewHierarchyManager.removeRootView(NativeViewHierarchyManager.java:665)
	at com.facebook.react.uimanager.UIViewOperationQueue$RemoveRootViewOperation.execute(UIViewOperationQueue.java:79)
	at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:910)
	at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:1023)
	at com.facebook.react.uimanager.UIViewOperationQueue.-$$Nest$mflushPendingBatches(Unknown Source:0)
	at com.facebook.react.uimanager.UIViewOperationQueue$2.runGuarded(UIViewOperationQueue.java:979)
	at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:29)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7839)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

It seems that the code is attempting to trigger the layout animation for views that are going to be removed, but due to the app being in a reloading state, the native side is not fully initialized. I believe that in such cases, it would be best to temporarily disable the layout animation. 

![Screenshot 2024-04-30 at 16 07 33](https://github.com/software-mansion/react-native-reanimated/assets/9578601/74aebe14-0619-4bc1-9927-a0860b22d68a)

> ⚠️ Note: I'm not 100% sure if that is a correct fix, however, I don't have any other ideas.  

## Test plan

The crash also happens without the `dev-client`, but it isn't that often. So it's easier to reproduce it like this. 
```
yarn create expo-app --template default@sdk-51
cd my-app
yarn expo install expo-dev-client
yarn expo run:android
# reload the app multiple times 
```