### PR TITLE
Remove `CoreFeatures.h` include

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -23,7 +23,6 @@
 #include <react/renderer/scheduler/Scheduler.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/primitives.h>
-#include <react/utils/CoreFeatures.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
 #include <functional>


### PR DESCRIPTION
## Summary

This PR removes `#include <react/utils/CoreFeatures.h>` in ReanimatedModuleProxy.cpp which breaks build on RN 0.77.

See also https://github.com/facebook/react-native/pull/45626

## Test plan
