### PR TITLE
fix: create symlink to common-app

### DIFF
--- a/apps/fabric-example/common-app
+++ b/apps/fabric-example/common-app
@@ -1,0 +1,1 @@
+../common-app

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -6,7 +6,7 @@
     "build": "",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --max-warnings=0 --ignore-pattern 'common-app/' .",
     "format": "prettier --write --list-different .",
     "start": "react-native start",
     "test": "jest"

--- a/apps/paper-example/common-app
+++ b/apps/paper-example/common-app
@@ -1,0 +1,1 @@
+../common-app

--- a/apps/paper-example/package.json
+++ b/apps/paper-example/package.json
@@ -6,7 +6,7 @@
     "build": "yarn patch-package",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --max-warnings=0 --ignore-pattern 'common-app/' .",
     "format": "prettier --write --list-different .",
     "start": "react-native start",
     "test": "jest"


### PR DESCRIPTION
## Summary

Similar to https://github.com/software-mansion/react-native-svg/pull/2512, it fixes resolving local images on Android by creating a symlink to the common directory, allowing images to be resolved without the `../` segment.

## Test plan

Run example app on Android and add
```tsx
<Image source={require('./assets/doge.png')} />
```
in `EmptyExample.tsx`