### PR TITLE
Fix slow animation on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -93,8 +93,7 @@ RequestRenderFunction makeRequestRender(REANodesManager *nodesManager)
       // TODO macOS targetTimestamp isn't available on macOS
       auto targetTimestamp = displayLink.timestamp + displayLink.duration;
 #endif
-      const double frameTimestamp =
-        calculateTimestampWithSlowAnimations(targetTimestamp) * 1000;
+      const double frameTimestamp = calculateTimestampWithSlowAnimations(targetTimestamp) * 1000;
       onRender(frameTimestamp);
     }];
   };

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -93,9 +93,8 @@ RequestRenderFunction makeRequestRender(REANodesManager *nodesManager)
       // TODO macOS targetTimestamp isn't available on macOS
       auto targetTimestamp = displayLink.timestamp + displayLink.duration;
 #endif
-      double frameTimestamp =
-
-          (targetTimestamp) * 1000;
+      const double frameTimestamp =
+        calculateTimestampWithSlowAnimations(targetTimestamp) * 1000;
       onRender(frameTimestamp);
     }];
   };


### PR DESCRIPTION
## Summary

This PR adds the missing call to `calculateTimestampWithSlowAnimations`, which is necessary to properly handle slow animations on iOS.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e09f3e50-5a12-472d-aea1-71d98c1638bb" /> | <video src="https://github.com/user-attachments/assets/d3a6d047-d443-4f3b-9947-b6f96ee9d479" /> |

## Test plan

Runa animation and toggle slow animation on iOS.
