### PR TITLE
[Web] Fix animations on Chromium 73 and older (#6269)

### DIFF
--- a/packages/react-native-reanimated/src/ReducedMotion.ts
+++ b/packages/react-native-reanimated/src/ReducedMotion.ts
@@ -8,7 +8,7 @@ export function isReducedMotionEnabledInSystem() {
   return isWeb()
     ? isWindowAvailable()
       ? // @ts-ignore Fallback if `window` is undefined.
-        !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
       : false
     : !!(global as localGlobal)._REANIMATED_IS_REDUCED_MOTION;
 }


### PR DESCRIPTION
## Summary

Fixes #6269 

`prefers-reduced-motion` was introduced in Chromium 74: https://chromestatus.com/feature/5597964353404928

The code on `main` branch seems not to care about the case when there is no definition of `prefers-reduced-motion`.

