### PR TITLE
docs: Styling for mobile Platform Compatibility

### DIFF
--- a/packages/docs-reanimated/src/css/overrides.css
+++ b/packages/docs-reanimated/src/css/overrides.css
@@ -8,7 +8,7 @@ table {
 }
 
 @media (max-width: 1280px) {
-  table {
+  table:not([class*='platform-compatibility']) {
     display: block;
     width: 100%;
   }


### PR DESCRIPTION
Before:
<img width="662" alt="image" src="https://github.com/user-attachments/assets/0e03e907-00b9-44f9-8b2b-75cf06c7b017">


After:
<img width="662" alt="image" src="https://github.com/user-attachments/assets/60787b5a-54c6-40a0-8b9a-c3abfd64a08c">
