### PR TITLE
added warning when animated component is rendered directly inside SafeAreaView

### DIFF
--- a/apple/LayoutReanimation/REAAnimationsManager.h
+++ b/apple/LayoutReanimation/REAAnimationsManager.h
@@ -23,6 +23,7 @@ typedef void (^REAAnimationRemovingBlock)(NSNumber *_Nonnull tag);
 typedef void (^REASharedTransitionRemovingBlock)(NSNumber *_Nonnull tag);
 #ifndef NDEBUG
 typedef void (^REACheckDuplicateSharedTagBlock)(REAUIView *view, NSNumber *_Nonnull viewTag);
+typedef void (^REACheckIsRenderedDirectlyInsideSafeArea)(REAUIView *view);
 #endif
 typedef void (^REACancelAnimationBlock)(NSNumber *_Nonnull tag);
 typedef NSNumber *_Nullable (^REAFindPrecedingViewTagForTransitionBlock)(NSNumber *_Nonnull tag);

--- a/apple/LayoutReanimation/REAAnimationsManager.m
+++ b/apple/LayoutReanimation/REAAnimationsManager.m
@@ -109,7 +109,7 @@ BOOL REANodeFind(id<RCTComponent> view, int (^block)(id<RCTComponent>))
       if ([parentClassName isEqualToString:@"RCTSafeAreaView"] ||
           [parentClassName isEqualToString:@"RNCSafeAreaView"]) {
         RCTLogWarn(
-            @"Animated components shouldn't be rendered directly inside <SafeAreaView />, consider wrapping it with additional <View />");
+            @"Animated components shouldn't be rendered directly inside <SafeAreaView />, consider wrapping your content with additional <View />");
       }
     };
 #endif

--- a/docs/docs/guides/troubleshooting.mdx
+++ b/docs/docs/guides/troubleshooting.mdx
@@ -235,6 +235,36 @@ Assign accessed properties to variables beforehand and use those in the worklet:
 +obj.propNotAccessedInWorklet = 3; // Everything is fine here.
 ```
 
+### Animated components shouldn't be rendered directly inside SafeAreaView, consider wrapping your content with additional View
+
+**Problem:** This warning is displayed to inform the user that Animated component is rendered directly inside SafeAreaView, which can break entering and layout animations.
+
+In the example below `Animated.View` is placed directly inside `SafeAreaView`:
+
+```jsx
+<SafeAreaView>
+  <View />
+  <Animated.View entering={FadeIn}>
+    <View />
+  </Animated.View>
+</SafeAreaView>
+```
+
+**Solution:**
+
+Wrapping your content with additional view container.
+
+```diff
+<SafeAreaView>
++ <View style={{flex: 1}}>
+    <View />
+    <Animated.View entering={FadeIn}>
+      <View />
+    </Animated.View>
++ </View>
+</SafeAreaView>
+```
+
 ## Threading issues
 
 ### Tried to synchronously call a non-worklet function on the UI thread


### PR DESCRIPTION
## Summary

Added warning log when animated component is rendered directly inside `SafeAreaView` from `react-native` or from `react-native-safe-area-context`. This should address [maintainer issue here](https://github.com/software-mansion/react-native-reanimated/issues/6046)

## Test plan

1. Inside `EmptyExample.tsx` paste the code
```jsx
import { StyleSheet, View, SafeAreaView as RNSafeAreaView } from 'react-native';
import React from 'react';
import Animated, { FadeIn } from 'react-native-reanimated';

const animation = FadeIn.delay(1000).duration(2000);

export default function EmptyExample() {
  return (
    <RNSafeAreaView>
      <View style={styles.greyBox} />
      <Animated.View entering={animation}>
        <View style={styles.redAnimatedBox} />
      </Animated.View>
    </RNSafeAreaView>
  );
}
const styles = StyleSheet.create({
  greyBox: {
    backgroundColor: 'grey',
    height: 100,
    width: '100%',
  },
  redAnimatedBox: {
    backgroundColor: 'red',
    height: 100,
    width: '100%',
  },
});

```
2. This should throw a warning in your console:
```
Animated components shouldn't be rendered directly inside <SafeAreaView />, consider wrapping your content with additional <View />
```

3. Apply changes below
```diff
import { StyleSheet, View, SafeAreaView as RNSafeAreaView } from 'react-native';
import React from 'react';
import Animated, { FadeIn } from 'react-native-reanimated';

const animation = FadeIn.delay(1000).duration(2000);

export default function EmptyExample() {
  return (
    <RNSafeAreaView>
+      <View>
        <View style={styles.greyBox} />
        <Animated.View entering={animation}>
          <View style={styles.redAnimatedBox} />
        </Animated.View>
+      </View>
    </RNSafeAreaView>
  );
}
const styles = StyleSheet.create({
  greyBox: {
    backgroundColor: 'grey',
    height: 100,
    width: '100%',
  },
  redAnimatedBox: {
    backgroundColor: 'red',
    height: 100,
    width: '100%',
  },
});

```
4. Reload the app, there shouldn't be a warning message in the console.