### PR TITLE
Use tabular nums in performance monitor

### DIFF
--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -197,6 +197,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 13,
+    fontVariant: ['tabular-nums'],
     color: '#ffff',
     fontFamily: 'monospace',
     paddingHorizontal: 3,


### PR DESCRIPTION
## Summary

This PR adds `fontVariant: ['tabular-nums']` in `<PerformanceMonitor />` component in order to prevent text jumps and for the sake of better readability.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/01d6941c-4a6d-41a4-9a2b-af4cc43e03ed" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/bb76c2ef-da66-4bcf-ab36-9a9734b02922" />
</td>
</tr>
</tbody>
</table>

## Test plan
