### PR TITLE
docs: Fix incorrect links in docs

### DIFF
--- a/packages/docs-reanimated/docs/advanced/setNativeProps.mdx
+++ b/packages/docs-reanimated/docs/advanced/setNativeProps.mdx
@@ -67,7 +67,7 @@ import SetNativePropsSrc from '!!raw-loader!@site/src/examples/SetNativeProps';
 
 ## Remarks
 
-- You should always reach for [`useAnimatedStyle`](docs/core/useAnimatedStyle) and [`useAnimatedProps`](docs/core/useAnimatedProps) first when animating styles or properties.
+- You should always reach for [`useAnimatedStyle`](/docs/core/useAnimatedStyle) and [`useAnimatedProps`](/docs/core/useAnimatedProps) first when animating styles or properties.
 
 - `setNativeProps` is supposed to only be used on the [UI thread](/docs/fundamentals/glossary#ui-thread).
 

--- a/packages/docs-reanimated/docs/animations/withClamp.mdx
+++ b/packages/docs-reanimated/docs/animations/withClamp.mdx
@@ -70,6 +70,6 @@ const clampedStyleWithDelay = useAnimatedStyle(() => {
 
 ### Returns
 
-`withClamp` returns an [animation object](/docs/fundamentals/glossary#animation-object). It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withClamp` returns an [animation object](/docs/fundamentals/glossary#animation-object). It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 <PlatformCompatibility android ios web />

--- a/packages/docs-reanimated/docs/animations/withDelay.mdx
+++ b/packages/docs-reanimated/docs/animations/withDelay.mdx
@@ -54,7 +54,7 @@ A parameter that determines how the animation responds to the device's reduced m
 
 ### Returns
 
-`withDelay` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withDelay` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 ## Example
 

--- a/packages/docs-reanimated/docs/animations/withRepeat.mdx
+++ b/packages/docs-reanimated/docs/animations/withRepeat.mdx
@@ -77,7 +77,7 @@ import { useRepeatPlayground } from '@site/src/components/InteractivePlayground'
 
 ### Returns
 
-`withRepeat` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withRepeat` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 ## Example
 

--- a/packages/docs-reanimated/docs/animations/withSequence.mdx
+++ b/packages/docs-reanimated/docs/animations/withSequence.mdx
@@ -50,11 +50,11 @@ A parameter that determines how the animation responds to the device's reduced m
 
 #### `...animations`
 
-Any number of [animation objects](docs/fundamentals/glossary#animation-object) to be run in a sequence.
+Any number of [animation objects](/docs/fundamentals/glossary#animation-object) to be run in a sequence.
 
 ### Returns
 
-`withSequence` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withSequence` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 ## Example
 

--- a/packages/docs-reanimated/docs/animations/withSpring.mdx
+++ b/packages/docs-reanimated/docs/animations/withSpring.mdx
@@ -109,7 +109,7 @@ A function called upon animation completion. If the animation is cancelled, the 
 
 ### Returns
 
-`withSpring` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withSpring` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 ## Example
 

--- a/packages/docs-reanimated/docs/animations/withTiming.mdx
+++ b/packages/docs-reanimated/docs/animations/withTiming.mdx
@@ -126,7 +126,7 @@ A function called upon animation completion. If the animation is cancelled, the 
 
 ### Returns
 
-`withTiming` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](docs/core/useAnimatedStyle).
+`withTiming` returns an [animation object](/docs/fundamentals/glossary#animation-object) which holds the current state of the animation. It can be either assigned directly to a [shared value](/docs/fundamentals/glossary#shared-value) or can be used as a value for a style object returned from [useAnimatedStyle](/docs/core/useAnimatedStyle).
 
 ## Example
 

--- a/packages/docs-reanimated/docs/fundamentals/glossary.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/glossary.mdx
@@ -71,7 +71,7 @@ Reanimated comes with 3 built-in animation functions:
 - [`withTiming`](/docs/animations/withTiming) lets you create an animation based on duration and [easing](https://easings.net/)
 - [`withDecay`](/docs/animations/withDecay) lets you create animations that mimic objects in motion that move with a given deceleration rate
 
-These functions can be combined with [animation modifiers](docs/fundamentals/glossary#animation-modifier) to create rich and complex animations.
+These functions can be combined with [animation modifiers](/docs/fundamentals/glossary#animation-modifier) to create rich and complex animations.
 
 ## Animation modifier
 
@@ -88,7 +88,7 @@ Reanimated comes with 3 built-in modifiers:
 
 An animation object is a value returned from [animation functions](/docs/fundamentals/glossary#animation-function) and [modifiers](/docs/fundamentals/glossary#animation-modifier) which holds the current state of the animation including its start and end conditions, as well as a `onFrame` function. These values allow to calculate the animation state for each frame.
 
-When you pass an animation object to a [shared value](docs/fundamentals/glossary#shared-value) it is automatically treated as an [animatable value](/docs/fundamentals/glossary#animatable-value).
+When you pass an animation object to a [shared value](/docs/fundamentals/glossary#shared-value) it is automatically treated as an [animatable value](/docs/fundamentals/glossary#animatable-value).
 
 For example, consider this code:
 

--- a/packages/docs-reanimated/docs/layout-animations/custom-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/custom-animations.mdx
@@ -7,7 +7,7 @@ sidebar_position: 4
 import EnteringExitingAnimationSrc from '!!raw-loader!@site/src/examples/CustomEnteringExiting';
 import LayoutAnimationSrc from '!!raw-loader!@site/src/examples/CustomLayoutAnimation';
 
-Custom animations give you a full control over the Entering/Exiting animations and Layout transitions. However, they tend to be hard to understand and maintain. We recommend starting with predefined [Entering/Exiting](docs/layout-animations/entering-exiting-animations), [Keyframes](/docs/layout-animations/keyframe-animations) and [Layout](/docs/layout-animations/layout-transitions) presets first before using custom animations.
+Custom animations give you a full control over the Entering/Exiting animations and Layout transitions. However, they tend to be hard to understand and maintain. We recommend starting with predefined [Entering/Exiting](/docs/layout-animations/entering-exiting-animations), [Keyframes](/docs/layout-animations/keyframe-animations) and [Layout](/docs/layout-animations/layout-transitions) presets first before using custom animations.
 
 ## Reference
 

--- a/packages/docs-reanimated/versioned_docs/version-2.x/fundamentals/shared-values.md
+++ b/packages/docs-reanimated/versioned_docs/version-2.x/fundamentals/shared-values.md
@@ -141,7 +141,7 @@ This is what you will observe:
 
 Animations in Reanimated 2 are first-class citizens, and the library comes bundled with a number of utility methods that help you run and customize animations (refer to the section about [animations](animations) to learn about the APIs in Reanimated 2 for controlling animations).
 One of the ways for animations to be launched is by starting an animated transition of a Shared Value.
-This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](/docs/2.x/api/animations/withTiming) or [`withSpring`](docs/2.x/api/animations/withSpring)):
+This can be done by wrapping the target value with one of the animation utility methods from reanimated library (e.g. [`withTiming`](/docs/2.x/api/animations/withTiming) or [`withSpring`](/docs/2.x/api/animations/withSpring)):
 
 ```js
 import { withTiming } from 'react-native-reanimated';


### PR DESCRIPTION
## Summary

Some links were missing the `/` at the beginning, thus, they were appended to the current page link instead of replacing it. As a result, the **Page Not Found** page was displayed instead of navigating to the desired page in docs.

![Screenshot 2024-08-21 at 11 18 51](https://github.com/user-attachments/assets/071b5e3a-7762-482b-95b1-a539363ab1da)

## Test plan

Just open reanimated docs and press on links that were changed in this PR. You will see that before these changes, links do not navigate to the desired page in docs.