### PR TITLE
chore: use yarn build when making Reanimated package

### DIFF
--- a/packages/react-native-reanimated/createNPMPackage.sh
+++ b/packages/react-native-reanimated/createNPMPackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 yarn install --immutable
-yarn bob build
+yarn build
 
 PREVIOUS_VERSION=$(node scripts/set-reanimated-version.js "$@")
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary

`yarn build` is now necessary when preparing Reanimated package.

## Test plan

🚀 
