### PR TITLE
fix: initializer file not loaded in Expo52

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -176,9 +176,13 @@
     }
   },
   "sideEffects": [
+    "./src/layoutReanimation/animationsManager.ts",
     "./lib/module/layoutReanimation/animationsManager.js",
+    "./src/core.ts",
     "./lib/module/core.js",
+    "./src/initializers.ts",
     "./lib/module/initializers.js",
+    "./src/index.ts",
     "./lib/module/index.js"
   ]
 }

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -10,7 +10,7 @@ import type {
 } from './commonTypes';
 import { ReanimatedError } from './errors';
 import { initializeUIRuntime } from './initializers';
-import { isFabric, isWeb, shouldBeUseWeb } from './PlatformChecker';
+import { isFabric, shouldBeUseWeb } from './PlatformChecker';
 import { ReanimatedModule } from './ReanimatedModule';
 import { SensorContainer } from './SensorContainer';
 import { makeShareableCloneRecursive } from './shareables';
@@ -153,9 +153,7 @@ export function unregisterSensor(sensorId: number): void {
   return sensorContainer.unregisterSensor(sensorId);
 }
 
-if (!isWeb()) {
-  initializeUIRuntime(ReanimatedModule);
-}
+initializeUIRuntime(ReanimatedModule);
 
 type FeaturesConfig = {
   enableLayoutAnimations: boolean;

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -6,7 +6,12 @@ import {
   registerLoggerConfig,
   replaceLoggerImplementation,
 } from './logger';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from './PlatformChecker';
+import {
+  isChromeDebugger,
+  isJest,
+  isWeb,
+  shouldBeUseWeb,
+} from './PlatformChecker';
 import type { IReanimatedModule } from './ReanimatedModule';
 import {
   callMicrotasks,
@@ -180,6 +185,9 @@ function setupRequestAnimationFrame() {
 }
 
 export function initializeUIRuntime(ReanimatedModule: IReanimatedModule) {
+  if (isWeb()) {
+    return;
+  }
   if (!ReanimatedModule) {
     // eslint-disable-next-line reanimated/use-reanimated-error
     throw new Error(


### PR DESCRIPTION
## Summary

Turns out that `sideEffects` field was ignored and `isWeb()` check evaluated to static false, removing `initializers.ts` from the bundle.

Fixes
- #6740
- #6839

## Test plan

Tested it on RNGH web example app using Expo52