### PR TITLE
fix: missing imports to DevMenuUtils for compatibility with version 72

### DIFF
--- a/android/src/reactNativeVersionPatch/ReactHost/72/com/swmansion/reanimated/DevMenuUtils.java
+++ b/android/src/reactNativeVersionPatch/ReactHost/72/com/swmansion/reanimated/DevMenuUtils.java
@@ -1,8 +1,13 @@
 package com.swmansion.reanimated;
 
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.devsupport.interfaces.DevOptionHandler;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+
 public class DevMenuUtils {
 
-    private void addDevMenuOption(ReactApplicationContext context, DevOptionHandler handler) {
+    public static void addDevMenuOption(ReactApplicationContext context, DevOptionHandler handler) {
     // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
     if (context.getApplicationContext() instanceof ReactApplication) {
       final DevSupportManager devSupportManager =


### PR DESCRIPTION
## Summary

Related Pull Request https://github.com/software-mansion/react-native-reanimated/pull/5997

Fixed #6076


Android build does not work for versions below 0.72.

![image](https://github.com/software-mansion/react-native-reanimated/assets/41789633/49a58298-c279-4522-a7c3-e0a0eb0c82c3)

## Test plan

Run `./gradlew bundleRelease` on versions below 0.72.