### PR TITLE
fix: brownfield integration

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/Fabric/REAInitializerRCTFabricSurface.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/Fabric/REAInitializerRCTFabricSurface.h
@@ -5,7 +5,7 @@
 
 @interface REAInitializerRCTFabricSurface : RCTFabricSurface
 
-@property REAModule *reaModule;
+@property __weak REAModule *reaModule;
 
 @end
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -193,9 +193,10 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (void)setReaSurfacePresenter
 {
-  if (reaSurface == nil) {
-    // we need only one instance because SurfacePresenter is the same during the application lifetime
-    reaSurface = [[REAInitializerRCTFabricSurface alloc] init];
+  if(_surfacePresenter && ![_surfacePresenter surfaceForRootTag:reaSurface.rootTag]) {
+    if (!reaSurface) {
+      reaSurface = [[REAInitializerRCTFabricSurface alloc] init];
+    }
     [_surfacePresenter registerSurface:reaSurface];
   }
   reaSurface.reaModule = self;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In brownfield, `    // we need only one instance because SurfacePresenter is the same during the application lifetime` is false since you can destroy RN and create it again.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
Run Reanimated in brownfield and try to create and destroy the whole RN a couple of times.