### PR TITLE
Bump python version and freeze cpplint

### DIFF
--- a/.github/workflows/reanimated-android-validation.yml
+++ b/.github/workflows/reanimated-android-validation.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.13]
     concurrency:
       group: validate-java-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/reanimated-android-validation.yml
+++ b/.github/workflows/reanimated-android-validation.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install cpplint
+          pip install cpplint==1.6.1
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
 

--- a/.github/workflows/reanimated-android-validation.yml
+++ b/.github/workflows/reanimated-android-validation.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     concurrency:
       group: validate-java-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/reanimated-common-validation.yml
+++ b/.github/workflows/reanimated-common-validation.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.13]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reanimated-common-validation.yml
+++ b/.github/workflows/reanimated-common-validation.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reanimated-common-validation.yml
+++ b/.github/workflows/reanimated-common-validation.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install cpplint
+          pip install cpplint==1.6.1
       - name: Install monorepo node dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

This PR bumps the python version in validation CI, so the `:=` operator used by `cpplint 2.0.0` is properly supported.

Also we temporarily freeze the `cpplint` version to 1.6.1 due to https://github.com/cpplint/cpplint/issues/293

## Test plan
