### PR TITLE
fix: Add missing CSSStyle type export

### DIFF
--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -7,12 +7,7 @@ import type {
 } from '../../createAnimatedComponent/commonTypes';
 import { isFabric, isWeb, shouldBeUseWeb } from '../../PlatformChecker';
 import { CSSManager } from '../managers';
-import type {
-  AnyComponent,
-  AnyRecord,
-  CSSStyleProperties,
-  PlainStyle,
-} from '../types';
+import type { AnyComponent, AnyRecord, CSSStyle, PlainStyle } from '../types';
 import { Platform, StyleSheet } from 'react-native';
 import type { StyleProp } from 'react-native';
 import { findHostInstance } from '../../platform-specific/findHostInstance';
@@ -41,7 +36,7 @@ export default class AnimatedComponent<
   _CSSManager?: CSSManager;
 
   _viewInfo?: ViewInfo;
-  _planStyle: CSSStyleProperties = {};
+  _planStyle: CSSStyle = {};
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
 
   constructor(ChildComponent: AnyComponent, props: P) {

--- a/packages/react-native-reanimated/src/css/index.ts
+++ b/packages/react-native-reanimated/src/css/index.ts
@@ -14,6 +14,7 @@ export type {
   CSSTransitionProperty,
   CSSTransitionDuration,
   CSSTransitionTimingFunction,
+  CSSStyle,
   CSSTransitionDelay,
   CSSTransitionProperties,
   CSSTransitionSettings,

--- a/packages/react-native-reanimated/src/css/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSManager.ts
@@ -9,7 +9,7 @@ import {
 import type { ViewInfo } from '../../createAnimatedComponent/commonTypes';
 import CSSTransitionManager from './CSSTransitionManager';
 import CSSAnimationsManager from './CSSAnimationsManager';
-import type { CSSStyleProperties } from '../types';
+import type { CSSStyle } from '../types';
 import { filterCSSAndStyleProperties } from '../utils';
 
 export default class CSSManager {
@@ -30,11 +30,11 @@ export default class CSSManager {
     }
   }
 
-  attach(style: CSSStyleProperties): void {
+  attach(style: CSSStyle): void {
     this.update(style, true);
   }
 
-  update(style: CSSStyleProperties, isMount = false): void {
+  update(style: CSSStyle, isMount = false): void {
     const [animationProperties, transitionProperties, filteredStyle] =
       filterCSSAndStyleProperties(style);
     const normalizedStyle = styleBuilder.buildFrom(filteredStyle);

--- a/packages/react-native-reanimated/src/css/managers/CSSManager.web.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSManager.web.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { ViewInfo } from '../../createAnimatedComponent/commonTypes';
 import type { ReanimatedHTMLElement } from '../../ReanimatedModule/js-reanimated';
-import type { CSSStyleProperties } from '../types';
+import type { CSSStyle } from '../types';
 import { filterCSSAndStyleProperties } from '../utils';
 import CSSAnimationsManager from './CSSAnimationsManager.web';
 import CSSTransitionManager from './CSSTransitionManager.web';
@@ -19,7 +19,7 @@ export default class CSSManager {
     this.transitionsManager = new CSSTransitionManager(this.element);
   }
 
-  attach(style: CSSStyleProperties): void {
+  attach(style: CSSStyle): void {
     const [animationConfig, transitionConfig] =
       filterCSSAndStyleProperties(style);
 
@@ -32,7 +32,7 @@ export default class CSSManager {
     }
   }
 
-  update(style: CSSStyleProperties): void {
+  update(style: CSSStyle): void {
     const [animationConfig, transitionConfig] =
       filterCSSAndStyleProperties(style);
 

--- a/packages/react-native-reanimated/src/css/stylesheet.ts
+++ b/packages/react-native-reanimated/src/css/stylesheet.ts
@@ -3,11 +3,11 @@ import { CSSKeyframesRuleImpl } from './models';
 import type {
   CSSAnimationKeyframes,
   CSSKeyframesRule,
-  CSSStyleProperties,
+  CSSStyle,
   PlainStyle,
 } from './types';
 
-type NamedStyles<T> = { [P in keyof T]: CSSStyleProperties };
+type NamedStyles<T> = { [P in keyof T]: CSSStyle };
 
 const create = <T extends NamedStyles<T>>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-native-reanimated/src/css/types/props.ts
+++ b/packages/react-native-reanimated/src/css/types/props.ts
@@ -3,6 +3,7 @@ import type { StyleProp } from 'react-native';
 import type { CSSAnimationProperties } from './animation';
 import type { PlainStyle } from './common';
 import type { CSSTransitionProperties } from './transition';
+import type { AnyRecord } from './helpers';
 
 /*
   Style type properties (properties that extends StyleProp<ViewStyle>)
@@ -17,14 +18,14 @@ type PickStyleProps<P> = Pick<
   }[keyof P]
 >;
 
-export type CSSStyleProperties<S extends PlainStyle = PlainStyle> = S &
+export type CSSStyle<S extends AnyRecord = PlainStyle> = S &
   Partial<CSSAnimationProperties<S>> &
   Partial<CSSTransitionProperties<S>>;
 
 type CSSStyleProps<P extends object> = {
   [K in keyof PickStyleProps<P>]: P[K] extends StyleProp<infer U>
     ? U extends object
-      ? StyleProp<CSSStyleProperties<U>>
+      ? StyleProp<CSSStyle<U>>
       : never
     : never;
 };

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -1,12 +1,12 @@
 'use strict';
 import { css } from '../../stylesheet';
-import type { CSSStyleProperties, CSSTransitionProperty } from '../../types';
+import type { CSSStyle, CSSTransitionProperty } from '../../types';
 import { filterCSSAndStyleProperties } from '../props';
 
 describe(filterCSSAndStyleProperties, () => {
   describe('animation config', () => {
     it('returns null if there is no animationName', () => {
-      const style: CSSStyleProperties = {
+      const style: CSSStyle = {
         transitionProperty: 'opacity',
         animationDuration: 100,
       };
@@ -19,7 +19,7 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     it('returns null if the animationName is an empty object', () => {
-      const style: CSSStyleProperties = {
+      const style: CSSStyle = {
         animationName: {},
         animationDuration: 100,
       };
@@ -31,7 +31,7 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     it('returns null if animationName is an empty keyframes object created with css.keyframes', () => {
-      const style: CSSStyleProperties = {
+      const style: CSSStyle = {
         animationName: css.keyframes({}),
         animationDuration: 100,
       };
@@ -43,7 +43,7 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     it('returns animation config if animationName is present', () => {
-      const style: CSSStyleProperties = {
+      const style: CSSStyle = {
         animationName: css.keyframes({
           from: { opacity: 0 },
           to: { opacity: 1 },
@@ -67,7 +67,7 @@ describe(filterCSSAndStyleProperties, () => {
         ['animationFillMode', 'both'],
         ['animationPlayState', 'paused'],
       ])(`returns %p setting`, (key, value) => {
-        const style: CSSStyleProperties = {
+        const style: CSSStyle = {
           animationName: css.keyframes({
             from: { opacity: 0 },
             to: { opacity: 1 },
@@ -85,7 +85,7 @@ describe(filterCSSAndStyleProperties, () => {
 
   describe('transition config', () => {
     it('returns null if there are no transition properties', () => {
-      const style: CSSStyleProperties = {};
+      const style: CSSStyle = {};
       expect(filterCSSAndStyleProperties(style)).toEqual([
         expect.any(Object),
         null,
@@ -94,11 +94,11 @@ describe(filterCSSAndStyleProperties, () => {
     });
 
     it('returns transition config if at least one transition property is present', () => {
-      const style1: CSSStyleProperties = {
+      const style1: CSSStyle = {
         transitionProperty: 'opacity',
         transitionDuration: 100,
       };
-      const style2: CSSStyleProperties = {
+      const style2: CSSStyle = {
         transitionDuration: 100,
       };
       expect(filterCSSAndStyleProperties(style1)).toEqual([
@@ -120,7 +120,7 @@ describe(filterCSSAndStyleProperties, () => {
         ['transitionTimingFunction', 'easeInOut'],
         ['transitionDelay', '1s'],
       ])(`returns %p setting`, (key, value) => {
-        const style: CSSStyleProperties = {
+        const style: CSSStyle = {
           transitionProperty: value as CSSTransitionProperty,
           [key]: value,
         };
@@ -135,7 +135,7 @@ describe(filterCSSAndStyleProperties, () => {
 
   describe('all together', () => {
     it('returns all configs and style without css configs', () => {
-      const style: CSSStyleProperties = {
+      const style: CSSStyle = {
         width: 100,
         transitionDuration: 100,
         height: 100,

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -2,6 +2,7 @@
 import type {
   AnyRecord,
   CSSAnimationProperties,
+  CSSStyle,
   CSSTransitionProperties,
   ExistingCSSAnimationProperties,
   PlainStyle,
@@ -13,8 +14,8 @@ import {
   isTransitionProp,
 } from './guards';
 
-export function filterCSSAndStyleProperties(
-  style: PlainStyle
+export function filterCSSAndStyleProperties<S extends AnyRecord>(
+  style: CSSStyle<S>
 ): [
   ExistingCSSAnimationProperties | null,
   CSSTransitionProperties | null,


### PR DESCRIPTION
## Summary

This PR adds missing `CSSStyle` type export which must have been accidentally removed and fixes `CSSStyle` type optional template param to properly support passing type specifier, like `ViewStyle`, `TextStyle` or `ImageStyle`.