### PR TITLE
docs: fix 'Edit this page' link

### DIFF
--- a/packages/docs-reanimated/docusaurus.config.js
+++ b/packages/docs-reanimated/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           sidebarCollapsible: false,
           editUrl:
-            'https://github.com/software-mansion/react-native-reanimated/tree/main/docs',
+            'https://github.com/software-mansion/react-native-reanimated/tree/main/packages/docs-reanimated',
           lastVersion: 'current', // <- this makes 3.x docs as default
           versions: {
             current: {
@@ -163,8 +163,8 @@ const config = {
                   type: 'asset/source',
                 },
                 {
-                  test: /\.tsx?$/
-                }
+                  test: /\.tsx?$/,
+                },
               ],
             },
             resolve: {


### PR DESCRIPTION
After the migration to monorepo "Edit this page" button in docs stopped working - it led to 404 not found.

This PR fixes the docusaurus configuration so the edit button routes to the correct place.
![image](https://github.com/software-mansion/react-native-reanimated/assets/39658211/981405e3-2a0d-4f50-b7ea-9a68a3c068c2)

### Before

![image](https://github.com/software-mansion/react-native-reanimated/assets/39658211/e4d97946-0234-4424-afbd-1484ec392ee3)

### After

![image](https://github.com/software-mansion/react-native-reanimated/assets/39658211/c24dd078-011d-4469-b36b-f6229b1d67fd)
