### PR TITLE
Fix bug in useSharedValueMock

### DIFF
--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -51,7 +51,7 @@ const hook = {
   // useHandler: ADD ME IF NEEDED
   useWorkletCallback: ID,
   useSharedValue: <Value>(init: Value) => {
-    let value = { value: init }
+    let value = { value: init };
     const handler = {
       get(target: any, prop: string) {
         if (prop === 'value') {
@@ -61,8 +61,12 @@ const hook = {
           return () => target.value;
         }
         if (prop === 'set') {
-          return (newValue: Value) => {
-            target.value = newValue;
+          return (newValue: Value | ((currentValue: Value) => Value)) => {
+            if (typeof newValue === 'function') {
+              target.value = (newValue as (currentValue: Value) => Value)(target.value);
+            } else {
+              target.value = newValue;
+            }
           };
         }
         return undefined;

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -50,7 +50,16 @@ const hook = {
   ): EventHandlerProcessed<Event, Context> => NOOP,
   // useHandler: ADD ME IF NEEDED
   useWorkletCallback: ID,
-  useSharedValue: <Value>(init: Value) => ({ value: init }),
+  useSharedValue: <Value>(init: Value) => {
+    let value = init;
+
+    return {
+      set: (newValue: Value) => {
+        value = newValue;
+      },
+      get: () => value
+    };
+  },
   // useReducedMotion: ADD ME IF NEEDED
   useAnimatedStyle: IMMEDIATE_CALLBACK_INVOCATION,
   useAnimatedGestureHandler: NOOP_FACTORY,

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -51,14 +51,31 @@ const hook = {
   // useHandler: ADD ME IF NEEDED
   useWorkletCallback: ID,
   useSharedValue: <Value>(init: Value) => {
-    let value = init;
-
-    return {
-      set: (newValue: Value) => {
-        value = newValue;
+    let value = { value: init }
+    const handler = {
+      get(target: any, prop: string) {
+        if (prop === 'value') {
+          return target.value;
+        }
+        if (prop === 'get') {
+          return () => target.value;
+        }
+        if (prop === 'set') {
+          return (newValue: Value) => {
+            target.value = newValue;
+          };
+        }
+        return undefined;
       },
-      get: () => value
+      set(target: any, prop: string, newValue: any) {
+        if (prop === 'value') {
+          target.value = newValue;
+          return true;
+        }
+        return false;
+      }
     };
+    return new Proxy(value, handler);
   },
   // useReducedMotion: ADD ME IF NEEDED
   useAnimatedStyle: IMMEDIATE_CALLBACK_INVOCATION,

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -51,9 +51,9 @@ const hook = {
   // useHandler: ADD ME IF NEEDED
   useWorkletCallback: ID,
   useSharedValue: <Value>(init: Value) => {
-    let value = { value: init };
-    const handler = {
-      get(target: any, prop: string) {
+    const value = { value: init };
+    return new Proxy(value, {
+      get(target, prop) {
         if (prop === 'value') {
           return target.value;
         }
@@ -63,23 +63,23 @@ const hook = {
         if (prop === 'set') {
           return (newValue: Value | ((currentValue: Value) => Value)) => {
             if (typeof newValue === 'function') {
-              target.value = (newValue as (currentValue: Value) => Value)(target.value);
+              target.value = (newValue as (currentValue: Value) => Value)(
+                target.value
+              );
             } else {
               target.value = newValue;
             }
           };
         }
-        return undefined;
       },
-      set(target: any, prop: string, newValue: any) {
+      set(target, prop: string, newValue) {
         if (prop === 'value') {
           target.value = newValue;
           return true;
         }
         return false;
-      }
-    };
-    return new Proxy(value, handler);
+      },
+    });
   },
   // useReducedMotion: ADD ME IF NEEDED
   useAnimatedStyle: IMMEDIATE_CALLBACK_INVOCATION,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

The API for sharedValue has changed from using .value to get() and set() methods. As a result, the mock that previously returned an object with a single value property no longer works in the tests.

## Test plan

This is a PR for the mocks, so it's not necessary for it.
