### PR TITLE
Fix one more path in docs publish CI

### DIFF
--- a/.github/workflows/publish-reanimated-docs.yml
+++ b/.github/workflows/publish-reanimated-docs.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Publish generated content to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          FOLDER: docs/build
+          FOLDER: packages/docs-reanimated/build
           BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Previous fix forgor about one path

## Test plan

https://github.com/software-mansion/react-native-reanimated/actions/runs/9483520775 - went through this time with publish as well
