### PR TITLE
Fix EXC_BAD_ACCESS crash on iOS in `[REAAnimationsManager clearSharedTransitionConfigForTag:]`

### DIFF
--- a/apple/LayoutReanimation/REAAnimationsManager.m
+++ b/apple/LayoutReanimation/REAAnimationsManager.m
@@ -619,6 +619,10 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (void)clearSharedTransitionConfigForTag:(NSNumber *)tag
 {
+  if (!_clearSharedTransitionConfigForTag) {
+    // TODO: find out why this method gets called but LayoutAnimationsManager is not initialized
+    return;
+  }
   _clearSharedTransitionConfigForTag(tag);
 }
 

--- a/apple/LayoutReanimation/REAAnimationsManager.m
+++ b/apple/LayoutReanimation/REAAnimationsManager.m
@@ -94,6 +94,9 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
     _clearAnimationConfigForTag = ^(NSNumber *tag) {
       // default implementation, this block will be replaced by a setter
     };
+    _clearSharedTransitionConfigForTag = ^(NSNumber *tag) {
+      // default implementation, this block will be replaced by a setter
+    };
 #ifndef NDEBUG
     _checkDuplicateSharedTag = ^(REAUIView *view, NSNumber *viewTag) {
       // default implementation, this block will be replaced by a setter
@@ -619,10 +622,6 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
 
 - (void)clearSharedTransitionConfigForTag:(NSNumber *)tag
 {
-  if (!_clearSharedTransitionConfigForTag) {
-    // TODO: find out why this method gets called but LayoutAnimationsManager is not initialized
-    return;
-  }
   _clearSharedTransitionConfigForTag(tag);
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/5947. Fixes https://github.com/software-mansion/react-native-reanimated/issues/5968.

When `react-native-reanimated` is installed but not used directly, switching between bottom tabs from `@react-navigation/bottom-tabs` will result in a `EXC_BAD_ACCESS` crash on iOS.

This PR adds missing mock for `_clearSharedTransitionConfigForTag` as suggested by @bartlomiejbloniarz.

## Test plan

Try repro from https://github.com/software-mansion/react-native-reanimated/issues/5947#issuecomment-2094789350
