### PR TITLE
Fix typo in react-native-nightly-reanimated-build-check-nightly.yml

### DIFF
--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -40,8 +40,8 @@ jobs:
           if npm view react-native dist-tags | grep -q 'next:' ; then
             echo "REACT_NATIVE_TAG=next" >> $GITHUB_ENV
           fi
-      - name: Install React Native
-        run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
+      # - name: Install React Native
+      #   run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
           npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }}

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -25,10 +25,10 @@ jobs:
       group: ${{ matrix.platform }}-react-native-nightly-${{ matrix.react-native-architecture }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      # - name: Setup Yarn
+      - name: Setup Yarn
         # Sometimes `npx react-native init` fails due to dependency mismatches or other
         # rather vague errors. This is a workaround for that.
-        # run: corepack enable && yarn init
+        run: corepack enable && yarn init
       - name: Set up JDK 18
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3
@@ -44,10 +44,10 @@ jobs:
         run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
-          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --pm yarn --skip-install --install-pods false --skip-git-init
-      - name: Add yarn.lock in app
-        working-directory: ${{ env.APP_NAME }}
-        run: touch yarn.lock
+          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --skip-install --install-pods false --skip-git-init
+      # - name: Add yarn.lock in app
+      #   working-directory: ${{ env.APP_NAME }}
+      #   run: touch yarn.lock
       - name: Install Reanimated
         working-directory: ${{ env.APP_NAME }}
         run: yarn add react-native-reanimated@https://github.com/software-mansion/react-native-reanimated.git#commit=${{ github.sha }}

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build_ios:
     if: github.repository == 'software-mansion/react-native-reanimated'
-    runs-on: $${{ matrix.platform == 'iOS' && 'macos-14' || 'ubuntu-latest'}}
+    runs-on: ${{ matrix.platform == 'iOS' && 'macos-14' || 'ubuntu-latest'}}
     strategy:
       matrix:
         react-native-architecture: ['Paper', 'Fabric']

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
-          yarn react-native init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --pm yarn --skip-install --install-pods false --skip-git-init
+          npx react-native init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --pm yarn --skip-install --install-pods false --skip-git-init
       - name: Add yarn.lock in app
         working-directory: ${{ env.APP_NAME }}
         run: touch yarn.lock

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -1,73 +1,45 @@
-name: React Native nightly Reanimated build check [Nightly]
+name: V8 Reanimated build check [Nightly]
 env:
-  YARN_ENABLE_HARDENED_MODE: 0
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 0
 on:
   pull_request:
     paths:
-      - .github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+      - .github/workflows/V8-reanimated-build-check-nightly.yml
+      - .github/workflows/helper/configureV8.js
   schedule:
     - cron: '37 19 * * *'
   workflow_dispatch:
 
 jobs:
-  build_ios:
+  build:
     if: github.repository == 'software-mansion/react-native-reanimated'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        react-native-architecture: ['Paper', 'Fabric']
-        platform: ['iOS', 'Android']
-      fail-fast: false
-    env:
-      REACT_NATIVE_TAG: nightly
-      APP_NAME: app
+    runs-on: ubuntu-latest
     concurrency:
-      group: ${{ matrix.platform }}-react-native-nightly-${{ matrix.react-native-architecture }}-${{ github.ref }}
+      group: build-v8-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      # - name: Setup Yarn
-        # Sometimes `npx react-native init` fails due to dependency mismatches or other
-        # rather vague errors. This is a workaround for that.
-        # run: corepack enable && yarn init
-      - name: Set up JDK 18
-        if: ${{ matrix.platform == 'Android' }}
-        uses: actions/setup-java@v3
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          path: 'reanimated_repo'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '18'
-      # - name: Load "next" tag if available
-      #   run: |
-      #     if npm view react-native dist-tags | grep -q 'next:' ; then
-      #       echo "REACT_NATIVE_TAG=next" >> $GITHUB_ENV
-      #     fi
-      # - name: Install React Native
-      #   run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
-      - name: Create app
-        run: |
-          npx react-native init app
-      # - name: Add yarn.lock in app
-      #   working-directory: ${{ env.APP_NAME }}
-      #   run: touch yarn.lock
+          java-version: '17'
+      - name: Create React Native app
+        run: npx react-native init app
+      - name: Install dependencies
+        working-directory: app
+        run: yarn install
       - name: Install Reanimated
-        working-directory: ${{ env.APP_NAME }}
+        working-directory: app
         run: yarn add react-native-reanimated@https://github.com/software-mansion/react-native-reanimated.git#commit=${{ github.sha }}
-      - name: Install Paper Pods (iOS)
-        if: ${{ matrix.react-native-architecture == 'Paper' && matrix.platform == 'iOS' }}
-        working-directory: app/ios
-        run: bundle install && bundle exec pod install
-      - name: Install Fabric Pods (iOS)
-        if: ${{ matrix.react-native-architecture == 'Fabric' && matrix.platform == 'iOS' }}
-        working-directory: app/ios
-        run: RCT_NEW_ARCH_ENABLED=1 bundle install && bundle exec pod install
-      - name: Setup Fabric (Android)
-        if: ${{ matrix.react-native-architecture == 'Fabric' && matrix.platform == 'Android' }}
-        working-directory: ${{ env.APP_NAME }}/android
-        run: sed -i 's/newArchEnabled=false/newArchEnabled=true/' gradle.properties
-      - name: Build app (iOS)
-        if: ${{ matrix.platform == 'iOS' }}
-        working-directory: ${{ env.APP_NAME }}
-        run: yarn react-native run-ios --simulator='iPhone 14'
-      - name: Build app (Android)
-        if: ${{ matrix.platform == 'Android' }}
-        working-directory: ${{ env.APP_NAME }}/android
+      - name: Install test dependencies
+        working-directory: app
+        run: yarn add react-native-v8 v8-android-jit
+      - name: Configure V8
+        run: node reanimated_repo/.github/workflows/helper/configureV8.js
+      - name: Build Android app
+        working-directory: app/android
         run: ./gradlew assembleDebug --console=plain

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -25,10 +25,10 @@ jobs:
       group: ${{ matrix.platform }}-react-native-nightly-${{ matrix.react-native-architecture }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Setup Yarn
+      # - name: Setup Yarn
         # Sometimes `npx react-native init` fails due to dependency mismatches or other
         # rather vague errors. This is a workaround for that.
-        run: corepack enable && yarn init
+        # run: corepack enable && yarn init
       - name: Set up JDK 18
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -1,11 +1,10 @@
-name: V8 Reanimated build check [Nightly]
+name: React Native nightly Reanimated build check [Nightly]
 env:
-  YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+  YARN_ENABLE_HARDENED_MODE: 0
 on:
   pull_request:
     paths:
-      - .github/workflows/V8-reanimated-build-check-nightly.yml
-      - .github/workflows/helper/configureV8.js
+      - .github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
   schedule:
     - cron: '37 19 * * *'
   workflow_dispatch:

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -1,6 +1,4 @@
 name: React Native nightly Reanimated build check [Nightly]
-env:
-  YARN_ENABLE_HARDENED_MODE: 0
 on:
   pull_request:
     paths:

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -23,10 +23,10 @@ jobs:
       group: ${{ matrix.platform }}-react-native-nightly-${{ matrix.react-native-architecture }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Setup Yarn
+      # - name: Setup Yarn
         # Sometimes `npx react-native init` fails due to dependency mismatches or other
         # rather vague errors. This is a workaround for that.
-        run: corepack enable && yarn init
+        # run: corepack enable && yarn init
       - name: Set up JDK 18
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
-          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --skip-install --install-pods false --skip-git-init
+          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }}
       # - name: Add yarn.lock in app
       #   working-directory: ${{ env.APP_NAME }}
       #   run: touch yarn.lock

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
-          npx react-native init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --pm yarn --skip-install --install-pods false --skip-git-init
+          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }} --pm yarn --skip-install --install-pods false --skip-git-init
       - name: Add yarn.lock in app
         working-directory: ${{ env.APP_NAME }}
         run: touch yarn.lock

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -1,4 +1,6 @@
 name: React Native nightly Reanimated build check [Nightly]
