### PR TITLE
Implement missing measurements on android

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -70,7 +70,7 @@ export default function RuntimeTestsExample() {
           testSuiteName: 'advanced API',
           importTest: () => {
             require('./tests/advancedAPI/useFrameCallback.test');
-            // require('./tests/advancedAPI/measure.test'); // crash on Android
+            require('./tests/advancedAPI/measure.test');
           },
         },
         {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
@@ -30,7 +30,8 @@ public class NativeMethodsHelper {
     buffer[1] -= rootY;
 
     float result[] = new float[6];
-    result[0] = result[1] = 0;
+    result[0] =  PixelUtil.toDIPFromPixel(view.getLeft());
+    result[1] =  PixelUtil.toDIPFromPixel(view.getTop());
     for (int i = 2; i < 6; ++i) result[i] = PixelUtil.toDIPFromPixel(buffer[i - 2]);
 
     return result;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeMethodsHelper.java
@@ -30,8 +30,8 @@ public class NativeMethodsHelper {
     buffer[1] -= rootY;
 
     float result[] = new float[6];
-    result[0] =  PixelUtil.toDIPFromPixel(view.getLeft());
-    result[1] =  PixelUtil.toDIPFromPixel(view.getTop());
+    result[0] = PixelUtil.toDIPFromPixel(view.getLeft());
+    result[1] = PixelUtil.toDIPFromPixel(view.getTop());
     for (int i = 2; i < 6; ++i) result[i] = PixelUtil.toDIPFromPixel(buffer[i - 2]);
 
     return result;


### PR DESCRIPTION
## Summary
Implement measurement of relative coordinates on Android.

## Test plan
I've added more logic to runtime tests to include parent component changes in calculations.


<details><summary> Example code to log measurement </summary>

```tsx
import React from 'react';
import { Button, StyleSheet, View } from 'react-native';
import type { MeasuredDimensions } from 'react-native-reanimated';
import Animated, {
  measure,
  runOnUI,
  useAnimatedRef,
  useSharedValue,
} from 'react-native-reanimated';

const EXPECTED_MEASUREMENT = {
  height: 100,
  pageX: 302,
  width: 80,
  x: 120,
  y: 150,
};

export default function App() {
  const animatedRef = useAnimatedRef<Animated.View>();

  const measurement = useSharedValue<MeasuredDimensions | null>(null);

  const handlePress = () => {
    runOnUI(() => {
      'worklet';
      measurement.value = measure(animatedRef);
      console.log(measurement.value);
    })();
  };

  return (
    <View style={styles.container}>
      <View style={styles.bigBox}>
        <Animated.View ref={animatedRef} style={styles.box} />
      </View>
      <Button onPress={handlePress} title="Click me" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  bigBox: {
    position: 'absolute',
    top: 0,
    left: EXPECTED_MEASUREMENT.pageX - EXPECTED_MEASUREMENT.x,
    height: 300,
    width: 300,
    borderColor: '#b58df1',
    borderWidth: 2,
  },
  box: {
    top: EXPECTED_MEASUREMENT.y,
    left: EXPECTED_MEASUREMENT.x,
    height: EXPECTED_MEASUREMENT.height,
    width: EXPECTED_MEASUREMENT.width,
    backgroundColor: '#b58df1',
  },
});

```
</summary>

