### PR TITLE
fix: Break circular reference in `AndroidUIScheduler`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/AndroidUIScheduler.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/AndroidUIScheduler.java
@@ -44,5 +44,6 @@ public class AndroidUIScheduler {
 
   public void deactivate() {
     mActive.set(false);
+    mHybridData.resetNative();
   }
 }


### PR DESCRIPTION
## Summary

Breaks circular reference in the `AndroidUIScheduler`.

`AndroidUIScheduler` is a `HybridClass` that has a C++ counterpart holding a global reference to the Java object. This structure creates a circular reference between C++ and Java, which the garbage collector cannot clean up. To resolve this issue, I manually remove the reference between Java and C++ by calling `resetNative` when the scheduler is deactivated.

## Test plan

- tested in Expo Go ✅ 