### PR TITLE
Make `useScrollviewOffset` ref nullable and simplify its code

### DIFF
--- a/__typetests__/common/useScrollViewOffsetTest.tsx
+++ b/__typetests__/common/useScrollViewOffsetTest.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useRef } from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, Button } from 'react-native';
 import Animated, { useAnimatedRef, useScrollViewOffset } from '../..';
 
 function UseScrollViewOffsetTest() {
@@ -51,6 +51,23 @@ function UseScrollViewOffsetTest() {
 
     return (
       <ScrollView ref={scrollViewRef}>
+        <Animated.View style={{ opacity: offset.value }} />
+      </ScrollView>
+    );
+  }
+
+  function UseScrollViewOffsetTest5() {
+    const [connectRef, setConnectRef] = React.useState(false);
+    const scrollViewRef = useAnimatedRef<Animated.ScrollView>();
+    // this will work because the ref is nullable
+    const offset = useScrollViewOffset(connectRef ? scrollViewRef : null);
+
+    return (
+      <ScrollView ref={scrollViewRef}>
+        <Button
+          title={`${connectRef ? 'Disconnect' : 'Connect'} ref`}
+          onPress={() => setConnectRef(!connectRef)}
+        />
         <Animated.View style={{ opacity: offset.value }} />
       </ScrollView>
     );

--- a/src/reanimated2/hook/useScrollViewOffset.ts
+++ b/src/reanimated2/hook/useScrollViewOffset.ts
@@ -26,54 +26,51 @@ export const useScrollViewOffset = IS_WEB
   : useScrollViewOffsetNative;
 
 function useScrollViewOffsetWeb(
-  animatedRef: AnimatedRef<AnimatedScrollView>,
+  animatedRef: AnimatedRef<AnimatedScrollView> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);
   const offset = useRef(providedOffset ?? internalOffset).current;
-  const scrollRef = useRef<AnimatedScrollView | null>(null);
 
   const eventHandler = useCallback(() => {
     'worklet';
-    const element = getWebScrollableElement(animatedRef.current);
-    // scrollLeft is the X axis scrolled offset, works properly also with RTL layout
-    offset.value =
-      element.scrollLeft === 0 ? element.scrollTop : element.scrollLeft;
+    if (animatedRef) {
+      const element = getWebScrollableElement(animatedRef.current);
+      // scrollLeft is the X axis scrolled offset, works properly also with RTL layout
+      offset.value =
+        element.scrollLeft === 0 ? element.scrollTop : element.scrollLeft;
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef.current]);
+  }, [animatedRef, animatedRef?.current]);
 
   useEffect(() => {
-    // We need to make sure that listener for old animatedRef value is removed
-    if (scrollRef.current !== null) {
-      getWebScrollableElement(scrollRef.current).removeEventListener(
-        'scroll',
-        eventHandler
-      );
-    }
-    scrollRef.current = animatedRef.current;
+    const element = animatedRef?.current
+      ? getWebScrollableElement(animatedRef.current)
+      : null;
 
-    const element = getWebScrollableElement(animatedRef.current);
-    element.addEventListener('scroll', eventHandler);
+    if (element) {
+      element.addEventListener('scroll', eventHandler);
+    }
     return () => {
-      element.removeEventListener('scroll', eventHandler);
+      if (element) {
+        element.removeEventListener('scroll', eventHandler);
+      }
     };
     // React here has a problem with `animatedRef.current` since a Ref .current
     // field shouldn't be used as a dependency. However, in this case we have
     // to do it this way.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef.current, eventHandler]);
+  }, [animatedRef, animatedRef?.current, eventHandler]);
 
   return offset;
 }
 
 function useScrollViewOffsetNative(
-  animatedRef: AnimatedRef<AnimatedScrollView>,
+  animatedRef: AnimatedRef<AnimatedScrollView> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);
   const offset = useRef(providedOffset ?? internalOffset).current;
