### PR TITLE
refactor: Obtain JsCallInvoker directly from context

### DIFF
--- a/packages/react-native-reanimated/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -24,8 +24,7 @@ public class NativeProxy extends NativeProxyCommon {
   @OptIn(markerClass = FrameworkAPI.class)
   public NativeProxy(ReactApplicationContext context, String valueUnpackerCode) {
     super(context);
-    CallInvokerHolderImpl holder =
-        (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
+    CallInvokerHolderImpl holder = (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
     LayoutAnimations LayoutAnimations = new LayoutAnimations(context);
     ReanimatedMessageQueueThread messageQueueThread = new ReanimatedMessageQueueThread();
     mHybridData =

--- a/packages/react-native-reanimated/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/paper/java/com/swmansion/reanimated/NativeProxy.java
@@ -25,7 +25,7 @@ public class NativeProxy extends NativeProxyCommon {
   public NativeProxy(ReactApplicationContext context, String valueUnpackerCode) {
     super(context);
     CallInvokerHolderImpl holder =
-        (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+        (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
     LayoutAnimations LayoutAnimations = new LayoutAnimations(context);
     ReanimatedMessageQueueThread messageQueueThread = new ReanimatedMessageQueueThread();
     mHybridData =

--- a/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/73/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/73/com/swmansion/reanimated/NativeProxy.java
@@ -21,8 +21,7 @@ public class NativeProxy extends NativeProxyCommon {
   public NativeProxy(ReactApplicationContext context, String valueUnpackerCode) {
     super(context);
     ReactFeatureFlagsWrapper.enableMountHooks();
-    CallInvokerHolderImpl holder =
-        (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
+    CallInvokerHolderImpl holder = (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
 
     FabricUIManager fabricUIManager =
         (FabricUIManager) UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);

--- a/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/73/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/73/com/swmansion/reanimated/NativeProxy.java
@@ -22,7 +22,7 @@ public class NativeProxy extends NativeProxyCommon {
     super(context);
     ReactFeatureFlagsWrapper.enableMountHooks();
     CallInvokerHolderImpl holder =
-        (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+        (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
 
     FabricUIManager fabricUIManager =
         (FabricUIManager) UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);

--- a/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/74/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/74/com/swmansion/reanimated/NativeProxy.java
@@ -47,7 +47,7 @@ public class NativeProxy extends NativeProxyCommon {
               valueUnpackerCode);
     } else {
       CallInvokerHolderImpl callInvokerHolder =
-          (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+          (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
       mHybridData =
           initHybrid(
               Objects.requireNonNull(context.getJavaScriptContextHolder()).get(),

--- a/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/latest/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/reactNativeVersionPatch/RuntimeExecutor/latest/com/swmansion/reanimated/NativeProxy.java
@@ -47,7 +47,7 @@ public class NativeProxy extends NativeProxyCommon {
               valueUnpackerCode);
     } else {
       CallInvokerHolderImpl callInvokerHolder =
-          (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
+          (CallInvokerHolderImpl) context.getJSCallInvokerHolder();
       mHybridData =
           initHybrid(
               Objects.requireNonNull(context.getJavaScriptContextHolder()).get(),


### PR DESCRIPTION
## Summary

<img width="829" alt="Screenshot 2024-09-24 at 17 27 16" src="https://github.com/user-attachments/assets/2e622c49-f238-4b95-bd72-f5d4a17c9ba2">


## Test plan

- [ ] Compatibility CI passes ([run](https://github.com/software-mansion/react-native-reanimated/actions/runs/11016769839))
- [x] 🚀 
