### PR TITLE
[Web LA] Start `exiting` after position fix

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -49,6 +49,7 @@ import type { FlatList, FlatListProps } from 'react-native';
 import { addHTMLMutationObserver } from '../layoutReanimation/web/domUtils';
 import { getViewInfo } from './getViewInfo';
 import { NativeEventsManager } from './NativeEventsManager';
+import type { ReanimatedHTMLElement } from '../js-reanimated';
 
 const IS_WEB = isWeb();
 
@@ -178,7 +179,7 @@ export function createAnimatedComponent(
 
         startWebLayoutAnimation(
           this.props,
-          this._component as HTMLElement,
+          this._component as ReanimatedHTMLElement,
           LayoutAnimationType.ENTERING
         );
       }
@@ -211,7 +212,7 @@ export function createAnimatedComponent(
 
         startWebLayoutAnimation(
           this.props,
-          this._component as HTMLElement,
+          this._component as ReanimatedHTMLElement,
           LayoutAnimationType.EXITING
         );
       } else if (exiting && !IS_WEB && !isFabric()) {
@@ -418,7 +419,7 @@ export function createAnimatedComponent(
       ) {
         tryActivateLayoutTransition(
           this.props,
-          this._component as HTMLElement,
+          this._component as ReanimatedHTMLElement,
           snapshot
         );
       }

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
@@ -29,6 +29,7 @@ import type { TransitionData } from './animationParser';
 import { Keyframe } from '../animationBuilder';
 import { makeElementVisible } from './componentStyle';
 import { EasingNameSymbol } from '../../Easing';
+import type { ReanimatedHTMLElement } from '../../js-reanimated';
 
 function chooseConfig<ComponentProps extends Record<string, unknown>>(
   animationType: LayoutAnimationType,
@@ -94,7 +95,7 @@ function maybeReportOverwrittenProperties(
 function chooseAction(
   animationType: LayoutAnimationType,
   animationConfig: AnimationConfig,
-  element: HTMLElement,
+  element: ReanimatedHTMLElement,
   transitionData: TransitionData
 ) {
   switch (animationType) {
@@ -183,7 +184,7 @@ export function startWebLayoutAnimation<
   ComponentProps extends Record<string, unknown>
 >(
   props: Readonly<AnimatedComponentProps<ComponentProps>>,
-  element: HTMLElement,
+  element: ReanimatedHTMLElement,
   animationType: LayoutAnimationType,
   transitionData?: TransitionData
 ) {
@@ -214,7 +215,7 @@ export function tryActivateLayoutTransition<
   ComponentProps extends Record<string, unknown>
 >(
   props: Readonly<AnimatedComponentProps<ComponentProps>>,
-  element: HTMLElement,
+  element: ReanimatedHTMLElement,
   snapshot: DOMRect
 ) {
   if (!props.layout) {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/transition/Curved.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/transition/Curved.web.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { ReanimatedHTMLElement } from '../../../js-reanimated';
 import { LayoutAnimationType } from '../..';
 import type { WebEasingsNames } from '../Easing.web';
 import { getEasingByName } from '../Easing.web';
@@ -33,8 +34,8 @@ function showChildren(
 }
 
 function prepareParent(
-  element: HTMLElement,
-  dummy: HTMLElement,
+  element: ReanimatedHTMLElement,
+  dummy: ReanimatedHTMLElement,
   animationConfig: AnimationConfig,
   transitionData: TransitionData
 ) {
@@ -76,7 +77,7 @@ function prepareParent(
 }
 
 function prepareDummy(
-  element: HTMLElement,
+  element: ReanimatedHTMLElement,
   animationConfig: AnimationConfig,
   transitionData: TransitionData,
   dummyTransitionKeyframeName: string
@@ -91,14 +92,14 @@ function prepareDummy(
     reversed: false,
   };
 
-  const dummy = element.cloneNode(true) as HTMLElement;
+  const dummy = element.cloneNode(true) as ReanimatedHTMLElement;
   resetStyle(dummy);
 
   return { dummy, dummyAnimationConfig };
 }
 
 export function prepareCurvedTransition(
-  element: HTMLElement,
+  element: ReanimatedHTMLElement,
   animationConfig: AnimationConfig,
   transitionData: TransitionData,
   dummyTransitionKeyframeName: string


### PR DESCRIPTION
## Summary

While preparing presentation about web LA I've found out that `exiting` animation has strange order of operations - first animation is started and then position of the element is adjusted (by scroll and other factors). In theory, this may lead to flickers so I believe it will be better to start animation after we adjust position.

## Test plan

Tested on example app