### PR TITLE
docs: Fix withTiming playground Power range visibility

### DIFF
--- a/packages/docs-reanimated/src/components/InteractivePlayground/useTimingPlayground/index.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useTimingPlayground/index.tsx
@@ -73,6 +73,12 @@ export default function useTimingPlayground() {
     }
   }, [isMobile]);
 
+  useEffect(() => {
+    if (!canNestEasing(easing)) {
+      setNestedEasing(initialState.nestedEasing);
+    }
+  }, [easing]);
+
   const resetOptions = () => {
     setDuration(initialState.duration);
 
@@ -154,6 +160,9 @@ export default function useTimingPlayground() {
       reduceMotion: ${formatReduceMotion(reduceMotion)},
     })
   `;
+
+  console.log('easing: ', easing);
+  console.log('nestedEasing: ', nestedEasing);
 
   const controls = (
     <>


### PR DESCRIPTION
The <Range/> of Power should be visible when `easing` or `nestedEasing` are set to `poly`. `nestedEasing` is only visible when `easing` is set to either `in`, `out` or `inOut`. So when we set `easing` to `in`, `nestedEasing` to `poly` and then set `easing` to `brezier` the Power <Range/> will stay.

To fix that we added reset of `nestedEasing` value if `easing` is changed to something other that `in`, `out` or `inOut`

Before:

https://github.com/software-mansion/react-native-reanimated/assets/59940332/326876b6-f0b9-4edc-b793-2b4c8fd0da9f


After:


https://github.com/software-mansion/react-native-reanimated/assets/59940332/579600a1-7db8-48a9-bf68-bfc3a5157826

