### PR TITLE
Delete duplicate `gradle-wrapper.properties`

### DIFF
--- a/apps/fabric-example/android/gradle-wrapper.properties
+++ b/apps/fabric-example/android/gradle-wrapper.properties
@@ -1,7 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
-networkTimeout=10000
-validateDistributionUrl=true
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Looks like this file is an unwanted duplicate of `apps/fabric-example/android/gradle/gradle-wrapper.properties`.

## Test plan
