### PR TITLE
Prevent disabling cleanup in progress transitions on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
+++ b/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
@@ -191,6 +191,10 @@ static BOOL _isConfigured = NO;
     currentTargetViewSnapshot.values[@"originXByParent"] = @(frameData.x);
     currentTargetViewSnapshot.values[@"originYByParent"] = @(frameData.y);
     sharedElement.sourceViewSnapshot = newSourceViewSnapshot;
+    
+    if (sharedElement.animationType == SHARED_ELEMENT_TRANSITION_PROGRESS){
+      continue;
+    }
 
     [self disableCleaningForViewTag:sourceView.reactTag];
     [self disableCleaningForViewTag:targetView.reactTag];

--- a/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
+++ b/packages/react-native-reanimated/apple/LayoutReanimation/REASharedTransitionManager.m
@@ -191,8 +191,9 @@ static BOOL _isConfigured = NO;
     currentTargetViewSnapshot.values[@"originXByParent"] = @(frameData.x);
     currentTargetViewSnapshot.values[@"originYByParent"] = @(frameData.y);
     sharedElement.sourceViewSnapshot = newSourceViewSnapshot;
-    
-    if (sharedElement.animationType == SHARED_ELEMENT_TRANSITION_PROGRESS){
+    // progress transition cleanups are triggered by RNSScreens events,
+    // so incrementing their counters would prevent some cleanups
+    if (sharedElement.animationType == SHARED_ELEMENT_TRANSITION_PROGRESS) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

This PR changes the way Progress Transitions are restarted. Since the `finishSharedTransition` method is triggered by `RNSScreens` events we shouldn't increase the restart counter, because this could cause the cleanup to never happen.
## Test plan

Check `[SET]` examples for regressions on iOS
