### PR TITLE
draft: fix infinite loop in REASharedTransitionManager

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASharedTransitionManager.m
+++ b/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASharedTransitionManager.m
@@ -251,7 +251,6 @@ static BOOL _isConfigured = NO;
     REAUIView *sharedViewScreen = [REAScreensHelper getScreenForView:sharedView];
     REAUIView *stack = [REAScreensHelper getStackForView:sharedViewScreen];
 
-
     NSMutableSet<NSNumber *> *visitedTags = [NSMutableSet new];
     const int maxIterations = 100; // Safety limit to prevent infinite loops
     int iterationCount = 0;
@@ -261,22 +260,22 @@ static BOOL _isConfigured = NO;
     REAUIView *siblingView = nil;
 
     do {
-	  if (siblingViewTag == nil || [visitedTags containsObject:siblingViewTag]) {
-	    siblingViewTag = nil;
-		break;
-  	  }
-	  [visitedTags addObject:siblingViewTag];
+      if (siblingViewTag == nil || [visitedTags containsObject:siblingViewTag]) {
+        siblingViewTag = nil;
+        break;
+      }
+      [visitedTags addObject:siblingViewTag];
 
-	  siblingView = [_animationManager viewForTag:siblingViewTag];
-	  if (siblingView == nil) {
-	    [self clearAllSharedConfigsForViewTag:siblingViewTag];
-	    siblingViewTag = _findPrecedingViewTagForTransition(sharedView.reactTag);
-	  }
-	  iterationCount++;
+      siblingView = [_animationManager viewForTag:siblingViewTag];
+      if (siblingView == nil) {
+        [self clearAllSharedConfigsForViewTag:siblingViewTag];
+        siblingViewTag = _findPrecedingViewTagForTransition(sharedView.reactTag);
+      }
+      iterationCount++;
     } while (siblingView == nil && siblingViewTag != nil && iterationCount < maxIterations);
 
     if (iterationCount >= maxIterations) {
-	  NSLog(@"Warning: Exceeded maximum iterations in getSharedElementForCurrentTransition");
+      NSLog(@"Warning: Exceeded maximum iterations in getSharedElementForCurrentTransition");
     }
 
     siblingView = [self maybeOverrideSiblingForTabNavigator:sharedView siblingView:siblingView];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This fixes an infinite loop in `REASharedTransitionManager`, in `getSharedElementForCurrentTransition`, when `siblingViewTag` is nil and `_findPrecedingViewTagForTransition` returns nil, it will get stuck in an infinite loop and freeze the app.


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

You can test this by setting sharedTransitionTags