### PR TITLE
Update ReanimatedPackage to supported stable API

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -4,10 +4,10 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_START;
 
 import androidx.annotation.NonNull;
+import com.facebook.react.BaseReactPackage;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMarker;
@@ -29,7 +29,7 @@ import java.util.Objects;
       ReanimatedModule.class,
       ReanimatedUIManager.class,
     })
-public class ReanimatedPackage extends TurboReactPackage implements ReactPackage {
+public class ReanimatedPackage extends BaseReactPackage implements ReactPackage {
   @Override
   public NativeModule getModule(String name, @NonNull ReactApplicationContext reactContext) {
     if (name.equals(ReanimatedModule.NAME)) {


### PR DESCRIPTION
## Summary

Replace the deprecated `TurboReactPackage` with the newer `BaseReactPackage` to improve compatibility with future React Native releases. Note that this change requires at least react-native@0.74+, but this should not be an issue as, according to the compatibility table, Reanimated@3.17.0 only supports versions 0.74 and above.

Similar change has been introduced in the SVG package https://github.com/software-mansion/react-native-svg/pull/2541

## Test plan

CI should pass
