### PR TITLE
Compatibility with 0.77 for findHostInstance

### DIFF
--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -42,8 +42,12 @@ function resolveFindHostInstance_DEPRECATED() {
   }
   if (isFabric()) {
     try {
+      const ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
+      // Since RN 0.77 ReactFabric exports findHostInstance_DEPRECATED in default object so we're trying to
+      // access it first, then fallback on named export
       findHostInstance_DEPRECATED =
-        require('react-native/Libraries/Renderer/shims/ReactFabric').findHostInstance_DEPRECATED;
+        ReactFabric?.default?.findHostInstance_DEPRECATED ??
+        ReactFabric?.findHostInstance_DEPRECATED;
     } catch (e) {
       throw new ReanimatedError(
         'Failed to resolve findHostInstance_DEPRECATED'

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -54,8 +54,12 @@ function resolveFindHostInstance_DEPRECATED() {
       );
     }
   } else {
+    const ReactNative = require('react-native/Libraries/Renderer/shims/ReactNative');
+    // Since RN 0.77 ReactFabric exports findHostInstance_DEPRECATED in default object so we're trying to
+    // access it first, then fallback on named export
     findHostInstance_DEPRECATED =
-      require('react-native/Libraries/Renderer/shims/ReactNative').findHostInstance_DEPRECATED;
+      ReactNative?.default?.findHostInstance_DEPRECATED ??
+      ReactNative?.findHostInstance_DEPRECATED;
   }
 }
 


### PR DESCRIPTION
## Summary

The method findHostInstance in react-native@0.77 has been moved from a named export to the default export. This PR fix compatibility issue.

## Test plan

Run application with `react-native@0.77`