### PR TITLE
Fix error persistancy in Performance Monitor

### DIFF
--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -242,7 +242,7 @@ function UiPerformance({
 }
 
 const DEFAULT_EXPECTED_FPS = 60;
-const DEFAULT_BUFFER_SIZE = 20;
+const DEFAULT_BUFFER_SIZE = 30;
 
 export type PerformanceMonitorProps = {
   /**

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -14,7 +14,6 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
   return {
     mainAccumulator: 0 as number,
     memoryAccumulator: 0 as number,
-    errorRateAccumulator: 0 as number,
 
     iterator: 0 as number,
     circularArray: new Float32Array(length),
@@ -29,7 +28,6 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
     expectedFps,
 
     arrayEndHandler() {
-      this.errorRateAccumulator += this.memoryAccumulator;
       this.memoryAccumulator = this.mainAccumulator;
       this.mainAccumulator = 0;
       this.iterator = 0;
@@ -133,10 +131,6 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
       const averageRenderTime =
         (this.mainAccumulator + this.memoryAccumulator) / this.length;
       return 1000 / averageRenderTime;
-    },
-
-    getErrorRate() {
-      return this.errorRateAccumulator;
     },
   };
 };

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -30,7 +30,7 @@ const contructCircularAccumulator = (length: number) => {
     },
 
     pushTimeDelta(timeDelta: number) {
-      if (this.iterator === this.length) {
+      if (this.iterator >= this.length) {
         this.arrayEndHandler();
       }
 
@@ -51,7 +51,7 @@ const contructCircularAccumulator = (length: number) => {
       this.pushTimeDelta(timeDifference);
     },
 
-    getCurrentFramerate(_info: string) {
+    getCurrentFramerate() {
       const averageRenderTime =
         (this.mainAccumulator + this.memoryAccumulator) / this.length;
       return 1000 / averageRenderTime;
@@ -99,13 +99,13 @@ function JsPerformance() {
       circularAccumulator.current.pushTimestamp(timestamp);
 
       jsFps.value = // JS is sampled every 2nd frame, thus * 2
-        (circularAccumulator.current.getCurrentFramerate('JS') * 2).toFixed(0);
+        (circularAccumulator.current.getCurrentFramerate() * 2).toFixed(0);
     });
   }, [jsFps]);
 
   const animatedProps = useAnimatedProps(() => {
     'worklet';
-    const text = 'JS: ' + jsFps.value ?? 'N/A';
+    const text = 'JS: ' + jsFps.value ?? 'N/A' + ' ';
     return { text, defaultValue: text };
   });
 
@@ -137,14 +137,14 @@ function UiPerformance() {
     timeSincePreviousFrame = Math.round(timeSincePreviousFrame);
     circularAccumulator.value.pushTimeDelta(timeSincePreviousFrame);
 
-    const currentFps = circularAccumulator.value.getCurrentFramerate('UI');
+    const currentFps = circularAccumulator.value.getCurrentFramerate();
 
     uiFps.value = currentFps.toFixed(0);
   });
 
   const animatedProps = useAnimatedProps(() => {
     'worklet';
-    const text = 'UI: ' + uiFps.value ?? 'N/A';
+    const text = 'UI: ' + uiFps.value ?? 'N/A' + ' ';
     return { text, defaultValue: text };
   });
 

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -9,42 +9,22 @@ import { useSharedValue, useAnimatedProps, useFrameCallback } from '../hook';
 import { createAnimatedComponent } from '../createAnimatedComponent';
 import { addWhitelistedNativeProps } from '../ConfigHelper';
 
-type CircularBuffer = ReturnType<typeof createCircularDoublesBuffer>;
-function createCircularDoublesBuffer(size: number) {
-  'worklet';
-
-  return {
-    next: 0 as number,
-    buffer: new Float32Array(size),
-    size,
-    count: 0 as number,
-
-    push(value: number): number | null {
-      const oldValue = this.buffer[this.next];
-      const oldCount = this.count;
-      this.buffer[this.next] = value;
-
-      this.next = (this.next + 1) % this.size;
-      this.count = Math.min(this.size, this.count + 1);
-      return oldCount === this.size ? oldValue : null;
-    },
-
-    front(): number | null {
-      const notEmpty = this.count > 0;
-      if (notEmpty) {
-        const current = this.next - 1;
-        const index = current < 0 ? this.size - 1 : current;
-        return this.buffer[index];
-      }
-      return null;
-    },
-
-    back(): number | null {
-      const notEmpty = this.count > 0;
-      return notEmpty ? this.buffer[this.next] : null;
-    },
-  };
+class PersistantAccumulator {
+  // issue:
+  // any issues which occured with CircularBuffer's frame summing, persisted over the entire runtime
+  // these issues were frequent due to frequent frame drops
+  // ---
+  // solution:
+  // remove persistency by quietly resetting the accumulator every X frames
+  // ---
+  // complete mechanism which avoids jumpiness:
+  // go through buffer i=0 -> X, at X save acc to mem, set acc to 0.
+  // framerate = (acc + mem) / 2*X
+  // error rate can be measured by reading mem before overwriting it with acc.
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const pa = new PersistantAccumulator();
 
 const DEFAULT_BUFFER_SIZE = 60;
 addWhitelistedNativeProps({ text: true });

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -48,7 +48,7 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
       }
 
       for (
-        let step = this.frameWeightScalingTable.length / 2;
+        let step = Math.floor(this.frameWeightScalingTable.length / 2);
         step > 1;
         step = Math.floor(step / 2)
       ) {
@@ -98,7 +98,7 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
       return bestWeightValue;
     },
 
-    pushTimeDelta(timeDelta: number) {
+    pushTimeDelta(timeDelta: number, repetitions?: number) {
       if (this.iterator >= this.length) {
         this.arrayEndHandler();
       }
@@ -107,10 +107,18 @@ const contructCircularAccumulator = (length: number, expectedFps: number) => {
         return;
       }
 
+      if (repetitions === undefined) {
+        repetitions = this.getDynamicIterationWeight(timeDelta);
+      }
+
       this.mainAccumulator += timeDelta;
       this.memoryAccumulator -= this.circularArray[this.iterator];
       this.circularArray[this.iterator] = timeDelta;
       this.iterator += 1;
+
+      if (repetitions > 1) {
+        this.pushTimeDelta(timeDelta, repetitions - 1);
+      }
     },
 
     pushTimestamp(time: number) {

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -190,7 +190,7 @@ function JsPerformance({
 
   const animatedProps = useAnimatedProps(() => {
     'worklet';
-    const text = 'JS: ' + jsFps.value ?? 'N/A' + ' ';
+    const text = 'JS: ' + (jsFps.value ?? 'N/A') + ' ';
     return { text, defaultValue: text };
   });
 
@@ -234,7 +234,7 @@ function UiPerformance({
 
   const animatedProps = useAnimatedProps(() => {
     'worklet';
-    const text = 'UI: ' + uiFps.value ?? 'N/A' + ' ';
+    const text = 'UI: ' + (uiFps.value ?? 'N/A') + ' ';
     return { text, defaultValue: text };
   });
 

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -24,7 +24,7 @@ const constructCircularAccumulator = (length: number, expectedFps: number) => {
     // divisions are expensive, use lookup tables for them
     frameWeightScalingTable: [] as { time: number; weight: number }[],
     frameWeightScalingLookupSteps: [] as number[],
-    previousWeightScalingIndex: 0 as number, // optimalisation - previous weight most likely to be the current one as well.
+    previousWeightScalingIndex: 0 as number, // optimization - previous weight most likely to be the current one as well.
     expectedFps,
 
     arrayEndHandler() {

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -246,8 +246,6 @@ const DEFAULT_BUFFER_SIZE = 30;
 
 export type PerformanceMonitorProps = {
   /**
-   * DEFAULT: 60
-   *
    * Sets the highest expected fps value.
    *
    * Affects dynamic smoothing rate, but isn't critical to component's operation.
@@ -255,8 +253,6 @@ export type PerformanceMonitorProps = {
   expectedFps?: number;
 
   /**
-   * DEFAULT: 20
-   *
    * Sets amount of previous frames used for smoothing at highest expectedFps.
    *
    * Automatically scales down at lower frame rates.
@@ -265,6 +261,13 @@ export type PerformanceMonitorProps = {
    */
   smoothingCoefficient?: number;
 };
+
+/**
+ * A component that lets you measure fps values on JS and UI threads on both the Paper and Fabric architectures.
+ *
+ * @param expectedFps - Uses the highest fps value that you expect to adjust dynamic smoothing at lower framerates.
+ * @param smoothingCoefficient - Determines amount of cached frames which will be used for fps value smoothing.
+ */
 export function PerformanceMonitor({
   expectedFps = DEFAULT_EXPECTED_FPS,
   smoothingCoefficient = DEFAULT_BUFFER_SIZE,

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -24,7 +24,6 @@ const constructCircularAccumulator = (length: number, expectedFps: number) => {
     // divisions are expensive, use lookup tables for them
     frameWeightScalingTable: [] as { time: number; weight: number }[],
     frameWeightScalingLookupSteps: [] as number[],
-    previousWeightScalingIndex: 0 as number, // optimization - previous weight most likely to be the current one as well.
     expectedFps,
 
     arrayEndHandler() {

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -24,24 +24,12 @@ const contructCircularAccumulator = (length: number) => {
 
     arrayEndHandler() {
       this.errorRateAccumulator += this.memoryAccumulator;
-
-      console.log(
-        '[MEM=] mem:',
-        this.memoryAccumulator,
-        '=',
-        this.mainAccumulator
-      );
       this.memoryAccumulator = this.mainAccumulator;
-
-      console.log('[ACC=] acc:', this.mainAccumulator, '=', 0);
       this.mainAccumulator = 0;
-
-      console.log('[IT=] it:', this.iterator, '=', 0);
       this.iterator = 0;
     },
 
     pushTimeDelta(timeDelta: number) {
-      console.log('[IT??] it:', this.iterator, '===', this.length);
       if (this.iterator === this.length) {
         this.arrayEndHandler();
       }
@@ -50,26 +38,9 @@ const contructCircularAccumulator = (length: number) => {
         return;
       }
 
-      console.log('[ACC++] acc:', this.mainAccumulator, '+=', timeDelta);
       this.mainAccumulator += timeDelta;
-
-      console.log(
-        '[MEM--] mem:',
-        this.memoryAccumulator,
-        '-=',
-        this.circularArray[this.iterator]
-      );
       this.memoryAccumulator -= this.circularArray[this.iterator];
-
-      console.log(
-        `[CA[${this.iterator}]]=:`,
-        this.circularArray[this.iterator],
-        '-=',
-        timeDelta
-      );
       this.circularArray[this.iterator] = timeDelta;
-
-      console.log('[IT++] it:', this.iterator, '+=', 1);
       this.iterator += 1;
     },
 
@@ -81,14 +52,6 @@ const contructCircularAccumulator = (length: number) => {
     },
 
     getCurrentFramerate(_info: string) {
-      // console.log(
-      //   '[',
-      //   info,
-      //   '] acc:',
-      //   this.mainAccumulator,
-      //   'mem:',
-      //   this.memoryAccumulator
-      // );
       const averageRenderTime =
         (this.mainAccumulator + this.memoryAccumulator) / this.length;
       return 1000 / averageRenderTime;

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -252,7 +252,24 @@ const DEFAULT_EXPECTED_FPS = 60;
 const DEFAULT_BUFFER_SIZE = 20;
 
 export type PerformanceMonitorProps = {
+  /**
+   * DEFAULT: 60
+   *
+   * Sets the highest expected fps value.
+   *
+   * Affects dynamic smoothing rate, but isn't critical to component's operation.
+   */
   expectedFps?: number;
+
+  /**
+   * DEFAULT: 20
+   *
+   * Sets amount of previous frames used for smoothing at highest expectedFps.
+   *
+   * Automatically scales down at lower frame rates.
+   *
+   * Affects jumpiness of the FPS measurements value.
+   */
   smoothingCoefficient?: number;
 };
 export function PerformanceMonitor({

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -8,8 +8,8 @@ import { useSharedValue, useAnimatedProps, useFrameCallback } from '../hook';
 import { createAnimatedComponent } from '../createAnimatedComponent';
 import { addWhitelistedNativeProps } from '../ConfigHelper';
 
-type CircularAccumulator = ReturnType<typeof contructCircularAccumulator>;
-const contructCircularAccumulator = (length: number, expectedFps: number) => {
+type CircularAccumulator = ReturnType<typeof constructCircularAccumulator>;
+const constructCircularAccumulator = (length: number, expectedFps: number) => {
   'worklet';
   return {
     mainAccumulator: 0 as number,
@@ -166,7 +166,7 @@ function JsPerformance({
 }: PerformanceProps) {
   const jsFps = useSharedValue<string | null>(null);
   const circularAccumulator = useRef<CircularAccumulator>(
-    contructCircularAccumulator(smoothingCoefficient, expectedFps)
+    constructCircularAccumulator(smoothingCoefficient, expectedFps)
   );
 
   useEffect(() => {
@@ -208,7 +208,7 @@ function UiPerformance({
   useFrameCallback(({ timeSincePreviousFrame }: FrameInfo) => {
     'worklet';
     if (circularAccumulator.value === null) {
-      circularAccumulator.value = contructCircularAccumulator(
+      circularAccumulator.value = constructCircularAccumulator(
         smoothingCoefficient,
         expectedFps
       );

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -244,16 +244,40 @@ function UiPerformance({
 const DEFAULT_EXPECTED_FPS = 60;
 const DEFAULT_BUFFER_SIZE = 30;
 
-export function PerformanceMonitor() {
+export type PerformanceMonitorProps = {
+  /**
+   * DEFAULT: 60
+   *
+   * Sets the highest expected fps value.
+   *
+   * Affects dynamic smoothing rate, but isn't critical to component's operation.
+   */
+  expectedFps?: number;
+
+  /**
+   * DEFAULT: 20
+   *
+   * Sets amount of previous frames used for smoothing at highest expectedFps.
+   *
+   * Automatically scales down at lower frame rates.
+   *
+   * Affects jumpiness of the FPS measurements value.
+   */
+  smoothingCoefficient?: number;
+};
+export function PerformanceMonitor({
+  expectedFps = DEFAULT_EXPECTED_FPS,
+  smoothingCoefficient = DEFAULT_BUFFER_SIZE,
+}: PerformanceMonitorProps) {
   return (
     <View style={styles.monitor}>
       <JsPerformance
-        expectedFps={DEFAULT_EXPECTED_FPS / 2} // /2 due to 2x lower sampling rate on JS due to performance issues
-        smoothingCoefficient={DEFAULT_BUFFER_SIZE}
+        expectedFps={expectedFps / 2} // /2 due to 2x lower sampling rate on JS due to performance issues
+        smoothingCoefficient={smoothingCoefficient}
       />
       <UiPerformance
-        expectedFps={DEFAULT_EXPECTED_FPS}
-        smoothingCoefficient={DEFAULT_BUFFER_SIZE}
+        expectedFps={expectedFps}
+        smoothingCoefficient={smoothingCoefficient}
       />
     </View>
   );

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -64,33 +64,37 @@ const constructCircularAccumulator = (length: number, expectedFps: number) => {
       let bestWeightMinTime = this.frameWeightScalingTable[0].time;
       let previousIndex = 0;
       let previousMinTime = bestWeightMinTime;
-      for (let i = 0; i < this.frameWeightScalingLookupSteps.length; i++) {
-        const step = this.frameWeightScalingLookupSteps[i];
+      for (let i = 0; ; i++) {
+        const clampedIterator = Math.min(
+          i,
+          this.frameWeightScalingLookupSteps.length - 1
+        );
+        const step = this.frameWeightScalingLookupSteps[clampedIterator];
         const checkedIndex =
           previousMinTime < timeDelta
             ? previousIndex + step
             : previousIndex - step;
 
         if (
-          checkedIndex > this.frameWeightScalingTable.length ||
-          checkedIndex < 0
+          checkedIndex < 0 ||
+          checkedIndex >= this.frameWeightScalingTable.length
         ) {
           break;
         }
 
-        const currentWeightScalingObject =
+        const checkedWeightScalingObject =
           this.frameWeightScalingTable[checkedIndex];
 
         if (
-          currentWeightScalingObject.time < timeDelta &&
-          currentWeightScalingObject.weight > bestWeightValue
+          checkedWeightScalingObject.time < timeDelta &&
+          checkedWeightScalingObject.weight > bestWeightValue
         ) {
-          bestWeightValue = currentWeightScalingObject.weight;
-          bestWeightMinTime = currentWeightScalingObject.time;
+          bestWeightValue = checkedWeightScalingObject.weight;
+          bestWeightMinTime = checkedWeightScalingObject.time;
         }
 
         previousIndex = checkedIndex;
-        previousMinTime = currentWeightScalingObject.time;
+        previousMinTime = checkedWeightScalingObject.time;
       }
 
       return bestWeightValue;
@@ -272,7 +276,7 @@ export function PerformanceMonitor({
   return (
     <View style={styles.monitor}>
       <JsPerformance
-        expectedFps={expectedFps ?? DEFAULT_EXPECTED_FPS}
+        expectedFps={(expectedFps ?? DEFAULT_EXPECTED_FPS) / 2} // /2 due to 2x lower sampling rate on JS due to performance issues
         smoothingCoefficient={smoothingCoefficient ?? DEFAULT_BUFFER_SIZE}
       />
       <UiPerformance

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -46,7 +46,7 @@ const constructCircularAccumulator = (length: number, expectedFps: number) => {
 
       for (
         let step = Math.floor(this.frameWeightScalingTable.length / 2);
-        step > 1;
+        step > 0;
         step = Math.floor(step / 2)
       ) {
         this.frameWeightScalingLookupSteps.push(step);
@@ -64,12 +64,8 @@ const constructCircularAccumulator = (length: number, expectedFps: number) => {
       let bestWeightMinTime = this.frameWeightScalingTable[0].time;
       let previousIndex = 0;
       let previousMinTime = bestWeightMinTime;
-      for (let i = 0; ; i++) {
-        const clampedIterator = Math.min(
-          i,
-          this.frameWeightScalingLookupSteps.length - 1
-        );
-        const step = this.frameWeightScalingLookupSteps[clampedIterator];
+      for (let i = 0; i < this.frameWeightScalingLookupSteps.length; i++) {
+        const step = this.frameWeightScalingLookupSteps[i];
         const checkedIndex =
           previousMinTime < timeDelta
             ? previousIndex + step

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -261,7 +261,10 @@ export {
   getAnimatedStyle,
 } from './jestUtils';
 export { LayoutAnimationConfig } from './component/LayoutAnimationConfig';
-export { PerformanceMonitor } from './component/PerformanceMonitor';
+export {
+  PerformanceMonitor,
+  type PerformanceMonitorProps,
+} from './component/PerformanceMonitor';
 export type {
   Adaptable,
   AdaptTransforms,


### PR DESCRIPTION
## UPDATE:

Replaced with this much simpler PR: [link](/software-mansion/react-native-reanimated/pull/6241)

#### Reasons:
- original mechanism could've been modified to achieve a very similar error-fixing effect
- dynamic array fill size is an overcomplicated for what it does.

### issue:
Issues which occur on CircularBuffer's total runtime accumulator, persist over the entire runtime
these issues are frequent, and occur due to dropped frames, which are almost guaranteed to happen to some degree.
After a couple minutes of runtime, effects were noticeable.
Previous implementation is also very prone to higher error rates at lower frame-rates.

### solution:
Implement Performance Monitor's frame storage in a self-regenerating way.
While I still use the circular buffer, the accumulator is saved and reset every revolution, it's state persists for one more revolution, but is completely wiped after that, thus errors don't persist for more than 2 revolutions of the frame buffer (by default: `66ms`).
  
---

Additionally, I added a dynamic update speed, which normalizes the time to complete the circular buffer revolution. By default, this time is equal to `0.33s`, but can be changed by adjusting newly added `expectedFps` and `smoothingCoefficient` props.