### PR TITLE
Add missing `targets` in build.gradle

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -260,6 +260,7 @@ android {
                         "-DREANIMATED_VERSION=${REANIMATED_VERSION}",
                         "-DHAS_EXTERNAL_WORKLETS=${hasExternalWorklets}"
                 abiFilters (*reactNativeArchitectures())
+                targets("reanimated", "worklets")
             }
         }
 


### PR DESCRIPTION
## Summary

This PR potentially fixes undefined symbol linking errors happening in RN apps when Reanimated is required by other third-party libraries like Live Markdown or Vision Camera caused by incorrect order of task execution caused by incomplete dependency graph which can be fixed by adding `targets` function call in `externalNativeBuild` to specify shared libraries. 

## Test plan
