### PR TITLE
Use `Number` instead of `parseInt`

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -105,7 +105,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     const duration: number = this.durationV ? this.durationV : 500;
     const animationKeyPoints: Array<number> = Array.from(
       Object.keys(this.definitions)
-    ).map(parseInt);
+    ).map(Number);
 
     const getAnimationDuration = (
       key: string,


### PR DESCRIPTION
## Summary
Replace `parseInt` with `Number`, as the second function correctly handles empty string and undefined.
```
Number(null) = 0
Number('') = 0
parseInt(null) = NaN
```

## Test plan
