### PR TITLE
docs: Add new supported props from RN 0.77 to supported props table

### DIFF
--- a/packages/docs-reanimated/docs/guides/supported-properties.mdx
+++ b/packages/docs-reanimated/docs/guides/supported-properties.mdx
@@ -78,6 +78,7 @@ Not all CSS properties are available and animatable in React Native. The followi
 | overflow                | <Yes/>  | <Yes/> | <Yes/> |
 | zIndex                  | <Yes/>  | <Yes/> | <Yes/> |
 | aspectRatio             | <Yes/>  | <Yes/> | <Yes/> |
+| boxSizing               | <No/>   | <No/>  | <Yes/> |
 | backgroundColor         | <Yes/>  | <Yes/> | <Yes/> |
 | color                   | <Yes/>  | <Yes/> | <Yes/> |
 | textDecorationColor     | <No/>   | <Yes/> | <Yes/> |
@@ -92,6 +93,7 @@ Not all CSS properties are available and animatable in React Native. The followi
 | borderLeftColor         | <Yes/>  | <Yes/> | <Yes/> |
 | borderStartColor        | <Yes/>  | <Yes/> | <Yes/> |
 | borderBlockColor        | <Yes/>  | <Yes/> | <Yes/> |
+| outlineColor            | <Yes/>  | <Yes/> | <Yes/> |
 | shadowColor             | <Yes/>  | <Yes/> | <Yes/> |
 | overlayColor            | <No/>   | <No/>  | <No/>  |
 | tintColor               | <Yes/>  | <Yes/> | <No/>  |
@@ -124,6 +126,9 @@ Not all CSS properties are available and animatable in React Native. The followi
 | borderRightWidth        | <Yes/>  | <Yes/> | <Yes/> |
 | borderCurve             | <No/>   | <No/>  | <No/>  |
 | borderStyle             | <Yes/>  | <Yes/> | <Yes/> |
+| outlineOffset           | <Yes/>  | <Yes/> | <Yes/> |
+| outlineStyle            | <Yes/>  | <Yes/> | <Yes/> |
+| outlineWidth            | <Yes/>  | <Yes/> | <Yes/> |
 | transformOrigin         | <Yes/>  | <Yes/> | <Yes/> |
 | transform               | <Yes/>  | <Yes/> | <Yes/> |
 | transformMatrix         | <No/>   | <No/>  | <No/>  |
@@ -134,6 +139,7 @@ Not all CSS properties are available and animatable in React Native. The followi
 | translateY              | <No/>   | <No/>  | <No/>  |
 | backfaceVisibility      | <Yes/>  | <Yes/> | <Yes/> |
 | opacity                 | <Yes/>  | <Yes/> | <Yes/> |
+| mixBlendMode            | <Yes/>  | <Yes/> | <Yes/> |
 | fontFamily              | <Yes/>  | <Yes/> | <Yes/> |
 | fontSize                | <Yes/>  | <Yes/> | <Yes/> |
 | fontStyle               | <Yes/>  | <Yes/> | <Yes/> |


### PR DESCRIPTION
## Summary

This PR just updates the table with docs after adding support for new RN props in CSS animations and transitions in the #6944 PR.