### PR TITLE
Unify nullable comparison

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/ReJest/RuntimeTestsApi.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/RuntimeTestsApi.ts
@@ -2,7 +2,7 @@ import type { Component, ReactElement } from 'react';
 import { TestRunner } from './TestRunner/TestRunner';
 import type { TestComponent } from './TestComponent';
 import type { SharedValue } from 'react-native-reanimated';
-import type { TestConfiguration, TestValue, NullableTestValue, BuildFunction } from './types';
+import type { TestConfiguration, TestValue, BuildFunction } from './types';
 import { DescribeDecorator, TestDecorator } from './types';
 
 export { Presets } from './Presets';
@@ -162,14 +162,6 @@ export async function waitForNotify(name: string) {
 
 export function expect(value: TestValue) {
   return testRunner.expect(value);
-}
-
-export function expectNullable(currentValue: NullableTestValue) {
-  return testRunner.expectNullable(currentValue);
-}
-
-export function expectNotNullable(currentValue: NullableTestValue) {
-  return testRunner.expectNotNullable(currentValue);
 }
 
 export function configure(config: TestConfiguration) {

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
@@ -21,7 +21,7 @@ import type {
   SharedTransitionAnimationsValues,
   LayoutAnimation,
 } from 'react-native-reanimated';
-import { Matchers, nullableMatch } from '../matchers/Matchers';
+import { Matchers } from '../matchers/Matchers';
 import { assertMockedAnimationTimestamp, assertTestCase, assertTestSuite } from './Asserts';
 import { createUpdatesContainer } from './UpdatesContainer';
 import { makeMutable, runOnJS } from 'react-native-reanimated';
@@ -324,16 +324,6 @@ export class TestRunner {
   public expect(currentValue: TestValue): Matchers {
     assertTestCase(this._currentTestCase);
     return new Matchers(currentValue, this._currentTestCase);
-  }
-
-  public expectNullable(currentValue: NullableTestValue) {
-    assertTestCase(this._currentTestCase);
-    nullableMatch(currentValue, this._currentTestCase);
-  }
-
-  public expectNotNullable(currentValue: NullableTestValue) {
-    assertTestCase(this._currentTestCase);
-    nullableMatch(currentValue, this._currentTestCase, true);
   }
 
   public beforeAll(job: () => void) {

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/TestRunner/TestRunner.ts
@@ -2,7 +2,6 @@ import type { Component, MutableRefObject, ReactElement } from 'react';
 import { useRef } from 'react';
 import type {
   BuildFunction,
-  NullableTestValue,
   Operation,
   SharedValueSnapshot,
   TestCase,

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/matchers/Matchers.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/matchers/Matchers.ts
@@ -1,5 +1,4 @@
-import { color } from '../utils/stringFormatUtils';
-import type { TestCase, TestValue, NullableTestValue } from '../types';
+import type { TestCase, TestValue } from '../types';
 import type { Matcher, MatcherArguments } from './rawMatchers';
 import {
   toBeMatcher,
@@ -7,6 +6,7 @@ import {
   toBeCalledMatcher,
   toBeCalledUIMatcher,
   toBeCalledJSMatcher,
+  toBeNullableMatcher,
 } from './rawMatchers';
 import { compareSnapshots } from './snapshotMatchers';
 import type { SingleViewSnapshot } from '../TestRunner/UpdatesContainer';
@@ -31,6 +31,7 @@ export class Matchers {
   }
 
   public toBe = this.decorateMatcher(toBeMatcher);
+  public toBeNullable = this.decorateMatcher(toBeNullableMatcher);
   public toBeWithinRange = this.decorateMatcher(toBeWithinRangeMatcher);
   public toBeCalled = this.decorateMatcher(toBeCalledMatcher);
   public toBeCalledUI = this.decorateMatcher(toBeCalledUIMatcher);
@@ -54,17 +55,5 @@ export class Matchers {
     if (mismatchError) {
       this._testCase.errors.push(mismatchError);
     }
-  }
-}
-
-export function nullableMatch(currentValue: NullableTestValue, testCase: TestCase, negation: boolean = false) {
-  const pass = currentValue === null || currentValue === undefined;
-
-  const coloredExpected = color('nullable', 'green');
-  const coloredReceived = color(currentValue, 'red');
-  const message = `Expected${negation ? ' NOT' : ''} ${coloredExpected} received ${coloredReceived}`;
-
-  if ((!pass && !negation) || (pass && negation)) {
-    testCase.errors.push(message);
   }
 }

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/matchers/rawMatchers.ts
@@ -4,10 +4,11 @@ import { ComparisonMode } from '../types';
 import { getComparator } from './Comparators';
 
 type ToBeArgs = [TestValue, ComparisonMode?];
+type ToBeNullArgs = [];
 type ToBeWithinRangeArgs = [number, number];
 type ToBeCalledArgs = [number];
 
-export type MatcherArguments = ToBeArgs | ToBeCalledArgs | ToBeWithinRangeArgs;
+export type MatcherArguments = ToBeArgs | ToBeNullArgs | ToBeCalledArgs | ToBeWithinRangeArgs;
 
 export type Matcher<Args extends MatcherArguments> = (
   currentValue: TestValue,
@@ -39,6 +40,16 @@ export const toBeMatcher: Matcher<ToBeArgs> = (currentValue, negation, expectedV
   };
 };
 
+export const toBeNullableMatcher: Matcher<ToBeNullArgs> = (currentValue, negation) => {
+  const coloredExpected = green('nullable');
+  const coloredReceived = red(currentValue);
+
+  return {
+    pass: currentValue === null || currentValue === undefined,
+    message: `Expected${negation ? ' NOT' : ''} ${coloredExpected} received ${coloredReceived}`,
+  };
+};
+
 export const toBeWithinRangeMatcher: Matcher<ToBeWithinRangeArgs> = (
   currentValue,
   negation,
@@ -51,7 +62,7 @@ export const toBeWithinRangeMatcher: Matcher<ToBeWithinRangeArgs> = (
 
   return {
     pass: isWithinRange && validInputTypes,
-    message: `Expected the value ${negation ? ' NOT' : ''}to be in range ${green(
+    message: `Expected the value${negation ? ' NOT' : ''} to be in range ${green(
       `[${minimumValue}, ${maximumValue}]`,
     )} received ${red(currentValue)}`,
   };

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/types.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/types.ts
@@ -103,12 +103,10 @@ export type TestValue =
   | number
   | bigint
   | Record<string, unknown>
+  | boolean
   | null
   | undefined
-  | boolean
   | OperationUpdate;
-
-export type NullableTestValue = TestValue | null | undefined;
 
 export type TestConfiguration = {
   render: Dispatch<SetStateAction<ReactNode | null>>;

--- a/apps/common-app/src/examples/RuntimeTests/ReJest/utils/stringFormatUtils.ts
+++ b/apps/common-app/src/examples/RuntimeTests/ReJest/utils/stringFormatUtils.ts
@@ -1,10 +1,10 @@
-import type { Mismatch, NullableTestValue } from '../types';
+import type { Mismatch, TestValue } from '../types';
 
 export function indentNestingLevel(nestingLevel: number) {
   return `  ${'   '.repeat(nestingLevel)}`;
 }
 
-function valueToPrettyString(message: NullableTestValue): string {
+function valueToPrettyString(message: TestValue): string {
   if (message === undefined) {
     return 'undefined';
   } else if (message === null) {
@@ -25,7 +25,7 @@ function valueToPrettyString(message: NullableTestValue): string {
   }
 }
 
-function adjustValueToLength(value: NullableTestValue, length: number) {
+function adjustValueToLength(value: TestValue, length: number) {
   const valueStr = valueToPrettyString(value);
 
   const messageLen = valueStr.length;
@@ -37,10 +37,7 @@ function adjustValueToLength(value: NullableTestValue, length: number) {
   }
 }
 
-export function color(
-  value: NullableTestValue,
-  color: 'cyan' | 'gray' | 'green' | 'yellow' | 'red' | 'lightGray' | 'orange',
-) {
+export function color(value: TestValue, color: 'cyan' | 'gray' | 'green' | 'yellow' | 'red' | 'lightGray' | 'orange') {
   const COLOR_CODES = {
     cyan: '\x1b[36m',
     gray: '\x1b[38;5;242m',
@@ -55,22 +52,22 @@ export function color(
   return `${COLOR_CODES[color]}${stringValue}${COLOR_CODES.reset}`;
 }
 
-export function cyan(x: NullableTestValue) {
+export function cyan(x: TestValue) {
   return color(x, 'cyan');
 }
-export function gray(x: NullableTestValue) {
+export function gray(x: TestValue) {
   return color(x, 'gray');
 }
-export function green(x: NullableTestValue) {
+export function green(x: TestValue) {
   return color(x, 'green');
 }
-export function yellow(x: NullableTestValue) {
+export function yellow(x: TestValue) {
   return color(x, 'yellow');
 }
-export function red(x: NullableTestValue) {
+export function red(x: TestValue) {
   return color(x, 'red');
 }
-export function orange(x: NullableTestValue) {
+export function orange(x: TestValue) {
   return color(x, 'orange');
 }
 

--- a/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/TestsOfTestingFramework.test.tsx
@@ -152,6 +152,33 @@ function WarningComponent() {
 }
 
 describe('Tests of Test Framework', () => {
+  test('Test  comparators', () => {
+    expect(1).toBe(1.0);
+    expect(2).not.toBe(1.0);
+
+    expect(1).not.toBe('1');
+    expect('1').toBe(1);
+
+    expect('cornflowerblue').not.toBe('#6495edff');
+    expect('cornflowerblue').toBe('#6495edff', ComparisonMode.COLOR);
+
+    expect({ backgroundColor: 'cornflowerblue' }).toBe({ backgroundColor: '#6495edff' });
+    expect({ width: 'cornflowerblue' }).not.toBe({ width: '#6495edff' });
+
+    expect(2).toBeWithinRange(1, 3);
+    expect(2).toBeWithinRange(1.99999999, 2.0000001);
+    expect(2).toBeWithinRange(2, 2);
+
+    expect(null).toBeNullable();
+    expect(undefined).toBeNullable();
+    expect([]).not.toBeNullable();
+    expect(0).not.toBeNullable();
+  });
+  test('Test comparators - expect error', () => {
+    expect(0).toBeNullable();
+    expect(2).not.toBeWithinRange(1.99999999, 2.0000001);
+  });
+
   test('withTiming - expect error', async () => {
     await render(<AnimatedComponent />);
     const component = getTestComponent('BrownComponent');

--- a/apps/common-app/src/examples/RuntimeTests/tests/utilities/relativeCoords.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/utilities/relativeCoords.test.tsx
@@ -3,16 +3,7 @@ import type { FlexStyle, ViewStyle } from 'react-native';
 import { StyleSheet } from 'react-native';
 import type { ComponentCoords } from 'react-native-reanimated';
 import Animated, { runOnUI, measure, getRelativeCoords, useAnimatedRef, useSharedValue } from 'react-native-reanimated';
-import {
-  describe,
-  test,
-  expect,
-  expectNotNullable,
-  render,
-  wait,
-  registerValue,
-  getRegisteredValue,
-} from '../../ReJest/RuntimeTestsApi';
+import { describe, test, expect, render, wait, registerValue, getRegisteredValue } from '../../ReJest/RuntimeTestsApi';
 
 const REGISTERED_VALUE_KEY = 'sv';
 
@@ -68,7 +59,7 @@ describe('getRelativeCoords', () => {
       await render(<CoordsComponent justifyContent={justifyContent} alignItems={alignItems} />);
       await wait(300);
       const coords = (await getRegisteredValue(REGISTERED_VALUE_KEY)).onUI;
-      expectNotNullable(coords);
+      expect(coords).not.toBeNullable();
       if (coords) {
         expect(Math.floor((coords as unknown as ComponentCoords).x)).toBe(expectedValueX);
         expect(Math.floor((coords as unknown as ComponentCoords).y)).toBe(expectedValueY);


### PR DESCRIPTION
## Summary
Change the way to verify that a certain value is nullable to match the existing API.
Actually jest exposes two separate functions:
* `expect(x).toBeNull()`
* `expect(x).toBeUndefined()`

So I had some doubts about having `expect(x).toBeNullable()` instead, but I've decided to keep the existing version.

## Test plan
