### PR TITLE
Add unhandled exception to TabNavigatorObserver catch block

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/TabNavigatorObserver.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/layoutReanimation/TabNavigatorObserver.java
@@ -114,7 +114,7 @@ public class TabNavigatorObserver {
           nextTransition.add(firstScreen);
         }
         firstScreen = null;
-      } catch (IllegalAccessException | InvocationTargetException e) {
+      } catch (IllegalAccessException | NullPointerException | InvocationTargetException e) {
         String message = e.getMessage() != null ? e.getMessage() : "Unable to get screen view";
         Log.e("[Reanimated]", message);
       }


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/issues/6724

Turns out that `TabNavigatorObserver's` `onFragmentUpdate` didn't handle `NullPointerException`, which in turn sometimes crashed release builds on android.

## Test plan

I wasn't able to create a simple reproduction but I have at least one SWM project that used the exact same code to patch Reanimated and it took care of their android crashes.
