### PR TITLE
Migrate `WorkletRuntime` to `jsi::NativeState`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -232,7 +232,7 @@ jsi::Value NativeReanimatedModule::createWorkletRuntime(
       rt, initializer, "[Reanimated] Initializer must be a worklet.");
   workletRuntime->runGuarded(initializerShareable);
   ReanimatedWorkletRuntimeDecorator::decorate(workletRuntime->getJSIRuntime());
-  return jsi::Object::createFromHostObject(rt, workletRuntime);
+  return workletRuntime->createValue(rt);
 }
 
 jsi::Value NativeReanimatedModule::scheduleOnRuntime(

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -18,7 +18,7 @@ using namespace react;
 
 namespace reanimated {
 
-class WorkletRuntime : public jsi::HostObject,
+class WorkletRuntime : public jsi::NativeState,
                        public std::enable_shared_from_this<WorkletRuntime> {
  public:
   explicit WorkletRuntime(
@@ -57,9 +57,7 @@ class WorkletRuntime : public jsi::HostObject,
     return "[WorkletRuntime \"" + name_ + "\"]";
   }
 
-  jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propName) override;
-
-  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+  jsi::Value createValue(jsi::Runtime &rt);
 
  private:
   const std::shared_ptr<std::recursive_mutex> runtimeMutex_;

--- a/packages/react-native-reanimated/src/runtimes.ts
+++ b/packages/react-native-reanimated/src/runtimes.ts
@@ -12,7 +12,7 @@ import {
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
 export type WorkletRuntime = {
-  __hostObjectWorkletRuntime: never;
+  __nativeStateWorkletRuntime: never;
   readonly name: string;
 };
 
@@ -21,7 +21,7 @@ export type WorkletRuntime = {
  *
  * @param name - A name used to identify the runtime which will appear in devices list in Chrome DevTools.
  * @param initializer - An optional worklet that will be run synchronously on the same thread immediately after the runtime is created.
- * @returns WorkletRuntime which is a jsi::HostObject\<reanimated::WorkletRuntime\> - {@link WorkletRuntime}
+ * @returns WorkletRuntime which is an object with jsi::NativeState\<reanimated::WorkletRuntime\> - {@link WorkletRuntime}
  * @see https://docs.swmansion.com/react-native-reanimated/docs/threading/createWorkletRuntime
  */
 // @ts-expect-error Check `runOnUI` overload.


### PR DESCRIPTION
## Summary

This PR migrates `WorkletRuntimeCollector` from `jsi::HostObject` to `jsi::NativeState` as recommended by the Hermes team.

To be merged after https://github.com/software-mansion/react-native-reanimated/pull/6389.

## Test plan
