### PR TITLE
dosc: Rewrite useEvent page

### DIFF
--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -82,24 +82,12 @@ The hook returns event handler that will be invoked when native event is dispatc
 
 ## Example
 
-```js
-function useAnimatedPagerScrollHandler(handlers, dependencies) {
-  const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
+import useEvent from '@site/src/examples/useHandlerEventExample';
+import useEventSrc from '!!raw-loader!@site/src/examples/useHandlerEventExample';
 
-  return useEvent(
-    (event) => {
-      'worklet';
-      const { onPageScroll } = handlers;
+<InteractiveExample src={useEventSrc} component={useEvent} />
 
-      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
-        onPageScroll(event, context);
-      }
-    },
-    ['onPageScroll'],
-    doDependenciesDiffer
-  );
-}
-```
+This example can be more easily implemented using [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset/).
 
 ## Remarks
 

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -112,12 +112,16 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
 }
 ```
 
+## Remarks
+
+- Keep in mind that not all scroll events are supported on the web, only `onScroll` is available across browsers.
+
 ## Platform compatibility
 
 <div className="platform-compatibility">
 
 | Android | iOS | Web |
 | ------- | --- | --- |
-| ✅      | ✅  | ❌  |
+| ✅      | ✅  | ✅  |
 
 </div>

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -9,37 +9,28 @@ sidebar_position: 4
 ## Reference
 
 ```js
