### PR TITLE
fix: Return value of set-reanimated-version.js script

### DIFF
--- a/packages/react-native-reanimated/createNPMPackage.sh
+++ b/packages/react-native-reanimated/createNPMPackage.sh
@@ -3,11 +3,11 @@
 yarn install --immutable
 yarn bob build
 
-PREVIOUS_VERSION=$(node scripts/set-reanimated-version.js $@)
+PREVIOUS_VERSION=$(node scripts/set-reanimated-version.js "$@")
 if [ $? -ne 0 ]; then
   exit 1
 fi
 npm pack
-node scripts/set-reanimated-version.js $PREVIOUS_VERSION
+node scripts/set-reanimated-version.js "$PREVIOUS_VERSION"
 
 echo "Done!"

--- a/packages/react-native-reanimated/scripts/set-reanimated-version.js
+++ b/packages/react-native-reanimated/scripts/set-reanimated-version.js
@@ -34,7 +34,7 @@ const currentVersion = packageJson.version;
 
 if (process.argv.length < 3) {
   console.log(currentVersion);
-  process.exit(1);
+  process.exit(0);
 }
 
 let version;


### PR DESCRIPTION
## Summary

I accidentally set the return value from 0 to 1 [here](https://github.com/software-mansion/react-native-reanimated/pull/6557/files/1aa3df2b0b458564ba5cfc2f04e67b803a2ee862#diff-15a6e10b865e98436e358bd843ebe5291db5141758f6dbffaecd6f009b5daee6L38) which in turn makes `createNPMPackage.sh` not pack the package when called without parameters.

## Test plan

🚀 
