### PR TITLE
docs: add info about prebuild to installation steps

### DIFF
--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -32,7 +32,7 @@ If you don't have an existing project, you can create a new Expo app using a tem
   </TabItem>
 </Tabs>
 
-Alternatively, you can dive into [our examples](https://github.com/software-mansion/react-native-reanimated/tree/3.3.0/app/src/examples) on GitHub.
+Alternatively, you can dive into [our examples](https://github.com/software-mansion/react-native-reanimated/tree/3.14.0/apps/common-app/src/examples) on GitHub.
 
 ## Installation
 
@@ -110,6 +110,14 @@ To learn more about the plugin head onto to [Reanimated babel plugin](/docs/fund
 
   </TabItem>
 </Tabs>
+
+### Expo development build
+
+When using an [Expo development build](https://docs.expo.dev/develop/development-builds/introduction/), run prebuild to update the native code in the `ios` and `android` directories.
+
+```bash
+npx expo prebuild
+```
 
 ### Platform specific setup
 


### PR DESCRIPTION
This PR adds a hint to the installation guide to rerun prebuild whenever someone is installing Reanimated in a Expo development client project.

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/d4dc8f7f-d236-4a11-812c-d45b2cdb2512">

