### PR TITLE
Add dark mode to button in `Hire us` section

### DIFF
--- a/docs/src/components/HireUsSection/styles.module.css
+++ b/docs/src/components/HireUsSection/styles.module.css
@@ -70,3 +70,19 @@
 .buttonNavyBorderStyling {
   border: 1px solid var(--swm-navy-light-100);
 }
+
+[data-theme='dark'] .buttonNavyStyling {
+  background-color: var(--swm-landing-button-purple);
+}
+
+[data-theme='dark'] .buttonNavyBorderStyling {
+  border: 1px solid var(--swm-landing-button-purple);
+}
+[data-theme='dark'] .buttonNavyStyling:hover {
+  background-color: transparent;
+  color: var(--swm-landing-button-purple);
+}
+
+[data-theme='dark'] .buttonNavyStyling:hover svg {
+  stroke: var(--swm-landing-button-purple);
+}


### PR DESCRIPTION
## Description

Normal:
<img width="1482" alt="Screenshot 2024-05-14 at 11 17 16" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/129b873d-506d-4859-8663-bb313d634241">

Hovered:
<img width="1482" alt="Screenshot 2024-05-14 at 11 17 20" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/623d0ed2-2edd-4f44-8b92-0d4077dfca10">


## Test plan

```
cd docs/
yarn

# to test development build
yarn start

# to test production build
yarn build
yarn serve
```
