### PR TITLE
Use `TurboModuleRegistry.getEnforcing` instead of `get`

### DIFF
--- a/apps/common-app/src/examples/ShareableFreezingExample.tsx
+++ b/apps/common-app/src/examples/ShareableFreezingExample.tsx
@@ -93,11 +93,7 @@ function tryModifyConvertedRemoteFunction() {
 }
 
 function tryModifyConvertedHostObject() {
-  const obj = TurboModuleRegistry.get('Clipboard');
-  if (!obj) {
-    console.warn('No host object found.');
-    return;
-  }
+  const obj = TurboModuleRegistry.getEnforcing('Clipboard');
   makeShareableCloneRecursive(obj);
   // @ts-expect-error It's ok
   obj.prop = 2; // shouldn't warn because it's not frozen

--- a/packages/react-native-reanimated/src/specs/NativeReanimatedModule.ts
+++ b/packages/react-native-reanimated/src/specs/NativeReanimatedModule.ts
@@ -6,4 +6,4 @@ interface Spec extends TurboModule {
   installTurboModule: () => boolean;
 }
 
-export default TurboModuleRegistry.get<Spec>('ReanimatedModule');
+export default TurboModuleRegistry.getEnforcing<Spec>('ReanimatedModule');

--- a/packages/react-native-reanimated/src/specs/NativeWorkletsModule.ts
+++ b/packages/react-native-reanimated/src/specs/NativeWorkletsModule.ts
@@ -9,4 +9,4 @@ interface Spec extends TurboModule {
   installTurboModule: (valueUnpackerCode: string) => boolean;
 }
 
-export default TurboModuleRegistry.get<Spec>('WorkletsModule');
+export default TurboModuleRegistry.getEnforcing<Spec>('WorkletsModule');

--- a/packages/react-native-worklets/src/specs/NativeDummyWorklets.ts
+++ b/packages/react-native-worklets/src/specs/NativeDummyWorklets.ts
@@ -6,4 +6,4 @@ interface Spec extends TurboModule {
   installTurboModule: () => boolean;
 }
 
-export default TurboModuleRegistry.get<Spec>('DummyWorklets');
+export default TurboModuleRegistry.getEnforcing<Spec>('DummyWorklets');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR migrates all usages of `TurboModuleRegistry.get` to `TurboModuleRegistry.getEnforcing` which throws an error if the module is not found.

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
