### PR TITLE
feat: Implement reanimated logger with stack trace customization

### DIFF
--- a/apps/common-app/src/examples/EmptyExample.tsx
+++ b/apps/common-app/src/examples/EmptyExample.tsx
@@ -1,8 +1,136 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { Text, StyleSheet, View } from 'react-native';
 
 import React from 'react';
+import type { ExtrapolationType } from 'react-native-reanimated';
+import Animated, {
+  getViewProp,
+  interpolate,
+  interpolateColor,
+  measure,
+  runOnUI,
+  useAnimatedReaction,
+  useAnimatedRef,
+  withSequence,
+} from 'react-native-reanimated';
+
+const EXAMPLE_NUMBER: number = 8;
+
+if (EXAMPLE_NUMBER === 4) {
+  /*
+  4.
+  Error: [Reanimated] Property `text` was whitelisted both as UI and native prop. Please remove it from one of the lists.
+  */
+  Animated.addWhitelistedNativeProps({ text: true });
+  Animated.addWhitelistedUIProps({ text: true });
+}
 
 export default function EmptyExample() {
+  if (EXAMPLE_NUMBER === 1) {
+    /* 
+    1.
+    [Reanimated] Tried to modify key `value` of an object which has been already passed to a worklet. See
+    https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#tried-to-modify-key-of-an-object-which-has-been-converted-to-a-shareable
+    for more details.
+   */
+    const a = { value: 1 };
+    runOnUI(() => {
+      console.log(a);
+    })();
+    a.value = 2;
+  }
+
+  if (EXAMPLE_NUMBER === 2) {
+    /* 
+    2.
+    [Reanimated] No animation was provided for the sequence
+   */
+    // withSequence();
+
+    // runOnUI(() => {
+    //   withSequence();
+    // });
+
+    useAnimatedReaction(
+      () => null,
+      () => {
+        withSequence();
+      }
+    );
+  }
+
+  if (EXAMPLE_NUMBER === 3) {
+    /*
+    3.
+    [Reanimated] The view with tag -1 is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).
+    */
+    const aref = useAnimatedRef();
+
+    runOnUI(() => {
+      measure(aref);
+    })();
+  }
+
+  if (EXAMPLE_NUMBER === 5) {
+    /*
+    5.
+    ReanimatedError: [Reanimated] Unsupported value for "interpolate"
+    Supported values: ["extend", "clamp", "identity", Extrapolatation.CLAMP, Extrapolatation.EXTEND, Extrapolatation.IDENTITY]
+    Valid example:
+            interpolate(value, [inputRange], [outputRange], "clamp"), js engine: reanimated
+    */
+    useAnimatedReaction(
+      () => null,
+      () => {
+        interpolate(
+          0,
+          [0, 1],
+          [0, 1],
+          'Invalid interpolation' as ExtrapolationType
+        );
+      }
+    );
+  }
+
+  if (EXAMPLE_NUMBER === 6) {
+    /*
+    6.
+    ReanimatedError: [Reanimated] Interpolation input and output ranges should contain at least two values., js engine: reanimated
+    */
+    useAnimatedReaction(
+      () => null,
+      () => {
+        interpolate(0, [0], [0, 1]);
+      }
+    );
+  }
+
+  if (EXAMPLE_NUMBER === 7) {
+    /*
+    7.
+    ReanimatedError: [Reanimated] Invalid color space provided: Invalid color space. Supported values are: ['RGB', 'HSV']., js engine: reanimated
+    */
+    useAnimatedReaction(
+      () => null,
+      () => {
+        interpolateColor(
+          0,
+          [0, 1],
+          ['red', 'blue'],
+          'Invalid color space' as 'RGB'
+        );
+      }
+    );
+  }
+
+  if (EXAMPLE_NUMBER === 8) {
+    /*
+    8.
+    ReanimatedError: 
+    */
+    getViewProp(0, 'opacity').catch(() => null);
+  }
+
   return (
     <View style={styles.container}>
       <Text>Hello world!</Text>

--- a/packages/react-native-reanimated/src/Bezier.ts
+++ b/packages/react-native-reanimated/src/Bezier.ts
@@ -1,4 +1,7 @@
 'use strict';
+
+import { logger } from './logger';
+
 /**
  * https://github.com/gre/bezier-easing
  * BezierEasing - use bezier curve for transition easing function
@@ -98,7 +101,7 @@ export function Bezier(
   }
 
   if (!(mX1 >= 0 && mX1 <= 1 && mX2 >= 0 && mX2 <= 1)) {
-    throw new Error('[Reanimated] Bezier x values must be in [0, 1] range.');
+    throw logger.createError('Bezier x values must be in [0, 1] range.');
   }
 
   if (mX1 === mY1 && mX2 === mY2) {

--- a/packages/react-native-reanimated/src/ConfigHelper.ts
+++ b/packages/react-native-reanimated/src/ConfigHelper.ts
@@ -1,11 +1,16 @@
 'use strict';
 import { PropsAllowlists } from './propsAllowlists';
 import { jsiConfigureProps } from './core';
+import { logger } from './logger';
+
 function assertNoOverlapInLists() {
   for (const key in PropsAllowlists.NATIVE_THREAD_PROPS_WHITELIST) {
     if (key in PropsAllowlists.UI_THREAD_PROPS_WHITELIST) {
-      throw new Error(
-        `[Reanimated] Property \`${key}\` was whitelisted both as UI and native prop. Please remove it from one of the lists.`
+      throw logger.createError(
+        `Property \`${key}\` was whitelisted both as UI and native prop. Please remove it from one of the lists.`,
+        {
+          trimStack: 'addWhitelistedUIProps|addWhitelistedNativeProps',
+        }
       );
     }
   }

--- a/packages/react-native-reanimated/src/NativeReanimated/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/NativeReanimated/NativeReanimated.ts
@@ -14,6 +14,7 @@ import type React from 'react';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import type { LayoutAnimationBatchItem } from '../layoutReanimation/animationBuilder/commonTypes';
 import ReanimatedModule from '../specs/NativeReanimatedModule';
+import { logger } from '../logger';
 
 // this is the type of `__reanimatedModuleProxy` which is injected using JSI
 export interface NativeReanimatedModule {
@@ -68,8 +69,8 @@ function assertSingleReanimatedInstance() {
     global._REANIMATED_VERSION_JS !== undefined &&
     global._REANIMATED_VERSION_JS !== jsVersion
   ) {
-    throw new Error(
-      `[Reanimated] Another instance of Reanimated was detected.
+    throw logger.createError(
+      `Another instance of Reanimated was detected.
 See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#another-instance-of-reanimated-was-detected\` for more details. Previous: ${global._REANIMATED_VERSION_JS}, current: ${jsVersion}.`
     );
   }
@@ -89,8 +90,8 @@ export class NativeReanimated {
       ReanimatedModule?.installTurboModule(valueUnpackerCode);
     }
     if (global.__reanimatedModuleProxy === undefined) {
-      throw new Error(
-        `[Reanimated] Native part of Reanimated doesn't seem to be initialized.
+      throw logger.createError(
+        `Native part of Reanimated doesn't seem to be initialized.
 See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#native-part-of-reanimated-doesnt-seem-to-be-initialized for more details.`
       );
     }

--- a/packages/react-native-reanimated/src/PropsRegistry.ts
+++ b/packages/react-native-reanimated/src/PropsRegistry.ts
@@ -1,4 +1,5 @@
 'use strict';
+import { logger } from './logger';
 import { isFabric } from './PlatformChecker';
 import { runOnUI } from './threads';
 
@@ -13,7 +14,7 @@ export function removeFromPropsRegistry(viewTag: number) {
 
 function flush() {
   if (__DEV__ && !isFabric()) {
-    throw new Error('[Reanimated] PropsRegistry is only available on Fabric.');
+    throw logger.createError('PropsRegistry is only available on Fabric.');
   }
   runOnUI(removeFromPropsRegistryOnUI)(VIEW_TAGS);
   VIEW_TAGS = [];

--- a/packages/react-native-reanimated/src/UpdateProps.ts
+++ b/packages/react-native-reanimated/src/UpdateProps.ts
@@ -13,6 +13,7 @@ import type { ReanimatedHTMLElement } from './js-reanimated';
 import { _updatePropsJS } from './js-reanimated';
 import { isFabric, isJest, shouldBeUseWeb } from './PlatformChecker';
 import { runOnUIImmediately } from './threads';
+import { logger } from './logger';
 
 let updateProps: (
   viewDescriptor: SharedValue<Descriptor[]>,
@@ -120,8 +121,8 @@ if (shouldBeUseWeb()) {
     // Jest attempts to access a property of this object to check if it is a Jest mock
     // so we can't throw an error in the getter.
     if (!isJest()) {
-      throw new Error(
-        '[Reanimated] `UpdatePropsManager` is not available on non-native platform.'
+      throw logger.createError(
+        '`UpdatePropsManager` is not available on non-native platform.'
       );
     }
   };

--- a/packages/react-native-reanimated/src/animation/clamp.ts
+++ b/packages/react-native-reanimated/src/animation/clamp.ts
@@ -12,6 +12,7 @@ import type {
   ReduceMotion,
 } from '../commonTypes';
 import type { ClampAnimation } from './commonTypes';
+import { logger } from '../logger';
 
 type withClampType = <T extends number | string>(
   config: {
@@ -52,8 +53,8 @@ export const withClamp = function <T extends number | string>(
         const finished = animationToClamp.onFrame(animationToClamp, now);
 
         if (animationToClamp.current === undefined) {
-          console.warn(
-            "[Reanimated] Error inside 'withClamp' animation, the inner animation has invalid current value"
+          logger.warn(
+            "Error inside 'withClamp' animation, the inner animation has invalid current value"
           );
           return true;
         } else {
@@ -96,8 +97,8 @@ export const withClamp = function <T extends number | string>(
           config.min !== undefined &&
           config.max < config.min
         ) {
-          console.warn(
-            '[Reanimated] Wrong config was provided to withClamp. Min value is bigger than max'
+          logger.warn(
+            'Wrong config was provided to withClamp. Min value is bigger than max'
           );
         }
 

--- a/packages/react-native-reanimated/src/animation/decay/decay.ts
+++ b/packages/react-native-reanimated/src/animation/decay/decay.ts
@@ -14,6 +14,7 @@ import type {
   InnerDecayAnimation,
 } from './utils';
 import { rigidDecay } from './rigidDecay';
+import { logger } from '../../logger';
 
 export type WithDecayConfig = DecayConfig;
 
@@ -27,26 +28,26 @@ function validateConfig(config: DefaultDecayConfig): void {
   'worklet';
   if (config.clamp) {
     if (!Array.isArray(config.clamp)) {
-      throw new Error(
-        `[Reanimated] \`config.clamp\` must be an array but is ${typeof config.clamp}.`
+      throw logger.createError(
+        `\`config.clamp\` must be an array but is ${typeof config.clamp}.`
       );
     }
     if (config.clamp.length !== 2) {
-      throw new Error(
-        `[Reanimated] \`clamp array\` must contain 2 items but is given ${
+      throw logger.createError(
+        `\`clamp array\` must contain 2 items but is given ${
           config.clamp.length as number
         }.`
       );
     }
   }
   if (config.velocityFactor <= 0) {
-    throw new Error(
-      `[Reanimated] \`config.velocityFactor\` must be greather then 0 but is ${config.velocityFactor}.`
+    throw logger.createError(
+      `\`config.velocityFactor\` must be greather then 0 but is ${config.velocityFactor}.`
     );
   }
   if (config.rubberBandEffect && !config.clamp) {
-    throw new Error(
-      '[Reanimated] You need to set `clamp` property when using `rubberBandEffect`.'
+    throw logger.createError(
+      'You need to set `clamp` property when using `rubberBandEffect`.'
     );
   }
 }

--- a/packages/react-native-reanimated/src/animation/sequence.ts
+++ b/packages/react-native-reanimated/src/animation/sequence.ts
@@ -8,6 +8,7 @@ import type {
   ReduceMotion,
   Timestamp,
 } from '../commonTypes';
+import { logger } from '../logger';
 
 /**
  * Lets you run animations in a sequence.
@@ -44,7 +45,9 @@ export function withSequence(
   }
 
   if (_animations.length === 0) {
-    console.warn('[Reanimated] No animation was provided for the sequence');
+    logger.warn('No animation was provided for the sequence', {
+      trimStack: 'withSequence',
+    });
 
     return defineAnimation<SequenceAnimation>(0, () => {
       'worklet';

--- a/packages/react-native-reanimated/src/animation/springUtils.ts
+++ b/packages/react-native-reanimated/src/animation/springUtils.ts
@@ -5,6 +5,7 @@ import type {
   Timestamp,
   ReduceMotion,
 } from '../commonTypes';
+import { logger } from '../logger';
 
 /**
  * Spring animation configuration.
@@ -108,7 +109,7 @@ export function checkIfConfigIsValid(config: DefaultSpringConfig): boolean {
   }
 
   if (errorMessage !== '') {
-    console.warn('[Reanimated] Invalid spring config' + errorMessage);
+    logger.warn('Invalid spring config' + errorMessage);
   }
 
   return errorMessage === '';

--- a/packages/react-native-reanimated/src/animation/styleAnimation.ts
+++ b/packages/react-native-reanimated/src/animation/styleAnimation.ts
@@ -12,6 +12,7 @@ import type {
 import type { StyleLayoutAnimation } from './commonTypes';
 import { withTiming } from './timing';
 import { ColorProperties, processColor } from '../Colors';
+import { logger } from '../logger';
 
 // resolves path to value for nested objects
 // if path cannot be resolved returns undefined
@@ -185,7 +186,7 @@ export function withStyleAnimation(
             prevVal = (prevAnimation as any).current;
           }
           if (prevVal === undefined) {
-            console.warn(
+            logger.warn(
               `Initial values for animation are missing for property ${currentEntry.path.join(
                 '.'
               )}`

--- a/packages/react-native-reanimated/src/animation/transformationMatrix/matrixUtils.tsx
+++ b/packages/react-native-reanimated/src/animation/transformationMatrix/matrixUtils.tsx
@@ -1,4 +1,7 @@
 'use strict';
+
+import { logger } from '../../logger';
+
 type FixedLengthArray<
   T,
   L extends number,
@@ -255,8 +258,8 @@ function transposeMatrix(matrix: AffineMatrix): AffineMatrix {
 function assertVectorsHaveEqualLengths(a: number[], b: number[]) {
   'worklet';
   if (__DEV__ && a.length !== b.length) {
-    throw new Error(
-      `[Reanimated] Cannot calculate inner product of two vectors of different lengths. Length of ${a.toString()} is ${
+    throw logger.createError(
+      `Cannot calculate inner product of two vectors of different lengths. Length of ${a.toString()} is ${
         a.length
       } and length of ${b.toString()} is ${b.length}.`
     );
@@ -348,7 +351,7 @@ export function decomposeMatrix(
 
   // normalize matrix
   if (matrix[15] === 0) {
-    throw new Error('[Reanimated] Invalid transform matrix.');
+    throw logger.createError('Invalid transform matrix.');
   }
   matrix.forEach((_, i) => (matrix[i] /= matrix[15]));
 

--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -36,13 +36,14 @@ import {
 import { shouldBeUseWeb } from '../PlatformChecker';
 import type { EasingFunctionFactory } from '../Easing';
 import { ReducedMotionManager } from '../ReducedMotion';
+import { logger } from '../logger';
 
 let IN_STYLE_UPDATER = false;
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
 if (__DEV__ && ReducedMotionManager.jsValue) {
-  console.warn(
-    `[Reanimated] Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#reduced-motion-setting-is-enabled-on-this-device.`
+  logger.warn(
+    `Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#reduced-motion-setting-is-enabled-on-this-device.`
   );
 }
 
@@ -65,8 +66,8 @@ export function assertEasingIsWorklet(
   }
 
   if (!isWorkletFunction(easing)) {
-    throw new Error(
-      '[Reanimated] The easing function is not a worklet. Please make sure you import `Easing` from react-native-reanimated.'
+    throw logger.createError(
+      'The easing function is not a worklet. Please make sure you import `Easing` from react-native-reanimated.'
     );
   }
 }
@@ -93,7 +94,7 @@ export function recognizePrefixSuffix(
       /([A-Za-z]*)(-?\d*\.?\d*)([eE][-+]?[0-9]+)?([A-Za-z%]*)/
     );
     if (!match) {
-      throw new Error("[Reanimated] Couldn't parse animation value.");
+      throw logger.createError("Couldn't parse animation value.");
     }
     const prefix = match[1];
     const suffix = match[4];

--- a/packages/react-native-reanimated/src/animationBuilder.tsx
+++ b/packages/react-native-reanimated/src/animationBuilder.tsx
@@ -6,6 +6,7 @@ import type {
 } from './layoutReanimation';
 import type { StyleProps } from './commonTypes';
 import type { NestedArray } from './createAnimatedComponent/commonTypes';
+import { logger } from './logger';
 
 const mockTargetValues: LayoutAnimationsValues = {
   targetOriginX: 0,
@@ -61,8 +62,8 @@ function maybeReportOverwrittenProperties(
   const commonProperties = getCommonProperties(layoutAnimationStyle, style);
 
   if (commonProperties.length > 0) {
-    console.warn(
-      `[Reanimated] ${
+    logger.warn(
+      `${
         commonProperties.length === 1 ? 'Property' : 'Properties'
       } "${commonProperties.join(
         ', '

--- a/packages/react-native-reanimated/src/component/ReducedMotionConfig.tsx
+++ b/packages/react-native-reanimated/src/component/ReducedMotionConfig.tsx
@@ -5,6 +5,7 @@ import {
   ReducedMotionManager,
   isReducedMotionEnabledInSystem,
 } from '../ReducedMotion';
+import { logger } from '../logger';
 
 /**
  * A component that lets you overwrite default reduce motion behavior globally in your application.
@@ -17,10 +18,8 @@ export function ReducedMotionConfig({ mode }: { mode: ReduceMotion }) {
     if (!__DEV__) {
       return;
     }
-    console.warn(
-      `[Reanimated] Reduced motion setting is overwritten with mode '${mode}'.`
-    );
-  }, []);
+    logger.warn(`Reduced motion setting is overwritten with mode '${mode}'.`);
+  }, [mode]);
 
   useEffect(() => {
     const wasEnabled = ReducedMotionManager.jsValue;

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -13,6 +13,7 @@ import { makeShareableCloneRecursive } from './shareables';
 import { initializeUIRuntime } from './initializers';
 import type { LayoutAnimationBatchItem } from './layoutReanimation/animationBuilder/commonTypes';
 import { SensorContainer } from './SensorContainer';
+import { logger } from './logger';
 
 export { startMapper, stopMapper } from './mappers';
 export { runOnJS, runOnUI, executeOnUIRuntimeSync } from './threads';
@@ -52,8 +53,9 @@ export function getViewProp<T>(
   component?: React.Component // required on Fabric
 ): Promise<T> {
   if (isFabric() && !component) {
-    throw new Error(
-      '[Reanimated] Function `getViewProp` requires a component to be passed as an argument on Fabric.'
+    throw logger.createError(
+      'Function `getViewProp` requires a component to be passed as an argument on Fabric.',
+      { trimStack: 'getViewProp' }
     );
   }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -50,6 +50,7 @@ import { addHTMLMutationObserver } from '../layoutReanimation/web/domUtils';
 import { getViewInfo } from './getViewInfo';
 import { NativeEventsManager } from './NativeEventsManager';
 import type { ReanimatedHTMLElement } from '../js-reanimated';
+import { logger } from '../logger';
 
 const IS_WEB = isWeb();
 
@@ -290,8 +291,8 @@ export function createAnimatedComponent(
         // hostInstance can be null for a component that doesn't render anything (render function returns null). Example: svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
         const hostInstance = RNRenderer.findHostInstance_DEPRECATED(component);
         if (!hostInstance) {
-          throw new Error(
-            '[Reanimated] Cannot find host instance for this component. Maybe it renders nothing?'
+          throw logger.createError(
+            'Cannot find host instance for this component. Maybe it renders nothing?'
           );
         }
 

--- a/packages/react-native-reanimated/src/fabricUtils.web.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.web.ts
@@ -1,6 +1,9 @@
 'use strict';
+
+import { logger } from './logger';
+
 export function getShadowNodeWrapperFromRef() {
-  throw new Error(
-    '[Reanimated] Trying to call `getShadowNodeWrapperFromRef` on web.'
+  throw logger.createError(
+    'Trying to call `getShadowNodeWrapperFromRef` on web.'
   );
 }

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -34,6 +34,7 @@ import type {
   AnimatedStyle,
 } from '../commonTypes';
 import { isWorkletFunction } from '../commonTypes';
+import { logger } from '../logger';
 
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
@@ -380,8 +381,8 @@ function checkSharedValueUsage(
     prop.value !== undefined
   ) {
     // if shared value is passed insted of its value, throw an error
-    throw new Error(
-      `[Reanimated] Invalid value passed to \`${currentKey}\`, maybe you forgot to use \`.value\`?`
+    throw logger.createError(
+      `Invalid value passed to \`${currentKey}\`, maybe you forgot to use \`.value\`?`
     );
   }
 }
@@ -422,8 +423,8 @@ export function useAnimatedStyle<Style extends DefaultStyle>(
       !dependencies &&
       !isWorkletFunction(updater)
     ) {
-      throw new Error(
-        `[Reanimated] \`useAnimatedStyle\` was used without a dependency array or Babel plugin. Please explicitly pass a dependency array, or enable the Babel plugin.
+      throw logger.createError(
+        `\`useAnimatedStyle\` was used without a dependency array or Babel plugin. Please explicitly pass a dependency array, or enable the Babel plugin.
 For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support#web-without-the-babel-plugin\`.`
       );
     }

--- a/packages/react-native-reanimated/src/hook/utils.ts
+++ b/packages/react-native-reanimated/src/hook/utils.ts
@@ -1,5 +1,6 @@
 'use strict';
 import type { WorkletFunction } from '../commonTypes';
+import { logger } from '../logger';
 import type { DependencyList } from './commonTypes';
 
 // Builds one big hash from multiple worklets' hashes.
@@ -108,12 +109,12 @@ export function shallowEqual<
 export function validateAnimatedStyles(styles: unknown[] | object) {
   'worklet';
   if (typeof styles !== 'object') {
-    throw new Error(
-      `[Reanimated] \`useAnimatedStyle\` has to return an object, found ${typeof styles} instead.`
+    throw logger.createError(
+      `\`useAnimatedStyle\` has to return an object, found ${typeof styles} instead.`
     );
   } else if (Array.isArray(styles)) {
-    throw new Error(
-      '[Reanimated] `useAnimatedStyle` has to return an object and cannot return static styles combined with dynamic ones. Please do merging where a component receives props.'
+    throw logger.createError(
+      '`useAnimatedStyle` has to return an object and cannot return static styles combined with dynamic ones. Please do merging where a component receives props.'
     );
   }
 }

--- a/packages/react-native-reanimated/src/interpolateColor.ts
+++ b/packages/react-native-reanimated/src/interpolateColor.ts
@@ -13,6 +13,7 @@ import { makeMutable } from './core';
 import { Extrapolation, interpolate } from './interpolation';
 import type { SharedValue } from './commonTypes';
 import { useSharedValue } from './hook/useSharedValue';
+import { logger } from './logger';
 
 /**
  * @deprecated Please use Extrapolation instead
@@ -236,10 +237,11 @@ export function interpolateColor(
       options
     );
   }
-  throw new Error(
-    `[Reanimated] Invalid color space provided: ${
+  throw logger.createError(
+    `Invalid color space provided: ${
       colorSpace as string
-    }. Supported values are: ['RGB', 'HSV'].`
+    }. Supported values are: ['RGB', 'HSV'].`,
+    { trimStack: 'interpolateColor_interpolateColor' }
   );
 }
 

--- a/packages/react-native-reanimated/src/interpolation.ts
+++ b/packages/react-native-reanimated/src/interpolation.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { logger } from './logger';
+
 /**
  * Extrapolation type.
  *
@@ -99,9 +101,10 @@ function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
 
   if (typeof type === 'string') {
     if (!isExtrapolate(type)) {
-      throw new Error(
-        `[Reanimated] Unsupported value for "interpolate" \nSupported values: ["extend", "clamp", "identity", Extrapolatation.CLAMP, Extrapolatation.EXTEND, Extrapolatation.IDENTITY]\n Valid example:
-        interpolate(value, [inputRange], [outputRange], "clamp")`
+      throw logger.createError(
+        `Unsupported value for "interpolate" \nSupported values: ["extend", "clamp", "identity", Extrapolatation.CLAMP, Extrapolatation.EXTEND, Extrapolatation.IDENTITY]\n Valid example:
+        interpolate(value, [inputRange], [outputRange], "clamp")`,
+        { trimStack: 'interpolate_interpolation' }
       );
     }
     extrapolationConfig.extrapolateLeft = type;
@@ -114,12 +117,13 @@ function validateType(type: ExtrapolationType): RequiredExtrapolationConfig {
     (type.extrapolateLeft && !isExtrapolate(type.extrapolateLeft)) ||
     (type.extrapolateRight && !isExtrapolate(type.extrapolateRight))
   ) {
-    throw new Error(
-      `[Reanimated] Unsupported value for "interpolate" \nSupported values: ["extend", "clamp", "identity", Extrapolatation.CLAMP, Extrapolatation.EXTEND, Extrapolatation.IDENTITY]\n Valid example:
+    throw logger.createError(
+      `Unsupported value for "interpolate" \nSupported values: ["extend", "clamp", "identity", Extrapolatation.CLAMP, Extrapolatation.EXTEND, Extrapolatation.IDENTITY]\n Valid example:
       interpolate(value, [inputRange], [outputRange], {
         extrapolateLeft: Extrapolation.CLAMP,
         extrapolateRight: Extrapolation.IDENTITY
-      }})`
+      }})`,
+      { trimStack: 'interpolate_interpolation' }
     );
   }
 
@@ -183,8 +187,9 @@ export function interpolate(
 ): number {
   'worklet';
   if (inputRange.length < 2 || outputRange.length < 2) {
-    throw new Error(
-      '[Reanimated] Interpolation input and output ranges should contain at least two values.'
+    throw logger.createError(
+      'Interpolation input and output ranges should contain at least two values.',
+      { trimStack: 'interpolate_interpolation' }
     );
   }
 

--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -9,6 +9,7 @@ import type {
 } from './createAnimatedComponent/commonTypes';
 import { isJest } from './PlatformChecker';
 import type { DefaultStyle } from './hook/commonTypes';
+import { logger } from './logger';
 
 declare global {
   namespace jest {
@@ -161,7 +162,7 @@ const afterTest = () => {
 };
 
 export const withReanimatedTimer = (animationTest: () => void) => {
-  console.warn(
+  logger.warn(
     'This method is deprecated, you should define your own before and after test hooks to enable jest.useFakeTimers(). Check out the documentation for details on testing'
   );
   beforeTest();
@@ -170,7 +171,7 @@ export const withReanimatedTimer = (animationTest: () => void) => {
 };
 
 export const advanceAnimationByTime = (time = frameTime) => {
-  console.warn(
+  logger.warn(
     'This method is deprecated, use jest.advanceTimersByTime directly'
   );
   jest.advanceTimersByTime(time);
@@ -178,7 +179,7 @@ export const advanceAnimationByTime = (time = frameTime) => {
 };
 
 export const advanceAnimationByFrame = (count: number) => {
-  console.warn(
+  logger.warn(
     'This method is deprecated, use jest.advanceTimersByTime directly'
   );
   jest.advanceTimersByTime(count * frameTime);
@@ -188,8 +189,8 @@ export const advanceAnimationByFrame = (count: number) => {
 const requireFunction = isJest()
   ? require
   : () => {
-      throw new Error(
-        '[Reanimated] `setUpTests` is available only in Jest environment.'
+      throw logger.createError(
+        '`setUpTests` is available only in Jest environment.'
       );
     };
 

--- a/packages/react-native-reanimated/src/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/js-reanimated/JSReanimated.ts
@@ -10,6 +10,7 @@ import { SensorType } from '../commonTypes';
 import type { WebSensor } from './WebSensor';
 import { mockedRequestAnimationFrame } from '../mockedRequestAnimationFrame';
 import type { WorkletRuntime } from '../runtimes';
+import { logger } from '../logger';
 
 // In Node.js environments (like when static rendering with Expo Router)
 // requestAnimationFrame is unavailable, so we use our mock.
@@ -25,8 +26,8 @@ export default class JSReanimated {
   platform?: Platform = undefined;
 
   makeShareableClone<T>(): ShareableRef<T> {
-    throw new Error(
-      '[Reanimated] makeShareableClone should never be called in JSReanimated.'
+    throw logger.createError(
+      'makeShareableClone should never be called in JSReanimated.'
     );
   }
 
@@ -39,14 +40,14 @@ export default class JSReanimated {
     _name: string,
     _initializer: ShareableRef<() => void>
   ): WorkletRuntime {
-    throw new Error(
-      '[Reanimated] createWorkletRuntime is not available in JSReanimated.'
+    throw logger.createError(
+      'createWorkletRuntime is not available in JSReanimated.'
     );
   }
 
   scheduleOnRuntime() {
-    throw new Error(
-      '[Reanimated] scheduleOnRuntime is not available in JSReanimated.'
+    throw logger.createError(
+      'scheduleOnRuntime is not available in JSReanimated.'
     );
   }
 
@@ -55,34 +56,26 @@ export default class JSReanimated {
     _eventName: string,
     _emitterReactTag: number
   ): number {
-    throw new Error(
-      '[Reanimated] registerEventHandler is not available in JSReanimated.'
+    throw logger.createError(
+      'registerEventHandler is not available in JSReanimated.'
     );
   }
 
   unregisterEventHandler(_: number): void {
-    throw new Error(
-      '[Reanimated] unregisterEventHandler is not available in JSReanimated.'
+    throw logger.createError(
+      'unregisterEventHandler is not available in JSReanimated.'
     );
   }
 
   enableLayoutAnimations() {
     if (isWeb()) {
-      console.warn(
-        '[Reanimated] Layout Animations are not supported on web yet.'
-      );
+      logger.warn('Layout Animations are not supported on web yet.');
     } else if (isJest()) {
-      console.warn(
-        '[Reanimated] Layout Animations are no-ops when using Jest.'
-      );
+      logger.warn('Layout Animations are no-ops when using Jest.');
     } else if (isChromeDebugger()) {
-      console.warn(
-        '[Reanimated] Layout Animations are no-ops when using Chrome Debugger.'
-      );
+      logger.warn('Layout Animations are no-ops when using Chrome Debugger.');
     } else {
-      console.warn(
-        '[Reanimated] Layout Animations are not supported on this configuration.'
-      );
+      logger.warn('Layout Animations are not supported on this configuration.');
     }
   }
 
@@ -112,8 +105,8 @@ export default class JSReanimated {
 
     if (!(this.getSensorName(sensorType) in window)) {
       // https://w3c.github.io/sensors/#secure-context
-      console.warn(
-        '[Reanimated] Sensor is not available.' +
+      logger.warn(
+        'Sensor is not available.' +
           (isWeb() && location.protocol !== 'https:'
             ? ' Make sure you use secure origin with `npx expo start --web --https`.'
             : '') +
@@ -208,20 +201,16 @@ export default class JSReanimated {
 
   subscribeForKeyboardEvents(_: ShareableRef<number>): number {
     if (isWeb()) {
-      console.warn(
-        '[Reanimated] useAnimatedKeyboard is not available on web yet.'
-      );
+      logger.warn('useAnimatedKeyboard is not available on web yet.');
     } else if (isJest()) {
-      console.warn(
-        '[Reanimated] useAnimatedKeyboard is not available when using Jest.'
-      );
+      logger.warn('useAnimatedKeyboard is not available when using Jest.');
     } else if (isChromeDebugger()) {
-      console.warn(
-        '[Reanimated] useAnimatedKeyboard is not available when using Chrome Debugger.'
+      logger.warn(
+        'useAnimatedKeyboard is not available when using Chrome Debugger.'
       );
     } else {
-      console.warn(
-        '[Reanimated] useAnimatedKeyboard is not available on this configuration.'
+      logger.warn(
+        'useAnimatedKeyboard is not available on this configuration.'
       );
     }
     return -1;
@@ -284,20 +273,18 @@ export default class JSReanimated {
     _component?: React.Component,
     _callback?: (result: T) => void
   ): Promise<T> {
-    throw new Error(
-      '[Reanimated] getViewProp is not available in JSReanimated.'
-    );
+    throw logger.createError('getViewProp is not available in JSReanimated.');
   }
 
   configureProps() {
-    throw new Error(
-      '[Reanimated] configureProps is not available in JSReanimated.'
+    throw logger.createError(
+      'configureProps is not available in JSReanimated.'
     );
   }
 
   executeOnUIRuntimeSync<T, R>(_shareable: ShareableRef<T>): R {
-    throw new Error(
-      '[Reanimated] `executeOnUIRuntimeSync` is not available in JSReanimated.'
+    throw logger.createError(
+      '`executeOnUIRuntimeSync` is not available in JSReanimated.'
     );
   }
 }

--- a/packages/react-native-reanimated/src/js-reanimated/index.ts
+++ b/packages/react-native-reanimated/src/js-reanimated/index.ts
@@ -7,24 +7,25 @@ import {
   createTextShadowValue,
 } from './webUtils';
 import { PropsAllowlists } from '../propsAllowlists';
+import { logger } from '../logger';
 
 const reanimatedJS = new JSReanimated();
 
 global._makeShareableClone = () => {
-  throw new Error(
-    '[Reanimated] _makeShareableClone should never be called in JSReanimated.'
+  throw logger.createError(
+    '_makeShareableClone should never be called in JSReanimated.'
   );
 };
 
 global._scheduleOnJS = () => {
-  throw new Error(
-    '[Reanimated] _scheduleOnJS should never be called in JSReanimated.'
+  throw logger.createError(
+    '_scheduleOnJS should never be called in JSReanimated.'
   );
 };
 
 global._scheduleOnRuntime = () => {
-  throw new Error(
-    '[Reanimated] _scheduleOnRuntime should never be called in JSReanimated.'
+  throw logger.createError(
+    '_scheduleOnRuntime should never be called in JSReanimated.'
   );
 };
 
@@ -94,8 +95,8 @@ export const _updatePropsJS = (
     } else {
       const componentName =
         'className' in component ? component?.className : '';
-      console.warn(
-        `[Reanimated] It's not possible to manipulate the component ${componentName}`
+      logger.warn(
+        `It's not possible to manipulate the component ${componentName}`
       );
     }
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
@@ -8,6 +8,7 @@ import type {
 
 import { ReduceMotion } from '../../commonTypes';
 import { getReduceMotionFromConfig } from '../../animation/util';
+import { logger } from '../../logger';
 
 export class BaseAnimationBuilder {
   durationV?: number;
@@ -21,7 +22,7 @@ export class BaseAnimationBuilder {
   ) => InstanceType<T>;
 
   build = (): EntryExitAnimationFunction | LayoutAnimationFunction => {
-    throw new Error('[Reanimated] Unimplemented method in child class.');
+    throw logger.createError('Unimplemented method in child class.');
   };
 
   /**

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -18,6 +18,7 @@ import {
   assertEasingIsWorklet,
   getReduceMotionFromConfig,
 } from '../../animation/util';
+import { logger } from '../../logger';
 
 interface KeyframePoint {
   duration: number;
@@ -54,8 +55,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     */
     if (this.definitions.from) {
       if (this.definitions['0']) {
-        throw new Error(
-          "[Reanimated] You cannot provide both keyframe 0 and 'from' as they both specified initial values."
+        throw logger.createError(
+          "You cannot provide both keyframe 0 and 'from' as they both specified initial values."
         );
       }
       this.definitions['0'] = this.definitions.from;
@@ -63,8 +64,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     }
     if (this.definitions.to) {
       if (this.definitions['100']) {
-        throw new Error(
-          "[Reanimated] You cannot provide both keyframe 100 and 'to' as they both specified values at the end of the animation."
+        throw logger.createError(
+          "You cannot provide both keyframe 100 and 'to' as they both specified values at the end of the animation."
         );
       }
       this.definitions['100'] = this.definitions.to;
@@ -75,8 +76,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
        Every other keyframe should contain properties from the set provided as initial values.
     */
     if (!this.definitions['0']) {
-      throw new Error(
-        "[Reanimated] Please provide 0 or 'from' keyframe with initial state of your object."
+      throw logger.createError(
+        "Please provide 0 or 'from' keyframe with initial state of your object."
       );
     }
     const initialValues: StyleProps = this.definitions['0'] as StyleProps;
@@ -130,8 +131,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       easing?: EasingFunction;
     }): void => {
       if (!(key in parsedKeyframes)) {
-        throw new Error(
-          "[Reanimated] Keyframe can contain only that set of properties that were provide with initial values (keyframe 0 or 'from')"
+        throw logger.createError(
+          "Keyframe can contain only that set of properties that were provide with initial values (keyframe 0 or 'from')"
         );
       }
 
@@ -150,8 +151,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       .sort((a: string, b: string) => parseInt(a) - parseInt(b))
       .forEach((keyPoint: string) => {
         if (parseInt(keyPoint) < 0 || parseInt(keyPoint) > 100) {
-          throw new Error(
-            '[Reanimated] Keyframe should be in between range 0 - 100.'
+          throw logger.createError(
+            'Keyframe should be in between range 0 - 100.'
           );
         }
         const keyframe: KeyframeProps = this.definitions[keyPoint];

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -13,6 +13,7 @@ import type {
   AnimationObject,
   TransformArrayItem,
 } from '../../commonTypes';
+import { logger } from '../../logger';
 
 export class EntryExitTransition
   extends BaseAnimationBuilder
@@ -187,9 +188,7 @@ export class EntryExitTransition
         ).map((value) => {
           const objectKeys = Object.keys(value);
           if (objectKeys?.length < 1) {
-            console.error(
-              `[Reanimated]: \${value} is not a valid Transform object`
-            );
+            logger.error(`\${value} is not a valid Transform object`);
             return value;
           }
 

--- a/packages/react-native-reanimated/src/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/sharedTransitions/ProgressTransitionManager.ts
@@ -7,6 +7,7 @@ import type {
 import { registerEventHandler, unregisterEventHandler } from '../../core';
 import { Platform } from 'react-native';
 import { isJest, shouldBeUseWeb } from '../../PlatformChecker';
+import { logger } from '../../logger';
 
 type TransitionProgressEvent = {
   closing: number;
@@ -229,8 +230,8 @@ if (shouldBeUseWeb()) {
     // Jest attempts to access a property of this object to check if it is a Jest mock
     // so we can't throw an error in the getter.
     if (!isJest()) {
-      throw new Error(
-        '[Reanimated] `ProgressTransitionRegister` is not available on non-native platform.'
+      throw logger.createError(
+        '`ProgressTransitionRegister` is not available on non-native platform.'
       );
     }
   };

--- a/packages/react-native-reanimated/src/layoutReanimation/sharedTransitions/SharedTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/sharedTransitions/SharedTransition.ts
@@ -16,6 +16,7 @@ import { ReduceMotion } from '../../commonTypes';
 import { ProgressTransitionManager } from './ProgressTransitionManager';
 import { updateLayoutAnimations } from '../../UpdateLayoutAnimations';
 import { getReduceMotionFromConfig } from '../../animation/util';
+import { logger } from '../../logger';
 
 const SUPPORTED_PROPS = [
   'width',
@@ -171,9 +172,7 @@ export class SharedTransition {
         animations = animationFactory(values);
         for (const key in animations) {
           if (!(SUPPORTED_PROPS as readonly string[]).includes(key)) {
-            throw new Error(
-              `[Reanimated] The prop '${key}' is not supported yet.`
-            );
+            throw logger.createError(`The prop '${key}' is not supported yet.`);
           }
         }
       } else {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
@@ -30,6 +30,7 @@ import { Keyframe } from '../animationBuilder';
 import { makeElementVisible } from './componentStyle';
 import { EasingNameSymbol } from '../../Easing';
 import type { ReanimatedHTMLElement } from '../../js-reanimated';
+import { logger } from '../../logger';
 
 function chooseConfig<ComponentProps extends Record<string, unknown>>(
   animationType: LayoutAnimationType,
@@ -57,8 +58,8 @@ function checkUndefinedAnimationFail(
     return false;
   }
 
-  console.warn(
-    "[Reanimated] Couldn't load entering/exiting animation. Current version supports only predefined animations with modifiers: duration, delay, easing, randomizeDelay, withCallback, reducedMotion."
+  logger.warn(
+    "Couldn't load entering/exiting animation. Current version supports only predefined animations with modifiers: duration, delay, easing, randomizeDelay, withCallback, reducedMotion."
   );
 
   return true;
@@ -83,8 +84,8 @@ function maybeReportOverwrittenProperties(
     return;
   }
 
-  console.warn(
-    `[Reanimated] ${
+  logger.warn(
+    `${
       commonProperties.length === 1 ? 'Property' : 'Properties'
     } [${commonProperties.join(
       ', '
@@ -165,8 +166,8 @@ function tryGetAnimationConfig<ComponentProps extends Record<string, unknown>>(
     if (
       !(keyframeTimestamps.includes('100') || keyframeTimestamps.includes('to'))
     ) {
-      console.warn(
-        `[Reanimated] Neither '100' nor 'to' was specified in Keyframe definition. This may result in wrong final position of your component. One possible solution is to duplicate last timestamp in definition as '100' (or 'to')`
+      logger.warn(
+        `Neither '100' nor 'to' was specified in Keyframe definition. This may result in wrong final position of your component. One possible solution is to duplicate last timestamp in definition as '100' (or 'to')`
       );
     }
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -23,6 +23,7 @@ import { Keyframe } from '../animationBuilder';
 import { ReducedMotionManager } from '../../ReducedMotion';
 import { prepareCurvedTransition } from './transition/Curved.web';
 import { EasingNameSymbol } from '../../Easing';
+import { logger } from '../../logger';
 
 function getEasingFromConfig(config: CustomConfig): string {
   if (!config.easingV) {
@@ -32,9 +33,7 @@ function getEasingFromConfig(config: CustomConfig): string {
   const easingName = config.easingV[EasingNameSymbol];
 
   if (!(easingName in WebEasings)) {
-    console.warn(
-      `[Reanimated] Selected easing is not currently supported on web.`
-    );
+    logger.warn(`Selected easing is not currently supported on web.`);
 
     return getEasingByName('linear');
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import type { ReanimatedHTMLElement } from '../../js-reanimated';
+import { logger } from '../../logger';
 import { isWindowAvailable } from '../../PlatformChecker';
 import { setElementPosition, snapshots } from './componentStyle';
 import { Animations } from './config';
@@ -32,9 +33,7 @@ export function configureWebLayoutAnimations() {
 
   predefinedAnimationsStyleTag.onload = () => {
     if (!predefinedAnimationsStyleTag.sheet) {
-      console.error(
-        '[Reanimated] Failed to create layout animations stylesheet.'
-      );
+      logger.error('Failed to create layout animations stylesheet.');
       return;
     }
 
@@ -63,9 +62,7 @@ export function insertWebAnimation(animationName: string, keyframe: string) {
   ) as HTMLStyleElement;
 
   if (!styleTag.sheet) {
-    console.error(
-      '[Reanimated] Failed to create layout animations stylesheet.'
-    );
+    logger.error('Failed to create layout animations stylesheet.');
     return;
   }
 
@@ -78,7 +75,7 @@ export function insertWebAnimation(animationName: string, keyframe: string) {
     const nextAnimationIndex = animationNameToIndex.get(nextAnimationName);
 
     if (nextAnimationIndex === undefined) {
-      throw new Error('[Reanimated] Failed to obtain animation index.');
+      throw logger.createError('Failed to obtain animation index.');
     }
 
     animationNameToIndex.set(animationNameList[i], nextAnimationIndex + 1);
@@ -101,7 +98,7 @@ function removeWebAnimation(
   const currentAnimationIndex = animationNameToIndex.get(animationName);
 
   if (currentAnimationIndex === undefined) {
-    throw new Error('[Reanimated] Failed to obtain animation index.');
+    throw logger.createError('Failed to obtain animation index.');
   }
 
   animationRemoveCallback();
@@ -116,7 +113,7 @@ function removeWebAnimation(
     const nextAnimationIndex = animationNameToIndex.get(nextAnimationName);
 
     if (nextAnimationIndex === undefined) {
-      throw new Error('[Reanimated] Failed to obtain animation index.');
+      throw logger.createError('Failed to obtain animation index.');
     }
 
     animationNameToIndex.set(animationNameList[i], nextAnimationIndex - 1);
@@ -149,7 +146,7 @@ function reattachElementToAncestor(child: ReanimatedHTMLElement, parent: Node) {
   const childSnapshot = snapshots.get(child);
 
   if (!childSnapshot) {
-    console.error('[Reanimated] Failed to obtain snapshot.');
+    logger.error('Failed to obtain snapshot.');
     return;
   }
 

--- a/packages/react-native-reanimated/src/logger/LogBox.ts
+++ b/packages/react-native-reanimated/src/logger/LogBox.ts
@@ -1,0 +1,42 @@
+import type { LogBoxStatic } from 'react-native';
+import { LogBox as RNLogBox } from 'react-native';
+
+export type LogLevel = 'warn' | 'error' | 'fatal' | 'syntax';
+
+type Message = {
+  content: string;
+  substitutions: { length: number; offset: number }[];
+};
+
+type Category = string;
+
+interface Location {
+  row: number;
+  column: number;
+}
+
+interface CodeFrame {
+  content: string;
+  location?: Location | null;
+  fileName: string;
+  collapse?: boolean;
+}
+
+type ComponentStack = CodeFrame[];
+
+type ComponentStackType = 'legacy' | 'stack';
+
+type LogData = {
+  level: LogLevel;
+  message: Message;
+  category: Category;
+  componentStack: ComponentStack;
+  componentStackType: ComponentStackType | null;
+  stack?: string;
+};
+
+interface LogBoxExtended extends LogBoxStatic {
+  addLog(data: LogData): void;
+}
+
+export const LogBox = RNLogBox as LogBoxExtended;

--- a/packages/react-native-reanimated/src/logger/LogBox.ts
+++ b/packages/react-native-reanimated/src/logger/LogBox.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { LogBoxStatic } from 'react-native';
 import { LogBox as RNLogBox } from 'react-native';
 
@@ -26,7 +27,7 @@ type ComponentStack = CodeFrame[];
 
 type ComponentStackType = 'legacy' | 'stack';
 
-type LogData = {
+export type LogData = {
   level: LogLevel;
   message: Message;
   category: Category;

--- a/packages/react-native-reanimated/src/logger/index.ts
+++ b/packages/react-native-reanimated/src/logger/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/packages/react-native-reanimated/src/logger/index.ts
+++ b/packages/react-native-reanimated/src/logger/index.ts
@@ -1,1 +1,2 @@
+'use strict';
 export * from './logger';

--- a/packages/react-native-reanimated/src/logger/logger.ts
+++ b/packages/react-native-reanimated/src/logger/logger.ts
@@ -1,0 +1,69 @@
+import type { LogLevel } from './LogBox';
+import { LogBox } from './LogBox';
+
+type LogOptions = {
+  trim?: string;
+};
+
+function createLogger(prefix: string) {
+  const formatMessage = (message: string) => `${prefix} ${message}`;
+
+  const warn = (message: string, options: LogOptions = {}) => {
+    output('warn', message, options);
+  };
+
+  const error = (message: string, options: LogOptions = {}) => {
+    output('error', message, options);
+  };
+
+  const fatal = (message: string, options: LogOptions = {}) => {
+    output('fatal', message, options);
+  };
+
+  const throwError = (message: string) => {
+    const formattedMessage = formatMessage(message);
+    throw new Error(formattedMessage);
+  };
+
+  const output = (level: LogLevel, message: string, options: LogOptions) => {
+    const { trim } = options;
+    const formattedMessage = formatMessage(message);
+    const errorStack = new Error().stack;
+    const stack = trim ? getTrimmedStackTrace(trim, errorStack) : errorStack;
+
+    LogBox.addLog({
+      level,
+      message: {
+        content: formattedMessage,
+        substitutions: [],
+      },
+      category: formattedMessage,
+      componentStack: [],
+      componentStackType: null,
+      stack,
+    });
+  };
+
+  const getTrimmedStackTrace = (trimStackUpTo: string, errorStack?: string) => {
+    const regex = new RegExp(trimStackUpTo);
+    const stackLines = errorStack?.split('\n') || [];
+
+    // Find the index of the first occurrence that matches the regex
+    const trimIndex = stackLines.findIndex((line) => regex.test(line));
+
+    // If a match is found, slice the stack up to that point (exclusive)
+    const trimmedStack =
+      trimIndex >= 0 ? stackLines.slice(trimIndex + 1) : stackLines;
+
+    return trimmedStack.join('\n');
+  };
+
+  return {
+    warn,
+    error,
+    fatal,
+    throw: throwError,
+  };
+}
+
+export const logger = createLogger('[Reanimated]');

--- a/packages/react-native-reanimated/src/logger/logger.ts
+++ b/packages/react-native-reanimated/src/logger/logger.ts
@@ -1,37 +1,82 @@
-import type { LogLevel } from './LogBox';
+'use strict';
+import { runOnJS } from '../threads';
+import type { LogData, LogLevel } from './LogBox';
 import { LogBox } from './LogBox';
 
+const addLog = LogBox.addLog.bind(LogBox);
+
+function log(data: LogData) {
+  addLog(data);
+
+  const consoleMessage = `${data.message.content}\n${data.stack}`;
+
+  // Log message to the console manually as calling LogBox.addLog
+  // does not log to the console
+  // (app will show only a single message as a result of deduplication
+  // mechanism in LogBox, so we can safely log to the console after
+  // calling LogBox.addLog)
+  switch (data.level) {
+    case 'warn':
+      console.warn(consoleMessage);
+      break;
+    case 'error':
+    case 'fatal':
+      console.error(consoleMessage);
+      break;
+  }
+}
+
 type LogOptions = {
-  trim?: string;
+  trimStack?: string | RegExp;
 };
 
 function createLogger(prefix: string) {
-  const formatMessage = (message: string) => `${prefix} ${message}`;
-
-  const warn = (message: string, options: LogOptions = {}) => {
-    output('warn', message, options);
+  const formatMessage = (message: string) => {
+    'worklet';
+    return `${prefix} ${message}`;
   };
 
-  const error = (message: string, options: LogOptions = {}) => {
-    output('error', message, options);
-  };
+  const getTrimmedStackTrace = (
+    errorStack?: string,
+    trimStack?: string | RegExp
+  ) => {
+    'worklet';
+    // remove the first line of the stack trace (it is always the Error constructor)
+    const stackLines = errorStack?.split('\n') || [];
+    // find fist non-Error and non-logger line of the stack trace
+    let trimIndex = stackLines.findIndex(
+      (line) => !line.includes('Error') && !line.includes('logger')
+    );
 
-  const fatal = (message: string, options: LogOptions = {}) => {
-    output('fatal', message, options);
-  };
+    if (trimStack) {
+      const regex = new RegExp(trimStack);
+      for (let i = trimIndex; i < stackLines.length; i++) {
+        if (regex.test(stackLines[i])) {
+          trimIndex = i + 1;
+          break;
+        }
+      }
+    }
 
-  const throwError = (message: string) => {
-    const formattedMessage = formatMessage(message);
-    throw new Error(formattedMessage);
+    // If a match is found, slice the stack up to that point (exclusive)
+    const trimmedStack =
+      trimIndex >= 0 ? stackLines.slice(trimIndex) : stackLines;
+
+    console.log({ trimmedStack, trimIndex });
+
+    return trimmedStack.join('\n');
   };
 
   const output = (level: LogLevel, message: string, options: LogOptions) => {
-    const { trim } = options;
+    'worklet';
+    const { trimStack } = options;
     const formattedMessage = formatMessage(message);
-    const errorStack = new Error().stack;
-    const stack = trim ? getTrimmedStackTrace(trim, errorStack) : errorStack;
 
-    LogBox.addLog({
+    const errorStack = new Error().stack;
+    const stack = getTrimmedStackTrace(errorStack, trimStack);
+    console.log({ stack });
+
+    runOnJS(log)({
       level,
       message: {
         content: formattedMessage,
@@ -44,25 +89,34 @@ function createLogger(prefix: string) {
     });
   };
 
-  const getTrimmedStackTrace = (trimStackUpTo: string, errorStack?: string) => {
-    const regex = new RegExp(trimStackUpTo);
-    const stackLines = errorStack?.split('\n') || [];
+  const warn = (message: string, options: LogOptions = {}) => {
+    'worklet';
+    output('warn', message, options);
+  };
 
-    // Find the index of the first occurrence that matches the regex
-    const trimIndex = stackLines.findIndex((line) => regex.test(line));
+  const error = (message: string, options: LogOptions = {}) => {
+    'worklet';
+    output('error', message, options);
+  };
 
-    // If a match is found, slice the stack up to that point (exclusive)
-    const trimmedStack =
-      trimIndex >= 0 ? stackLines.slice(trimIndex + 1) : stackLines;
+  const fatal = (message: string, options: LogOptions = {}) => {
+    'worklet';
+    output('fatal', message, options);
+  };
 
-    return trimmedStack.join('\n');
+  const createError = (message: string, options: LogOptions = {}): Error => {
+    'worklet';
+    const formattedMessage = formatMessage(message);
+    const err = new Error(formattedMessage);
+    err.stack = getTrimmedStackTrace(err.stack, options.trimStack);
+    return err;
   };
 
   return {
     warn,
     error,
     fatal,
-    throw: throwError,
+    createError,
   };
 }
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -18,7 +18,7 @@ function checkInvalidReadDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
       'Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
-      { trim: 'get value' }
+      { trimStack: 'get value' }
     );
   }
 }
@@ -27,7 +27,7 @@ function checkInvalidWriteDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
       'Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
-      { trim: 'set value' }
+      { trimStack: 'set value' }
     );
   }
 }
@@ -107,13 +107,13 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
     },
 
     get _value(): Value {
-      throw new Error(
-        '[Reanimated] Reading from `_value` directly is only possible on the UI runtime. Perhaps you passed an Animated Style to a non-animated component?'
+      throw logger.createError(
+        'Reading from `_value` directly is only possible on the UI runtime. Perhaps you passed an Animated Style to a non-animated component?'
       );
     },
     set _value(_newValue: Value) {
-      throw new Error(
-        '[Reanimated] Setting `_value` directly is only possible on the UI runtime. Perhaps you want to assign to `value` instead?'
+      throw logger.createError(
+        'Setting `_value` directly is only possible on the UI runtime. Perhaps you want to assign to `value` instead?'
       );
     },
 
@@ -123,13 +123,13 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
       })();
     },
     addListener: () => {
-      throw new Error(
-        '[Reanimated] Adding listeners is only possible on the UI runtime.'
+      throw logger.createError(
+        'Adding listeners is only possible on the UI runtime.'
       );
     },
     removeListener: () => {
-      throw new Error(
-        '[Reanimated] Removing listeners is only possible on the UI runtime.'
+      throw logger.createError(
+        'Removing listeners is only possible on the UI runtime.'
       );
     },
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { shouldBeUseWeb } from './PlatformChecker';
 import type { Mutable } from './commonTypes';
+import { logger } from './logger';
 import { isFirstReactRender, isReactRendering } from './reactUtils';
 import { shareableMappingCache } from './shareableMappingCache';
 import { makeShareableCloneRecursive } from './shareables';
@@ -15,16 +16,18 @@ function shouldWarnAboutAccessDuringRender() {
 
 function checkInvalidReadDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
-    console.warn(
-      '[Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    logger.warn(
+      'Reading from `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
+      { trim: 'get value' }
     );
   }
 }
 
 function checkInvalidWriteDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
-    console.warn(
-      '[Reanimated] Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.'
+    logger.warn(
+      'Writing to `value` during component render. Please ensure that you do not access the `value` property while React is rendering a component.',
+      { trim: 'set value' }
     );
   }
 }

--- a/packages/react-native-reanimated/src/platform-specific/checkCppVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/checkCppVersion.ts
@@ -1,19 +1,20 @@
 'use strict';
+import { logger } from '../logger';
 import { jsVersion } from './jsVersion';
 
 export function checkCppVersion() {
   const cppVersion = global._REANIMATED_VERSION_CPP;
   if (cppVersion === undefined) {
-    console.warn(
-      `[Reanimated] Couldn't determine the version of the native part of Reanimated.
+    logger.warn(
+      `Couldn't determine the version of the native part of Reanimated.
     See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#couldnt-determine-the-version-of-the-native-part-of-reanimated\` for more details.`
     );
     return;
   }
   const ok = matchVersion(jsVersion, cppVersion);
   if (!ok) {
-    throw new Error(
-      `[Reanimated] Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs ${cppVersion}).
+    throw logger.createError(
+      `Mismatch between JavaScript part and native part of Reanimated (${jsVersion} vs ${cppVersion}).
     See \`https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#mismatch-between-javascript-part-and-native-part-of-reanimated\` for more details.`
     );
   }

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -12,6 +12,7 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 import type { Component } from 'react';
+import { logger } from '../logger';
 
 type DispatchCommand = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -58,19 +59,15 @@ function dispatchCommandPaper(
 }
 
 function dispatchCommandJest() {
-  console.warn('[Reanimated] dispatchCommand() is not supported with Jest.');
+  logger.warn('dispatchCommand() is not supported with Jest.');
 }
 
 function dispatchCommandChromeDebugger() {
-  console.warn(
-    '[Reanimated] dispatchCommand() is not supported with Chrome Debugger.'
-  );
+  logger.warn('dispatchCommand() is not supported with Chrome Debugger.');
 }
 
 function dispatchCommandDefault() {
-  console.warn(
-    '[Reanimated] dispatchCommand() is not supported on this configuration.'
-  );
+  logger.warn('dispatchCommand() is not supported on this configuration.');
 }
 
 if (!shouldBeUseWeb()) {

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.web.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { logger } from '../logger';
+
 export function dispatchCommand() {
-  console.warn('[Reanimated] dispatchCommand() is not supported on web.');
+  logger.warn('dispatchCommand() is not supported on web.');
 }

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -12,6 +12,7 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 import type { Component } from 'react';
+import { logger } from '../logger';
 
 type Measure = <T extends Component>(
   animatedRef: AnimatedRef<T>
@@ -34,26 +35,30 @@ function measureFabric(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
 
   const viewTag = animatedRef();
   if (viewTag === -1) {
-    console.warn(
-      `[Reanimated] The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+    logger.warn(
+      `The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`,
+      { trimStack: 'measureFabric_measure' }
     );
     return null;
   }
 
   const measured = global._measureFabric!(viewTag as ShadowNodeWrapper);
   if (measured === null) {
-    console.warn(
-      `[Reanimated] The view has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+    logger.warn(
+      `The view has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`,
+      { trimStack: 'measureFabric_measure' }
     );
     return null;
   } else if (measured.x === -1234567) {
-    console.warn(
-      `[Reanimated] The view returned an invalid measurement response. Please make sure the view is currently rendered.`
+    logger.warn(
+      `The view returned an invalid measurement response. Please make sure the view is currently rendered.`,
+      { trimStack: 'measureFabric_measure' }
     );
     return null;
   } else if (isNaN(measured.x)) {
-    console.warn(
-      `[Reanimated] The view gets view-flattened on Android. To disable view-flattening, set \`collapsable={false}\` on this component.`
+    logger.warn(
+      `The view gets view-flattened on Android. To disable view-flattening, set \`collapsable={false}\` on this component.`,
+      { trimStack: 'measureFabric_measure' }
     );
     return null;
   } else {
@@ -69,32 +74,36 @@ function measurePaper(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
 
   const viewTag = animatedRef();
   if (viewTag === -1) {
-    console.warn(
-      `[Reanimated] The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+    logger.warn(
+      `The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`,
+      { trimStack: 'measurePaper_measure' }
     );
     return null;
   }
 
   const measured = global._measurePaper!(viewTag as number);
   if (measured === null) {
-    console.warn(
-      `[Reanimated] The view with tag ${
+    logger.warn(
+      `The view with tag ${
         viewTag as number
-      } has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+      } has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`,
+      { trimStack: 'measurePaper_measure' }
     );
     return null;
   } else if (measured.x === -1234567) {
-    console.warn(
-      `[Reanimated] The view with tag ${
+    logger.warn(
+      `The view with tag ${
         viewTag as number
-      } returned an invalid measurement response. Please make sure the view is currently rendered.`
+      } returned an invalid measurement response. Please make sure the view is currently rendered.`,
+      { trimStack: 'measurePaper_measure' }
     );
     return null;
   } else if (isNaN(measured.x)) {
-    console.warn(
-      `[Reanimated] The view with tag ${
+    logger.warn(
+      `The view with tag ${
         viewTag as number
-      } gets view-flattened on Android. To disable view-flattening, set \`collapsable={false}\` on this component.`
+      } gets view-flattened on Android. To disable view-flattening, set \`collapsable={false}\` on this component.`,
+      { trimStack: 'measurePaper_measure' }
     );
     return null;
   } else {
@@ -103,19 +112,17 @@ function measurePaper(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
 }
 
 function measureJest() {
-  console.warn('[Reanimated] measure() cannot be used with Jest.');
+  logger.warn('[measure() cannot be used with Jest.');
   return null;
 }
 
 function measureChromeDebugger() {
-  console.warn('[Reanimated] measure() cannot be used with Chrome Debugger.');
+  logger.warn('[measure() cannot be used with Chrome Debugger.');
   return null;
 }
 
 function measureDefault() {
-  console.warn(
-    '[Reanimated] measure() is not supported on this configuration.'
-  );
+  logger.warn('[measure() is not supported on this configuration.');
   return null;
 }
 

--- a/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
@@ -2,6 +2,7 @@
 import type { MeasuredDimensions } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import type { Component } from 'react';
+import { logger } from '../logger';
 
 export function measure<T extends Component>(
   animatedRef: AnimatedRef<T>
@@ -9,8 +10,8 @@ export function measure<T extends Component>(
   const element = animatedRef() as HTMLElement | -1;
 
   if (element === -1) {
-    console.warn(
-      `[Reanimated] The view with tag ${element} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
+    logger.warn(
+      `The view with tag ${element} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
     );
     return null;
   }

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -12,6 +12,7 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 import type { Component } from 'react';
+import { logger } from '../logger';
 
 type ScrollTo = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -62,19 +63,15 @@ function scrollToPaper(
 }
 
 function scrollToJest() {
-  console.warn('[Reanimated] scrollTo() is not supported with Jest.');
+  logger.warn('scrollTo() is not supported with Jest.');
 }
 
 function scrollToChromeDebugger() {
-  console.warn(
-    '[Reanimated] scrollTo() is not supported with Chrome Debugger.'
-  );
+  logger.warn('scrollTo() is not supported with Chrome Debugger.');
 }
 
 function scrollToDefault() {
-  console.warn(
-    '[Reanimated] scrollTo() is not supported on this configuration.'
-  );
+  logger.warn('scrollTo() is not supported on this configuration.');
 }
 
 if (!shouldBeUseWeb()) {

--- a/packages/react-native-reanimated/src/platformFunctions/setGestureState.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setGestureState.ts
@@ -1,4 +1,5 @@
 'use strict';
+import { logger } from '../logger';
 import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type SetGestureState = (handlerTag: number, newState: number) => void;
@@ -8,28 +9,22 @@ export let setGestureState: SetGestureState;
 function setGestureStateNative(handlerTag: number, newState: number) {
   'worklet';
   if (!_WORKLET) {
-    console.warn(
-      '[Reanimated] You can not use setGestureState in non-worklet function.'
-    );
+    logger.warn('You can not use setGestureState in non-worklet function.');
     return;
   }
   global._setGestureState(handlerTag, newState);
 }
 
 function setGestureStateJest() {
-  console.warn('[Reanimated] setGestureState() cannot be used with Jest.');
+  logger.warn('setGestureState() cannot be used with Jest.');
 }
 
 function setGestureStateChromeDebugger() {
-  console.warn(
-    '[Reanimated] setGestureState() cannot be used with Chrome Debugger.'
-  );
+  logger.warn('setGestureState() cannot be used with Chrome Debugger.');
 }
 
 function setGestureStateDefault() {
-  console.warn(
-    '[Reanimated] setGestureState() is not supported on this configuration.'
-  );
+  logger.warn('setGestureState() is not supported on this configuration.');
 }
 
 if (!shouldBeUseWeb()) {

--- a/packages/react-native-reanimated/src/platformFunctions/setGestureState.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setGestureState.web.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { logger } from '../logger';
+
 export function setGestureState() {
-  console.warn('[Reanimated] setGestureState() is not available on web.');
+  logger.warn('setGestureState() is not available on web.');
 }

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -13,6 +13,7 @@ import type {
 } from '../hook/commonTypes';
 import type { Component } from 'react';
 import { processColorsInProps } from '../Colors';
+import { logger } from '../logger';
 
 type SetNativeProps = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -33,9 +34,7 @@ function setNativePropsFabric(
 ) {
   'worklet';
   if (!_WORKLET) {
-    console.warn(
-      '[Reanimated] setNativeProps() can only be used on the UI runtime.'
-    );
+    logger.warn('setNativeProps() can only be used on the UI runtime.');
     return;
   }
   const shadowNodeWrapper = animatedRef() as ShadowNodeWrapper;
@@ -49,9 +48,7 @@ function setNativePropsPaper(
 ) {
   'worklet';
   if (!_WORKLET) {
-    console.warn(
-      '[Reanimated] setNativeProps() can only be used on the UI runtime.'
-    );
+    logger.warn('setNativeProps() can only be used on the UI runtime.');
     return;
   }
   const tag = animatedRef() as number;
@@ -61,19 +58,15 @@ function setNativePropsPaper(
 }
 
 function setNativePropsJest() {
-  console.warn('[Reanimated] setNativeProps() is not supported with Jest.');
+  logger.warn('setNativeProps() is not supported with Jest.');
 }
 
 function setNativePropsChromeDebugger() {
-  console.warn(
-    '[Reanimated] setNativeProps() is not supported with Chrome Debugger.'
-  );
+  logger.warn('setNativeProps() is not supported with Chrome Debugger.');
 }
 
 function setNativePropsDefault() {
-  console.warn(
-    '[Reanimated] setNativeProps() is not supported on this configuration.'
-  );
+  logger.warn('setNativeProps() is not supported on this configuration.');
 }
 
 if (!shouldBeUseWeb()) {

--- a/packages/react-native-reanimated/src/runtimes.ts
+++ b/packages/react-native-reanimated/src/runtimes.ts
@@ -2,6 +2,7 @@
 import { isWorkletFunction } from './commonTypes';
 import type { WorkletFunction } from './commonTypes';
 import { setupCallGuard, setupConsole } from './initializers';
+import { logger } from './logger';
 import NativeReanimatedModule from './NativeReanimated';
 import { shouldBeUseWeb } from './PlatformChecker';
 import {
@@ -59,8 +60,8 @@ export function runOnRuntime<Args extends unknown[], ReturnValue>(
 ): (...args: Args) => void {
   'worklet';
   if (__DEV__ && !SHOULD_BE_USE_WEB && !isWorkletFunction(worklet)) {
-    throw new Error(
-      '[Reanimated] The function passed to `runOnRuntime` is not a worklet.' +
+    throw logger.createError(
+      'The function passed to `runOnRuntime` is not a worklet.' +
         (_WORKLET
           ? ' Please make sure that `processNestedWorklets` option in Reanimated Babel plugin is enabled.'
           : '')

--- a/packages/react-native-reanimated/src/screenTransition/RNScreensTurboModule.ts
+++ b/packages/react-native-reanimated/src/screenTransition/RNScreensTurboModule.ts
@@ -1,11 +1,12 @@
 'use strict';
+import { logger } from '../logger';
 import type { RNScreensTurboModuleType } from './commonTypes';
 
 function noopFactory<T>(defaultReturnValue?: T): () => T {
   return () => {
     'worklet';
-    console.warn(
-      '[Reanimated] RNScreensTurboModule has not been found. Check that you have installed `react-native-screens@3.30.0` or newer in your project and rebuilt your app.'
+    logger.warn(
+      'RNScreensTurboModule has not been found. Check that you have installed `react-native-screens@3.30.0` or newer in your project and rebuilt your app.'
     );
     return defaultReturnValue as T;
   };

--- a/packages/react-native-reanimated/src/shareables.ts
+++ b/packages/react-native-reanimated/src/shareables.ts
@@ -13,6 +13,7 @@ import {
   shareableMappingCache,
   shareableMappingFlag,
 } from './shareableMappingCache';
+import { logger } from './logger';
 
 // for web/chrome debugger/jest environments this file provides a stub implementation
 // where no shareable references are used. Instead, the objects themselves are used
@@ -116,8 +117,8 @@ export function makeShareableCloneRecursive<T>(
     if (depth === DETECT_CYCLIC_OBJECT_DEPTH_THRESHOLD) {
       processedObjectAtThresholdDepth = value;
     } else if (value === processedObjectAtThresholdDepth) {
-      throw new Error(
-        '[Reanimated] Trying to convert a cyclic object to a shareable. This is not supported.'
+      throw logger.createError(
+        'Trying to convert a cyclic object to a shareable. This is not supported.'
       );
     }
   } else {
@@ -340,10 +341,11 @@ function freezeObjectIfDev<T extends object>(value: T) {
         return element;
       },
       set() {
-        console.warn(
-          `[Reanimated] Tried to modify key \`${key}\` of an object which has been already passed to a worklet. See 
+        logger.warn(
+          `Tried to modify key \`${key}\` of an object which has been already passed to a worklet. See 
 https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#tried-to-modify-key-of-an-object-which-has-been-converted-to-a-shareable 
-for more details.`
+for more details.`,
+          { trimStack: 'at set ' }
         );
       },
     });

--- a/packages/react-native-reanimated/src/valueUnpacker.ts
+++ b/packages/react-native-reanimated/src/valueUnpacker.ts
@@ -2,6 +2,7 @@
 import { shouldBeUseWeb } from './PlatformChecker';
 import { isWorkletFunction } from './commonTypes';
 import type { WorkletFunction } from './commonTypes';
+import { logger } from './logger';
 
 function valueUnpacker(
   objectToUnpack: any,
@@ -88,19 +89,19 @@ if (__DEV__ && !shouldBeUseWeb()) {
     'worklet';
   }) as WorkletFunction<[], void>;
   if (!isWorkletFunction(testWorklet)) {
-    throw new Error(
-      `[Reanimated] Failed to create a worklet. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#failed-to-create-a-worklet for more details.`
+    throw logger.createError(
+      `Failed to create a worklet. See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#failed-to-create-a-worklet for more details.`
     );
   }
   if (!isWorkletFunction(valueUnpacker)) {
-    throw new Error('[Reanimated] `valueUnpacker` is not a worklet');
+    throw logger.createError('`valueUnpacker` is not a worklet');
   }
   const closure = (valueUnpacker as ValueUnpacker).__closure;
   if (closure === undefined) {
-    throw new Error('[Reanimated] `valueUnpacker` closure is undefined');
+    throw logger.createError('`valueUnpacker` closure is undefined');
   }
   if (Object.keys(closure).length !== 0) {
-    throw new Error('[Reanimated] `valueUnpacker` must have empty closure');
+    throw logger.createError('`valueUnpacker` must have empty closure');
   }
 }
 


### PR DESCRIPTION
## Summary

This PR implements better logger to ensure that call stacks in logs are clear and properly show the culprit of the issue.

he default default stack trace, included after calling `console.warn`/`console.error`, contains all calls up with function calls in the library source code and even `console` call itself. It is a bit confusing, because the real source of the problem often is not visible in the call stack until the complete call stack is revealed and the proper call is found.

This new logger is intended to make calls stacks more readable by excluding unnecessary calls from reanimated source code in some warnings where it's better to show the place in the user code which caused the issue. It also adds the `[Reanimated]` prefix to all logs automatically, so it is no longer necessary to remember about adding this prefix manually in every log message.

## Remarks

Some error/warning call stacks cannot be beautified, especially if these are native stacks or execution of the specific function is not tied to the component (e.g. the component schedules the animation but the error is thrown after the animation starts).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
