### PR TITLE
Fixes of dark-theme and values in docs

### DIFF
--- a/packages/docs-reanimated/src/css/colors.css
+++ b/packages/docs-reanimated/src/css/colors.css
@@ -258,7 +258,7 @@
 
   /* Versions dropdown */
   --swm-dropdown-versions-background: var(--swm-off-white);
-  --swm-dropdown-versions-item: var(--swm-off-white);
+  --swm-dropdown-versions-item: var(--swm-navy-light-100);
   --swm-dropdown-versions-item-border: var(--swm-purple-light-40);
   --swm-dropdown-versions-item-background: var(--swm-purple-light-20);
 

--- a/packages/docs-reanimated/src/css/overrides.css
+++ b/packages/docs-reanimated/src/css/overrides.css
@@ -115,6 +115,8 @@ button[class*='DocSearch-Button'] {
   margin: 0 !important;
 }
 
+/* versions dropdown on landing */
+
 [class*='plugin-pages'] [class*='dropdown--right'] > a:first-child {
   color: var(--swm-off-white) !important;
 }
@@ -122,6 +124,8 @@ button[class*='DocSearch-Button'] {
 [class*='plugin-pages'] [class*='dropdown__menu'] a:hover {
   color: var(--swm-dropdown-versions-item-hover) !important;
 }
+
+/* examples sidebar */
 
 [class*='plugin-blog'] [class*='sidebar'] {
   background-color: transparent;

--- a/packages/docs-reanimated/src/css/overrides.css
+++ b/packages/docs-reanimated/src/css/overrides.css
@@ -110,7 +110,19 @@ table thead tr {
   font-size: var(--swm-h1-font-size);
 }
 
-/* TODO: Remove after @swmansion-t-rex-ui 0.0.10 patch */
+/* TODO: Remove after @swmansion-t-rex-ui 0.0.11 patch */
 button[class*='DocSearch-Button'] {
   margin: 0 !important;
+}
+
+[class*='plugin-pages'] [class*='dropdown--right'] > a:first-child {
+  color: var(--swm-off-white) !important;
+}
+
+[class*='plugin-pages'] [class*='dropdown__menu'] a:hover {
+  color: var(--swm-dropdown-versions-item-hover) !important;
+}
+
+[class*='plugin-blog'] [class*='sidebar'] {
+  background-color: transparent;
 }

--- a/packages/docs-reanimated/src/examples/DecayBasic.tsx
+++ b/packages/docs-reanimated/src/examples/DecayBasic.tsx
@@ -31,7 +31,10 @@ export default function App() {
       offset.value = withDecay({
         velocity: event.velocityX,
         rubberBandEffect: true,
-        clamp: [-(width.value / 2) + SIZE / 2, width.value / 2 - SIZE / 2],
+        clamp: [
+          -(width.value / 2) + SIZE / 2 + 50,
+          width.value / 2 - SIZE / 2 - 50,
+        ],
       });
       // highlight-end
     });

--- a/packages/docs-reanimated/src/examples/DecayBasic.tsx
+++ b/packages/docs-reanimated/src/examples/DecayBasic.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native-gesture-handler';
 
 const SIZE = 120;
+const BOUNDARY_OFFSET = 50;
 
 export default function App() {
   const offset = useSharedValue<number>(0);
@@ -32,8 +33,8 @@ export default function App() {
         velocity: event.velocityX,
         rubberBandEffect: true,
         clamp: [
-          -(width.value / 2) + SIZE / 2 + 50,
-          width.value / 2 - SIZE / 2 - 50,
+          -(width.value / 2) + SIZE / 2 + BOUNDARY_OFFSET,
+          width.value / 2 - SIZE / 2 - BOUNDARY_OFFSET,
         ],
       });
       // highlight-end

--- a/packages/docs-reanimated/src/examples/SpringBasic.tsx
+++ b/packages/docs-reanimated/src/examples/SpringBasic.tsx
@@ -12,7 +12,7 @@ interface AppProps {
 }
 
 export default function App({ width }: AppProps) {
-  const offset = useSharedValue<number>(width / 2 - 240);
+  const offset = useSharedValue<number>(width / 2 - 120);
 
   const animatedStyles = useAnimatedStyle(() => ({
     transform: [{ translateX: offset.value }],

--- a/packages/docs-reanimated/src/examples/SpringBasic.tsx
+++ b/packages/docs-reanimated/src/examples/SpringBasic.tsx
@@ -12,7 +12,7 @@ interface AppProps {
 }
 
 export default function App({ width }: AppProps) {
-  const offset = useSharedValue<number>(width / 2 - 120);
+  const offset = useSharedValue<number>(width / 2 - 240);
 
   const animatedStyles = useAnimatedStyle(() => ({
     transform: [{ translateX: offset.value }],

--- a/packages/docs-reanimated/static/examples/BottomSheet.js
+++ b/packages/docs-reanimated/static/examples/BottomSheet.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useColorScheme } from '@mui/material';
 import {
   Pressable,
   SafeAreaView,
@@ -16,6 +17,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 function BottomSheet({ isOpen, toggleSheet, duration = 500, children }) {
+  const { colorScheme } = useColorScheme();
   const height = useSharedValue(0);
   const progress = useDerivedValue(() =>
     withTiming(isOpen.value ? 0 : 1, { duration })
@@ -23,6 +25,7 @@ function BottomSheet({ isOpen, toggleSheet, duration = 500, children }) {
 
   const sheetStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: progress.value * 2 * height.value }],
+    backgroundColor: colorScheme === 'light' ? '#f8f9ff' : '#272B3C',
   }));
 
   const backdropStyle = useAnimatedStyle(() => ({
@@ -50,7 +53,6 @@ function BottomSheet({ isOpen, toggleSheet, duration = 500, children }) {
 
 const sheetStyles = StyleSheet.create({
   sheet: {
-    backgroundColor: '#f8f9ff',
     padding: 16,
     paddingRight: '2rem',
     paddingLeft: '2rem',
@@ -71,11 +73,17 @@ const sheetStyles = StyleSheet.create({
 });
 
 export default function App() {
+  const { colorScheme } = useColorScheme();
   const isOpen = useSharedValue(false);
 
   const toggleSheet = () => {
     isOpen.value = !isOpen.value;
   };
+
+  const contentStyle = useAnimatedStyle(() => ({
+    color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
+    textDecorationColor: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
+  }));
 
   return (
     <SafeAreaView style={styles.container}>
@@ -87,14 +95,16 @@ export default function App() {
         <View style={styles.flex} />
       </View>
       <BottomSheet isOpen={isOpen} toggleSheet={toggleSheet}>
-        <Text style={styles.bottomSheetContent}>
+        <Animated.Text style={contentStyle}>
           Discover the indispensable convenience of a bottom sheet in mobile
           app. Seamlessly integrated, it provides quick access to supplementary
           features and refined details.
-        </Text>
+        </Animated.Text>
         <View style={styles.buttonContainer}>
-          <Pressable style={styles.bottomSheetButton}>
-            <Text style={styles.bottomSheetButtonText}>Read more</Text>
+          <Pressable style={[styles.bottomSheetButton]}>
+            <Animated.Text style={[styles.bottomSheetButtonText, contentStyle]}>
+              Read more
+            </Animated.Text>
           </Pressable>
         </View>
       </BottomSheet>
@@ -136,15 +146,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: '#001a72',
     paddingBottom: 2,
   },
   bottomSheetButtonText: {
     fontWeight: 600,
-    color: '#001a72',
-  },
-  bottomSheetContent: {
-    color: '#001a72',
+    textDecorationLine: 'underline',
   },
 });

--- a/packages/docs-reanimated/static/examples/BottomSheet.js
+++ b/packages/docs-reanimated/static/examples/BottomSheet.js
@@ -25,8 +25,11 @@ function BottomSheet({ isOpen, toggleSheet, duration = 500, children }) {
 
   const sheetStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: progress.value * 2 * height.value }],
-    backgroundColor: colorScheme === 'light' ? '#f8f9ff' : '#272B3C',
   }));
+
+  const backgroundColorSheetStyle = {
+    backgroundColor: colorScheme === 'light' ? '#f8f9ff' : '#272B3C',
+  };
 
   const backdropStyle = useAnimatedStyle(() => ({
     opacity: 1 - progress.value,
@@ -44,7 +47,7 @@ function BottomSheet({ isOpen, toggleSheet, duration = 500, children }) {
         onLayout={(e) => {
           height.value = e.nativeEvent.layout.height;
         }}
-        style={[sheetStyles.sheet, sheetStyle]}>
+        style={[sheetStyles.sheet, sheetStyle, backgroundColorSheetStyle]}>
         {children}
       </Animated.View>
     </>
@@ -80,10 +83,10 @@ export default function App() {
     isOpen.value = !isOpen.value;
   };
 
-  const contentStyle = useAnimatedStyle(() => ({
+  const contentStyle = {
     color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
     textDecorationColor: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
-  }));
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -102,9 +105,9 @@ export default function App() {
         </Animated.Text>
         <View style={styles.buttonContainer}>
           <Pressable style={[styles.bottomSheetButton]}>
-            <Animated.Text style={[styles.bottomSheetButtonText, contentStyle]}>
+            <Text style={[styles.bottomSheetButtonText, contentStyle]}>
               Read more
-            </Animated.Text>
+            </Text>
           </Pressable>
         </View>
       </BottomSheet>

--- a/packages/docs-reanimated/static/examples/SectionList.js
+++ b/packages/docs-reanimated/static/examples/SectionList.js
@@ -198,7 +198,6 @@ const sectionListStyles = StyleSheet.create({
     padding: 4,
     marginHorizontal: 4,
     margin: 8,
-    borderBottomColor: '#001a72',
     overflow: 'hidden',
   },
   tableOfContents: {

--- a/packages/docs-reanimated/static/examples/SectionList.js
+++ b/packages/docs-reanimated/static/examples/SectionList.js
@@ -111,9 +111,6 @@ const TableOfContentsElement = ({
 
   const tableOfContentsElementTextStyle = useAnimatedStyle(() => ({
     color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
-  }));
-
-  const tableOfContentsElementStyle = useAnimatedStyle(() => ({
     borderBottomColor: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
   }));
 

--- a/packages/docs-reanimated/static/examples/SectionList.js
+++ b/packages/docs-reanimated/static/examples/SectionList.js
@@ -109,10 +109,10 @@ const TableOfContentsElement = ({
   const { colorScheme } = useColorScheme();
   const style = useSelectedStyle(visibleIndex, index);
 
-  const tableOfContentsElementTextStyle = useAnimatedStyle(() => ({
+  const tableOfContentsElementTextStyle = {
     color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
     borderBottomColor: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
-  }));
+  };
 
   return (
     <Pressable

--- a/packages/docs-reanimated/static/examples/SectionList.js
+++ b/packages/docs-reanimated/static/examples/SectionList.js
@@ -1,5 +1,6 @@
 import { FlashList } from '@shopify/flash-list';
 import React, { useRef, useState } from 'react';
+import { useColorScheme } from '@mui/material';
 import { Pressable, StyleSheet, Text, View, SafeAreaView } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -105,7 +106,16 @@ const TableOfContentsElement = ({
   visibleIndex,
   sectionCardsRef,
 }) => {
+  const { colorScheme } = useColorScheme();
   const style = useSelectedStyle(visibleIndex, index);
+
+  const tableOfContentsElementTextStyle = useAnimatedStyle(() => ({
+    color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
+  }));
+
+  const tableOfContentsElementStyle = useAnimatedStyle(() => ({
+    borderBottomColor: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
+  }));
 
   return (
     <Pressable
@@ -113,8 +123,13 @@ const TableOfContentsElement = ({
         sectionCardsRef.current?.scrollToIndex({ index, animated: true });
         visibleIndex.value = index;
       }}
-      style={sectionListStyles.tableOfContentsElement}>
-      <Animated.Text style={[style, sectionListStyles.tableOfContentsElement]}>
+      style={[sectionListStyles.tableOfContentsElement]}>
+      <Animated.Text
+        style={[
+          style,
+          sectionListStyles.tableOfContentsElement,
+          tableOfContentsElementTextStyle,
+        ]}>
         {item}
       </Animated.Text>
     </Pressable>
@@ -184,10 +199,9 @@ const sectionListStyles = StyleSheet.create({
   },
   tableOfContentsElement: {
     padding: 4,
-    color: '#001a72',
     marginHorizontal: 4,
-    borderBottomColor: '#001a72',
     margin: 8,
+    borderBottomColor: '#001a72',
     overflow: 'hidden',
   },
   tableOfContents: {
@@ -201,6 +215,7 @@ const SectionCards = ({
   sectionCardsRef,
   tableOfContentsRef,
 }) => {
+  const { colorScheme } = useColorScheme();
   const heights = sections.map((_) => SECTION_HEIGHT);
 
   const getOffsetStarts = () =>
@@ -226,10 +241,16 @@ const SectionCards = ({
     }
   };
 
+  const sectionNameStyle = useAnimatedStyle(() => ({
+    color: colorScheme === 'light' ? '#001a72' : '#f8f9ff',
+  }));
+
   const renderItem = ({ item }) => {
     return (
       <View>
-        <Text style={sectionCardStyles.header}> {item.name}</Text>
+        <Animated.Text style={[sectionCardStyles.header, sectionNameStyle]}>
+          {item.name}
+        </Animated.Text>
         <SectionCardsElement>
           <Text style={sectionCardStyles.content}>{item.content}</Text>
         </SectionCardsElement>
@@ -287,7 +308,6 @@ const sectionCardStyles = StyleSheet.create({
     borderRadius: 24,
   },
   header: {
-    color: '#001a72',
     textAlign: 'center',
     fontSize: 24,
     fontWeight: 'bold',


### PR DESCRIPTION
### Add offset 'margins' so withDecay example would look cleaner

Before:

https://github.com/software-mansion/react-native-reanimated/assets/59940332/752191ee-8202-42f0-be3e-1255533417ba

After:

https://github.com/software-mansion/react-native-reanimated/assets/59940332/e91d5701-efeb-4255-a350-c516381b27b9


### Add dark theme to __Section List__ and __Bottom Sheet__

Before:

<img width="400" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/87f1f66a-9528-47ee-a4ed-923a134987c4">
<img width="400" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/d966e918-0bd3-482e-9c3c-6eed1d1829d2">


After:

<img width="400" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/57ba60b7-adff-4850-95a1-d7c55506966e">
<img width="400" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/e0c9250c-7ba0-48d1-898c-13c8bf68d6cd">


### Fix `--swm-dropdown-versions-item` color on light-theme

Before:

<img width="234" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/bf3e6fce-a90f-4137-b903-12385604fe33">


After:

<img width="234" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/4772fc04-3692-4918-a916-6430bc613c83">

### Remove different background on Examples' sidebar

Before: 

<img width="352" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/4170fa9c-227f-4058-9fda-d9efe49434aa">


After: 

<img width="352" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/c5fe4ae0-4479-459b-ab41-28135599fd6a">
