### PR TITLE
Bugfix - don't require render in every test

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
@@ -55,7 +55,6 @@ export class TestRunner {
   private _currentTestCase: TestCase | null = null;
   private _renderHook: (component: ReactElement<Component> | null) => void = () => {};
   private _valueRegistry: Record<string, SharedValue> = {};
-  private _wasRenderedNull: boolean = false;
   private _includesOnly: boolean = false;
   private _syncUIRunner: SyncUIRunner = new SyncUIRunner();
   private _renderLock: RenderLock = new RenderLock();

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
@@ -94,10 +94,11 @@ export class TestRunner {
   }
 
   public async render(component: ReactElement<Component> | null) {
-    if (!component && this._wasRenderedNull) {
+    if (!component && this._renderLock.wasRenderedNull()) {
       return;
     }
-    this._wasRenderedNull = !component;
+
+    this._renderLock.setRenderedNull(!component);
     this._renderLock.lock();
 
     try {

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/utils/SyncUIRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/utils/SyncUIRunner.ts
@@ -39,12 +39,22 @@ export class SyncUIRunner extends WaitForUnlock {
 }
 
 export class RenderLock extends WaitForUnlock {
+  private _wasRenderedNull: boolean = true;
+
   public lock() {
     this._setLock(true);
   }
 
   public unlock() {
     this._setLock(false);
+  }
+
+  public wasRenderedNull() {
+    return this._wasRenderedNull;
+  }
+
+  public setRenderedNull(wasRenderedNull: boolean) {
+    this._wasRenderedNull = wasRenderedNull;
   }
 
   public async waitForUnlock(maxWaitTime?: number) {


### PR DESCRIPTION
## Summary
Since the very beginning of testing framework we had the following bug - if a given test doesn't include any render then the tests freeze. After debugging I've found that we should have initiated `_wasRenderedNull` with the opposite value:

```diff
- private _wasRenderedNull: boolean = false;
+ private _wasRenderedNull: boolean = true;
```

## Test plan
