### PR TITLE
Add SVG color properties to list of color attributes to parse

### DIFF
--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -340,6 +340,12 @@ export const ColorProperties = makeShareable([
   'tintColor',
   'textShadowColor',
   'overlayColor',
+  // SVG color properties
+  'fill',
+  'floodColor',
+  'lightingColor',
+  'stopColor',
+  'stroke',
 ]);
 
 // // ts-prune-ignore-next Exported for the purpose of tests only


### PR DESCRIPTION
## Summary

This PR will significantly enhance the developer experience when animating SVGs, as with these changes, the `SVGAdapter` is no longer required (at least for animating **colors**). It's related to the following PR: https://github.com/software-mansion/react-native-svg/pull/2471

## Test plan

At this point, the changes will not impact the current behavior and need to be tested within the `react-native-svg` repository until the release. Once the RNSVG release is out, I will add an example to the Reanimated repository.