### PR TITLE
Set default keyboard state

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
@@ -4,7 +4,7 @@ import androidx.core.view.WindowInsetsCompat;
 import com.facebook.react.uimanager.PixelUtil;
 
 public class Keyboard {
-  private KeyboardState mState;
+  private KeyboardState mState = KeyboardState.UNKNOWN;
   private int mHeight = 0;
   private int mActiveTransitionCounter = 0;
   private static final int CONTENT_TYPE_MASK = WindowInsetsCompat.Type.ime();


### PR DESCRIPTION
## Summary

This PR addresses a requested issue that randomly occurs on some Android devices:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int com.swmansion.reanimated.keyboard.KeyboardState.asInt()' on a null object reference
        at com.swmansion.reanimated.keyboard.KeyboardAnimationManager.notifyAboutKeyboardChange(KeyboardAnimationManager.java:45)
```
This NullPointerException was likely caused by the lack of a default value for the `mState` field.
