### PR TITLE
docs: Fix linking to `Contributing to the code` section

### DIFF
--- a/packages/docs-reanimated/docs/guides/contributing.mdx
+++ b/packages/docs-reanimated/docs/guides/contributing.mdx
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to Reanimated! From triaging and com
 
 3. **Reviewing Pull Requests** &ndash; reviewing Pull Requests is crucial as it may help catch corner cases or bugs that the contributor didn't notice. Every review matters as it may help us polish quality of the library.
 
-4. **Contributing to the Code** &ndash; contributions to the source code generally come in the form of Pull Requests. By contributing to the code you help us with solving issues, fixing bugs or introducing new, amazing features. If you want to start your adventure with open source it's good idea to take a look at [good first issue](https://github.com/software-mansion/react-native-reanimated/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22) on GitHub. Read more about [contributing to code here](#contributing-to-code).
+4. **Contributing to the Code** &ndash; contributions to the source code generally come in the form of Pull Requests. By contributing to the code you help us with solving issues, fixing bugs or introducing new, amazing features. If you want to start your adventure with open source it's good idea to take a look at [good first issue](https://github.com/software-mansion/react-native-reanimated/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22) on GitHub. Read more about [contributing to code here](#contributing-to-the-code).
 
 ### Repository overview
 
@@ -219,7 +219,7 @@ Our workflow usually starts from editing `apps/common-app/src/examples/EmptyExam
 
 :::info
 
-If you want to implement a new feature or fix a bug, but still are unsure after reading through this section or could use some guidance, you can reach Reanimated Team on [discord](https://discord.com/channels/464786597288738816/1216675825584181330).
+If you want to implement a new feature or fix a bug, but still are unsure after reading through this section or could use some guidance, you can reach Reanimated Team on [Discord](https://discord.com/channels/464786597288738816/1216675825584181330).
 
 :::
 


### PR DESCRIPTION
## Summary

In the [Contributing](https://docs.swmansion.com/react-native-reanimated/docs/guides/contributing) section, right now in the 4th point of Ways to contribute subsection, paragraph "contributing to code here" does not redirect to the given subsection at all. This PR fixes this by changing the id of the subsection to the correct one.
I've also changed `discord` to `Discord` in one of paragraphs, since that small `d` has caught my attention 😄.  
