### PR TITLE
fix: layout animation NPE crash

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public class AnimationsManager implements ViewHierarchyObserver {
-  private WeakReference<AndroidUIScheduler> mWeakAndroidUIScheduler;
+  private WeakReference<AndroidUIScheduler> mWeakAndroidUIScheduler = new WeakReference<>(null);
   private ReactContext mContext;
   private UIManager mUIManager;
   private NativeMethodsHolder mNativeMethodsHolder;
@@ -102,11 +102,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
       return;
     }
 
-    if (mWeakAndroidUIScheduler != null) {
-      AndroidUIScheduler androidUIScheduler = mWeakAndroidUIScheduler.get();
-      if (androidUIScheduler != null) {
-        androidUIScheduler.triggerUI();
-      }
+    AndroidUIScheduler androidUIScheduler = mWeakAndroidUIScheduler.get();
+    if (androidUIScheduler != null) {
+      androidUIScheduler.triggerUI();
+    } else {
+      return;
     }
     int tag = view.getId();
     HashMap<String, Object> targetValues = after.toTargetMap();

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/AnimationsManager.java
@@ -102,9 +102,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
       return;
     }
 
-    AndroidUIScheduler androidUIScheduler = mWeakAndroidUIScheduler.get();
-    if (androidUIScheduler != null) {
-      androidUIScheduler.triggerUI();
+    if (mWeakAndroidUIScheduler != null) {
+      AndroidUIScheduler androidUIScheduler = mWeakAndroidUIScheduler.get();
+      if (androidUIScheduler != null) {
+        androidUIScheduler.triggerUI();
+      }
     }
     int tag = view.getId();
     HashMap<String, Object> targetValues = after.toTargetMap();


### PR DESCRIPTION
## Summary

After update to Reanimated 3.16.x we started to have hundreds of crashes due to this error:
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference.
```
More info could be found in this issue #4472 

## Test plan

I am not able to reproduce issue locally since it's happening for some small percentage of users. According to stack trace I am pretty sure it will help but I am not sure if it's proper fix because I don't have deeper understanding of surrounding code.
