### PR TITLE
fix: docs: Recenter slider thumb

### DIFF
--- a/packages/docs-reanimated/src/components/InteractivePlayground/index.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/index.tsx
@@ -146,7 +146,7 @@ const RangeStyling = {
   color: 'var(--swm-interactive-slider)', // color of the main path of slider
   '& .MuiSlider-thumb': {
     backgroundColor: 'var(--swm-interactive-slider)', //color of thumb
-    transform: 'translate(-50%, -40%)',
+    transform: 'translate(-50%, -50%)',
   },
   '& .MuiSlider-rail': {
     color: 'var(--swm-interactive-slider-rail)', //color of the rail (remaining area of slider)
@@ -158,7 +158,7 @@ const DisabledRangeStyling = {
   color: 'var(--swm-interactive-slider)', // color of the main path of slider
   '& .MuiSlider-thumb': {
     backgroundColor: '#ccc', //color of thumb
-    transform: 'translate(-50%, -40%)',
+    transform: 'translate(-50%, -50%)',
   },
   '& .MuiSlider-rail': {
     color: 'var(--swm-interactive-slider-rail)', //color of the rail (remaining area of slider)


### PR DESCRIPTION
Range slider's thumb was not centered, we fixed that 🚀 

Before:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/a5ce9aaa-cd23-4e1e-a5cd-eb595711d4f7">

After:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/52e46a7b-3d67-4be2-a40e-ff69899af298">

## Test plan

Sliders are on playgrounds - i.e. `withSpring` or `withTiming`