### PR TITLE
Fix `Keyframe` mock

### DIFF
--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -320,7 +320,7 @@ const core = {
 const layoutReanimation = {
   BaseAnimationBuilder: new BaseAnimationMock(),
   ComplexAnimationBuilder: new BaseAnimationMock(),
-  Keyframe: new BaseAnimationMock(),
+  Keyframe: BaseAnimationMock,
   // Flip
   FlipInXUp: new BaseAnimationMock(),
   FlipInYLeft: new BaseAnimationMock(),


### PR DESCRIPTION
## Summary

`Keyframe` is used with a constructor in our api, so the mocks should reflect that.
## Test plan
