### PR TITLE
Assert that `workletsModuleProxy` is found

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -110,6 +110,7 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModuleBridgeless(
       makePlatformDepMethodsHolderBridgeless(moduleRegistry, nodesManager, reaModule);
 
   const auto workletsModuleProxy = [workletsModule getWorkletsModuleProxy];
+  assert(workletsModuleProxy != nullptr);
   auto uiScheduler = std::make_shared<REAIOSUIScheduler>();
   auto jsScheduler = std::make_shared<JSScheduler>(runtime, runtimeExecutor);
   constexpr auto isBridgeless = true;


### PR DESCRIPTION
## Summary

The following crash happened to me during an app reload. The top stack frame points to `getValueUnpackerCode` but the actual offender is inside `createReanimatedModuleBridgeless` where `workletsModuleProxy` returned from `[workletsModule getWorkletsModuleProxy]` is `nullptr`.

<img width="1624" alt="Screenshot 2024-12-02 at 12 59 30" src="https://github.com/user-attachments/assets/a15b8a16-00a9-42aa-abca-4bb03c264986">

## Test plan
