### PR TITLE
docs: fix transparent sidebar

### DIFF
--- a/packages/docs-reanimated/src/css/overrides.css
+++ b/packages/docs-reanimated/src/css/overrides.css
@@ -127,6 +127,6 @@ button[class*='DocSearch-Button'] {
 
 /* examples sidebar */
 
-[class*='plugin-blog'] [class*='sidebar'] {
+[class*='plugin-blog'] [class*='sidebar']:not([class*='navbar-sidebar']) {
   background-color: transparent;
 }


### PR DESCRIPTION
Before, on Examples page, sidebar was transparent due to insufficient css selector from past PR. In this PR we made more accurate selector to fix this problem.

Before: 
<img width="383" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/b3b18d64-fef3-4ba0-8f56-03bc04098749">

After:
<img width="383" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/0c4140b0-870f-4472-a89c-6d5a8a4562bd">
