### PR TITLE
Fix pendulum example to not crash on empty mass input field

### DIFF
--- a/apps/common-app/src/examples/PendulumExample.tsx
+++ b/apps/common-app/src/examples/PendulumExample.tsx
@@ -162,7 +162,10 @@ export default function SpringExample() {
                 {
                   fontSize: useConfigWithDuration
                     ? 50
-                    : Math.min(0.75 * Number.parseFloat(mass), 40) + 10,
+                    : Math.min(
+                        0.75 * Number.parseFloat(mass === '' ? '0' : mass),
+                        40
+                      ) + 10,
                 },
               ]}>
               {/* Using here view with border radius would be more natural, but views with border radius and rotation are bugged on android */}


### PR DESCRIPTION
(cherry picked from commit 21967b1b0d3dc7e5e0d53b08a7436069e8dd3726)

## Summary

Inputting empty string into the mass field would crash the app on android.
This PR fixes this issue.

## Test plan

- open `Pendulum` example
- switch to `non-duration based config`
- delete all data from the `mass` input field