### PR TITLE
Assess and remove unnecessary usage of `Float32Array`

### DIFF
--- a/packages/react-native-reanimated/src/Bezier.ts
+++ b/packages/react-native-reanimated/src/Bezier.ts
@@ -90,7 +90,7 @@ export function Bezier(
   mX2: number,
   mY2: number
 ): (x: number) => number {
-  'worklet';
+  ('worklet');
 
   function LinearEasing(x: number): number {
     'worklet';
@@ -105,12 +105,12 @@ export function Bezier(
     return LinearEasing;
   }
 
-  // Precompute samples table
   const float32ArraySupported = typeof Float32Array === 'function';
   const sampleValues = float32ArraySupported
     ? new Float32Array(kSplineTableSize)
     : new Array(kSplineTableSize);
 
+  // Precompute samples table
   for (let i = 0; i < kSplineTableSize; ++i) {
     sampleValues[i] = calcBezier(i * kSampleStepSize, mX1, mX2);
   }

--- a/packages/react-native-reanimated/src/Bezier.ts
+++ b/packages/react-native-reanimated/src/Bezier.ts
@@ -90,7 +90,7 @@ export function Bezier(
   mX2: number,
   mY2: number
 ): (x: number) => number {
-  ('worklet');
+  'worklet';
 
   function LinearEasing(x: number): number {
     'worklet';

--- a/packages/react-native-reanimated/src/Bezier.ts
+++ b/packages/react-native-reanimated/src/Bezier.ts
@@ -105,15 +105,11 @@ export function Bezier(
     return LinearEasing;
   }
 
-  // FIXME: Float32Array is not available in Hermes right now
-  //
-  // var float32ArraySupported = typeof Float32Array === 'function';
-  // const sampleValues = float32ArraySupported
-  // ? new Float32Array(kSplineTableSize)
-  // : new Array(kSplineTableSize);
-
   // Precompute samples table
-  const sampleValues = new Array(kSplineTableSize);
+  const float32ArraySupported = typeof Float32Array === 'function';
+  const sampleValues = float32ArraySupported
+    ? new Float32Array(kSplineTableSize)
+    : new Array(kSplineTableSize);
 
   for (let i = 0; i < kSplineTableSize; ++i) {
     sampleValues[i] = calcBezier(i * kSampleStepSize, mX1, mX2);

--- a/packages/react-native-reanimated/src/Bezier.ts
+++ b/packages/react-native-reanimated/src/Bezier.ts
@@ -105,10 +105,7 @@ export function Bezier(
     return LinearEasing;
   }
 
-  const float32ArraySupported = typeof Float32Array === 'function';
-  const sampleValues = float32ArraySupported
-    ? new Float32Array(kSplineTableSize)
-    : new Array(kSplineTableSize);
+  const sampleValues = new Array(kSplineTableSize);
 
   // Precompute samples table
   for (let i = 0; i < kSplineTableSize; ++i) {


### PR DESCRIPTION
## Summary

This PR removes a 4-year-old TODO in the `Bezier` library, keeping `Arrays` and removing mentions of `Float32Arrays`.

This is due to `Float32Arrays` having a very specific `WebGL` use case, and generally being slower than regular `Arrays`, especially when they're dynamically re-allocated over and over again as it is the case in the `Bezier` library.

Live speed demo: [link](https://jsperf.app/float32array-slowness-test/2)
Live demo results:
![image](https://github.com/software-mansion/react-native-reanimated/assets/74246391/7551de0b-b9ab-439e-9853-fee0178253af)

## Test plan

not-applicable

## Notes

Using `Float32Array` here has no effect on precision, and no measurable speed improvement/degradation was noted on the production-like-conditions tests that I did.