### PR TITLE
Remove header to fix broken tests on android

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
@@ -63,9 +63,7 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
 
   return (
     <View style={styles.container}>
-      {started ? (
-        <Text style={styles.reloadText}>Reload the app to run the tests again</Text>
-      ) : (
+      {started ? null : (
         <>
           <TestSelector tests={tests} testSelectionCallbacks={testSelectionCallbacks} />
           <Pressable onPressOut={handleStartClick} style={styles.button}>
@@ -252,6 +250,8 @@ const styles = StyleSheet.create({
     marginRight: 10,
     borderWidth: 2,
     backgroundColor: 'white',
+    borderColor: 'navy',
+    borderRadius: 5,
   },
   checkedCheckbox: {
     backgroundColor: 'navy',

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
@@ -256,11 +256,6 @@ const styles = StyleSheet.create({
   checkedCheckbox: {
     backgroundColor: 'navy',
   },
-  reloadText: {
-    fontSize: 20,
-    color: 'navy',
-    alignSelf: 'center',
-  },
   pressedButton: {
     zIndex: 2,
     backgroundColor: '#FFFA',

--- a/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/ReanimatedRuntimeTestsRunner/RuntimeTestsRunner.tsx
@@ -42,6 +42,8 @@ interface RuntimeTestRunnerProps {
 export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
   const [component, setComponent] = useState<ReactNode | null>(null);
   const [started, setStarted] = useState<boolean>(false);
+  const [finished, setFinished] = useState<boolean>(false);
+
   const testSelectionCallbacks = useRef<Set<() => void>>(new Set());
   useEffect(() => {
     if (renderLock) {
@@ -52,6 +54,7 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
   async function run() {
     renderLock = configure({ render: setComponent });
     await runTests();
+    setFinished(true);
   }
 
   function handleStartClick() {
@@ -71,9 +74,9 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
           </Pressable>
         </>
       )}
-
       {/* Don't render anything if component is undefined to prevent blinking */}
       {component || null}
+      {finished ? <Text style={styles.reloadText}>Reload the app to run the tests again</Text> : null}
     </View>
   );
 }
@@ -255,6 +258,11 @@ const styles = StyleSheet.create({
   },
   checkedCheckbox: {
     backgroundColor: 'navy',
+  },
+  reloadText: {
+    fontSize: 20,
+    color: 'navy',
+    alignSelf: 'center',
   },
   pressedButton: {
     zIndex: 2,

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/objects.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/objects.test.tsx
@@ -41,7 +41,7 @@ const AnimatedComponent = ({
   );
 };
 
-describe('withTiming animation of WIDTH', () => {
+describe.only('withTiming animation of WIDTH', () => {
   test.each([
     {
       startStyle: { width: 10 },

--- a/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/objects.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/animations/withTiming/objects.test.tsx
@@ -41,7 +41,7 @@ const AnimatedComponent = ({
   );
 };
 
-describe.only('withTiming animation of WIDTH', () => {
+describe('withTiming animation of WIDTH', () => {
   test.each([
     {
       startStyle: { width: 10 },


### PR DESCRIPTION

## Summary
The height of information "Reload the app to run the tests again" was causing broken tests on android. This height was included in results of `getViewProp("top")` including snapshots**BEFORE:**
<img width="977" alt="image" src="https://github.com/user-attachments/assets/4e7e75c8-e3bd-427f-bcd5-00212edda721">
**AFTER:**
<img width="977" alt="image" src="https://github.com/user-attachments/assets/4127f8f5-81dd-4cf7-a751-7d783f5cbe23">

## Test plan
