### PR TITLE
[reJest] Fixes problem with opacity comparation

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/matchers/Comparators.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/matchers/Comparators.ts
@@ -18,6 +18,12 @@ const COMPARATORS: {
     return bothAreNaNs || ((bothAreNumbers || bothAreBigInts) && value === expected);
   },
 
+  [ComparisonMode.FLOAT]: (expected, value) => {
+    const bothAreNumbers = typeof value === 'number' && typeof expected === 'number';
+    const bothAreNaNs = bothAreNumbers && isNaN(value) && isNaN(expected);
+    return bothAreNaNs || Math.abs(Number(value) - Number(expected)) < Number.EPSILON;
+  },
+
   [ComparisonMode.COLOR]: (expected, value) => {
     if (!isColor(expected) || !isColor(value)) {
       return false;
@@ -28,6 +34,12 @@ const COMPARATORS: {
   [ComparisonMode.DISTANCE]: (expected, value) => {
     const valueAsNumber = Number(value);
     return !isNaN(valueAsNumber) && Math.abs(valueAsNumber - Number(expected)) < DISTANCE_TOLERANCE;
+  },
+
+  [ComparisonMode.CLOSE_DISTANCE]: (expected, value) => {
+    const bothAreNumbers = typeof value === 'number' && typeof expected === 'number';
+    const bothAreNaNs = bothAreNumbers && isNaN(value) && isNaN(expected);
+    return bothAreNaNs || Math.abs(Number(value) - Number(expected)) < 0.00001;
   },
 
   [ComparisonMode.ARRAY]: (expected, value) => {
@@ -95,7 +107,7 @@ export function getComparator(mode: ComparisonMode) {
 export function getComparisonModeForProp(prop: ValidPropNames): ComparisonMode {
   const propToComparisonModeDict = {
     zIndex: ComparisonMode.NUMBER,
-    opacity: ComparisonMode.NUMBER,
+    opacity: ComparisonMode.CLOSE_DISTANCE,
     width: ComparisonMode.DISTANCE,
     height: ComparisonMode.DISTANCE,
     top: ComparisonMode.DISTANCE,

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/matchers/Comparators.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/matchers/Comparators.ts
@@ -31,12 +31,12 @@ const COMPARATORS: {
     return processColor(expected) === processColor(value);
   },
 
-  [ComparisonMode.DISTANCE]: (expected, value) => {
+  [ComparisonMode.PIXEL]: (expected, value) => {
     const valueAsNumber = Number(value);
     return !isNaN(valueAsNumber) && Math.abs(valueAsNumber - Number(expected)) < DISTANCE_TOLERANCE;
   },
 
-  [ComparisonMode.CLOSE_DISTANCE]: (expected, value) => {
+  [ComparisonMode.FLOAT_DISTANCE]: (expected, value) => {
     const bothAreNumbers = typeof value === 'number' && typeof expected === 'number';
     const bothAreNaNs = bothAreNumbers && isNaN(value) && isNaN(expected);
     return bothAreNaNs || Math.abs(Number(value) - Number(expected)) < 0.00001;
@@ -85,7 +85,7 @@ const COMPARATORS: {
 
   [ComparisonMode.AUTO]: (expected, value) => {
     if (typeof expected === 'number') {
-      return COMPARATORS[ComparisonMode.DISTANCE](expected, value);
+      return COMPARATORS[ComparisonMode.PIXEL](expected, value);
     }
     if (typeof expected === 'string') {
       return COMPARATORS[ComparisonMode.STRING](expected, value);
@@ -107,11 +107,11 @@ export function getComparator(mode: ComparisonMode) {
 export function getComparisonModeForProp(prop: ValidPropNames): ComparisonMode {
   const propToComparisonModeDict = {
     zIndex: ComparisonMode.NUMBER,
-    opacity: ComparisonMode.CLOSE_DISTANCE,
-    width: ComparisonMode.DISTANCE,
-    height: ComparisonMode.DISTANCE,
-    top: ComparisonMode.DISTANCE,
-    left: ComparisonMode.DISTANCE,
+    opacity: ComparisonMode.FLOAT_DISTANCE,
+    width: ComparisonMode.PIXEL,
+    height: ComparisonMode.PIXEL,
+    top: ComparisonMode.PIXEL,
+    left: ComparisonMode.PIXEL,
     backgroundColor: ComparisonMode.COLOR,
   };
   return propToComparisonModeDict[prop];

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/types.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/types.ts
@@ -76,7 +76,9 @@ export function isValidPropName(propName: string): propName is ValidPropNames {
 export enum ComparisonMode {
   STRING = 'STRING',
   DISTANCE = 'DISTANCE',
+  CLOSE_DISTANCE = 'CLOSE_DISTANCE',
   NUMBER = 'NUMBER',
+  FLOAT = 'FLOAT',
   COLOR = 'COLOR',
   ARRAY = 'ARRAY',
   OBJECT = 'OBJECT',

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/types.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/types.ts
@@ -75,8 +75,8 @@ export function isValidPropName(propName: string): propName is ValidPropNames {
 
 export enum ComparisonMode {
   STRING = 'STRING',
-  DISTANCE = 'DISTANCE',
-  CLOSE_DISTANCE = 'CLOSE_DISTANCE',
+  PIXEL = 'PIXEL',
+  FLOAT_DISTANCE = 'FLOAT_DISTANCE',
   NUMBER = 'NUMBER',
   FLOAT = 'FLOAT',
   COLOR = 'COLOR',

--- a/apps/common-app/src/examples/RuntimeTests/tests/advancedAPI/measure.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/advancedAPI/measure.test.tsx
@@ -169,7 +169,7 @@ describe('Test measuring component during the animation', () => {
     const observedWidths = (await getRegisteredValue(OBSERVED_WIDTHS_REF)).onJS as Array<[number, number]>;
     observedWidths.forEach(([width, timeSinceFirstFrame]) => {
       const expectedWidth = Math.min(FINAL_WIDTH, (timeSinceFirstFrame * FINAL_WIDTH) / DURATION);
-      expect(width).toBe(expectedWidth, ComparisonMode.DISTANCE);
+      expect(width).toBe(expectedWidth, ComparisonMode.PIXEL);
     });
   });
 });

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/arrays.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/arrays.test.tsx
@@ -113,17 +113,17 @@ describe('withSequence animation of number', () => {
       const margin = 30;
 
       await wait(200 + DELAY / 2);
-      expect(await componentOne.getAnimatedStyle('left')).toBe(finalValues[0] + margin, ComparisonMode.DISTANCE);
-      expect(await componentTwo.getAnimatedStyle('left')).toBe(finalValues[1] + margin, ComparisonMode.DISTANCE);
-      expect(await componentThree.getAnimatedStyle('left')).toBe(finalValues[2] + margin, ComparisonMode.DISTANCE);
+      expect(await componentOne.getAnimatedStyle('left')).toBe(finalValues[0] + margin, ComparisonMode.PIXEL);
+      expect(await componentTwo.getAnimatedStyle('left')).toBe(finalValues[1] + margin, ComparisonMode.PIXEL);
+      expect(await componentThree.getAnimatedStyle('left')).toBe(finalValues[2] + margin, ComparisonMode.PIXEL);
       await wait(300 + DELAY / 2);
-      expect(await componentOne.getAnimatedStyle('left')).toBe(middleValues[0] + margin, ComparisonMode.DISTANCE);
-      expect(await componentTwo.getAnimatedStyle('left')).toBe(middleValues[1] + margin, ComparisonMode.DISTANCE);
-      expect(await componentThree.getAnimatedStyle('left')).toBe(middleValues[2] + margin, ComparisonMode.DISTANCE);
+      expect(await componentOne.getAnimatedStyle('left')).toBe(middleValues[0] + margin, ComparisonMode.PIXEL);
+      expect(await componentTwo.getAnimatedStyle('left')).toBe(middleValues[1] + margin, ComparisonMode.PIXEL);
+      expect(await componentThree.getAnimatedStyle('left')).toBe(middleValues[2] + margin, ComparisonMode.PIXEL);
       await wait(200 + DELAY);
-      expect(await componentOne.getAnimatedStyle('left')).toBe(finalValues[0] + 20 + margin, ComparisonMode.DISTANCE);
-      expect(await componentTwo.getAnimatedStyle('left')).toBe(finalValues[1] + 20 + margin, ComparisonMode.DISTANCE);
-      expect(await componentThree.getAnimatedStyle('left')).toBe(finalValues[2] + 20 + margin, ComparisonMode.DISTANCE);
+      expect(await componentOne.getAnimatedStyle('left')).toBe(finalValues[0] + 20 + margin, ComparisonMode.PIXEL);
+      expect(await componentTwo.getAnimatedStyle('left')).toBe(finalValues[1] + 20 + margin, ComparisonMode.PIXEL);
+      expect(await componentThree.getAnimatedStyle('left')).toBe(finalValues[2] + 20 + margin, ComparisonMode.PIXEL);
     },
   );
 });

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/cancelAnimation.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/cancelAnimation.test.tsx
@@ -50,19 +50,19 @@ describe(`Test cancelling animation `, () => {
     await render(<CancelComponent />);
     await wait(500);
     const component = getTestComponent(COMPONENT_REF);
-    expect(await component.getAnimatedStyle('width')).toBe(50, ComparisonMode.DISTANCE);
+    expect(await component.getAnimatedStyle('width')).toBe(50, ComparisonMode.PIXEL);
   });
   test('Cancelling animation with *****cancelAnimation***** finishes the whole sequence', async () => {
     await render(<CancelComponent shouldCancelAnimation />);
     await wait(500);
     const component = getTestComponent(COMPONENT_REF);
-    expect(await component.getAnimatedStyle('width')).not.toBe(50, ComparisonMode.DISTANCE);
+    expect(await component.getAnimatedStyle('width')).not.toBe(50, ComparisonMode.PIXEL);
   });
   test('Cancelling animation by *****starting new animation***** finishes the whole sequence', async () => {
     await render(<CancelComponent shouldStartNewAnimation />);
     await wait(500);
     const component = getTestComponent(COMPONENT_REF);
-    expect(await component.getAnimatedStyle('width')).not.toBe(50, ComparisonMode.DISTANCE);
+    expect(await component.getAnimatedStyle('width')).not.toBe(50, ComparisonMode.PIXEL);
   });
 });
 

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/numbers.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withSequence/numbers.test.tsx
@@ -131,16 +131,16 @@ describe('WithSequence animation of number', () => {
       await wait(DELAY / 2);
       // TODO The condition below is not fulfilled, decide whether its bug or expected behavior
       // expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[0], ComparisonMode.DISTANCE);
-      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[0], ComparisonMode.DISTANCE);
+      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[0], ComparisonMode.PIXEL);
       await wait(200 + DELAY);
-      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[1], ComparisonMode.DISTANCE);
-      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[1], ComparisonMode.DISTANCE);
+      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[1], ComparisonMode.PIXEL);
+      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[1], ComparisonMode.PIXEL);
       await wait(300 + DELAY);
-      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[2], ComparisonMode.DISTANCE);
-      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[2], ComparisonMode.DISTANCE);
+      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[2], ComparisonMode.PIXEL);
+      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[2], ComparisonMode.PIXEL);
       await wait(200 + DELAY);
-      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[3], ComparisonMode.DISTANCE);
-      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[3], ComparisonMode.DISTANCE);
+      expect(await activeComponent.getAnimatedStyle('left')).toBe(stopValues[3], ComparisonMode.PIXEL);
+      expect(await passiveComponent.getAnimatedStyle('left')).toBe(stopValues[3], ComparisonMode.PIXEL);
     },
   );
 });

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/arrays.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/arrays.test.tsx
@@ -105,7 +105,7 @@ describe('withTiming animation of ARRAY', () => {
       for (const component of components) {
         expect(await component.getAnimatedStyle('width')).toBe(
           startWidths[index] * scalars[index],
-          ComparisonMode.DISTANCE,
+          ComparisonMode.PIXEL,
         );
         index += 1;
       }
@@ -114,7 +114,7 @@ describe('withTiming animation of ARRAY', () => {
       for (const component of components) {
         expect(await component.getAnimatedStyle('width')).toBe(
           finalWidths[index] * scalars[index],
-          ComparisonMode.DISTANCE,
+          ComparisonMode.PIXEL,
         );
         index += 1;
       }

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/basic.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/basic.test.tsx
@@ -97,8 +97,8 @@ describe('withTiming animation of WIDTH', () => {
       const componentActive = getTestComponent(WIDTH_COMPONENT_ACTIVE_REF);
       const WidthComponentPassive = getTestComponent(WIDTH_COMPONENT_PASSIVE_REF);
       await wait(1000);
-      expect(await componentActive.getAnimatedStyle('width')).toBe(finalWidthInPixels, ComparisonMode.DISTANCE);
-      expect(await WidthComponentPassive.getAnimatedStyle('width')).toBe(finalWidthInPixels, ComparisonMode.DISTANCE);
+      expect(await componentActive.getAnimatedStyle('width')).toBe(finalWidthInPixels, ComparisonMode.PIXEL);
+      expect(await WidthComponentPassive.getAnimatedStyle('width')).toBe(finalWidthInPixels, ComparisonMode.PIXEL);
     },
   );
 
@@ -107,8 +107,8 @@ describe('withTiming animation of WIDTH', () => {
     const componentActive = getTestComponent(WIDTH_COMPONENT_ACTIVE_REF);
     const WidthComponentPassive = getTestComponent(WIDTH_COMPONENT_PASSIVE_REF);
     await wait(1000);
-    expect(await componentActive.getAnimatedStyle('width')).not.toBe(100, ComparisonMode.DISTANCE);
-    expect(await WidthComponentPassive.getAnimatedStyle('width')).not.toBe(100, ComparisonMode.DISTANCE);
+    expect(await componentActive.getAnimatedStyle('width')).not.toBe(100, ComparisonMode.PIXEL);
+    expect(await WidthComponentPassive.getAnimatedStyle('width')).not.toBe(100, ComparisonMode.PIXEL);
   });
 });
 

--- a/apps/common-app/src/examples/RuntimeTests/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/core/useAnimatedStyle/reuseAnimatedStyle.test.tsx
@@ -110,9 +110,9 @@ describe('Test reusing animatedStyles', () => {
       // Check the distance from the top
       const finalStyleFull = { height: 80, top: 0, margin: 0, ...finalStyle };
       const { height, margin, top } = finalStyleFull;
-      expect(await componentOne.getAnimatedStyle('top')).toBe(top + margin, ComparisonMode.DISTANCE);
-      expect(await componentTwo.getAnimatedStyle('top')).toBe(top + 3 * margin + height, ComparisonMode.DISTANCE);
-      expect(await componentThree.getAnimatedStyle('top')).toBe(top + 5 * margin + 2 * height, ComparisonMode.DISTANCE);
+      expect(await componentOne.getAnimatedStyle('top')).toBe(top + margin, ComparisonMode.PIXEL);
+      expect(await componentTwo.getAnimatedStyle('top')).toBe(top + 3 * margin + height, ComparisonMode.PIXEL);
+      expect(await componentThree.getAnimatedStyle('top')).toBe(top + 5 * margin + 2 * height, ComparisonMode.PIXEL);
 
       // Check the remaining props
       for (const key of ['width', 'height', 'left', 'opacity', 'backgroundColor'] as const) {

--- a/apps/common-app/src/examples/RuntimeTests/tests/core/useDerivedValue/basic.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/core/useDerivedValue/basic.test.tsx
@@ -123,7 +123,7 @@ describe('Test useDerivedValue changing width', () => {
         const waitTime =
           animationType === AnimationType.NONE ? 50 : animationType === AnimationType.TIMING ? 350 : 1800;
         await wait(waitTime);
-        expect(await testComponent.getAnimatedStyle('width')).toBe(derivedFun(finalWidth), ComparisonMode.DISTANCE);
+        expect(await testComponent.getAnimatedStyle('width')).toBe(derivedFun(finalWidth), ComparisonMode.PIXEL);
         const updates = updatesContainerActive.getUpdates();
         const naiveUpdates = await updatesContainerActive.getNativeSnapshots();
         await unmockAnimationTimer();

--- a/apps/common-app/src/examples/RuntimeTests/tests/core/useDerivedValue/chain.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/core/useDerivedValue/chain.test.tsx
@@ -148,7 +148,7 @@ describe('Test chained useDerivedValue', () => {
     });
 
     for (let i = 0; i < 10; i++) {
-      expect(await components[i].getAnimatedStyle('width')).toBe(expectedValues[i], ComparisonMode.DISTANCE);
+      expect(await components[i].getAnimatedStyle('width')).toBe(expectedValues[i], ComparisonMode.PIXEL);
     }
   });
 });


### PR DESCRIPTION
## Summary

Due to some platform limitations, certain properties may not be exact values as originally set, for example, opacity. This PR introduces new comparators, `CLOSE_DISTANCE` and `FLOAT`, which can be used in cases where we can't achieve the exact value as originally set.
