### PR TITLE
fix: Animation assignment with compiler-safe API

### DIFF
--- a/apps/common-app/src/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -49,6 +49,8 @@ export default function RuntimeTestsExample() {
             require('./tests/core/useAnimatedStyle/reuseAnimatedStyle.test');
             require('./tests/core/useDerivedValue/basic.test');
             require('./tests/core/useDerivedValue/chain.test');
+
+            require('./tests/core/useSharedValue/animationsCompilerApi.test');
           },
         },
         {

--- a/apps/common-app/src/examples/RuntimeTests/tests/core/useSharedValue/animationsCompilerApi.test.tsx
+++ b/apps/common-app/src/examples/RuntimeTests/tests/core/useSharedValue/animationsCompilerApi.test.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+import {
+  useSharedValue,
+  withClamp,
+  withDecay,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  describe,
+  test,
+  expect,
+  render,
+  registerValue,
+  getRegisteredValue,
+  wait,
+} from '../../../ReJest/RuntimeTestsApi';
+import { ComparisonMode } from '../../../ReJest/types';
+import { ProgressBar } from './components';
+
+const SHARED_VALUE_REF = 'SHARED_VALUE_REF';
+
+describe(`Test animation assignments on Shared Value using compiler API`, () => {
+  const WithTiming = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withTiming(100));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithClamp = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withClamp({ min: 0, max: 100 }, withTiming(200)));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithDecay = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withDecay({}));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithDelay = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withDelay(100, withTiming(100)));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithSpring = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withSpring(100, { duration: 250 }));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithRepeat = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withRepeat(withTiming(100), 2, true));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  const WithSequence = ({ progress }: { progress: number }) => {
+    const sharedValue = useSharedValue(0);
+    registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+    useEffect(() => {
+      sharedValue.set(withSequence(withTiming(100), withTiming(200)));
+    });
+    return <ProgressBar progress={progress} />;
+  };
+
+  test('WithTiming', async () => {
+    await render(<WithTiming progress={0} />);
+    await wait(300);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(100, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(100, ComparisonMode.NUMBER);
+  });
+
+  test('WithClamp', async () => {
+    await render(<WithClamp progress={0.16} />);
+    await wait(300);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(100, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(100, ComparisonMode.NUMBER);
+  });
+
+  test('WithDecay', async () => {
+    await render(<WithDecay progress={0.32} />);
+    await wait(300);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(0, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(0, ComparisonMode.NUMBER);
+  });
+
+  test('WithDelay', async () => {
+    await render(<WithDelay progress={0.48} />);
+    await wait(400);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(100, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(100, ComparisonMode.NUMBER);
+  });
+
+  test('WithSpring', async () => {
+    await render(<WithSpring progress={0.64} />);
+    await wait(300);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(100, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(100, ComparisonMode.NUMBER);
+  });
+
+  test('WithRepeat', async () => {
+    await render(<WithRepeat progress={0.8} />);
+    await wait(600);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(0, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(0, ComparisonMode.NUMBER);
+  });
+
+  test('WithSequence', async () => {
+    await render(<WithSequence progress={0.96} />);
+    await wait(600);
+    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValue.onJS).toBe(200, ComparisonMode.NUMBER);
+    expect(sharedValue.onUI).toBe(200, ComparisonMode.NUMBER);
+  });
+});

--- a/apps/common-app/src/examples/SharedElementTransitions/LayoutAnimation.tsx
+++ b/apps/common-app/src/examples/SharedElementTransitions/LayoutAnimation.tsx
@@ -51,10 +51,7 @@ function Screen2({ navigation }: NativeStackScreenProps<ParamListBase>) {
         quis ipsum. Nunc tincidunt risus quam, et sagittis neque hendrerit et.
       </Animated.Text>
       <Animated.View entering={SlideInLeft.delay(1000)} exiting={SlideOutLeft}>
-        <Button
-          title="go back"
-          onPress={() => navigation.popTo('Screen1')}
-        />
+        <Button title="go back" onPress={() => navigation.popTo('Screen1')} />
       </Animated.View>
     </View>
   );

--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -528,7 +528,9 @@ export function defineAnimation<
   if (_WORKLET || SHOULD_BE_USE_WEB) {
     return create();
   }
-  // @ts-ignore: eslint-disable-line
+  create.__isAnimationDefinition = true;
+
+  // @ts-expect-error it's fine
   return create;
 }
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -58,10 +58,14 @@ function addCompilerSafeGetAndSet<Value>(mutable: PartialMutable<Value>): void {
     },
     set: {
       value(newValue: Value | ((value: Value) => Value)) {
-        if (typeof newValue === 'function') {
+        if (
+          typeof newValue === 'function' &&
+          // If we have an animation definition, we don't want to call it here.
+          !(newValue as Record<string, unknown>).__isAnimationDefinition
+        ) {
           mutable.value = (newValue as (value: Value) => Value)(mutable.value);
         } else {
-          mutable.value = newValue;
+          mutable.value = newValue as Value;
         }
       },
       configurable: false,


### PR DESCRIPTION
## Summary

When I added compiler-safe API for shared values, I accidentally forgot that animations exist and that their assignment to shared values has to be handled separately.

Fixes
 - #6613

## Test plan

Added relevant runtime test suite and adjusted some others.
