### PR TITLE
Update base-class for ReanimatedPackage

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -6,8 +6,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 import androidx.annotation.NonNull;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactPackage;
-import com.facebook.react.TurboReactPackage;
+import com.facebook.react.BaseReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMarker;
@@ -36,7 +35,7 @@ import java.util.Objects;
       ReanimatedModule.class,
       ReanimatedUIManager.class,
     })
-public class ReanimatedPackage extends TurboReactPackage implements ReactPackage {
+public class ReanimatedPackage extends BaseReactPackage {
   @Override
   public NativeModule getModule(
       @NonNull String name, @NonNull ReactApplicationContext reactContext) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -4,9 +4,9 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_START;
 
 import androidx.annotation.NonNull;
+import com.facebook.react.BaseReactPackage;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.BaseReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMarker;


### PR DESCRIPTION
## Summary

TurboReactPackage is deprecated and will be removed in a future release. BaseReactPackage is a swap-in replacement and exists in older React Native versions too.

## Test plan

CI