### PR TITLE
Access Reanimated runtime only from UI thread

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -221,7 +221,7 @@ void ReanimatedModuleProxy::scheduleOnUI(
   });
 }
 
-jsi::Value NativeReanimatedModule::executeOnUIRuntimeSync(
+jsi::Value ReanimatedModuleProxy::executeOnUIRuntimeSync(
             jsi::Runtime &rt,
             const jsi::Value &worklet) {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -4,6 +4,8 @@
 #include <reanimated/Tools/CollectionUtils.h>
 #include <reanimated/Tools/FeaturesConfig.h>
 #include <unordered_map>
+#include <mutex>
+#include <condition_variable>
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->
Currently synchronous calls from js thread only waits for lock but still access UI runtime from js thread. That causes hermes to go for slow path as it only remembers last cached thread. More info here https://github.com/facebook/hermes/issues/1572

Improvement:
- calling from js on UI thread is much faster

Downside:
- we now need to wait for UI thread even when lock is not taken (some non reanimated things runs on UI thread)

Possible alternatives:
- make hermes cache multiple threads with threads local 
- create another thread and make ui also call exec sync so we don't need to wait for UI thread when lock is not taken
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
