### PR TITLE
Add `outlineColor` to ColorProperties list

### DIFF
--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -335,6 +335,7 @@ export const ColorProperties = makeShareable([
   'borderBlockEndColor',
   'borderBlockStartColor',
   'color',
+  'outlineColor',
   'shadowColor',
   'textDecorationColor',
   'tintColor',


### PR DESCRIPTION
## Summary

Add support for animating the `outlineColor` prop, introduced in `react-native` via https://github.com/facebook/react-native/pull/46284, by including it in the ColorProperties list.
