### PR TITLE
Lazy initalize layout aniamtions in the Commit Hook

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -2,6 +2,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/PropsRegistry.h>
+#include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
 
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
@@ -16,7 +17,7 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
   ReanimatedCommitHook(
       const std::shared_ptr<PropsRegistry> &propsRegistry,
       const std::shared_ptr<UIManager> &uiManager,
-      const std::function<void(SurfaceId)> initializeLayoutAnimations);
+      const std::shared_ptr<LayoutAnimationsProxy> &layoutAnimationsProxy);
 
   ~ReanimatedCommitHook() noexcept override;
 
@@ -46,9 +47,9 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
 
   std::shared_ptr<UIManager> uiManager_;
 
-  std::function<void(SurfaceId)> initializeLayoutAnimations_;
+  std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy_;
 
-  std::unordered_set<SurfaceId> initializedSurfaces_;
+  SurfaceId currentMaxSurfaceId_ = -1;
 
   std::mutex mutex_;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -51,7 +51,7 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
 
   SurfaceId currentMaxSurfaceId_ = -1;
 
-  std::mutex mutex_;
+  std::mutex mutex_; // Protects `currentMaxSurfaceId_`.
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -15,7 +15,8 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
  public:
   ReanimatedCommitHook(
       const std::shared_ptr<PropsRegistry> &propsRegistry,
-      const std::shared_ptr<UIManager> &uiManager);
+      const std::shared_ptr<UIManager> &uiManager,
+      const std::function<void(SurfaceId)> initializeLayoutAnimations);
 
   ~ReanimatedCommitHook() noexcept override;
 
@@ -44,6 +45,12 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
   std::shared_ptr<PropsRegistry> propsRegistry_;
 
   std::shared_ptr<UIManager> uiManager_;
+
+  std::function<void(SurfaceId)> initializeLayoutAnimations_;
+
+  std::unordered_set<SurfaceId> initializedSurfaces_;
+
+  std::mutex mutex_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -879,14 +879,6 @@ void NativeReanimatedModule::initializeLayoutAnimationsProxy() {
   }
 }
 
-void NativeReanimatedModule::initializeLayoutAnimations(SurfaceId surfaceId) {
-  uiManager_->getShadowTreeRegistry().visit(
-      surfaceId, [this](const ShadowTree &shadowTree) {
-        shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
-            layoutAnimationsProxy_);
-      });
-}
-
 #endif // RCT_NEW_ARCH_ENABLED
 
 jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -857,9 +857,7 @@ void NativeReanimatedModule::initializeFabric(
   mountHook_ =
       std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_);
   commitHook_ = std::make_shared<ReanimatedCommitHook>(
-      propsRegistry_, uiManager_, [this](SurfaceId surfaceId) {
-        initializeLayoutAnimations(surfaceId);
-      });
+      propsRegistry_, uiManager_, layoutAnimationsProxy_);
 }
 
 void NativeReanimatedModule::initializeLayoutAnimationsProxy() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -137,7 +137,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   void initializeFabric(const std::shared_ptr<UIManager> &uiManager);
 
-  void initializeLayoutAnimations();
+  void initializeLayoutAnimationsProxy();
+
+  void initializeLayoutAnimations(SurfaceId surfaceId);
 
   std::string obtainPropFromShadowNode(
       jsi::Runtime &rt,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -139,8 +139,6 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   void initializeLayoutAnimationsProxy();
 
-  void initializeLayoutAnimations(SurfaceId surfaceId);
-
   std::string obtainPropFromShadowNode(
       jsi::Runtime &rt,
       const std::string &propName,


### PR DESCRIPTION
## Summary

Since RN 0.76 the first surface is created after our `initializeTurboModule` method is called on iOS. This change is probably a result of [this PR](https://github.com/facebook/react-native/commit/a778979ed604d1dc7707faf4a3836e3deba136c6#diff-ebba7a8b74cc36d5a03437c3999863076246c6c4eb5559fd1a58719b720fd755). This breaks our initialization of `layoutAnimationsProxy_`, so now we lazy initialize it for every surface in the Commit hook.

## Test plan
Check if layout animations work in the `fabric-example` app.
