### PR TITLE
Update RN pager view patch file

### DIFF
--- a/.yarn/patches/react-native-pager-view-npm-6.3.3-7b62f58674.patch
+++ b/.yarn/patches/react-native-pager-view-npm-6.3.3-7b62f58674.patch
@@ -1,5 +1,5 @@
 diff --git a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
-index aa974a6bad63f5015a75834f9740abacd0771e0d..c8e2f8583a5fbd89216b982d6115c34375f009e5 100644
+index aa974a6bad63f5015a75834f9740abacd0771e0d..e9c4a52d4b98550b4c8f326ccf9b9bbf66cb615b 100644
 --- a/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
 +++ b/android/src/fabric/java/com/reactnativepagerview/PagerViewViewManager.kt
 @@ -88,7 +88,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>(), RNCViewPa
@@ -7,12 +7,12 @@ index aa974a6bad63f5015a75834f9740abacd0771e0d..c8e2f8583a5fbd89216b982d6115c343
      }
  
 -    override fun addView(host: NestedScrollableHost, child: View?, index: Int) {
-+    fun addView(host: NestedScrollableHost, child: View?, index: Int) {
++    override fun addView(host: NestedScrollableHost, child: View, index: Int) {
          PagerViewViewManagerImpl.addView(host, child, index)
      }
  
 diff --git a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
-index 4d0adffe6a658de709319e0700b35f726783dca2..d3d99a2f2b8ce7f91e4056d07664d4fb6efc8115 100644
+index 4d0adffe6a658de709319e0700b35f726783dca2..959362c62af06f791088c416e2db8f1629ab63ce 100644
 --- a/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
 +++ b/android/src/paper/java/com/reactnativepagerview/PagerViewViewManager.kt
 @@ -69,7 +69,7 @@ class PagerViewViewManager : ViewGroupManager<NestedScrollableHost>() {
@@ -20,7 +20,7 @@ index 4d0adffe6a658de709319e0700b35f726783dca2..d3d99a2f2b8ce7f91e4056d07664d4fb
      }
  
 -    override fun addView(host: NestedScrollableHost, child: View?, index: Int) {
-+    fun addView(host: NestedScrollableHost, child: View?, index: Int) {
++    override fun addView(host: NestedScrollableHost, child: View, index: Int) {
          PagerViewViewManagerImpl.addView(host, child, index)
      }
  

--- a/yarn.lock
+++ b/yarn.lock
@@ -18452,11 +18452,11 @@ __metadata:
 
 "react-native-pager-view@patch:react-native-pager-view@npm%3A6.3.3#~/.yarn/patches/react-native-pager-view-npm-6.3.3-7b62f58674.patch":
   version: 6.3.3
-  resolution: "react-native-pager-view@patch:react-native-pager-view@npm%3A6.3.3#~/.yarn/patches/react-native-pager-view-npm-6.3.3-7b62f58674.patch::version=6.3.3&hash=e38677"
+  resolution: "react-native-pager-view@patch:react-native-pager-view@npm%3A6.3.3#~/.yarn/patches/react-native-pager-view-npm-6.3.3-7b62f58674.patch::version=6.3.3&hash=7b73d2"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/2f141dbc984a50fbfe818a90fe3094d0d0c898bb88f6be8dd580351b6ef152f958446b02abddecd7e3b621e205220ad30acd5922490cdfb60d336696cfd4e095
+  checksum: 10/00005f38fa2be6d3e21a3dd61dbd97424ceb401240a8b360f080ea1a6a930a70bcfb8cda109a67880b2277f2ffeb052b7487c8839e6551efa4636d81b47750fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Our patch to `react-native-pager-view` for `RN 0.75-rc.6` works, but seems like it isn't the best way to do that, as stated [here](https://github.com/callstack/react-native-pager-view/issues/850#issuecomment-2275240214). In short, removing the `override` keyword will cause tab bar navigation crashes. Instead, I adjusted the functions' signature, so that they actually override something.

## Test plan

Try building android examples
