### PR TITLE
Update testing-with-jest.mdx

### DIFF
--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -37,6 +37,9 @@ Add the following line to your `jest-setup.js` file:
 
 ```js
 require('react-native-reanimated').setUpTests();
+global.navigator = {
+  userAgent: undefined,
+};
 ```
 
 - `setUpTests()` can take optional config argument. Default config is `{ fps: 60 }`.


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

When using `useAnimatedSensor` jest tests break on the expectation of a global navigator object being available

`src/js-reanimated/JSReanimated.ts`
