### PR TITLE
Fix Reduced Motion example

### DIFF
--- a/apps/common-app/src/examples/ReducedMotionExample.tsx
+++ b/apps/common-app/src/examples/ReducedMotionExample.tsx
@@ -31,10 +31,11 @@ const SIMPLE_EXAMPLES = [
     text: 'withDelay',
   },
   {
-    animation: () => withSequence(
-      withTiming((toValue + initialValue) / 2, { duration }),
-      withSpring(toValue, { duration })
-    ),
+    animation: () =>
+      withSequence(
+        withTiming((toValue + initialValue) / 2, { duration }),
+        withSpring(toValue, { duration })
+      ),
     text: 'withSequence',
   },
 ];
@@ -60,46 +61,51 @@ const REPEAT_EXAMPLES = [
 
 const CONFIG_EXAMPLES = [
   {
-    animation: () => withTiming(toValue, {
-      reduceMotion: ReduceMotion.Always,
-      duration,
-    }),
+    animation: () =>
+      withTiming(toValue, {
+        reduceMotion: ReduceMotion.Always,
+        duration,
+      }),
     text: 'always\nreduce',
   },
   {
-    animation: () => withTiming(toValue, {
-      reduceMotion: ReduceMotion.Never,
-      duration,
-    }),
+    animation: () =>
+      withTiming(toValue, {
+        reduceMotion: ReduceMotion.Never,
+        duration,
+      }),
     text: 'never\nreduce',
   },
   {
-    animation: () => withTiming(toValue, {
-      reduceMotion: ReduceMotion.System,
-      duration,
-    }),
-    text: 'system\nreduce',
-  },
-  {
-    animation: () => withSequence(
-      ReduceMotion.Always,
-      withTiming(initialValue + (toValue - initialValue) / 3, { duration }),
-      withTiming(initialValue + (2 * (toValue - initialValue)) / 3, {
+    animation: () =>
+      withTiming(toValue, {
         reduceMotion: ReduceMotion.System,
         duration,
       }),
-      withTiming(toValue, { reduceMotion: ReduceMotion.Never, duration })
-    ),
+    text: 'system\nreduce',
+  },
+  {
+    animation: () =>
+      withSequence(
+        ReduceMotion.Always,
+        withTiming(initialValue + (toValue - initialValue) / 3, { duration }),
+        withTiming(initialValue + (2 * (toValue - initialValue)) / 3, {
+          reduceMotion: ReduceMotion.System,
+          duration,
+        }),
+        withTiming(toValue, { reduceMotion: ReduceMotion.Never, duration })
+      ),
     text: 'nested sequence',
   },
   {
-    animation: () => withRepeat(
-      withTiming(toValue, { duration }),
-      3,
-      true,
-      undefined,
-      ReduceMotion.Always
-    ),
+    animation: () =>
+      withRepeat(
+        withTiming(toValue, { duration }),
+        3,
+        true,
+        undefined,
+        ReduceMotion.Always
+      ),
     text: 'nested repeat',
   },
 ];

--- a/apps/common-app/src/examples/ReducedMotionExample.tsx
+++ b/apps/common-app/src/examples/ReducedMotionExample.tsx
@@ -24,14 +24,14 @@ const toValue = 100;
 const initialValue = -100;
 
 const SIMPLE_EXAMPLES = [
-  { animation: withTiming(toValue, { duration }), text: 'withTiming' },
-  { animation: withSpring(toValue, { duration }), text: 'withSpring' },
+  { animation: () => withTiming(toValue, { duration }), text: 'withTiming' },
+  { animation: () => withSpring(toValue, { duration }), text: 'withSpring' },
   {
-    animation: withDelay(1000, withTiming(toValue, { duration })),
+    animation: () => withDelay(1000, withTiming(toValue, { duration })),
     text: 'withDelay',
   },
   {
-    animation: withSequence(
+    animation: () => withSequence(
       withTiming((toValue + initialValue) / 2, { duration }),
       withSpring(toValue, { duration })
     ),
@@ -41,47 +41,47 @@ const SIMPLE_EXAMPLES = [
 
 const REPEAT_EXAMPLES = [
   {
-    animation: withRepeat(withTiming(toValue, { duration }), -1, true),
+    animation: () => withRepeat(withTiming(toValue, { duration }), -1, true),
     text: 'withRepeat (infinite)',
   },
   {
-    animation: withRepeat(withTiming(toValue, { duration }), 4, true),
+    animation: () => withRepeat(withTiming(toValue, { duration }), 4, true),
     text: 'withRepeat (even)',
   },
   {
-    animation: withRepeat(withTiming(toValue, { duration }), 3, true),
+    animation: () => withRepeat(withTiming(toValue, { duration }), 3, true),
     text: 'withRepeat (odd)',
   },
   {
-    animation: withRepeat(withTiming(toValue, { duration }), 4, false),
+    animation: () => withRepeat(withTiming(toValue, { duration }), 4, false),
     text: 'withRepeat\n(no reverse)',
   },
 ];
 
 const CONFIG_EXAMPLES = [
   {
-    animation: withTiming(toValue, {
+    animation: () => withTiming(toValue, {
       reduceMotion: ReduceMotion.Always,
       duration,
     }),
     text: 'always\nreduce',
   },
   {
-    animation: withTiming(toValue, {
+    animation: () => withTiming(toValue, {
       reduceMotion: ReduceMotion.Never,
       duration,
     }),
     text: 'never\nreduce',
   },
   {
-    animation: withTiming(toValue, {
+    animation: () => withTiming(toValue, {
       reduceMotion: ReduceMotion.System,
       duration,
     }),
     text: 'system\nreduce',
   },
   {
-    animation: withSequence(
+    animation: () => withSequence(
       ReduceMotion.Always,
       withTiming(initialValue + (toValue - initialValue) / 3, { duration }),
       withTiming(initialValue + (2 * (toValue - initialValue)) / 3, {
@@ -93,7 +93,7 @@ const CONFIG_EXAMPLES = [
     text: 'nested sequence',
   },
   {
-    animation: withRepeat(
+    animation: () => withRepeat(
       withTiming(toValue, { duration }),
       3,
       true,
@@ -187,7 +187,7 @@ function HookExample() {
   );
 }
 
-function Example(props: { animation: number; text: string }) {
+function Example(props: { animation: () => number; text: string }) {
   const sv = useSharedValue(initialValue);
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -195,7 +195,7 @@ function Example(props: { animation: number; text: string }) {
   }));
 
   const handlePress = () => {
-    sv.value = props.animation;
+    sv.value = props.animation();
   };
 
   return (


### PR DESCRIPTION
## Summary

Previously, animations were defined in the global scope, so if they were run once, they couldn't be run again. I simply replaced static animations with a lambda that creates a new animation every time.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/21de2620-24f2-4d27-8e82-3217ddeab07e" /> | <video src="https://github.com/user-attachments/assets/ac178ce6-c6d5-4cc0-9029-43341b20b278" /> |

## Test plan

Run `ReducedMotion` example
