### PR TITLE
Fix 2048 example

### DIFF
--- a/apps/common-app/src/examples/Game2048Example.tsx
+++ b/apps/common-app/src/examples/Game2048Example.tsx
@@ -226,6 +226,11 @@ export default function Game2048Example() {
   const [tiles, setTiles] = React.useState(makeInitialBoard);
   const [gameOver, setGameOver] = React.useState(false);
 
+  const handleReset = React.useCallback(() => {
+    setTiles(makeInitialBoard());
+    setGameOver(false);
+  }, []);
+
   const fling = Gesture.Pan()
     .runOnJS(true)
     .onEnd((e) => {
@@ -244,11 +249,6 @@ export default function Game2048Example() {
         }, 500);
       }
     });
-
-  const handleReset = React.useCallback(() => {
-    setTiles(makeInitialBoard());
-    setGameOver(false);
-  }, []);
 
   return (
     <GestureHandlerRootView style={styles.container}>


### PR DESCRIPTION
## Summary

2048 example was crashing on web because of a function being referenced before being initialised.

## Test plan

![image](https://github.com/software-mansion/react-native-reanimated/assets/77503811/1b5ed7f8-1fe9-4d60-8442-b73b131f0bf8)
