### PR TITLE
docs: Rewrite getRelativeCoords documentation page

### DIFF
--- a/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -17,7 +17,11 @@ const Comp = () => {
 
   const gestureHandler = useAnimatedGestureHandler({
     onEnd: (event) => {
-      getRelativeCoords(animatedRef, event.absoluteX, event.absoluteY);
+      const coords = getRelativeCoords(
+        animatedRef,
+        event.absoluteX,
+        event.absoluteY
+      );
     },
   });
 
@@ -53,7 +57,7 @@ interface ComponentCoords {
 
 #### `animatedRef`
 
-[Animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView (or other scrollable) component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
+The product of [`useAnimatedRef`](/docs/core/useAnimatedRef) is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread). This ref should be passed as a prop to the view relative to which we want to know coordinates.
 
 #### `absoluteX`
 

--- a/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -4,43 +4,20 @@ sidebar_position: 4
 
 # getRelativeCoords
 
-import DocsCompatibilityInfo from '../_shared/_docs_compatibility_info.mdx';
+`getRelativeCoords` determines the location on the screen, relative to the given view.
 
-<DocsCompatibilityInfo />
+## Reference
 
-Determines the location on the screen, relative to the given view. It might be useful when there are only absolute coordinates available and you need coordinates relative to the parent.
+```tsx
+import { getRelativeCoords } from 'react-native-reanimated';
 
-### Arguments
-
-#### animatedRef
-
-The product of [`useAnimatedRef`](/docs/core/useAnimatedRef) is Reanimated's extension of a standard React ref (delivers the view tag on the UI thread). This ref should be passed as a prop to the view relative to which we want to know coordinates.
-
-#### x
-
-Absolute `x` coordinate.
-
-#### y
-
-Absolute `y` coordinate
-
-### Returns
-
-Object which contains relative coordinates
-
-- `x`
-- `y`
-
-### Example
-
-```js
 const Comp = () => {
-  const aref = useAnimatedRef();
+  const animatedRef = useAnimatedRef();
   // ...
 
   const gestureHandler = useAnimatedGestureHandler({
     onEnd: (event) => {
-      getRelativeCoords(aref, event.absoluteX, event.absoluteY);
+      getRelativeCoords(animatedRef, event.absoluteX, event.absoluteY);
     },
   });
 
@@ -53,3 +30,59 @@ const Comp = () => {
   );
 };
 ```
+
+<details>
+<summary>Type definitions</summary>
+
+```typescript
+function getRelativeCoords(
+  animatedRef: AnimatedRef<Component>,
+  absoluteX: number,
+  absoluteY: number
+): ComponentCoords | null;
+
+interface ComponentCoords {
+  x: number;
+  y: number;
+}
+```
+
+</details>
+
+### Arguments
+
+#### `animatedRef`
+
+[Animated ref](/docs/core/useAnimatedRef#returns) connected to the ScrollView (or other scrollable) component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
+
+#### `absoluteX`
+
+Number which is an absolute `x` coordinate.
+
+#### `absoluteY`
+
+Number which is an absolute `y` coordinate.
+
+### Returns
+
+Object which contains relative coordinates
+
+- `x`
+- `y`
+
+### Example
+
+import RelativeCoords from '@site/src/examples/RelativeCoords';
+import RelativeCoordsSrc from '!!raw-loader!@site/src/examples/RelativeCoords';
+
+<InteractiveExample src={RelativeCoordsSrc} component={RelativeCoords} />
+
+## Platform compatibility
+
+<div className="platform-compatibility">
+
+| Android | iOS | Web |
+| ------- | --- | --- |
+| ✅      | ✅  | ✅  |
+
+</div>

--- a/packages/docs-reanimated/src/examples/RelativeCoords.tsx
+++ b/packages/docs-reanimated/src/examples/RelativeCoords.tsx
@@ -4,10 +4,12 @@ import Animated, {
   useAnimatedRef,
   getRelativeCoords,
 } from 'react-native-reanimated';
+import { useColorScheme } from '@mui/material';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 const RelativeCoords = () => {
   const animatedRef = useAnimatedRef();
+  const { colorScheme } = useColorScheme();
   const [coords, setCoords] = useState({ x: 0, y: 0 });
 
   const tapGesture = Gesture.Tap().onEnd((event) => {
@@ -21,10 +23,15 @@ const RelativeCoords = () => {
     }
   });
 
+  const textColor =
+    colorScheme === 'light' ? styles.darkText : styles.lightText;
+
   return (
     <View style={styles.container}>
-      <Text style={styles.coordsData}>Relative coordinates to parent:</Text>
-      <Text style={[styles.coordsData, styles.coords]}>
+      <Text style={[styles.coordsData, textColor]}>
+        Relative coordinates to parent:
+      </Text>
+      <Text style={[styles.coordsData, styles.coords, textColor]}>
         x={coords.x.toFixed()} y=
         {coords.y.toFixed()}
       </Text>
@@ -66,6 +73,12 @@ const styles = StyleSheet.create({
     fontFamily: 'Aeonik',
     fontSize: 16,
     fontWeight: 'bold',
+  },
+  lightText: {
+    color: 'var(--swm-off-white)',
+  },
+  darkText: {
+    color: 'var(--swm-navy-light-100)',
   },
 });
 

--- a/packages/docs-reanimated/src/examples/RelativeCoords.tsx
+++ b/packages/docs-reanimated/src/examples/RelativeCoords.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedRef,
+  getRelativeCoords,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+
+const RelativeCoords = () => {
+  const animatedRef = useAnimatedRef();
+  const [coords, setCoords] = useState({ x: 0, y: 0 });
+  const [boxCoords, setBoxCoords] = useState({ x: 0, y: 0 });
+
+  const tapGesture = Gesture.Tap().onEnd((event) => {
+    const relativeCoords = getRelativeCoords(
+      animatedRef,
+      event.absoluteX,
+      event.absoluteY
+    );
+    setBoxCoords({ x: event.x, y: event.y });
+    if (relativeCoords) {
+      setCoords(relativeCoords);
+    }
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.coordsData}>Relative coordinates to parent:</Text>
+      <Text style={[styles.coordsData, styles.coords]}>
+        x={coords.x.toFixed()} y=
+        {coords.y.toFixed()}
+      </Text>
+      <Text style={styles.coordsData}>Coordinates inside box:</Text>
+      <Text style={[styles.coordsData, styles.coords]}>
+        x={boxCoords.x.toFixed()} y=
+        {boxCoords.y.toFixed()}
+      </Text>
+      <GestureDetector gesture={tapGesture}>
+        <Animated.View ref={animatedRef} style={styles.innerView}>
+          <Text style={styles.text}>Tap anywhere inside.</Text>
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  innerView: {
+    width: 300,
+    height: 300,
+    backgroundColor: 'var(--swm-purple-light-80)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 40,
+    cursor: 'pointer',
+  },
+  coordsData: {
+    fontSize: 20,
+    fontFamily: 'Aeonik',
+    color: 'var(--swm-navy-light-100)',
+  },
+  coords: {
+    marginBottom: 16,
+    fontWeight: '500',
+  },
+  text: {
+    color: 'var(--swm-off-white)',
+    fontFamily: 'Aeonik',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+
+export default RelativeCoords;

--- a/packages/docs-reanimated/src/examples/RelativeCoords.tsx
+++ b/packages/docs-reanimated/src/examples/RelativeCoords.tsx
@@ -9,7 +9,6 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 const RelativeCoords = () => {
   const animatedRef = useAnimatedRef();
   const [coords, setCoords] = useState({ x: 0, y: 0 });
-  const [boxCoords, setBoxCoords] = useState({ x: 0, y: 0 });
 
   const tapGesture = Gesture.Tap().onEnd((event) => {
     const relativeCoords = getRelativeCoords(
@@ -17,7 +16,6 @@ const RelativeCoords = () => {
       event.absoluteX,
       event.absoluteY
     );
-    setBoxCoords({ x: event.x, y: event.y });
     if (relativeCoords) {
       setCoords(relativeCoords);
     }
@@ -29,11 +27,6 @@ const RelativeCoords = () => {
       <Text style={[styles.coordsData, styles.coords]}>
         x={coords.x.toFixed()} y=
         {coords.y.toFixed()}
-      </Text>
-      <Text style={styles.coordsData}>Coordinates inside box:</Text>
-      <Text style={[styles.coordsData, styles.coords]}>
-        x={boxCoords.x.toFixed()} y=
-        {boxCoords.y.toFixed()}
       </Text>
       <GestureDetector gesture={tapGesture}>
         <Animated.View ref={animatedRef} style={styles.innerView}>


### PR DESCRIPTION
To be up to date we rewritten [getRelativeCoords](https://docs.swmansion.com/react-native-reanimated/docs/utilities/getRelativeCoords/) and implemented InteractiveExample.

- [#6165](https://github.com/software-mansion/react-native-reanimated/pull/6165) - needs to be merged before - it bumped `react-native-reanimated` to latest where `getRelativeCoords` work

Before:

https://github.com/software-mansion/react-native-reanimated/assets/59940332/6372409d-6eb7-4d8c-b339-13ea8090b509


After:


https://github.com/software-mansion/react-native-reanimated/assets/59940332/a4335d87-0dc3-4dab-93da-86f7ffbb9ba0

