### PR TITLE
added eslint-plugin-import with config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     'prettier',
     'plugin:import/typescript',
     'plugin:react-hooks/recommended',
+    'plugin:import/recommended',
   ],
   plugins: [
     'react',
@@ -88,5 +89,37 @@ module.exports = {
     'jest/prefer-to-have-length': 'warn',
     'jest/valid-expect': 'error',
     'react/react-in-jsx-scope': 'off',
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        pathGroups: [
+          {
+            pattern: 'react-native',
+            group: 'external',
+            position: 'before',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['builtin'],
+        distinctGroup: false,
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
+    'import/no-self-import': 'error',
+    'import/no-cycle': 'error',
+    'import/no-useless-path-segments': 'error',
+    'import/newline-after-import': 'error',
+    'import/first': 'error',
   },
 };

--- a/packages/eslint-plugin-reanimated/package.json
+++ b/packages/eslint-plugin-reanimated/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/utils": "^6.19.1",
     "esbuild": "^0.20.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-import": "^2.29.1",
     "jest": "^29.7.0",
     "prettier": "2.8.8",
     "ts-jest": "^29.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11590,7 +11590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.25.4":
+"eslint-plugin-import@npm:^2.25.4, eslint-plugin-import@npm:^2.29.1":
   version: 2.29.1
   resolution: "eslint-plugin-import@npm:2.29.1"
   dependencies:
@@ -11772,6 +11772,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:^6.19.1"
     esbuild: "npm:^0.20.0"
     eslint: "npm:^8.57.0"
+    eslint-plugin-import: "npm:^2.29.1"
     jest: "npm:^29.7.0"
     prettier: "npm:2.8.8"
     ts-jest: "npm:^29.1.2"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
The PR introduces a [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) mainly for maintaining a consistent order of imports. It is the most used eslint plugin for such cases and has the greatest number of available configs. This starting configuration consists of a rule that will keep imports in this order: `builtin -> external (with imports from react-native at the top) -> internal -> parent -> sibling -> index`. Besides that, I've added rules that will prevent **self imports**, **cycles**, and **useless path segments**. Also, I think that it's nice to keep all imports at the top of the file and an empty line after them. 

Let me know what do you think about this configuration!
