### PR TITLE
refactor: rename cpp NativeWorkletsModule to WorkletsModuleProxy

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.cpp
@@ -52,7 +52,7 @@ using namespace facebook;
 namespace reanimated {
 
 NativeReanimatedModule::NativeReanimatedModule(
-    const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+    const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -63,13 +63,13 @@ NativeReanimatedModule::NativeReanimatedModule(
           isBridgeless ? nullptr : jsScheduler->getJSCallInvoker()),
       isBridgeless_(isBridgeless),
       isReducedMotion_(isReducedMotion),
-      nativeWorkletsModule_(nativeWorkletsModule),
+      workletsModuleProxy_(workletsModuleProxy),
       jsScheduler_(jsScheduler),
       uiScheduler_(uiScheduler),
-      valueUnpackerCode_(nativeWorkletsModule->getValueUnpackerCode()),
+      valueUnpackerCode_(workletsModuleProxy->getValueUnpackerCode()),
       uiWorkletRuntime_(std::make_shared<WorkletRuntime>(
           rnRuntime,
-          nativeWorkletsModule->getJSQueue(),
+          workletsModuleProxy->getJSQueue(),
           jsScheduler_,
           "Reanimated UI runtime",
           true /* supportsLocking */,
@@ -231,7 +231,7 @@ jsi::Value NativeReanimatedModule::createWorkletRuntime(
     const jsi::Value &initializer) {
   auto workletRuntime = std::make_shared<WorkletRuntime>(
       rt,
-      nativeWorkletsModule_->getJSQueue(),
+      workletsModuleProxy_->getJSQueue(),
       jsScheduler_,
       name.asString(rt).utf8(rt),
       false /* supportsLocking */,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/NativeReanimatedModule.h
@@ -12,7 +12,7 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
-#include <worklets/NativeModules/NativeWorkletsModule.h>
+#include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/Registries/EventHandlerRegistry.h>
 #include <worklets/Tools/JSScheduler.h>
 #include <worklets/Tools/SingleInstanceChecker.h>
@@ -33,7 +33,7 @@ namespace reanimated {
 class NativeReanimatedModule : public NativeReanimatedModuleSpec {
  public:
   NativeReanimatedModule(
-      const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+      const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
       jsi::Runtime &rnRuntime,
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -174,9 +174,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
     return isReducedMotion_;
   }
 
-  [[nodiscard]] inline std::shared_ptr<NativeWorkletsModule>
-  getNativeWorkletsModule() const {
-    return nativeWorkletsModule_;
+  [[nodiscard]] inline std::shared_ptr<WorkletsModuleProxy>
+  getWorkletsModuleProxy() const {
+    return workletsModuleProxy_;
   }
 
  private:
@@ -193,7 +193,7 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
   const bool isBridgeless_;
   const bool isReducedMotion_;
-  const std::shared_ptr<NativeWorkletsModule> nativeWorkletsModule_;
+  const std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
   const std::shared_ptr<JSScheduler> jsScheduler_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
   const std::string valueUnpackerCode_;

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -5,7 +5,7 @@
 #include <react/renderer/uimanager/primitives.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
-#include <worklets/NativeModules/NativeWorkletsModule.h>
+#include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/SharedItems/Shareables.h>
 
 #ifdef __ANDROID__
@@ -18,16 +18,16 @@ using namespace facebook;
 
 namespace worklets {
 
-NativeWorkletsModule::NativeWorkletsModule(
+WorkletsModuleProxy::WorkletsModuleProxy(
     const std::string &valueUnpackerCode,
     const std::shared_ptr<MessageQueueThread> &jsQueue)
-    : NativeWorkletsModuleSpec(nullptr),
+    : WorkletsModuleProxySpec(nullptr),
       valueUnpackerCode_(valueUnpackerCode),
       jsQueue_(jsQueue) {}
 
-NativeWorkletsModule::~NativeWorkletsModule() {}
+WorkletsModuleProxy::~WorkletsModuleProxy() {}
 
-jsi::Value NativeWorkletsModule::makeShareableClone(
+jsi::Value WorkletsModuleProxy::makeShareableClone(
     jsi::Runtime &rt,
     const jsi::Value &value,
     const jsi::Value &shouldRetainRemote,

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cxxreact/MessageQueueThread.h>
-#include <worklets/NativeModules/NativeWorkletsModuleSpec.h>
+#include <worklets/NativeModules/WorkletsModuleProxySpec.h>
 #include <worklets/Tools/SingleInstanceChecker.h>
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 #include <memory>
@@ -9,13 +9,13 @@
 
 namespace worklets {
 
-class NativeWorkletsModule : public NativeWorkletsModuleSpec {
+class WorkletsModuleProxy : public WorkletsModuleProxySpec {
  public:
-  explicit NativeWorkletsModule(
+  explicit WorkletsModuleProxy(
       const std::string &valueUnpackerCode,
       const std::shared_ptr<MessageQueueThread> &jsQueue);
 
-  ~NativeWorkletsModule();
+  ~WorkletsModuleProxy();
 
   jsi::Value makeShareableClone(
       jsi::Runtime &rt,
@@ -35,7 +35,7 @@ class NativeWorkletsModule : public NativeWorkletsModuleSpec {
   const std::string valueUnpackerCode_;
   const std::shared_ptr<MessageQueueThread> jsQueue_;
 #ifndef NDEBUG
-  SingleInstanceChecker<NativeWorkletsModule> singleInstanceChecker_;
+  SingleInstanceChecker<WorkletsModuleProxy> singleInstanceChecker_;
 #endif // NDEBUG
 };
 

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.cpp
@@ -1,9 +1,9 @@
-#include <worklets/NativeModules/NativeWorkletsModuleSpec.h>
+#include <worklets/NativeModules/WorkletsModuleProxySpec.h>
 
 #include <utility>
 
 #define WORKLETS_SPEC_PREFIX(FN_NAME) \
-  __hostFunction_NativeWorkletsModuleSpec_##FN_NAME
+  __hostFunction_WorkletsModuleProxySpec_##FN_NAME
 
 namespace worklets {
 
@@ -12,12 +12,12 @@ static jsi::Value WORKLETS_SPEC_PREFIX(makeShareableClone)(
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
-  return static_cast<NativeWorkletsModuleSpec *>(&turboModule)
+  return static_cast<WorkletsModuleProxySpec *>(&turboModule)
       ->makeShareableClone(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
 }
 
-NativeWorkletsModuleSpec::NativeWorkletsModuleSpec(
+WorkletsModuleProxySpec::WorkletsModuleProxySpec(
     const std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeWorklets", jsInvoker) {
   methodMap_["makeShareableClone"] =

--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
@@ -9,9 +9,9 @@ using namespace react;
 
 namespace worklets {
 
-class JSI_EXPORT NativeWorkletsModuleSpec : public TurboModule {
+class JSI_EXPORT WorkletsModuleProxySpec : public TurboModule {
  protected:
-  explicit NativeWorkletsModuleSpec(
+  explicit WorkletsModuleProxySpec(
       const std::shared_ptr<CallInvoker> jsInvoker);
 
  public:

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
@@ -4,11 +4,11 @@ namespace worklets {
 
 void RNRuntimeWorkletDecorator::decorate(
     jsi::Runtime &rnRuntime,
-    const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule) {
+    const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy) {
   rnRuntime.global().setProperty(
       rnRuntime,
       "__workletsModuleProxy",
-      jsi::Object::createFromHostObject(rnRuntime, nativeWorkletsModule));
+      jsi::Object::createFromHostObject(rnRuntime, workletsModuleProxy));
 }
 
 } // namespace worklets

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <worklets/NativeModules/NativeWorkletsModule.h>
+#include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <memory>
 
 using namespace facebook;
@@ -13,7 +13,7 @@ class RNRuntimeWorkletDecorator {
  public:
   static void decorate(
       jsi::Runtime &rnRuntime,
-      const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule);
+      const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy);
 };
 
 } // namespace worklets

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -28,7 +28,7 @@ using namespace react;
 
 NativeProxy::NativeProxy(
     jni::alias_ref<NativeProxy::javaobject> jThis,
-    const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+    const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
     jsi::Runtime *rnRuntime,
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
     const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -42,7 +42,7 @@ NativeProxy::NativeProxy(
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       nativeReanimatedModule_(std::make_shared<NativeReanimatedModule>(
-          nativeWorkletsModule,
+          workletsModuleProxy,
           *rnRuntime,
           std::make_shared<JSScheduler>(*rnRuntime, jsCallInvoker),
           uiScheduler,
@@ -58,7 +58,7 @@ NativeProxy::NativeProxy(
 #ifdef RCT_NEW_ARCH_ENABLED
 NativeProxy::NativeProxy(
     jni::alias_ref<NativeProxy::javaobject> jThis,
-    const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+    const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
     jsi::Runtime *rnRuntime,
     RuntimeExecutor runtimeExecutor,
     const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -68,7 +68,7 @@ NativeProxy::NativeProxy(
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       nativeReanimatedModule_(std::make_shared<NativeReanimatedModule>(
-          nativeWorkletsModule,
+          workletsModuleProxy,
           *rnRuntime,
           std::make_shared<JSScheduler>(*rnRuntime, runtimeExecutor),
           uiScheduler,
@@ -123,11 +123,10 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
 ) {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
   auto uiScheduler = androidUiScheduler->cthis()->getUIScheduler();
-  auto nativeWorkletsModule =
-      jWorkletsModule->cthis()->getNativeWorkletsModule();
+  auto workletsModuleProxy = jWorkletsModule->cthis()->getWorkletsModuleProxy();
   return makeCxxInstance(
       jThis,
-      nativeWorkletsModule,
+      workletsModuleProxy,
       (jsi::Runtime *)jsContext,
       jsCallInvoker,
       uiScheduler,
@@ -151,11 +150,10 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybridBridgeless(
         fabricUIManager) {
   auto uiScheduler = androidUiScheduler->cthis()->getUIScheduler();
   auto runtimeExecutor = runtimeExecutorHolder->cthis()->get();
-  auto nativeWorkletsModule =
-      jWorkletsModule->cthis()->getNativeWorkletsModule();
+  auto workletsModuleProxy = jWorkletsModule->cthis()->getWorkletsModuleProxy();
   return makeCxxInstance(
       jThis,
-      nativeWorkletsModule,
+      workletsModuleProxy,
       (jsi::Runtime *)jsContext,
       runtimeExecutor,
       uiScheduler,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -275,7 +275,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
 
   explicit NativeProxy(
       jni::alias_ref<NativeProxy::jhybridobject> jThis,
-      const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+      const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
       jsi::Runtime *rnRuntime,
       const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
       const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -290,7 +290,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
 #ifdef RCT_NEW_ARCH_ENABLED
   explicit NativeProxy(
       jni::alias_ref<NativeProxy::jhybridobject> jThis,
-      const std::shared_ptr<NativeWorkletsModule> &nativeWorkletsModule,
+      const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,
       jsi::Runtime *rnRuntime,
       RuntimeExecutor runtimeExecutor,
       const std::shared_ptr<UIScheduler> &uiScheduler,

--- a/packages/react-native-reanimated/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -24,10 +24,10 @@ WorkletsModule::WorkletsModule(
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
-      nativeWorkletsModule_(std::make_shared<NativeWorkletsModule>(
+      workletsModuleProxy_(std::make_shared<WorkletsModuleProxy>(
           valueUnpackerCode,
           std::make_shared<JMessageQueueThread>(messageQueueThread))) {
-  RNRuntimeWorkletDecorator::decorate(*rnRuntime_, nativeWorkletsModule_);
+  RNRuntimeWorkletDecorator::decorate(*rnRuntime_, workletsModuleProxy_);
 }
 
 jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(

--- a/packages/react-native-reanimated/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -13,7 +13,7 @@
 #include <react/jni/JMessageQueueThread.h>
 #include <react/jni/WritableNativeMap.h>
 
-#include <worklets/NativeModules/NativeWorkletsModule.h>
+#include <worklets/NativeModules/WorkletsModuleProxy.h>
 
 #include <memory>
 #include <string>
@@ -36,15 +36,15 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
 
   static void registerNatives();
 
-  inline std::shared_ptr<NativeWorkletsModule> getNativeWorkletsModule() {
-    return nativeWorkletsModule_;
+  inline std::shared_ptr<WorkletsModuleProxy> getWorkletsModuleProxy() {
+    return workletsModuleProxy_;
   }
 
  private:
   friend HybridBase;
   jni::global_ref<WorkletsModule::javaobject> javaPart_;
   jsi::Runtime *rnRuntime_;
-  std::shared_ptr<NativeWorkletsModule> nativeWorkletsModule_;
+  std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
 
   explicit WorkletsModule(
       jni::alias_ref<WorkletsModule::jhybridobject> jThis,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -72,10 +72,10 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
   std::shared_ptr<JSScheduler> jsScheduler = std::make_shared<JSScheduler>(rnRuntime, jsInvoker);
   constexpr auto isBridgeless = false;
 
-  const auto nativeWorkletsModule = [workletsModule getNativeWorkletsModule];
+  const auto workletsModuleProxy = [workletsModule getWorkletsModuleProxy];
 
   auto nativeReanimatedModule = std::make_shared<NativeReanimatedModule>(
-      nativeWorkletsModule,
+      workletsModuleProxy,
       rnRuntime,
       jsScheduler,
       uiScheduler,
@@ -109,13 +109,13 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModuleBridgeless(
   PlatformDepMethodsHolder platformDepMethodsHolder =
       makePlatformDepMethodsHolderBridgeless(moduleRegistry, nodesManager, reaModule);
 
-  const auto nativeWorkletsModule = [workletsModule getNativeWorkletsModule];
+  const auto workletsModuleProxy = [workletsModule getWorkletsModuleProxy];
   auto uiScheduler = std::make_shared<REAIOSUIScheduler>();
   auto jsScheduler = std::make_shared<JSScheduler>(runtime, runtimeExecutor);
   constexpr auto isBridgeless = true;
 
   auto nativeReanimatedModule = std::make_shared<NativeReanimatedModule>(
-      nativeWorkletsModule,
+      workletsModuleProxy,
       runtime,
       jsScheduler,
       uiScheduler,

--- a/packages/react-native-reanimated/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-reanimated/apple/worklets/apple/WorkletsModule.h
@@ -1,9 +1,9 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
-#import <worklets/NativeModules/NativeWorkletsModule.h>
+#import <worklets/NativeModules/WorkletsModuleProxy.h>
 
 @interface WorkletsModule : RCTEventEmitter <RCTBridgeModule>
 
-- (std::shared_ptr<worklets::NativeWorkletsModule>)getNativeWorkletsModule;
+- (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 
 @end

--- a/packages/react-native-reanimated/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-reanimated/apple/worklets/apple/WorkletsModule.mm
@@ -4,8 +4,8 @@
 #import <worklets/apple/WorkletsModule.h>
 #import <worklets/tools/SingleInstanceChecker.h>
 
-using worklets::NativeWorkletsModule;
 using worklets::RNRuntimeWorkletDecorator;
+using worklets::WorkletsModuleProxy;
 
 @interface RCTBridge (JSIRuntime)
 - (void *)runtime;
@@ -17,15 +17,15 @@ using worklets::RNRuntimeWorkletDecorator;
 @end
 
 @implementation WorkletsModule {
-  std::shared_ptr<NativeWorkletsModule> nativeWorkletsModule_;
+  std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
 #ifndef NDEBUG
   worklets::SingleInstanceChecker<WorkletsModule> singleInstanceChecker_;
 #endif // NDEBUG
 }
 
-- (std::shared_ptr<NativeWorkletsModule>)getNativeWorkletsModule
+- (std::shared_ptr<WorkletsModuleProxy>)getWorkletsModuleProxy
 {
-  return nativeWorkletsModule_;
+  return workletsModuleProxy_;
 }
 
 @synthesize moduleRegistry = _moduleRegistry;
@@ -39,8 +39,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
   auto jsQueue = std::make_shared<WorkletsMessageThread>([NSRunLoop currentRunLoop], ^(NSError *error) {
     throw error;
   });
-  nativeWorkletsModule_ = std::make_shared<NativeWorkletsModule>(std::string([valueUnpackerCode UTF8String]), jsQueue);
-  RNRuntimeWorkletDecorator::decorate(rnRuntime, nativeWorkletsModule_);
+  workletsModuleProxy_ = std::make_shared<WorkletsModuleProxy>(std::string([valueUnpackerCode UTF8String]), jsQueue);
+  RNRuntimeWorkletDecorator::decorate(rnRuntime, workletsModuleProxy_);
 
   return @YES;
 }


### PR DESCRIPTION
## Summary

Analogous to:
- #6766 

`NativeWorkletsModule` is the name of the ObjC/Java modules generated from `WorkletsModule`. It's confusing that we name some Cpp object the same way. With this change Cpp `NativeWorkletsModule` becomes `WorkletsModuleProxy`, the same name we use to refer to it from JavaScript.

## Test plan

CI
