### PR TITLE
Drop pre-release tag for nightly version

### DIFF
--- a/packages/react-native-reanimated/scripts/set-reanimated-version.js
+++ b/packages/react-native-reanimated/scripts/set-reanimated-version.js
@@ -57,7 +57,7 @@ if (IS_SET_CUSTOM) {
     }).stdout.trim();
     const shortCommit = currentCommit.slice(0, 9);
 
-    version = `${currentVersion}-nightly-${dateIdentifier}-${shortCommit}`;
+    version = `${currentVersion.split('-')[0]}-nightly-${dateIdentifier}-${shortCommit}`;
   } else if (IS_FRESH) {
     version = `${currentVersion}-${dateIdentifier}`;
   }


### PR DESCRIPTION
## Summary

This PR changes the logic of generating nightly release version name.

Before this change, the next published version would be `4.0.0-beta.1-nightly-20250121-9a907dd8b`.

After this change, it will be `4.0.0-nightly-20250121-9a907dd8b` (without `-beta.1` part).

## Test plan
