### PR TITLE
Pass error stack from call site to mutable warnings

### DIFF
--- a/packages/react-native-reanimated/src/logger/logger.ts
+++ b/packages/react-native-reanimated/src/logger/logger.ts
@@ -47,7 +47,7 @@ function formatMessage(message: string) {
   return `[Reanimated] ${message}`;
 }
 
-function createLog(level: LogBoxLogLevel, message: string): LogData {
+function createLog(level: LogBoxLogLevel, message: string, errorOpts?: ErrorOpts): LogData {
   'worklet';
   const formattedMessage = formatMessage(message);
 
@@ -61,7 +61,7 @@ function createLog(level: LogBoxLogLevel, message: string): LogData {
     componentStack: [],
     componentStackType: null,
     // eslint-disable-next-line reanimated/use-reanimated-error
-    stack: new Error().stack,
+    stack: errorOpts?.stack || new Error().stack,
   };
 }
 
@@ -119,10 +119,15 @@ type LogOptions = {
   strict?: boolean;
 };
 
+type ErrorOpts = {
+  stack?: string;
+}
+
 function handleLog(
   level: Exclude<LogBoxLogLevel, 'syntax' | 'fatal'>,
   message: string,
-  options: LogOptions
+  options: LogOptions,
+  errorOpts?: ErrorOpts,
 ) {
   'worklet';
   const config = __reanimatedLoggerConfig;
@@ -140,16 +145,16 @@ function handleLog(
     message += `\n\n${DOCS_REFERENCE}`;
   }
 
-  config.logFunction(createLog(level, message));
+  config.logFunction(createLog(level, message, errorOpts));
 }
 
 export const logger = {
-  warn(message: string, options: LogOptions = {}) {
+  warn(message: string, options: LogOptions = {}, errorOpts: ErrorOpts = {}) {
     'worklet';
-    handleLog('warn', message, options);
+    handleLog('warn', message, options, errorOpts);
   },
-  error(message: string, options: LogOptions = {}) {
+  error(message: string, options: LogOptions = {}, errorOpts: ErrorOpts = {}) {
     'worklet';
-    handleLog('error', message, options);
+    handleLog('error', message, options, errorOpts);
   },
 };

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -15,20 +15,22 @@ function shouldWarnAboutAccessDuringRender() {
   return __DEV__ && isReactRendering() && !isFirstReactRender();
 }
 
-function checkInvalidReadDuringRender() {
+function checkInvalidReadDuringRender(stack?: string) {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
       "Reading from `value` during component render. Please ensure that you don't access the `value` property nor use `get` method of a shared value while React is rendering a component.",
-      { strict: true }
+      { strict: true },
+      { stack }
     );
   }
 }
 
-function checkInvalidWriteDuringRender() {
+function checkInvalidWriteDuringRender(stack?: string) {
   if (shouldWarnAboutAccessDuringRender()) {
     logger.warn(
-      "Writing to `value` during component render. Please ensure that you don't access the `value` property nor use `set` method of a shared value while React is rendering a component.",
-      { strict: true }
+      '!!Writing to `value` during component render. Please ensure that you do not access the `value` property or use `set` method of a shared value while React is rendering a component.',
+      { strict: true },
+      { stack }
     );
   }
 }
@@ -149,14 +151,14 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
 
   const mutable: PartialMutable<Value> = {
     get value(): Value {
-      checkInvalidReadDuringRender();
+      checkInvalidReadDuringRender(Error().stack);
       const uiValueGetter = executeOnUIRuntimeSync((sv: Mutable<Value>) => {
         return sv.value;
       });
       return uiValueGetter(mutable as Mutable<Value>);
     },
     set value(newValue) {
-      checkInvalidWriteDuringRender();
+      checkInvalidWriteDuringRender(Error().stack);
       runOnUI(() => {
         mutable.value = newValue;
       })();
@@ -205,11 +207,11 @@ function makeMutableWeb<Value>(initial: Value): Mutable<Value> {
 
   const mutable: PartialMutable<Value> = {
     get value(): Value {
-      checkInvalidReadDuringRender();
+      checkInvalidReadDuringRender(Error().stack);
       return value;
     },
     set value(newValue) {
-      checkInvalidWriteDuringRender();
+      checkInvalidWriteDuringRender(Error().stack);
       valueSetter(mutable as Mutable<Value>, newValue);
     },
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Introduced in Reanimated 3.16, the "Writing/Reading to `value` during component render" warning is very difficult to debug because the error stack is created through several layers of log calls. By passing the error stack from the call site where the mutable is called, users can pinpoint the site where the mutable was invalidly read/write at the second stack trace line.

## Test plan

1. Write or read to a mutable value in a render function, the second stack trace line should be the call site where the error occured.
