### PR TITLE
Enable `-Wpedantic` flag on Android and use `std::vector` instead of VLA to pass arguments to `_scheduleOnJS`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
@@ -4,6 +4,8 @@
 #include "Shareables.h"
 #include "WorkletRuntime.h"
 
+#include <vector>
+
 #ifdef ANDROID
 #include "Logger.h"
 #else
@@ -110,13 +112,11 @@ void WorkletRuntimeDecorator::decorate(
             auto argsArray =
                 shareableArgs->toJSValue(rt).asObject(rt).asArray(rt);
             auto argsSize = argsArray.size(rt);
-            // number of arguments is typically relatively small so it is ok to
-            // to use VLAs here, hence disabling the lint rule
-            jsi::Value args[argsSize]; // NOLINT(runtime/arrays)
+            std::vector<jsi::Value> args(argsSize);
             for (size_t i = 0; i < argsSize; i++) {
               args[i] = argsArray.getValueAtIndex(rt, i);
             }
-            remoteFun.asObject(rt).asFunction(rt).call(rt, args, argsSize);
+            remoteFun.asObject(rt).asFunction(rt).call(rt, const_cast<const jsi::Value *>(args.data()), args.size());
           }
         });
       });

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -15,7 +15,7 @@ add_compile_options(${folly_FLAGS})
 
 string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} -DREANIMATED_VERSION=${REANIMATED_VERSION} -DHERMES_ENABLE_DEBUGGER=${HERMES_ENABLE_DEBUGGER}")
 
-string(APPEND CMAKE_CXX_FLAGS " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all -std=c++${CMAKE_CXX_STANDARD} -Wall -Werror")
+string(APPEND CMAKE_CXX_FLAGS " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all -std=c++${CMAKE_CXX_STANDARD} -Wall -Wpedantic -Werror")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
     string(APPEND CMAKE_CXX_FLAGS " -DRCT_NEW_ARCH_ENABLED")


### PR DESCRIPTION
## Summary

Just wanted to enable `-Wpedantic` flag on Android like React Native does.

## Test plan

Tested on runOnUI / runOnJS example.
