### PR TITLE
feat: add support for isNavigationBarTranslucentAndroid

### DIFF
--- a/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
+++ b/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
@@ -101,10 +101,14 @@ import AnimatedKeyboardSrc from '!!raw-loader!@site/src/examples/AnimatedKeyboar
 
 - On Android, using the `useAnimatedKeyboard` hook expands root view to full screen ([immersive mode](https://developer.android.com/develop/ui/views/layout/immersive)) and takes control over insets management.
 
-  - When `isStatusBarTranslucentAndroid` is `false` it applies the top and bottom margins according to the insets.
+  - When `isStatusBarTranslucentAndroid` is `false` it applies the top  margin according to the insets.
 
-  - When `isStatusBarTranslucentAndroid` is `true` it applies bottom padding according to the navigation inset and sets top margin to `0`.
+  - When `isStatusBarTranslucentAndroid` is `true` it sets top margin to `0`.
 
+  - When `isNavigationBarTranslucentAndroid` is `false` it applies the bottom margin according to the insets.
+
+  - When `isNavigationBarTranslucentAndroid` is `true` it sets bottom margin to `0`.
+  
 - On Android, when using navigation with native header, `isStatusBarTranslucentAndroid` doesn't affect the top inset.
 
 - On Android SDK < 30, when status bar is hidden, the keyboard reverts to the default Android behavior.

--- a/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
+++ b/packages/docs-reanimated/docs/device/useAnimatedKeyboard.mdx
@@ -101,14 +101,14 @@ import AnimatedKeyboardSrc from '!!raw-loader!@site/src/examples/AnimatedKeyboar
 
 - On Android, using the `useAnimatedKeyboard` hook expands root view to full screen ([immersive mode](https://developer.android.com/develop/ui/views/layout/immersive)) and takes control over insets management.
 
-  - When `isStatusBarTranslucentAndroid` is `false` it applies the top  margin according to the insets.
+  - When `isStatusBarTranslucentAndroid` is `false` it applies the top margin according to the insets.
 
   - When `isStatusBarTranslucentAndroid` is `true` it sets top margin to `0`.
 
   - When `isNavigationBarTranslucentAndroid` is `false` it applies the bottom margin according to the insets.
 
   - When `isNavigationBarTranslucentAndroid` is `true` it sets bottom margin to `0`.
-  
+
 - On Android, when using navigation with native header, `isStatusBarTranslucentAndroid` doesn't affect the top inset.
 
 - On Android SDK < 30, when status bar is hidden, the keyboard reverts to the default Android behavior.

--- a/packages/docs-reanimated/versioned_docs/version-2.x/api/hooks/useAnimatedKeyboard.md
+++ b/packages/docs-reanimated/versioned_docs/version-2.x/api/hooks/useAnimatedKeyboard.md
@@ -48,6 +48,8 @@ Properties:
 
 - `isStatusBarTranslucentAndroid`[bool] - if you want to use translucent status bar on Android, set this option to `true`. Defaults to `false`. Ignored on iOS.
 
+- `isNavigationBarTranslucentAndroid`[bool] - if you want to use translucent navigation bar on Android, set this option to `true`. Defaults to `false`. Ignored on iOS.
+
 ### Example
 
 ```js

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -876,7 +876,8 @@ void NativeReanimatedModule::initializeLayoutAnimations() {
 jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
     jsi::Runtime &rt,
     const jsi::Value &handlerWorklet,
-    const jsi::Value &isStatusBarTranslucent) {
+    const jsi::Value &isStatusBarTranslucent,
+    const jsi::Value &isNavigationBarTranslucent) {
   auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
       rt,
       handlerWorklet,
@@ -886,7 +887,8 @@ jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
         uiWorkletRuntime_->runGuarded(
             shareableHandler, jsi::Value(keyboardState), jsi::Value(height));
       },
-      isStatusBarTranslucent.getBool());
+      isStatusBarTranslucent.getBool(),
+      isNavigationBarTranslucent.getBool());
 }
 
 void NativeReanimatedModule::unsubscribeFromKeyboardEvents(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -157,7 +157,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       jsi::Runtime &rt,
       const jsi::Value &keyboardEventContainer,
       const jsi::Value &isStatusBarTranslucent,
-      const jsi:Value &isNavigationBarTranslucent) override
+      const jsi::Value &isNavigationBarTranslucent) override;
   void unsubscribeFromKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &listenerId) override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -156,7 +156,8 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
   jsi::Value subscribeForKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &keyboardEventContainer,
-      const jsi::Value &isStatusBarTranslucent) override;
+      const jsi::Value &isStatusBarTranslucent,
+      const jsi:Value &isNavigationBarTranslucent) override
   void unsubscribeFromKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &listenerId) override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -138,7 +138,7 @@ static jsi::Value SPEC_PREFIX(subscribeForKeyboardEvents)(
     const jsi::Value *args,
     size_t) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->subscribeForKeyboardEvents(rt, std::move(args[0]), std::move(args[1]));
+      ->subscribeForKeyboardEvents(rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
 
 static jsi::Value SPEC_PREFIX(unsubscribeFromKeyboardEvents)(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -138,7 +138,8 @@ static jsi::Value SPEC_PREFIX(subscribeForKeyboardEvents)(
     const jsi::Value *args,
     size_t) {
   return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->subscribeForKeyboardEvents(rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+      ->subscribeForKeyboardEvents(
+          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
 
 static jsi::Value SPEC_PREFIX(unsubscribeFromKeyboardEvents)(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.h
@@ -82,7 +82,8 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
   virtual jsi::Value subscribeForKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &keyboardEventContainer,
-      const jsi::Value &isStatusBarTranslucent) = 0;
+      const jsi::Value &isStatusBarTranslucent,
+      const jsi::Value &isNavigationBarTranslucent) = 0;
   virtual void unsubscribeFromKeyboardEvents(
       jsi::Runtime &rt,
       const jsi::Value &listenerId) = 0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -72,7 +72,7 @@ using ConfigurePropsFunction = std::function<void(
     const jsi::Value &uiProps,
     const jsi::Value &nativeProps)>;
 using KeyboardEventSubscribeFunction =
-    std::function<int(std::function<void(int, int)>, bool)>;
+    std::function<int(std::function<void(int, int)>, bool, bool)>;
 using KeyboardEventUnsubscribeFunction = std::function<void(int)>;
 using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.cpp
@@ -419,7 +419,7 @@ int NativeProxy::subscribeForKeyboardEvents(
     bool isStatusBarTranslucent,
     bool isNavigationBarTranslucent) {
   static const auto method =
-      getJniMethod<int(KeyboardWorkletWrapper::javaobject, bool)>(
+      getJniMethod<int(KeyboardWorkletWrapper::javaobject, bool, bool)>(
           "subscribeForKeyboardEvents");
   return method(
       javaPart_.get(),

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.cpp
@@ -416,14 +416,16 @@ void NativeProxy::setGestureState(int handlerTag, int newState) {
 
 int NativeProxy::subscribeForKeyboardEvents(
     std::function<void(int, int)> callback,
-    bool isStatusBarTranslucent) {
+    bool isStatusBarTranslucent,
+    bool isNavigationBarTranslucent) {
   static const auto method =
       getJniMethod<int(KeyboardWorkletWrapper::javaobject, bool)>(
           "subscribeForKeyboardEvents");
   return method(
       javaPart_.get(),
       KeyboardWorkletWrapper::newObjectCxxArgs(std::move(callback)).get(),
-      isStatusBarTranslucent);
+      isStatusBarTranslucent,
+      isNavigationBarTranslucent);
 }
 
 void NativeProxy::unsubscribeFromKeyboardEvents(int listenerId) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/NativeProxy.h
@@ -221,7 +221,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   void unregisterSensor(int sensorId);
   int subscribeForKeyboardEvents(
       std::function<void(int, int)> callback,
-      bool isStatusBarTranslucent);
+      bool isStatusBarTranslucent,
+      bool isNavigationBarTranslucent);
   void unsubscribeFromKeyboardEvents(int listenerId);
 #ifdef RCT_NEW_ARCH_ENABLED
   // nothing

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/Keyboard.java
@@ -18,9 +18,10 @@ public class Keyboard {
     return mHeight;
   }
 
-  public void updateHeight(WindowInsetsCompat insets) {
+  public void updateHeight(WindowInsetsCompat insets, boolean isNavigationBarTranslucent) {
     int contentBottomInset = insets.getInsets(CONTENT_TYPE_MASK).bottom;
-    int systemBarBottomInset = insets.getInsets(SYSTEM_BAR_TYPE_MASK).bottom;
+    int systemBarBottomInset =
+        isNavigationBarTranslucent ? 0 : insets.getInsets(SYSTEM_BAR_TYPE_MASK).bottom;
     int keyboardHeightDip = contentBottomInset - systemBarBottomInset;
     int keyboardHeight = (int) PixelUtil.toDIPFromPixel(Math.max(0, keyboardHeightDip));
     if (keyboardHeight <= 0 && mState == KeyboardState.OPEN) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationCallback.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationCallback.java
@@ -9,11 +9,15 @@ public class KeyboardAnimationCallback extends WindowInsetsAnimationCompat.Callb
   private final Keyboard mKeyboard;
   private final NotifyAboutKeyboardChangeFunction mNotifyAboutKeyboardChange;
   private static final int CONTENT_TYPE_MASK = WindowInsetsCompat.Type.ime();
+  private final boolean mIsNavigationBarTranslucent;
 
   public KeyboardAnimationCallback(
-      Keyboard keyboard, NotifyAboutKeyboardChangeFunction notifyAboutKeyboardChange) {
+      Keyboard keyboard,
+      NotifyAboutKeyboardChangeFunction notifyAboutKeyboardChange,
+      boolean isNavigationBarTranslucent) {
     super(WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE);
     mNotifyAboutKeyboardChange = notifyAboutKeyboardChange;
+    mIsNavigationBarTranslucent = isNavigationBarTranslucent;
     mKeyboard = keyboard;
   }
 
@@ -43,7 +47,7 @@ public class KeyboardAnimationCallback extends WindowInsetsAnimationCompat.Callb
       }
     }
     if (isAnyKeyboardAnimationRunning) {
-      mKeyboard.updateHeight(insets);
+      mKeyboard.updateHeight(insets, mIsNavigationBarTranslucent);
       mNotifyAboutKeyboardChange.call();
     }
     return insets;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
@@ -22,7 +22,9 @@ public class KeyboardAnimationManager {
   }
 
   public int subscribeForKeyboardUpdates(
-      KeyboardWorkletWrapper callback, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
+      KeyboardWorkletWrapper callback,
+      boolean isStatusBarTranslucent,
+      boolean isNavigationBarTranslucent) {
     int listenerId = mNextListenerId++;
     if (mListeners.isEmpty()) {
       KeyboardAnimationCallback keyboardAnimationCallback =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
@@ -28,7 +28,8 @@ public class KeyboardAnimationManager {
     int listenerId = mNextListenerId++;
     if (mListeners.isEmpty()) {
       KeyboardAnimationCallback keyboardAnimationCallback =
-          new KeyboardAnimationCallback(mKeyboard, this::notifyAboutKeyboardChange);
+          new KeyboardAnimationCallback(
+              mKeyboard, this::notifyAboutKeyboardChange, isNavigationBarTranslucent);
       mWindowsInsetsManager.startObservingChanges(
           keyboardAnimationCallback, isStatusBarTranslucent, isNavigationBarTranslucent);
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/KeyboardAnimationManager.java
@@ -22,13 +22,13 @@ public class KeyboardAnimationManager {
   }
 
   public int subscribeForKeyboardUpdates(
-      KeyboardWorkletWrapper callback, boolean isStatusBarTranslucent) {
+      KeyboardWorkletWrapper callback, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
     int listenerId = mNextListenerId++;
     if (mListeners.isEmpty()) {
       KeyboardAnimationCallback keyboardAnimationCallback =
           new KeyboardAnimationCallback(mKeyboard, this::notifyAboutKeyboardChange);
       mWindowsInsetsManager.startObservingChanges(
-          keyboardAnimationCallback, isStatusBarTranslucent);
+          keyboardAnimationCallback, isStatusBarTranslucent, isNavigationBarTranslucent);
     }
     mListeners.put(listenerId, callback);
     return listenerId;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -38,7 +38,7 @@ public class WindowsInsetsManager {
   public void startObservingChanges(
       KeyboardAnimationCallback keyboardAnimationCallback, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
     mIsStatusBarTranslucent = isStatusBarTranslucent;
-    mIsNavigationBarTranslucent = isNavigationBarTranslucent
+    mIsNavigationBarTranslucent = isNavigationBarTranslucent;
     updateWindowDecor(false);
 
     Activity currentActivity = getCurrentActivity();

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -15,6 +15,7 @@ import java.lang.ref.WeakReference;
 public class WindowsInsetsManager {
 
   private boolean mIsStatusBarTranslucent = false;
+  private boolean mIsNavigationBarTranslucent = false;
   private final WeakReference<ReactApplicationContext> mReactContext;
   private final Keyboard mKeyboard;
   private final NotifyAboutKeyboardChangeFunction mNotifyAboutKeyboardChange;
@@ -35,8 +36,9 @@ public class WindowsInsetsManager {
   }
 
   public void startObservingChanges(
-      KeyboardAnimationCallback keyboardAnimationCallback, boolean isStatusBarTranslucent) {
+      KeyboardAnimationCallback keyboardAnimationCallback, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
     mIsStatusBarTranslucent = isStatusBarTranslucent;
+    mIsNavigationBarTranslucent = isNavigationBarTranslucent
     updateWindowDecor(false);
 
     Activity currentActivity = getCurrentActivity();
@@ -51,7 +53,7 @@ public class WindowsInsetsManager {
   }
 
   public void stopObservingChanges() {
-    updateWindowDecor(!mIsStatusBarTranslucent);
+    updateWindowDecor(!mIsStatusBarTranslucent && !mIsNavigationBarTranslucent);
     updateInsets(0, 0);
 
     Activity currentActivity = getCurrentActivity();
@@ -120,11 +122,8 @@ public class WindowsInsetsManager {
     int matchParentFlag = FrameLayout.LayoutParams.MATCH_PARENT;
     FrameLayout.LayoutParams params =
         new FrameLayout.LayoutParams(matchParentFlag, matchParentFlag);
-    if (mIsStatusBarTranslucent) {
-      params.setMargins(0, 0, 0, paddingBottom);
-    } else {
-      params.setMargins(0, paddingTop, 0, paddingBottom);
-    }
+
+    params.setMargins(0, mIsStatusBarTranslucent ? 0 : paddingTop, 0, mIsNavigationBarTranslucent ? 0 : paddingBottom);
     return params;
   }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -87,7 +87,7 @@ public class WindowsInsetsManager {
   private WindowInsetsCompat onApplyWindowInsetsListener(View view, WindowInsetsCompat insets) {
     WindowInsetsCompat defaultInsets = ViewCompat.onApplyWindowInsets(view, insets);
     if (mKeyboard.getState() == KeyboardState.OPEN) {
-      mKeyboard.updateHeight(insets);
+      mKeyboard.updateHeight(insets, mIsNavigationBarTranslucent);
       mNotifyAboutKeyboardChange.call();
     }
     setWindowInsets(defaultInsets);

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboard/WindowsInsetsManager.java
@@ -36,7 +36,9 @@ public class WindowsInsetsManager {
   }
 
   public void startObservingChanges(
-      KeyboardAnimationCallback keyboardAnimationCallback, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
+      KeyboardAnimationCallback keyboardAnimationCallback,
+      boolean isStatusBarTranslucent,
+      boolean isNavigationBarTranslucent) {
     mIsStatusBarTranslucent = isStatusBarTranslucent;
     mIsNavigationBarTranslucent = isNavigationBarTranslucent;
     updateWindowDecor(false);
@@ -123,7 +125,11 @@ public class WindowsInsetsManager {
     FrameLayout.LayoutParams params =
         new FrameLayout.LayoutParams(matchParentFlag, matchParentFlag);
 
-    params.setMargins(0, mIsStatusBarTranslucent ? 0 : paddingTop, 0, mIsNavigationBarTranslucent ? 0 : paddingBottom);
+    params.setMargins(
+        0,
+        mIsStatusBarTranslucent ? 0 : paddingTop,
+        0,
+        mIsNavigationBarTranslucent ? 0 : paddingBottom);
     return params;
   }
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -205,7 +205,9 @@ public abstract class NativeProxyCommon {
 
   @DoNotStrip
   public int subscribeForKeyboardEvents(
-      KeyboardWorkletWrapper keyboardWorkletWrapper, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
+      KeyboardWorkletWrapper keyboardWorkletWrapper,
+      boolean isStatusBarTranslucent,
+      boolean isNavigationBarTranslucent) {
     return keyboardAnimationManager.subscribeForKeyboardUpdates(
         keyboardWorkletWrapper, isStatusBarTranslucent, isNavigationBarTranslucent);
   }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -205,9 +205,9 @@ public abstract class NativeProxyCommon {
 
   @DoNotStrip
   public int subscribeForKeyboardEvents(
-      KeyboardWorkletWrapper keyboardWorkletWrapper, boolean isStatusBarTranslucent) {
+      KeyboardWorkletWrapper keyboardWorkletWrapper, boolean isStatusBarTranslucent, boolean isNavigationBarTranslucent) {
     return keyboardAnimationManager.subscribeForKeyboardUpdates(
-        keyboardWorkletWrapper, isStatusBarTranslucent);
+        keyboardWorkletWrapper, isStatusBarTranslucent, isNavigationBarTranslucent);
   }
 
   @DoNotStrip

--- a/packages/react-native-reanimated/apple/reanimated/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/native/PlatformDepMethodsHolderImpl.mm
@@ -269,8 +269,8 @@ UnregisterSensorFunction makeUnregisterSensorFunction(ReanimatedSensorContainer 
 KeyboardEventSubscribeFunction makeSubscribeForKeyboardEventsFunction(REAKeyboardEventObserver *keyboardObserver)
 {
   auto subscribeForKeyboardEventsFunction =
-      [=](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater, bool isStatusBarTranslucent) {
-        // ignore isStatusBarTranslucent - it's Android only
+      [=](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater, bool isStatusBarTranslucent, bool isNavigationBarTranslucent) {
+        // ignore isStatusBarTranslucent and isNavigationBarTranslucent - those are Android only
         return [keyboardObserver subscribeForKeyboardEvents:^(int keyboardState, int height) {
           keyboardEventDataUpdater(keyboardState, height);
         }];

--- a/packages/react-native-reanimated/apple/reanimated/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/native/PlatformDepMethodsHolderImpl.mm
@@ -269,7 +269,9 @@ UnregisterSensorFunction makeUnregisterSensorFunction(ReanimatedSensorContainer 
 KeyboardEventSubscribeFunction makeSubscribeForKeyboardEventsFunction(REAKeyboardEventObserver *keyboardObserver)
 {
   auto subscribeForKeyboardEventsFunction =
-      [=](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater, bool isStatusBarTranslucent, bool isNavigationBarTranslucent) {
+      [=](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater,
+          bool isStatusBarTranslucent,
+          bool isNavigationBarTranslucent) {
         // ignore isStatusBarTranslucent and isNavigationBarTranslucent - those are Android only
         return [keyboardObserver subscribeForKeyboardEvents:^(int keyboardState, int height) {
           keyboardEventDataUpdater(keyboardState, height);

--- a/packages/react-native-reanimated/src/NativeReanimated/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/NativeReanimated/NativeReanimated.ts
@@ -54,7 +54,8 @@ export interface NativeReanimatedModule {
   configureProps(uiProps: string[], nativeProps: string[]): void;
   subscribeForKeyboardEvents(
     handler: ShareableRef<number>,
-    isStatusBarTranslucent: boolean
+    isStatusBarTranslucent: boolean,
+    isNavigationBarTranslucent: boolean
   ): number;
   unsubscribeFromKeyboardEvents(listenerId: number): void;
   configureLayoutAnimationBatch(
@@ -212,11 +213,13 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
 
   subscribeForKeyboardEvents(
     handler: ShareableRef<number>,
-    isStatusBarTranslucent: boolean
+    isStatusBarTranslucent: boolean,
+    isNavigationBarTranslucent: boolean
   ) {
     return this.InnerNativeModule.subscribeForKeyboardEvents(
       handler,
-      isStatusBarTranslucent
+      isStatusBarTranslucent,
+      isNavigationBarTranslucent
     );
   }
 

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -298,6 +298,7 @@ export interface MeasuredDimensions {
 
 export interface AnimatedKeyboardOptions {
   isStatusBarTranslucentAndroid?: boolean;
+  isNavigationBarTranslucentAndroid?: boolean;
 }
 
 /**

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -120,7 +120,8 @@ export function subscribeForKeyboardEvents(
   }
   return NativeReanimatedModule.subscribeForKeyboardEvents(
     makeShareableCloneRecursive(handleAndFlushAnimationFrame),
-    options.isStatusBarTranslucentAndroid ?? false
+    options.isStatusBarTranslucentAndroid ?? false,
+    options.isNavigationBarTranslucentAndroid ?? false
   );
 }
 

--- a/packages/react-native-reanimated/src/hook/useAnimatedKeyboard.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedKeyboard.ts
@@ -19,7 +19,10 @@ import { KeyboardState } from '../commonTypes';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/device/useAnimatedKeyboard
  */
 export function useAnimatedKeyboard(
-  options: AnimatedKeyboardOptions = { isStatusBarTranslucentAndroid: false }
+  options: AnimatedKeyboardOptions = {
+    isStatusBarTranslucentAndroid: false,
+    isNavigationBarTranslucentAndroid: false,
+  }
 ): AnimatedKeyboardInfo {
   const ref = useRef<AnimatedKeyboardInfo | null>(null);
   const listenerId = useRef<number>(-1);


### PR DESCRIPTION
## Summary

Resolves #6043. For StatusBar we have a flag that removes top padding when we want to render RN stuff "under" StatusBar. A similar problem was raised in  #6043, but for NavigationBar, so I added another flag `isNavigationBarTranslucentAndroid` that removes bottom padding as well. Currently, I see no way to make it automatic. I tried one approach to remove the flags in #5889, but it doesn't seem to be the performant solution. 

## Preview 

|Before|After without flag|After with flag|
|-|-|-|
|<img width="602" alt="before" src="https://github.com/user-attachments/assets/0032efbe-342a-4e06-81ee-f7351bb032f7">|<img width="602" alt="after-without-flag" src="https://github.com/user-attachments/assets/6f259329-9bf4-4bbb-8ce4-32d671e65a5a">|<img width="602" alt="after-with-flag" src="https://github.com/user-attachments/assets/81c43052-f3b3-4a3b-a9cb-bd974e851c43">|

## Test plan

Testing is a bit tricky, because an example from the issue uses a navigation bar package from Expo, which requires Expo and our example app doesn't have Expo. 

What I did:

<details>
<summary>Steps</summary>

```bash
# clone reanimated from current branch 
git clone https://github.com/software-mansion/react-native-reanimated.git
# checkout current branch
git checkout @maciekstosio/Add-support-for-isNavigationBarTranslucentAndroid
# install
yarn && yarn build
# build npm package
cd packages/react-native-reanimated
./createNPMPackage.sh --fresh
# next, create simple expo project
npx create-expo-stack
# install library for navigation bar
npx expo install expo-navigation-bar
# install reanimated 
npx expo install react-native-reanimated
# replace in package.json path to locally-build package i.e.:
"react-native-reanimated": "file:react-native-reanimated.tgz"
# yarn install 
# npx expo run:android
```

</details>

<details>
<summary>App.tsx to test</summary>

```jsx
import * as NavigationBar from 'expo-navigation-bar';
import React, { useEffect } from 'react';
import Animated, {
  useAnimatedKeyboard,
  useAnimatedStyle,
} from 'react-native-reanimated';
import {
  Platform,
  StatusBar,
  StyleSheet,
  TextInput,
  View,
  Text,
  Button,
} from 'react-native';

export default function EmptyExample() {
  const keyboard = useAnimatedKeyboard({
    isNavigationBarTranslucentAndroid: true,
  });

  const animatedStyles = useAnimatedStyle(() => ({
    transform: [{ translateY: -keyboard.height.value }],
  }));

  useEffect(() => {
    StatusBar.setBarStyle('dark-content');
    NavigationBar.setBackgroundColorAsync('transparent');
  }, []);

  return (
    <Animated.View
      style={[
        styles.container,
        animatedStyles,
        { justifyContent: 'flex-end', borderWidth: 5, borderColor: '#ff0' },
      ]}>
      <View
        style={[
          styles.center,
          {
            height: 200,
            backgroundColor: '#f0f',
            borderWidth: 5,
            borderColor: '#0ff',
          },
        ]}>
        <Text>{`Android ${Platform.constants['Release']}`}</Text>
        <TextInput placeholder="Test" />
      </View>
    </Animated.View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1, backgroundColor: 'rgba(255,0,255,0.2)' },
  center: { justifyContent: 'center', alignItems: 'center' },
});
```

</details>