### PR TITLE
Remove empty.cpp

### DIFF
--- a/packages/react-native-reanimated/android/empty.cpp
+++ b/packages/react-native-reanimated/android/empty.cpp
@@ -1,1 +1,0 @@
-// required for compilation purpose


### PR DESCRIPTION
## Summary
This PR removes `empty.cpp` as it is no longer needed.

There are no current usages of `empty.cpp` in our codebase.

It all started here:

https://github.com/software-mansion/react-native-reanimated/blob/dea5cc2c713724ee1705daea62d18733c4ce4127/android/CMakeLists.txt#L317-L325

## Test plan
