### PR TITLE
feat: Move commonjs exports down for worklet files

### DIFF
--- a/packages/react-native-reanimated/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/plugin.test.ts.snap
@@ -990,7 +990,7 @@ exports[`babel plugin for file workletization doesn't workletize function outsid
 }"
 `;
 
-exports[`babel plugin for file workletization moves CommonJS exports to the bottom of the file 1`] = `
+exports[`babel plugin for file workletization moves CommonJS export to the bottom of the file 1`] = `
 "var _worklet_15780239751281_init_data = {
   code: "function foo_null1(){}",
   location: "/dev/null",
@@ -1008,6 +1008,73 @@ var foo = function () {
 }();
 var bar = 1;
 exports.foo = foo;"
+`;
+
+exports[`babel plugin for file workletization moves multiple CommonJS exports to the bottom of the file 1`] = `
+"var _worklet_15780239751281_init_data = {
+  code: "function foo_null1(){}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foo = function () {
+  var _e = [new global.Error(), 1, -27];
+  var foo_null1 = function foo_null1() {};
+  foo_null1.__closure = {};
+  foo_null1.__workletHash = 15780239751281;
+  foo_null1.__initData = _worklet_15780239751281_init_data;
+  foo_null1.__stackDetails = _e;
+  return foo_null1;
+}();
+var _worklet_552304524261_init_data = {
+  code: "function bar_null2(){}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var bar = function () {
+  var _e = [new global.Error(), 1, -27];
+  var bar_null2 = function bar_null2() {};
+  bar_null2.__closure = {};
+  bar_null2.__workletHash = 552304524261;
+  bar_null2.__initData = _worklet_552304524261_init_data;
+  bar_null2.__stackDetails = _e;
+  return bar_null2;
+}();
+var _worklet_9955902016844_init_data = {
+  code: "function baz_null3(){}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var baz = function () {
+  var _e = [new global.Error(), 1, -27];
+  var baz_null3 = function baz_null3() {};
+  baz_null3.__closure = {};
+  baz_null3.__workletHash = 9955902016844;
+  baz_null3.__initData = _worklet_9955902016844_init_data;
+  baz_null3.__stackDetails = _e;
+  return baz_null3;
+}();
+var _worklet_3271684035845_init_data = {
+  code: "function foobar_null4(){}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foobar = function () {
+  var _e = [new global.Error(), 1, -27];
+  var foobar_null4 = function foobar_null4() {};
+  foobar_null4.__closure = {};
+  foobar_null4.__workletHash = 3271684035845;
+  foobar_null4.__initData = _worklet_3271684035845_init_data;
+  foobar_null4.__stackDetails = _e;
+  return foobar_null4;
+}();
+exports.foo = foo;
+exports.bar = bar;
+exports.baz = baz;
+exports.foobar = foobar;"
 `;
 
 exports[`babel plugin for file workletization workletizes ArrowFunctionExpression 1`] = `

--- a/packages/react-native-reanimated/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/plugin.test.ts.snap
@@ -990,6 +990,26 @@ exports[`babel plugin for file workletization doesn't workletize function outsid
 }"
 `;
 
+exports[`babel plugin for file workletization moves CommonJS exports to the bottom of the file 1`] = `
+"var _worklet_15780239751281_init_data = {
+  code: "function foo_null1(){}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\"",
+  version: "x.y.z"
+};
+var foo = function () {
+  var _e = [new global.Error(), 1, -27];
+  var foo_null1 = function foo_null1() {};
+  foo_null1.__closure = {};
+  foo_null1.__workletHash = 15780239751281;
+  foo_null1.__initData = _worklet_15780239751281_init_data;
+  foo_null1.__stackDetails = _e;
+  return foo_null1;
+}();
+var bar = 1;
+exports.foo = foo;"
+`;
+
 exports[`babel plugin for file workletization workletizes ArrowFunctionExpression 1`] = `
 "var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",

--- a/packages/react-native-reanimated/__tests__/plugin.test.ts
+++ b/packages/react-native-reanimated/__tests__/plugin.test.ts
@@ -2392,7 +2392,7 @@ describe('babel plugin', () => {
       expect(code).toMatchSnapshot();
     });
 
-    it('moves CommonJS exports to the bottom of the file', () => {
+    it('moves CommonJS export to the bottom of the file', () => {
       const input = html`<script>
         'worklet';
         exports.foo = foo;
@@ -2402,6 +2402,23 @@ describe('babel plugin', () => {
 
       const { code } = runPlugin(input);
       expect(code).toContain('var bar = 1;\nexports.foo = foo;');
+      expect(code).toMatchSnapshot();
+    });
+
+    it('moves multiple CommonJS exports to the bottom of the file', () => {
+      const input = html`<script>
+        'worklet';
+        exports.foo = foo;
+        exports.bar = bar;
+        function foo() {}
+        function bar() {}
+        function baz() {}
+        exports.baz = baz;
+        exports.foobar = foobar;
+        function foobar() {}
+      </script>`;
+
+      const { code } = runPlugin(input);
       expect(code).toMatchSnapshot();
     });
   });

