### PR TITLE
fix empty export on web

### DIFF
--- a/packages/react-native-reanimated/src/platform-specific/RNRenderer.web.ts
+++ b/packages/react-native-reanimated/src/platform-specific/RNRenderer.web.ts
@@ -1,3 +1,3 @@
 // RNRender is not used for web. An export is still defined to eliminate warnings from bundlers such as esbuild.
-
+'use strict';
 export {};

--- a/packages/react-native-reanimated/src/platform-specific/RNRenderer.web.ts
+++ b/packages/react-native-reanimated/src/platform-specific/RNRenderer.web.ts
@@ -1,3 +1,3 @@
-'use strict';
 // RNRender is not used for web. An export is still defined to eliminate warnings from bundlers such as esbuild.
-module.exports = null;
+
+export {};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

React Native Babel preset uses a loose plugin to convert imports to commonjs, we're investigating switching to a more standard approach in Expo CLI here https://github.com/expo/expo/pull/30005 which aligns with how Metro is used at Meta.
 
When running on the kitchen sink, I found that there was an invalid expression in reanimated where it exports null and then destructures null. This error didn't occur previously because the commonjs plugin deferred access to the null object until later.

**Before**

```js
var _Math = _$$_REQUIRE(_dependencyMap[0]);

// Later ...

_Math.add
```

This coincidentally didn't throw because the deferred code is never accessed.

**After**

```js
var add = _$$_REQUIRE(_dependencyMap[0]).add;
```

This throws because the `null` is accessed when the module is loaded.

## Test plan

Bundle a Metro web project with experimentalImportSupport enabled:

```js
config.transformer.getTransformOptions = async () => ({
  transform: {
    experimentalImportSupport: true,
    inlineRequires: false,
  },
});
```

Then run `npx serve dist` -> Error was there but not anymore.