### PR TITLE
fix: build error with c++17

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -36,7 +36,7 @@
 
 // Standard `__cplusplus` macro reference:
 // https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros
-#if REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 20202L
+#if REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 202002L
 // Implicit copy capture of `this` is deprecated in NDK27, which uses C++20.
 #define COPY_CAPTURE_WITH_THIS [ =, this ] // NOLINT (whitespace/braces)
 #else
@@ -44,7 +44,7 @@
 // explicitly disallows C++20 features, including the syntax above. Therefore we
 // fallback to the deprecated syntax here.
 #define COPY_CAPTURE_WITH_THIS [=] // NOLINT (whitespace/braces)
-#endif // REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 20202L
+#endif // REACT_NATIVE_MINOR_VERSION >= 75 || __cplusplus >= 202002L
 
 using namespace facebook;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
There was a small typo in #6553 which caused building with c++17 to still fail.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Build works again with RN 0.72 which uses c++17.

## Notes

- Fixes https://github.com/software-mansion/react-native-reanimated/issues/6512#issuecomment-2407118212
- Fixes #6584
