### PR TITLE
Workaround for V8EXECUTOR_LIB NOTFOUND error in worklets CMakeLists.txt

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/worklets/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/src/main/cpp/worklets/CMakeLists.txt
@@ -118,7 +118,7 @@ elseif(${JS_RUNTIME} STREQUAL "v8")
         PRIVATE
         "${JS_RUNTIME_DIR}/src"
     )
-    file(GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/*/jni/${ANDROID_ABI}")
+    file(GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/**/*/jni/${ANDROID_ABI}")
     find_library(
         V8EXECUTOR_LIB
         v8executor

--- a/packages/react-native-reanimated/android/src/main/cpp/worklets/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/src/main/cpp/worklets/CMakeLists.txt
@@ -118,7 +118,7 @@ elseif(${JS_RUNTIME} STREQUAL "v8")
         PRIVATE
         "${JS_RUNTIME_DIR}/src"
     )
-    file(GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/**/*/jni/${ANDROID_ABI}")
+    file(GLOB V8_SO_DIR "${JS_RUNTIME_DIR}/android/build/intermediates/library_jni/**/jni/${ANDROID_ABI}")
     find_library(
         V8EXECUTOR_LIB
         v8executor


### PR DESCRIPTION
Using v8 javascript engine was causing react-native-reanimated gradle build to fail: https://github.com/software-mansion/react-native-reanimated/issues/3570

Changing the `V8_SO_DIR` according to the recommendation from @reinismu fixes this: https://github.com/Kudo/react-native-v8/issues/208#issuecomment-2255387059

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #3570

## Test plan

I'm not sure how the current CI is passing (https://github.com/software-mansion/react-native-reanimated/issues/3570#issuecomment-2367494988), but that would be the way to test it.