### PR TITLE
docs: update compatibility table for fabric

### DIFF
--- a/docs/docs/guides/compatibility.mdx
+++ b/docs/docs/guides/compatibility.mdx
@@ -37,11 +37,11 @@ Reanimated does support [bridgeless mode](https://github.com/reactwg/react-nativ
 
 <div className="compatibility">
 
-|                                    | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   |
-| ---------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ |
-| <Version version="3.9.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> |
-| <Version version="3.6.x - 3.8.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.1.x – 3.5.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.0.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+|                                     | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   |
+| ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ |
+| <Version version="3.9.x – 3.12.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> |
+| <Version version="3.6.x – 3.8.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.0.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  |
 
 </div>

--- a/docs/docs/guides/compatibility.mdx
+++ b/docs/docs/guides/compatibility.mdx
@@ -33,7 +33,7 @@ Reanimated 2 won't receive support for newest React Native versions. To get the 
 
 To use Reanimated with [the experimental New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page), update the package to at least version 3.0.0. Due to the vast number of breaking-changes related to the New Architecture in each React Native version, as a rule of thumb Reanimated supports the latest stable version of React Native.
 
-Reanimated does support [bridgeless mode](https://github.com/reactwg/react-native-new-architecture/discussions/154).
+Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-native-new-architecture/discussions/154).
 
 <div className="compatibility">
 


### PR DESCRIPTION
This PR adds a missing version label for the New Architecture in the compatibility table. Also, tiny grammar fix `Reanimated does support` -> `Reanimated supports`.

## Before

<img width="987" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/39658211/8afcfec9-6ce1-4bf4-b9c5-9dc3b3983982">



## After  

<img width="999" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/39658211/a9502713-10d9-429c-906a-4faa7e81c378">