### PR TITLE
Fix uncaught exception 'NSUnknownKeyException' on app reload on iOS

### DIFF
--- a/apple/LayoutReanimation/REASwizzledUIManager.mm
+++ b/apple/LayoutReanimation/REASwizzledUIManager.mm
@@ -220,8 +220,7 @@ std::atomic<bool> hasPendingBlocks;
       CGSize contentSize = shadowView.layoutMetrics.frame.size;
 
       RCTExecuteOnMainQueue(^{
-        RCTUIManager *uiManager = [self valueForKey:@"_uiManager"];
-        REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
+        REAUIView *view = [originalSelf viewForReactTag:(NSNumber *)reactTag];
         RCTAssert(view != nil, @"view (for ID %@) not found", reactTag);
 
         RCTRootView *rootView = (RCTRootView *)[view superview];
@@ -245,7 +244,7 @@ std::atomic<bool> hasPendingBlocks;
     for (NSNumber *reactTag in reactTags) {
       RCTFrameData frameData = frameDataArray[index++];
 
-      REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
+      REAUIView *view = [originalSelf viewForReactTag:(NSNumber *)reactTag];
       CGRect frame = frameData.frame;
 
       UIUserInterfaceLayoutDirection layoutDirection = frameData.layoutDirection;
@@ -331,7 +330,7 @@ std::atomic<bool> hasPendingBlocks;
     index = 0;
     for (NSNumber *reactTag in reactTags) {
       RCTFrameData frameData = frameDataArray[index++];
-      REAUIView *view = [uiManager viewForReactTag:(NSNumber *)reactTag];
+      REAUIView *view = [originalSelf viewForReactTag:(NSNumber *)reactTag];
       BOOL isNew = frameData.isNew;
       CGRect frame = frameData.frame;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/5973.

```
*** Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<RCTUIManager 0x600002bbd340> valueForUndefinedKey:]: this class is not key value coding-compliant for the key _uiManager.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804ae138 __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x0000000180087db4 objc_exception_throw + 56
	2   CoreFoundation                      0x00000001804adcdc -[NSException init] + 0
	3   Foundation                          0x0000000180d6acf8 -[NSObject(NSKeyValueCoding) valueForUndefinedKey:] + 188
	4   Foundation                          0x0000000180d69c60 -[NSObject(NSKeyValueCoding) valueForKey:] + 260
	5   ReanimatedExample                   0x0000000104a079c0 __70-[REASwizzledUIManager reanimated_uiBlockWithLayoutUpdateForRootView:]_block_invoke + 48
	6   ReanimatedExample                   0x0000000104bf23fc __RCTExecuteOnMainQueue_block_invoke + 40
	7   libdispatch.dylib                   0x0000000108557ec4 _dispatch_call_block_and_release + 24
	8   libdispatch.dylib                   0x000000010855973c _dispatch_client_callout + 16
	9   libdispatch.dylib                   0x00000001085693f8 _dispatch_main_queue_drain + 1228
	10  libdispatch.dylib                   0x0000000108568f1c _dispatch_main_queue_callback_4CF + 40
	11  CoreFoundation                      0x000000018040e9a0 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
	12  CoreFoundation                      0x00000001804090b8 __CFRunLoopRun + 1936
	13  CoreFoundation                      0x0000000180408514 CFRunLoopRunSpecific + 572
	14  GraphicsServices                    0x000000018ef06ae4 GSEventRunModal + 160
	15  UIKitCore                           0x00000001853e8040 -[UIApplication _run] + 868
	16  UIKitCore                           0x00000001853ebcc8 UIApplicationMain + 124
	17  ReanimatedExample                   0x00000001048a26cc main + 96
	18  dyld                                0x00000001075b1544 start_sim + 20
	19  ???                                 0x000000010784a0e0 0x0 + 4421099744
	20  ???                                 0xfb7e800000000000 0x0 + 18122062688073809920
)
libc++abi: terminating due to uncaught exception of type NSException
```

This PR is a follow-up to https://github.com/software-mansion/react-native-reanimated/pull/5957.

Note that SETs still don't work properly after reload but this is not a regression from this PR as it also happens on main.

## Test plan

1. Launch Reanimated Example app
2. Open "[SET] Card" example
3. Reload the app
4. Confirm there's no crash
