### PR TITLE
Clear `operationsInBatch_` before terminating UI runtime

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -198,7 +198,9 @@ ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
   frameCallbacks_.clear();
+#ifdef RCT_NEW_ARCH_ENABLED
   operationsInBatch_.clear();
+#endif // RCT_NEW_ARCH_ENABLED
   uiWorkletRuntime_.reset();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -198,6 +198,7 @@ ReanimatedModuleProxy::~ReanimatedModuleProxy() {
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
   frameCallbacks_.clear();
+  operationsInBatch_.clear();
   uiWorkletRuntime_.reset();
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the following crash that happens during a reload due to `jsi::Value` outliving the UI runtime.

The offending `jsi::Value` comes from `operationsInBatch_` inside `ReanimatedModuleProxy` (formerly `NativeReanimatedModule`.

In `~ReanimatedModuleProxy` we manually clear data structures containing `jsi::Value` prior to resetting `uiWorkletRuntime_` which effectively terminates the runtimes. It looks like we forgot about `operationsInBatch_`.

<img width="1624" alt="Screenshot 2024-12-02 at 13 00 08" src="https://github.com/user-attachments/assets/23c8df28-885e-45e7-b88c-779edc3c4fb5">

## Test plan

1. Launch FabricExample app
2. Reload the app several times
3. Repeat steps 1 and 2 several times
