### PR TITLE
useAnimatedKeyboard fixes (iOS)

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
@@ -169,13 +169,6 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
   return keyboardHeight;
 }
 
-- (float)getStaticKeyboardHeight
-{
-  CGRect measuringFrame = _measuringView.frame;
-  CGFloat keyboardHeight = measuringFrame.size.height;
-  return keyboardHeight;
-}
-
 - (void)updateKeyboardFrame
 {
   CGFloat keyboardHeight = 0;
@@ -188,7 +181,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
       _state = _state == OPENING ? OPEN : CLOSED;
     }
     if (_state == OPEN || _state == CLOSED) {
-      keyboardHeight = [self getStaticKeyboardHeight];
+      keyboardHeight = _targetKeyboardHeight;
     }
     // stop display link updates if no animation is running
     [[self getDisplayLink] setPaused:YES];

--- a/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
@@ -198,6 +198,14 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
   auto window = [[[UIApplication sharedApplication] delegate] window];
 
   /*
+   The keyboard frame is in the screen's coordinate space and must first be converted
+   to the window coordinate space in order to support Slide Over and Stage Manager on
+   iPadOS.
+   */
+  beginFrame = [window convertRect:beginFrame fromCoordinateSpace:window.screen.coordinateSpace];
+  endFrame = [window convertRect:endFrame fromCoordinateSpace:window.screen.coordinateSpace];
+
+  /*
    In some cases, such as when the user has enabled "prefer cross-fade transitions" or
    when the keyboard is floating, the begin or end frame is an empty rectangle. In
    such cases we should treat the keyboard as closed, rather than at (0, 0).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

fix: return correct height for detached keyboard on iOS (fixes #5584, #6440)
fix: don't clobber keyboard height when keyboard did not animate on iOS
fix: convert keyboard position to window coordinate space on iOS (Stage Manager compatibility)
fix: don't prematurely update keyboard height during dismissal on iOS
fix: don't jump to height when iOS keyboard is rapidly opened/closed (fixes #6727)
fix: correct height when keyboard opened from shortcuts bar on iOS

## Test plan

Can be tested with the useAnimatedKeyboard example.

1. Enable iPad for the example project.
2. Launch the useAnimatedKeyboard example.
3. Open the keyboard, then undock or float the keyboard. The view should not transform when undocked or floating.
4. Dock the keyboard
5. Hide the keyboard, note that the view should now be transformed by the keyboard height
6. Enable Reduce Motion in Accessibility, and Prefers Cross-Fade Transitions
7. Open the keyboard, note that he transform should work as expected
