### PR TITLE
fix missing NavLink in docs

### DIFF
--- a/docs/src/css/examples.css
+++ b/docs/src/css/examples.css
@@ -2,7 +2,7 @@ time {
   display: none;
 }
 
-.pagination-nav {
+[aria-label='Blog post page navigation'].pagination-nav {
   display: none;
 }
 


### PR DESCRIPTION
After this fix the pagination is hidden on `Examples` page but visible on `Docs` page.