### PR TITLE
fix: build issues on visionOS

### DIFF
--- a/apple/REASlowAnimations.mm
+++ b/apple/REASlowAnimations.mm
@@ -1,6 +1,7 @@
 #import <RNReanimated/REASlowAnimations.h>
 #if TARGET_IPHONE_SIMULATOR
 #import <dlfcn.h>
+#import <QuartzCore/QuartzCore.h>
 #endif
 
 namespace reanimated {

--- a/apple/REASlowAnimations.mm
+++ b/apple/REASlowAnimations.mm
@@ -1,5 +1,5 @@
-#import <RNReanimated/REASlowAnimations.h>
 #import <QuartzCore/QuartzCore.h>
+#import <RNReanimated/REASlowAnimations.h>
 #if TARGET_IPHONE_SIMULATOR
 #import <dlfcn.h>
 #endif

--- a/apple/REASlowAnimations.mm
+++ b/apple/REASlowAnimations.mm
@@ -1,7 +1,7 @@
 #import <RNReanimated/REASlowAnimations.h>
+#import <QuartzCore/QuartzCore.h>
 #if TARGET_IPHONE_SIMULATOR
 #import <dlfcn.h>
-#import <QuartzCore/QuartzCore.h>
 #endif
 
 namespace reanimated {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes build issues for visionOS. The `CACurrentMediaTime` API comes from QuartzCore which was not imported in this file. Unfortunately, visionOS is more strict and requires explicit imports, this shouldn't cause any issues on other platforms.

## Test plan

Build the app for visionOS