-function useEventExample() {
-  const dependencies = [{ isWeb: false }];
-  const handlers = {
-    onScroll: (event) => {
-      'worklet';
-      console.log(event);
-    },
-  };
+import { useEvent } from 'react-native-reanimated';
 
-  const { context, doDependenciesDiffer, useWeb } = useHandler(
-    handlers,
-    dependencies
-  );
+function useAnimatedPagerScrollHandler(handlers, dependencies) {
+  const { context, doDependenciesDiffer } = useHandler(handlers, dependencies);
 
   // highlight-start
-  const customScrollHandler = useEvent(
+  return useEvent(
     (event) => {
       'worklet';
-      const { onScroll } = handlers;
-      if (onScroll && event.eventName.endsWith('onScroll')) {
-        context.eventName = event.eventName + useWeb;
-        onScroll(event);
+      const { onPageScroll } = handlers;
+
+      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
+        onPageScroll(event, context);
       }
     },
-    ['onScroll'],
+    ['onPageScroll'],
     doDependenciesDiffer
   );
-  // highlight-end
-
-  return <Animated.ScrollView onScroll={customScrollHandler} />;
 }
+// highlight-end
+
+return <Animated.View onScroll={useAnimatedPagerScrollHandler} />;
 ```
 
 <details>

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # useEvent
 
-`useEvent` is a low-level hook. It returns event handler that will be called when native event occurs. You can use it to create custom event handler hooks, like `useAnimatedGestureHandler` or `useAnimatedScrollHandler`.
+`useEvent` is a low-level hook. It returns event handler that will be called when native event occurs. You can use it to create custom event handler hooks, like [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset/) or [`useAnimatedScrollHandler`](/docs/scroll/useAnimatedScrollHandler/).
 
 ## Reference
 
@@ -77,13 +77,11 @@ Function that receives event object with native payload, that can be passed to c
 - `event` - event object.
   The payload can differ depending on the type of the event.
 
-- `context` <Optional /> - JS object that was used to store some state.
-
 #### `eventNames` <Optional/>
 
 Array of event names that will be handled by handler.
 
-#### `rebuilt` <Optional/>
+#### `rebuild` <Optional/>
 
 Value indicating whether handler should be rebuilt.
 

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -4,26 +4,84 @@ sidebar_position: 4
 
 # useEvent
 
-import DocsCompatibilityInfo from '../_shared/_docs_compatibility_info.mdx';
-
-<DocsCompatibilityInfo />
-
 This is low-level hook returning event handler that will be invoked with native events, which should be used in order to create custom event handler hook like `useAnimatedGestureHandler` or `useAnimatedScrollHandler`.
+
+## Reference
+
+```js
+function useEventExample() {
+  const dependencies = [{ isWeb: false }];
+  const handlers = {
+    onScroll: (event) => {
+      'worklet';
+      console.log(event);
+    },
+  };
+
+  const { context, doDependenciesDiffer, useWeb } = useHandler(
+    handlers,
+    dependencies
+  );
+
+  // highlight-start
+  const customScrollHandler = useEvent(
+    (event) => {
+      'worklet';
+      const { onScroll } = handlers;
+      if (onScroll && event.eventName.endsWith('onScroll')) {
+        context.eventName = event.eventName + useWeb;
+        onScroll(event);
+      }
+    },
+    ['onScroll'],
+    doDependenciesDiffer
+  );
+  // highlight-end
+
+  return <Animated.ScrollView onScroll={customScrollHandler} />;
+}
+```
+
+<details>
+<summary>Type definitions</summary>
+
+```typescript
+function useEvent<
+  Event extends object,
+  Context extends Record<string, unknown> = never
+>(
+  handler: EventHandler<Event, Context>,
+  eventNames?: string[],
+  rebuild?: boolean
+): EventHandlerProcessed<Event, Context>;
+
+type EventHandler<
+  Event extends object,
+  Context extends Record<string, unknown> = never
+> = (event: ReanimatedEvent<Event>, context?: Context) => void;
+
+type EventHandlerProcessed<
+  Event extends object,
+  Context extends Record<string, unknown> = never
+> = (event: Event, context?: Context) => void;
+```
+
+</details>
 
 ### Arguments
 
-#### `handler` [function]
+#### `handler`
 
 Handler will receive event object with native payload, that can be passed to custom handler hook's worklets.
 
-- `event` [object] - event object.
+- `event` - event object.
   The payload can differ depending on the type of the event.
 
-#### `eventNames` [Array]
+#### `eventNames` <Optional/>
 
 Array of event names that will be handled by handler.
 
-#### `rebuilt` [boolean]
+#### `rebuilt` <Optional/>
 
 Value indicating whether handler should be rebuilt.
 
@@ -47,6 +105,17 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
       }
     },
     ['onPageScroll'],
-    doDependenciesDiffer,
+    doDependenciesDiffer
   );
+}
 ```
+
+## Platform compatibility
+
+<div className="platform-compatibility">
+
+| Android | iOS | Web |
+| ------- | --- | --- |
+| ✅      | ✅  | ✅  |
+
+</div>

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -82,8 +82,8 @@ The hook returns event handler that will be invoked when native event is dispatc
 
 ## Example
 
-import useEvent from '@site/src/examples/useHandlerEventExample';
-import useEventSrc from '!!raw-loader!@site/src/examples/useHandlerEventExample';
+import useEvent from '@site/src/examples/UseHandlerEventExample';
+import useEventSrc from '!!raw-loader!@site/src/examples/UseHandlerEventExample';
 
 <InteractiveExample src={useEventSrc} component={useEvent} />
 

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # useEvent
 
-This is low-level hook returning event handler that will be invoked with native events, which should be used in order to create custom event handler hook like `useAnimatedGestureHandler` or `useAnimatedScrollHandler`.
+`useEvent` is a low-level hook. It returns event handler that will be called when native event occurs. You can use it to create custom event handler hooks, like `useAnimatedGestureHandler` or `useAnimatedScrollHandler`.
 
 ## Reference
 
@@ -72,10 +72,12 @@ type EventHandlerProcessed<
 
 #### `handler`
 
-Handler will receive event object with native payload, that can be passed to custom handler hook's worklets.
+Function that receives event object with native payload, that can be passed to custom handler hook's worklets.
 
 - `event` - event object.
   The payload can differ depending on the type of the event.
+
+- `context` <Optional /> - JS object that was used to store some state.
 
 #### `eventNames` <Optional/>
 
@@ -116,6 +118,6 @@ function useAnimatedPagerScrollHandler(handlers, dependencies) {
 
 | Android | iOS | Web |
 | ------- | --- | --- |
-| ✅      | ✅  | ✅  |
+| ✅      | ✅  | ❌  |
 
 </div>

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -95,9 +95,9 @@ const styles = StyleSheet.create({
     marginHorizontal: 20,
   },
   lightText: {
-    color: 'var(--swm-off-white) !important',
+    color: '#001a72',
   },
   darkText: {
-    color: 'var(--swm-navy-light-100)',
+    color: '#f8f9ff',
   },
 });

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Animated, {
   useHandler,
   useEvent,
@@ -6,11 +6,13 @@ import Animated, {
   useAnimatedProps,
   type ScrollEvent,
 } from 'react-native-reanimated';
+import { useColorScheme } from '@mui/material';
 import { TextInput, SafeAreaView, View, StyleSheet } from 'react-native';
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 function UseHandlerExample() {
+  const { colorScheme } = useColorScheme();
   const offsetY = useSharedValue(0);
 
   const handlers = {
@@ -43,6 +45,9 @@ function UseHandlerExample() {
 
   const BRAND_COLORS = ['#fa7f7c', '#b58df1', '#ffe780', '#82cab2', '#87cce8'];
 
+  const textColor =
+    colorScheme === 'light' ? styles.darkText : styles.lightText;
+
   const content = BRAND_COLORS.map((color, index) => (
     <View
       key={index}
@@ -60,7 +65,7 @@ function UseHandlerExample() {
       <AnimatedTextInput
         animatedProps={animatedProps}
         editable={false}
-        style={styles.header}
+        style={[styles.header, textColor]}
       />
       <Animated.ScrollView onScroll={scrollHandler}>
         <View style={styles.container}>{content}</View>
@@ -77,12 +82,10 @@ const styles = StyleSheet.create({
     height: 350,
   },
   header: {
-    backgroundColor: '#f8f9ff',
     paddingVertical: 16,
     paddingHorizontal: 32,
     textAlign: 'center',
     fontFamily: 'Aeonik',
-    color: '#001a72',
     marginTop: '-1px',
   },
   section: {
@@ -90,5 +93,11 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     marginVertical: 10,
     marginHorizontal: 20,
+  },
+  lightText: {
+    color: 'var(--swm-off-white) !important',
+  },
+  darkText: {
+    color: 'var(--swm-navy-light-100)',
   },
 });


### PR DESCRIPTION
To be up to date we rewritten [useEvent](https://docs.swmansion.com/react-native-reanimated/docs/advanced/useEvent/).