--- a/packages/react-native-reanimated/__tests__/plugin.test.ts
+++ b/packages/react-native-reanimated/__tests__/plugin.test.ts
@@ -2391,6 +2391,19 @@ describe('babel plugin', () => {
       expect(code).not.toHaveWorkletData();
       expect(code).toMatchSnapshot();
     });
+
+    it('moves CommonJS exports to the bottom of the file', () => {
+      const input = html`<script>
+        'worklet';
+        exports.foo = foo;
+        function foo() {}
+        const bar = 1;
+      </script>`;
+
+      const { code } = runPlugin(input);
+      expect(code).toContain('var bar = 1;\nexports.foo = foo;');
+      expect(code).toMatchSnapshot();
+    });
   });
 
   describe('for context objects', () => {

--- a/packages/react-native-reanimated/plugin/build/plugin.js
+++ b/packages/react-native-reanimated/plugin/build/plugin.js
@@ -1217,16 +1217,17 @@ var require_file = __commonJS({
     }
     function dehoistCommonJSExports(program) {
       const statements = program.body;
-      let statementsLength = statements.length;
-      for (let i = 0; i < statementsLength; i++) {
-        const statement = statements[i];
+      let end = statements.length;
+      let current = 0;
+      while (current < end) {
+        const statement = statements[current];
         if (!isCommonJSExport(statement)) {
+          current++;
           continue;
         }
-        const exportStatement = statements.splice(i, 1);
+        const exportStatement = statements.splice(current, 1);
         statements.push(...exportStatement);
-        statementsLength--;
-        i--;
+        end--;
       }
     }
     function isCommonJSExport(statement) {

--- a/packages/react-native-reanimated/plugin/build/plugin.js
+++ b/packages/react-native-reanimated/plugin/build/plugin.js
@@ -1125,6 +1125,7 @@ var require_file = __commonJS({
     exports2.processIfWorkletFile = processIfWorkletFile;
     function processWorkletFile(programPath) {
       const statements = programPath.get("body");
+      dehoistCommonJSExports(programPath.node);
       statements.forEach((statement) => {
         const candidatePath = getCandidate(statement);
         processWorkletizableEntity(candidatePath);
@@ -1213,6 +1214,23 @@ var require_file = __commonJS({
     }
     function appendWorkletClassMarker(classBody) {
       classBody.body.push((0, types_12.classProperty)((0, types_12.identifier)("__workletClass"), (0, types_12.booleanLiteral)(true)));
+    }
+    function dehoistCommonJSExports(program) {
+      const statements = program.body;
+      let statementsLength = statements.length;
+      for (let i = 0; i < statementsLength; i++) {
+        const statement = statements[i];
+        if (!isCommonJSExport(statement)) {
+          continue;
+        }
+        const exportStatement = statements.splice(i, 1);
+        statements.push(...exportStatement);
+        statementsLength--;
+        i--;
+      }
+    }
+    function isCommonJSExport(statement) {
+      return (0, types_12.isExpressionStatement)(statement) && (0, types_12.isAssignmentExpression)(statement.expression) && (0, types_12.isMemberExpression)(statement.expression.left) && (0, types_12.isIdentifier)(statement.expression.left.object) && statement.expression.left.object.name === "exports";
     }
   }
 });

--- a/packages/react-native-reanimated/plugin/src/file.ts
+++ b/packages/react-native-reanimated/plugin/src/file.ts
@@ -196,16 +196,20 @@ function appendWorkletClassMarker(classBody: ClassBody) {
 
 function dehoistCommonJSExports(program: Program) {
   const statements = program.body;
-  let statementsLength = statements.length;
-  for (let i = 0; i < statementsLength; i++) {
-    const statement = statements[i];
+  let end = statements.length;
+  let current = 0;
+
+  while (current < end) {
+    const statement = statements[current];
     if (!isCommonJSExport(statement)) {
+      current++;
       continue;
     }
-    const exportStatement = statements.splice(i, 1);
+    const exportStatement = statements.splice(current, 1);
     statements.push(...exportStatement);
-    statementsLength--;
-    i--;
+    // We just removed one element from non-processed part,
+    // so we need to decrement the end index but not the current index.
+    end--;
   }
 }
 


### PR DESCRIPTION
## Summary

Since Reanimated Babel Plugin breaks hoisting and [newer Typescript hoists CommonJS exports by default](https://github.com/microsoft/TypeScript/pull/57669) we sometimes need to dehoist those exports.

## Test plan

- [x] Add unit test suite.
- [x] Runtime tests pass.
