### PR TITLE
fix: Crash on UI Scheduling with invalidated WorkletsModuleProxy

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -7,6 +7,7 @@
 #include <worklets/Tools/UIScheduler.h>
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 
 namespace worklets {
@@ -74,6 +75,8 @@ class WorkletsModuleProxy : public WorkletsModuleProxySpec {
 #ifndef NDEBUG
   SingleInstanceChecker<WorkletsModuleProxy> singleInstanceChecker_;
 #endif // NDEBUG
+  bool isValid_{true};
+  std::shared_mutex uiWorkletRuntimeMutex_;
 };
 
 } // namespace worklets


### PR DESCRIPTION
## Summary

When React Native is destroyed on reload, it runs the destructors for Native Modules on the JavaScript thread. Therefore, even though React Native instance is being destroyed, UI thread can still perform operations on the UI runtime. This leads to a crash where `scheduleOnUI` is called from the UI thread when `WorkletsModuleProxy` destructor has already released `uiWorkletRuntime`.

To fix this, I'm adding a simple shared mutex. `WorkletsModuleProxy` can be cleaned up only when no scheduling takes place and scheduling cannot be performed after `WorkletsModuleProxy` was invalidated.

## Test plan

Try reloading Android now and see that it doesn't crash on `scheduleOnUI` anymore.
