### PR TITLE
docs: Add markdown header to docs

### DIFF
--- a/packages/docs-reanimated/docs/guides/debugging-worklets.mdx
+++ b/packages/docs-reanimated/docs/guides/debugging-worklets.mdx
@@ -1,8 +1,9 @@
 ---
 id: debugging
-title: 'Debugging worklets'
 sidebar_label: 'Debugging worklets'
 ---
+
+# Debugging worklets
 
 import {
   SummaryTable,

--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -1,8 +1,9 @@
 ---
 id: testing
-title: 'Testing with Jest'
 sidebar_label: 'Testing with Jest'
 ---
+
+# Testing with Jest
 
 import DocsCompatibilityInfo from '../_shared/_docs_compatibility_info.mdx';
 

--- a/packages/docs-reanimated/versioned_docs/version-2.x/api/miscellaneous/interpolateColors.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-2.x/api/miscellaneous/interpolateColors.mdx
@@ -1,8 +1,9 @@
 ---
 id: interpolateColors
-title: 'interpolateColor'
 sidebar_label: 'interpolateColor'
 ---
+
+# interpolateColor
 
 import { ColorWidgets } from './color_widget/widget';
 


### PR DESCRIPTION
Few docs were missing markdown header - instead they had docusaurus title property. Because of that it wasn't possible to generate og images for them. In the future these docs will be rewritten to meet current style guide. 

That's why we decided to add `# Title` in docs instead of fix for `title: ...` in generate-og-images.js script. If we were to add fix to the script it will become redundant within a month or two.

Following docs were added a header:
- interpolateColor
- Debugging worklets
- Testing with Jest