### PR TITLE
refactor: move _WORKLET injection to Worklets decorator

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
@@ -6,8 +6,6 @@ namespace reanimated {
 void RNRuntimeDecorator::decorate(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<ReanimatedModuleProxy> &reanimatedModuleProxy) {
-  rnRuntime.global().setProperty(rnRuntime, "_WORKLET", false);
-
   jsi::Runtime &uiRuntime = reanimatedModuleProxy->getUIRuntime();
   auto workletRuntimeValue =
       rnRuntime.global()

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
@@ -5,6 +5,8 @@ namespace worklets {
 void RNRuntimeWorkletDecorator::decorate(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy) {
+  rnRuntime.global().setProperty(rnRuntime, "_WORKLET", false);
+
   rnRuntime.global().setProperty(
       rnRuntime,
       "__workletsModuleProxy",


### PR DESCRIPTION
## Summary

`RNRuntimeWorkletDecorator` executes before `RNRuntimeDecorator` already.

## Test plan

Works fine 👍 
