### PR TITLE
Migrate `WorkletRuntimeCollector` to `jsi::NativeState`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeCollector.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeCollector.h
@@ -8,11 +8,11 @@
 
 namespace reanimated {
 
-class WorkletRuntimeCollector : public jsi::HostObject {
-  // When worklet runtime is created, we inject an instance of this class as a
-  // `jsi::HostObject` into the global object. When worklet runtime is
-  // terminated, the object is garbage-collected, which runs the C++ destructor.
-  // In the destructor, we unregister the worklet runtime from the registry.
+class WorkletRuntimeCollector : public jsi::NativeState {
+  // When worklet runtime is created, we inject an object with native state into
+  // the global object. When worklet runtime is terminated, the object is
+  // garbage-collected, which runs the C++ destructor. In the destructor, we
+  // unregister the worklet runtime from the registry.
 
  public:
   explicit WorkletRuntimeCollector(jsi::Runtime &runtime) : runtime_(runtime) {
@@ -24,9 +24,9 @@ class WorkletRuntimeCollector : public jsi::HostObject {
   }
 
   static void install(jsi::Runtime &rt) {
-    auto collector = std::make_shared<WorkletRuntimeCollector>(rt);
-    auto object = jsi::Object::createFromHostObject(rt, collector);
-    rt.global().setProperty(rt, "__workletRuntimeCollector", object);
+    const jsi::Object obj(rt);
+    obj.setNativeState(rt, std::make_shared<WorkletRuntimeCollector>(rt));
+    rt.global().setProperty(rt, "__workletRuntimeCollector", obj);
   }
 
  private:


### PR DESCRIPTION
## Summary

This PR migrates `WorkletRuntimeCollector` from `jsi::HostObject` to `jsi::NativeState` as recommended by the Hermes team.

To be merged after https://github.com/software-mansion/react-native-reanimated/pull/6389.

## Test plan
