### PR TITLE
Migrate `ShareableJSRef` to `jsi::NativeState`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -70,11 +70,10 @@ jsi::Value makeShareableClone(
       shareable =
           std::make_shared<ShareableArrayBuffer>(rt, object.getArrayBuffer(rt));
     } else if (object.isHostObject(rt)) {
-      if (object.isHostObject<ShareableJSRef>(rt)) {
-        return object;
-      }
       shareable =
           std::make_shared<ShareableHostObject>(rt, object.getHostObject(rt));
+    } else if (object.hasNativeState<ShareableNativeState>(rt)) {
+      return object;
     } else {
       if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
         shareable = std::make_shared<RetainingShareable<ShareableObject>>(
@@ -119,7 +118,7 @@ jsi::Value makeShareableClone(
     throw std::runtime_error(
         "[Reanimated] Attempted to convert an unsupported value type.");
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return ShareableNativeState::createObjectWithShareableNativeState(rt, shareable);
 }
 
 std::shared_ptr<Shareable> extractShareableOrThrow(
@@ -128,8 +127,8 @@ std::shared_ptr<Shareable> extractShareableOrThrow(
     const std::string &errorMessage) {
   if (maybeShareableValue.isObject()) {
     auto object = maybeShareableValue.asObject(rt);
-    if (object.isHostObject<ShareableJSRef>(rt)) {
-      return object.getHostObject<ShareableJSRef>(rt)->value();
+    if (object.hasNativeState<ShareableNativeState>(rt)) {
+      return object.getNativeState<ShareableNativeState>(rt)->getShareable();
     }
     throw std::runtime_error(
         "[Reanimated] Attempted to extract from a HostObject that wasn't converted to a Shareable.");
@@ -169,7 +168,7 @@ jsi::Value RetainingShareable<BaseClass>::toJSValue(jsi::Runtime &rt) {
   return BaseClass::toJSValue(rt);
 }
 
-ShareableJSRef::~ShareableJSRef() {}
+ShareableNativeState::~ShareableNativeState() {}
 
 ShareableArray::ShareableArray(jsi::Runtime &rt, const jsi::Array &array)
     : Shareable(ArrayType) {
@@ -271,11 +270,11 @@ jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
 #ifndef NDEBUG
     return getValueUnpacker(rt).call(
         rt,
-        ShareableJSRef::newHostObject(rt, shared_from_this()),
+        ShareableNativeState::createObjectWithShareableNativeState(rt, shared_from_this()),
         jsi::String::createFromAscii(rt, "RemoteFunction"),
         jsi::String::createFromUtf8(rt, name_));
 #else
-    return ShareableJSRef::newHostObject(rt, shared_from_this());
+    return ShareableNativeState::createObjectWithShareableNativeState(rt, shared_from_this());
 #endif
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.h
@@ -116,25 +116,26 @@ class RetainingShareable : virtual public BaseClass {
   }
 };
 
-class ShareableJSRef : public jsi::HostObject {
+class ShareableNativeState : public jsi::NativeState {
  private:
-  const std::shared_ptr<Shareable> value_;
+  const std::shared_ptr<Shareable> shareable_;
 
  public:
-  explicit ShareableJSRef(const std::shared_ptr<Shareable> &value)
-      : value_(value) {}
+  explicit ShareableNativeState(const std::shared_ptr<Shareable> &shareable)
+      : shareable_(shareable) {}
 
-  virtual ~ShareableJSRef();
+  virtual ~ShareableNativeState();
 
-  std::shared_ptr<Shareable> value() const {
-    return value_;
+  std::shared_ptr<Shareable> getShareable() const {
+    return shareable_;
   }
 
-  static jsi::Object newHostObject(
+  static jsi::Object createObjectWithShareableNativeState(
       jsi::Runtime &rt,
       const std::shared_ptr<Shareable> &value) {
-    return jsi::Object::createFromHostObject(
-        rt, std::make_shared<ShareableJSRef>(value));
+    jsi::Object obj(rt);
+    obj.setNativeState(rt, std::make_shared<ShareableNativeState>(value));
+    return obj;
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

According to [this tweet](https://x.com/tmikov/status/1821219997181763956) posted by @tmikov from Hermes team, usage of `jsi::HostObject` is strongly discouraged.

This PR migrates `ShareableJSRef` that used to be a `jsi::HostObject` to `jsi::NativeState` as well as renames it to `ShareableNativeState` for consistency and updates all usages accordingly.

> [!CAUTION]
> `jsi::NativeState` was added in React Native 0.71 but requires 0.72 to work correctly on Android or iOS. Also, it still does *not* work on some platforms, e.g. latest macOS with JSC (Hermes disabled). Let's hold this PR until `jsi::NativeState` is supported on all supported configurations.

> [!NOTE]  
> TODO: compare performance

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
