### PR TITLE
Screen transition example  update - use proper import from screens instead of mock

### DIFF
--- a/apps/common-app/src/examples/ScreenTransitionExample.tsx
+++ b/apps/common-app/src/examples/ScreenTransitionExample.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck - It will be removed after release of react-native-screens, because currently 'react-native-screens/gesture-handler' import doesn't exist.
 import React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import {
@@ -10,12 +9,7 @@ import {
   ScreenTransition,
   AnimatedScreenTransition,
 } from 'react-native-reanimated';
-
-// This is a temporary workaround until react-native-screens release with 'react-native-screens/gesture-handler' import.
-// import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
-function GestureDetectorProvider({ children }) {
-  return children;
-}
+import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 
 function MainScreen({ navigation }: NativeStackScreenProps<ParamListBase>) {
   return (

--- a/apps/fabric-example/ios/FabricExample/Info.plist
+++ b/apps/fabric-example/ios/FabricExample/Info.plist
@@ -68,6 +68,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/apps/paper-example/ios/ReanimatedExample/Info.plist
+++ b/apps/paper-example/ios/ReanimatedExample/Info.plist
@@ -69,6 +69,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

After release of `react-native-screens` we can remove temporary mock from example app and use proper import from rn-screens.

I had to make modifications to `UIViewControllerBasedStatusBarAppearance` because we are using the native stack from `rn-screens` until the changes are upstreamed to `react-navigation` - [Pull Request Link](https://github.com/react-navigation/react-navigation/pull/11943)

## Test plan

Run screen transition example in example app.