### PR TITLE
Fix `ReanimatedCommitHook` cloning

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -70,7 +70,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
           propsMap[&family].emplace_back(props);
         });
 
-    rootNode = cloneShadowTreeWithNewProps(*rootNode, propsMap);
+    rootNode = cloneShadowTreeWithNewPropsUnmounted(rootNode, propsMap);
 
     // If the commit comes from React Native then pause commits from
     // Reanimated since the ShadowTree to be committed by Reanimated may not

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -77,6 +77,10 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
   }
 
   auto shadowNode = std::const_pointer_cast<ShadowNode>(oldShadowNode);
+  auto layoutableShadowNode = std::dynamic_pointer_cast<LayoutableShadowNode>(shadowNode);
+  if (layoutableShadowNode){
+    layoutableShadowNode->dirtyLayout();
+  }
 
   const auto family = &shadowNode->getFamily();
   const auto affectedChildrenIt = childrenMap.find(family);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -1,14 +1,16 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <react/renderer/core/DynamicPropsUtilities.h>
+#include <reanimated/Fabric/ShadowTreeCloner.h>
 
 #include <ranges>
 #include <utility>
 
 namespace reanimated {
 
-ChildrenMap calculateChildrenMap(const RootShadowNode &oldRootNode, const PropsMap &propsMap){
+ChildrenMap calculateChildrenMap(
+    const RootShadowNode &oldRootNode,
+    const PropsMap &propsMap) {
   ChildrenMap childrenMap;
 
   for (auto &[family, _] : propsMap) {
@@ -69,12 +71,13 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
     ShadowNode::Shared const &oldShadowNode,
     const ChildrenMap &childrenMap,
     const PropsMap &propsMap) {
-  if (oldShadowNode->getHasBeenPromoted()){
-    return cloneShadowTreeWithNewPropsRecursive(*oldShadowNode, childrenMap, propsMap);
+  if (oldShadowNode->getHasBeenPromoted()) {
+    return cloneShadowTreeWithNewPropsRecursive(
+        *oldShadowNode, childrenMap, propsMap);
   }
-  
+
   auto shadowNode = std::const_pointer_cast<ShadowNode>(oldShadowNode);
-  
+
   const auto family = &shadowNode->getFamily();
   const auto affectedChildrenIt = childrenMap.find(family);
   const auto propsIt = propsMap.find(family);
@@ -82,8 +85,9 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
 
   if (affectedChildrenIt != childrenMap.end()) {
     for (const auto index : affectedChildrenIt->second) {
-      auto clone = cloneShadowTreeWithNewPropsUnmountedRecursive(children[index], childrenMap, propsMap);
-      if (clone != children[index]){
+      auto clone = cloneShadowTreeWithNewPropsUnmountedRecursive(
+          children[index], childrenMap, propsMap);
+      if (clone != children[index]) {
         shadowNode->replaceChild(*children[index], clone, index);
       }
     }
@@ -100,23 +104,24 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
           propsParserContext, newProps, RawProps(props));
     }
   }
-  
+
   if (newProps) {
-    auto& props = shadowNode->getProps();
-    auto& mutableProps = const_cast<Props::Shared&>(props);
+    auto &props = shadowNode->getProps();
+    auto &mutableProps = const_cast<Props::Shared &>(props);
 
 #ifdef ANDROID
-    auto& newPropsRef = const_cast<Props&>(*newProps);
+    auto &newPropsRef = const_cast<Props &>(*newProps);
     newPropsRef.rawProps = mergeDynamicProps(
-            mutableProps->rawProps,
-            newProps->rawProps,
-            NullValueStrategy::Override);
+        mutableProps->rawProps,
+        newProps->rawProps,
+        NullValueStrategy::Override);
 #endif
     mutableProps = newProps;
-    auto layoutableShadowNode = static_pointer_cast<YogaLayoutableShadowNode>(shadowNode);
+    auto layoutableShadowNode =
+        static_pointer_cast<YogaLayoutableShadowNode>(shadowNode);
     layoutableShadowNode->updateYogaProps();
   }
-  
+
   return shadowNode;
 }
 
@@ -124,20 +129,23 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(
     const RootShadowNode &oldRootNode,
     const PropsMap &propsMap) {
   auto childrenMap = calculateChildrenMap(oldRootNode, propsMap);
-  
+
   // This cast is safe, because this function returns a clone
   // of the oldRootNode, which is an instance of RootShadowNode
-  return std::static_pointer_cast<RootShadowNode>(cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap));
+  return std::static_pointer_cast<RootShadowNode>(
+      cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap));
 }
 
 RootShadowNode::Unshared cloneShadowTreeWithNewPropsUnmounted(
     RootShadowNode::Unshared const &oldRootNode,
-    const PropsMap &propsMap){
+    const PropsMap &propsMap) {
   auto childrenMap = calculateChildrenMap(*oldRootNode, propsMap);
-  
+
   // This cast is safe, because this function returns a clone
   // of the oldRootNode, which is an instance of RootShadowNode
-  return std::static_pointer_cast<RootShadowNode>(cloneShadowTreeWithNewPropsUnmountedRecursive(oldRootNode, childrenMap, propsMap));
+  return std::static_pointer_cast<RootShadowNode>(
+      cloneShadowTreeWithNewPropsUnmountedRecursive(
+          oldRootNode, childrenMap, propsMap));
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -1,11 +1,33 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/ShadowTreeCloner.h>
+#include <react/renderer/core/DynamicPropsUtilities.h>
 
 #include <ranges>
 #include <utility>
 
 namespace reanimated {
+
+ChildrenMap calculateChildrenMap(const RootShadowNode &oldRootNode, const PropsMap &propsMap){
+  ChildrenMap childrenMap;
+
+  for (auto &[family, _] : propsMap) {
+    const auto ancestors = family->getAncestors(oldRootNode);
+
+    for (const auto &[parentNode, index] :
+         std::ranges::reverse_view(ancestors)) {
+      const auto parentFamily = &parentNode.get().getFamily();
+      auto &affectedChildren = childrenMap[parentFamily];
+
+      if (affectedChildren.contains(index)) {
+        continue;
+      }
+
+      affectedChildren.insert(index);
+    }
+  }
+  return childrenMap;
+}
 
 ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
     const ShadowNode &shadowNode,
@@ -43,31 +65,79 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
   return result;
 }
 
-RootShadowNode::Unshared cloneShadowTreeWithNewProps(
-    const RootShadowNode &oldRootNode,
+ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
+    ShadowNode::Shared const &oldShadowNode,
+    const ChildrenMap &childrenMap,
     const PropsMap &propsMap) {
-  ChildrenMap childrenMap;
+  if (oldShadowNode->getHasBeenPromoted()){
+    return cloneShadowTreeWithNewPropsRecursive(*oldShadowNode, childrenMap, propsMap);
+  }
+  
+  auto shadowNode = std::const_pointer_cast<ShadowNode>(oldShadowNode);
+  
+  const auto family = &shadowNode->getFamily();
+  const auto affectedChildrenIt = childrenMap.find(family);
+  const auto propsIt = propsMap.find(family);
+  auto children = shadowNode->getChildren();
 
-  for (auto &[family, _] : propsMap) {
-    const auto ancestors = family->getAncestors(oldRootNode);
-
-    for (const auto &[parentNode, index] :
-         std::ranges::reverse_view(ancestors)) {
-      const auto parentFamily = &parentNode.get().getFamily();
-      auto &affectedChildren = childrenMap[parentFamily];
-
-      if (affectedChildren.contains(index)) {
-        continue;
+  if (affectedChildrenIt != childrenMap.end()) {
+    for (const auto index : affectedChildrenIt->second) {
+      auto clone = cloneShadowTreeWithNewPropsUnmountedRecursive(children[index], childrenMap, propsMap);
+      if (clone != children[index]){
+        shadowNode->replaceChild(*children[index], clone, index);
       }
-
-      affectedChildren.insert(index);
     }
   }
 
+  Props::Shared newProps = nullptr;
+
+  if (propsIt != propsMap.end()) {
+    PropsParserContext propsParserContext{
+        shadowNode->getSurfaceId(), *shadowNode->getContextContainer()};
+    newProps = shadowNode->getProps();
+    for (const auto &props : propsIt->second) {
+      newProps = shadowNode->getComponentDescriptor().cloneProps(
+          propsParserContext, newProps, RawProps(props));
+    }
+  }
+  
+  if (newProps) {
+    auto& props = shadowNode->getProps();
+    auto& mutableProps = const_cast<Props::Shared&>(props);
+
+#ifdef ANDROID
+    auto& newPropsRef = const_cast<Props&>(*newProps);
+    newPropsRef.rawProps = mergeDynamicProps(
+            mutableProps->rawProps,
+            newProps->rawProps,
+            NullValueStrategy::Override);
+#endif
+    mutableProps = newProps;
+    auto layoutableShadowNode = static_pointer_cast<YogaLayoutableShadowNode>(shadowNode);
+    layoutableShadowNode->updateYogaProps();
+  }
+  
+  return shadowNode;
+}
+
+RootShadowNode::Unshared cloneShadowTreeWithNewProps(
+    const RootShadowNode &oldRootNode,
+    const PropsMap &propsMap) {
+  auto childrenMap = calculateChildrenMap(oldRootNode, propsMap);
+  
   // This cast is safe, because this function returns a clone
   // of the oldRootNode, which is an instance of RootShadowNode
-  return std::static_pointer_cast<RootShadowNode>(
-      cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap));
+  return std::static_pointer_cast<RootShadowNode>(cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap));
+}
+
+RootShadowNode::Unshared cloneShadowTreeWithNewPropsUnmounted(
+    RootShadowNode::Unshared const &oldRootNode,
+    const PropsMap &propsMap){
+  auto childrenMap = calculateChildrenMap(*oldRootNode, propsMap);
+  
+  // This cast is safe, because this function returns a clone
+  // of the oldRootNode, which is an instance of RootShadowNode
+  return std::static_pointer_cast<RootShadowNode>(cloneShadowTreeWithNewPropsUnmountedRecursive(oldRootNode, childrenMap, propsMap));
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -77,8 +77,9 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsUnmountedRecursive(
   }
 
   auto shadowNode = std::const_pointer_cast<ShadowNode>(oldShadowNode);
-  auto layoutableShadowNode = std::dynamic_pointer_cast<LayoutableShadowNode>(shadowNode);
-  if (layoutableShadowNode){
+  auto layoutableShadowNode =
+      std::dynamic_pointer_cast<LayoutableShadowNode>(shadowNode);
+  if (layoutableShadowNode) {
     layoutableShadowNode->dirtyLayout();
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
@@ -24,6 +24,10 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(
     const RootShadowNode &oldRootNode,
     const PropsMap &propsMap);
 
+RootShadowNode::Unshared cloneShadowTreeWithNewPropsUnmounted(
+    RootShadowNode::Unshared const &oldRootShadowNode,
+    const PropsMap &propsMap);
+
 } // namespace reanimated
 
 #endif // RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Summary

This PR changes the way the `ShadowTree` is updated in the commit hook. Previously we would always clone the updated nodes, leading to RN also cloning the remaining nodes (some of them have never been mounted, as we are in the commit hook). 

When RN clones uncommited nodes, it doesn't clone the state from the source node, but instead uses last mounted state, meaning that some of the updates will be lost.

To fix that, we don't clone unmounted `ShadowNodes` but instead change them in place. To recognize if a node was mounted we use the `getHasBeenPromoted` method. 

This change needs to be well tested as modifying nodes in place has to be done carefully, since it's not really the intended way.

fixes #6659

## Test plan
Check behaviour of the repro from #6659, ChessboardExample, BokehExample
