### PR TITLE
Remove fontawesome dependency from example app

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -8,9 +8,6 @@
     "format": "prettier --write --list-different ."
   },
   "peerDependencies": {
-    "@fortawesome/fontawesome-svg-core": "*",
-    "@fortawesome/free-solid-svg-icons": "*",
-    "@fortawesome/react-native-fontawesome": "*",
     "@react-native-async-storage/async-storage": "*",
     "@react-native-community/slider": "*",
     "@react-native-masked-view/masked-view": "*",
@@ -34,9 +31,6 @@
     "react-strict-dom": "*"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.4.0",
-    "@fortawesome/free-solid-svg-icons": "^6.4.0",
-    "@fortawesome/react-native-fontawesome": "^0.3.0",
     "@react-native-async-storage/async-storage": "^1.22.3",
     "@react-native-community/slider": "^4.5.0",
     "@react-native-masked-view/masked-view": "^0.3.1",

--- a/apps/common-app/src/examples/AnimatedTabBarExample.tsx
+++ b/apps/common-app/src/examples/AnimatedTabBarExample.tsx
@@ -9,45 +9,37 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import {
+  Text,
   View,
   Dimensions,
   StyleSheet,
   TouchableWithoutFeedback,
 } from 'react-native';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import {
-  faCoffee,
-  faTrash,
-  faUser,
-  faList,
-  faReply,
-} from '@fortawesome/free-solid-svg-icons';
 import Svg, { Path } from 'react-native-svg';
 import * as shape from 'd3-shape';
-import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 const { width, height } = Dimensions.get('window');
 
 const tabs = [
   {
     name: 'coffee',
-    item: faCoffee,
+    item: '☕️',
   },
   {
     name: 'list',
-    item: faList,
+    item: '📝',
   },
   {
     name: 'reply',
-    item: faReply,
+    item: '🔁',
   },
   {
     name: 'trash',
-    item: faTrash,
+    item: '🗑',
   },
   {
     name: 'user',
-    item: faUser,
+    item: '👤',
   },
 ];
 
@@ -101,10 +93,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     zIndex: 5,
   },
