### PR TITLE
Improve `PerformanceMonitor`'s functionality

### DIFF
--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -84,11 +84,11 @@ function completeBufferRoutine(
   return getFps(measuredRangeDuration / buffer.count);
 }
 
-function JsPerformance() {
+function JsPerformance({ smoothingFrames }: { smoothingFrames: number }) {
   const jsFps = useSharedValue<string | null>(null);
   const totalRenderTime = useSharedValue(0);
   const circularBuffer = useRef<CircularBuffer>(
-    createCircularDoublesBuffer(DEFAULT_BUFFER_SIZE)
+    createCircularDoublesBuffer(smoothingFrames)
   );
 
   useEffect(() => {
@@ -122,13 +122,13 @@ function JsPerformance() {
   );
 }
 
-function UiPerformance() {
+function UiPerformance({ smoothingFrames }: { smoothingFrames: number }) {
   const uiFps = useSharedValue<string | null>(null);
   const circularBuffer = useSharedValue<CircularBuffer | null>(null);
 
   useFrameCallback(({ timestamp }: FrameInfo) => {
     if (circularBuffer.value === null) {
-      circularBuffer.value = createCircularDoublesBuffer(DEFAULT_BUFFER_SIZE);
+      circularBuffer.value = createCircularDoublesBuffer(smoothingFrames);
     }
 
     timestamp = Math.round(timestamp);
@@ -154,11 +154,29 @@ function UiPerformance() {
   );
 }
 
-export function PerformanceMonitor() {
+export type PerformanceMonitorProps = {
+  /**
+   * Sets amount of previous frames used for smoothing at highest expectedFps.
+   *
+   * Automatically scales down at lower frame rates.
+   *
+   * Affects jumpiness of the FPS measurements value.
+   */
+  smoothingFrames?: number;
+};
+
+/**
+ * A component that lets you measure fps values on JS and UI threads on both the Paper and Fabric architectures.
+ *
+ * @param smoothingFrames - Determines amount of saved frames which will be used for fps value smoothing.
+ */
+export function PerformanceMonitor({
+  smoothingFrames = DEFAULT_BUFFER_SIZE,
+}: PerformanceMonitorProps) {
   return (
     <View style={styles.monitor}>
-      <JsPerformance />
-      <UiPerformance />
+      <JsPerformance smoothingFrames={smoothingFrames} />
+      <UiPerformance smoothingFrames={smoothingFrames} />
     </View>
   );
 }

--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -107,7 +107,7 @@ function JsPerformance() {
   }, [jsFps, totalRenderTime]);
 
   const animatedProps = useAnimatedProps(() => {
-    const text = 'JS: ' + jsFps.value ?? 'N/A';
+    const text = 'JS: ' + (jsFps.value ?? 'N/A') + ' ';
     return { text, defaultValue: text };
   });
 
@@ -139,7 +139,7 @@ function UiPerformance() {
   });
 
   const animatedProps = useAnimatedProps(() => {
-    const text = 'UI: ' + uiFps.value ?? 'N/A';
+    const text = 'UI: ' + (uiFps.value ?? 'N/A') + ' ';
     return { text, defaultValue: text };
   });
 

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -261,7 +261,10 @@ export {
   getAnimatedStyle,
 } from './jestUtils';
 export { LayoutAnimationConfig } from './component/LayoutAnimationConfig';
-export { PerformanceMonitor } from './component/PerformanceMonitor';
+export {
+  PerformanceMonitor,
+  type PerformanceMonitorProps,
+} from './component/PerformanceMonitor';
 export type {
   Adaptable,
   AdaptTransforms,

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -261,10 +261,8 @@ export {
   getAnimatedStyle,
 } from './jestUtils';
 export { LayoutAnimationConfig } from './component/LayoutAnimationConfig';
-export {
-  PerformanceMonitor,
-  type PerformanceMonitorProps,
-} from './component/PerformanceMonitor';
+export { PerformanceMonitor } from './component/PerformanceMonitor';
+export type { PerformanceMonitorProps } from './component/PerformanceMonitor';
 export type {
   Adaptable,
   AdaptTransforms,


### PR DESCRIPTION
## Summary

PerformanceMonitor unnecessarily used accumulator and time delta calculations.
I replaced those with time range measurement and added component props to modify smoothing amount.

Additionally smoothing is now modifiable via the `PerformanceMonitorProps`, 
which are exported alongside `PerformanceMonitor`
## Test plan

Not consistently reproducible.

## Issue videos:

| exhibit 1 (`smoothing=5`) | exhibit 2 | exhibit 3 |
| --- | --- | --- |
| <video src="https://github.com/software-mansion/react-native-reanimated/assets/74246391/3a729ba5-1273-4529-ae5b-14ff6b7981e8"></video> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/74246391/ba3c7a96-19b5-46fb-aeb2-b27c4c66e36e"></video> | <video src="https://github.com/software-mansion/react-native-reanimated/assets/74246391/f2b24cdf-74b0-472c-8301-33b1e010630b"></video> |

## New code video:

https://github.com/software-mansion/react-native-reanimated/assets/74246391/d245ad37-ead5-474a-8c8b-92f0ff1efec4

#### Related
This PR is a simpler successor to [this](https://github.com/software-mansion/react-native-reanimated/pull/6198) PR.
