### PR TITLE
fix: proper types for userAgent and vendor

### DIFF
--- a/packages/react-native-reanimated/src/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/js-reanimated/JSReanimated.ts
@@ -311,7 +311,7 @@ enum Platform {
 
 declare global {
   interface Navigator {
-    userAgent?: string;
-    vendor?: string;
+    userAgent: string;
+    vendor: string;
   }
 }


### PR DESCRIPTION
## Summary

PR restoring proper types for `Navigator`.

When this code would be removed, VSCode takes me to definitions from TS, which show it the same way: 
![image](https://github.com/user-attachments/assets/c0a480d6-af3e-4ffb-831c-47f04060cb7c)


## Test plan
