### PR TITLE
Fix crash on macos when using Layout Animations

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
+++ b/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
@@ -39,15 +39,15 @@ const int DEFAULT_MODAL_TOP_OFFSET = 69; // Default iOS modal is shifted from sc
                 withOffsetY:(double)offsetY
 {
 #if TARGET_OS_OSX
-    NSView *mainWindow = UIApplication.sharedApplication.keyWindow.contentView;
+    NSView *mainWindowView = UIApplication.sharedApplication.keyWindow.contentView;
 #else
   REAUIView *mainWindow = RCTKeyWindow();
 #endif
-  CGPoint absolutePosition = [[view superview] convertPoint:view.center toView:mainWindow];
+  CGPoint absolutePosition = [[view superview] convertPoint:view.center toView:mainWindowView];
   _values = [NSMutableDictionary new];
 #if TARGET_OS_OSX
-  _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.frame.size.width];
-  _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.frame.size.height];
+  _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindowView.frame.size.width];
+  _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindowView.frame.size.height];
 #else
   _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.bounds.size.width];
   _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.bounds.size.height];

--- a/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
+++ b/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
@@ -39,15 +39,15 @@ const int DEFAULT_MODAL_TOP_OFFSET = 69; // Default iOS modal is shifted from sc
                 withOffsetY:(double)offsetY
 {
 #if TARGET_OS_OSX
-  NSView *mainWindowView = UIApplication.sharedApplication.keyWindow.contentView;
+  NSView *mainWindow = UIApplication.sharedApplication.keyWindow.contentView;
 #else
   REAUIView *mainWindow = RCTKeyWindow();
 #endif
-  CGPoint absolutePosition = [[view superview] convertPoint:view.center toView:mainWindowView];
+  CGPoint absolutePosition = [[view superview] convertPoint:view.center toView:mainWindow];
   _values = [NSMutableDictionary new];
 #if TARGET_OS_OSX
-  _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindowView.frame.size.width];
-  _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindowView.frame.size.height];
+  _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.frame.size.width];
+  _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.frame.size.height];
 #else
   _values[@"windowWidth"] = [NSNumber numberWithDouble:mainWindow.bounds.size.width];
   _values[@"windowHeight"] = [NSNumber numberWithDouble:mainWindow.bounds.size.height];

--- a/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
+++ b/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
@@ -39,7 +39,7 @@ const int DEFAULT_MODAL_TOP_OFFSET = 69; // Default iOS modal is shifted from sc
                 withOffsetY:(double)offsetY
 {
 #if TARGET_OS_OSX
-    NSView *mainWindowView = UIApplication.sharedApplication.keyWindow.contentView;
+  NSView *mainWindowView = UIApplication.sharedApplication.keyWindow.contentView;
 #else
   REAUIView *mainWindow = RCTKeyWindow();
 #endif

--- a/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
+++ b/packages/react-native-reanimated/apple/reanimated/LayoutReanimation/REASnapshot.m
@@ -39,7 +39,7 @@ const int DEFAULT_MODAL_TOP_OFFSET = 69; // Default iOS modal is shifted from sc
                 withOffsetY:(double)offsetY
 {
 #if TARGET_OS_OSX
-  REAUIView *mainWindow = UIApplication.sharedApplication.keyWindow;
+    NSView *mainWindow = UIApplication.sharedApplication.keyWindow.contentView;
 #else
   REAUIView *mainWindow = RCTKeyWindow();
 #endif


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Previously we were passing a window to function convertPoint, that accepts only view. It was causing a crash, therefore we should pass the contentView of the window.
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan
Tested on several examples:
* Olympic example
* [LA] Basic Layout Animation
* [LA] Entering and Exiting with Layout 
* [LA] Carousel
<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
