### PR TITLE
Bump reanimated version to 3.16.0

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1747,7 +1747,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1767,10 +1767,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
+    - RNReanimated/reanimated (= 3.16.0)
+    - RNReanimated/worklets (= 3.16.0)
     - Yoga
-  - RNReanimated/reanimated (3.15.0):
+  - RNReanimated/reanimated (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1790,9 +1790,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.15.0)
+    - RNReanimated/reanimated/apple (= 3.16.0)
     - Yoga
-  - RNReanimated/reanimated/apple (3.15.0):
+  - RNReanimated/reanimated/apple (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1813,7 +1813,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2229,11 +2229,11 @@ SPEC CHECKSUMS:
   RNCPicker: d051e0647af8b2ad01a3d39a6b5dd9b7c0ccc166
   RNFlashList: 6f169ad83e52579b7754cbbcec1b004c27d82c93
   RNGestureHandler: c374c750a0a9bacd95f5c740d146ab9428549d6b
-  RNReanimated: 65ef35c65567513684ed3d69548e686708c7aac9
+  RNReanimated: 8ad1573711ca38673125fc9a774bfd0040e6e1f1
   RNScreens: de6e57426ba0e6cbc3fb5b4f496e7f08cb2773c2
   RNSVG: 08750404f92a36162a92522cc77dee437be1d257
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 8833bd4378ffd79f1dea711d6dc7231c09e63590
+  Yoga: 2a74e67570a7902969ff44f35dd41f47a9693be8
 
 PODFILE CHECKSUM: 3eb88d49c8fe32af0ac2c85501e29d29171f1070
 

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -1023,25 +1023,25 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
-  - RNReanimated/reanimated (3.15.0):
+    - RNReanimated/reanimated (= 3.16.0)
+    - RNReanimated/worklets (= 3.16.0)
+  - RNReanimated/reanimated (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.15.0)
-  - RNReanimated/reanimated/apple (3.15.0):
+    - RNReanimated/reanimated/apple (= 3.16.0)
+  - RNReanimated/reanimated/apple (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1270,10 +1270,10 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
   RNCPicker: 0173dedc74776227ec6dcc61bb85cd9f07bbb2ac
   RNGestureHandler: bb81850add626ddd265294323310fec6e861c96b
-  RNReanimated: 143bc4c36bc4a0491bcd1dacadb52d1f11ace9eb
+  RNReanimated: c9553b713ac50df956e2ad3a0576690211bfcc31
   RNSVG: 01eb8d8a0e2289ec3ecc9626ce920e00d2174992
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
-  Yoga: 329461de6a23b9e0c108d197fd0f6e87c8c8ecf2
+  Yoga: 0639c9c8a20ae8043b0b64e2ef6d7a2cd5806aac
 
 PODFILE CHECKSUM: ddae34ca2842288eb8f70e6df3c2d638c2f56027
 

--- a/apps/paper-example/ios/Podfile.lock
+++ b/apps/paper-example/ios/Podfile.lock
@@ -1601,7 +1601,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1621,10 +1621,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
+    - RNReanimated/reanimated (= 3.16.0)
+    - RNReanimated/worklets (= 3.16.0)
     - Yoga
-  - RNReanimated/reanimated (3.15.0):
+  - RNReanimated/reanimated (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1644,9 +1644,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.15.0)
+    - RNReanimated/reanimated/apple (= 3.16.0)
     - Yoga
-  - RNReanimated/reanimated/apple (3.15.0):
+  - RNReanimated/reanimated/apple (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1667,7 +1667,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.16.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2019,11 +2019,11 @@ SPEC CHECKSUMS:
   RNCPicker: 0173dedc74776227ec6dcc61bb85cd9f07bbb2ac
   RNFlashList: 115dd44377580761bff386a0caebf165424cf16f
   RNGestureHandler: 6dfe7692a191ee224748964127114edf057a1475
-  RNReanimated: 4041681b103869cace498be2aac8d8944b3cd123
+  RNReanimated: 47ffa5dbd10add47b77de7b0f5848346f21df0c6
   RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
   RNSVG: 01eb8d8a0e2289ec3ecc9626ce920e00d2174992
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 8833bd4378ffd79f1dea711d6dc7231c09e63590
+  Yoga: 2a74e67570a7902969ff44f35dd41f47a9693be8
 
 PODFILE CHECKSUM: 44956aee8c836a85949aa1fa8dde2c10e661633e
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1031,25 +1031,25 @@ PODS:
     - React-jsi (= 0.73.4-0)
     - React-logger (= 0.73.4-0)
     - React-perflogger (= 0.73.4-0)
-  - RNReanimated (3.15.0):
+  - RNReanimated (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.15.0)
-    - RNReanimated/worklets (= 3.15.0)
-  - RNReanimated/reanimated (3.15.0):
+    - RNReanimated/reanimated (= 3.16.0)
+    - RNReanimated/worklets (= 3.16.0)
+  - RNReanimated/reanimated (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.15.0)
-  - RNReanimated/reanimated/apple (3.15.0):
+    - RNReanimated/reanimated/apple (= 3.16.0)
+  - RNReanimated/reanimated/apple (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-  - RNReanimated/worklets (3.15.0):
+  - RNReanimated/worklets (3.16.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1267,9 +1267,9 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 20b2202e3396589a71069d12ae9f328949c7c7b8
   React-utils: 0307d396f233e47a167b5aaf045b0e4e1dc19d74
   ReactCommon: 17891ca337bfa5a7263649b09f27a8c664537bf2
-  RNReanimated: d3a18527c394a3a97c23179ac54c817ec30a4e6e
+  RNReanimated: 6b9a23735fd2d6ad4249a07a1525c9778287587d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: e7f2a2256464d4ef7b3825d216bd22aac3b449c1
+  Yoga: ab50eb8f7fcf1b36aad1801b5687b66b2c0aa000
 
 PODFILE CHECKSUM: c2efe42da2b9ce73832f8f03df86727f3f712fff
 

--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -9,20 +9,21 @@ sidebar_label: Compatibility
 
 <div className="compatibility">
 
-|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   |
-| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Spacer/>                            |        |        |        |        |        |        |        |        |        |        |        |        |        |
-| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   |
+| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.16.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Spacer/>                            |        |        |        |        |        |        |        |        |        |        |        |        |        |        |
+| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>
 
@@ -38,12 +39,13 @@ Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-nativ
 
 <div className="compatibility">
 
-|                                     | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   |
-| ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.15.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> |
-| <Version version="3.9.x – 3.14.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.1.x – 3.5.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                     | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   |
+| ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.16.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.15.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.9.x – 3.14.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "test": "jest",

--- a/packages/react-native-reanimated/scripts/set-reanimated-version.js
+++ b/packages/react-native-reanimated/scripts/set-reanimated-version.js
@@ -58,10 +58,7 @@ if (IS_SET_CUSTOM) {
     }).stdout.trim();
     const shortCommit = currentCommit.slice(0, 9);
 
-    const [major, minor] = currentVersion.split('.');
-    const patch = 0;
-    const nextMinor = Number(minor) + 1;
-    version = `${major}.${nextMinor}.${patch}-nightly-${dateIdentifier}-${shortCommit}`;
+    version = `${currentVersion}-nightly-${dateIdentifier}-${shortCommit}`;
   } else if (IS_FRESH) {
     version = `${currentVersion}-${dateIdentifier}`;
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -105,7 +105,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     const duration: number = this.durationV ? this.durationV : 500;
     const animationKeyPoints: Array<number> = Array.from(
       Object.keys(this.definitions)
-    ).map((value) => parseInt(value, 10));
+    ).map(parseInt);
 
     const getAnimationDuration = (
       key: string,

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -105,7 +105,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     const duration: number = this.durationV ? this.durationV : 500;
     const animationKeyPoints: Array<number> = Array.from(
       Object.keys(this.definitions)
-    ).map(parseInt);
+    ).map((value) => parseInt(value, 10));
 
     const getAnimationDuration = (
       key: string,

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -4,4 +4,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '3.15.0';
+export const jsVersion = '3.16.0';


### PR DESCRIPTION
## Summary

This PR bumps the Reanimated version to 3.16.0 and updates the compatibility table (there is also a minor Keyframe fix). This PR doesn't follow the usual release PR scheme, as we want to change the way we do releases. Now the `next` reanimated version will be used on main and release package will be made from a separate branch.

## Test plan
