### PR TITLE
docs: Add example to useHandler docs

### DIFF
--- a/packages/docs-reanimated/docs/advanced/useHandler.mdx
+++ b/packages/docs-reanimated/docs/advanced/useHandler.mdx
@@ -87,12 +87,6 @@ An optional array of dependencies.
 
 Only relevant when using Reanimated [without the Babel plugin on the Web.](/docs/guides/web-support/#web-without-the-babel-plugin)
 
-This array may contain:
-
-- `undefined` (argument skipped) - worklet will be rebuilt if there is any change in any of the callbacks' bodies or any values from their closure (variables from outer scope used in worklet).
-- `[]` - worklet will be rebuilt only if any of the callbacks' bodies changes.
-- `[val1, val2, ..., valN]` - worklet will be rebuilt if there is any change in any of the callbacks bodies or in any values from the given array.
-
 ### Returns
 
 The hook returns a context that will be reused by event handlers and value that indicates whether worklets should be rebuilt. If different implementation is needed for web, `useWeb` boolean is returned to check for web environment
@@ -103,6 +97,8 @@ import useHandler from '@site/src/examples/useHandlerEventExample';
 import useHandlerSrc from '!!raw-loader!@site/src/examples/useHandlerEventExample';
 
 <InteractiveExample src={useHandlerSrc} component={useHandler} />
+
+This example can be more easily implemented using [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset/).
 
 ## Platform compatibility
 

--- a/packages/docs-reanimated/docs/advanced/useHandler.mdx
+++ b/packages/docs-reanimated/docs/advanced/useHandler.mdx
@@ -9,15 +9,9 @@ sidebar_position: 5
 ## Reference
 
 ```js
-function useHandlerExample() {
-  const dependencies = [{ isWeb: false }];
-  const handlers = {
-    onScroll: (event) => {
-      'worklet';
-      console.log(event);
-    },
-  };
+import { useEvent, useHandler } from 'react-native-reanimated';
 
+function useAnimatedPagerScrollHandler(handlers, dependencies) {
   // highlight-start
   const { context, doDependenciesDiffer, useWeb } = useHandler(
     handlers,
@@ -25,22 +19,20 @@ function useHandlerExample() {
   );
   // highlight-end
 
-  const customScrollHandler = useEvent(
+  return useEvent(
     (event) => {
       'worklet';
-      const { onScroll } = handlers;
-      if (onScroll && event.eventName.endsWith('onScroll')) {
-        context.eventName = event.eventName + useWeb;
-        onScroll(event);
+      const { onPageScroll } = handlers;
+
+      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
+        onPageScroll(event, context);
       }
     },
     // highlight-start
-    ['onScroll'],
+    ['onPageScroll'],
     doDependenciesDiffer
     // highlight-end
   );
-
-  return <Animated.ScrollView onScroll={customScrollHandler} />;
 }
 ```
 
@@ -91,7 +83,9 @@ Each of the event worklets will receive the following parameters when called:
 
 #### `dependencies` <Optional />
 
-Changes in `dependencies` array cause `useHandler` hook to receive updated values during rerender of the wrapping component. This matters when, for instance, worklet uses values dependent on the component's state.
+An optional array of dependencies.
+
+Only relevant when using Reanimated [without the Babel plugin on the Web.](/docs/guides/web-support/#web-without-the-babel-plugin)
 
 This array may contain:
 
@@ -105,27 +99,10 @@ The hook returns a context that will be reused by event handlers and value that 
 
 ## Example
 
-```jsx
-function useAnimatedPagerScrollHandler(handlers, dependencies) {
-  const { context, doDependenciesDiffer, useWeb } = useHandler(
-    handlers,
-    dependencies
-  );
+import useHandler from '@site/src/examples/useHandlerEventExample';
+import useHandlerSrc from '!!raw-loader!@site/src/examples/useHandlerEventExample';
 
-  return useEvent(
-    (event) => {
-      'worklet';
-      const { onPageScroll } = handlers;
-
-      if (onPageScroll && event.eventName.endsWith('onPageScroll')) {
-        onPageScroll(event, context);
-      }
-    },
-    ['onPageScroll'],
-    doDependenciesDiffer
-  );
-}
-```
+<InteractiveExample src={useHandlerSrc} component={useHandler} />
 
 ## Platform compatibility
 

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Animated, {
+  useHandler,
+  useEvent,
+  useSharedValue,
+  useAnimatedProps,
+} from 'react-native-reanimated';
+import { TextInput, SafeAreaView, View, StyleSheet } from 'react-native';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+function UseHandlerExample() {
+  const offsetY = useSharedValue(0);
+
+  const handlers = {
+    onScroll: (event: any) => {
+      'worklet';
+      offsetY.value = event.contentOffset.y;
+    },
+  };
+
+  const { context, doDependenciesDiffer } = useHandler(handlers);
+
+  const scrollHandler = useEvent(
+    (event) => {
+      'worklet';
+      const { onScroll } = handlers;
+      if (onScroll) {
+        onScroll(event);
+      }
+    },
+    ['onScroll'],
+    doDependenciesDiffer
+  );
+
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      text: `Offset: ${Math.round(offsetY.value)}`,
+      defaultValue: `Offset: ${offsetY.value}`,
+    };
+  });
+
+  const BRAND_COLORS = ['#fa7f7c', '#b58df1', '#ffe780', '#82cab2', '#87cce8'];
+
+  const content = BRAND_COLORS.map((color, index) => (
+    <View
+      key={index}
+      style={[
+        styles.section,
+        {
+          backgroundColor: color,
+        },
+      ]}
+    />
+  ));
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <AnimatedTextInput
+        animatedProps={animatedProps}
+        editable={false}
+        style={styles.header}
+      />
+      <Animated.ScrollView onScroll={scrollHandler}>
+        <View style={styles.container}>{content}</View>
+      </Animated.ScrollView>
+    </SafeAreaView>
+  );
+}
+
+export default UseHandlerExample;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 32,
+    height: 350,
+  },
+  header: {
+    backgroundColor: '#f8f9ff',
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    textAlign: 'center',
+    fontFamily: 'Aeonik',
+    color: '#001a72',
+    marginTop: '-1px',
+  },
+  section: {
+    height: 150,
+    borderRadius: 20,
+    marginVertical: 10,
+    marginHorizontal: 20,
+  },
+});

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -35,8 +35,8 @@ function UseHandlerExample() {
 
   const animatedProps = useAnimatedProps(() => {
     return {
-      text: `Offset: ${Math.round(offsetY.value)}`,
-      defaultValue: `Offset: ${offsetY.value}`,
+      text: `Scroll offset: ${Math.round(offsetY.value)}px`,
+      defaultValue: `Scroll offset: ${offsetY.value}px`,
     };
   });
 

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -4,6 +4,7 @@ import Animated, {
   useEvent,
   useSharedValue,
   useAnimatedProps,
+  type ScrollEvent,
 } from 'react-native-reanimated';
 import { TextInput, SafeAreaView, View, StyleSheet } from 'react-native';
 
@@ -13,7 +14,7 @@ function UseHandlerExample() {
   const offsetY = useSharedValue(0);
 
   const handlers = {
-    onScroll: (event) => {
+    onScroll: (event: ScrollEvent) => {
       'worklet';
       offsetY.value = event.contentOffset.y;
     },
@@ -22,7 +23,7 @@ function UseHandlerExample() {
   const { context, doDependenciesDiffer } = useHandler(handlers);
 
   const scrollHandler = useEvent(
-    (event) => {
+    (event: ScrollEvent) => {
       'worklet';
       const { onScroll } = handlers;
       if (onScroll) {

--- a/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
+++ b/packages/docs-reanimated/src/examples/UseHandlerEventExample.tsx
@@ -13,7 +13,7 @@ function UseHandlerExample() {
   const offsetY = useSharedValue(0);
 
   const handlers = {
-    onScroll: (event: any) => {
+    onScroll: (event) => {
       'worklet';
       offsetY.value = event.contentOffset.y;
     },


### PR DESCRIPTION
Few copy changes and added an example to [useHandler](https://docs.swmansion.com/react-native-reanimated/docs/advanced/useHandler/) docs.

<img width="911" alt="image" src="https://github.com/user-attachments/assets/8cbad3f0-5d86-4897-8621-9115b91c5dd7">