### PR TITLE
Add comment for `canOverrideExistingModule` in `ReactModuleInfo` constructor on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -65,7 +65,7 @@ public class ReanimatedPackage extends BaseReactPackage implements ReactPackage 
           new ReactModuleInfo(
               reactModule.name(),
               moduleClass.getName(),
-              true,
+              true, // override UIManagerModule
               reactModule.needsEagerInit(),
               reactModule.isCxxModule(),
               BuildConfig.IS_NEW_ARCHITECTURE_ENABLED));


### PR DESCRIPTION
## Summary

This PR adds a comment in `ReactModuleInfo` constructor in ReanimatedPackage.java.

We set `canOverrideExistingModule` to `true` because Reanimated overrides `UIManagerModule`.

## Test plan
