### PR TITLE
Fix SET in Expo Go

### DIFF
--- a/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
+++ b/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
@@ -27,7 +27,6 @@
   NSMutableSet<REAUIView *> *_reattachedViews;
   BOOL _isStackDropped;
   BOOL _isAsyncSharedTransitionConfigured;
-  BOOL _isConfigured;
   BOOL _clearScreen;
   BOOL _isInteractive;
   REAUIView *_disappearingScreen;
@@ -39,6 +38,14 @@
   different context of execution (self != REASharedTransitionManager)
 */
 static REASharedTransitionManager *_sharedTransitionManager;
+/*
+  It needs to be a static field because there is a possibility of instantiating
+  `REASharedTransitionManager` more than once, such as in Expo Go. Method swizzling
+  operates at the class level rather than the instance level, so `_isConfigured`
+  should also be a static field to inform every instance that the swizzling process
+  has occurred successfully.
+*/
+static BOOL _isConfigured = NO;
 
 - (instancetype)initWithAnimationsManager:(REAAnimationsManager *)animationManager
 {


### PR DESCRIPTION
## Summary

This pull request aims to address the lack of Shared Element Transition in Expo Go. The issue stemmed from the initialization process of SET. In Expo Go, Reanimated gets instantiated twice (once for the Expo client and once for the actual application). During initialization, `REASharedTransitionManager` attempts to swizzle certain methods from `react-native-screens` but aims to do so only once:

```objc
static dispatch_once_t onceToken;
dispatch_once(&onceToken, ^{
  ...
  _isConfigured = YES;
});
```

The variable `_isConfigured` was only set to true if the swizzling process completed successfully. The problem appeared when the second instance attempted to set up the `screens` integration, as it had already been done, resulting in the new instance failing to set `_isConfigured` to true, even if the method swizzling was successful.

The solution involves changing `_isConfigured` to a class field instead of an instance field.

## Test plan

Run Shared Element Transition in Expo Go