### PR TITLE
chore: Fix deprecated `this` captures in lambdas for NDK 27

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -198,7 +198,7 @@ void NativeReanimatedModule::scheduleOnUI(
     const jsi::Value &worklet) {
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
       rt, worklet, "[Reanimated] Only worklets can be scheduled to run on UI.");
-  uiScheduler_->scheduleOnUI([=] {
+  uiScheduler_->scheduleOnUI([=, this] {
 #if JS_RUNTIME_HERMES
     // JSI's scope defined here allows for JSI-objects to be cleared up after
     // each runtime loop. Within these loops we typically create some temporary
@@ -265,7 +265,7 @@ jsi::Value NativeReanimatedModule::registerEventHandler(
       rt, worklet, "[Reanimated] Event handler must be a worklet.");
   int emitterReactTagInt = emitterReactTag.asNumber();
 
-  uiScheduler_->scheduleOnUI([=] {
+  uiScheduler_->scheduleOnUI([=, this] {
     auto handler = std::make_shared<WorkletEventHandler>(
         newRegistrationId, eventNameStr, emitterReactTagInt, handlerShareable);
     eventHandlerRegistry_->registerEventHandler(std::move(handler));
@@ -279,7 +279,7 @@ void NativeReanimatedModule::unregisterEventHandler(
     const jsi::Value &registrationId) {
   uint64_t id = registrationId.asNumber();
   uiScheduler_->scheduleOnUI(
-      [=] { eventHandlerRegistry_->unregisterEventHandler(id); });
+      [=, this] { eventHandlerRegistry_->unregisterEventHandler(id); });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -375,7 +375,7 @@ jsi::Value NativeReanimatedModule::getViewProp(
 
   const int viewTagInt = viewTag.asNumber();
 
-  uiScheduler_->scheduleOnUI([=]() {
+  uiScheduler_->scheduleOnUI([=, this]() {
     jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
     const jsi::Value propNameValue =
         jsi::String::createFromUtf8(uiRuntime, propNameStr);
@@ -882,7 +882,7 @@ jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
       handlerWorklet,
       "[Reanimated] Keyboard event handler must be a worklet.");
   return subscribeForKeyboardEventsFunction_(
-      [=](int keyboardState, int height) {
+      [=, this](int keyboardState, int height) {
         uiWorkletRuntime_->runGuarded(
             shareableHandler, jsi::Value(keyboardState), jsi::Value(height));
       },


### PR DESCRIPTION
## Summary

`-Wall` and `-Werror` in NDK 27 make deprecation warnings fail the compilation process. NDK 27 isn't yet used in React Native, therefore this is more of a feature than a fix.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/6466
