### PR TITLE
chore: Bump prettier in docs

### DIFF
--- a/packages/docs-reanimated/docs/core/useDerivedValue.mdx
+++ b/packages/docs-reanimated/docs/core/useDerivedValue.mdx
@@ -37,8 +37,9 @@ interface SharedValue<Value = unknown> {
 interface DerivedValue<Value = unknown>
   extends Readonly<Omit<SharedValue<Value>, 'set'>> {
   /**
-   * @deprecated Derived values are readonly, don't use this method. It's here only to prevent breaking changes in TypeScript types.
-   * It will be removed in the future.
+   * @deprecated Derived values are readonly, don't use this method. It's here
+   *   only to prevent breaking changes in TypeScript types. It will be removed
+   *   in the future.
    */
   set: SharedValue<Value>['set'];
 }

--- a/packages/docs-reanimated/prettier.config.js
+++ b/packages/docs-reanimated/prettier.config.js
@@ -1,0 +1,7 @@
+const defaultConfig = require("../../prettier.config");
+
+module.exports = {
+  ...defaultConfig,
+  // Override plugins that don't work with Prettier 2.x
+  plugins: [],
+};

--- a/packages/docs-reanimated/prettier.config.js
+++ b/packages/docs-reanimated/prettier.config.js
@@ -1,5 +1,8 @@
 const defaultConfig = require("../../prettier.config");
 
+// We can't bump to Prettier 3.x because current version of Docusaurus
+// crashes on build with it.
+
 module.exports = {
   ...defaultConfig,
   // Override plugins that don't work with Prettier 2.x

--- a/packages/docs-reanimated/versioned_docs/version-2.x/tutorials/LayoutAnimations/animated_list.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-2.x/tutorials/LayoutAnimations/animated_list.mdx
@@ -47,8 +47,9 @@ Here you can see the effect of the changes we will make going through this tutor
     the full code to edit yourself&nbsp;
     <a href="https://gist.github.com/jmysliv/87b15453aab173a63a4d22fcc5b1d603">
       here
-    </a>). Let's focus on the parts that we will animate, in this case - the Participant
-    component.
+    </a>
+    ). Let's focus on the parts that we will animate, in this case - the
+    Participant component.
   </div>
   <FullCode />
 </TutorialStep>

--- a/packages/docs-reanimated/yarn.lock
+++ b/packages/docs-reanimated/yarn.lock
@@ -11566,9 +11566,9 @@ prepend-http@^2.0.0:
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
 prettier@^2.8.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
-  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary

After bumping Prettier in the monorepo docs should have it bumped too since they inherit `prettier.config.js`.

Fixes CI failing in:
- #6467 
- #6468