### PR TITLE
Fix `getAnimatedStyle` error when called with component that doesn't have animated styles

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -28,7 +28,7 @@ const defaultFramerateConfig = {
   fps: 60,
 };
 
-const isEmpty = (obj: object) => Object.keys(obj).length === 0;
+const isEmpty = (obj: object | undefined) => !obj || Object.keys(obj).length === 0;
 const getStylesFromObject = (obj: object) => {
   return obj === undefined
     ? {}
@@ -93,7 +93,7 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
 
   const inlineStyles = getStylesFromObject(jestInlineStyles);
 
-  currentStyle = isEmpty(jestAnimatedStyleValue as object)
+  currentStyle = isEmpty(jestAnimatedStyleValue as object | undefined)
     ? { ...styleObject, ...inlineStyles }
     : { ...styleObject, ...jestAnimatedStyleValue };
 


### PR DESCRIPTION
`isEmpty` will return `false` if it is passed in `undefined`, instead of throwing an error.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

If `getAnimatedStyle` is passed in a component that doesn't have animated styles, it throws an error saying "Cannot convert undefined or null to object". This happens because `jestUtils.ts` has an `isEmpty` function that calls `Object.keys` with an argument that can potentially be `undefined`. The arg can potentially be `undefined` because it comes from `const jestAnimatedStyleValue = component.props.jestAnimatedStyle?.value;`

This issue was introduced in version 3.16.0.

## Test plan

Can be simply tested on a browser console. Just run:

`(obj => Object.keys(obj).length === 0)(undefined) // throws error` 

`(obj => !obj || Object.keys(obj).length === 0)(undefined) // returns true as expected` 

`(obj => !obj || Object.keys(obj).length === 0)({test: 'something'}) // returns false as expected` 