### PR TITLE
refactor: split makeMutable to web and native implementations

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { withStyleAnimation } from '../animation/styleAnimation';
 import type { SharedValue } from '../commonTypes';
-import { makeUIMutable } from '../mutables';
+import { makeMutableUI } from '../mutables';
 import { LayoutAnimationType } from './animationBuilder';
 import { runOnUIImmediately } from '../threads';
 import type {
@@ -73,7 +73,7 @@ function createLayoutAnimationManager(): {
 
       let value = mutableValuesForTag.get(tag);
       if (value === undefined) {
-        value = makeUIMutable(style.initialValues);
+        value = makeMutableUI(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
         stopObservingProgress(tag, value);

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { shouldBeUseWeb } from './PlatformChecker';
-import type { Mutable } from './commonTypes';
+import type { Mutable, SharedValue } from './commonTypes';
 import { makeShareableCloneRecursive } from './shareables';
 import { shareableMappingCache } from './shareableMappingCache';
 import { executeOnUIRuntimeSync, runOnUI } from './threads';
@@ -10,7 +10,7 @@ const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
 type Listener<Value> = (newValue: Value) => void;
 
-export function makeUIMutable<Value>(initial: Value): Mutable<Value> {
+export function makeMutableUI<Value>(initial: Value): Mutable<Value> {
   'worklet';
 
   const listeners = new Map<number, Listener<Value>>();
@@ -57,88 +57,99 @@ export function makeUIMutable<Value>(initial: Value): Mutable<Value> {
   return self;
 }
 
-export function makeMutable<Value>(initial: Value): Mutable<Value> {
-  let value: Value = initial;
+function makeMutableNative<Value>(initial: Value): Mutable<Value> {
   const handle = makeShareableCloneRecursive({
     __init: () => {
       'worklet';
-      return makeUIMutable(initial);
+      return makeMutableUI(initial);
     },
   });
-  // listeners can only work on JS thread on Web and jest environments
-  const listeners = SHOULD_BE_USE_WEB
-    ? new Map<number, Listener<Value>>()
-    : undefined;
   const mutable: Mutable<Value> = {
     set value(newValue) {
-      if (SHOULD_BE_USE_WEB) {
-        valueSetter(mutable, newValue);
-      } else {
-        runOnUI(() => {
-          mutable.value = newValue;
-        })();
-      }
+      runOnUI(() => {
+        mutable.value = newValue;
+      })();
     },
     get value(): Value {
-      if (SHOULD_BE_USE_WEB) {
-        return value;
-      }
       const uiValueGetter = executeOnUIRuntimeSync((sv: Mutable<Value>) => {
         return sv.value;
       });
       return uiValueGetter(mutable);
     },
-    set _value(newValue: Value) {
-      if (!SHOULD_BE_USE_WEB) {
-        throw new Error(
-          '[Reanimated] Setting `_value` directly is only possible on the UI runtime. Perhaps you want to assign to `value` instead?'
-        );
-      }
-      value = newValue;
-      listeners!.forEach((listener) => {
-        listener(newValue);
-      });
+    set _value(_newValue: Value) {
+      throw new Error(
+        '[Reanimated] Setting `_value` directly is only possible on the UI runtime. Perhaps you want to assign to `value` instead?'
+      );
     },
     get _value(): Value {
-      if (SHOULD_BE_USE_WEB) {
-        return value;
-      }
       throw new Error(
         '[Reanimated] Reading from `_value` directly is only possible on the UI runtime. Perhaps you passed an Animated Style to a non-animated component?'
       );
     },
 
     modify: (modifier, forceUpdate = true) => {
-      if (!SHOULD_BE_USE_WEB) {
-        runOnUI(() => {
-          mutable.modify(modifier, forceUpdate);
-        })();
-      } else {
-        valueSetter(
-          mutable,
-          modifier !== undefined ? modifier(mutable.value) : mutable.value,
-          forceUpdate
-        );
-      }
+      valueSetter(
+        mutable,
+        modifier !== undefined ? modifier(mutable.value) : mutable.value,
+        forceUpdate
+      );
     },
-    addListener: (id: number, listener: Listener<Value>) => {
-      if (!SHOULD_BE_USE_WEB) {
-        throw new Error(
-          '[Reanimated] Adding listeners is only possible on the UI runtime.'
-        );
-      }
-      listeners!.set(id, listener);
+    addListener: () => {
+      throw new Error(
+        '[Reanimated] Adding listeners is only possible on the UI runtime.'
+      );
     },
-    removeListener: (id: number) => {
-      if (!SHOULD_BE_USE_WEB) {
-        throw new Error(
-          '[Reanimated] Removing listeners is only possible on the UI runtime.'
-        );
-      }
-      listeners!.delete(id);
+    removeListener: () => {
+      throw new Error(
+        '[Reanimated] Removing listeners is only possible on the UI runtime.'
+      );
     },
     _isReanimatedSharedValue: true,
   };
   shareableMappingCache.set(mutable, handle);
   return mutable;
 }
+
+function makeMutableWeb<Value>(initial: Value): SharedValue<Value> {
+  let value: Value = initial;
+  // Listeners are needed only in Web implementation.
+  const listeners = new Map<number, Listener<Value>>();
+  const mutable: Mutable<Value> = {
+    set value(newValue) {
+      valueSetter(mutable, newValue);
+    },
+    get value(): Value {
+      return value;
+    },
+    set _value(newValue: Value) {
+      value = newValue;
+      listeners.forEach((listener) => {
+        listener(newValue);
+      });
+    },
+    get _value(): Value {
+      return value;
+    },
+
+    modify: (modifier, forceUpdate = true) => {
+      valueSetter(
+        mutable,
+        modifier !== undefined ? modifier(mutable.value) : mutable.value,
+        forceUpdate
+      );
+    },
+    addListener: (id: number, listener: Listener<Value>) => {
+      listeners.set(id, listener);
+    },
+    removeListener: (id: number) => {
+      listeners.delete(id);
+    },
+    _isReanimatedSharedValue: true,
+  };
+
+  return mutable;
+}
+
+export const makeMutable = SHOULD_BE_USE_WEB
+  ? makeMutableWeb
+  : makeMutableNative;

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -1,8 +1,8 @@
 'use strict';
 import { shouldBeUseWeb } from './PlatformChecker';
-import type { Mutable, SharedValue } from './commonTypes';
-import { makeShareableCloneRecursive } from './shareables';
+import type { Mutable } from './commonTypes';
 import { shareableMappingCache } from './shareableMappingCache';
+import { makeShareableCloneRecursive } from './shareables';
 import { executeOnUIRuntimeSync, runOnUI } from './threads';
 import { valueSetter } from './valueSetter';
 
@@ -114,7 +114,7 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
   return mutable;
 }
 
-function makeMutableWeb<Value>(initial: Value): SharedValue<Value> {
+function makeMutableWeb<Value>(initial: Value): Mutable<Value> {
   let value: Value = initial;
   const listeners = new Map<number, Listener<Value>>();
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -88,11 +88,9 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
     },
 
     modify: (modifier, forceUpdate = true) => {
-      valueSetter(
-        mutable,
-        modifier !== undefined ? modifier(mutable.value) : mutable.value,
-        forceUpdate
-      );
+      runOnUI(() => {
+        mutable.modify(modifier, forceUpdate);
+      })();
     },
     addListener: () => {
       throw new Error(


### PR DESCRIPTION
## Summary

Currently Web and Native implementations of `makeMutable` are bundled together and are hard to read. I split them for more clarity in the code, and also to prepare `makeMutable` for its further changes.

## Test plan

- [x] Runtime tests pass.
