### PR TITLE
Fix layout animation crashes on the New Architecture

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -116,6 +116,9 @@ void LayoutAnimationsManager::startLayoutAnimation(
   std::shared_ptr<Shareable> config;
   {
     auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
+    if (!collection::contains(getConfigsForType(type), tag)){
+        return;
+    }
     config = getConfigsForType(type)[tag];
   }
   // TODO: cache the following!!

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -116,8 +116,8 @@ void LayoutAnimationsManager::startLayoutAnimation(
   std::shared_ptr<Shareable> config;
   {
     auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
-    if (!collection::contains(getConfigsForType(type), tag)){
-        return;
+    if (!collection::contains(getConfigsForType(type), tag)) {
+      return;
     }
     config = getConfigsForType(type)[tag];
   }


### PR DESCRIPTION
## Summary

This PR adds a `contains` check for layout animation config. When we schedule the start of an animation, we check if an animation is configured for the given view. But it might happen that before the `LayoutAnimationsManager::startLayoutAnimation` function gets executed, the view gets removed. When the view is removed we clear the config, so the `startLayoutAnimation` function will get a `nullptr` config, resulting in a crash.

fixes #6908

## Test plan
