### PR TITLE
Fix location after shared element transition

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/SharedTransitionManager.java
@@ -483,8 +483,10 @@ public class SharedTransitionManager {
       }
       Snapshot viewSourcePreviousSnapshot = mSnapshotRegistry.get(viewTag);
       if (viewSourcePreviousSnapshot != null) {
+        int originX = viewSourcePreviousSnapshot.originX;
         int originY = viewSourcePreviousSnapshot.originY;
         if (findStack(view) == null) {
+          viewSourcePreviousSnapshot.originX = viewSourcePreviousSnapshot.originXByParent;
           viewSourcePreviousSnapshot.originY = viewSourcePreviousSnapshot.originYByParent;
         }
         Map<String, Object> snapshotMap = viewSourcePreviousSnapshot.toBasicMap();
@@ -500,6 +502,7 @@ public class SharedTransitionManager {
           }
         }
         mAnimationsManager.progressLayoutAnimation(viewTag, preparedValues, true);
+        viewSourcePreviousSnapshot.originX = originX;
         viewSourcePreviousSnapshot.originY = originY;
       }
       if (mViewTagsToHide.contains(tag)) {


### PR DESCRIPTION
## Summary

This pull request addresses the restoration of component location after a shared transition. Previously, the component offset was restored based on the absolute position of the component on the screen. However, this method is more suitable for positioning components absolutely. When the component is reattached to its original parent, we now aim to restore the offset from the parent instead of the global offset from the screen border.

| before | after |
| --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/d4b2254a-48a0-4c7c-8075-7a8e12343b5a" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/46a304bb-a00b-46d3-a6d6-396c987eaf3d" /> |

