### PR TITLE
Fix hermesCommand path for android release bundle

### DIFF
--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "../../node_modules/react-native/sdks/hermesc/osx-bin/hermesc"
+    hermesCommand = "../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]

--- a/apps/paper-example/android/app/build.gradle
+++ b/apps/paper-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "../../node_modules/react-native/sdks/hermesc/osx-bin/hermesc"
+    hermesCommand = "../../node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]

--- a/apps/paper-example/android/app/build.gradle
+++ b/apps/paper-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    // hermesCommand = "$rootDir/my-custom-hermesc/bin/hermesc"
+    hermesCommand = "../../node_modules/react-native/sdks/hermesc/osx-bin/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
## Summary

Yeah so it turns out `hermesCommand` path was commented out (and wrong) in PaperExample `build.gradle`.
I've seen that this change was introduced while ensuring RN0.71 compatibility so I am a bit confused..

## Test plan

Launch android paper example with release bundle
