### PR TITLE
Fix  `MountingOverrideDelegate` initialization

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -38,7 +38,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     if (surfaceId > currentMaxSurfaceId_) {
       uiManager_->getShadowTreeRegistry().enumerate(
           [this](const ShadowTree &shadowTree, bool &stop) {
-            if (shadowTree.getSurfaceId() <= currentMaxSurfaceId_){
+            if (shadowTree.getSurfaceId() <= currentMaxSurfaceId_) {
               return;
             }
             shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -38,6 +38,9 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     if (surfaceId > currentMaxSurfaceId_) {
       uiManager_->getShadowTreeRegistry().enumerate(
           [this](const ShadowTree &shadowTree, bool &stop) {
+            if (shadowTree.getSurfaceId() <= currentMaxSurfaceId_){
+              return;
+            }
             shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(
                 layoutAnimationsProxy_);
           });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -25,6 +25,8 @@ class ReanimatedCommitHook : public UIManagerCommitHook {
 
   void commitHookWasUnregistered(UIManager const &) noexcept override {}
 
+  void maybeInitializeLayoutAnimations(SurfaceId surfaceId);
+
   RootShadowNode::Unshared shadowTreeWillCommit(
       ShadowTree const &shadowTree,
       RootShadowNode::Shared const &oldRootShadowNode,


### PR DESCRIPTION
## Summary

Currently we use the `setMountingOverrideDelegate` function to pass `LayoutAnimationProxy` to every surface, when we find out that a new surface was created. However, the `setMountingOverrideDelegate` function actually doesn't override the `MountingOverrideDelegate` - it stores all of them. This would lead to us processing the same transaction multiple times, so now we skip each already configured surface.
## Test plan
