### PR TITLE
Deprecate `combineTransition`

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -248,12 +248,8 @@ export class EntryExitTransition
 }
 
 /**
- * Lets you combine two layout animations into a layout transition. You can modify the behavior by chaining methods like `.delay(500)`.
- *
- * @param exiting - Layout animation used when components are removed from layout (eg. `FadeOut`).
- * @param entering - Layout animation used when components are added to layout (eg. `FadeIn`).
- * @returns A custom layout transition. You pass it to the `layout` prop on [an Animated component](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#animated-component).
- * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions#combine-transition
+ * @deprecated Please use `EntryExitTransition.entering(entering).exiting(exiting)` instead.
+ * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions
  */
 export function combineTransition(
   exiting: BaseAnimationBuilder | typeof BaseAnimationBuilder,


### PR DESCRIPTION
## Summary

The `combineTransition` method doesn't seem to be necessary. It doesn't add any additional logic, duplicates the public API, and misleadingly suggests that `combineTransition` and `EntryExitTransition` are distinct entities. In fact, it has even been removed from the documentation page [here](https://github.com/software-mansion/react-native-reanimated/pull/6144).
