### PR TITLE
Fix missing imports for RN72 compatibility

### DIFF
--- a/packages/react-native-reanimated/android/src/reactNativeVersionPatch/ReactHost/72/com/swmansion/reanimated/DevMenuUtils.java
+++ b/packages/react-native-reanimated/android/src/reactNativeVersionPatch/ReactHost/72/com/swmansion/reanimated/DevMenuUtils.java
@@ -1,8 +1,13 @@
 package com.swmansion.reanimated;
 
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.devsupport.interfaces.DevOptionHandler;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+
 public class DevMenuUtils {
 
-    private void addDevMenuOption(ReactApplicationContext context, DevOptionHandler handler) {
+    public static void addDevMenuOption(ReactApplicationContext context, DevOptionHandler handler) {
     // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
     if (context.getApplicationContext() instanceof ReactApplication) {
       final DevSupportManager devSupportManager =


### PR DESCRIPTION
## Summary

This is a copied version of https://github.com/software-mansion/react-native-reanimated/pull/6073, it was needed because of monorepo migration.

## Test plan

:shipit: 
