### PR TITLE
fix: Restore backwards C++ compatibility for NDK23

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -38,12 +38,12 @@
 // https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros
 #if REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 20202L
 // Implicit copy capture of `this` is deprecated in NDK27, which uses C++20.
-#define COPY_CAPTURE_WITH_THIS [ =, this ]
+#define COPY_CAPTURE_WITH_THIS [ =, this ] // NOLINT (whitespace/braces)
 #else
 // React Native 0.75 is the last one which allows NDK23. NDK23 uses C++17 and
 // explicitly disallows C++20 features, including the syntax above. Therefore we
 // fallback to the deprecated syntax here.
-#define COPY_CAPTURE_WITH_THIS [=]
+#define COPY_CAPTURE_WITH_THIS [=] // NOLINT (whitespace/braces)
 #endif // REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 20202L
 
 using namespace facebook;


### PR DESCRIPTION
## Summary

Turns out preliminary support for NDK27 in
- #6495

broke support for NDK23. This PR brings back support for NDK23 which is used in React Native 0.72.

## Test plan

- [ ] All GitHub actions pass.

## Notes

Fixes
- #6512
