### PR TITLE
Bring back useFrameCallback cleanup

### DIFF
--- a/packages/react-native-reanimated/src/hook/useFrameCallback.ts
+++ b/packages/react-native-reanimated/src/hook/useFrameCallback.ts
@@ -43,11 +43,14 @@ export function useFrameCallback(
   useEffect(() => {
     ref.current.callbackId =
       frameCallbackRegistry.registerFrameCallback(callback);
-    const memoizedId = ref.current.callbackId;
+    const memoizedFrameCallback = ref.current;
     ref.current.setActive(ref.current.isActive);
 
     return () => {
-      frameCallbackRegistry.unregisterFrameCallback(memoizedId);
+      frameCallbackRegistry.unregisterFrameCallback(
+        memoizedFrameCallback.callbackId
+      );
+      memoizedFrameCallback.callbackId = -1;
     };
   }, [callback, autostart]);
 


### PR DESCRIPTION
## Summary

https://github.com/software-mansion/react-native-reanimated/pull/6143 was supposed to improve cleanup of `useFrameCallback` but also deleted a needed line - setting `callbackId` of callback registry to -1. Seems like some code is dependent on this value and it caused some crashes such as this one: https://github.com/software-mansion/react-native-reanimated/pull/6143. I haven't found a reliable way to reproduce the issue since we got the info from issue creator's sentry. Nonetheless, analysis of the code has shown that we need to set the `callbackId` to -1 on cleanup, otherwise we perform operations that shouldn't be done anymore (e.g there's this check: https://github.com/software-mansion/react-native-reanimated/blob/818ed78870bf41b6255abdd16b153444761101b2/packages/react-native-reanimated/src/frameCallback/FrameCallbackRegistryUI.ts#L105-L107).

## Test plan

As stated, the issue isn't really reproducible but the change doesn't risk any regression and time will tell if it fixes the problem


