### PR TITLE
Remove unnecessary color processing in `interpolateColor`

### DIFF
--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -9,7 +9,7 @@
 /* eslint no-bitwise: 0 */
 import type { StyleProps } from './commonTypes';
 import { makeShareable } from './core';
-import { isAndroid, isWeb } from './PlatformChecker';
+import { isAndroid } from './PlatformChecker';
 
 interface RGB {
   r: number;

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -511,9 +511,6 @@ export const blue = (c: number): number => {
   return c & 255;
 };
 
-const IS_WEB = isWeb();
-const IS_ANDROID = isAndroid();
-
 export const rgbaColor = (
   r: number,
   g: number,
@@ -521,22 +518,9 @@ export const rgbaColor = (
   alpha = 1
 ): number | string => {
   'worklet';
-  if (IS_WEB || !_WORKLET) {
-    // Replace tiny values like 1.234e-11 with 0:
-    const safeAlpha = alpha < 0.001 ? 0 : alpha;
-    return `rgba(${r}, ${g}, ${b}, ${safeAlpha})`;
-  }
-
-  const c =
-    Math.round(alpha * 255) * (1 << 24) +
-    Math.round(r) * (1 << 16) +
-    Math.round(g) * (1 << 8) +
-    Math.round(b);
-  if (IS_ANDROID) {
-    // on Android color is represented as signed 32 bit int
-    return c < (1 << 31) >>> 0 ? c : c - 4294967296; // 4294967296 == Math.pow(2, 32);
-  }
-  return c;
+  // Replace tiny values like 1.234e-11 with 0:
+  const safeAlpha = alpha < 0.001 ? 0 : alpha;
+  return `rgba(${r}, ${g}, ${b}, ${safeAlpha})`;
 };
 
 /**
@@ -657,6 +641,8 @@ export function isColor(value: unknown): boolean {
   }
   return processColorInitially(value) != null;
 }
+
+const IS_ANDROID = isAndroid();
 
 export function processColor(color: unknown): number | null | undefined {
   'worklet';


### PR DESCRIPTION
## Summary

Our `interpolateColor` function seems to have some unnecessary color processing in it. It was added some 3-4 years ago and should not be needed by now.

## Why

There is a function called `rgbaColor` which is used in `hsvToColor` (which in turn is used only in `interpolateColor`) as well as directly in `interpolateColor`. So it's safe to say it is used ***only*** there. All it does is take r,g,b,a values, runs a small check on them and then returns a rgba string.
It has a check whether we are on UI thread or not. If we were on UI, it returned a number-formatted color (formatted for native platforms) instead of the usual rgba string. The problem is, these values are then directly returned from the function. I believe it was needed back then, but now we have a function called `processColorInProps` which does exactly that + it doesn't interfere with returned values of `interpolateColor`. Taking all these things into consideration, I believe this check in `rgbaColor` function is not needed anymore.

Moreover, it creates problems. When `interpolateColor` gets called on UI thread (for example by using it inside `useDerivedValue` hook as shown by this issue: https://github.com/software-mansion/react-native-reanimated/issues/6119), the user gets these number-formatted colors which don't work when passed anywhere.

## Test plan

Copy `App.tsx` from snack linked to the mentioned issue and make sure the text stays blue. Also, check out Color Interpolation example from the example app.

Tested on iOS and Android (both Paper and Fabric) as well as Web. I've noticed neither issues nor regressions.
