### PR TITLE
fix: docs: Access before initialization on withSpring and withTiming

### DIFF
--- a/packages/docs-reanimated/src/components/InteractivePlayground/useSpringPlayground/Example.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useSpringPlayground/Example.tsx
@@ -23,6 +23,8 @@ export default function App({ width, options }: Props) {
   const shouldReduceMotion =
     options.reduceMotion === ReduceMotion.Always ||
     (options.reduceMotion === ReduceMotion.System && reduceMotion);
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+
   const callback = (isFinished) => {
     setTimeout(() => {
       if (isFinished) {
@@ -31,7 +33,6 @@ export default function App({ width, options }: Props) {
       }
     }, 1000);
   };
-  const [buttonDisabled, setButtonDisabled] = useState(false);
 
   const animatedStyles = useAnimatedStyle(() => {
     return {

--- a/packages/docs-reanimated/src/components/InteractivePlayground/useTimingPlayground/Example.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useTimingPlayground/Example.tsx
@@ -23,6 +23,8 @@ export default function App({ width, options }: Props) {
   const shouldReduceMotion =
     options.reduceMotion === ReduceMotion.Always ||
     (options.reduceMotion === ReduceMotion.System && reduceMotion);
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+
   const callback = (isFinished) => {
     setTimeout(
       () => {
@@ -34,7 +36,6 @@ export default function App({ width, options }: Props) {
       shouldReduceMotion ? 1000 : options.duration
     );
   };
-  const [buttonDisabled, setButtonDisabled] = useState(false);
 
   const animatedStyles = useAnimatedStyle(() => {
     return {


### PR DESCRIPTION
Before on docs using `withSpring` and `withTiming` playgrounds (Customising animations, withSpring, withTiming):

<img width="790" alt="image" src="https://github.com/user-attachments/assets/796d725a-ea68-499d-9f2a-12ee6b8faa2d">


After:

<img width="924" alt="image" src="https://github.com/user-attachments/assets/fbf925bb-f9dc-444d-990e-4a8942863a34">


## Test plan
1. Run `yarn && yarn build && yarn serve`
2. Check `Customising animations`, `withSpring`, `withTiming` documentation pages (they are must, but full docs checkup is recommended)
