### PR TITLE
Set version for prefab in build.gradle

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -130,6 +130,9 @@ def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 100
 def REANIMATED_VERSION = getReanimatedVersion()
 def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 
+// Set version for prefab
+version REANIMATED_VERSION
+
 // We download various C++ open-source dependencies into downloads.
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.


### PR DESCRIPTION
## Summary

This PR sets version for `react-native-reanimated` project in build.gradle so it is passed to prefab tool.

## Test plan

1. Build example app.
2. Run `find . -name prefab.json`
3. Confirm that `"version": "4.0.0-beta.1"` is present in `prefab.json`