### PR TITLE
fix(Android, Paper): Lost update on render

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -17,6 +17,7 @@ export let getViewInfo = (element: any) => {
   return getViewInfo73(element);
 };
 
+// This gets invoked on Paper on 0.76
 function getViewInfo73(element: any) {
   return {
     // we can access view tag in the same way it's accessed here https://github.com/facebook/react/blob/e3f4eb7272d4ca0ee49f27577156b57eeb07cf73/packages/react-native-renderer/src/ReactFabric.js#L146

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -2,7 +2,7 @@
 import type { MutableRefObject } from 'react';
 import { useEffect, useRef } from 'react';
 
-import { makeShareable, startMapper, stopMapper } from '../core';
+import { makeShareable, runOnUI, startMapper, stopMapper } from '../core';
 import updateProps, { updatePropsJestWrapper } from '../UpdateProps';
 import { initialUpdaterRun } from '../animation';
 import { useSharedValue } from './useSharedValue';
@@ -549,6 +549,9 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
     const mapperId = startMapper(fun, inputs);
     return () => {
       stopMapper(mapperId);
+      if (Platform.OS === 'android' && !globalThis._IS_FABRIC) {
+        runOnUI(() => (remoteState.isFirstRun = true))();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies);


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/6677

Due to the React Native Android's batching of Native Views creation, sometimes the update from Reanimated for a component might come before the corresponding view was actually created. This used to crash the app which was fixed in:
- https://github.com/software-mansion/react-native-reanimated/pull/5767)

However, the above fix didn't address the fact the update was lost. This pull request re-applies first Animated Style update so then the update would be applied on the second frame, instead of not at all.

## Test plan

Test it on the reproduction in https://github.com/software-mansion/react-native-reanimated/issues/6677

@bartlomiejbloniarz Do you think it can affect Layout Animations?

## Note

This should probably be handled in Android specific native code but I failed there to force the UIManager to create the View when we have an update pending.