+env:
+  YARN_ENABLE_IMMUTABLE_INSTALLS: 0
 on:
   pull_request:
     paths:

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -1,4 +1,6 @@
 name: React Native nightly Reanimated build check [Nightly]
+env:
+  YARN_ENABLE_HARDENED_MODE: 0
 on:
   pull_request:
     paths:
@@ -10,7 +12,7 @@ on:
 jobs:
   build_ios:
     if: github.repository == 'software-mansion/react-native-reanimated'
-    runs-on: ${{ matrix.platform == 'iOS' && 'macos-14' || 'ubuntu-latest'}}
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
         react-native-architecture: ['Paper', 'Fabric']
@@ -33,16 +35,16 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '18'
-      - name: Load "next" tag if available
-        run: |
-          if npm view react-native dist-tags | grep -q 'next:' ; then
-            echo "REACT_NATIVE_TAG=next" >> $GITHUB_ENV
-          fi
+      # - name: Load "next" tag if available
+      #   run: |
+      #     if npm view react-native dist-tags | grep -q 'next:' ; then
+      #       echo "REACT_NATIVE_TAG=next" >> $GITHUB_ENV
+      #     fi
       # - name: Install React Native
       #   run: yarn add react-native@${{ env.REACT_NATIVE_TAG }}
       - name: Create app
         run: |
-          npx @react-native-community/cli init ${{ env.APP_NAME }} --version ${{ env.REACT_NATIVE_TAG }}
+          npx react-native init app
       # - name: Add yarn.lock in app
       #   working-directory: ${{ env.APP_NAME }}
       #   run: touch yarn.lock


### PR DESCRIPTION
## Summary

⚠️ Wait until CI will pass
This PR fixes our failing CIs:
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/3580a3cb-563f-42eb-a0f7-794572fd3f71">
This happens because of typo in the name of GitHub runner 🫣
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/269790cc-0ba0-41af-b444-af1a683e8f69">


## Test plan

Check CI
