### PR TITLE
Add missing null-check to `findHostInstanceFastPath`

### DIFF
--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -18,7 +18,10 @@ type HostInstancePaper = {
 
 export type HostInstance = HostInstanceFabric & HostInstancePaper;
 
-function findHostInstanceFastPath(maybeNativeRef: HostInstance) {
+function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
+  if (!maybeNativeRef) {
+    return undefined;
+  }
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&


### PR DESCRIPTION
## Summary

This PR adds a missing null check for certain components using `useAnimatedRef` that do not contain the `_componentRef` field.

## Test plan

Use FlashList as a animated component
