### PR TITLE
Fix `web-example` 

### DIFF
--- a/apps/web-example/metro.config.js
+++ b/apps/web-example/metro.config.js
@@ -1,5 +1,8 @@
 const { getDefaultConfig } = require('expo/metro-config');
+
 const path = require('path');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
+const escape = require('escape-string-regexp');
 
 // Find the project and workspace directories
 const projectRoot = __dirname;
@@ -14,5 +17,14 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(monorepoRoot, 'node_modules'),
 ];
+
+const modulesToBlock = ['@react-native'];
+
+config.resolver.blacklistRE = exclusionList(
+  modulesToBlock.map(
+    (m) =>
+      new RegExp(`^${escape(path.join(monorepoRoot, 'node_modules', m))}\\/.*$`)
+  )
+);
 
 module.exports = config;


### PR DESCRIPTION
## Summary

Following the transition to a monorepo structure, our web-example app stopped working due to an asset loading issue. Turns out that the `getAssetByID` function from `react-native-web` was being called from the incorrect module. We believe this might have resulted in one module blocking an asset while another module was trying to load it, causing the application to crash.

This PR modifies the `metro.config.js` inside the `web-example` folder. It is now configured to ignore the `@react-native` module from the root, which allows assets to load correctly.

## Test plan

Run `web-example`.
