### PR TITLE
Fix broken link in documentation

### DIFF
--- a/packages/react-native-reanimated/plugin/README-dev.md
+++ b/packages/react-native-reanimated/plugin/README-dev.md
@@ -103,7 +103,7 @@ Some use cases might've been overlooked and on the other hand - some might work 
 
 ## Plugin's applications
 
-To get some more information about certain edge cases or use cases not listed here, try looking them up in our [tests](https://github.com/software-mansion/react-native-reanimated/blob/main/__tests__/plugin.test.ts).
+To get some more information about certain edge cases or use cases not listed here, try looking them up in our [tests](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/__tests__/plugin.test.ts).
 
 ### What can be a worklet?
 


### PR DESCRIPTION
## Summary

Fixes broken link in documentation - the location of file changed after migration to the monorepo