### PR TITLE
Add mutable value read/write during render warning

### DIFF
--- a/apps/common-app/src/examples/InvalidValueAccessExample.tsx
+++ b/apps/common-app/src/examples/InvalidValueAccessExample.tsx
@@ -7,6 +7,10 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+Animated.configureLogger({
+  strict: true,
+});
+
 export default function InvalidValueAccessExample() {
   const [counter, setCounter] = React.useState(0);
   const [updateFromUseEffect, setUpdateFromUseEffect] = React.useState(false);

--- a/apps/common-app/src/examples/InvalidValueAccessExample.tsx
+++ b/apps/common-app/src/examples/InvalidValueAccessExample.tsx
@@ -2,12 +2,15 @@ import { Text, StyleSheet, View, Button } from 'react-native';
 
 import React, { useEffect } from 'react';
 import Animated, {
+  configureReanimatedLogger,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
 
-Animated.configureLogger({
+configureReanimatedLogger({
+  // change to `false` or remove the `configureReanimatedLogger` call to
+  // disable the warning
   strict: true,
 });
 

--- a/apps/common-app/src/examples/InvalidValueAccessExample.tsx
+++ b/apps/common-app/src/examples/InvalidValueAccessExample.tsx
@@ -1,0 +1,82 @@
+import { Text, StyleSheet, View, Button } from 'react-native';
+
+import React, { useEffect } from 'react';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+export default function InvalidValueAccessExample() {
+  const [counter, setCounter] = React.useState(0);
+  const [updateFromUseEffect, setUpdateFromUseEffect] = React.useState(false);
+  const sv = useSharedValue(0);
+
+  if (!updateFromUseEffect) {
+    // logs writing to `value`... warning
+    sv.value = counter;
+    // logs reading from `value`... warning
+    console.log('shared value:', sv.value);
+  }
+
+  useEffect(() => {
+    if (updateFromUseEffect) {
+      // no warning is logged
+      sv.value = counter;
+      // no warning is logged
+      console.log('useEffect shared value:', sv.value);
+    }
+  }, [sv, counter, updateFromUseEffect]);
+
+  const reRender = () => {
+    setCounter((prev) => prev + 1);
+  };
+
+  const animatedBarStyle = useAnimatedStyle(() => ({
+    transform: [{ scaleX: withTiming(Math.sin((sv.value * Math.PI) / 10)) }],
+  }));
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.text}>
+          Update from:{' '}
+          <Text style={styles.highlight}>
+            {updateFromUseEffect ? 'useEffect' : 'component'}
+          </Text>
+        </Text>
+        <Button
+          title="change"
+          onPress={() => setUpdateFromUseEffect((prev) => !prev)}
+        />
+      </View>
+      <Button title="Re-render" onPress={reRender} />
+      <Text>Counter: {counter}</Text>
+      <Animated.View style={[styles.bar, animatedBarStyle]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  bar: {
+    height: 20,
+    backgroundColor: 'blue',
+    width: '100%',
+  },
+  text: {
+    fontSize: 16,
+  },
+  highlight: {
+    fontWeight: 'bold',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+});

--- a/apps/common-app/src/examples/index.ts
+++ b/apps/common-app/src/examples/index.ts
@@ -133,6 +133,7 @@ import TabNavigatorExample from './SharedElementTransitions/TabNavigatorExample'
 import StrictDOMExample from './StrictDOMExample';
 import BottomTabsExample from './LayoutAnimations/BottomTabs';
 import ListItemLayoutAnimation from './LayoutAnimations/ListItemLayoutAnimation';
+import InvalidValueAccessExample from './InvalidValueAccessExample';
 
 interface Example {
   icon?: string;
@@ -182,6 +183,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🥶',
     title: 'Freezing shareables',
     screen: FreezingShareablesExample,
+  },
+  InvalidReadWriteExample: {
+    icon: '🔒',
+    title: 'Invalid read/write during render',
+    screen: InvalidValueAccessExample,
   },
 
   // About

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -15,7 +15,7 @@ function shouldWarnAboutAccessDuringRender() {
 }
 
 function checkInvalidReadDuringRender() {
-  if (shouldWarnAboutAccessDuringRender()) {
+  if (__DEV__ && shouldWarnAboutAccessDuringRender()) {
     console.warn(
       '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
     );
@@ -23,7 +23,7 @@ function checkInvalidReadDuringRender() {
 }
 
 function checkInvalidWriteDuringRender() {
-  if (shouldWarnAboutAccessDuringRender()) {
+  if (__DEV__ && shouldWarnAboutAccessDuringRender()) {
     console.warn(
       '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
     );

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -112,7 +112,6 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
     },
     set value(newValue) {
       if (shouldWarnInvalidAccess()) {
-        console.log('warn 2');
         console.warn(invalidWriteWarning);
       }
       runOnUI(() => {

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -10,13 +10,24 @@ import { valueSetter } from './valueSetter';
 
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
-const invalidReadWarning =
-  '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.';
-const invalidWriteWarning =
-  '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.';
-
-function shouldWarnInvalidAccess() {
+function shouldWarnAboutAccessDuringRender() {
   return isReactRendering() && !isFirstReactRender();
+}
+
+function checkInvalidReadDuringRender() {
+  if (shouldWarnAboutAccessDuringRender()) {
+    console.warn(
+      '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    );
+  }
+}
+
+function checkInvalidWriteDuringRender() {
+  if (shouldWarnAboutAccessDuringRender()) {
+    console.warn(
+      '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    );
+  }
 }
 
 type Listener<Value> = (newValue: Value) => void;
@@ -102,18 +113,14 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
 
   const mutable: Mutable<Value> = {
     get value(): Value {
-      if (shouldWarnInvalidAccess()) {
-        console.warn(invalidReadWarning);
-      }
+      checkInvalidReadDuringRender();
       const uiValueGetter = executeOnUIRuntimeSync((sv: Mutable<Value>) => {
         return sv.value;
       });
       return uiValueGetter(mutable);
     },
     set value(newValue) {
-      if (shouldWarnInvalidAccess()) {
-        console.warn(invalidWriteWarning);
-      }
+      checkInvalidWriteDuringRender();
       runOnUI(() => {
         mutable.value = newValue;
       })();
@@ -161,12 +168,11 @@ function makeMutableWeb<Value>(initial: Value): Mutable<Value> {
 
   const mutable: Mutable<Value> = {
     get value(): Value {
+      checkInvalidReadDuringRender();
       return value;
     },
     set value(newValue) {
-      if (shouldWarnInvalidAccess()) {
-        console.warn(invalidWriteWarning);
-      }
+      checkInvalidWriteDuringRender();
       valueSetter(mutable, newValue);
     },
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -15,7 +15,7 @@ function shouldWarnAboutAccessDuringRender() {
 }
 
 function checkInvalidReadDuringRender() {
-  if (__DEV__ && shouldWarnAboutAccessDuringRender()) {
+  if (shouldWarnAboutAccessDuringRender()) {
     console.warn(
       '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
     );
@@ -23,7 +23,7 @@ function checkInvalidReadDuringRender() {
 }
 
 function checkInvalidWriteDuringRender() {
-  if (__DEV__ && shouldWarnAboutAccessDuringRender()) {
+  if (shouldWarnAboutAccessDuringRender()) {
     console.warn(
       '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
     );

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -2,6 +2,7 @@
 import { shouldBeUseWeb } from './PlatformChecker';
 import type { Mutable } from './commonTypes';
 import { ReanimatedError } from './errors';
+import { logger } from './logger';
 import { isFirstReactRender, isReactRendering } from './reactUtils';
 import { shareableMappingCache } from './shareableMappingCache';
 import { makeShareableCloneRecursive } from './shareables';
@@ -16,16 +17,18 @@ function shouldWarnAboutAccessDuringRender() {
 
 function checkInvalidReadDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
-    console.warn(
-      '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    logger.warn(
+      'Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
+      { strict: true }
     );
   }
 }
 
 function checkInvalidWriteDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
-    console.warn(
-      '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    logger.warn(
+      'Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
+      { strict: true }
     );
   }
 }

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -11,7 +11,7 @@ import { valueSetter } from './valueSetter';
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
 function shouldWarnAboutAccessDuringRender() {
-  return isReactRendering() && !isFirstReactRender();
+  return __DEV__ && isReactRendering() && !isFirstReactRender();
 }
 
 function checkInvalidReadDuringRender() {

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -7,7 +7,7 @@ function getCurrentReactOwner() {
     React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ||
     // @ts-expect-error React secret internals aren't typed
     React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
-  return ReactSharedInternals.ReactCurrentOwner.current;
+  return ReactSharedInternals?.ReactCurrentOwner?.current;
 }
 
 export function isReactRendering() {

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import React from 'react';
 
 function getCurrentReactOwner() {

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -11,8 +11,7 @@ export function isReactRendering() {
 
 export function isFirstReactRender() {
   const currentOwner = getCurrentReactOwner()
-  // This is not null only after the first render and stores all the
-  // data from the previous render.
-  const alternate = currentOwner?.alternate;
-  return isReactRendering() && !alternate;
+  // alternate is not null only after the first render and stores all the
+  // data from the previous component render
+  return currentOwner && !currentOwner?.alternate;
 }

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -2,7 +2,8 @@ import React from 'react';
 
 function getCurrentReactOwner() {
   // @ts-expect-error React secret internals aren't typed
-  return React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current;
+  return React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    .ReactCurrentOwner.current;
 }
 
 export function isReactRendering() {
@@ -10,7 +11,7 @@ export function isReactRendering() {
 }
 
 export function isFirstReactRender() {
-  const currentOwner = getCurrentReactOwner()
+  const currentOwner = getCurrentReactOwner();
   // alternate is not null only after the first render and stores all the
   // data from the previous component render
   return currentOwner && !currentOwner?.alternate;

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -2,9 +2,12 @@
 import React from 'react';
 
 function getCurrentReactOwner() {
-  // @ts-expect-error React secret internals aren't typed
-  return React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-    .ReactCurrentOwner.current;
+  const ReactSharedInternals =
+    // @ts-expect-error React secret internals aren't typed
+    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ||
+    // @ts-expect-error React secret internals aren't typed
+    React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+  return ReactSharedInternals.ReactCurrentOwner.current;
 }
 
 export function isReactRendering() {

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export function isReactRendering() {
+  // @ts-expect-error React secret internals aren't typed
+  return !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current;
+}

--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -1,6 +1,18 @@
 import React from 'react';
 
-export function isReactRendering() {
+function getCurrentReactOwner() {
   // @ts-expect-error React secret internals aren't typed
-  return !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current;
+  return React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current;
+}
+
+export function isReactRendering() {
+  return !!getCurrentReactOwner();
+}
+
+export function isFirstReactRender() {
+  const currentOwner = getCurrentReactOwner()
+  // This is not null only after the first render and stores all the
+  // data from the previous render.
+  const alternate = currentOwner?.alternate;
+  return isReactRendering() && !alternate;
 }


### PR DESCRIPTION
## Summary

This PR adds warnings shown when the SharedValue `.value` property is accessed (read or written) while the component is being rendered.
The initial render is ignored as all reanimated hooks are executed for the first time during the initial render (e.g. `useAnimatedStyle` builds the initial component style).

## Test plan

- open the **Invalid read/write during render** example in the example app,
- press on the **Re-render** button to trigger re-render, which will access `.value` property of the shared value from the component function body,
- see warnings about invalid read and invalid write
