### PR TITLE
Change namespace `reanimated` to `worklets`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.h
@@ -13,6 +13,7 @@
 namespace reanimated {
 
 using namespace facebook;
+using namespace worklets;
 
 enum SensorType {
   ACCELEROMETER = 1,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -18,6 +18,7 @@
 namespace reanimated {
 
 using namespace facebook;
+using namespace worklets;
 
 struct LayoutAnimationConfig {
   int tag;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/ReanimatedWorkletRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/ReanimatedWorkletRuntimeDecorator.cpp
@@ -7,6 +7,8 @@
 
 namespace reanimated {
 
+using namespace worklets;
+
 void ReanimatedWorkletRuntimeDecorator::decorate(jsi::Runtime &rt) {
   jsi_utils::installJsiFunction(
       rt, "_log", [](jsi::Runtime &rt, const jsi::Value &value) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
@@ -3,6 +3,8 @@
 
 namespace reanimated {
 
+using namespace worklets;
+
 void UIRuntimeDecorator::decorate(
     jsi::Runtime &uiRuntime,
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/worklets/Registries/EventHandlerRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Registries/EventHandlerRegistry.cpp
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 
-namespace reanimated {
+namespace worklets {
 
 void EventHandlerRegistry::registerEventHandler(
     const std::shared_ptr<WorkletEventHandler> &eventHandler) {
@@ -91,4 +91,4 @@ bool EventHandlerRegistry::isAnyHandlerWaitingForEvent(
   return it != eventMappingsWithTag.end() && !it->second.empty();
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Registries/EventHandlerRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Registries/EventHandlerRegistry.h
@@ -13,7 +13,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletEventHandler;
 
@@ -46,4 +46,4 @@ class EventHandlerRegistry {
       const int emitterReactTag);
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.cpp
@@ -1,8 +1,8 @@
 #include <worklets/Registries/WorkletRuntimeRegistry.h>
 
-namespace reanimated {
+namespace worklets {
 
 std::set<jsi::Runtime *> WorkletRuntimeRegistry::registry_{};
 std::mutex WorkletRuntimeRegistry::mutex_{};
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.h
@@ -7,7 +7,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletRuntimeRegistry {
  private:
@@ -36,4 +36,4 @@ class WorkletRuntimeRegistry {
   }
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -2,7 +2,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 jsi::Function getValueUnpacker(jsi::Runtime &rt) {
   auto valueUnpacker = rt.global().getProperty(rt, "__valueUnpacker");
@@ -331,4 +331,4 @@ jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {
   }
 }
 
-} /* namespace reanimated */
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.h
@@ -11,7 +11,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 jsi::Function getValueUnpacker(jsi::Runtime &rt);
 
@@ -360,4 +360,4 @@ class ShareableScalar : public Shareable {
   Data data_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/AsyncQueue.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/AsyncQueue.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-namespace reanimated {
+namespace worklets {
 
 AsyncQueue::AsyncQueue(std::string name)
     : state_(std::make_shared<AsyncQueueState>()) {
@@ -49,4 +49,4 @@ void AsyncQueue::push(std::function<void()> &&job) {
   state_->cv.notify_one();
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/AsyncQueue.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/AsyncQueue.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-namespace reanimated {
+namespace worklets {
 
 struct AsyncQueueState {
   std::atomic_bool running{true};
@@ -32,4 +32,4 @@ class AsyncQueue {
   const std::shared_ptr<AsyncQueueState> state_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSISerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSISerializer.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <sstream>
 
+namespace worklets {
+
 const std::vector<std::string> SUPPORTED_ERROR_TYPES = {
     "Error",
     "AggregateError",
@@ -336,3 +338,5 @@ std::string stringifyJSIValue(jsi::Runtime &rt, const jsi::Value &value) {
 
   return serializer.stringifyJSIValueRecursively(value, true);
 }
+
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSISerializer.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSISerializer.h
@@ -6,7 +6,8 @@
 
 using namespace facebook;
 
-namespace {
+namespace worklets {
+
 class JSISerializer {
  public:
   explicit JSISerializer(jsi::Runtime &rt);
@@ -40,6 +41,7 @@ class JSISerializer {
   jsi::Runtime &rt_;
   jsi::Object visitedNodes_;
 };
-} // namespace
 
 std::string stringifyJSIValue(jsi::Runtime &rt, const jsi::Value &value);
+
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSLogger.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSLogger.cpp
@@ -1,7 +1,7 @@
 #include <worklets/Tools/JSLogger.h>
 #include <memory>
 
-namespace reanimated {
+namespace worklets {
 
 void JSLogger::warnOnJS(const std::string &warning) const {
 #ifndef NDEBUG
@@ -13,4 +13,4 @@ void JSLogger::warnOnJS(const std::string &warning) const {
 #endif // NDEBUG
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSLogger.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSLogger.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <string>
 
-namespace reanimated {
+namespace worklets {
 
 class JSLogger {
  public:
@@ -17,4 +17,4 @@ class JSLogger {
   const std::shared_ptr<JSScheduler> jsScheduler_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSScheduler.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSScheduler.cpp
@@ -5,7 +5,8 @@
 using namespace facebook;
 using namespace react;
 
-namespace reanimated {
+namespace worklets {
+
 JSScheduler::JSScheduler(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<CallInvoker> &jsCallInvoker)
@@ -36,4 +37,4 @@ const std::shared_ptr<CallInvoker> JSScheduler::getJSCallInvoker() const {
   return jsCallInvoker_;
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSScheduler.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/JSScheduler.h
@@ -9,11 +9,11 @@
 using namespace facebook;
 using namespace react;
 
-using Job = std::function<void(jsi::Runtime &rt)>;
-
-namespace reanimated {
+namespace worklets {
 
 class JSScheduler {
+  using Job = std::function<void(jsi::Runtime &rt)>;
+
  public:
   // With `jsCallInvoker`.
   explicit JSScheduler(
@@ -38,4 +38,4 @@ class JSScheduler {
   const std::shared_ptr<CallInvoker> jsCallInvoker_ = nullptr;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedJSIUtils.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedJSIUtils.cpp
@@ -3,7 +3,7 @@
 
 using namespace facebook;
 
-namespace reanimated::jsi_utils {
+namespace worklets::jsi_utils {
 
 jsi::Array convertStringToArray(
     jsi::Runtime &rt,
@@ -23,4 +23,4 @@ jsi::Array convertStringToArray(
   return matrix;
 }
 
-} // namespace reanimated::jsi_utils
+} // namespace worklets::jsi_utils

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedJSIUtils.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedJSIUtils.h
@@ -8,8 +8,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
-namespace jsi_utils {
+namespace worklets::jsi_utils {
 
 // `get` functions take a pointer to `jsi::Value` and
 // call an appropriate method to cast to the native type
@@ -172,5 +171,4 @@ jsi::Array convertStringToArray(
     const std::string &value,
     const unsigned int expectedSize);
 
-} // namespace jsi_utils
-} // namespace reanimated
+} // namespace worklets::jsi_utils

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedVersion.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedVersion.cpp
@@ -13,7 +13,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 std::string getReanimatedCppVersion() {
   return std::string(REANIMATED_VERSION_STRING);
@@ -92,4 +92,4 @@ bool matchVersion(const std::string &version1, const std::string &version2) {
 }
 #endif // NDEBUG
 
-}; // namespace reanimated
+}; // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedVersion.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/ReanimatedVersion.h
@@ -9,11 +9,11 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 std::string getReanimatedCppVersion();
 void injectReanimatedCppVersion(jsi::Runtime &);
 bool matchVersion(const std::string &, const std::string &);
 void checkJSVersion(jsi::Runtime &, const std::shared_ptr<JSLogger> &);
 
-}; // namespace reanimated
+}; // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/ThreadSafeQueue.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/ThreadSafeQueue.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <utility>
 
-namespace reanimated {
+namespace worklets {
 
 //
 // Copyright (c) 2013 Juan Palacios juan.palacios.puyana@gmail.com
@@ -46,4 +46,4 @@ class ThreadSafeQueue {
   mutable std::condition_variable cond_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/UIScheduler.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/UIScheduler.cpp
@@ -3,7 +3,7 @@
 
 #include <utility>
 
-namespace reanimated {
+namespace worklets {
 
 void UIScheduler::scheduleOnUI(std::function<void()> job) {
   uiJobs_.push(std::move(job));
@@ -17,4 +17,4 @@ void UIScheduler::triggerUI() {
   }
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/UIScheduler.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/UIScheduler.h
@@ -6,7 +6,7 @@
 
 #include <atomic>
 
-namespace reanimated {
+namespace worklets {
 
 class UIScheduler {
  public:
@@ -19,4 +19,4 @@ class UIScheduler {
   ThreadSafeQueue<std::function<void()>> uiJobs_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/WorkletEventHandler.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/WorkletEventHandler.cpp
@@ -1,6 +1,6 @@
 #include <worklets/Tools/WorkletEventHandler.h>
 
-namespace reanimated {
+namespace worklets {
 
 void WorkletEventHandler::process(
     const std::shared_ptr<WorkletRuntime> &workletRuntime,
@@ -26,4 +26,4 @@ bool WorkletEventHandler::shouldIgnoreEmitterReactTag() const {
   return emitterReactTag_ == -1;
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/Tools/WorkletEventHandler.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/Tools/WorkletEventHandler.h
@@ -10,7 +10,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletEventHandler {
   const uint64_t handlerId_;
@@ -38,4 +38,4 @@ class WorkletEventHandler {
   bool shouldIgnoreEmitterReactTag() const;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.cpp
@@ -18,7 +18,7 @@
 #include <hermes/hermes.h>
 #endif
 
-namespace reanimated {
+namespace worklets {
 
 using namespace facebook;
 using namespace react;
@@ -117,6 +117,6 @@ ReanimatedHermesRuntime::~ReanimatedHermesRuntime() {
 #endif // HERMES_ENABLE_DEBUGGER
 }
 
-} // namespace reanimated
+} // namespace worklets
 
 #endif // JS_RUNTIME_HERMES

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.h
@@ -36,7 +36,7 @@
 #endif
 #endif // HERMES_ENABLE_DEBUGGER
 
-namespace reanimated {
+namespace worklets {
 
 using namespace facebook;
 using namespace react;
@@ -142,6 +142,6 @@ class ReanimatedHermesRuntime
 #endif // HERMES_ENABLE_DEBUGGER
 };
 
-} // namespace reanimated
+} // namespace worklets
 
 #endif // JS_RUNTIME_HERMES

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedRuntime.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedRuntime.cpp
@@ -14,7 +14,7 @@
 #include <jsc/JSCRuntime.h>
 #endif // JS_RUNTIME
 
-namespace reanimated {
+namespace worklets {
 
 using namespace facebook;
 using namespace react;
@@ -49,4 +49,4 @@ std::shared_ptr<jsi::Runtime> ReanimatedRuntime::make(
 #endif
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedRuntime.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/ReanimatedRuntime.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <string>
 
-namespace reanimated {
+namespace worklets {
 
 using namespace facebook;
 using namespace react;
@@ -27,4 +27,4 @@ class ReanimatedRuntime {
       const std::string &name);
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -6,7 +6,7 @@
 
 #include <jsi/decorator.h>
 
-namespace reanimated {
+namespace worklets {
 
 class AroundLock {
   const std::shared_ptr<std::recursive_mutex> mutex_;
@@ -146,4 +146,4 @@ void scheduleOnRuntime(
   workletRuntime->runAsyncGuarded(shareableWorklet);
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -15,7 +15,7 @@
 using namespace facebook;
 using namespace react;
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletRuntime : public jsi::HostObject,
                        public std::enable_shared_from_this<WorkletRuntime> {
@@ -81,4 +81,4 @@ void scheduleOnRuntime(
     const jsi::Value &workletRuntimeValue,
     const jsi::Value &shareableWorkletValue);
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeCollector.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeCollector.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletRuntimeCollector : public jsi::HostObject {
   // When worklet runtime is created, we inject an instance of this class as a
@@ -33,4 +33,4 @@ class WorkletRuntimeCollector : public jsi::HostObject {
   jsi::Runtime &runtime_;
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-namespace reanimated {
+namespace worklets {
 
 static inline double performanceNow() {
   // copied from JSExecutor.cpp
@@ -72,7 +72,7 @@ void WorkletRuntimeDecorator::decorate(
          const jsi::Value &value,
          const jsi::Value &nativeStateSource) {
         auto shouldRetainRemote = jsi::Value::undefined();
-        return reanimated::makeShareableClone(
+        return makeShareableClone(
             rt, value, shouldRetainRemote, nativeStateSource);
       });
 
@@ -117,8 +117,7 @@ void WorkletRuntimeDecorator::decorate(
       [](jsi::Runtime &rt,
          const jsi::Value &workletRuntimeValue,
          const jsi::Value &shareableWorkletValue) {
-        reanimated::scheduleOnRuntime(
-            rt, workletRuntimeValue, shareableWorkletValue);
+        scheduleOnRuntime(rt, workletRuntimeValue, shareableWorkletValue);
       });
 
   jsi::Object performance(rt);
@@ -136,4 +135,4 @@ void WorkletRuntimeDecorator::decorate(
   rt.global().setProperty(rt, "performance", performance);
 }
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
@@ -9,7 +9,7 @@
 
 using namespace facebook;
 
-namespace reanimated {
+namespace worklets {
 
 class WorkletRuntimeDecorator {
  public:
@@ -19,4 +19,4 @@ class WorkletRuntimeDecorator {
       const std::shared_ptr<JSScheduler> &jsScheduler);
 };
 
-} // namespace reanimated
+} // namespace worklets

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/AndroidUIScheduler.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/AndroidUIScheduler.h
@@ -13,6 +13,7 @@
 namespace reanimated {
 
 using namespace facebook;
+using namespace worklets;
 
 class AndroidUIScheduler : public jni::HybridClass<AndroidUIScheduler> {
  public:

--- a/packages/react-native-reanimated/apple/reanimated/native/REAIOSUIScheduler.h
+++ b/packages/react-native-reanimated/apple/reanimated/native/REAIOSUIScheduler.h
@@ -9,6 +9,7 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
+using namespace worklets;
 
 class REAIOSUIScheduler : public UIScheduler {
  public:


### PR DESCRIPTION
## Summary

This PR renames `namespace reanimated` to `namespace worklets` in `Common/cpp/worklets` as well as updates all its usages:
```diff
+using namespace worklets;
```

## Test plan

See if CI is green.
