### PR TITLE
fix: add missing include

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/REASlowAnimations.h
+++ b/packages/react-native-reanimated/apple/reanimated/REASlowAnimations.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 namespace reanimated {
 
 CGFloat getUIAnimationDragCoefficient(void);


### PR DESCRIPTION
## Summary

This PR adds missing import for the header file. 

This was breaking visionOS builds. 

The `CFTimeInterval` comes from Core Foundation so we need to have foundation imported to make this work. 



## Test plan

CI Green
