### PR TITLE
Fix wrong exiting animation indices [New Architecture]

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -484,6 +484,7 @@ bool LayoutAnimationsProxy::startAnimationsRecursively(
         hasAnimatedChildren = true;
       } else {
         endAnimationsRecursively(subNode, mutations);
+        toBeRemoved.push_back(subNode);
       }
     } else if (startAnimationsRecursively(
                    subNode,


### PR DESCRIPTION
## Summary

When an exiting animation is finished, we mark some views for removal. Then we trigger `pullTransaction` to apply those removals. However, it might happen that RN also tries to perform some transaction at the same time. In the algorithm responsible for triggering exiting animations, if we encounter a view marked for removal, we handle it right there by calling `endAnimationsRecursively`. However, we also have to add this view to the `toBeRemoved` list. Otherwise its neighbors will have incorrect indices, and when one of them is removed the app will crash. 

## Test plan

Test `[LA] View Flattening` example with:
```js
  useEffect(() => {
    setInterval(() => {
      setVisible((prev) => !prev);
    }, 0);
  }, []);
```
