### PR TITLE
fix: useAnimatedProps text not working on web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/AmountExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/AmountExample.tsx
@@ -3,11 +3,20 @@ import Animated, {
   useDerivedValue,
   useSharedValue,
   withTiming,
+  createAnimatedPropAdapter,
 } from 'react-native-reanimated';
-import { Button, StyleSheet, TextInput, View } from 'react-native';
+import { Button, Platform, StyleSheet, TextInput, View } from 'react-native';
 import React, { useCallback } from 'react';
 
 Animated.addWhitelistedNativeProps({ text: true });
+
+const textAdapter = createAnimatedPropAdapter(
+  (props: Record<string, unknown>) => {
+    props._setAttributeDirectly = true;
+    props.value = props.text;
+  },
+  ['value']
+);
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
@@ -22,9 +31,13 @@ export default function AmountExample() {
     return `$${sv.value.toFixed(2)}`;
   });
 
-  const animatedProps = useAnimatedProps(() => {
-    return { text: text.value, defaultValue: text.value };
-  });
+  const animatedProps = useAnimatedProps(
+    () => {
+      return { text: text.value, defaultValue: text.value };
+    },
+    [],
+    Platform.OS === 'web' ? [textAdapter] : undefined
+  );
 
   const setValue = useCallback(
     (delta: number) => {

--- a/apps/common-app/src/apps/reanimated/examples/JSPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/JSPropsExample.tsx
@@ -8,6 +8,7 @@ import Animated, {
   useDerivedValue,
   useAnimatedProps,
   interpolate,
+  createAnimatedPropAdapter,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
@@ -46,6 +47,14 @@ function angleToValue(angle: number, min: number, max: number) {
   'worklet';
   return interpolate(angle, [0, 360], [min, max]);
 }
+
+const textAdapter = createAnimatedPropAdapter(
+  (props: Record<string, unknown>) => {
+    props._setAttributeDirectly = true;
+    props.value = props.text;
+  },
+  ['value']
+);
 
 type CircularSliderProps = {
   size: number;
@@ -109,10 +118,14 @@ function CircularSlider(props: CircularSliderProps) {
     };
   });
 
-  const animatedInputProps = useAnimatedProps(() => {
-    const text = String(currentValue.value);
-    return { text, defaultValue: text };
-  });
+  const animatedInputProps = useAnimatedProps(
+    () => {
+      const text = String(currentValue.value);
+      return { text, defaultValue: text };
+    },
+    undefined,
+    [textAdapter]
+  );
 
   const gesture = Gesture.Pan()
     .minDistance(0)


### PR DESCRIPTION
fix: web-example not starting because of metro-resolver version mismatch
feature: Add AnimatedPathExample to the repo

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

- Fixed an issue that on web you were not able to use useAnimatedProps to animate text on TextInput (#6202)
- Fixed the version mismatch for web-example app

## Test plan

You can check example app. Examples:
- AmountExample
- JSPropsExample

