### PR TITLE
Remove `config[:reanimated_node_modules_dir]` in reanimated_utils.rb

### DIFF
--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -13,7 +13,6 @@ def find_config()
     :react_native_minor_version => nil,
     :is_tvos_target => nil,
     :react_native_node_modules_dir => nil,
-    :reanimated_node_modules_dir => nil,
     :react_native_common_dir => nil,
   }
 
@@ -38,7 +37,6 @@ def find_config()
     result[:react_native_minor_version] = 1000
   end
   result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
-  result[:reanimated_node_modules_dir] = File.expand_path(File.join(__dir__, '..', '..'))
 
   pods_root = Pod::Config.instance.project_pods_root
   react_native_common_dir_absolute = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')


### PR DESCRIPTION
## Summary

This PR removes `config[:reanimated_node_modules_dir]` because it looks like it's unused (at least I hope so).

Apart from this, the value is incorrect (it's `/Users/tomekzaw/RNOS/react-native-reanimated/packages` on my setup but should be `/Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated`).

## Test plan
