### PR TITLE
fix: missing headers on new arch

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -30,6 +30,8 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #include <iomanip>
+#include <sstream>
+#include <string>
 #endif // RCT_NEW_ARCH_ENABLED
 
 // Standard `__cplusplus` macro reference:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
PR adding back headers removed in https://github.com/software-mansion/react-native-reanimated/pull/6537. For some reason, locally they are not needed, probably to some different setup or having the libraries set globally somewhere, but it caused failures in Expensify: https://github.com/Expensify/App/actions/runs/11857735322/job/33046828856. They should be included since methods from them are used.


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
