### PR TITLE
fix: Release build failing because of missing worklets namespace

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReanimatedVersion.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReanimatedVersion.cpp
@@ -81,7 +81,7 @@ void checkJSVersion(
 #else
 void checkJSVersion(
     jsi::Runtime &rnRuntime,
-    const std::shared_ptr<JSLogger> &jsLogger) {
+    const std::shared_ptr<worklets::JSLogger> &jsLogger) {
   // In release builds we don't check the version, hence
   // this function is a NOOP.
 }


### PR DESCRIPTION
## Summary

This PR fixes build crash because of missing namespace usage.

## Test plan

Just build the app in the release mode (I tested on android).