### PR TITLE
Enable V8 nightly CI

### DIFF
--- a/.github/workflows/V8-reanimated-build-check-nightly.yml
+++ b/.github/workflows/V8-reanimated-build-check-nightly.yml
@@ -3,11 +3,11 @@ env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: 0
 on:
   pull_request:
-  paths:
-  - .github/workflows/build-v8-nightly.yml
-  - .github/workflows/helper/configureV8.js
+    paths:
+      - .github/workflows/build-v8-nightly.yml
+      - .github/workflows/helper/configureV8.js
   schedule:
-  - cron: '37 19 * * *'
+    - cron: '37 19 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/V8-reanimated-build-check-nightly.yml
+++ b/.github/workflows/V8-reanimated-build-check-nightly.yml
@@ -4,7 +4,7 @@ env:
 on:
   pull_request:
     paths:
-      - .github/workflows/build-v8-nightly.yml
+      - .github/workflows/V8-reanimated-build-check-nightly.yml
       - .github/workflows/helper/configureV8.js
   schedule:
     - cron: '37 19 * * *'

--- a/.github/workflows/V8-reanimated-build-check-nightly.yml
+++ b/.github/workflows/V8-reanimated-build-check-nightly.yml
@@ -2,13 +2,12 @@ name: V8 Reanimated build check [Nightly]
 env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: 0
 on:
-  # Disabled until V8 gets support for RN 0.74
-  # pull_request:
-  # paths:
-  # - .github/workflows/build-v8-nightly.yml
-  # - .github/workflows/helper/configureV8.js
-  # schedule:
-  # - cron: '37 19 * * *'
+  pull_request:
+  paths:
+  - .github/workflows/build-v8-nightly.yml
+  - .github/workflows/helper/configureV8.js
+  schedule:
+  - cron: '37 19 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Now V8 supports react native 0.75 so we can turn on our CI 🎉 

## Test plan

Check CI ✅ 
