### PR TITLE
fix: Quick fix for broken inline styles

### DIFF
--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -1,4 +1,5 @@
 'use strict';
+import { isSharedValue } from '../../isSharedValue';
 import type {
   AnyRecord,
   CSSAnimationProperties,
@@ -33,7 +34,7 @@ export function filterCSSAndStyleProperties<S extends AnyRecord>(
       animationProperties[prop] = value;
     } else if (isTransitionProp(prop)) {
       transitionProperties[prop] = value;
-    } else {
+    } else if (!isSharedValue(value)) {
       filteredStyle[prop] = value;
     }
   }


### PR DESCRIPTION
## Summary

This PR adds missing check for shared values in the style filtering function.

## Test plan

<details>
<summary>Source code</summary>

```tsx
import { useState } from 'react';
import Animated, { useSharedValue } from 'react-native-reanimated';

export default function PlaygroundScreen(): Element {
  const [state, setState] = useState({});
  const backgroundColor = useSharedValue('blue');

  return (
    <Animated.View
      style={[
        {
          backgroundColor,
          height: 200,
          width: 200,
        },
      ]}
    />
  );
}
```
</details>