### PR TITLE
Adjust Playground dark theme

### DIFF
--- a/packages/docs-reanimated/src/components/InteractivePlayground/index.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/index.tsx
@@ -191,7 +191,7 @@ export function Range({
   return (
     <>
       <div className={styles.row}>
-        <label style={{ color: disabled ? '#aaa' : 'black' }}>{label}</label>
+        <label style={{ color: disabled && '#aaa' }}>{label}</label>
         <TextField
           type="number"
           hiddenLabel


### PR DESCRIPTION
On interactivePlayground preserve disabled input color, but make enabled text color adapt to color theme.

Before:
<img width="800" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/70c7c60e-2d28-45de-ac1d-db4f50ff1a8f">
<img width="800" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/4c5b9323-0a8d-4574-b1ea-768d71b98f3d">

After:
<img width="800" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/7356650d-fd80-45fe-8499-de234a3a818e">
<img width="800" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/e5a16868-834e-4016-99a6-a01b34ceb927">
