### PR TITLE
Fix "folly::toJson: JSON object value was an INF"

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -448,7 +448,7 @@ void NativeProxy::handleEvent(
   std::string eventAsString;
   try {
     eventAsString = event->toString();
-  } catch (std::exception &) {
+  } catch (...) {
     // Events from other libraries may contain NaN or INF values which
     // cannot be represented in JSON. See
     // https://github.com/software-mansion/react-native-reanimated/issues/1776


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This PR fixes the following error (or crash in release mode) on Android:

```
folly::toJson: JSON object value was an INF when serializing value at "..."
```

<img width="443" alt="Screenshot 2024-11-28 at 14 56 22" src="https://github.com/user-attachments/assets/c6c70e8f-a214-43b6-9e6e-848ee801fab7">

---

Haven't seen this one in a while as this was previously fixed in https://github.com/software-mansion/react-native-reanimated/pull/2901 but it looks like now even `catch (std::exception &e)` is not enough so we need to try with `catch (...)`. Probably symbol linking is broken somewhere again.

Stack trace:

```
Fatal Exception: java.lang.RuntimeException: folly::toJson: JSON object value was an INF when serializing value at "progress"
       at com.facebook.react.bridge.NativeMap.toString(NativeMap.kt)
       at com.swmansion.reanimated.nativeProxy.EventHandler.receiveEvent(EventHandler.java)
       at com.swmansion.reanimated.nativeProxy.EventHandler.receiveEvent(EventHandler.java:25)
       at com.facebook.react.uimanager.events.Event.dispatch(Event.java:173)
       at com.swmansion.reanimated.NodesManager.handleEvent(NodesManager.java:350)
       at com.swmansion.reanimated.NodesManager.onEventDispatch(NodesManager.java:336)
...
```

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
