### PR TITLE
Fix all autoFixable problems inside app/common

### DIFF
--- a/apps/common-app/src/App.tsx
+++ b/apps/common-app/src/App.tsx
@@ -15,24 +15,14 @@ import {
   GestureHandlerRootView,
   RectButton,
 } from 'react-native-gesture-handler';
-import {
-  HeaderBackButton,
-  HeaderBackButtonProps,
-} from '@react-navigation/elements';
-import {
-  NativeStackNavigationProp,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
-import {
-  NavigationContainer,
-  NavigationProp,
-  PathConfigMap,
-  useNavigation,
-} from '@react-navigation/native';
-import {
-  StackNavigationProp,
-  createStackNavigator,
-} from '@react-navigation/stack';
+import type { HeaderBackButtonProps } from '@react-navigation/elements';
+import { HeaderBackButton } from '@react-navigation/elements';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NavigationProp, PathConfigMap } from '@react-navigation/native';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+import { createStackNavigator } from '@react-navigation/stack';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { EXAMPLES } from './examples';
@@ -53,7 +43,7 @@ interface HomeScreenProps {
     | NativeStackNavigationProp<RootStackParamList, 'Home'>;
 }
 
-const EXAMPLES_NAMES = Object.keys(EXAMPLES) as (keyof typeof EXAMPLES)[];
+const EXAMPLES_NAMES = Object.keys(EXAMPLES);
 
 function findExamples(search: string) {
   if (search === '') {
@@ -181,7 +171,7 @@ function BackButton(props: HeaderBackButtonProps) {
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
 export default function App() {
-  const [isReady, setIsReady] = React.useState(__DEV__ ? false : true);
+  const [isReady, setIsReady] = React.useState(!__DEV__);
   const [initialState, setInitialState] = React.useState();
 
   React.useEffect(() => {

--- a/apps/common-app/src/examples/AnimatedTabBarExample.tsx
+++ b/apps/common-app/src/examples/AnimatedTabBarExample.tsx
@@ -24,7 +24,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import Svg, { Path } from 'react-native-svg';
 import * as shape from 'd3-shape';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 const { width, height } = Dimensions.get('window');
 

--- a/apps/common-app/src/examples/ChatHeadsExample.tsx
+++ b/apps/common-app/src/examples/ChatHeadsExample.tsx
@@ -8,10 +8,8 @@ import Animated, {
   withSpring,
   clamp,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 

--- a/apps/common-app/src/examples/ComposedHandlerInternalMergingExample.tsx
+++ b/apps/common-app/src/examples/ComposedHandlerInternalMergingExample.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import type { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import type { EventHandlerProcessed } from 'react-native-reanimated';
 import Animated, {
-  EventHandlerProcessed,
   interpolateColor,
   useAnimatedScrollHandler,
   useAnimatedStyle,

--- a/apps/common-app/src/examples/CubesExample.tsx
+++ b/apps/common-app/src/examples/CubesExample.tsx
@@ -222,7 +222,7 @@ function CubeWithEulerAngles() {
       transformOrigin(matrix, origin);
 
       return {
-        transform: [{ perspective: 1000 }, { matrix: matrix }],
+        transform: [{ perspective: 1000 }, { matrix }],
         backgroundColor: sidesColors[i],
       };
     })
@@ -261,7 +261,7 @@ function CubeWithQuaternions() {
       transformOrigin(matrix, origin);
 
       return {
-        transform: [{ perspective: 1000 }, { matrix: matrix }],
+        transform: [{ perspective: 1000 }, { matrix }],
         backgroundColor: sidesColors[i],
       };
     })

--- a/apps/common-app/src/examples/CustomHandler/AnimatedText.tsx
+++ b/apps/common-app/src/examples/CustomHandler/AnimatedText.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import {
-  StyleProp,
-  StyleSheet,
-  TextInput,
-  TextInputProps,
-  TextStyle,
-} from 'react-native';
-import Animated, {
-  SharedValue,
-  useAnimatedProps,
-} from 'react-native-reanimated';
-import type { AnimatedStyle } from 'react-native-reanimated';
+import type { StyleProp, TextInputProps, TextStyle } from 'react-native';
+import { StyleSheet, TextInput } from 'react-native';
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
+import type { AnimatedStyle, SharedValue } from 'react-native-reanimated';
 
 Animated.addWhitelistedNativeProps({ text: true });
 

--- a/apps/common-app/src/examples/CustomHandler/PagerExample.tsx
+++ b/apps/common-app/src/examples/CustomHandler/PagerExample.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
-  SharedValue,
   useDerivedValue,
   useSharedValue,
 } from 'react-native-reanimated';

--- a/apps/common-app/src/examples/CustomHandler/useAnimatedPagerHandler.ts
+++ b/apps/common-app/src/examples/CustomHandler/useAnimatedPagerHandler.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PageScrollStateChangedNativeEvent,
   PagerViewOnPageScrollEvent,
   PagerViewOnPageSelectedEvent,

--- a/apps/common-app/src/examples/DragAndSnapExample.tsx
+++ b/apps/common-app/src/examples/DragAndSnapExample.tsx
@@ -8,10 +8,8 @@ import Animated, {
   interpolate,
   Extrapolation,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 export default function DragAndSnapExample() {
   const translation = {

--- a/apps/common-app/src/examples/EmojiWaterfallExample.tsx
+++ b/apps/common-app/src/examples/EmojiWaterfallExample.tsx
@@ -1,6 +1,6 @@
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   Easing,
-  SharedValue,
   interpolate,
   useAnimatedStyle,
   useSharedValue,

--- a/apps/common-app/src/examples/ExtrapolationExample.tsx
+++ b/apps/common-app/src/examples/ExtrapolationExample.tsx
@@ -8,10 +8,8 @@ import Animated, {
   withTiming,
   Extrapolation,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 export default function ExtrapolationExample() {
   const translation = {

--- a/apps/common-app/src/examples/FrameCallbackExample.tsx
+++ b/apps/common-app/src/examples/FrameCallbackExample.tsx
@@ -1,5 +1,5 @@
+import type { FrameInfo } from 'react-native-reanimated';
 import Animated, {
-  FrameInfo,
   useAnimatedStyle,
   useFrameCallback,
   useSharedValue,

--- a/apps/common-app/src/examples/Game2048Example.tsx
+++ b/apps/common-app/src/examples/Game2048Example.tsx
@@ -1,4 +1,5 @@
-import { Text, StyleSheet, View, ColorValue, Alert } from 'react-native';
+import type { ColorValue } from 'react-native';
+import { Text, StyleSheet, View, Alert } from 'react-native';
 import Animated, { LinearTransition, ZoomIn } from 'react-native-reanimated';
 
 import React from 'react';

--- a/apps/common-app/src/examples/GestureHandlerExample.tsx
+++ b/apps/common-app/src/examples/GestureHandlerExample.tsx
@@ -3,14 +3,16 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-import {
-  Gesture,
-  GestureDetector,
-  GestureHandlerRootView,
+import type {
   GestureStateManager,
   GestureTouchEvent,
   GestureUpdateEvent,
   PanGestureChangeEventPayload,
+} from 'react-native-gesture-handler';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 
 import React from 'react';

--- a/apps/common-app/src/examples/IPodExample.tsx
+++ b/apps/common-app/src/examples/IPodExample.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, Dimensions, Text } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -9,12 +10,9 @@ import Animated, {
   useAnimatedGestureHandler,
   Extrapolation,
   interpolate,
-  SharedValue,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 const data = [
   { artist: 'Nirvana', song: 'Smells Like Teen Spirit' },

--- a/apps/common-app/src/examples/JSPropsExample.tsx
+++ b/apps/common-app/src/examples/JSPropsExample.tsx
@@ -1,4 +1,5 @@
-import { TextInput, View, StyleSheet, ColorValue } from 'react-native';
+import type { ColorValue } from 'react-native';
+import { TextInput, View, StyleSheet } from 'react-native';
 import React from 'react';
 import Svg, { Path, Circle, G } from 'react-native-svg';
 import Animated, {

--- a/apps/common-app/src/examples/LayoutAnimations/Carousel.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/Carousel.tsx
@@ -1,12 +1,6 @@
 import Animated, { SlideInLeft, SlideOutRight } from 'react-native-reanimated';
-import {
-  Button,
-  Image,
-  ImageSourcePropType,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import type { ImageSourcePropType } from 'react-native';
+import { Button, Image, StyleSheet, Text, View } from 'react-native';
 import React, { useState } from 'react';
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);

--- a/apps/common-app/src/examples/LayoutAnimations/CustomLayout.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/CustomLayout.tsx
@@ -1,5 +1,5 @@
+import type { LayoutAnimationFunction } from 'react-native-reanimated';
 import Animated, {
-  LayoutAnimationFunction,
   makeMutable,
   withDelay,
   withSequence,

--- a/apps/common-app/src/examples/LayoutAnimations/HabitsExample.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/HabitsExample.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Platform, Pressable, StyleSheet, View, Text } from 'react-native';
+import type { AnimatedProps } from 'react-native-reanimated';
 import Animated, {
   FadeInLeft,
   FadeInDown,
   ZoomIn,
   LightSpeedInLeft,
   BounceIn,
-  AnimatedProps,
   FadeOut,
 } from 'react-native-reanimated';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';

--- a/apps/common-app/src/examples/LayoutAnimations/Modal.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/Modal.tsx
@@ -1,7 +1,9 @@
-import Animated, {
+import type {
   EntryAnimationsValues,
   EntryExitAnimationFunction,
   ExitAnimationsValues,
+} from 'react-native-reanimated';
+import Animated, {
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated';

--- a/apps/common-app/src/examples/LayoutAnimations/ModalNewAPI.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/ModalNewAPI.tsx
@@ -1,7 +1,9 @@
-import Animated, {
+import type {
   EntryAnimationsValues,
   EntryExitAnimationFunction,
   ExitAnimationsValues,
+} from 'react-native-reanimated';
+import Animated, {
   Layout,
   withDelay,
   withTiming,

--- a/apps/common-app/src/examples/LayoutAnimations/NativeModals.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/NativeModals.tsx
@@ -1,11 +1,9 @@
 import { Alert, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
-import {
-  NativeStackNavigationProp,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React, { useState } from 'react';
 
-import { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/native';
 
 // import { createStackNavigator } from "@react-navigation/stack";
 

--- a/apps/common-app/src/examples/LayoutAnimations/NestedNativeStacksWithLayout.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/NestedNativeStacksWithLayout.tsx
@@ -2,10 +2,8 @@ import Animated, { SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import { Button, StyleSheet, View } from 'react-native';
 
 import React from 'react';
-import {
-  NativeStackScreenProps,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 type ParamList = {
   First?: {};

--- a/apps/common-app/src/examples/LayoutAnimations/ReactionsCounterExample.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/ReactionsCounterExample.tsx
@@ -1,6 +1,8 @@
-import Animated, {
+import type {
   EntryAnimationsValues,
   ExitAnimationsValues,
+} from 'react-native-reanimated';
+import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withDelay,

--- a/apps/common-app/src/examples/LayoutAnimations/WaterfallGridExample.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/WaterfallGridExample.tsx
@@ -1,5 +1,5 @@
+import type { BaseAnimationBuilder } from 'react-native-reanimated';
 import Animated, {
-  BaseAnimationBuilder,
   BounceOut,
   CurvedTransition,
   FadingTransition,
@@ -11,7 +11,8 @@ import Animated, {
   SequencedTransition,
   combineTransition,
 } from 'react-native-reanimated';
-import { Image, LayoutChangeEvent, Text, View, StyleSheet } from 'react-native';
+import type { LayoutChangeEvent } from 'react-native';
+import { Image, Text, View, StyleSheet } from 'react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView, TapGestureHandler } from 'react-native-gesture-handler';
 
@@ -120,7 +121,7 @@ export function WaterfallGrid({
           key={pok.address}
           style={[
             {
-              width: width,
+              width,
               height: pokHeight,
               backgroundColor: pok.color,
               left: cur * width + (cur + 1) * margin,
@@ -135,7 +136,7 @@ export function WaterfallGrid({
             <AnimatedImage
               layout={layoutTransition}
               source={{ uri: pok.address }}
-              style={{ width: width, height: width }}
+              style={{ width, height: width }}
             />
           </TapGestureHandler>
         </Animated.View>
@@ -148,7 +149,7 @@ export function WaterfallGrid({
       {cardsMemo.length === 0 && <Text> Loading </Text>}
       {cardsMemo.length !== 0 && (
         <ScrollView>
-          <View style={{ height: height }}>{cardsMemo}</View>
+          <View style={{ height }}>{cardsMemo}</View>
         </ScrollView>
       )}
     </View>
@@ -167,7 +168,7 @@ export default function WaterfallGridExample() {
           style={styles.picker}
           itemStyle={{ height: 50 }}
           onValueChange={(itemValue) => {
-            setSelectedTransition(itemValue as string);
+            setSelectedTransition(itemValue);
           }}>
           <Picker.Item label="LinearTransition" value="LinearTransition" />
           <Picker.Item

--- a/apps/common-app/src/examples/LightBoxExample.tsx
+++ b/apps/common-app/src/examples/LightBoxExample.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useEffect, Component } from 'react';
+import type { Component } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,

--- a/apps/common-app/src/examples/LiquidSwipe/Weave.tsx
+++ b/apps/common-app/src/examples/LiquidSwipe/Weave.tsx
@@ -1,5 +1,5 @@
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
-  SharedValue,
   useAnimatedProps,
   useDerivedValue,
 } from 'react-native-reanimated';
@@ -14,7 +14,8 @@ import {
 } from './WeaveHelpers';
 
 import MaskedView from '@react-native-masked-view/masked-view';
-import React, { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
+import React from 'react';
 
 const { width, height } = Dimensions.get('window');
 const AnimatedPath = Animated.createAnimatedComponent(Path);

--- a/apps/common-app/src/examples/LogExample.tsx
+++ b/apps/common-app/src/examples/LogExample.tsx
@@ -58,7 +58,7 @@ export default function LogExample() {
           bar?: string;
         };
 
-        let a: RecursiveObject = {};
+        const a: RecursiveObject = {};
         a.foo = a;
         a.bar = 'bar';
         test(a, '{"foo": {...}, "bar": "bar"}');
@@ -66,7 +66,7 @@ export default function LogExample() {
       {
         type RecursiveArray = (number | RecursiveArray)[];
 
-        let b: RecursiveArray = [];
+        const b: RecursiveArray = [];
         b.push(1);
         b.push(b);
         test(b, '[1, [...]]');

--- a/apps/common-app/src/examples/NewestShadowNodesRegistryRemoveExample.tsx
+++ b/apps/common-app/src/examples/NewestShadowNodesRegistryRemoveExample.tsx
@@ -1,4 +1,5 @@
-import { GestureResponderEvent, StyleSheet, View } from 'react-native';
+import type { GestureResponderEvent } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import React from 'react';
 import Animated, {

--- a/apps/common-app/src/examples/OldMeasureExample.tsx
+++ b/apps/common-app/src/examples/OldMeasureExample.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode, useRef } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import React, { useRef } from 'react';
 import { StyleSheet, View, Text, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, {
@@ -12,10 +13,8 @@ import Animated, {
   useAnimatedRef,
 } from 'react-native-reanimated';
 import type { AnimatedRef } from 'react-native-reanimated';
-import {
-  TapGestureHandler,
-  TapGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { TapGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { TapGestureHandler } from 'react-native-gesture-handler';
 import '../types';
 
 const labels = ['apple', 'banana', 'kiwi', 'milk', 'water'];

--- a/apps/common-app/src/examples/PendulumExample.tsx
+++ b/apps/common-app/src/examples/PendulumExample.tsx
@@ -3,15 +3,23 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-import { StyleSheet, TextInput, Text, TouchableOpacity } from 'react-native';
-import { View } from 'react-native';
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import {
+  StyleSheet,
+  TextInput,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { Dispatch, SetStateAction } from 'react';
+import React, { useState } from 'react';
+import type {
+  GestureStateManager,
+  GestureTouchEvent,
+} from 'react-native-gesture-handler';
 import {
   Gesture,
   GestureDetector,
   GestureHandlerRootView,
-  GestureStateManager,
-  GestureTouchEvent,
 } from 'react-native-gesture-handler';
 
 const NAVY = '#001A72';

--- a/apps/common-app/src/examples/PinExample.tsx
+++ b/apps/common-app/src/examples/PinExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Text, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -8,12 +9,9 @@ import Animated, {
   scrollTo,
   useDerivedValue,
   useAnimatedRef,
-  SharedValue,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 const indices = [0, 1, 2, 3];

--- a/apps/common-app/src/examples/PlanetsExample.tsx
+++ b/apps/common-app/src/examples/PlanetsExample.tsx
@@ -6,7 +6,8 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { Circle, Ellipse, Path, Svg } from 'react-native-svg';
-import { ColorValue, StyleSheet, View } from 'react-native';
+import type { ColorValue } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import React, { useEffect, useState } from 'react';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);

--- a/apps/common-app/src/examples/RainbowExample.tsx
+++ b/apps/common-app/src/examples/RainbowExample.tsx
@@ -1,9 +1,9 @@
 import { Text, StyleSheet, View, Button } from 'react-native';
 
 import React, { useEffect } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   Easing,
-  SharedValue,
   useAnimatedStyle,
   useSharedValue,
   withRepeat,

--- a/apps/common-app/src/examples/RuntimeTests/tests/utilities/relativeCoords.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/utilities/relativeCoords.test.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import { FlexStyle, StyleSheet, ViewStyle } from 'react-native';
-import Animated, {
-  runOnUI,
-  measure,
-  getRelativeCoords,
-  ComponentCoords,
-  useAnimatedRef,
-  useSharedValue,
-} from 'react-native-reanimated';
+import type { FlexStyle, ViewStyle } from 'react-native';
+import { StyleSheet } from 'react-native';
+import type { ComponentCoords } from 'react-native-reanimated';
+import Animated, { runOnUI, measure, getRelativeCoords, useAnimatedRef, useSharedValue } from 'react-native-reanimated';
 import {
   describe,
   test,

--- a/apps/common-app/src/examples/ScreenStackExample.tsx
+++ b/apps/common-app/src/examples/ScreenStackExample.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackNavigationProp,
-} from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   Easing,
   useAnimatedStyle,

--- a/apps/common-app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
+++ b/apps/common-app/src/examples/ScreenStackHeaderConfigBackgroundColorExample.tsx
@@ -3,12 +3,14 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import type {
+  GestureUpdateEvent,
+  PanGestureChangeEventPayload,
+} from 'react-native-gesture-handler';
 import {
   Gesture,
   GestureDetector,
   GestureHandlerRootView,
-  GestureUpdateEvent,
-  PanGestureChangeEventPayload,
 } from 'react-native-gesture-handler';
 import {
   Screen,

--- a/apps/common-app/src/examples/ScreenTransitionExample.tsx
+++ b/apps/common-app/src/examples/ScreenTransitionExample.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from 'react-native-screens/native-stack';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  ScreenTransition,
-  AnimatedScreenTransition,
-} from 'react-native-reanimated';
+import type { NativeStackScreenProps } from 'react-native-screens/native-stack';
+import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { AnimatedScreenTransition } from 'react-native-reanimated';
+import { ScreenTransition } from 'react-native-reanimated';
 import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
 
 function MainScreen({ navigation }: NativeStackScreenProps<ParamListBase>) {

--- a/apps/common-app/src/examples/ScrollableViewExample.tsx
+++ b/apps/common-app/src/examples/ScrollableViewExample.tsx
@@ -7,17 +7,10 @@ import Animated, {
   withTiming,
   Easing,
 } from 'react-native-reanimated';
-import {
-  View,
-  Dimensions,
-  Platform,
-  StyleSheet,
-  LayoutChangeEvent,
-} from 'react-native';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { LayoutChangeEvent } from 'react-native';
+import { View, Dimensions, Platform, StyleSheet } from 'react-native';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 import { useHeaderHeight } from '@react-navigation/elements';
 
 const windowDimensions = Dimensions.get('window');

--- a/apps/common-app/src/examples/SharedElementTransitions/BorderRadii.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/BorderRadii.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   SharedTransition,
   SharedTransitionType,

--- a/apps/common-app/src/examples/SharedElementTransitions/Card.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/Card.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { View, TouchableNativeFeedback, StyleSheet } from 'react-native';
-import {
-  createNativeStackNavigator,
+import type {
   NativeStackNavigationProp,
   NativeStackScreenProps,
 } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 type ParamList = {
@@ -36,7 +36,7 @@ function Card({
 }: CardProps) {
   const goNext = (screenName: keyof ParamList) => {
     navigation.navigate(screenName, {
-      title: title,
+      title,
       sharedTransitionTag: transitionTag,
     });
   };

--- a/apps/common-app/src/examples/SharedElementTransitions/ChangeTheme.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ChangeTheme.tsx
@@ -14,12 +14,10 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { Button, StyleSheet, View, Text } from 'react-native';
-import {
-  NativeStackScreenProps,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/native';
 
 const Stack = createNativeStackNavigator();
 const Context = createContext({

--- a/apps/common-app/src/examples/SharedElementTransitions/CustomTransition.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/CustomTransition.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   SharedTransition,
   withSpring,

--- a/apps/common-app/src/examples/SharedElementTransitions/DuplicateTags.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/DuplicateTags.tsx
@@ -1,8 +1,6 @@
-import { ParamListBase } from '@react-navigation/native';
-import {
-  NativeStackScreenProps,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { StyleSheet, TouchableNativeFeedback, View, Text } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';

--- a/apps/common-app/src/examples/SharedElementTransitions/FlatList.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/FlatList.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import type {
+  TouchableWithoutFeedbackProps,
+  ListRenderItemInfo,
+} from 'react-native';
 import {
   View,
   Button,
@@ -6,13 +10,9 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  TouchableWithoutFeedbackProps,
-  ListRenderItemInfo,
 } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/apps/common-app/src/examples/SharedElementTransitions/Gallery.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/Gallery.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { View, Text, StyleSheet, Pressable, Dimensions } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, { FadeIn } from 'react-native-reanimated';
 
 const florence = require('./assets/florence.jpg');

--- a/apps/common-app/src/examples/SharedElementTransitions/ImageStack.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ImageStack.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
-import {
-  View,
-  ImageSourcePropType,
-  Pressable,
-  ScrollView,
-  Button,
-  StyleSheet,
-} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { ImageSourcePropType } from 'react-native';
+import { View, Pressable, ScrollView, Button, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 const florence = require('./assets/florence.jpg');

--- a/apps/common-app/src/examples/SharedElementTransitions/LayoutAnimation.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/LayoutAnimation.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { Button, View, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, { SlideInLeft, SlideOutLeft } from 'react-native-reanimated';
 
 const photo = require('./assets/image.jpg');

--- a/apps/common-app/src/examples/SharedElementTransitions/ManyScreens.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ManyScreens.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 const Stack = createNativeStackNavigator();

--- a/apps/common-app/src/examples/SharedElementTransitions/ManyTags.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ManyTags.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { Button, View, Text, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 const photo = require('./assets/image.jpg');

--- a/apps/common-app/src/examples/SharedElementTransitions/Modals.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/Modals.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { TouchableNativeFeedback, StyleSheet } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   runOnJS,
   useAnimatedGestureHandler,
@@ -11,10 +9,8 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import { PanGestureHandler } from 'react-native-gesture-handler';
 
 type ParamList = {
   Screen1?: object;
@@ -41,7 +37,7 @@ function Card({
 }: CardProps) {
   const goNext = (screenName: keyof ParamList) => {
     navigation.navigate(screenName, {
-      title: title,
+      title,
       sharedTransitionTag: transitionTag,
     });
   };

--- a/apps/common-app/src/examples/SharedElementTransitions/NestedRotation.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/NestedRotation.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 import { createContext } from 'react';
 

--- a/apps/common-app/src/examples/SharedElementTransitions/NestedStacks.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/NestedStacks.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 const Stack = createNativeStackNavigator();

--- a/apps/common-app/src/examples/SharedElementTransitions/Profiles.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/Profiles.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ImageSourcePropType } from 'react-native';
 import {
   View,
   Text,
@@ -9,12 +10,9 @@ import {
   FlatList,
   StatusBar,
   Platform,
-  ImageSourcePropType,
 } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   FadeIn,
   runOnJS,

--- a/apps/common-app/src/examples/SharedElementTransitions/ProgressTransition.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ProgressTransition.tsx
@@ -7,10 +7,8 @@ import {
   Dimensions,
   StatusBar,
 } from 'react-native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   FadeInDown,
   FadeInLeft,

--- a/apps/common-app/src/examples/SharedElementTransitions/ReducedMotionSharedExample.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/ReducedMotionSharedExample.tsx
@@ -6,12 +6,10 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { Button, StyleSheet, View } from 'react-native';
-import {
-  NativeStackScreenProps,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/native';
 
 const Stack = createNativeStackNavigator();
 

--- a/apps/common-app/src/examples/SharedElementTransitions/RestoreState.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/RestoreState.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { Button, View, StyleSheet } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated from 'react-native-reanimated';
 
 const Stack = createNativeStackNavigator();

--- a/apps/common-app/src/examples/SharedElementTransitions/TransitionRestart.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/TransitionRestart.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { View, Button, StyleSheet, StyleProp, ViewStyle } from 'react-native';
-import { ParamListBase } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Animated, {
   SharedTransition,
   SharedTransitionType,

--- a/apps/common-app/src/examples/SwipeableListExample.tsx
+++ b/apps/common-app/src/examples/SwipeableListExample.tsx
@@ -9,11 +9,11 @@ import Animated, {
   Easing,
   runOnJS,
 } from 'react-native-reanimated';
+import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
 import {
   PanGestureHandler,
   TouchableOpacity,
   FlatList,
-  PanGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';
 
 const windowDimensions = Dimensions.get('window');

--- a/apps/common-app/src/examples/WithClampExample.tsx
+++ b/apps/common-app/src/examples/WithClampExample.tsx
@@ -4,7 +4,8 @@ import Animated, {
   withSpring,
   withClamp,
 } from 'react-native-reanimated';
-import { View, Text, Button, StyleSheet, ViewStyle } from 'react-native';
+import type { ViewStyle } from 'react-native';
+import { View, Text, Button, StyleSheet } from 'react-native';
 import React, { useState } from 'react';
 
 const VIOLET = '#b58df1';

--- a/apps/common-app/src/examples/WorkletRuntimeExample.tsx
+++ b/apps/common-app/src/examples/WorkletRuntimeExample.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
+import type { WorkletRuntime } from 'react-native-reanimated';
 import Animated, {
   Easing,
-  WorkletRuntime,
   createWorkletRuntime,
   runOnJS,
   runOnUI,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Run eslint with `--fix` flag.
These test are broken since when introducing monorepo we unified eslint rules and made them more demanding.

Most of the changes is to `prefer import type`.

The others are:
* Remove type cast when its not needed
<img width="1066" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/1692ba27-232d-4806-b019-593cb7087910">

* Don't have unnecessary conditions
<img width="1066" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/e23c9381-22a7-490f-84e1-f78eb24eb696">

* Use property shorthand
<img width="1066" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/64ea7bf1-18f4-47bc-95a6-ea60f12fd0c3">

* When possible use `const` instead of `let`
<img width="1066" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/56199675/fc0c911d-3c05-4585-a468-e1c3ba715bf2">

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

All changes were made automatically.
<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
