### PR TITLE
fix: class factory included in sort

### DIFF
--- a/packages/react-native-reanimated/plugin/build/plugin.js
+++ b/packages/react-native-reanimated/plugin/build/plugin.js
@@ -1351,9 +1351,9 @@ var require_class = __commonJS({
       (0, assert_1.strict)(classPath.node.id);
       const className = classPath.node.id.name;
       const polyfilledClassAst = getPolyfilledAst(classPath.node, state);
+      sortPolyfills(polyfilledClassAst);
       appendWorkletDirectiveToPolyfills(polyfilledClassAst.program.body);
       replaceClassDeclarationWithFactoryAndCall(polyfilledClassAst.program.body, className);
-      sortPolyfills(polyfilledClassAst);
       polyfilledClassAst.program.body.push((0, types_12.returnStatement)((0, types_12.identifier)(className)));
       const factoryFactory = (0, types_12.functionExpression)(null, [], (0, types_12.blockStatement)([...polyfilledClassAst.program.body]));
       const factoryCall = (0, types_12.callExpression)(factoryFactory, []);

--- a/packages/react-native-reanimated/plugin/src/class.ts
+++ b/packages/react-native-reanimated/plugin/src/class.ts
@@ -68,14 +68,14 @@ function processClass(
 
   const polyfilledClassAst = getPolyfilledAst(classPath.node, state);
 
+  sortPolyfills(polyfilledClassAst);
+
   appendWorkletDirectiveToPolyfills(polyfilledClassAst.program.body);
 
   replaceClassDeclarationWithFactoryAndCall(
     polyfilledClassAst.program.body,
     className
   );
-
-  sortPolyfills(polyfilledClassAst);
 
   polyfilledClassAst.program.body.push(returnStatement(identifier(className)));
 


### PR DESCRIPTION
## Summary

Starting to sort polyfills after we transform a class into a class factory sometimes causes unwanted entries in the list of elements to sort. This fixes it.
