### PR TITLE
Add remark about reading SharedValue from the js thread

### DIFF
--- a/packages/docs-reanimated/docs/core/useSharedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useSharedValue.mdx
@@ -67,6 +67,8 @@ import SharedValueSrc from '!!raw-loader!@site/src/examples/SharedValue';
 
 - When you change the `sv.value` Reanimated will update the styles and keep the shared value in sync between the threads. However, this won't trigger a typical React re-render because a shared value is a plain JavaScript object.
 
+- When you read the `sv.value` on the [JavaScrupt thread](/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if you are running a lot of animations or reading a value multiple times the wait time needed to synchronize both threads may significantly grow.
+
 - When you change the `sv.value` the update will happen synchronously on the [UI thread](/docs/fundamentals/glossary#ui-thread). On the other hand, on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread) the update is asynchronous. This means when you try to immediately log the `value` after the change it will log the previously stored value.
 
 <Indent>

--- a/packages/docs-reanimated/docs/core/useSharedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useSharedValue.mdx
@@ -67,7 +67,7 @@ import SharedValueSrc from '!!raw-loader!@site/src/examples/SharedValue';
 
 - When you change the `sv.value` Reanimated will update the styles and keep the shared value in sync between the threads. However, this won't trigger a typical React re-render because a shared value is a plain JavaScript object.
 
-- When you read the `sv.value` on the [JavaScrupt thread](/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if you are running a lot of animations or reading a value multiple times the wait time needed to synchronize both threads may significantly grow.
+- When you read the `sv.value` on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if you are running a lot of animations or reading a value multiple times, the wait time needed to synchronize both threads may significantly increase.
 
 - When you change the `sv.value` the update will happen synchronously on the [UI thread](/docs/fundamentals/glossary#ui-thread). On the other hand, on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread) the update is asynchronous. This means when you try to immediately log the `value` after the change it will log the previously stored value.
 

--- a/packages/docs-reanimated/docs/core/useSharedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useSharedValue.mdx
@@ -67,7 +67,7 @@ import SharedValueSrc from '!!raw-loader!@site/src/examples/SharedValue';
 
 - When you change the `sv.value` Reanimated will update the styles and keep the shared value in sync between the threads. However, this won't trigger a typical React re-render because a shared value is a plain JavaScript object.
 
-- When you read the `sv.value` on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if you are running a lot of animations or reading a value multiple times, the wait time needed to synchronize both threads may significantly increase.
+- When you read the `sv.value` on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if the UI thread is busy or you are reading a value multiple times, the wait time needed to synchronize both threads may significantly increase.
 
 - When you change the `sv.value` the update will happen synchronously on the [UI thread](/docs/fundamentals/glossary#ui-thread). On the other hand, on the [JavaScript thread](/docs/fundamentals/glossary#javascript-thread) the update is asynchronous. This means when you try to immediately log the `value` after the change it will log the previously stored value.
 


### PR DESCRIPTION
## Summary

Reading from a shared value on the js thread may block the JS thread until the UI runtime finishes whatever it's doing. This isn't really communicated clearly and adding it to the docs seems like the best option as we don't want to show warnings.

## Test plan

I asked ChatGPT to point out problems (it did).
