### PR TITLE
Update compatibility table

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -9,22 +9,23 @@ sidebar_label: Compatibility
 
 <div className="compatibility">
 
-|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   |
-| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.0-nightly"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.16.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Spacer/>                            |        |        |        |        |        |        |        |        |        |        |        |        |        |        |
-| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   |
+| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.17.0-nightly"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.16.7"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.16.0 – 3.16.6"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Spacer/>                            |        |        |        |        |        |        |        |        |        |        |        |        |        |        |        |
+| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>
 
@@ -40,14 +41,15 @@ Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-nativ
 
 <div className="compatibility">
 
-|                                     | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   |
-| ----------------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.0-nightly"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.16.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.15.x"/>         | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.9.x – 3.14.x"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.1.x – 3.5.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   |
+| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.17.0-nightly"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>


### PR DESCRIPTION
## Summary

This PR adds Reanimated 3.16.7 row and React Native 0.77 column in the compatibility table in the docs.

## Test plan
