### PR TITLE
android list item layout animation

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -210,18 +210,18 @@ public class AnimationsManager implements ViewHierarchyObserver {
     }
 
     ViewGroup parent = (ViewGroup) view.getParent();
-
-    if (parent == null) {
-      return;
-    }
-
     ViewManager viewManager = resolveViewManager(tag);
-    ViewManager parentViewManager = resolveViewManager(parent.getId());
 
     if (viewManager == null) {
       return;
     }
 
+    if (parent == null) {
+      setNewProps(newStyle, view, viewManager, isSharedTransition);
+      return;
+    }
+
+    ViewManager parentViewManager = resolveViewManager(parent.getId());
     setNewProps(newStyle, view, viewManager, parentViewManager, parent.getId(), isSharedTransition);
   }
 
@@ -331,48 +331,96 @@ public class AnimationsManager implements ViewHierarchyObserver {
       ViewManager parentViewManager,
       Integer parentTag,
       boolean isPositionAbsolute) {
-    float x =
-        (props.get(Snapshot.ORIGIN_X) != null)
-            ? ((Double) props.get(Snapshot.ORIGIN_X)).floatValue()
-            : PixelUtil.toDIPFromPixel(view.getLeft());
-    float y =
-        (props.get(Snapshot.ORIGIN_Y) != null)
-            ? ((Double) props.get(Snapshot.ORIGIN_Y)).floatValue()
-            : PixelUtil.toDIPFromPixel(view.getTop());
-    float width =
-        (props.get(Snapshot.WIDTH) != null)
-            ? ((Double) props.get(Snapshot.WIDTH)).floatValue()
-            : PixelUtil.toDIPFromPixel(view.getWidth());
-    float height =
-        (props.get(Snapshot.HEIGHT) != null)
-            ? ((Double) props.get(Snapshot.HEIGHT)).floatValue()
-            : PixelUtil.toDIPFromPixel(view.getHeight());
+    HashMap<String, Float> viewSize = getViewSize(props, view);
+    float x = viewSize.get("x");
+    float y = viewSize.get("y");
+    float width = viewSize.get("width");
+    float height = viewSize.get("height");
 
     if (props.containsKey(Snapshot.TRANSFORM_MATRIX)) {
-      float[] matrixValues = new float[9];
-      if (props.get(Snapshot.TRANSFORM_MATRIX) instanceof ReadableNativeArray) {
-        // this array comes from JavaScript
-        ReadableNativeArray matrixArray =
-            (ReadableNativeArray) props.get(Snapshot.TRANSFORM_MATRIX);
-        for (int i = 0; i < 9; i++) {
-          matrixValues[i] = ((Double) matrixArray.getDouble(i)).floatValue();
-        }
-      } else {
-        // this array comes from Java
-        ArrayList<Float> casted = (ArrayList<Float>) props.get(Snapshot.TRANSFORM_MATRIX);
-        for (int i = 0; i < 9; i++) {
-          matrixValues[i] = casted.get(i);
-        }
-      }
-      view.setScaleX(matrixValues[0]);
-      view.setScaleY(matrixValues[4]);
-      // as far, let's support only scale and translation. Rotation maybe the future feature
-      // http://eecs.qmul.ac.uk/~gslabaugh/publications/euler.pdf
-
-      props.remove(Snapshot.TRANSFORM_MATRIX);
+      performTransformMatrixUpdate(props, view);
     }
 
     updateLayout(view, parentViewManager, parentTag, x, y, width, height, isPositionAbsolute);
+    updateProps(props, view, viewManager);
+  }
+
+  public void setNewProps(
+          Map<String, Object> props,
+          View view,
+          ViewManager viewManager,
+          boolean isPositionAbsolute) {
+    HashMap<String, Float> viewSize = getViewSize(props, view);
+    float x = viewSize.get("x");
+    float y = viewSize.get("y");
+    float width = viewSize.get("width");
+    float height = viewSize.get("height");
+
+    if (props.containsKey(Snapshot.TRANSFORM_MATRIX)) {
+      performTransformMatrixUpdate(props, view);
+    }
+
+    updateLayout(view, x, y, width, height, isPositionAbsolute);
+    updateProps(props, view, viewManager);
+  }
+
+  private static HashMap<String, Float> getViewSize(Map<String, Object> props,
+                                                    View view) {
+    HashMap<String, Float> map = new HashMap<>();
+
+    float x =
+            (props.get(Snapshot.ORIGIN_X) != null)
+                    ? ((Double) props.get(Snapshot.ORIGIN_X)).floatValue()
+                    : PixelUtil.toDIPFromPixel(view.getLeft());
+    float y =
+            (props.get(Snapshot.ORIGIN_Y) != null)
+                    ? ((Double) props.get(Snapshot.ORIGIN_Y)).floatValue()
+                    : PixelUtil.toDIPFromPixel(view.getTop());
+    float width =
+            (props.get(Snapshot.WIDTH) != null)
+                    ? ((Double) props.get(Snapshot.WIDTH)).floatValue()
+                    : PixelUtil.toDIPFromPixel(view.getWidth());
+    float height =
+            (props.get(Snapshot.HEIGHT) != null)
+                    ? ((Double) props.get(Snapshot.HEIGHT)).floatValue()
+                    : PixelUtil.toDIPFromPixel(view.getHeight());
+
+    map.put("x", x);
+    map.put("y", y);
+    map.put("width", width);
+    map.put("height", height);
+
+    return map;
+  }
+
+  private static void performTransformMatrixUpdate(Map<String, Object> props,
+                                 View view) {
+    float[] matrixValues = new float[9];
+    if (props.get(Snapshot.TRANSFORM_MATRIX) instanceof ReadableNativeArray) {
+      // this array comes from JavaScript
+      ReadableNativeArray matrixArray =
+              (ReadableNativeArray) props.get(Snapshot.TRANSFORM_MATRIX);
+      for (int i = 0; i < 9; i++) {
+        matrixValues[i] = ((Double) matrixArray.getDouble(i)).floatValue();
+      }
+    } else {
+      // this array comes from Java
+      ArrayList<Float> casted = (ArrayList<Float>) props.get(Snapshot.TRANSFORM_MATRIX);
+      for (int i = 0; i < 9; i++) {
+        matrixValues[i] = casted.get(i);
+      }
+    }
+    view.setScaleX(matrixValues[0]);
+    view.setScaleY(matrixValues[4]);
+    // as far, let's support only scale and translation. Rotation maybe the future feature
+    // http://eecs.qmul.ac.uk/~gslabaugh/publications/euler.pdf
+
+    props.remove(Snapshot.TRANSFORM_MATRIX);
+  }
+
+  private static void updateProps(Map<String, Object> props,
+                                  View view,
+                                  ViewManager viewManager) {
     props.remove(Snapshot.ORIGIN_X);
     props.remove(Snapshot.ORIGIN_Y);
     props.remove(Snapshot.GLOBAL_ORIGIN_X);
@@ -380,7 +428,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     props.remove(Snapshot.WIDTH);
     props.remove(Snapshot.HEIGHT);
 
-    if (props.size() == 0) {
+    if (props.isEmpty()) {
       return;
     }
 
@@ -487,6 +535,34 @@ public class AnimationsManager implements ViewHierarchyObserver {
       }
       viewToUpdate.layout(x, y, x + width, y + height);
     }
+  }
+
+  public void updateLayout(
+          View viewToUpdate,
+          float xf,
+          float yf,
+          float widthf,
+          float heightf,
+          boolean isPositionAbsolute) {
+
+    int x = Math.round(PixelUtil.toPixelFromDIP(xf));
+    int y = Math.round(PixelUtil.toPixelFromDIP(yf));
+    int width = Math.round(PixelUtil.toPixelFromDIP(widthf));
+    int height = Math.round(PixelUtil.toPixelFromDIP(heightf));
+
+    viewToUpdate.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+
+    if (isPositionAbsolute) {
+      Point newPoint = new Point(x, y);
+      View viewToUpdateParent = (View) viewToUpdate.getParent();
+      Point convertedPoint = convertScreenLocationToViewCoordinates(newPoint, viewToUpdateParent);
+      x = convertedPoint.x;
+      y = convertedPoint.y;
+    }
+
+    viewToUpdate.layout(x, y, x + width, y + height);
   }
 
   public boolean shouldAnimateExiting(int tag, boolean shouldAnimate) {

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -346,10 +346,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public void setNewProps(
-          Map<String, Object> props,
-          View view,
-          ViewManager viewManager,
-          boolean isPositionAbsolute) {
+      Map<String, Object> props, View view, ViewManager viewManager, boolean isPositionAbsolute) {
     HashMap<String, Float> viewSize = getViewSize(props, view);
     float x = viewSize.get("x");
     float y = viewSize.get("y");
@@ -364,26 +361,25 @@ public class AnimationsManager implements ViewHierarchyObserver {
     updateProps(props, view, viewManager);
   }
 
-  private static HashMap<String, Float> getViewSize(Map<String, Object> props,
-                                                    View view) {
+  private static HashMap<String, Float> getViewSize(Map<String, Object> props, View view) {
     HashMap<String, Float> map = new HashMap<>();
 
     float x =
-            (props.get(Snapshot.ORIGIN_X) != null)
-                    ? ((Double) props.get(Snapshot.ORIGIN_X)).floatValue()
-                    : PixelUtil.toDIPFromPixel(view.getLeft());
+        (props.get(Snapshot.ORIGIN_X) != null)
+            ? ((Double) props.get(Snapshot.ORIGIN_X)).floatValue()
+            : PixelUtil.toDIPFromPixel(view.getLeft());
     float y =
-            (props.get(Snapshot.ORIGIN_Y) != null)
-                    ? ((Double) props.get(Snapshot.ORIGIN_Y)).floatValue()
-                    : PixelUtil.toDIPFromPixel(view.getTop());
+        (props.get(Snapshot.ORIGIN_Y) != null)
+            ? ((Double) props.get(Snapshot.ORIGIN_Y)).floatValue()
+            : PixelUtil.toDIPFromPixel(view.getTop());
     float width =
-            (props.get(Snapshot.WIDTH) != null)
-                    ? ((Double) props.get(Snapshot.WIDTH)).floatValue()
-                    : PixelUtil.toDIPFromPixel(view.getWidth());
+        (props.get(Snapshot.WIDTH) != null)
+            ? ((Double) props.get(Snapshot.WIDTH)).floatValue()
+            : PixelUtil.toDIPFromPixel(view.getWidth());
     float height =
-            (props.get(Snapshot.HEIGHT) != null)
-                    ? ((Double) props.get(Snapshot.HEIGHT)).floatValue()
-                    : PixelUtil.toDIPFromPixel(view.getHeight());
+        (props.get(Snapshot.HEIGHT) != null)
+            ? ((Double) props.get(Snapshot.HEIGHT)).floatValue()
+            : PixelUtil.toDIPFromPixel(view.getHeight());
 
     map.put("x", x);
     map.put("y", y);
@@ -393,13 +389,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
     return map;
   }
 
-  private static void performTransformMatrixUpdate(Map<String, Object> props,
-                                 View view) {
+  private static void performTransformMatrixUpdate(Map<String, Object> props, View view) {
     float[] matrixValues = new float[9];
     if (props.get(Snapshot.TRANSFORM_MATRIX) instanceof ReadableNativeArray) {
       // this array comes from JavaScript
-      ReadableNativeArray matrixArray =
-              (ReadableNativeArray) props.get(Snapshot.TRANSFORM_MATRIX);
+      ReadableNativeArray matrixArray = (ReadableNativeArray) props.get(Snapshot.TRANSFORM_MATRIX);
       for (int i = 0; i < 9; i++) {
         matrixValues[i] = ((Double) matrixArray.getDouble(i)).floatValue();
       }
@@ -418,9 +412,7 @@ public class AnimationsManager implements ViewHierarchyObserver {
     props.remove(Snapshot.TRANSFORM_MATRIX);
   }
 
-  private static void updateProps(Map<String, Object> props,
-                                  View view,
-                                  ViewManager viewManager) {
+  private static void updateProps(Map<String, Object> props, View view, ViewManager viewManager) {
     props.remove(Snapshot.ORIGIN_X);
     props.remove(Snapshot.ORIGIN_Y);
     props.remove(Snapshot.GLOBAL_ORIGIN_X);
@@ -538,12 +530,12 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public void updateLayout(
-          View viewToUpdate,
-          float xf,
-          float yf,
-          float widthf,
-          float heightf,
-          boolean isPositionAbsolute) {
+      View viewToUpdate,
+      float xf,
+      float yf,
+      float widthf,
+      float heightf,
+      boolean isPositionAbsolute) {
 
     int x = Math.round(PixelUtil.toPixelFromDIP(xf));
     int y = Math.round(PixelUtil.toPixelFromDIP(yf));
@@ -551,8 +543,8 @@ public class AnimationsManager implements ViewHierarchyObserver {
     int height = Math.round(PixelUtil.toPixelFromDIP(heightf));
 
     viewToUpdate.measure(
-            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
 
     if (isPositionAbsolute) {
       Point newPoint = new Point(x, y);

--- a/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/layoutReanimation/ReanimatedNativeHierarchyManager.java
@@ -54,14 +54,10 @@ class ReaLayoutAnimator extends LayoutAnimationController {
     if (!isLayoutAnimationEnabled()) {
       return super.shouldAnimateLayout(viewToAnimate);
     }
-    // if view parent is null, skip animation: view have been clipped, we don't want animation to
-    // resume when view is re-attached to parent, which is the standard android animation behavior.
+
     // If there's a layout handling animation going on, it should be animated nonetheless since the
     // ongoing animation needs to be updated.
-    if (viewToAnimate == null) {
-      return false;
-    }
-    return (viewToAnimate.getParent() != null);
+    return viewToAnimate != null;
   }
 
   @Override

--- a/app/src/examples/LayoutAnimations/ListItemLayoutAnimation.tsx
+++ b/app/src/examples/LayoutAnimations/ListItemLayoutAnimation.tsx
@@ -1,0 +1,89 @@
+import Animated, {
+  LinearTransition,
+  SlideOutRight,
+} from 'react-native-reanimated';
+import {
+  StyleSheet,
+  Text,
+  SafeAreaView,
+  Pressable,
+  ListRenderItemInfo,
+} from 'react-native';
+import React, { useState } from 'react';
+
+interface DataItem {
+  id: number;
+  color: string;
+}
+
+const DATA: Array<DataItem> = [
+  { id: 0, color: '#F1C40F' },
+  { id: 1, color: '#FF5733' },
+  { id: 2, color: '#C70039' },
+  { id: 3, color: '#900C3F' },
+  { id: 4, color: '#2ECC71' },
+  { id: 5, color: '#16A085' },
+  { id: 6, color: '#8E44AD' },
+  { id: 7, color: '#E67E22' },
+  { id: 8, color: '#2980B9' },
+  { id: 9, color: '#2C3E50' },
+  { id: 10, color: '#1ABC9C' },
+  { id: 11, color: '#581845' },
+  { id: 12, color: '#34495E' },
+  { id: 13, color: '#3498DB' },
+];
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+interface ListItemProps extends DataItem {
+  onPress: (id: number) => void;
+}
+
+function ListItem({ id, color, onPress }: ListItemProps) {
+  return (
+    <AnimatedPressable
+      key={id}
+      exiting={SlideOutRight}
+      onPress={() => onPress(id)}
+      style={[styles.item, { backgroundColor: color }]}>
+      <Text>Press to remove {id}</Text>
+    </AnimatedPressable>
+  );
+}
+
+export default function ListItemLayoutAnimation() {
+  const [data, setData] = useState<Array<DataItem>>(DATA);
+
+  const removeElement = (id: number) => {
+    setData((prevData) => prevData.filter((item) => item.id !== id));
+  };
+
+  const renderItem = ({ item }: ListRenderItemInfo<DataItem>) => {
+    return <ListItem id={item.id} color={item.color} onPress={removeElement} />;
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Animated.FlatList
+        itemLayoutAnimation={LinearTransition.delay(300)}
+        data={data}
+        renderItem={renderItem}
+        contentContainerStyle={styles.content}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+  },
+  item: {
+    height: 150,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/src/examples/index.ts
+++ b/app/src/examples/index.ts
@@ -128,6 +128,7 @@ import ComposedHandlerDifferentEventsExample from './ComposedHandlerDifferentEve
 import ComposedHandlerInternalMergingExample from './ComposedHandlerInternalMergingExample';
 import BorderRadiiExample from './SharedElementTransitions/BorderRadii';
 import FreezingShareablesExample from './ShareableFreezingExample';
+import ListItemLayoutAnimation from './LayoutAnimations/ListItemLayoutAnimation';
 
 interface Example {
   icon?: string;
@@ -711,6 +712,11 @@ export const EXAMPLES: Record<string, Example> = {
   ChangeTheme: {
     title: '[LA] Change theme',
     screen: ChangeThemeExample,
+    missingOnFabric: true,
+  },
+  ListItemLayoutAnimation: {
+    title: '[LA] List item layout animation',
+    screen: ListItemLayoutAnimation,
     missingOnFabric: true,
   },
 


### PR DESCRIPTION
## Summary
Previously Android flat list items that were rendered out of the screen weren't animated at all. This caused some issues like  [this one](https://github.com/software-mansion/react-native-reanimated/issues/5821). This PR should allow animating Android components that are rendered out of the screen.

## Note
There are still some issues with `itemLayoutAnimation` for the last element on the list. This issue is related to the fact that when removing elements from the list, flat list component is changing its size before layout animation finishes., but that's general issue (both iOS and Android).

## Test plan
