### PR TITLE
fix: Break circular reference in `LayoutAnimation`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/LayoutAnimations.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/LayoutAnimations.cpp
@@ -115,6 +115,10 @@ jni::local_ref<JArrayInt> LayoutAnimations::getSharedGroup(const int tag) {
   return jGroup;
 }
 
+void LayoutAnimations::invalidate() {
+  javaPart_ = nullptr;
+}
+
 void LayoutAnimations::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", LayoutAnimations::initHybrid),

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/LayoutAnimations.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/LayoutAnimations.h
@@ -67,6 +67,8 @@ class LayoutAnimations : public jni::HybridClass<LayoutAnimations> {
   int findPrecedingViewTagForTransition(int tag);
   jni::local_ref<JArrayInt> getSharedGroup(const int tag);
 
+  void invalidate();
+
  private:
   friend HybridBase;
   jni::global_ref<LayoutAnimations::javaobject> javaPart_;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -82,6 +82,8 @@ NativeProxy::~NativeProxy() {
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
   reanimatedModuleProxy_->cleanupSensors();
+
+  layoutAnimations_->cthis()->invalidate();
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -82,8 +82,6 @@ NativeProxy::~NativeProxy() {
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
   reanimatedModuleProxy_->cleanupSensors();
-
-  layoutAnimations_->cthis()->invalidate();
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
@@ -623,7 +621,10 @@ void NativeProxy::setupLayoutAnimations() {
 }
 
 void NativeProxy::invalidateCpp() {
+  layoutAnimations_->cthis()->invalidate();
+
   workletsModuleProxy_.reset();
+
   if (reanimatedModuleProxy_ != nullptr) {
     reanimatedModuleProxy_->invalidate();
   }


### PR DESCRIPTION
## Summary

Breaks circular reference in the `LayoutAnimations`.

`LayoutAnimations ` is a `HybridClass` with a C++ counterpart holding a global reference to the Java object. This structure creates a circular reference between C++ and Java, which the garbage collector cannot clean up. To resolve this issue, I manually removed the reference between C++ and Java by resetting the global ref during the destructor of the `NativeProxy`.

## Test plan

- tested in Expo Go ✅ 