### PR TITLE
fix: race condition with frame callbacks

### DIFF
--- a/packages/react-native-reanimated/src/frameCallback/FrameCallbackRegistryUI.ts
+++ b/packages/react-native-reanimated/src/frameCallback/FrameCallbackRegistryUI.ts
@@ -47,7 +47,10 @@ export const prepareUIRegistry = runOnUIImmediately(() => {
         const delta = timestamp - this.previousFrameTimestamp;
 
         this.activeFrameCallbacks.forEach((callbackId: number) => {
-          const callbackDetails = this.frameCallbackRegistry.get(callbackId)!;
+          const callbackDetails = this.frameCallbackRegistry.get(callbackId);
+          if (!callbackDetails) {
+            return;
+          }
 
           const { startTime } = callbackDetails;
 
@@ -109,8 +112,10 @@ export const prepareUIRegistry = runOnUIImmediately(() => {
         this.activeFrameCallbacks.add(callbackId);
         this.runCallbacks(this.nextCallId);
       } else {
-        const callback = this.frameCallbackRegistry.get(callbackId)!;
-        callback.startTime = null;
+        const callback = this.frameCallbackRegistry.get(callbackId);
+        if (callback) {
+          callback.startTime = null;
+        }
 
         this.activeFrameCallbacks.delete(callbackId);
         if (this.activeFrameCallbacks.size === 0) {


### PR DESCRIPTION
## Summary

Fixes #6299 #6158

## Test plan

I haven't yet been able to reproduce the issue - we just have it in Sentry -, but I assume that this is a race condition where `setActive(false)` is called after the callback was removed, where perhaps the component was unmounted.

