### PR TITLE
fix: don't overwrite `propKeysManagedByAnimated` with `nil`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -179,6 +179,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
 #ifdef RCT_NEW_ARCH_ENABLED
   bool isThereAnyLayoutProp(jsi::Runtime &rt, const jsi::Object &props);
+  jsi::Object getUIProps(jsi::Runtime &rt, const jsi::Object &props);
   jsi::Value filterNonAnimatableProps(
       jsi::Runtime &rt,
       const jsi::Value &props);

--- a/packages/react-native-reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/REANodesManager.mm
@@ -432,9 +432,7 @@ using namespace facebook::react;
   REAUIView<RCTComponentViewProtocol> *componentView =
       [componentViewRegistry findComponentViewWithTag:[viewTag integerValue]];
 
-  NSSet<NSString *> *propKeysManagedByAnimated = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
   [surfacePresenter synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
-  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:propKeysManagedByAnimated];
 
   // `synchronouslyUpdateViewOnUIThread` does not flush props like `backgroundColor` etc.
   // so that's why we need to call `finalizeUpdates` here.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Do not overwrite `propKeysManagedByAnimated` with `nil`

## Explanation

When you copy `propKeysManagedByAnimated` - you are copying `nil`. Later on in 

```objc
[_mountingManager synchronouslyUpdateViewOnUIThread:tag changedProps:props componentDescriptor:*componentDescriptor];
```

props gets set to `nil` and then `NSSet` with `transform` key, but in 

```objc
[componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:propKeysManagedByAnimated];
```

you set it back to `nil`.

As a result if re-render during animation happens, it may lead to unexpected jumps during the animation.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
