### PR TITLE
fix side effects

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -169,8 +169,8 @@
   },
   "sideEffects": [
     "./lib/module/reanimated2/layoutReanimation/animationsManager.js",
-    "./lib/reanimated2/core",
-    "./lib/index"
+    "./lib/module/reanimated2/core.js",
+    "./lib/module/index.js"
   ],
   "packageManager": "yarn@4.1.1"
 }

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -168,6 +168,7 @@
     }
   },
   "sideEffects": [
+    "./lib/module/reanimated2/layoutReanimation/animationsManager.js",
     "./lib/reanimated2/core",
     "./lib/index"
   ],


### PR DESCRIPTION
## Summary

Been playing with an implementation of side effects in Expo CLI and noticed that reanimated has an unmarked side effect which causes tree shaking to remove required globals.
