### PR TITLE
docs: Edit this page button should go directly to edit page

### DIFF
--- a/packages/docs-reanimated/docusaurus.config.js
+++ b/packages/docs-reanimated/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           sidebarCollapsible: false,
           editUrl:
-            'https://github.com/software-mansion/react-native-reanimated/tree/main/packages/docs-reanimated',
+            'https://github.com/software-mansion/react-native-reanimated/edit/main/packages/docs-reanimated',
           lastVersion: 'current', // <- this makes 3.x docs as default
           versions: {
             current: {


### PR DESCRIPTION
Microoptimization over a fix in https://github.com/software-mansion/react-native-reanimated/pull/6176

The link can route directly to the edit page which saves an additional click ;) 