### PR TITLE
refactor: enforce ReanimatedModule load before first isFabric call

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -161,6 +161,14 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec {
     return workletsModuleProxy_;
   }
 
+  [[nodiscard]] inline jsi::Value isFabric() override {
+#ifdef RCT_NEW_ARCH_ENABLED
+    return jsi::Value(true);
+#else
+    return jsi::Value(false);
+#endif // RCT_NEW_ARCH_ENABLED
+  }
+
  private:
   void commonInit(const PlatformDepMethodsHolder &platformDepMethodsHolder);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -121,6 +121,14 @@ static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)(
   return jsi::Value::undefined();
 }
 
+static jsi::Value REANIMATED_SPEC_PREFIX(isFabric)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<ReanimatedModuleProxySpec *>(&turboModule)->isFabric();
+}
+
 ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
     const std::shared_ptr<CallInvoker> &jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
@@ -148,5 +156,7 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)};
   methodMap_["setShouldAnimateExitingForTag"] =
       MethodMetadata{2, REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)};
+
+  methodMap_["isFabric"] = MethodMetadata{0, REANIMATED_SPEC_PREFIX(isFabric)};
 }
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -78,6 +78,8 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &viewTag,
       const jsi::Value &shouldAnimate) = 0;
+
+  virtual jsi::Value isFabric() = 0;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
@@ -19,13 +19,6 @@ void RNRuntimeDecorator::decorate(
   rnRuntime.global().setProperty(
       rnRuntime, "_WORKLET_RUNTIME", workletRuntimeValue);
 
-#ifdef RCT_NEW_ARCH_ENABLED
-  constexpr auto isFabric = true;
-#else
-  constexpr auto isFabric = false;
-#endif // RCT_NEW_ARCH_ENABLED
-  rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", isFabric);
-
   rnRuntime.global().setProperty(
       rnRuntime, "_IS_BRIDGELESS", reanimatedModuleProxy->isBridgeless());
 

--- a/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -47,13 +47,6 @@ void WorkletRuntimeDecorator::decorate(
 
   rt.global().setProperty(rt, "_LABEL", jsi::String::createFromAscii(rt, name));
 
-#ifdef RCT_NEW_ARCH_ENABLED
-  constexpr auto isFabric = true;
-#else
-  constexpr auto isFabric = false;
-#endif // RCT_NEW_ARCH_ENABLED
-  rt.global().setProperty(rt, "_IS_FABRIC", isFabric);
-
 #ifndef NDEBUG
   auto evalWithSourceUrl = [](jsi::Runtime &rt,
                               const jsi::Value &thisValue,

--- a/packages/react-native-reanimated/src/PlatformChecker.ts
+++ b/packages/react-native-reanimated/src/PlatformChecker.ts
@@ -1,5 +1,6 @@
 'use strict';
 import { Platform } from 'react-native';
+import { ReanimatedModule } from './ReanimatedModule';
 
 // This type is necessary since some libraries tend to do a lib check
 // and this file causes type errors on `global` access.
@@ -34,9 +35,17 @@ export function shouldBeUseWeb() {
   return isJest() || isChromeDebugger() || isWeb() || isWindows();
 }
 
-export function isFabric() {
-  return !!(global as localGlobal)._IS_FABRIC;
-}
+export let isFabric = () => {
+  if (ReanimatedModule.isFabric()) {
+    isFabric = () => true;
+    global._IS_FABRIC = true;
+    return true;
+  } else {
+    isFabric = () => false;
+    global._IS_FABRIC = false;
+    return false;
+  }
+};
 
 export function isWindowAvailable() {
   // the window object is unavailable when building the server portion of a site that uses SSG

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -157,4 +157,8 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   unsubscribeFromKeyboardEvents(listenerId: number) {
     this.#reanimatedModuleProxy.unsubscribeFromKeyboardEvents(listenerId);
   }
+
+  isFabric() {
+    return this.#reanimatedModuleProxy.isFabric();
+  }
 }

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -263,6 +263,10 @@ class JSReanimated implements IReanimatedModule {
       'configureProps is not available in JSReanimated.'
     );
   }
+
+  isFabric() {
+    return false;
+  }
 }
 
 // Lack of this export breaks TypeScript generation since

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -51,4 +51,6 @@ export interface ReanimatedModuleProxy {
   ): void;
 
   setShouldAnimateExitingForTag(viewTag: number, shouldAnimate: boolean): void;
+
+  isFabric(): boolean;
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { NativeEventEmitter, Platform } from 'react-native';
 import type { NativeModule } from 'react-native';
-import { shouldBeUseWeb } from '../PlatformChecker';
+import { isFabric, shouldBeUseWeb } from '../PlatformChecker';
 import type { StyleProps } from '../commonTypes';
 import { runOnJS, runOnUIImmediately } from '../threads';
 import type {
@@ -146,7 +146,7 @@ type JSPropsUpdaterOptions =
 let JSPropsUpdater: JSPropsUpdaterOptions;
 if (SHOULD_BE_USE_WEB) {
   JSPropsUpdater = JSPropsUpdaterWeb;
-} else if (global._IS_FABRIC) {
+} else if (isFabric()) {
   JSPropsUpdater = JSPropsUpdaterFabric;
 } else {
   JSPropsUpdater = JSPropsUpdaterPaper;


### PR DESCRIPTION
## Summary

So we wouldn't have initialization order issues anymore. I kept `_IS_FABRIC` in global because we depend on it in our examples and runtime tests.

In a follow up PR we could add the optimization that `isFabric()` is called only once when necessary.

## Test plan

Run the Example app and bare BokehExample.
