### PR TITLE
docs: fix broken link in reanimated babel plugin docs

### DIFF
--- a/packages/docs-reanimated/docs/reanimated-babel-plugin/options.md
+++ b/packages/docs-reanimated/docs/reanimated-babel-plugin/options.md
@@ -186,7 +186,7 @@ JS THREAD
 
 This output occurs because the entire `global` object (!) would be copied to the UI thread for it to be assigned by `setOnUI`. Then, `readOnUI` would again copy the `global` object and read from this copy.
 
-There is a [huge list of identifiers whitelisted by default](https://github.com/software-mansion/react-native-reanimated/blob/main/plugin/src/globals.ts).
+There is a [huge list of identifiers whitelisted by default](https://github.com/software-mansion/react-native-reanimated/blob/3.14.0/packages/react-native-reanimated/plugin/src/globals.ts).
 
 ### substituteWebPlatformChecks
 


### PR DESCRIPTION
After the change to monorepo link leads to 404