### PR TITLE
Put back the README.md file in the npm package

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -32,7 +32,9 @@
     "build": "yarn build:plugin && bob build",
     "build:plugin": "cd plugin && yarn install && yarn build",
     "circular-dependency-check": "yarn madge --extensions js,ts,tsx --circular src lib",
-    "use-strict-check": "node ./scripts/validate-use-strict.js"
+    "use-strict-check": "node ./scripts/validate-use-strict.js",
+    "prepack": "cp ../../README.md ./README.md",
+    "postpack": "rm ./README.md"
   },
   "main": "lib/module/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

This PR adds the `README.md` file back to the NPM package. After migration to a monorepo, the `README.md` file's location was changed to the parent directory. Unfortunately, you can't include a file from the parent directory in an npm package, and symlinks don't work for this either.

## Test plan

run `npm pack` and check if README.md is inside