### PR TITLE
Add Keyframe animation caching

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -36,6 +36,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
   reduceMotionV: ReduceMotion = ReduceMotion.System;
   callbackV?: (finished: boolean) => void;
   definitions: MaybeInvalidKeyframeProps;
+  parsedAnimation?: EntryExitAnimationFunction;
 
   /*
     Keyframe definition should be passed in the constructor as the map
@@ -232,7 +233,11 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
     const { keyframes, initialValues } = this.parseDefinitions();
     const callback = this.callbackV;
 
-    return () => {
+    if (this.parsedAnimation) {
+      return this.parsedAnimation;
+    }
+
+    this.parsedAnimation = () => {
       'worklet';
       const animations: StylePropsWithArrayTransform = {};
 
@@ -296,6 +301,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         callback,
       };
     };
+    return this.parsedAnimation;
   };
 }
 


### PR DESCRIPTION
## Summary

Our current implementation of keyframe parsing mutates the keyframe definition object (e.g. we remove the easing function).  If we try to call `build()` on a `Keyframe` object more than once, we will end up with a different animation after the first time. This is bad because we want people to memoize their Keyframes. I decided to fix this problem by caching the calculated animation. This fixes this problem, and also allows us to reuse the result of parsing.

## Test plan
