### PR TITLE
Fix configuring unconfigurable properties 

### DIFF
--- a/apps/common-app/src/examples/ShareableFreezingExample.tsx
+++ b/apps/common-app/src/examples/ShareableFreezingExample.tsx
@@ -68,6 +68,13 @@ export default function FreezingShareables() {
           onPress={tryModifyConvertedInt32Array}
         />
       </View>
+      <View style={styles.textAndButton}>
+        <Text style={styles.text}>🤫</Text>
+        <Button
+          title="Modify unconfigurable object"
+          onPress={tryModifyUnconfigurableObject}
+        />
+      </View>
     </View>
   );
 }
@@ -92,7 +99,7 @@ function tryModifyConvertedHostObject() {
     return;
   }
   makeShareableCloneRecursive(obj);
-  // @ts-expect-error
+  // @ts-expect-error It's ok
   obj.prop = 2; // shouldn't warn because it's not frozen
 }
 
@@ -107,21 +114,22 @@ function tryModifyConvertedPlainObject() {
 function tryModifyConvertedRegExpLiteral() {
   const obj = /a/;
   makeShareableCloneRecursive(obj);
-  // @ts-expect-error
+  // @ts-expect-error It's ok
   obj.prop = 2; // shouldn't warn because it's not frozen
 }
 
 function tryModifyConvertedRegExpInstance() {
+  // eslint-disable-next-line prefer-regex-literals
   const obj = new RegExp('a');
   makeShareableCloneRecursive(obj);
-  // @ts-expect-error
+  // @ts-expect-error It's ok
   obj.prop = 2; // shouldn't warn because it's not frozen
 }
 
 function tryModifyConvertedArrayBuffer() {
   const obj = new ArrayBuffer(8);
   makeShareableCloneRecursive(obj);
-  // @ts-expect-error
+  // @ts-expect-error It's ok
   obj.prop = 2; // shouldn't warn because it's not frozen
 }
 
@@ -129,6 +137,17 @@ function tryModifyConvertedInt32Array() {
   const obj = new Int32Array(2);
   makeShareableCloneRecursive(obj);
   obj[1] = 2; // shouldn't warn because it's not frozen
+}
+
+function tryModifyUnconfigurableObject() {
+  const obj = {};
+  Object.defineProperty(obj, 'prop', {
+    value: 1,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
+  makeShareableCloneRecursive(obj);
 }
 
 const styles = StyleSheet.create({

--- a/packages/react-native-reanimated/src/shareables.ts
+++ b/packages/react-native-reanimated/src/shareables.ts
@@ -318,6 +318,10 @@ function freezeObjectIfDev<T extends object>(value: T) {
     return;
   }
   Object.entries(value).forEach(([key, element]) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
+    if (!descriptor.configurable) {
+      return;
+    }
     Object.defineProperty(value, key, {
       get() {
         return element;


### PR DESCRIPTION
## Summary

Fixes #6066. When implementing more meaningful way of shareable freezing I overlooked the case when some properties would be unconfigurable. This PR fixes this.

## Test plan

New button in `ShareableFreezing` example checks that it doesn't throw anymore.
