### PR TITLE
Set CMake version on Android just like react-native

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -280,6 +280,7 @@ android {
     }
     externalNativeBuild {
         cmake {
+            version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
             path "CMakeLists.txt"
         }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR sets CMake version used to compile native code on Android just like react-native does in its [build.gradle.kts](https://github.com/facebook/react-native/blob/3350050edc6bdec1652448863ab0c6872d2ac4ed/packages/react-native/ReactAndroid/build.gradle.kts#L48C20-L50).

Hopefully this should eliminate some hard-to-spot errors caused by building with a different CMake version.

I tried to access extra properties using `safeExtGet` and `safeAppExtGet` as well as via `project(":packages:react-native:ReactAndroid").properties` but with no luck.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
