### PR TITLE
refactor: rename cpp NativeReanimatedModule to ReanimatedModuleProxy

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -1,7 +1,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
-#include <reanimated/NativeModules/NativeReanimatedModule.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
 #include <react/renderer/animations/utils.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -19,7 +19,7 @@
 
 namespace reanimated {
 
-class NativeReanimatedModule;
+class ReanimatedModuleProxy;
 
 using namespace facebook;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1,4 +1,4 @@
-#include <reanimated/NativeModules/NativeReanimatedModule.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #include <reanimated/RuntimeDecorators/ReanimatedWorkletRuntimeDecorator.h>
 #include <reanimated/RuntimeDecorators/UIRuntimeDecorator.h>
 #include <reanimated/Tools/CollectionUtils.h>
@@ -51,7 +51,7 @@ using namespace facebook;
 
 namespace reanimated {
 
-NativeReanimatedModule::NativeReanimatedModule(
+ReanimatedModuleProxy::ReanimatedModuleProxy(
     const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<JSScheduler> &jsScheduler,
@@ -59,7 +59,7 @@ NativeReanimatedModule::NativeReanimatedModule(
     const PlatformDepMethodsHolder &platformDepMethodsHolder,
     const bool isBridgeless,
     const bool isReducedMotion)
-    : NativeReanimatedModuleSpec(
+    : ReanimatedModuleProxySpec(
           isBridgeless ? nullptr : jsScheduler->getJSCallInvoker()),
       isBridgeless_(isBridgeless),
       isReducedMotion_(isReducedMotion),
@@ -101,7 +101,7 @@ NativeReanimatedModule::NativeReanimatedModule(
   commonInit(platformDepMethodsHolder);
 }
 
-void NativeReanimatedModule::commonInit(
+void ReanimatedModuleProxy::commonInit(
     const PlatformDepMethodsHolder &platformDepMethodsHolder) {
   auto requestAnimationFrame =
       [this](jsi::Runtime &rt, const jsi::Value &callback) {
@@ -193,7 +193,7 @@ void NativeReanimatedModule::commonInit(
       platformDepMethodsHolder.maybeFlushUIUpdatesQueueFunction);
 }
 
-NativeReanimatedModule::~NativeReanimatedModule() {
+ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // event handler registry and frame callbacks store some JSI values from UI
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
@@ -201,7 +201,7 @@ NativeReanimatedModule::~NativeReanimatedModule() {
   uiWorkletRuntime_.reset();
 }
 
-void NativeReanimatedModule::scheduleOnUI(
+void ReanimatedModuleProxy::scheduleOnUI(
     jsi::Runtime &rt,
     const jsi::Value &worklet) {
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
@@ -219,13 +219,13 @@ void NativeReanimatedModule::scheduleOnUI(
   });
 }
 
-jsi::Value NativeReanimatedModule::executeOnUIRuntimeSync(
+jsi::Value ReanimatedModuleProxy::executeOnUIRuntimeSync(
     jsi::Runtime &rt,
     const jsi::Value &worklet) {
   return uiWorkletRuntime_->executeSync(rt, worklet);
 }
 
-jsi::Value NativeReanimatedModule::createWorkletRuntime(
+jsi::Value ReanimatedModuleProxy::createWorkletRuntime(
     jsi::Runtime &rt,
     const jsi::Value &name,
     const jsi::Value &initializer) {
@@ -243,7 +243,7 @@ jsi::Value NativeReanimatedModule::createWorkletRuntime(
   return jsi::Object::createFromHostObject(rt, workletRuntime);
 }
 
-jsi::Value NativeReanimatedModule::scheduleOnRuntime(
+jsi::Value ReanimatedModuleProxy::scheduleOnRuntime(
     jsi::Runtime &rt,
     const jsi::Value &workletRuntimeValue,
     const jsi::Value &shareableWorkletValue) {
@@ -251,7 +251,7 @@ jsi::Value NativeReanimatedModule::scheduleOnRuntime(
   return jsi::Value::undefined();
 }
 
-jsi::Value NativeReanimatedModule::registerEventHandler(
+jsi::Value ReanimatedModuleProxy::registerEventHandler(
     jsi::Runtime &rt,
     const jsi::Value &worklet,
     const jsi::Value &eventName,
@@ -273,7 +273,7 @@ jsi::Value NativeReanimatedModule::registerEventHandler(
   return jsi::Value(static_cast<double>(newRegistrationId));
 }
 
-void NativeReanimatedModule::unregisterEventHandler(
+void ReanimatedModuleProxy::unregisterEventHandler(
     jsi::Runtime &,
     const jsi::Value &registrationId) {
   uint64_t id = registrationId.asNumber();
@@ -297,7 +297,7 @@ static inline std::string intColorToHex(const int val) {
   return hexColor;
 }
 
-std::string NativeReanimatedModule::obtainPropFromShadowNode(
+std::string ReanimatedModuleProxy::obtainPropFromShadowNode(
     jsi::Runtime &rt,
     const std::string &propName,
     const ShadowNode::Shared &shadowNode) {
@@ -340,7 +340,7 @@ std::string NativeReanimatedModule::obtainPropFromShadowNode(
       "` with function `getViewProp` is not supported"));
 }
 
-jsi::Value NativeReanimatedModule::getViewProp(
+jsi::Value ReanimatedModuleProxy::getViewProp(
     jsi::Runtime &rnRuntime,
     const jsi::Value &shadowNodeWrapper,
     const jsi::Value &propName,
@@ -365,7 +365,7 @@ jsi::Value NativeReanimatedModule::getViewProp(
 
 #else
 
-jsi::Value NativeReanimatedModule::getViewProp(
+jsi::Value ReanimatedModuleProxy::getViewProp(
     jsi::Runtime &rnRuntime,
     const jsi::Value &viewTag,
     const jsi::Value &propName,
@@ -398,14 +398,14 @@ jsi::Value NativeReanimatedModule::getViewProp(
 
 #endif
 
-jsi::Value NativeReanimatedModule::enableLayoutAnimations(
+jsi::Value ReanimatedModuleProxy::enableLayoutAnimations(
     jsi::Runtime &,
     const jsi::Value &config) {
   FeaturesConfig::setLayoutAnimationEnabled(config.getBool());
   return jsi::Value::undefined();
 }
 
-jsi::Value NativeReanimatedModule::configureProps(
+jsi::Value ReanimatedModuleProxy::configureProps(
     jsi::Runtime &rt,
     const jsi::Value &uiProps,
     const jsi::Value &nativeProps) {
@@ -428,7 +428,7 @@ jsi::Value NativeReanimatedModule::configureProps(
   return jsi::Value::undefined();
 }
 
-jsi::Value NativeReanimatedModule::configureLayoutAnimationBatch(
+jsi::Value ReanimatedModuleProxy::configureLayoutAnimationBatch(
     jsi::Runtime &rt,
     const jsi::Value &layoutAnimationsBatch) {
   auto array = layoutAnimationsBatch.asObject(rt).asArray(rt);
@@ -464,7 +464,7 @@ jsi::Value NativeReanimatedModule::configureLayoutAnimationBatch(
   return jsi::Value::undefined();
 }
 
-void NativeReanimatedModule::setShouldAnimateExiting(
+void ReanimatedModuleProxy::setShouldAnimateExiting(
     jsi::Runtime &rt,
     const jsi::Value &viewTag,
     const jsi::Value &shouldAnimate) {
@@ -472,21 +472,21 @@ void NativeReanimatedModule::setShouldAnimateExiting(
       viewTag.asNumber(), shouldAnimate.getBool());
 }
 
-bool NativeReanimatedModule::isAnyHandlerWaitingForEvent(
+bool ReanimatedModuleProxy::isAnyHandlerWaitingForEvent(
     const std::string &eventName,
     const int emitterReactTag) {
   return eventHandlerRegistry_->isAnyHandlerWaitingForEvent(
       eventName, emitterReactTag);
 }
 
-void NativeReanimatedModule::requestAnimationFrame(
+void ReanimatedModuleProxy::requestAnimationFrame(
     jsi::Runtime &rt,
     const jsi::Value &callback) {
   frameCallbacks_.push_back(std::make_shared<jsi::Value>(rt, callback));
   maybeRequestRender();
 }
 
-void NativeReanimatedModule::maybeRequestRender() {
+void ReanimatedModuleProxy::maybeRequestRender() {
   if (!renderRequested_) {
     renderRequested_ = true;
     jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
@@ -494,7 +494,7 @@ void NativeReanimatedModule::maybeRequestRender() {
   }
 }
 
-void NativeReanimatedModule::onRender(double timestampMs) {
+void ReanimatedModuleProxy::onRender(double timestampMs) {
   auto callbacks = std::move(frameCallbacks_);
   frameCallbacks_.clear();
   jsi::Runtime &uiRuntime = uiWorkletRuntime_->getJSIRuntime();
@@ -504,7 +504,7 @@ void NativeReanimatedModule::onRender(double timestampMs) {
   }
 }
 
-jsi::Value NativeReanimatedModule::registerSensor(
+jsi::Value ReanimatedModuleProxy::registerSensor(
     jsi::Runtime &rt,
     const jsi::Value &sensorType,
     const jsi::Value &interval,
@@ -519,18 +519,18 @@ jsi::Value NativeReanimatedModule::registerSensor(
       sensorDataHandler);
 }
 
-void NativeReanimatedModule::unregisterSensor(
+void ReanimatedModuleProxy::unregisterSensor(
     jsi::Runtime &,
     const jsi::Value &sensorId) {
   animatedSensorModule_.unregisterSensor(sensorId);
 }
 
-void NativeReanimatedModule::cleanupSensors() {
+void ReanimatedModuleProxy::cleanupSensors() {
   animatedSensorModule_.unregisterAllSensors();
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
-bool NativeReanimatedModule::isThereAnyLayoutProp(
+bool ReanimatedModuleProxy::isThereAnyLayoutProp(
     jsi::Runtime &rt,
     const jsi::Object &props) {
   const jsi::Array propNames = props.getPropertyNames(rt);
@@ -546,7 +546,7 @@ bool NativeReanimatedModule::isThereAnyLayoutProp(
   return false;
 }
 
-jsi::Value NativeReanimatedModule::filterNonAnimatableProps(
+jsi::Value ReanimatedModuleProxy::filterNonAnimatableProps(
     jsi::Runtime &rt,
     const jsi::Value &props) {
   jsi::Object nonAnimatableProps(rt);
@@ -570,7 +570,7 @@ jsi::Value NativeReanimatedModule::filterNonAnimatableProps(
 }
 #endif // RCT_NEW_ARCH_ENABLED
 
-bool NativeReanimatedModule::handleEvent(
+bool ReanimatedModuleProxy::handleEvent(
     const std::string &eventName,
     const int emitterReactTag,
     const jsi::Value &payload,
@@ -584,7 +584,7 @@ bool NativeReanimatedModule::handleEvent(
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
-bool NativeReanimatedModule::handleRawEvent(
+bool ReanimatedModuleProxy::handleRawEvent(
     const RawEvent &rawEvent,
     double currentTime) {
   const EventTarget *eventTarget = rawEvent.eventTarget.get();
@@ -615,7 +615,7 @@ bool NativeReanimatedModule::handleRawEvent(
   return res;
 }
 
-void NativeReanimatedModule::updateProps(
+void ReanimatedModuleProxy::updateProps(
     jsi::Runtime &rt,
     const jsi::Value &operations) {
   auto array = operations.asObject(rt).asArray(rt);
@@ -630,7 +630,7 @@ void NativeReanimatedModule::updateProps(
   }
 }
 
-void NativeReanimatedModule::performOperations() {
+void ReanimatedModuleProxy::performOperations() {
   if (operationsInBatch_.empty() && tagsToRemove_.empty()) {
     // nothing to do
     return;
@@ -755,7 +755,7 @@ void NativeReanimatedModule::performOperations() {
   }
 }
 
-void NativeReanimatedModule::removeFromPropsRegistry(
+void ReanimatedModuleProxy::removeFromPropsRegistry(
     jsi::Runtime &rt,
     const jsi::Value &viewTags) {
   auto array = viewTags.asObject(rt).asArray(rt);
@@ -764,7 +764,7 @@ void NativeReanimatedModule::removeFromPropsRegistry(
   }
 }
 
-void NativeReanimatedModule::dispatchCommand(
+void ReanimatedModuleProxy::dispatchCommand(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeValue,
     const jsi::Value &commandNameValue,
@@ -775,7 +775,7 @@ void NativeReanimatedModule::dispatchCommand(
   uiManager_->dispatchCommand(shadowNode, commandName, args);
 }
 
-jsi::String NativeReanimatedModule::obtainProp(
+jsi::String ReanimatedModuleProxy::obtainProp(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeWrapper,
     const jsi::Value &propName) {
@@ -787,7 +787,7 @@ jsi::String NativeReanimatedModule::obtainProp(
   return jsi::String::createFromUtf8(rt, resultStr);
 }
 
-jsi::Value NativeReanimatedModule::measure(
+jsi::Value ReanimatedModuleProxy::measure(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeValue) {
   // based on implementation from UIManagerBinding.cpp
@@ -831,7 +831,7 @@ jsi::Value NativeReanimatedModule::measure(
   return result;
 }
 
-void NativeReanimatedModule::initializeFabric(
+void ReanimatedModuleProxy::initializeFabric(
     const std::shared_ptr<UIManager> &uiManager) {
   uiManager_ = uiManager;
 
@@ -843,7 +843,7 @@ void NativeReanimatedModule::initializeFabric(
       propsRegistry_, uiManager_, layoutAnimationsProxy_);
 }
 
-void NativeReanimatedModule::initializeLayoutAnimationsProxy() {
+void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
   uiManager_->setAnimationDelegate(nullptr);
   auto scheduler = reinterpret_cast<Scheduler *>(uiManager_->getDelegate());
   auto componentDescriptorRegistry =
@@ -864,7 +864,7 @@ void NativeReanimatedModule::initializeLayoutAnimationsProxy() {
 
 #endif // RCT_NEW_ARCH_ENABLED
 
-jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
+jsi::Value ReanimatedModuleProxy::subscribeForKeyboardEvents(
     jsi::Runtime &rt,
     const jsi::Value &handlerWorklet,
     const jsi::Value &isStatusBarTranslucent,
@@ -884,7 +884,7 @@ jsi::Value NativeReanimatedModule::subscribeForKeyboardEvents(
       isNavigationBarTranslucent.getBool());
 }
 
-void NativeReanimatedModule::unsubscribeFromKeyboardEvents(
+void ReanimatedModuleProxy::unsubscribeFromKeyboardEvents(
     jsi::Runtime &,
     const jsi::Value &listenerId) {
   unsubscribeFromKeyboardEventsFunction_(listenerId.asNumber());

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -2,7 +2,7 @@
 
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
-#include <reanimated/NativeModules/NativeReanimatedModuleSpec.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -30,9 +30,9 @@
 
 namespace reanimated {
 
-class NativeReanimatedModule : public NativeReanimatedModuleSpec {
+class ReanimatedModuleProxy : public ReanimatedModuleProxySpec {
  public:
-  NativeReanimatedModule(
+  ReanimatedModuleProxy(
       const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
       jsi::Runtime &rnRuntime,
       const std::shared_ptr<JSScheduler> &jsScheduler,
@@ -41,7 +41,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       const bool isBridgeless,
       const bool isReducedMotion);
 
-  ~NativeReanimatedModule();
+  ~ReanimatedModuleProxy();
 
   void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) override;
   jsi::Value executeOnUIRuntimeSync(jsi::Runtime &rt, const jsi::Value &worklet)
@@ -235,8 +235,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;
 
 #ifndef NDEBUG
-  worklets::SingleInstanceChecker<NativeReanimatedModule>
-      singleInstanceChecker_;
+  worklets::SingleInstanceChecker<ReanimatedModuleProxy> singleInstanceChecker_;
 #endif // NDEBUG
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -1,9 +1,9 @@
-#include <reanimated/NativeModules/NativeReanimatedModuleSpec.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
 
 #include <utility>
 
 #define REANIMATED_SPEC_PREFIX(FN_NAME) \
-  __hostFunction_NativeReanimatedModuleSpec_##FN_NAME
+  __hostFunction_ReanimatedModuleProxySpec_##FN_NAME
 
 namespace reanimated {
 
@@ -14,7 +14,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(scheduleOnUI)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->scheduleOnUI(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
@@ -24,7 +24,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(executeOnUIRuntimeSync)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->executeOnUIRuntimeSync(rt, std::move(args[0]));
 }
 
@@ -33,7 +33,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(createWorkletRuntime)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->createWorkletRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
@@ -42,7 +42,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(scheduleOnRuntime)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->scheduleOnRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
@@ -51,7 +51,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(registerEventHandler)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->registerEventHandler(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
@@ -61,7 +61,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unregisterEventHandler)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->unregisterEventHandler(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
@@ -71,7 +71,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(getViewProp)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->getViewProp(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
   return jsi::Value::undefined();
@@ -82,7 +82,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(enableLayoutAnimations)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->enableLayoutAnimations(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
@@ -92,7 +92,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(registerSensor)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->registerSensor(
           rt,
           std::move(args[0]),
@@ -106,7 +106,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unregisterSensor)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->unregisterSensor(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
@@ -116,7 +116,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(configureProps)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->configureProps(rt, std::move(args[0]), std::move(args[1]));
   return jsi::Value::undefined();
 }
@@ -126,7 +126,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(subscribeForKeyboardEvents)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->subscribeForKeyboardEvents(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
@@ -136,7 +136,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unsubscribeFromKeyboardEvents)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->unsubscribeFromKeyboardEvents(rt, std::move(args[0]));
   return jsi::Value::undefined();
 }
@@ -146,7 +146,7 @@ static jsi::Value REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->configureLayoutAnimationBatch(rt, std::move(args[0]));
 }
 
@@ -155,12 +155,12 @@ static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->setShouldAnimateExiting(rt, std::move(args[0]), std::move(args[1]));
   return jsi::Value::undefined();
 }
 
-NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
+ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
     const std::shared_ptr<CallInvoker> &jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
   methodMap_["scheduleOnUI"] =

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -12,9 +12,9 @@ using namespace react;
 
 namespace reanimated {
 
-class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
+class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
  protected:
-  explicit NativeReanimatedModuleSpec(
+  explicit ReanimatedModuleProxySpec(
       const std::shared_ptr<CallInvoker> &jsInvoker);
 
  public:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
@@ -5,10 +5,10 @@ namespace reanimated {
 
 void RNRuntimeDecorator::decorate(
     jsi::Runtime &rnRuntime,
-    const std::shared_ptr<NativeReanimatedModule> &nativeReanimatedModule) {
+    const std::shared_ptr<ReanimatedModuleProxy> &reanimatedModuleProxy) {
   rnRuntime.global().setProperty(rnRuntime, "_WORKLET", false);
 
-  jsi::Runtime &uiRuntime = nativeReanimatedModule->getUIRuntime();
+  jsi::Runtime &uiRuntime = reanimatedModuleProxy->getUIRuntime();
   auto workletRuntimeValue =
       rnRuntime.global()
           .getPropertyAsObject(rnRuntime, "ArrayBuffer")
@@ -29,22 +29,22 @@ void RNRuntimeDecorator::decorate(
   rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", isFabric);
 
   rnRuntime.global().setProperty(
-      rnRuntime, "_IS_BRIDGELESS", nativeReanimatedModule->isBridgeless());
+      rnRuntime, "_IS_BRIDGELESS", reanimatedModuleProxy->isBridgeless());
 
 #ifndef NDEBUG
-  checkJSVersion(rnRuntime, nativeReanimatedModule->getJSLogger());
+  checkJSVersion(rnRuntime, reanimatedModuleProxy->getJSLogger());
 #endif // NDEBUG
   injectReanimatedCppVersion(rnRuntime);
 
   rnRuntime.global().setProperty(
       rnRuntime,
       "_REANIMATED_IS_REDUCED_MOTION",
-      nativeReanimatedModule->isReducedMotion());
+      reanimatedModuleProxy->isReducedMotion());
 
   rnRuntime.global().setProperty(
       rnRuntime,
       "__reanimatedModuleProxy",
-      jsi::Object::createFromHostObject(rnRuntime, nativeReanimatedModule));
+      jsi::Object::createFromHostObject(rnRuntime, reanimatedModuleProxy));
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/NativeModules/NativeReanimatedModule.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
 #include <jsi/jsi.h>
 
@@ -14,7 +14,7 @@ class RNRuntimeDecorator {
  public:
   static void decorate(
       jsi::Runtime &rnRuntime,
-      const std::shared_ptr<NativeReanimatedModule> &nativeReanimatedModule);
+      const std::shared_ptr<ReanimatedModuleProxy> &reanimatedModuleProxy);
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -41,7 +41,7 @@ NativeProxy::NativeProxy(
     )
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
-      nativeReanimatedModule_(std::make_shared<NativeReanimatedModule>(
+      reanimatedModuleProxy_(std::make_shared<ReanimatedModuleProxy>(
           nativeWorkletsModule,
           *rnRuntime,
           std::make_shared<JSScheduler>(*rnRuntime, jsCallInvoker),
@@ -67,7 +67,7 @@ NativeProxy::NativeProxy(
         fabricUIManager)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
-      nativeReanimatedModule_(std::make_shared<NativeReanimatedModule>(
+      reanimatedModuleProxy_(std::make_shared<ReanimatedModuleProxy>(
           nativeWorkletsModule,
           *rnRuntime,
           std::make_shared<JSScheduler>(*rnRuntime, runtimeExecutor),
@@ -84,12 +84,12 @@ void NativeProxy::commonInit(
         &fabricUIManager) {
   const auto &uiManager =
       fabricUIManager->getBinding()->getScheduler()->getUIManager();
-  nativeReanimatedModule_->initializeFabric(uiManager);
+  reanimatedModuleProxy_->initializeFabric(uiManager);
   // removed temporarily, event listener mechanism needs to be fixed on RN side
   // eventListener_ = std::make_shared<EventListener>(
-  //     [nativeReanimatedModule,
+  //     [reanimatedModuleProxy,
   //      getAnimationTimestamp](const RawEvent &rawEvent) {
-  //       return nativeReanimatedModule->handleRawEvent(
+  //       return reanimatedModuleProxy->handleRawEvent(
   //           rawEvent, getAnimationTimestamp());
   //     });
   // reactScheduler_ = binding->getScheduler();
@@ -104,7 +104,7 @@ NativeProxy::~NativeProxy() {
   // cleanup all animated sensors here, since NativeProxy
   // has already been destroyed when AnimatedSensorModule's
   // destructor is ran
-  nativeReanimatedModule_->cleanupSensors();
+  reanimatedModuleProxy_->cleanupSensors();
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
@@ -206,7 +206,7 @@ void NativeProxy::injectCppVersion() {
 void NativeProxy::installJSIBindings() {
   jsi::Runtime &rnRuntime = *rnRuntime_;
   WorkletRuntimeCollector::install(rnRuntime);
-  RNRuntimeDecorator::decorate(rnRuntime, nativeReanimatedModule_);
+  RNRuntimeDecorator::decorate(rnRuntime, reanimatedModuleProxy_);
 #ifndef NDEBUG
   checkJavaVersion(rnRuntime);
   injectCppVersion();
@@ -219,13 +219,13 @@ void NativeProxy::installJSIBindings() {
 bool NativeProxy::isAnyHandlerWaitingForEvent(
     const std::string &eventName,
     const int emitterReactTag) {
-  return nativeReanimatedModule_->isAnyHandlerWaitingForEvent(
+  return reanimatedModuleProxy_->isAnyHandlerWaitingForEvent(
       eventName, emitterReactTag);
 }
 
 void NativeProxy::performOperations() {
 #ifdef RCT_NEW_ARCH_ENABLED
-  nativeReanimatedModule_->performOperations();
+  reanimatedModuleProxy_->performOperations();
 #endif
 }
 
@@ -462,7 +462,7 @@ void NativeProxy::handleEvent(
     return;
   }
 
-  jsi::Runtime &rt = nativeReanimatedModule_->getUIRuntime();
+  jsi::Runtime &rt = reanimatedModuleProxy_->getUIRuntime();
   jsi::Value payload;
   try {
     payload = jsi::Value::createFromJsonUtf8(
@@ -472,7 +472,7 @@ void NativeProxy::handleEvent(
     return;
   }
 
-  nativeReanimatedModule_->handleEvent(
+  reanimatedModuleProxy_->handleEvent(
       eventName->toString(), emitterReactTag, payload, getAnimationTimestamp());
 }
 
@@ -558,14 +558,14 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 }
 
 void NativeProxy::setupLayoutAnimations() {
-  auto weakNativeReanimatedModule =
-      std::weak_ptr<NativeReanimatedModule>(nativeReanimatedModule_);
+  auto weakReanimatedModuleProxy =
+      std::weak_ptr<ReanimatedModuleProxy>(reanimatedModuleProxy_);
 
   layoutAnimations_->cthis()->setAnimationStartingBlock(
-      [weakNativeReanimatedModule](
+      [weakReanimatedModuleProxy](
           int tag, int type, alias_ref<JMap<jstring, jstring>> values) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          jsi::Runtime &rt = nativeReanimatedModule->getUIRuntime();
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          jsi::Runtime &rt = reanimatedModuleProxy->getUIRuntime();
           jsi::Object yogaValues(rt);
           for (const auto &entry : *values) {
             try {
@@ -586,25 +586,24 @@ void NativeProxy::setupLayoutAnimations() {
                   "[Reanimated] Failed to convert value to number.");
             }
           }
-          nativeReanimatedModule->layoutAnimationsManager()
-              .startLayoutAnimation(
-                  rt, tag, static_cast<LayoutAnimationType>(type), yogaValues);
+          reanimatedModuleProxy->layoutAnimationsManager().startLayoutAnimation(
+              rt, tag, static_cast<LayoutAnimationType>(type), yogaValues);
         }
       });
 
   layoutAnimations_->cthis()->setHasAnimationBlock(
-      [weakNativeReanimatedModule](int tag, int type) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          return nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag, int type) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          return reanimatedModuleProxy->layoutAnimationsManager()
               .hasLayoutAnimation(tag, static_cast<LayoutAnimationType>(type));
         }
         return false;
       });
 
   layoutAnimations_->cthis()->setShouldAnimateExitingBlock(
-      [weakNativeReanimatedModule](int tag, bool shouldAnimate) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          return nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag, bool shouldAnimate) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          return reanimatedModuleProxy->layoutAnimationsManager()
               .shouldAnimateExiting(tag, shouldAnimate);
         }
         return false;
@@ -612,35 +611,35 @@ void NativeProxy::setupLayoutAnimations() {
 
 #ifndef NDEBUG
   layoutAnimations_->cthis()->setCheckDuplicateSharedTag(
-      [weakNativeReanimatedModule](int viewTag, int screenTag) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int viewTag, int screenTag) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          reanimatedModuleProxy->layoutAnimationsManager()
               .checkDuplicateSharedTag(viewTag, screenTag);
         }
       });
 #endif
 
   layoutAnimations_->cthis()->setClearAnimationConfigBlock(
-      [weakNativeReanimatedModule](int tag) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          reanimatedModuleProxy->layoutAnimationsManager()
               .clearLayoutAnimationConfig(tag);
         }
       });
 
   layoutAnimations_->cthis()->setCancelAnimationForTag(
-      [weakNativeReanimatedModule](int tag) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          jsi::Runtime &rt = nativeReanimatedModule->getUIRuntime();
-          nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          jsi::Runtime &rt = reanimatedModuleProxy->getUIRuntime();
+          reanimatedModuleProxy->layoutAnimationsManager()
               .cancelLayoutAnimation(rt, tag);
         }
       });
 
   layoutAnimations_->cthis()->setFindPrecedingViewTagForTransition(
-      [weakNativeReanimatedModule](int tag) {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          return nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag) {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          return reanimatedModuleProxy->layoutAnimationsManager()
               .findPrecedingViewTagForTransition(tag);
         } else {
           return -1;
@@ -648,9 +647,9 @@ void NativeProxy::setupLayoutAnimations() {
       });
 
   layoutAnimations_->cthis()->setGetSharedGroupBlock(
-      [weakNativeReanimatedModule](int tag) -> std::vector<int> {
-        if (auto nativeReanimatedModule = weakNativeReanimatedModule.lock()) {
-          return nativeReanimatedModule->layoutAnimationsManager()
+      [weakReanimatedModuleProxy](int tag) -> std::vector<int> {
+        if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
+          return reanimatedModuleProxy->layoutAnimationsManager()
               .getSharedGroup(tag);
         } else {
           return {};

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/NativeModules/NativeReanimatedModule.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #include <reanimated/android/AndroidUIScheduler.h>
 #include <reanimated/android/JNIHelper.h>
 #include <reanimated/android/LayoutAnimations.h>
@@ -181,7 +181,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   friend HybridBase;
   jni::global_ref<NativeProxy::javaobject> javaPart_;
   jsi::Runtime *rnRuntime_;
-  std::shared_ptr<NativeReanimatedModule> nativeReanimatedModule_;
+  std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy_;
   jni::global_ref<LayoutAnimations::javaobject> layoutAnimations_;
 #ifndef NDEBUG
   void checkJavaVersion(jsi::Runtime &);

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -50,7 +50,7 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 @implementation REAModule {
 #ifdef RCT_NEW_ARCH_ENABLED
   __weak RCTSurfacePresenter *_surfacePresenter;
-  std::weak_ptr<NativeReanimatedModule> weakNativeReanimatedModule_;
+  std::weak_ptr<ReanimatedModuleProxy> weakReanimatedModuleProxy_;
 #else
   NSMutableArray<AnimatedOperation> *_operations;
 #endif // RCT_NEW_ARCH_ENABLED
@@ -104,8 +104,8 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 {
   const auto &uiManager = [self getUIManager];
   react_native_assert(uiManager.get() != nil);
-  if (auto nativeReanimatedModule = weakNativeReanimatedModule_.lock()) {
-    nativeReanimatedModule->initializeFabric(uiManager);
+  if (auto reanimatedModuleProxy = weakReanimatedModuleProxy_.lock()) {
+    reanimatedModuleProxy->initializeFabric(uiManager);
   }
 }
 
@@ -142,16 +142,16 @@ RCT_EXPORT_MODULE(ReanimatedModule);
     if (strongSelf == nil) {
       return;
     }
-    if (auto nativeReanimatedModule = strongSelf->weakNativeReanimatedModule_.lock()) {
+    if (auto reanimatedModuleProxy = strongSelf->weakReanimatedModuleProxy_.lock()) {
       auto eventListener =
-          std::make_shared<facebook::react::EventListener>([nativeReanimatedModule](const RawEvent &rawEvent) {
+          std::make_shared<facebook::react::EventListener>([reanimatedModuleProxy](const RawEvent &rawEvent) {
             if (!RCTIsMainQueue()) {
               // event listener called on the JS thread, let's ignore this event
               // as we cannot safely access worklet runtime here
               // and also we don't care about topLayout events
               return false;
             }
-            return nativeReanimatedModule->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
+            return reanimatedModuleProxy->handleRawEvent(rawEvent, CACurrentMediaTime() * 1000);
           });
       [scheduler addEventListener:eventListener];
     }
@@ -291,10 +291,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
         callbackBlock(runtime);
       }];
     });
-    auto nativeReanimatedModule = reanimated::createReanimatedModuleBridgeless(
+    auto reanimatedModuleProxy = reanimated::createReanimatedModuleBridgeless(
         self, _moduleRegistry, rnRuntime, workletsModule, executorFunction);
     [self attachReactEventListener];
-    [self commonInit:nativeReanimatedModule withRnRuntime:rnRuntime];
+    [self commonInit:reanimatedModuleProxy withRnRuntime:rnRuntime];
 #else
     [NSException raise:@"Missing bridge" format:@"[Reanimated] Failed to obtain the bridge."];
 #endif // RCT_NEW_ARCH_ENABLED
@@ -304,11 +304,11 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
         : nullptr;
 
     if (jsiRuntime) {
-      auto nativeReanimatedModule =
+      auto reanimatedModuleProxy =
           reanimated::createReanimatedModule(self, self.bridge, self.bridge.jsCallInvoker, workletsModule);
       jsi::Runtime &rnRuntime = *jsiRuntime;
 
-      [self commonInit:nativeReanimatedModule withRnRuntime:rnRuntime];
+      [self commonInit:reanimatedModuleProxy withRnRuntime:rnRuntime];
     }
   }
   return @YES;
@@ -322,13 +322,12 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 }
 #endif // RCT_NEW_ARCH_ENABLED
 
-- (void)commonInit:(std::shared_ptr<NativeReanimatedModule>)nativeReanimatedModule
-     withRnRuntime:(jsi::Runtime &)rnRuntime
+- (void)commonInit:(std::shared_ptr<ReanimatedModuleProxy>)reanimatedModuleProxy withRnRuntime:(jsi::Runtime &)rnRuntime
 {
   WorkletRuntimeCollector::install(rnRuntime);
-  RNRuntimeDecorator::decorate(rnRuntime, nativeReanimatedModule);
+  RNRuntimeDecorator::decorate(rnRuntime, reanimatedModuleProxy);
 #ifdef RCT_NEW_ARCH_ENABLED
-  weakNativeReanimatedModule_ = nativeReanimatedModule;
+  weakReanimatedModuleProxy_ = reanimatedModuleProxy;
   if (self->_surfacePresenter != nil) {
     // reload, uiManager is null right now, we need to wait for `installReanimatedAfterReload`
     [self injectDependencies:rnRuntime];

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -313,7 +313,7 @@ using namespace facebook::react;
 - (void)performOperations
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-  _performOperations(); // calls NativeReanimatedModule::performOperations
+  _performOperations(); // calls ReanimatedModuleProxy::performOperations
   _wantRunUpdates = NO;
 #else
   if (_operationsInBatch.count != 0) {

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -1,7 +1,7 @@
 #if __cplusplus
 
 #import <React/RCTEventDispatcher.h>
-#import <reanimated/NativeModules/NativeReanimatedModule.h>
+#import <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #import <reanimated/apple/LayoutReanimation/REAAnimationsManager.h>
 #import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
@@ -14,14 +14,14 @@ namespace reanimated {
 
 static inline bool getIsReducedMotion();
 
-std::shared_ptr<reanimated::NativeReanimatedModule> createReanimatedModule(
+std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModule(
     REAModule *reaModule,
     RCTBridge *bridge,
     const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule);
 
 #ifdef RCT_NEW_ARCH_ENABLED
-std::shared_ptr<reanimated::NativeReanimatedModule>
+std::shared_ptr<reanimated::ReanimatedModuleProxy>
 createReanimatedModuleBridgeless(
     REAModule *reaModule,
     RCTModuleRegistry *moduleRegistry,
@@ -32,13 +32,13 @@ createReanimatedModuleBridgeless(
 
 void commonInit(
     REAModule *reaModule,
-    std::shared_ptr<NativeReanimatedModule> nativeReanimatedModule);
+    std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy);
 
 #ifdef RCT_NEW_ARCH_ENABLED
 // nothing
 #else // RCT_NEW_ARCH_ENABLED
 void setupLayoutAnimationCallbacks(
-    std::shared_ptr<NativeReanimatedModule> nativeReanimatedModule,
+    std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy,
     REAAnimationsManager *animationsManager);
 #endif // RCT_NEW_ARCH_ENABLED
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
@@ -5,7 +5,7 @@
 #import <REAModule.h>
 #import <REANodesManager.h>
 #import <React/RCTEventDispatcher.h>
-#import <reanimated/NativeModules/NativeReanimatedModule.h>
+#import <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
 #import <memory>
 


### PR DESCRIPTION
## Summary

`NativeReanimatedModule` is the name of the ObjC/Java modules generated from `REAModule` and `ReanimatedModule`. It's confusing that we name some Cpp object the same way. With this change Cpp `NativeReanimatedModule` becomes `ReanimatedModuleProxy`, the same name we use to refer to it from JavaScript.

## Test plan

CI
