### PR TITLE
Make animation RollInLeft work with modifers

### DIFF
--- a/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
+++ b/src/reanimated2/layoutReanimation/defaultAnimations/Roll.ts
@@ -38,7 +38,7 @@ export class RollInLeft
       return {
         animations: {
           transform: [
-            { translateX: delayFunction(delay, animation(0), config) },
+            { translateX: delayFunction(delay, animation(0, config)) },
             { rotate: delayFunction(delay, animation('0deg', config)) },
           ],
         },


### PR DESCRIPTION
## Summary
There was a typo that made our entering animation RollInLeft ignorant to modifiers:
```diff
-   { translateX: delayFunction(delay, animation(0), config) },
+   { translateX: delayFunction(delay, animation(0, config)) },
```

## Test plan
