### PR TITLE
Add warning when passing incorrect transformOrigin

### DIFF
--- a/packages/react-native-reanimated/src/UpdateProps.ts
+++ b/packages/react-native-reanimated/src/UpdateProps.ts
@@ -32,6 +32,11 @@ if (shouldBeUseWeb()) {
   updateProps = (viewDescriptors, updates) => {
     'worklet';
     processColorsInProps(updates);
+    if ('transformOrigin' in updates) {
+      if (!Array.isArray(updates.transformOrigin)) {
+        throw new ReanimatedError('Please use transformOrigin in array form');
+      }
+    }
     global.UpdatePropsManager.update(viewDescriptors, updates);
   };
 }

--- a/packages/react-native-reanimated/src/UpdateProps.ts
+++ b/packages/react-native-reanimated/src/UpdateProps.ts
@@ -32,7 +32,7 @@ if (shouldBeUseWeb()) {
   updateProps = (viewDescriptors, updates) => {
     'worklet';
     processColorsInProps(updates);
-    if ('transformOrigin' in updates) {
+    if (updates.transformOrigin) {
       if (!Array.isArray(updates.transformOrigin)) {
         throw new ReanimatedError('Please use transformOrigin in array form');
       }


### PR DESCRIPTION
## Summary
Some view props, like colors are processed on JS level, so we process it in updateProps function:

https://github.com/software-mansion/react-native-reanimated/blob/f03ab1465b8347a0c56ad05a23173b3ac079a9c5/packages/react-native-reanimated/src/UpdateProps.ts#L34

However we don't implement our copy of [processTransformOrigin](https://github.com/facebook/react-native/blob/6aeca53b3ed4530e57a31d7a5593ae16b550b985/packages/react-native/Libraries/StyleSheet/processTransformOrigin.js#L19) and passing transformOrigin in a form of string crashes the app with a confusing error "Exception in HostFunction: <unknown>, js engine: reanimated"

Yet, if transformOrigin is provided as an array of 3 numbers (just as you would get after calling processTransformOrigin on it) everything works fine, so I've added a warning explaining the problem.

> [!NOTE]  
> Similarly a fontVariant in form of string passed in useAnimatedStyle will not work. However this is not going to crash the whole app, so we probably want to ignore it. Also fontVariant accepts quantified values, so it doesn't make as much sense to animate it.

## Test plan
This crash: https://github.com/software-mansion/react-native-reanimated/issues/5895 doesn't have misleading error message.