### PR TITLE
[Web LA] Remove `existingTransform`

### DIFF
--- a/src/reanimated2/layoutReanimation/web/animationParser.ts
+++ b/src/reanimated2/layoutReanimation/web/animationParser.ts
@@ -1,7 +1,5 @@
 'use strict';
 
-import type { TransformsStyle } from 'react-native';
-
 export interface ReanimatedWebTransformProperties {
   translateX?: string;
   translateY?: string;
@@ -66,34 +64,4 @@ export function convertAnimationObjectToKeyframes(
   keyframe += `} `; // Keyframe end
 
   return keyframe;
-}
-
-export function convertTransformToString(
-  transform: NonNullable<TransformsStyle['transform']> | undefined
-) {
-  if (!transform) {
-    return '';
-  }
-
-  type RNTransformProp = (typeof transform)[number];
-
-  let transformString = '';
-
-  // @ts-ignore `transform` cannot be string because in that case
-  // we throw error in `extractTransformFromStyle`
-  transform.forEach((transformObject: RNTransformProp) => {
-    for (const [key, value] of Object.entries(transformObject)) {
-      if (key === 'reversed') {
-        continue;
-      }
-
-      if (key.indexOf('translate') < 0) {
-        transformString += `${key}(${value}) `;
-      } else {
-        transformString += `${key}(${value}px) `;
-      }
-    }
-  });
-
-  return transformString;
 }

--- a/src/reanimated2/layoutReanimation/web/createAnimation.ts
+++ b/src/reanimated2/layoutReanimation/web/createAnimation.ts
@@ -1,9 +1,8 @@
 'use strict';
 
-import { Animations, AnimationsData, TransitionType } from './config';
+import { TransitionType } from './config';
 import { convertAnimationObjectToKeyframes } from './animationParser';
 import type {
-  AnimationData,
   ReanimatedWebTransformProperties,
   TransitionData,
 } from './animationParser';
@@ -14,90 +13,33 @@ import { FadingTransition } from './transition/Fading.web';
 import { insertWebAnimation } from './domUtils';
 
 // Translate values are passed as numbers. However, if `translate` property receives number, it will not automatically
-// convert it to `px`. Therefore if we want to keep existing transform we have to add 'px' suffix to each of translate values
+// convert it to `px`. Therefore if we want to keep transform we have to add 'px' suffix to each of translate values
 // that are present inside transform.
+//
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function addPxToTranslate(
-  existingTransform: NonNullable<TransformsStyle['transform']>
+  transform: NonNullable<TransformsStyle['transform']>
 ) {
-  type RNTransformProp = (typeof existingTransform)[number];
+  type RNTransformProp = (typeof transform)[number];
 
   // @ts-ignore `existingTransform` cannot be string because in that case
   // we throw error in `extractTransformFromStyle`
-  const newTransform = existingTransform.map(
-    (transformProp: RNTransformProp) => {
-      const newTransformProp: ReanimatedWebTransformProperties = {};
-      for (const [key, value] of Object.entries(transformProp)) {
-        if (key.includes('translate')) {
-          // @ts-ignore After many trials we decided to ignore this error - it says that we cannot use 'key' to index this object.
-          // Sadly it doesn't go away after using cast `key as keyof TransformProperties`.
-          newTransformProp[key] = `${value}px`;
-        } else {
-          // @ts-ignore same as above.
-          newTransformProp[key] = value;
-        }
+  const newTransform = transform.map((transformProp: RNTransformProp) => {
+    const newTransformProp: ReanimatedWebTransformProperties = {};
+    for (const [key, value] of Object.entries(transformProp)) {
+      if (key.includes('translate')) {
+        // @ts-ignore After many trials we decided to ignore this error - it says that we cannot use 'key' to index this object.
+        // Sadly it doesn't go away after using cast `key as keyof TransformProperties`.
+        newTransformProp[key] = `${value}px`;
+      } else {
+        // @ts-ignore same as above.
+        newTransformProp[key] = value;
       }
-      return newTransformProp;
     }
-  );
+    return newTransformProp;
+  });
 
   return newTransform;
-}
-
-// In order to keep existing transform throughout animation, we have to add it to each of keyframe step.
-function addExistingTransform(
-  newAnimationData: AnimationData,
-  newTransform: ReanimatedWebTransformProperties[]
-) {
-  for (const keyframeStepProperties of Object.values(newAnimationData.style)) {
-    if (!keyframeStepProperties.transform) {
-      // If transform doesn't exist, we add only transform that already exists
-      keyframeStepProperties.transform = newTransform;
-    } else {
-      // We insert existing transformations before ours.
-      Array.prototype.unshift.apply(
-        keyframeStepProperties.transform,
-        newTransform
-      );
-    }
-  }
-}
-
-/**
- *  Modifies default animation by preserving transformations that given element already contains.
- *
- * @param animationName - Name of the animation to be modified (e.g. `FadeIn`).
- * @param existingTransform - Transform values that element already contains.
- * @returns Animation parsed to keyframe string.
- */
-export function createAnimationWithExistingTransform(
-  animationName: string,
-  existingTransform: NonNullable<TransformsStyle['transform']>,
-  layoutTransition?: AnimationData
-) {
-  let newAnimationData;
-
-  if (layoutTransition) {
-    newAnimationData = layoutTransition;
-  } else {
-    if (!(animationName in Animations)) {
-      return '';
-    }
-    newAnimationData = structuredClone(AnimationsData[animationName]);
-  }
-
-  const keyframeName = generateNextCustomKeyframeName();
-
-  newAnimationData.name = keyframeName;
-
-  const newTransform = addPxToTranslate(existingTransform);
-
-  addExistingTransform(newAnimationData, newTransform);
-
-  const keyframe = convertAnimationObjectToKeyframes(newAnimationData);
-
-  insertWebAnimation(keyframeName, keyframe);
-
-  return keyframeName;
 }
 
 let customKeyframeCounter = 0;
@@ -115,8 +57,7 @@ function generateNextCustomKeyframeName() {
  */
 export function TransitionGenerator(
   transitionType: TransitionType,
-  transitionData: TransitionData,
-  existingTransform: TransformsStyle['transform'] | undefined
+  transitionData: TransitionData
 ) {
   const transitionKeyframeName = generateNextCustomKeyframeName();
   let transitionObject;
@@ -140,14 +81,6 @@ export function TransitionGenerator(
         transitionData
       );
       break;
-  }
-
-  if (existingTransform) {
-    return createAnimationWithExistingTransform(
-      '',
-      existingTransform,
-      transitionObject
-    );
   }
 
   const transitionKeyframe =


### PR DESCRIPTION
## Summary

A while ago I've noticed that layout animations on mobile throw warning if one tries to add animation into `View` that has `transform` property. Now, while working on #5277 I've decided to remove code responsible for applying existing transform on web. Here are the reasons why I believe it is good idea:

1. It unifies behavior with mobile platforms, which are main target of `reanimated`.
2. Some of `transforms` were not applied correctly and required additional calculations to be implemented (like `skew`).
3. Removing existing transforms means removing a lot of `ifs` and unnecessary code.

## Test plan

Tested on example app on `LA` examples.
