### PR TITLE
[reJest] Remove calltracker usage form internal logic

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
@@ -572,7 +572,7 @@ export class TestRunner {
     const incrementJS = () => {
       counterJS++;
     }
-    const consoleLogMock = (message: string) => {
+    const mockedConsoleFunction = (message: string) => {
       'worklet';
       if (_WORKLET) {
         counterUI.value++;
@@ -581,12 +581,12 @@ export class TestRunner {
       }
       recordedMessage.value = message.split('\n\nThis error is located at:')[0];
     };
-    console.error = consoleLogMock;
-    console.warn = consoleLogMock;
+    console.error = mockedConsoleFunction;
+    console.warn = mockedConsoleFunction;
     await this.runOnUIBlocking(() => {
       'worklet';
-      console.error = consoleLogMock;
-      console.warn = consoleLogMock;
+      console.error = mockedConsoleFunction;
+      console.warn = mockedConsoleFunction;
     });
 
     const restoreConsole = async () => {

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
@@ -306,35 +306,10 @@ export class TestRunner {
     }
 
     if (testCase.decorator === TestDecorator.FAILING || testCase.decorator === TestDecorator.WARN) {
-      const consoleTrackerRef = testCase.decorator === TestDecorator.FAILING ? 'console.error' : 'console.warn';
-      const message = makeMutable('');
-
-      const newConsoleFuncJS = (warning: string) => {
-        this.callTracker(consoleTrackerRef);
-        message.value = warning.split('\n\nThis error is located at:')[0];
-      };
-      console.error = newConsoleFuncJS;
-      console.warn = newConsoleFuncJS;
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const callTrackerCopy = this.callTracker;
-
-      runOnUI(() => {
-        'worklet';
-        const newConsoleFuncUI = (warning: string) => {
-          callTrackerCopy(consoleTrackerRef);
-          message.value = warning.split('\n\nThis error is located at:')[0];
-        };
-        console.error = newConsoleFuncUI;
-        console.warn = newConsoleFuncUI;
-      })();
-
+      const [restoreConsole, checkErrors] = await this.mockConsole(testCase);
       await testCase.run();
-
-      this.expect(this.getTrackerCallCount(consoleTrackerRef)).toBeCalled(1);
-      if (testCase.warningMessage) {
-        this.expect(message.value).toBe(testCase.warningMessage, ComparisonMode.STRING);
-      }
+      await restoreConsole();
+      await checkErrors();
     } else {
       await testCase.run();
     }
@@ -584,5 +559,47 @@ export class TestRunner {
       console.log('✅ All tests passed!');
     }
     console.log('\n');
+  }
+
+  private async mockConsole(testCase: TestCase) {
+    const counter = makeMutable(0);
+    const recordedMessage = makeMutable('');
+
+    const originalError = console.error;
+    const originalWarning = console.warn;
+
+    const consoleLogMock = (message: string) => {
+      'worklet';
+      counter.value++;
+      recordedMessage.value = message.split('\n\nThis error is located at:')[0];
+    };
+    console.error = consoleLogMock;
+    console.warn = consoleLogMock;
+    await this.runOnUIBlocking(() => {
+      'worklet';
+      console.error = consoleLogMock;
+      console.warn = consoleLogMock;
+    });
+
+    const self = this;
+    async function restoreConsole() {
+      console.error = originalError;
+      console.warn = originalWarning;
+      await self.runOnUIBlocking(() => {
+        'worklet';
+        console.error = originalError;
+        console.warn = originalWarning;
+      });
+    }
+    
+    async function checkErrors() {
+      if (testCase.decorator != TestDecorator.WARN && testCase.decorator != TestDecorator.FAILING) {
+        return;
+      }
+      self.expect(counter.value).toBe(1);
+      self.expect(recordedMessage.value).toBe(testCase.warningMessage);
+    }
+
+    return [restoreConsole, checkErrors];
   }
 }

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
@@ -571,7 +571,7 @@ export class TestRunner {
 
     const incrementJS = () => {
       counterJS++;
-    }
+    };
     const mockedConsoleFunction = (message: string) => {
       'worklet';
       if (_WORKLET) {
@@ -597,7 +597,7 @@ export class TestRunner {
         console.error = originalError;
         console.warn = originalWarning;
       });
-    }
+    };
 
     const checkErrors = async () => {
       if (testCase.decorator != TestDecorator.WARN && testCase.decorator != TestDecorator.FAILING) {
@@ -606,7 +606,7 @@ export class TestRunner {
       const count = counterUI.value + counterJS;
       this.expect(count).toBe(1);
       this.expect(recordedMessage.value).toBe(testCase.warningMessage);
-    }
+    };
 
     return [restoreConsole, checkErrors];
   }

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/TestRunner.ts
@@ -13,7 +13,7 @@ import type {
   TestValue,
   TrackerCallCount,
 } from './types';
-import { ComparisonMode, DescribeDecorator, TestDecorator } from './types';
+import { DescribeDecorator, TestDecorator } from './types';
 import { TestComponent } from './TestComponent';
 import { EMPTY_LOG_PLACEHOLDER, applyMarkdown, color, formatString, indentNestingLevel } from './stringFormatUtils';
 import type { SharedValue } from 'react-native-reanimated';
@@ -309,7 +309,7 @@ export class TestRunner {
       const [restoreConsole, checkErrors] = await this.mockConsole(testCase);
       await testCase.run();
       await restoreConsole();
-      await checkErrors();
+      checkErrors();
     } else {
       await testCase.run();
     }
@@ -561,7 +561,7 @@ export class TestRunner {
     console.log('\n');
   }
 
-  private async mockConsole(testCase: TestCase) {
+  private async mockConsole(testCase: TestCase): Promise<[() => Promise<void>, () => void]> {
     const counterUI = makeMutable(0);
     let counterJS = 0;
     const recordedMessage = makeMutable('');
@@ -599,8 +599,8 @@ export class TestRunner {
       });
     };
 
-    const checkErrors = async () => {
-      if (testCase.decorator != TestDecorator.WARN && testCase.decorator != TestDecorator.FAILING) {
+    const checkErrors = () => {
+      if (testCase.decorator !== TestDecorator.WARN && testCase.decorator !== TestDecorator.FAILING) {
         return;
       }
       const count = counterUI.value + counterJS;

--- a/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
@@ -146,6 +146,11 @@ const LayoutAnimation = () => {
   );
 };
 
+function WarningComponent() {
+  console.warn('message');
+  return <View />;
+}
+
 describe.skip('Tests of Test Framework', () => {
   test('withTiming - expect error', async () => {
     await render(<AnimatedComponent />);
@@ -264,6 +269,6 @@ describe.skip('Tests of Test Framework', () => {
   });
 
   test.warn('warning test', 'message', async () => {
-    console.warn('message');
+    await render(<WarningComponent />);
   });
 });

--- a/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
@@ -262,4 +262,8 @@ describe.skip('Tests of Test Framework', () => {
     await waitForNotify('notifyUI');
     expect(await component.getAnimatedStyle('width')).toBe('100');
   });
+
+  test.warn('warning test', 'message', async () => {
+    console.warn('message');
+  });
 });


### PR DESCRIPTION
## Summary

This PR removes the usage of `callTracker` from the internal logic. It is replaced with a simple mutable value. Additionally, the PR adds the possibility to restore the original implementation of `console.log` and `console.error` after running a test case.