### PR TITLE
Remove `shouldYield` commit option

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -703,10 +703,7 @@ void ReanimatedModuleProxy::performOperations() {
           },
           {/* .enableStateReconciliation = */
            false,
-           /* .mountSynchronously = */ true,
-           /* .shouldYield = */ [this]() {
-             return propsRegistry_->shouldReanimatedSkipCommit();
-           }});
+           /* .mountSynchronously = */ true});
     });
   }
 }


### PR DESCRIPTION
## Summary

This PR removes `shouldYield` commit option that was used in `ShadowTree::commit` in `ReanimatedModuleProxy::performOperations`.

The reason for the change is that `shouldYield` commit option has been removed in RN 0.77 in https://github.com/facebook/react-native/pull/47191.

## Test plan
