### PR TITLE
[Web LA] Fix `easing`

### DIFF
--- a/packages/react-native-reanimated/src/Easing.ts
+++ b/packages/react-native-reanimated/src/Easing.ts
@@ -313,4 +313,15 @@ const EasingObject = {
   inOut,
 };
 
+export const EasingNameSymbol = Symbol('easingName');
+
+for (const [easingName, easing] of Object.entries(EasingObject)) {
+  Object.defineProperty(easing, EasingNameSymbol, {
+    value: easingName,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+}
+
 export const Easing = EasingObject;

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -25,7 +25,7 @@ import { EasingNameSymbol } from '../../Easing';
 
 function getEasingFromConfig(config: CustomConfig): string {
   if (!config.easingV) {
-    return `cubic-bezier(${WebEasings['linear'].toString()})`;
+    return `cubic-bezier(${WebEasings.linear.toString()})`;
   }
 
   const easingName = config.easingV[EasingNameSymbol];
@@ -35,7 +35,7 @@ function getEasingFromConfig(config: CustomConfig): string {
       `[Reanimated] Selected easing is not currently supported on web.`
     );
 
-    return `cubic-bezier(${WebEasings['linear'].toString()})`;
+    return `cubic-bezier(${WebEasings.linear.toString()})`;
   }
 
   return `cubic-bezier(${WebEasings[

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -24,12 +24,23 @@ import { ReducedMotionManager } from '../../ReducedMotion';
 import { EasingNameSymbol } from '../../Easing';
 
 function getEasingFromConfig(config: CustomConfig): string {
-  const easingName =
-    config.easingV && config.easingV[EasingNameSymbol] in WebEasings
-      ? (config.easingV[EasingNameSymbol] as WebEasingsNames)
-      : 'linear';
+  if (!config.easingV) {
+    return `cubic-bezier(${WebEasings['linear'].toString()})`;
+  }
 
-  return `cubic-bezier(${WebEasings[easingName].toString()})`;
+  const easingName = config.easingV[EasingNameSymbol];
+
+  if (!(easingName in WebEasings)) {
+    console.warn(
+      `[Reanimated] Selected easing is not currently supported on web.`
+    );
+
+    return `cubic-bezier(${WebEasings['linear'].toString()})`;
+  }
+
+  return `cubic-bezier(${WebEasings[
+    easingName as WebEasingsNames
+  ].toString()})`;
 }
 
 function getRandomDelay(maxDelay = 1000) {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -21,11 +21,12 @@ import type { ReanimatedSnapshot, ScrollOffsets } from './componentStyle';
 import { setElementPosition, snapshots } from './componentStyle';
 import { Keyframe } from '../animationBuilder';
 import { ReducedMotionManager } from '../../ReducedMotion';
+import { EasingNameSymbol } from '../../Easing';
 
 function getEasingFromConfig(config: CustomConfig): string {
   const easingName =
-    config.easingV && config.easingV.name in WebEasings
-      ? (config.easingV.name as WebEasingsNames)
+    config.easingV && config.easingV[EasingNameSymbol] in WebEasings
+      ? (config.easingV[EasingNameSymbol] as WebEasingsNames)
       : 'linear';
 
   return `cubic-bezier(${WebEasings[easingName].toString()})`;

--- a/packages/react-native-reanimated/src/layoutReanimation/web/config.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/config.ts
@@ -57,8 +57,13 @@ export interface AnimationConfig {
   reversed: boolean;
 }
 
+interface EasingType {
+  (): number;
+  [EasingNameSymbol: symbol]: string;
+}
+
 export interface CustomConfig {
-  easingV?: () => number;
+  easingV?: EasingType;
   durationV?: number;
   delayV?: number;
   randomizeDelay?: boolean;


### PR DESCRIPTION
## Summary

After #6163 was merged, each `worklet` function follows new naming convention. Since `easings` are `worklets`, their `name` property has also been changed. In web layout animations we were applying `easing` based on its name, therefore changing it resulted in only default `linear` easing being available on web.

This PR adds new `Symbol` into easing functions so that we can once again get their name and apply correct easing to animations.

## Test plan

Tested on _**BasicLayoutAnimation**_ example with `Easing.exp`
