### PR TITLE
fix: Change import to uppercase

### DIFF
--- a/packages/docs-reanimated/docs/advanced/useHandler.mdx
+++ b/packages/docs-reanimated/docs/advanced/useHandler.mdx
@@ -93,8 +93,8 @@ The hook returns a context that will be reused by event handlers and value that 
 
 ## Example
 
-import useHandler from '@site/src/examples/useHandlerEventExample';
-import useHandlerSrc from '!!raw-loader!@site/src/examples/useHandlerEventExample';
+import useHandler from '@site/src/examples/UseHandlerEventExample';
+import useHandlerSrc from '!!raw-loader!@site/src/examples/UseHandlerEventExample';
 
 <InteractiveExample src={useHandlerSrc} component={useHandler} />
 


### PR DESCRIPTION
This PR fixes docs building by changing name of imported file to uppercase.