### PR TITLE
[Web LA] Fix chrome flickers

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -156,6 +156,8 @@ export function setElementAnimation(
   };
 
   if (animationConfig.animationType === LayoutAnimationType.ENTERING) {
+    // On chrome sometimes entering animations flicker. This is most likely caused by animation being interrupted
+    // by already started tasks. To avoid flickering, we use `requestAnimationFrame`, which will run callback right before repaint.
     requestAnimationFrame(configureAnimation);
   } else {
     configureAnimation();

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -148,12 +148,18 @@ export function setElementAnimation(
 ) {
   const { animationName, duration, delay, easing } = animationConfig;
 
-  requestAnimationFrame(() => {
+  const configureAnimation = () => {
     element.style.animationName = animationName;
     element.style.animationDuration = `${duration}s`;
     element.style.animationDelay = `${delay}s`;
     element.style.animationTimingFunction = easing;
-  });
+  };
+
+  if (animationConfig.animationType === LayoutAnimationType.ENTERING) {
+    requestAnimationFrame(configureAnimation);
+  } else {
+    configureAnimation();
+  }
 
   element.onanimationend = () => {
     if (shouldSavePosition) {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -148,10 +148,12 @@ export function setElementAnimation(
 ) {
   const { animationName, duration, delay, easing } = animationConfig;
 
-  element.style.animationName = animationName;
-  element.style.animationDuration = `${duration}s`;
-  element.style.animationDelay = `${delay}s`;
-  element.style.animationTimingFunction = easing;
+  requestAnimationFrame(() => {
+    element.style.animationName = animationName;
+    element.style.animationDuration = `${duration}s`;
+    element.style.animationDelay = `${delay}s`;
+    element.style.animationTimingFunction = easing;
+  });
 
   element.onanimationend = () => {
     if (shouldSavePosition) {


### PR DESCRIPTION
## Summary

Currently some of our animations flicker on google chrome browser. This PR moves setting animation into `requestAnimationFrame` callback - this way we will be sure that animation will be properly set before next repaint.

## Comparison

### Before

https://github.com/software-mansion/react-native-reanimated/assets/63123542/fe674d23-d1bb-44c3-a870-335c330c7073

### After

https://github.com/software-mansion/react-native-reanimated/assets/63123542/2a4833a7-c3d9-4a59-b108-a7f4cc166f1f

## Test plan

Tested on default animations example
