### PR TITLE
Speed up precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,8 +4,14 @@
 REANIMATED_PATH=packages/react-native-reanimated
 
 yarn lint-staged
+
 cd $REANIMATED_PATH
-yarn type:check:all
+# This step can take several seconds, so we don't want to run it on irrelevant commits.
+! git diff-index --name-only HEAD -- | grep "$REANIMATED_PATH/src/.*\.\(ts\|tsx\)$" >/dev/null
+if [ $? -eq 1 ]; then
+  yarn type:check:all
+  yarn find-unused-code:js
+fi
 
 # This automatically builds Reanimated Babel plugin JavaScript files if their
 # TypeScript counterparts were changed. It also adds the output file to the commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,17 +6,16 @@ REANIMATED_PATH=packages/react-native-reanimated
 yarn lint-staged
 cd $REANIMATED_PATH
 yarn type:check:all
-yarn find-unused-code:js
 
 # This automatically builds Reanimated Babel plugin JavaScript files if their
 # TypeScript counterparts were changed. It also adds the output file to the commit
 # if the built file differs from currently committed one.
-! git diff-index HEAD --name-only |\
-grep -E '^plugin/' > /dev/null
+! git diff-index HEAD --name-only |
+  grep -E '^plugin/' >/dev/null
 if [ $? -eq 1 ]; then
   yarn build:plugin
-  ! git status -u |\
-  grep -E 'plugin/build/plugin\.js' > /dev/null
+  ! git status -u |
+    grep -E 'plugin/build/plugin\.js' >/dev/null
   if [ $? -eq 1 ]; then
     git add plugin/build/plugin.js
     echo "[Reanimated] Plugin files were automatically built and changes were spotted.\

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -21,7 +21,7 @@
     "format:android": "find android/src/ -iname \"*.h\" -o -iname \"*.cpp\" | xargs clang-format -i",
     "format:common": "find Common/ -iname \"*.h\" -o -iname \"*.cpp\" | xargs clang-format -i",
     "format:docs": "cd docs && yarn format",
-    "find-unused-code:js": "yarn ts-prune --ignore \"index|.web.\" --error  ",
+    "find-unused-code:js": "yarn ts-prune --ignore \"index|.web.\" --error",
     "type:check:src": "yarn tsc --noEmit",
     "type:check:plugin": "cd plugin && yarn type:check:src && cd ..",
     "type:check:app": "./scripts/test-ts.sh ../../apps/common-app/src/App.tsx",


### PR DESCRIPTION
I measured which bits of precommit take so long:

![Screenshot 2024-07-08 at 11 04 17](https://github.com/software-mansion/react-native-reanimated/assets/40713406/12d4b237-a6a7-4666-a111-b1c2108196b4)

I decided to simply call it conditionally.