+  emoji: {
+    fontSize: 25,
+  },
 });
 
 type ButtonProps = {
-  item: IconProp;
+  item: string;
   index: number;
   activeIndex: Animated.SharedValue<number>;
   width: number;
@@ -141,7 +136,7 @@ function Button({
     <TouchableWithoutFeedback onPress={() => (activeIndex.value = index)}>
       <View style={styles.tab}>
         <Animated.View style={staticIconStyle}>
-          <FontAwesomeIcon icon={item} color="black" size={25} />
+          <Text style={styles.emoji}>{item}</Text>
         </Animated.View>
       </View>
     </TouchableWithoutFeedback>
@@ -149,7 +144,7 @@ function Button({
 }
 
 type ActiveIconProps = {
-  item: IconProp;
+  item: string;
   index: number;
   activeIndex: Animated.SharedValue<number>;
   width: number;
@@ -170,7 +165,7 @@ function ActiveIcon({ item, index, activeIndex }: ActiveIconProps) {
   return (
     <Animated.View style={[styles.circleIcon, circleIconStyle]}>
       <View style={styles.activeIcon}>
-        <FontAwesomeIcon icon={item} color="black" size={25} />
+        <Text style={styles.emoji}>{item}</Text>
       </View>
     </Animated.View>
   );

--- a/apps/common-app/src/examples/LayoutAnimations/HabitsExample.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/HabitsExample.tsx
@@ -9,8 +9,6 @@ import Animated, {
   BounceIn,
   FadeOut,
 } from 'react-native-reanimated';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faCheck, faClose } from '@fortawesome/free-solid-svg-icons';
 
 const data = [
   { label: 'Water plants', icon: '🌿', isDone: true },
@@ -81,7 +79,7 @@ function Summary({ onPress }: SummaryProps) {
         Great job!
       </Animated.Text>
       <Animated.View entering={BounceIn} style={styles.checkmark}>
-        <FontAwesomeIcon icon={faCheck} size={64} color="white" />
+        <Text style={styles.summaryIcon}>{'✅'}</Text>
       </Animated.View>
       <Animated.Text style={styles.label}>
         {data.filter((item) => item.isDone).length} out of {data.length} habits
@@ -115,11 +113,7 @@ function ListItem({ label, icon, isDone, index }: ListItemProps) {
         {label}
       </Animated.Text>
       <Animated.View entering={FadeInLeft.delay(400 * index)}>
-        <FontAwesomeIcon
-          icon={isDone ? faCheck : faClose}
-          size={32}
-          color="white"
-        />
+        <Text>{isDone ? '✅' : '❌'}</Text>
       </Animated.View>
     </Animated.View>
   );
@@ -219,5 +213,8 @@ const styles = StyleSheet.create({
     fontSize: 28,
     color: 'white',
     fontWeight: 'bold',
+  },
+  summaryIcon: {
+    fontSize: 64,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,45 +4204,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-common-types@npm:6.5.2":
-  version: 6.5.2
-  resolution: "@fortawesome/fontawesome-common-types@npm:6.5.2"
-  checksum: 10/a918b2dd6566db6878999e1c4523fa8d0fcc3c79f00086b48a36c365e543ac16a2950618f47893a8369d4ee13e454baf1f5108f7238bdf6ec2bea459b6c517ca
-  languageName: node
-  linkType: hard
-
-"@fortawesome/fontawesome-svg-core@npm:^6.4.0":
-  version: 6.5.2
-  resolution: "@fortawesome/fontawesome-svg-core@npm:6.5.2"
-  dependencies:
-    "@fortawesome/fontawesome-common-types": "npm:6.5.2"
-  checksum: 10/03cc6d9662f2014e2fbbf47e9678a6a21108edeb78ff551207eeb12404daa8bfa5c6dd30a474d3fca897e856ff4b45d35261bb445fc30994c46d91783722684d
-  languageName: node
-  linkType: hard
-
-"@fortawesome/free-solid-svg-icons@npm:^6.4.0":
-  version: 6.5.2
-  resolution: "@fortawesome/free-solid-svg-icons@npm:6.5.2"
-  dependencies:
-    "@fortawesome/fontawesome-common-types": "npm:6.5.2"
-  checksum: 10/2f6dde7eddc8ab9ed09d220c2dad6cb53922842d3f764ea9d393162ba50971b5be8f16e0c9a225ec808d6a2e92769a0d194e7e1ae8f98ccdd53f7a59aee2e31b
-  languageName: node
-  linkType: hard
-
-"@fortawesome/react-native-fontawesome@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@fortawesome/react-native-fontawesome@npm:0.3.0"
-  dependencies:
-    humps: "npm:^2.0.1"
-    prop-types: "npm:^15.7.2"
-  peerDependencies:
-    "@fortawesome/fontawesome-svg-core": ~1 || ~6
-    react-native: ">= 0.67"
-    react-native-svg: ">= 11.x"
-  checksum: 10/c538b9f36b1fa5c079be3aa597984c9c36833b513d70b0364b4c7abf30edba0952baafee25db78e35f8af51fbb39573fa2f0792ff9cf959fb3245e49babb752f
-  languageName: node
-  linkType: hard
-
 "@gar/promisify@npm:^1.0.1":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -8870,9 +8831,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "common-app@workspace:apps/common-app"
   dependencies:
-    "@fortawesome/fontawesome-svg-core": "npm:^6.4.0"
-    "@fortawesome/free-solid-svg-icons": "npm:^6.4.0"
-    "@fortawesome/react-native-fontawesome": "npm:^0.3.0"
     "@react-native-async-storage/async-storage": "npm:^1.22.3"
     "@react-native-community/slider": "npm:^4.5.0"
     "@react-native-masked-view/masked-view": "npm:^0.3.1"
@@ -8900,9 +8858,6 @@ __metadata:
     react-strict-dom: "npm:^0.0.17"
     typescript: "npm:~5.3.0"
   peerDependencies:
-    "@fortawesome/fontawesome-svg-core": "*"
-    "@fortawesome/free-solid-svg-icons": "*"
-    "@fortawesome/react-native-fontawesome": "*"
     "@react-native-async-storage/async-storage": "*"
     "@react-native-community/slider": "*"
     "@react-native-masked-view/masked-view": "*"
@@ -12594,13 +12549,6 @@ __metadata:
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
   checksum: 10/30f8870d831cdcd2d6ec0486a7d35d49384996742052cee792854273fa9dd9e7d5db06bb7985d4953e337e10714e994e0302e90dc6848069171b05ec836d65b0
-  languageName: node
-  linkType: hard
-
-"humps@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "humps@npm:2.0.1"
-  checksum: 10/16e63cba9659c54cdc5d55bc5f50033939e959cfb6a65d2e9aa36a7ac882e70c66fdb5b0cb28fb81a204681a28cc1051eecbed7b70d4ede2435ab13ebaa8ac2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
I noticed that `@fontawesome` dependency is present in the repository but is used in 2 demo screens only - the size of unpacked dependencies are following:
- `@fortawesome/fontawesome-svg-core`: 397 kB
- `@fortawesome/free-solid-svg-icons`: 5.09 MB
- `@fortawesome/react-native-fontawesome`: 33.4 kB

I believe that plain text emojis (which are present on eg. examples list) could be used instead of fontawesome icons.

## Test plan
Open `Tab bar` and `Habits` example from the example app