### PR TITLE
Expose `worklets` as prefab

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -244,6 +244,9 @@ android {
         reanimated {
             headers prefabHeadersDir.absolutePath
         }
+        worklets {
+            headers prefabHeadersDir.absolutePath
+        }
     }
 
     defaultConfig {
@@ -428,14 +431,14 @@ def assertMinimalReactNativeVersion = task assertMinimalReactNativeVersionTask {
 
 task prepareHeadersForPrefab(type: Copy) {
     from("$projectDir/src/main/cpp")
-    from("$projectDir/../Common/cpp/AnimatedSensor")
-    from("$projectDir/../Common/cpp/Fabric")
-    from("$projectDir/../Common/cpp/LayoutAnimations")
-    from("$projectDir/../Common/cpp/NativeModules")
-    from("$projectDir/../Common/cpp/ReanimatedRuntime")
-    from("$projectDir/../Common/cpp/Registries")
-    from("$projectDir/../Common/cpp/SharedItems")
-    from("$projectDir/../Common/cpp/Tools")
+    from("$projectDir/../Common/cpp/reanimated/AnimatedSensor")
+    from("$projectDir/../Common/cpp/reanimated/Fabric")
+    from("$projectDir/../Common/cpp/reanimated/LayoutAnimations")
+    from("$projectDir/../Common/cpp/reanimated/NativeModules")
+    from("$projectDir/../Common/cpp/worklets/Registries")
+    from("$projectDir/../Common/cpp/worklets/SharedItems")
+    from("$projectDir/../Common/cpp/worklets/Tools")
+    from("$projectDir/../Common/cpp/worklets/WorkletRuntime")
     include("*.h")
     into(prefabHeadersDir)
 }
@@ -487,6 +490,7 @@ def resolveTaskFactory(String taskName, String artifactLocalName, File reactNati
 task packageNdkLibs(type: Copy) {
     from("$buildDir/reanimated-ndk/all")
     include("**/libreanimated.so")
+    include("**/libworklets.so")
     into("$projectDir/src/main/jniLibs")
 }
 


### PR DESCRIPTION
## Summary

This PR fixes existing prefab integration and extends it for `libworklets.so` along with its header files.

## Test plan

I have personally tested out these changes in react-native-live-markdown.
