### PR TITLE
chore: rephrase render shared value read warning

### DIFF
--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -18,7 +18,7 @@ function shouldWarnAboutAccessDuringRender() {
 function checkInvalidReadDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
-      'Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.',
+      "Reading from `value` during component render. Please ensure that you don't access the `value` property nor use `get` method of a shared value while React is rendering a component.",
       { strict: true }
     );
   }
@@ -27,7 +27,7 @@ function checkInvalidReadDuringRender() {
 function checkInvalidWriteDuringRender() {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
-      'Writing to `value` during component render. Please ensure that you do not access the `value` property or use `set` method of a shared value while React is rendering a component.',
+      "Writing to `value` during component render. Please ensure that you don't access the `value` property nor use `set` method of a shared value while React is rendering a component.",
       { strict: true }
     );
   }


### PR DESCRIPTION
## Summary

Turns out it can be understood that you should be using `get` in render instead of `.value`.

## Test plan
