### PR TITLE
refactor(Worklets): Move shareable creation to Worklets

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -253,15 +253,6 @@ jsi::Value NativeReanimatedModule::scheduleOnRuntime(
   return jsi::Value::undefined();
 }
 
-jsi::Value NativeReanimatedModule::makeShareableClone(
-    jsi::Runtime &rt,
-    const jsi::Value &value,
-    const jsi::Value &shouldRetainRemote,
-    const jsi::Value &nativeStateSource) {
-  return reanimated::makeShareableClone(
-      rt, value, shouldRetainRemote, nativeStateSource);
-}
-
 jsi::Value NativeReanimatedModule::registerEventHandler(
     jsi::Runtime &rt,
     const jsi::Value &worklet,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -44,12 +44,6 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   ~NativeReanimatedModule();
 
-  jsi::Value makeShareableClone(
-      jsi::Runtime &rt,
-      const jsi::Value &value,
-      const jsi::Value &shouldRetainRemote,
-      const jsi::Value &nativeStateSource) override;
-
   void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) override;
   jsi::Value executeOnUIRuntimeSync(jsi::Runtime &rt, const jsi::Value &worklet)
       override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -2,25 +2,14 @@
 
 #include <utility>
 
-#define SPEC_PREFIX(FN_NAME) __hostFunction_NativeReanimatedModuleSpec_##FN_NAME
+#define REANIMATED_SPEC_PREFIX(FN_NAME) \
+  __hostFunction_NativeReanimatedModuleSpec_##FN_NAME
 
 namespace reanimated {
 
-// SharedValue
-
-static jsi::Value SPEC_PREFIX(makeShareableClone)(
-    jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const jsi::Value *args,
-    size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
-      ->makeShareableClone(
-          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
-}
-
 // scheduler
 
-static jsi::Value SPEC_PREFIX(scheduleOnUI)(
+static jsi::Value REANIMATED_SPEC_PREFIX(scheduleOnUI)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -30,7 +19,7 @@ static jsi::Value SPEC_PREFIX(scheduleOnUI)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(executeOnUIRuntimeSync)(
+static jsi::Value REANIMATED_SPEC_PREFIX(executeOnUIRuntimeSync)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -39,7 +28,7 @@ static jsi::Value SPEC_PREFIX(executeOnUIRuntimeSync)(
       ->executeOnUIRuntimeSync(rt, std::move(args[0]));
 }
 
-static jsi::Value SPEC_PREFIX(createWorkletRuntime)(
+static jsi::Value REANIMATED_SPEC_PREFIX(createWorkletRuntime)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -48,7 +37,7 @@ static jsi::Value SPEC_PREFIX(createWorkletRuntime)(
       ->createWorkletRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
-static jsi::Value SPEC_PREFIX(scheduleOnRuntime)(
+static jsi::Value REANIMATED_SPEC_PREFIX(scheduleOnRuntime)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -57,7 +46,7 @@ static jsi::Value SPEC_PREFIX(scheduleOnRuntime)(
       ->scheduleOnRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
-static jsi::Value SPEC_PREFIX(registerEventHandler)(
+static jsi::Value REANIMATED_SPEC_PREFIX(registerEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -67,7 +56,7 @@ static jsi::Value SPEC_PREFIX(registerEventHandler)(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
 
-static jsi::Value SPEC_PREFIX(unregisterEventHandler)(
+static jsi::Value REANIMATED_SPEC_PREFIX(unregisterEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -77,7 +66,7 @@ static jsi::Value SPEC_PREFIX(unregisterEventHandler)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(getViewProp)(
+static jsi::Value REANIMATED_SPEC_PREFIX(getViewProp)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -88,7 +77,7 @@ static jsi::Value SPEC_PREFIX(getViewProp)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(enableLayoutAnimations)(
+static jsi::Value REANIMATED_SPEC_PREFIX(enableLayoutAnimations)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -98,7 +87,7 @@ static jsi::Value SPEC_PREFIX(enableLayoutAnimations)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(registerSensor)(
+static jsi::Value REANIMATED_SPEC_PREFIX(registerSensor)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -112,7 +101,7 @@ static jsi::Value SPEC_PREFIX(registerSensor)(
           std::move(args[3]));
 }
 
-static jsi::Value SPEC_PREFIX(unregisterSensor)(
+static jsi::Value REANIMATED_SPEC_PREFIX(unregisterSensor)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -122,7 +111,7 @@ static jsi::Value SPEC_PREFIX(unregisterSensor)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(configureProps)(
+static jsi::Value REANIMATED_SPEC_PREFIX(configureProps)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -132,7 +121,7 @@ static jsi::Value SPEC_PREFIX(configureProps)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(subscribeForKeyboardEvents)(
+static jsi::Value REANIMATED_SPEC_PREFIX(subscribeForKeyboardEvents)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -142,7 +131,7 @@ static jsi::Value SPEC_PREFIX(subscribeForKeyboardEvents)(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
 
-static jsi::Value SPEC_PREFIX(unsubscribeFromKeyboardEvents)(
+static jsi::Value REANIMATED_SPEC_PREFIX(unsubscribeFromKeyboardEvents)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -152,7 +141,7 @@ static jsi::Value SPEC_PREFIX(unsubscribeFromKeyboardEvents)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value SPEC_PREFIX(configureLayoutAnimationBatch)(
+static jsi::Value REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -161,7 +150,7 @@ static jsi::Value SPEC_PREFIX(configureLayoutAnimationBatch)(
       ->configureLayoutAnimationBatch(rt, std::move(args[0]));
 }
 
-static jsi::Value SPEC_PREFIX(setShouldAnimateExiting)(
+static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -174,37 +163,38 @@ static jsi::Value SPEC_PREFIX(setShouldAnimateExiting)(
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     const std::shared_ptr<CallInvoker> &jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
-  methodMap_["makeShareableClone"] =
-      MethodMetadata{2, SPEC_PREFIX(makeShareableClone)};
-
-  methodMap_["scheduleOnUI"] = MethodMetadata{1, SPEC_PREFIX(scheduleOnUI)};
+  methodMap_["scheduleOnUI"] =
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(scheduleOnUI)};
   methodMap_["executeOnUIRuntimeSync"] =
-      MethodMetadata{1, SPEC_PREFIX(executeOnUIRuntimeSync)};
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(executeOnUIRuntimeSync)};
   methodMap_["createWorkletRuntime"] =
-      MethodMetadata{2, SPEC_PREFIX(createWorkletRuntime)};
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(createWorkletRuntime)};
   methodMap_["scheduleOnRuntime"] =
-      MethodMetadata{2, SPEC_PREFIX(scheduleOnRuntime)};
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(scheduleOnRuntime)};
 
   methodMap_["registerEventHandler"] =
-      MethodMetadata{3, SPEC_PREFIX(registerEventHandler)};
+      MethodMetadata{3, REANIMATED_SPEC_PREFIX(registerEventHandler)};
   methodMap_["unregisterEventHandler"] =
-      MethodMetadata{1, SPEC_PREFIX(unregisterEventHandler)};
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(unregisterEventHandler)};
 
-  methodMap_["getViewProp"] = MethodMetadata{3, SPEC_PREFIX(getViewProp)};
+  methodMap_["getViewProp"] =
+      MethodMetadata{3, REANIMATED_SPEC_PREFIX(getViewProp)};
   methodMap_["enableLayoutAnimations"] =
-      MethodMetadata{2, SPEC_PREFIX(enableLayoutAnimations)};
-  methodMap_["registerSensor"] = MethodMetadata{4, SPEC_PREFIX(registerSensor)};
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(enableLayoutAnimations)};
+  methodMap_["registerSensor"] =
+      MethodMetadata{4, REANIMATED_SPEC_PREFIX(registerSensor)};
   methodMap_["unregisterSensor"] =
-      MethodMetadata{1, SPEC_PREFIX(unregisterSensor)};
-  methodMap_["configureProps"] = MethodMetadata{2, SPEC_PREFIX(configureProps)};
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(unregisterSensor)};
+  methodMap_["configureProps"] =
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(configureProps)};
   methodMap_["subscribeForKeyboardEvents"] =
-      MethodMetadata{2, SPEC_PREFIX(subscribeForKeyboardEvents)};
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(subscribeForKeyboardEvents)};
   methodMap_["unsubscribeFromKeyboardEvents"] =
-      MethodMetadata{1, SPEC_PREFIX(unsubscribeFromKeyboardEvents)};
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(unsubscribeFromKeyboardEvents)};
 
   methodMap_["configureLayoutAnimationBatch"] =
-      MethodMetadata{1, SPEC_PREFIX(configureLayoutAnimationBatch)};
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)};
   methodMap_["setShouldAnimateExitingForTag"] =
-      MethodMetadata{2, SPEC_PREFIX(setShouldAnimateExiting)};
+      MethodMetadata{2, REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)};
 }
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModuleSpec.h
@@ -18,13 +18,6 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       const std::shared_ptr<CallInvoker> &jsInvoker);
 
  public:
-  // SharedValue
-  virtual jsi::Value makeShareableClone(
-      jsi::Runtime &rt,
-      const jsi::Value &value,
-      const jsi::Value &shouldRetainRemote,
-      const jsi::Value &nativeStateSource) = 0;
-
   // Scheduling
   virtual void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) = 0;
   virtual jsi::Value executeOnUIRuntimeSync(

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModule.cpp
@@ -6,6 +6,7 @@
 #endif // RCT_NEW_ARCH_ENABLED
 
 #include <worklets/NativeModules/NativeWorkletsModule.h>
+#include <worklets/SharedItems/Shareables.h>
 
 #ifdef __ANDROID__
 #include <fbjni/fbjni.h>
@@ -22,4 +23,16 @@ NativeWorkletsModule::NativeWorkletsModule(const std::string &valueUnpackerCode)
       valueUnpackerCode_(valueUnpackerCode) {}
 
 NativeWorkletsModule::~NativeWorkletsModule() {}
+
+jsi::Value NativeWorkletsModule::makeShareableClone(
+    jsi::Runtime &rt,
+    const jsi::Value &value,
+    const jsi::Value &shouldRetainRemote,
+    const jsi::Value &nativeStateSource) {
+  // TODO: It might be a good idea to rename one of these methods to avoid
+  // confusion.
+  return worklets::makeShareableClone(
+      rt, value, shouldRetainRemote, nativeStateSource);
+}
+
 } // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModule.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModule.h
@@ -12,6 +12,12 @@ class NativeWorkletsModule : public NativeWorkletsModuleSpec {
 
   ~NativeWorkletsModule();
 
+  jsi::Value makeShareableClone(
+      jsi::Runtime &rt,
+      const jsi::Value &value,
+      const jsi::Value &shouldRetainRemote,
+      const jsi::Value &nativeStateSource) override;
+
   [[nodiscard]] inline std::string getValueUnpackerCode() const {
     return valueUnpackerCode_;
   }

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModuleSpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModuleSpec.cpp
@@ -1,9 +1,27 @@
 #include <worklets/NativeModules/NativeWorkletsModuleSpec.h>
 
+#include <utility>
+
+#define WORKLETS_SPEC_PREFIX(FN_NAME) \
+  __hostFunction_NativeWorkletsModuleSpec_##FN_NAME
+
 namespace worklets {
+
+static jsi::Value WORKLETS_SPEC_PREFIX(makeShareableClone)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<NativeWorkletsModuleSpec *>(&turboModule)
+      ->makeShareableClone(
+          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+}
 
 NativeWorkletsModuleSpec::NativeWorkletsModuleSpec(
     const std::shared_ptr<CallInvoker> jsInvoker)
-    : TurboModule("NativeWorklets", jsInvoker) {}
+    : TurboModule("NativeWorklets", jsInvoker) {
+  methodMap_["makeShareableClone"] =
+      MethodMetadata{2, WORKLETS_SPEC_PREFIX(makeShareableClone)};
+}
 
 } // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModuleSpec.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/NativeWorkletsModuleSpec.h
@@ -13,6 +13,13 @@ class JSI_EXPORT NativeWorkletsModuleSpec : public TurboModule {
  protected:
   explicit NativeWorkletsModuleSpec(
       const std::shared_ptr<CallInvoker> jsInvoker);
+
+ public:
+  virtual jsi::Value makeShareableClone(
+      jsi::Runtime &rt,
+      const jsi::Value &value,
+      const jsi::Value &shouldRetainRemote,
+      const jsi::Value &nativeStateSource) = 0;
 };
 
 } // namespace worklets

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -64,18 +64,6 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     this.#reanimatedModuleProxy = global.__reanimatedModuleProxy;
   }
 
-  makeShareableClone<T>(
-    value: T,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ) {
-    return this.#reanimatedModuleProxy.makeShareableClone(
-      value,
-      shouldPersistRemote,
-      nativeStateSource
-    );
-  }
-
   scheduleOnUI<T>(shareable: ShareableRef<T>) {
     return this.#reanimatedModuleProxy.scheduleOnUI(shareable);
   }

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -42,12 +42,6 @@ class JSReanimated implements IReanimatedModule {
   sensors = new Map<number, WebSensor>();
   platform?: Platform = undefined;
 
-  makeShareableClone<T>(): ShareableRef<T> {
-    throw new ReanimatedError(
-      'makeShareableClone should never be called in JSReanimated.'
-    );
-  }
-
   scheduleOnUI<T>(worklet: ShareableRef<T>) {
     // @ts-ignore web implementation has still not been updated after the rewrite, this will be addressed once the web implementation updates are ready
     requestAnimationFrameImpl(worklet);

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -11,12 +11,6 @@ import type { WorkletRuntime } from '../runtimes';
 
 /** Type of `__reanimatedModuleProxy` injected with JSI. */
 export interface ReanimatedModuleProxy {
-  makeShareableClone<T>(
-    value: T,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ): ShareableRef<T>;
-
   scheduleOnUI<T>(shareable: ShareableRef<T>): void;
 
   executeOnUIRuntimeSync<T, R>(shareable: ShareableRef<T>): R;

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -5,74 +5,19 @@ import type {
   TransformsStyle,
   ImageStyle,
 } from 'react-native';
-import type { WorkletRuntime } from './runtimes';
+import type { WorkletsModuleProxy } from './worklets';
+import type { ReanimatedModuleProxy } from './ReanimatedModule';
 
-export interface IWorkletsModule {
-  makeShareableClone<TValue>(
-    value: TValue,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ): ShareableRef<TValue>;
-}
+export interface IWorkletsModule extends WorkletsModuleProxy {}
 
-export interface IReanimatedModule {
-  registerSensor(
-    sensorType: number,
-    interval: number,
-    iosReferenceFrame: number,
-    handler: ShareableRef<(data: Value3D | ValueRotation) => void>
-  ): number;
-
-  unregisterSensor(sensorId: number): void;
-
-  registerEventHandler<TValue>(
-    eventHandler: ShareableRef<TValue>,
-    eventName: string,
-    emitterReactTag: number
-  ): number;
-
-  unregisterEventHandler(id: number): void;
-
+export interface IReanimatedModule
+  extends Omit<ReanimatedModuleProxy, 'getViewProp'> {
   getViewProp<TValue>(
     viewTag: number,
     propName: string,
     component: React.Component | undefined,
     callback?: (result: TValue) => void
   ): Promise<TValue>;
-
-  configureLayoutAnimationBatch(
-    layoutAnimationsBatch: LayoutAnimationBatchItem[]
-  ): void;
-
-  setShouldAnimateExitingForTag(viewTag: number, shouldAnimate: boolean): void;
-
-  enableLayoutAnimations(flag: boolean): void;
-
-  configureProps(uiProps: string[], nativeProps: string[]): void;
-
-  subscribeForKeyboardEvents(
-    handler: ShareableRef<number>,
-    isStatusBarTranslucent: boolean,
-    isNavigationBarTranslucent: boolean
-  ): number;
-
-  unsubscribeFromKeyboardEvents(listenerId: number): void;
-
-  scheduleOnUI<TValue>(shareable: ShareableRef<TValue>): void;
-
-  executeOnUIRuntimeSync<TValue, TResult>(
-    shareable: ShareableRef<TValue>
-  ): TResult;
-
-  createWorkletRuntime(
-    name: string,
-    initializer: ShareableRef<() => void>
-  ): WorkletRuntime;
-
-  scheduleOnRuntime<TValue>(
-    workletRuntime: WorkletRuntime,
-    shareableWorklet: ShareableRef<TValue>
-  ): void;
 }
 
 export type LayoutAnimationsOptions =

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -7,7 +7,13 @@ import type {
 } from 'react-native';
 import type { WorkletRuntime } from './runtimes';
 
-export interface IWorkletsModule {}
+export interface IWorkletsModule {
+  makeShareableClone<TValue>(
+    value: TValue,
+    shouldPersistRemote: boolean,
+    nativeStateSource?: object
+  ): ShareableRef<TValue>;
+}
 
 export interface IReanimatedModule {
   registerSensor(
@@ -51,12 +57,6 @@ export interface IReanimatedModule {
   ): number;
 
   unsubscribeFromKeyboardEvents(listenerId: number): void;
-
-  makeShareableClone<TValue>(
-    value: TValue,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ): ShareableRef<TValue>;
 
   scheduleOnUI<TValue>(shareable: ShareableRef<TValue>): void;
 

--- a/packages/react-native-reanimated/src/shareables.ts
+++ b/packages/react-native-reanimated/src/shareables.ts
@@ -13,7 +13,7 @@ import {
   shareableMappingFlag,
 } from './shareableMappingCache';
 import { logger } from './logger';
-import { ReanimatedModule } from './ReanimatedModule';
+import { WorkletsModule } from './worklets';
 
 // for web/chrome debugger/jest environments this file provides a stub implementation
 // where no shareable references are used. Instead, the objects themselves are used
@@ -273,7 +273,7 @@ Offending code was: \`${getWorkletCode(value)}\``);
         shareableMappingCache.set(value, inaccessibleObject);
         return inaccessibleObject;
       }
-      const adapted = ReanimatedModule.makeShareableClone(
+      const adapted = WorkletsModule.makeShareableClone(
         toAdapt,
         shouldPersistRemote,
         value
@@ -283,7 +283,7 @@ Offending code was: \`${getWorkletCode(value)}\``);
       return adapted;
     }
   }
-  return ReanimatedModule.makeShareableClone(
+  return WorkletsModule.makeShareableClone(
     value,
     shouldPersistRemote,
     undefined

--- a/packages/react-native-reanimated/src/worklets/WorkletsModule/JSWorklets.ts
+++ b/packages/react-native-reanimated/src/worklets/WorkletsModule/JSWorklets.ts
@@ -1,9 +1,16 @@
 'use strict';
 
-import type { IWorkletsModule } from '../../commonTypes';
+import type { IWorkletsModule, ShareableRef } from '../../commonTypes';
+import { ReanimatedError } from '../../errors';
 
 export function createJSWorkletsModule(): IWorkletsModule {
   return new JSWorklets();
 }
 
-class JSWorklets implements IWorkletsModule {}
+class JSWorklets implements IWorkletsModule {
+  makeShareableClone<T>(): ShareableRef<T> {
+    throw new ReanimatedError(
+      'makeShareableClone should never be called in JSWorklets.'
+    );
+  }
+}

--- a/packages/react-native-reanimated/src/worklets/WorkletsModule/NativeWorklets.ts
+++ b/packages/react-native-reanimated/src/worklets/WorkletsModule/NativeWorklets.ts
@@ -25,4 +25,16 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     }
     this.#workletsModuleProxy = global.__workletsModuleProxy;
   }
+
+  makeShareableClone<T>(
+    value: T,
+    shouldPersistRemote: boolean,
+    nativeStateSource?: object
+  ) {
+    return this.#workletsModuleProxy.makeShareableClone(
+      value,
+      shouldPersistRemote,
+      nativeStateSource
+    );
+  }
 }

--- a/packages/react-native-reanimated/src/worklets/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-reanimated/src/worklets/WorkletsModule/workletsModuleProxy.ts
@@ -1,4 +1,12 @@
 'use strict';
 
+import type { ShareableRef } from '../../commonTypes';
+
 /** Type of `__workletsModuleProxy` injected with JSI. */
-export interface WorkletsModuleProxy {}
+export interface WorkletsModuleProxy {
+  makeShareableClone<T>(
+    value: T,
+    shouldPersistRemote: boolean,
+    nativeStateSource?: object
+  ): ShareableRef<T>;
+}

--- a/packages/react-native-reanimated/src/worklets/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-reanimated/src/worklets/WorkletsModule/workletsModuleProxy.ts
@@ -4,9 +4,9 @@ import type { ShareableRef } from '../../commonTypes';
 
 /** Type of `__workletsModuleProxy` injected with JSI. */
 export interface WorkletsModuleProxy {
-  makeShareableClone<T>(
-    value: T,
+  makeShareableClone<TValue>(
+    value: TValue,
     shouldPersistRemote: boolean,
     nativeStateSource?: object
-  ): ShareableRef<T>;
+  ): ShareableRef<TValue>;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Moving `makeShareableClone` function from `NativeReanimatedModule` to `NativeWorkletsModule`.

## Test plan

CI