-  const scrollRef = useRef<AnimatedScrollView | null>(null);
-  const scrollRefTag = useRef<number | null>(null);
 
   const eventHandler = useEvent<RNNativeScrollEvent>(
     (event: ReanimatedScrollEvent) => {
@@ -89,37 +86,21 @@ function useScrollViewOffsetNative(
   ) as unknown as EventHandlerInternal<ReanimatedScrollEvent>;
 
   useEffect(() => {
-    // We need to make sure that listener for old animatedRef value is removed
-    if (scrollRef.current !== null && scrollRefTag.current !== null) {
-      eventHandler.workletEventHandler.unregisterFromEvents(
-        scrollRefTag.current
-      );
+    const elementTag = animatedRef?.getTag() ?? null;
+
+    if (elementTag) {
+      eventHandler.workletEventHandler.registerForEvents(elementTag);
     }
-
-    // Store the ref and viewTag for future cleanup
-    scrollRef.current = animatedRef.current;
-    scrollRefTag.current = animatedRef.getTag();
-
-    if (scrollRefTag === null) {
-      console.warn(
-        '[Reanimated] ScrollViewOffset failed to resolve the view tag from animated ref. Did you forget to attach the ref to a component?'
-      );
-    } else {
-      eventHandler.workletEventHandler.registerForEvents(scrollRefTag.current);
-    }
-
     return () => {
-      if (scrollRefTag.current !== null) {
-        eventHandler.workletEventHandler.unregisterFromEvents(
-          scrollRefTag.current
-        );
+      if (elementTag) {
+        eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
       }
     };
     // React here has a problem with `animatedRef.current` since a Ref .current
     // field shouldn't be used as a dependency. However, in this case we have
     // to do it this way.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef.current, eventHandler]);
+  }, [animatedRef, animatedRef?.current, eventHandler]);
 
   return offset;
 }


### PR DESCRIPTION
## Summary

https://github.com/software-mansion/react-native-reanimated/pull/5942 needs `useScrollViewOffset`'s ref to be nullable - hence the PR. I also checked and a lot of cleanup code in the hook was redundant.

## Test plan

You can run the following code, it checks both switching between nullable and non-nullable ref, as well as two different scrolls: (add some logs in hook's registering/unregistering to see that cleanups work fine)

<details><summary>Code</summary>

``` TYPESCRIPT
import React from 'react';
import Animated, {
  useAnimatedRef,
  useDerivedValue,
  useScrollViewOffset,
} from 'react-native-reanimated';
import { Button, StyleSheet, Text, View } from 'react-native';

export default function EmptyExample() {
  const [refConnected, setRefConnected] = React.useState(false);
  const [refSwitched, setRefSwitched] = React.useState(false);
  const aref = useAnimatedRef<Animated.ScrollView>();
  const bref = useAnimatedRef<Animated.ScrollView>();
  const scrollHandler = useScrollViewOffset(
    refConnected ? (refSwitched ? bref : aref) : null
  );

  useDerivedValue(() => {
    console.log(scrollHandler.value);
  });

  const onButtonPress = () => {
    setRefConnected(!refConnected);
  };

  const onSwitchButtonPress = () => {
    setRefSwitched(!refSwitched);
  };

  return (
    <>
      <View style={styles.positionView}>
        <Text>Test</Text>
      </View>
      <View style={styles.divider} />
      <Button
        title={`${refConnected ? 'Disconnect' : 'Connect'} the hook`}
        onPress={onButtonPress}
      />
      <Button
        title={`Change ref to the ${refSwitched ? 'first' : 'second'} scroll`}
        onPress={onSwitchButtonPress}
      />
      <Animated.ScrollView
        ref={aref}
        style={[styles.scrollView, { backgroundColor: 'teal' }]}>
        {[...Array(100)].map((_, i) => (
          <Text key={i} style={styles.text}>
            {i}
          </Text>
        ))}
      </Animated.ScrollView>
      <Animated.ScrollView
        ref={bref}
        style={[styles.scrollView, { backgroundColor: 'pink' }]}>
        {[...Array(100)].map((_, i) => (
          <Text key={i} style={styles.text}>
            {i}
          </Text>
        ))}
      </Animated.ScrollView>
    </>
  );
}

const styles = StyleSheet.create({
  positionView: {
    margin: 20,
    alignItems: 'center',
  },
  scrollView: {
    flex: 1,
    width: '100%',
  },
  text: {
    fontSize: 50,
    textAlign: 'center',
  },
  divider: {
    backgroundColor: 'black',
    height: 1,
  },
});

```
</details>

