### PR TITLE
Fix nightly build CI

### DIFF
--- a/.github/workflows/build-npm-package-action.yml
+++ b/.github/workflows/build-npm-package-action.yml
@@ -77,7 +77,9 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}
           path: "packages/react-native-reanimated/${{ env.PACKAGE_NAME }}"
 
-      - run: npm publish $PACKAGE_NAME --tag nightly
+      - name: Publish npm package
+        working-directory: packages/react-native-reanimated
+        run: npm publish $PACKAGE_NAME --tag nightly
         if: ${{ inputs.publish_on_npm }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/build-npm-package-action.yml
+++ b/.github/workflows/build-npm-package-action.yml
@@ -77,8 +77,11 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}
           path: "packages/react-native-reanimated/${{ env.PACKAGE_NAME }}"
 
-      - name: Publish npm package
+      - name: Move package to repo root
         working-directory: packages/react-native-reanimated
+        run: mv $PACKAGE_NAME ../../
+
+      - name: Publish npm package
         run: npm publish $PACKAGE_NAME --tag nightly
         if: ${{ inputs.publish_on_npm }}
         env:


### PR DESCRIPTION
## Summary

Nightly build CI got hit with a recoil from monorepo integration.
Also, running `npm publish` from Reanimated package root (that contained packed `.tgz` file) would use files of Reanimated instead of the package, thus the move operation.

## Test plan

![image](https://github.com/software-mansion/react-native-reanimated/assets/77503811/9436f88f-8727-4fec-a23f-22d3cb27cb0d)
