### PR TITLE
docs: bump `@swmansion/t-rex-ui` to 0.0.12

### DIFF
--- a/packages/docs-reanimated/package.json
+++ b/packages/docs-reanimated/package.json
@@ -28,7 +28,7 @@
     "@mdx-js/react": "^1.6.22",
     "@mui/material": "^5.12.0",
     "@shopify/flash-list": "^1.6.3",
-    "@swmansion/t-rex-ui": "^0.0.9",
+    "@swmansion/t-rex-ui": "^0.0.12",
     "@vercel/og": "^0.6.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-expo": "^9.2.2",

--- a/packages/docs-reanimated/src/theme/DocSidebar/index.js
+++ b/packages/docs-reanimated/src/theme/DocSidebar/index.js
@@ -12,7 +12,17 @@ export default function DocSidebarWrapper(props) {
     logo: useBaseUrl('/img/logo-hero.svg'),
     title: useBaseUrl('/img/title-hero.svg'),
   };
+
+  const newItems = ['animations/withClamp'];
+  const experimentalItems = ['shared-element-transitions/overview'];
+
   return (
-    <DocSidebar heroImages={heroImages} titleImages={titleImages} {...props} />
+    <DocSidebar
+      newItems={newItems}
+      experimentalItems={experimentalItems}
+      heroImages={heroImages}
+      titleImages={titleImages}
+      {...props}
+    />
   );
 }

--- a/packages/docs-reanimated/yarn.lock
+++ b/packages/docs-reanimated/yarn.lock
@@ -3905,10 +3905,10 @@
     "@svgr/plugin-jsx" "^6.5.1"
     "@svgr/plugin-svgo" "^6.5.1"
 
-"@swmansion/t-rex-ui@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.npmjs.org/@swmansion/t-rex-ui/-/t-rex-ui-0.0.9.tgz#192c8e6beabcbb885b37e485157b610e2b8599b9"
-  integrity sha512-4FoJP/7RFeDB36YEvRd0dvqZ7jbq9xipbyOFk0uM7Dpc9xgkO3ZVhPuS6lbHOvN3L8/rvBE/d6nDRZH3yd8Y9g==
+"@swmansion/t-rex-ui@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.npmjs.org/@swmansion/t-rex-ui/-/t-rex-ui-0.0.12.tgz#fffdc8a222773fb77019d188a60dd60decbe8ddf"
+  integrity sha512-l2gtWH6Z9CVl1GoZoypkcMM0mYBShOBvE13ct40sKc7LwqKtFv+PCrdYwMbGcd2kj95fhG7dTyueZW2pMP6R1w==
   dependencies:
     "@docsearch/react" "^3.6.0"
     "@docusaurus/core" "^2.4.3"


### PR DESCRIPTION
Important changes from 0.0.12:
* [navbar_links ](https://github.com/software-mansion-labs/t-rex-ui/commit/cab20427bf28d8325e6cc97dc7ac329927edb019) 
* [search modal style fix](https://github.com/software-mansion-labs/t-rex-ui/commit/c1a69ac4fd81458b9bd24314aaa74a0d30b0f2bf)
* [hire us links](https://github.com/software-mansion-labs/t-rex-ui/commit/8ef15757524a395d3f12b57c85c9f561a3398120)
* [sidebar labels](https://github.com/software-mansion-labs/t-rex-ui/commit/ba1932ae6fa4a30e3fdb6144f62e6e30fdea3e73) such as `New` and `Experimental` 

Also DocSidebar was modified with newItems and experimentalItems

<img width="596" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/92edb604-c1b4-4ad4-b74d-5fa9d069bdd8">
<img width="367" alt="image" src="https://github.com/software-mansion/react-native-reanimated/assets/59940332/deff5a79-4ab0-4c8a-9553-4dead5e08b75">
