### PR TITLE
chore: Fix codegen dir in examples

### DIFF
--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -13,7 +13,7 @@ react {
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
-    codegenDir = file("../../../../node_modules/@react-native/codegen")
+    codegenDir = file("../../../../node_modules/react-native/node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
     cliFile = file("../../../../node_modules/react-native/cli.js")
 

--- a/apps/paper-example/android/app/build.gradle
+++ b/apps/paper-example/android/app/build.gradle
@@ -13,7 +13,7 @@ react {
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
-    codegenDir = file("../../../../node_modules/@react-native/codegen")
+    codegenDir = file("../../../../node_modules/react-native/node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
     cliFile = file("../../../../node_modules/react-native/cli.js")
 


### PR DESCRIPTION
## Summary

It turns out that after
- #6488

The location of `@react-native/codegen` in our monorepo changed and examples had trouble building.

