### PR TITLE
docs: Move Platform Compatibility to MDXComponents

### DIFF
--- a/packages/docs-reanimated/docs/advanced/dispatchCommand.mdx
+++ b/packages/docs-reanimated/docs/advanced/dispatchCommand.mdx
@@ -5,7 +5,6 @@ sidebar_position: 7
 # dispatchCommand
 
 import DispatchCommandSrc from '!!raw-loader!@site/src/examples/DispatchCommand';
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
 
 `dispatchCommand` allows you to run commands on a native component from the UI thread directly.
 

--- a/packages/docs-reanimated/docs/advanced/makeMutable.mdx
+++ b/packages/docs-reanimated/docs/advanced/makeMutable.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 9
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # makeMutable
 
 :::caution

--- a/packages/docs-reanimated/docs/advanced/measure.mdx
+++ b/packages/docs-reanimated/docs/advanced/measure.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # measure
 
 `measure` lets you synchronously get the dimensions and position of a view on the screen, all on the [UI thread](/docs/fundamentals/glossary#ui-thread).

--- a/packages/docs-reanimated/docs/advanced/setNativeProps.mdx
+++ b/packages/docs-reanimated/docs/advanced/setNativeProps.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 8
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # setNativeProps
 
 `setNativeProps` lets you imperatively update component properties.

--- a/packages/docs-reanimated/docs/advanced/useAnimatedReaction.mdx
+++ b/packages/docs-reanimated/docs/advanced/useAnimatedReaction.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useAnimatedReaction
 
 `useAnimatedReaction` allows you to respond to changes in a [shared value](/docs/fundamentals/glossary#shared-value). It's especially useful when comparing values previously stored in the shared value with the current one.

--- a/packages/docs-reanimated/docs/advanced/useComposedEventHandler.mdx
+++ b/packages/docs-reanimated/docs/advanced/useComposedEventHandler.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 6
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useComposedEventHandler
 
 This is a hook that lets you compose [useEvent](/docs/advanced/useEvent)-based event handlers (such as [useAnimatedScrollHandler](/docs/scroll/useAnimatedScrollHandler) or your own custom ones) into a single, combined event handler.

--- a/packages/docs-reanimated/docs/advanced/useEvent.mdx
+++ b/packages/docs-reanimated/docs/advanced/useEvent.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 4
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useEvent
 
 `useEvent` is a low-level hook. It returns event handler that will be called when native event occurs. You can use it to create custom event handler hooks, like [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset/) or [`useAnimatedScrollHandler`](/docs/scroll/useAnimatedScrollHandler/).

--- a/packages/docs-reanimated/docs/advanced/useFrameCallback.mdx
+++ b/packages/docs-reanimated/docs/advanced/useFrameCallback.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useFrameCallback
 
 `useFrameCallback` lets you run a function on every frame update.

--- a/packages/docs-reanimated/docs/advanced/useHandler.mdx
+++ b/packages/docs-reanimated/docs/advanced/useHandler.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 5
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useHandler
 
 `useHandler` is a low-level hook. It returns a context object and a value that tells you if the worklet needs to be rebuilt. You can use it to create custom event handler hooks, like [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset/) or [`useAnimatedScrollHandler`](/docs/scroll/useAnimatedScrollHandler/).

--- a/packages/docs-reanimated/docs/animations/withClamp.mdx
+++ b/packages/docs-reanimated/docs/animations/withClamp.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 7
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withClamp
 
 `withClamp` is an [animation modifier](/docs/fundamentals/glossary#animation-modifier) that lets you limit the scope of movement of your animation to make it stay within some predefined range.

--- a/packages/docs-reanimated/docs/animations/withDecay.mdx
+++ b/packages/docs-reanimated/docs/animations/withDecay.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withDecay
 
 `withDecay` lets you create animations that mimic objects in motion with friction. The animation will start with the provided velocity and slow down over time according to the given deceleration rate until it stops.

--- a/packages/docs-reanimated/docs/animations/withDelay.mdx
+++ b/packages/docs-reanimated/docs/animations/withDelay.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 6
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withDelay
 
 `withDelay` is an [animation modifier](/docs/fundamentals/glossary#animation-modifier) that lets you start an animation with a delay.

--- a/packages/docs-reanimated/docs/animations/withRepeat.mdx
+++ b/packages/docs-reanimated/docs/animations/withRepeat.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 5
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withRepeat
 
 `withRepeat` is an [animation modifier](/docs/fundamentals/glossary#animation-modifier) that lets you repeat an animation given number of times or run it indefinitely.

--- a/packages/docs-reanimated/docs/animations/withSequence.mdx
+++ b/packages/docs-reanimated/docs/animations/withSequence.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 4
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withSequence
 
 `withSequence` is an [animation modifier](/docs/fundamentals/glossary#animation-modifier) that lets you run animations in a sequence.

--- a/packages/docs-reanimated/docs/animations/withSpring.mdx
+++ b/packages/docs-reanimated/docs/animations/withSpring.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withSpring
 
 `withSpring` lets you create spring-based animations.

--- a/packages/docs-reanimated/docs/animations/withTiming.mdx
+++ b/packages/docs-reanimated/docs/animations/withTiming.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # withTiming
 
 `withTiming` lets you create an animation based on duration and [easing](https://easings.net/).

--- a/packages/docs-reanimated/docs/components/ReducedMotionConfig.mdx
+++ b/packages/docs-reanimated/docs/components/ReducedMotionConfig.mdx
@@ -5,8 +5,6 @@ sidebar_label: ReducedMotionConfig
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `ReducedMotionConfig` component let's you change behavior in response to the device's reduced motion accessibility setting. By default it disables all animation when the reduced motion is enabled on a device. You can adjust it for your specific use case. You can learn more about [Accessibility](/docs/guides/accessibility) and [`useReducedMotion`](/docs/device/useReducedMotion) in Reanimated.
 
 ## Reference

--- a/packages/docs-reanimated/docs/core/cancelAnimation.mdx
+++ b/packages/docs-reanimated/docs/core/cancelAnimation.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 7
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # cancelAnimation
 
 `cancelAnimation` lets you cancel a running animation paired to a [shared value](/docs/fundamentals/glossary#shared-value).

--- a/packages/docs-reanimated/docs/core/createAnimatedComponent.mdx
+++ b/packages/docs-reanimated/docs/core/createAnimatedComponent.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 6
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # createAnimatedComponent
 
 `createAnimatedComponent` lets you create an Animated version of any React Native component. Wrapping a component with `createAnimatedComponent` allows Reanimated to animate any prop or style associated with that component.

--- a/packages/docs-reanimated/docs/core/useAnimatedProps.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedProps.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useAnimatedProps
 
 `useAnimatedProps` lets you create an animated props object which can be animated using [shared values](/docs/fundamentals/glossary#shared-value). This object is used to animate properties of third-party components.

--- a/packages/docs-reanimated/docs/core/useAnimatedRef.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedRef.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 4
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useAnimatedRef
 
 `useAnimatedRef` lets you get a reference of a view. Used alongside [`measure`](/docs/advanced/measure), [`scrollTo`](/docs/scroll/scrollTo), and [`useScrollViewOffset`](/docs/scroll/useScrollViewOffset) functions.

--- a/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useAnimatedStyle
 
 `useAnimatedStyle` lets you create a styles object, similar to `StyleSheet` styles, which can be animated using [shared values](/docs/fundamentals/glossary#shared-value).

--- a/packages/docs-reanimated/docs/core/useDerivedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useDerivedValue.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 5
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useDerivedValue
 
 `useDerivedValue` lets you create new [shared values](/docs/fundamentals/glossary#shared-value) based on existing ones while keeping them reactive.

--- a/packages/docs-reanimated/docs/core/useSharedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useSharedValue.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useSharedValue
 
 `useSharedValue` lets you define [shared values](/docs/fundamentals/glossary#shared-value) in your components.

--- a/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
+++ b/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `useAnimatedKeyboard` lets you create animations based on state and height of the virtual keyboard.
 
 :::caution

--- a/packages/docs-reanimated/docs/device/useAnimatedSensor.mdx
+++ b/packages/docs-reanimated/docs/device/useAnimatedSensor.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `useAnimatedSensor` lets you create animations based on data from the device's sensors. You can access:
 
 - **Accelerometer** - the device acceleration (without gravity).

--- a/packages/docs-reanimated/docs/device/useReducedMotion.mdx
+++ b/packages/docs-reanimated/docs/device/useReducedMotion.mdx
@@ -5,8 +5,6 @@ sidebar_label: useReducedMotion
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `useReducedMotion` lets you query the reduced motion system setting. You can use it to disable animations.
 
 ## Reference

--- a/packages/docs-reanimated/docs/layout-animations/custom-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/custom-animations.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 4
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # Custom animations
 
 import EnteringExitingAnimationSrc from '!!raw-loader!@site/src/examples/CustomEnteringExiting';

--- a/packages/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # Entering/Exiting animations
 
 Entering/Exiting animations let you animate elements when they are added to or removed from the view hierarchy.

--- a/packages/docs-reanimated/docs/layout-animations/keyframe-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/keyframe-animations.mdx
@@ -4,7 +4,6 @@ sidebar_position: 2
 
 import Keyframe from '@site/src/examples/KeyframeAnimation';
 import KeyframeSrc from '!!raw-loader!@site/src/examples/KeyframeAnimation';
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
 
 # Keyframe animations
 

--- a/packages/docs-reanimated/docs/layout-animations/layout-animation-config.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/layout-animation-config.mdx
@@ -4,8 +4,6 @@ title: LayoutAnimationConfig
 sidebar_label: Skipping Layout Animations
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `LayoutAnimationConfig` is a component that lets you skip entering and exiting animations.
 
 ## Reference

--- a/packages/docs-reanimated/docs/layout-animations/layout-transitions.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/layout-transitions.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # Layout transitions
 
 Layout transitions allows you to replace layout changes with smooth transitions. Each layout change may include changes of size and position and both of them can be animated.

--- a/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/list-layout-animations.mdx
@@ -4,8 +4,6 @@ title: List Layout Animations
 sidebar_label: List Layout Animations
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 `itemLayoutAnimation` lets you define a [layout transition](/docs/layout-animations/layout-transitions) that's applied when list items layout changes. You can use one of the [predefined transitions](/docs/layout-animations/layout-transitions#predefined-transitions) like `LinearTransition` or create [your own transition](/docs/layout-animations/custom-animations#custom-layout-transition).
 
 ## Example

--- a/packages/docs-reanimated/docs/scroll/scrollTo.mdx
+++ b/packages/docs-reanimated/docs/scroll/scrollTo.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # scrollTo
 
 `scrollTo` lets you synchronously scroll to a given X or Y offset.

--- a/packages/docs-reanimated/docs/scroll/useAnimatedScrollHandler.mdx
+++ b/packages/docs-reanimated/docs/scroll/useAnimatedScrollHandler.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useAnimatedScrollHandler
 
 `useAnimatedScrollHandler` is a hook that returns an event handler reference. It can be used with React Native's scrollable components.

--- a/packages/docs-reanimated/docs/scroll/useScrollViewOffset.mdx
+++ b/packages/docs-reanimated/docs/scroll/useScrollViewOffset.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # useScrollViewOffset
 
 `useScrollViewOffset` lets you to create animations based on the offset of a `ScrollView`.

--- a/packages/docs-reanimated/docs/threading/createWorkletRuntime.mdx
+++ b/packages/docs-reanimated/docs/threading/createWorkletRuntime.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # createWorkletRuntime
 
 `createWorkletRuntime` lets you create a new JS runtime which can be used to run [worklets](/docs/fundamentals/glossary#worklet) possibly on different threads than [JS](/docs/fundamentals/glossary#javascript-thread) or [UI thread](/docs/fundamentals/glossary#ui-thread). This function is supposed to be used by third-party libraries that need to integrate with worklets. The return value represents the runtime and it's supposed to be passed to C++ side using JSI (JavaScript Interface) for further operations.

--- a/packages/docs-reanimated/docs/threading/runOnJS.mdx
+++ b/packages/docs-reanimated/docs/threading/runOnJS.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # runOnJS
 
 `runOnJS` lets you asynchronously run non-[workletized](/docs/fundamentals/glossary#to-workletize) functions that couldn't otherwise run on the [UI thread](/docs/fundamentals/glossary#ui-thread). This applies to most external libraries as they don't have their functions marked with `"worklet";` directive.

--- a/packages/docs-reanimated/docs/threading/runOnUI.mdx
+++ b/packages/docs-reanimated/docs/threading/runOnUI.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # runOnUI
 
 `runOnUI` lets you asynchronously run [workletized](/docs/fundamentals/glossary#to-workletize) functions on the [UI thread](/docs/fundamentals/glossary#ui-thread).

--- a/packages/docs-reanimated/docs/utilities/clamp.mdx
+++ b/packages/docs-reanimated/docs/utilities/clamp.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 2
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # clamp
 
 `clamp` lets you limit a value within a specified range.

--- a/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 4
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # getRelativeCoords
 
 `getRelativeCoords` determines the location on the screen, relative to the given view.

--- a/packages/docs-reanimated/docs/utilities/interpolate.mdx
+++ b/packages/docs-reanimated/docs/utilities/interpolate.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 1
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # interpolate
 
 `interpolate` lets you map a value from one range to another using linear interpolation.

--- a/packages/docs-reanimated/docs/utilities/interpolateColor.mdx
+++ b/packages/docs-reanimated/docs/utilities/interpolateColor.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 3
 ---
 
-import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
-
 # interpolateColor
 
 `interpolateColor` maps input range to output colors using linear interpolation.

--- a/packages/docs-reanimated/src/theme/MDXComponents.js
+++ b/packages/docs-reanimated/src/theme/MDXComponents.js
@@ -3,6 +3,7 @@ import MDXComponents from '@theme-original/MDXComponents';
 import InteractiveExample from '@site/src/components/InteractiveExample';
 import InteractivePlayground from '@site/src/components/InteractivePlayground';
 import CollapsibleCode from '@site/src/components/CollapsibleCode';
+import PlatformCompatibility from '@site/src/components/PlatformCompatibility';
 import ExampleVideo from '@site/src/components/ExampleVideo';
 import { Yes, No, Version, Spacer } from '@site/src/components/Compatibility';
 import Optional from '@site/src/components/Optional';
@@ -19,6 +20,7 @@ export default {
   InteractiveExample,
   InteractivePlayground,
   CollapsibleCode,
+  PlatformCompatibility,
   ExampleVideo,
   Yes,
   No,


### PR DESCRIPTION
This PR moves PlatformCompatibility component to `MDXComponents.js`, to use it in docs without importing.

Additionally:
* removes imports from 43 files
* removes `display: block` on table

Before (with `display: block`):
<img width="550" alt="image" src="https://github.com/user-attachments/assets/8e4b9866-21d9-436c-99c9-005cb3caa3be">

After (without `display: block`):
<img width="552" alt="image" src="https://github.com/user-attachments/assets/7c2d4e44-c533-4821-b558-884d7994fb10">
