### PR TITLE
chore: Add separate tsconfig for metro-config

### DIFF
--- a/packages/react-native-reanimated/metro-config/tsconfig.json
+++ b/packages/react-native-reanimated/metro-config/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json",
+}

--- a/packages/react-native-reanimated/tsconfig.json
+++ b/packages/react-native-reanimated/tsconfig.json
@@ -5,5 +5,5 @@
       "react-native-reanimated": ["./src"]
     }
   },
-  "include": ["src", "metro-config"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Including both `src` and `metro-config` in `tsconfig.json` of Reanimated package sometimes falsely suggests TypeScript that there should be `lib/module/src` and `lib/module/metro-config` directories.

## Test plan

🚀 
