### PR TITLE
fix:`withDecay` animation not starting if inital value is set to 0

### DIFF
--- a/packages/react-native-reanimated/src/animation/decay/decay.ts
+++ b/packages/react-native-reanimated/src/animation/decay/decay.ts
@@ -113,6 +113,7 @@ export const withDecay = function (
       onFrame: decay,
       onStart,
       callback,
+      forceRunAnimation: true,
       velocity: config.velocity ?? 0,
       initialVelocity: 0,
       current: 0,

--- a/packages/react-native-reanimated/src/animation/decay/utils.ts
+++ b/packages/react-native-reanimated/src/animation/decay/utils.ts
@@ -13,16 +13,23 @@ const IS_WEB = isWeb();
 export const VELOCITY_EPS = IS_WEB ? 1 / 20 : 1;
 export const SLOPE_FACTOR = 0.1;
 
+/*
+ * The `forceRunAnimation` prop is necessary to run withDecay animation when
+ * related sharedValue stays as `0`. It allows to skip animation check and start
+ * animation immediately
+ */
+
 export interface DecayAnimation extends Animation<DecayAnimation> {
   lastTimestamp: Timestamp;
   startTimestamp: Timestamp;
   initialVelocity: number;
   velocity: number;
   current: AnimatableValue;
+  forceRunAnimation: boolean;
 }
 
 export interface InnerDecayAnimation
-  extends Omit<DecayAnimation, 'current'>,
+  extends Omit<DecayAnimation, 'current' | 'forceRunAnimation'>,
     AnimationObject {
   current: number;
   springActive?: boolean;

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -31,6 +31,7 @@ export function valueSetter<Value>(
     // built in animations that are not higher order(withTiming, withSpring) hold target value in .current
     if (
       mutable._value === animation.current &&
+      !animation.forceRunAnimation &&
       !animation.isHigherOrder &&
       !forceUpdate
     ) {


### PR DESCRIPTION
## Summary

This PR introduces a new property `forceRunAnimation` to our `DecayAnimation` object. It allows us to skip conditional check that prevented `withDecay` from running if the initial value was set to `0`. 

Fixes #6680. 

## Test plan

Run code snippet in React Native Paper example 🚀 

<details>
<summary>Code snippet used in issue</summary>

```ts
import React from 'react';
import { Pressable, Text } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withDecay,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const translateY = useSharedValue(0); 

  const style = useAnimatedStyle(() => ({
    transform: [{ translateY: translateY.value }],
  }));

  return (
    <>
      <Pressable
        style={{ padding: 100, backgroundColor: 'purple' }}
        onPress={() => {
          translateY.value = withDecay({
            velocity: 200,
          });
        }}>
        <Text style={{ fontSize: 50 }}>open</Text>
      </Pressable>
      <Animated.View
        style={[
          {
            backgroundColor: 'blue',
            width: 100,
            height: 100,
          },
          style,
        ]}
      />
    </>
  );
}

```
</details>
