### PR TITLE
Fix slow animation on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -78,6 +78,7 @@ public abstract class NativeProxyCommon {
     if (slowAnimationsEnabled) {
       firstUptime = SystemClock.uptimeMillis();
     }
+    mNodesManager.setSlowAnimations(slowAnimationsEnabled);
   }
 
   private void addDevMenuOption() {

--- a/cspell.json
+++ b/cspell.json
@@ -36,7 +36,8 @@
     "workletize",
     "workletized",
     "workletizes",
-    "worklets"
+    "worklets",
+    "gesturehandler"
   ],
   "flagWords": [
     "ere",


### PR DESCRIPTION
## Summary

This PR fixes the issue of slow animations on Android. We utilize two different sources of timestamps on Android, so we need to slow down both of them instead of just one to fix the problem. Previously, almost all animations were canceled immediately after starting because the current frame timestamp was 10 times higher than the slowed-down start timestamp.

| before | after |
| --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/0221e94e-b1b7-48d2-9092-85265dbb36b0
" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/5dcd926e-8c94-44e5-a5a5-7b8e60ebf333" /> |