### PR TITLE
Fix crash caused by using `ShareableHandle` in multiple remote runtimes

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -293,7 +293,8 @@ jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
     return jsi::Value(rt, *remoteValue_);
   }
   auto initObj = initializer_->toJSValue(rt);
-  return getValueUnpacker(rt).call(rt, initObj, jsi::String::createFromAscii(rt, "Handle"));
+  return getValueUnpacker(rt).call(
+      rt, initObj, jsi::String::createFromAscii(rt, "Handle"));
 }
 
 jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {

--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -289,7 +289,11 @@ jsi::Value ShareableHandle::toJSValue(jsi::Runtime &rt) {
       remoteRuntime_ = &rt;
     }
   }
-  return jsi::Value(rt, *remoteValue_);
+  if (&rt == remoteRuntime_) {
+    return jsi::Value(rt, *remoteValue_);
+  }
+  auto initObj = initializer_->toJSValue(rt);
+  return getValueUnpacker(rt).call(rt, initObj, jsi::String::createFromAscii(rt, "Handle"));
 }
 
 jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {


### PR DESCRIPTION
## Summary
Fixes https://github.com/Expensify/react-native-live-markdown/issues/574. See root cause analysis in https://github.com/Expensify/react-native-live-markdown/issues/574#issuecomment-2526377216.

This PR fixes a crash caused by calling `ShareableHandle::toJSValue` with second remote runtime after initializing `remoteValue_` with a `jsi::Value` belonging to the first remote runtime.

I assume that this is a rare scenario so we only memoize the value for the first remote runtime and we recreate the value for all subsequent runtimes.

## Test plan

Reproduction:

<details>
<summary>EmptyExample.tsx</summary>

```tsx
import { Text, StyleSheet, View } from 'react-native';

import React from 'react';
import {
  createWorkletRuntime,
  runOnRuntime,
  useAnimatedStyle,
} from 'react-native-reanimated';

const regex = /\d/;

const workletRuntime = createWorkletRuntime('another');

export default function EmptyExample() {
  useAnimatedStyle(() => {
    console.log('useAnimatedStyle', String(regex));
    return {};
  });

  runOnRuntime(workletRuntime, () => {
    'worklet';
    console.log('runOnRuntime', String(regex));
    return {};
  })();

  return (
    <View style={styles.container}>
      <Text>Hello world!</Text>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

</details>
