### PR TITLE
[Web LA] Fill in missing keyframes in default animations

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Bounce.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Bounce.web.ts
@@ -69,6 +69,7 @@ export const BounceOutData = {
   BounceOut: {
     name: 'BounceOut',
     style: {
+      0: { transform: [{ scale: 1 }] },
       15: { transform: [{ scale: 1.1 }] },
       30: { transform: [{ scale: 0.9 }] },
       45: { transform: [{ scale: 1.2 }] },
@@ -80,6 +81,7 @@ export const BounceOutData = {
   BounceOutRight: {
     name: 'BounceOutRight',
     style: {
+      0: { transform: [{ translateX: '0px' }] },
       15: { transform: [{ translateX: '-10px' }] },
       30: { transform: [{ translateX: '10px' }] },
       45: { transform: [{ translateX: '-20px' }] },
@@ -91,6 +93,7 @@ export const BounceOutData = {
   BounceOutLeft: {
     name: 'BounceOutLeft',
     style: {
+      0: { transform: [{ translateX: '0px' }] },
       15: { transform: [{ translateX: '10px' }] },
       30: { transform: [{ translateX: '-10px' }] },
       45: { transform: [{ translateX: '20px' }] },
@@ -102,6 +105,7 @@ export const BounceOutData = {
   BounceOutUp: {
     name: 'BounceOutUp',
     style: {
+      0: { transform: [{ translateY: '0px' }] },
       15: { transform: [{ translateY: '10px' }] },
       30: { transform: [{ translateY: '-10px' }] },
       45: { transform: [{ translateY: '20px' }] },
@@ -113,6 +117,7 @@ export const BounceOutData = {
   BounceOutDown: {
     name: 'BounceOutDown',
     style: {
+      0: { transform: [{ translateY: '0px' }] },
       15: { transform: [{ translateY: '-10px' }] },
       30: { transform: [{ translateY: '10px' }] },
       45: { transform: [{ translateY: '-20px' }] },

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Fade.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Fade.web.ts
@@ -6,7 +6,10 @@ const DEFAULT_FADE_TIME = 0.3;
 export const FadeInData = {
   FadeIn: {
     name: 'FadeIn',
-    style: { 0: { opacity: 0 } },
+    style: {
+      0: { opacity: 0 },
+      100: { opacity: 1 },
+    },
     duration: DEFAULT_FADE_TIME,
   },
 
@@ -16,6 +19,10 @@ export const FadeInData = {
       0: {
         opacity: 0,
         transform: [{ translateX: '25px' }],
+      },
+      100: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
       },
     },
     duration: DEFAULT_FADE_TIME,
@@ -28,6 +35,10 @@ export const FadeInData = {
         opacity: 0,
         transform: [{ translateX: '-25px' }],
       },
+      100: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
     },
     duration: DEFAULT_FADE_TIME,
   },
@@ -38,6 +49,10 @@ export const FadeInData = {
       0: {
         opacity: 0,
         transform: [{ translateY: '-25px' }],
+      },
+      100: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
       },
     },
     duration: DEFAULT_FADE_TIME,
@@ -50,6 +65,10 @@ export const FadeInData = {
         opacity: 0,
         transform: [{ translateY: '25px' }],
       },
+      100: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
     },
     duration: DEFAULT_FADE_TIME,
   },
@@ -58,13 +77,20 @@ export const FadeInData = {
 export const FadeOutData = {
   FadeOut: {
     name: 'FadeOut',
-    style: { 100: { opacity: 0 } },
+    style: {
+      0: { opacity: 1 },
+      100: { opacity: 0 },
+    },
     duration: DEFAULT_FADE_TIME,
   },
 
   FadeOutRight: {
     name: 'FadeOutRight',
     style: {
+      0: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
       100: {
         opacity: 0,
         transform: [{ translateX: '25px' }],
@@ -76,6 +102,10 @@ export const FadeOutData = {
   FadeOutLeft: {
     name: 'FadeOutLeft',
     style: {
+      0: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
       100: {
         opacity: 0,
         transform: [{ translateX: '-25px' }],
@@ -87,6 +117,10 @@ export const FadeOutData = {
   FadeOutUp: {
     name: 'FadeOutUp',
     style: {
+      0: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
       100: {
         opacity: 0,
         transform: [{ translateY: '-25px' }],
@@ -98,6 +132,10 @@ export const FadeOutData = {
   FadeOutDown: {
     name: 'FadeOutDown',
     style: {
+      0: {
+        opacity: 1,
+        transform: [{ translateX: '0px' }],
+      },
       100: {
         opacity: 0,
         transform: [{ translateY: '25px' }],

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Fade.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Fade.web.ts
@@ -52,7 +52,7 @@ export const FadeInData = {
       },
       100: {
         opacity: 1,
-        transform: [{ translateX: '0px' }],
+        transform: [{ translateY: '0px' }],
       },
     },
     duration: DEFAULT_FADE_TIME,
@@ -67,7 +67,7 @@ export const FadeInData = {
       },
       100: {
         opacity: 1,
-        transform: [{ translateX: '0px' }],
+        transform: [{ translateY: '0px' }],
       },
     },
     duration: DEFAULT_FADE_TIME,
@@ -119,7 +119,7 @@ export const FadeOutData = {
     style: {
       0: {
         opacity: 1,
-        transform: [{ translateX: '0px' }],
+        transform: [{ translateY: '0px' }],
       },
       100: {
         opacity: 0,
@@ -134,7 +134,7 @@ export const FadeOutData = {
     style: {
       0: {
         opacity: 1,
-        transform: [{ translateX: '0px' }],
+        transform: [{ translateY: '0px' }],
       },
       100: {
         opacity: 0,

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Lightspeed.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Lightspeed.web.ts
@@ -37,6 +37,10 @@ export const LightSpeedOutData = {
   LightSpeedOutRight: {
     name: 'LightSpeedOutRight',
     style: {
+      0: {
+        transform: [{ translateX: '0vw', skewX: '0deg' }],
+        opacity: 1,
+      },
       100: {
         transform: [{ translateX: '100vw', skewX: '-45deg' }],
         opacity: 0,
@@ -48,6 +52,10 @@ export const LightSpeedOutData = {
   LightSpeedOutLeft: {
     name: 'LightSpeedOutLeft',
     style: {
+      0: {
+        transform: [{ translateX: '0vw', skew: '0deg' }],
+        opacity: 1,
+      },
       100: {
         transform: [{ translateX: '-100vw', skew: '45deg' }],
         opacity: 0,

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Pinwheel.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Pinwheel.web.ts
@@ -23,6 +23,10 @@ export const PinwheelData = {
   PinwheelOut: {
     name: 'PinwheelOut',
     style: {
+      0: {
+        transform: [{ rotate: '0rad', scale: 1 }],
+        opacity: 1,
+      },
       100: {
         transform: [{ rotate: '5rad', scale: 0 }],
         opacity: 0,

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Roll.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Roll.web.ts
@@ -10,6 +10,9 @@ export const RollInData = {
       0: {
         transform: [{ translateX: '-100vw', rotate: '-180deg' }],
       },
+      100: {
+        transform: [{ translateX: '0vw', rotate: '0deg' }],
+      },
     },
     duration: DEFAULT_ROLL_TIME,
   },
@@ -20,6 +23,9 @@ export const RollInData = {
       0: {
         transform: [{ translateX: '100vw', rotate: '180deg' }],
       },
+      100: {
+        transform: [{ translateX: '0vw', rotate: '0deg' }],
+      },
     },
     duration: DEFAULT_ROLL_TIME,
   },
@@ -29,6 +35,9 @@ export const RollOutData = {
   RollOutLeft: {
     name: 'RollOutLeft',
     style: {
+      0: {
+        transform: [{ translateX: '0vw', rotate: '0deg' }],
+      },
       100: {
         transform: [{ translateX: '-100vw', rotate: '-180deg' }],
       },
@@ -39,6 +48,9 @@ export const RollOutData = {
   RollOutRight: {
     name: 'RollOutRight',
     style: {
+      0: {
+        transform: [{ translateX: '0vw', rotate: '0deg' }],
+      },
       100: {
         transform: [{ translateX: '100vw', rotate: '180deg' }],
       },

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Rotate.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Rotate.web.ts
@@ -17,6 +17,16 @@ export const RotateInData = {
         ],
         opacity: 0,
       },
+      100: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
     },
     duration: DEFAULT_ROTATE_TIME,
   },
@@ -33,6 +43,16 @@ export const RotateInData = {
           },
         ],
         opacity: 0,
+      },
+      100: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
       },
     },
     duration: DEFAULT_ROTATE_TIME,
@@ -51,6 +71,16 @@ export const RotateInData = {
         ],
         opacity: 0,
       },
+      100: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
     },
     duration: DEFAULT_ROTATE_TIME,
   },
@@ -68,6 +98,16 @@ export const RotateInData = {
         ],
         opacity: 0,
       },
+      100: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
     },
     duration: DEFAULT_ROTATE_TIME,
   },
@@ -77,6 +117,16 @@ export const RotateOutData = {
   RotateOutDownLeft: {
     name: 'RotateOutDownLeft',
     style: {
+      0: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
       100: {
         transform: [
           {
@@ -94,6 +144,16 @@ export const RotateOutData = {
   RotateOutDownRight: {
     name: 'RotateOutDownRight',
     style: {
+      0: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
       100: {
         transform: [
           {
@@ -111,6 +171,16 @@ export const RotateOutData = {
   RotateOutUpLeft: {
     name: 'RotateOutUpLeft',
     style: {
+      0: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
       100: {
         transform: [
           {
@@ -128,6 +198,16 @@ export const RotateOutData = {
   RotateOutUpRight: {
     name: 'RotateOutUpRight',
     style: {
+      0: {
+        transform: [
+          {
+            translateX: '0%',
+            translateY: '0%',
+            rotate: '0deg',
+          },
+        ],
+        opacity: 1,
+      },
       100: {
         transform: [
           {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animation/Zoom.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animation/Zoom.web.ts
@@ -81,6 +81,7 @@ export const ZoomOutData = {
   ZoomOut: {
     name: 'ZoomOut',
     style: {
+      0: { transform: [{ scale: 1 }] },
       100: { transform: [{ scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -89,6 +90,7 @@ export const ZoomOutData = {
   ZoomOutRotate: {
     name: 'ZoomOutRotate',
     style: {
+      0: { transform: [{ scale: 1, rotate: '0rad' }] },
       100: { transform: [{ scale: 0, rotate: '0.3rad' }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -97,6 +99,7 @@ export const ZoomOutData = {
   ZoomOutRight: {
     name: 'ZoomOutRight',
     style: {
+      0: { transform: [{ translateX: '0vw', scale: 1 }] },
       100: { transform: [{ translateX: '100vw', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -105,7 +108,8 @@ export const ZoomOutData = {
   ZoomOutLeft: {
     name: 'ZoomOutLeft',
     style: {
-      100: { transform: [{ translateX: '-100vw', scale: 1 }] },
+      0: { transform: [{ translateX: '0vw', scale: 1 }] },
+      100: { transform: [{ translateX: '-100vw', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
   },
@@ -113,6 +117,7 @@ export const ZoomOutData = {
   ZoomOutUp: {
     name: 'ZoomOutUp',
     style: {
+      0: { transform: [{ translateX: '0vh', scale: 1 }] },
       100: { transform: [{ translateY: '-100vh', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -121,6 +126,7 @@ export const ZoomOutData = {
   ZoomOutDown: {
     name: 'ZoomOutDown',
     style: {
+      0: { transform: [{ translateX: '0vh', scale: 1 }] },
       100: { transform: [{ translateY: '100vh', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -129,6 +135,7 @@ export const ZoomOutData = {
   ZoomOutEasyUp: {
     name: 'ZoomOutEasyUp',
     style: {
+      0: { transform: [{ translateY: '0%', scale: 1 }] },
       100: { transform: [{ translateY: '-100%', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,
@@ -137,6 +144,7 @@ export const ZoomOutData = {
   ZoomOutEasyDown: {
     name: 'ZoomOutEasyDown',
     style: {
+      0: { transform: [{ translateY: '0%', scale: 1 }] },
       100: { transform: [{ translateY: '100%', scale: 0 }] },
     },
     duration: DEFAULT_ZOOM_TIME,


### PR DESCRIPTION
## Summary

This PR adds missing `keyframe` steps definitions in default layout animations. While they are not necessary for animations to work, I've found some problems with it while implementing `withInitialValues` modifier.

It turns out if you do not specify a property in initial `keyframe` step and then you decide to change it in next `keyframe` steps, it may not work.

> [!NOTE]
> Example below was written in pure `HTML` and `CSS` on [W3Schools Tryit Editor](https://www.w3schools.com/cssref/tryit.php?filename=trycss3_keyframes). However, since this PR is about web layout animations, it applies to them in the same manner as to animations in `HTML` and `CSS`.

### Initial state
Consider this example:

```CSS
#box {
  width: 100px;
  height: 100px;
  background: red;
  animation: myAnimation 2s;
}

@keyframes myAnimation {
  100% {
    opacity: 0;
    transform: rotate(5rad) scale(0);
   }
}
```
In this case, `div` with id `box` will perform `PinwheelOut` animation:

https://github.com/software-mansion/react-native-reanimated/assets/63123542/0e7f1b71-658b-45cf-b3e9-0737c9066728

### Adding initial values

Now, suppose that we want to use `withInitialValues` modifier and add `scale: 2`. This will result in the following `keyframe`:

```CSS
@keyframes myAnimation {
  0% {
    transform: scale(2);
  }
  100% {
    opacity: 0;
    transform: rotate(5rad) scale(0);
   }
}
```
Now the animation looks like this:

https://github.com/software-mansion/react-native-reanimated/assets/63123542/772ef0e8-f829-40c6-87a9-5a1558da855b

This animation is broken for two reasons:

1. There is no rotation applied to the component
2. There is a moment when component simply disappears, instead of smoothly changing `opacity` from `1` to `0`

### Filling remaining properties

Now, if we fill in remaining `keyframe` properties, it will look like this:

```CSS
@keyframes myAnimation {
  0% {
    opacity: 1;
    transform: rotate(0rad) scale(2);
  }
  100% {
    opacity: 0;
    transform: rotate(5rad) scale(0);
   }
}
```

And the resulting animation looks like this:

https://github.com/software-mansion/react-native-reanimated/assets/63123542/97778a16-9117-4723-8e90-42cca5b0d06d

### Order of properties

> [!CAUTION]
> Order of properties between `keyframe` steps does matter!

It is obvious that order of operations inside `transform` matters. However, it is also important to keep order of those operations between `keyframes`. In the example above, if we switch `rotation` with `scale` like this:

```CSS
@keyframes myAnimation {
  0% {
    opacity: 1;
    transform: scale(2) rotate(0rad);
  }
  100% {
    opacity: 0;
    transform: rotate(5rad) scale(0);
   }
}
```
The animation will look like this:

https://github.com/software-mansion/react-native-reanimated/assets/63123542/216d679b-3e3d-4fab-af07-869ad65984f4

So even though all properties were provided, we still do not get proper animation.

## Potential issues

Problem described in the _**Order of properties**_ paragraph may lead to some problems, since layout animations on web are created dynamically from objects that contain `keyframe` description. While mixing order of `keyframe` steps doesn't change anything (you can for example specify `to` before `from` and it will work correctly), order inside transform does matter. This may be problematic because we are iterating over objects using `Object.entries` method. However, up to this point, no issues were reported.

## Test plan

Tested on **_Default Layout Animations_** example.
