### PR TITLE
Fix prefab headers

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -147,7 +147,8 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def reactNativeThirdParty = new File("$reactNativeRootDir/ReactAndroid/src/main/jni/third-party")
 def reactNativeAndroidDownloadDir = new File("$reactNativeRootDir/ReactAndroid/build/downloads")
 
-def prefabHeadersDir = project.file("$buildDir/prefab-headers/reanimated")
+def workletsPrefabHeadersDir = project.file("$buildDir/prefab-headers/worklets")
+def reanimatedPrefabHeadersDir = project.file("$buildDir/prefab-headers/reanimated")
 
 def JS_RUNTIME = {
     // Override JS runtime with environment variable
@@ -231,11 +232,11 @@ android {
     }
 
     prefab {
-        reanimated {
-            headers prefabHeadersDir.absolutePath
-        }
         worklets {
-            headers prefabHeadersDir.absolutePath
+            headers workletsPrefabHeadersDir.absolutePath
+        }
+        reanimated {
+            headers reanimatedPrefabHeadersDir.absolutePath
         }
     }
 
@@ -264,7 +265,7 @@ android {
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
         buildConfigField("int", "REACT_NATIVE_MINOR_VERSION", REACT_NATIVE_MINOR_VERSION.toString())
-        
+
         consumerProguardFiles 'proguard-rules.pro'
     }
     externalNativeBuild {
@@ -354,7 +355,7 @@ android {
                 }
             }
 
-            // ReanimatedUIManager & ReanimatedUIImplementation 
+            // ReanimatedUIManager & ReanimatedUIImplementation
             if (REACT_NATIVE_MINOR_VERSION <= 73) {
                 srcDirs += "src/reactNativeVersionPatch/ReanimatedUIManager/73"
             } else if (REACT_NATIVE_MINOR_VERSION <= 74) {
@@ -370,7 +371,7 @@ android {
                 srcDirs += "src/reactNativeVersionPatch/ReactHost/latest"
             }
 
-            // ReactFeatureFlags 
+            // ReactFeatureFlags
             if (IS_NEW_ARCHITECTURE_ENABLED) {
                 if (REACT_NATIVE_MINOR_VERSION <= 72) {
                     srcDirs += "src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/72"
@@ -445,20 +446,18 @@ def assertMinimalReactNativeVersion = task assertMinimalReactNativeVersionTask {
     }
 }
 
-task prepareHeadersForPrefab(type: Copy) {
-    from("$projectDir/src/main/cpp/reanimated")
-    from("$projectDir/../Common/cpp/reanimated/AnimatedSensor")
-    from("$projectDir/../Common/cpp/reanimated/Fabric")
-    from("$projectDir/../Common/cpp/reanimated/LayoutAnimations")
-    from("$projectDir/../Common/cpp/reanimated/NativeModules")
-    from("$projectDir/../Common/cpp/reanimated/RuntimeDecorators")
-    from("$projectDir/../Common/cpp/reanimated/Tools")
-    from("$projectDir/../Common/cpp/worklets/Registries")
-    from("$projectDir/../Common/cpp/worklets/SharedItems")
-    from("$projectDir/../Common/cpp/worklets/Tools")
-    from("$projectDir/../Common/cpp/worklets/WorkletRuntime")
-    include("*.h")
-    into(prefabHeadersDir)
+task prepareWorkletsHeadersForPrefabs(type: Copy) {
+    from("$projectDir/src/main/cpp")
+    from("$projectDir/../Common/cpp")
+    include("**/*.h")
+    into(workletsPrefabHeadersDir)
+}
+
+task prepareReanimatedHeadersForPrefabs(type: Copy) {
+    from("$projectDir/src/main/cpp")
+    from("$projectDir/../Common/cpp")
+    include("**/*.h")
+    into(reanimatedPrefabHeadersDir)
 }
 
 tasks.preBuild {
@@ -480,7 +479,8 @@ task printVersions {
 task createNativeDepsDirectories() {
     downloadsDir.mkdirs()
     thirdPartyNdkDir.mkdirs()
-    prefabHeadersDir.mkdirs()
+    workletsPrefabHeadersDir.mkdirs()
+    reanimatedPrefabHeadersDir.mkdirs()
 }
 
 task packageNdkLibs(type: Copy) {
@@ -527,7 +527,8 @@ def nativeBuildDependsOn(dependsOnTask) {
 }
 
 afterEvaluate {
-    preBuild.dependsOn(prepareHeadersForPrefab)
+    preBuild.dependsOn(prepareWorkletsHeadersForPrefabs)
+    preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)
 
     tasks.forEach({ task ->
         if (task.name.contains("JniLibFolders")) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
This PR fixes exposed prefab headers after splitting the native libraries into `reanimated` and `worklets`.

Based on https://github.com/Expensify/react-native-live-markdown/blob/%40tomekzaw/worklets/.yarn/patches/react-native-reanimated-npm-3.16.0-nightly-20240929-c4bb3a543-0d5ade5027.patch.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
