### PR TITLE
docs: Add keyExtractor remark to itemLayoutAnimation documentation

### DIFF
--- a/apps/common-app/src/examples/LayoutAnimations/ListItemLayoutAnimation.tsx
+++ b/apps/common-app/src/examples/LayoutAnimations/ListItemLayoutAnimation.tsx
@@ -175,7 +175,7 @@ const styles = StyleSheet.create({
   },
   listItem: {
     padding: 20,
-    backgroundColor: '#ad8ee9',
+    backgroundColor: '#b58df1',
     shadowColor: '#000',
     shadowOpacity: 0.05,
   },
@@ -197,6 +197,6 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#b59aeb',
+    color: '#b58df1',
   },
 });

--- a/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
@@ -45,7 +45,7 @@ function App() {
 
 <Indent>
 
-```javascript
+```jsx
 function App() {
   const [transition, setTransition] = useState(LinearTransition);
 
@@ -68,6 +68,26 @@ function App() {
       renderItem={renderItem}
       // highlight-next-line
       itemLayoutAnimation={transition}
+    />
+  );
+}
+```
+
+</Indent>
+
+- If the list items contain neither a `key` nor `id` property (see [FlatList](https://reactnative.dev/docs/flatlist#keyextractor)), you must provide your own implementation of the `keyExtractor` function that returns a unique key for each element.
+
+<Indent>
+
+```jsx
+function App() {
+  return (
+    <Animated.FlatList
+      data={data}
+      renderItem={renderItem}
+      itemLayoutAnimation={LinearTransition}
+      // highlight-next-line
+      keyExtractor={customKeyExtractor}
     />
   );
 }

--- a/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
@@ -75,7 +75,7 @@ function App() {
 
 </Indent>
 
-- If the list items contain neither a `key` nor `id` property (see [FlatList](https://reactnative.dev/docs/flatlist#keyextractor)), you must provide your own implementation of the `keyExtractor` function that returns a unique key for each element.
+- If the list items contain neither a `key` nor `id` property (which are used by default by the FlatList [keyExtractor](https://reactnative.dev/docs/flatlist#keyextractor) to create list item keys), you must provide your own implementation of the `keyExtractor` function that returns a unique key for each list item.
 
 <Indent>
 


### PR DESCRIPTION
## Summary

This PR adds information about `keyExtractor` to the **Remarks** section in the documentation. 

I decided to add this remark after seeing [this](https://github.com/software-mansion/react-native-reanimated/discussions/6322) discussion in which the `itemLayoutAnimation` takes no effect.

## Screenshot with changes

<img width="968" alt="image" src="https://github.com/user-attachments/assets/fd2cbb93-5a9f-4a41-bc93-650f3920ab8a">


