### PR TITLE
fix typo on object key for `targetValues` in custom-animations.mdx

### DIFF
--- a/docs/docs/layout-animations/custom-animations.mdx
+++ b/docs/docs/layout-animations/custom-animations.mdx
@@ -113,7 +113,7 @@ function CardView() {
   const entering = (targetValues) => {
     'worklet';
     const animations = {
-      originX: withTiming(targetValues.originX, { duration: 3000 }),
+      originX: withTiming(targetValues.targetOriginX, { duration: 3000 }),
       opacity: withTiming(1, { duration: 2000 }),
       borderRadius: withDelay(4000, withTiming(30, { duration: 3000 })),
       transform: [


### PR DESCRIPTION
## Summary

This fixes a typo on the key of `targetValues`, `targetOriginX.originX` should be `targetValues.targetOriginX`

