### PR TITLE
Fix useSharedValue type definition in docs

### DIFF
--- a/packages/docs-reanimated/docs/core/useSharedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useSharedValue.mdx
@@ -36,10 +36,7 @@ interface SharedValue<Value = unknown> {
   ) => void;
 }
 
-function useSharedValue<Value>(
-  initialValue: Value,
-  oneWayReadsOnly?: boolean
-): SharedValue<Value>;
+function useSharedValue<Value>(initialValue: Value): SharedValue<Value>;
 ```
 
 </details>


### PR DESCRIPTION
## Summary

Fixes `useSharedValue` type definition in docs after changes in the #4300 PR.

## Test plan

No tests :)