### PR TITLE
chore: Silence next-example linter warnings

### DIFF
--- a/apps/next-example/pages/_app.js
+++ b/apps/next-example/pages/_app.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import Head from 'next/head';
 
 export default function App({ Component, pageProps }) {

--- a/apps/next-example/pages/index.js
+++ b/apps/next-example/pages/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import { StyleSheet, Text, View } from 'react-native';
 
 const styles = StyleSheet.create({

--- a/apps/next-example/pages/noreanimated.js
+++ b/apps/next-example/pages/noreanimated.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import { StyleSheet, View, Text } from 'react-native';
 
 export default function App() {

--- a/apps/next-example/pages/reanimated.js
+++ b/apps/next-example/pages/reanimated.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import { StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 

--- a/apps/next-example/pages/ssg.js
+++ b/apps/next-example/pages/ssg.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import Animated, {
   PinwheelIn,
   useAnimatedStyle,

--- a/apps/next-example/pages/ssr.js
+++ b/apps/next-example/pages/ssr.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import Animated, {
   PinwheelIn,
   useAnimatedStyle,

--- a/apps/next-example/pages/test.js
+++ b/apps/next-example/pages/test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import Animated, {
   PinwheelIn,
   useAnimatedStyle,


### PR DESCRIPTION
Linter wants JSDoc types but it's not worth to add them IMO
