### PR TITLE
Update versions in compatibility check workflow

### DIFF
--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -25,6 +25,8 @@ jobs:
             { version: '0.75', architecture: 'Fabric' },
             { version: '0.76', architecture: 'Paper' },
             { version: '0.76', architecture: 'Fabric' },
+            { version: '0.77', architecture: 'Paper' },
+            { version: '0.77', architecture: 'Fabric' },
           ]
       fail-fast: false
     env:


### PR DESCRIPTION
## Summary

This PR adds React Native 0.77 for Paper and Fabric to the test matrix in compatibility check workflow for GitHub Actions.

## Test plan
