### PR TITLE
Fix docs-check CI trigger path

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/docs-check.yml'
-      - 'packages/react-native-reanimated/docs/**'
+      - packages/docs-reanimated/**
   merge_group:
     branches:
       - main


### PR DESCRIPTION
## Summary

As stated, the docs-check CI wasn't triggering on docs-related PRs. This one fixes it.

## Test plan

👍 
