### PR TITLE
[Web] Add `findNodeHandle` web version

### DIFF
--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import type { ReactNode } from 'react';
 import { setShouldAnimateExitingForTag } from '../core';
-import { findNodeHandle } from 'react-native';
+import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 
 export const SkipEnteringContext =
   createContext<React.MutableRefObject<boolean> | null>(null);

--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -1,5 +1,6 @@
 'use strict';
-import { NativeEventEmitter, Platform, findNodeHandle } from 'react-native';
+import { NativeEventEmitter, Platform } from 'react-native';
+import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 import type { NativeModule } from 'react-native';
 import { shouldBeUseWeb } from '../PlatformChecker';
 import type { StyleProps } from '../commonTypes';

--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -8,7 +8,7 @@ import type {
 } from './commonTypes';
 import { has } from './utils';
 import { WorkletEventHandler } from '../WorkletEventHandler';
-import { findNodeHandle } from 'react-native';
+import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 
 export class NativeEventsManager implements INativeEventsManager {
   readonly #managedComponent: ManagedAnimatedComponent;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -503,7 +503,7 @@ export function createAnimatedComponent(
                 : getReduceMotionFromConfig();
             if (!reduceMotionInExiting) {
               updateLayoutAnimations(
-                tag as number,
+                tag,
                 LayoutAnimationType.EXITING,
                 maybeBuild(
                   exiting,
@@ -517,7 +517,7 @@ export function createAnimatedComponent(
           const skipEntering = this.context?.current;
           if (entering && !skipEntering && !IS_WEB) {
             updateLayoutAnimations(
-              tag as number,
+              tag,
               LayoutAnimationType.ENTERING,
               maybeBuild(
                 entering,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -7,7 +7,8 @@ import type {
   MutableRefObject,
 } from 'react';
 import React from 'react';
-import { findNodeHandle, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 import '../layoutReanimation/animationsManager';
 import invariant from 'invariant';
 import { adaptViewConfig } from '../ConfigHelper';
@@ -478,9 +479,7 @@ export function createAnimatedComponent(
       setLocalRef: (ref) => {
         // TODO update config
 
-        const tag = IS_WEB
-          ? (ref as HTMLElement)
-          : findNodeHandle(ref as Component);
+        const tag = findNodeHandle(ref as Component);
 
         this._componentViewTag = tag as number;
 

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -7,7 +7,8 @@ import type { ShadowNodeWrapper } from '../commonTypes';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import { makeShareableCloneRecursive } from '../shareables';
 import { shareableMappingCache } from '../shareableMappingCache';
-import { Platform, findNodeHandle } from 'react-native';
+import { Platform } from 'react-native';
+import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 import type { ScrollView, FlatList } from 'react-native';
 import { isFabric, isWeb } from '../PlatformChecker';
 

--- a/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.ts
@@ -1,0 +1,3 @@
+import { findNodeHandle } from 'react-native';
+
+export { findNodeHandle };

--- a/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.ts
@@ -1,3 +1,4 @@
+'use strict';
 import { findNodeHandle } from 'react-native';
 
 export { findNodeHandle };

--- a/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
@@ -1,3 +1,4 @@
+'use strict';
 import type { Component, ComponentClass } from 'react';
 
 export function findNodeHandle(

--- a/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentClass } from 'react';
+import type { Component, ComponentClass } from 'react';
 
 export function findNodeHandle(
   componentOrHandle: null | number | Component<any, any> | ComponentClass<any>

--- a/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/findNodeHandle.web.ts
@@ -1,0 +1,7 @@
+import { Component, ComponentClass } from 'react';
+
+export function findNodeHandle(
+  componentOrHandle: null | number | Component<any, any> | ComponentClass<any>
+) {
+  return componentOrHandle;
+}


### PR DESCRIPTION
## Summary

In many places we use `findNodeHandle` function to get native view that is represented by React component. The problem is that usage of this function on `web` leads to warnings (which are shown via `console.error`), that this function in deprecated and should not be used.

I've already done 3 PRs that remove usage of `findNodeHandle` on `web`, but it keeps reappearing. That's why I've decided to create our version of this function. On native platforms it is just export from `react-native`. On `web` it returns component that is passed into the function.

>[!CAUTION]
>Note that `findNodeHandle`(or to be exact, `findDOMNode`) will be [removed in next major version of React](https://react.dev/reference/react-dom/findDOMNode) (i.e. React 19)


## Test plan

Verifed on our web-example that it uses web version of `findNodeHandle`. 

>[!NOTE]
>In our example app you can still see depracation warning. This is because of `GestureDetector` from `react-native-gesture-handler` and it has to be fixed in mentioned library.