### PR TITLE
Fix web exiting animation in StrictMode

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -220,8 +220,6 @@ export function handleExitingAnimation(
   dummy.reanimatedDummy = true;
 
   element.style.animationName = '';
-  // We hide current element so only its copy with proper animation will be displayed
-  element.style.visibility = 'hidden';
 
   // After cloning the element, we want to move all children from original element to its clone. This is because original element
   // will be unmounted, therefore when this code executes in child component, parent will be either empty or removed soon.


### PR DESCRIPTION
## Summary

This PR aims to fixing the web exiting animation when StrictMode is enabled. With StrictMode triggering an additional simulated unmount, our listeners detected the need for an exiting animation. The problem originated from setting `visibility = 'hidden'` on the original component, which remained present, and creating a copy for animation. As a result, the original component was hidden from view in the DOM tree. The solution proposed is simply to eliminate the hiding of components. This adjustment is safe even for scenarios without StrictMode, as the component that is hidden is removed in the same frame, ensuring consistency with the previous behavior.

| before | after |
| --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/07530231-58e4-429f-bae4-84e876ccc474" /> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/36106620/d4c3324d-74bd-4c3a-9c34-29207268ac95" /> |


## Test plan

<details>
<summary>code</summary>

```js
import { Button } from 'react-native';
import React, { useEffect, useState } from 'react';
import Animated, { FadeOutRight } from 'react-native-reanimated';

function Component() {
  useEffect(() => {
    console.log('Component mounted');
    return () => {
      console.log('Component unmounted');
    };
  }, []);
  return (
    <Animated.View exiting={FadeOutRight.duration(1000)} style={{width: 100, height: 100, borderWidth: 2, backgroundColor: 'lightblue'}} />
  );
}

export default function EmptyExample() {
  const [toggle, setToggle] = useState(true);
  return (
    <React.StrictMode>
    <>
      <Button title="Press me" onPress={() => {
        setToggle(!toggle)
        console.log('Button pressed');
      }} />
      {toggle && <Component />}
    </>
    </React.StrictMode>
  );
}

```

</details>
