### PR TITLE
Add sticky header example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/StickyHeaderExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/StickyHeaderExample.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import Animated, {
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+const styles = StyleSheet.create({
+  stickyHeader: {
+    height: 80,
+    backgroundColor: 'navy',
+  },
+  listItem: {
+    padding: 16,
+  },
+});
+
+export default function StickyHeaderExample() {
+  const offset = useSharedValue(0);
+
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    offset.value = event.contentOffset.y;
+  });
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return { transform: [{ translateY: offset.value }] };
+  });
+
+  return (
+    <Animated.ScrollView onScroll={scrollHandler}>
+      <Animated.View style={[styles.stickyHeader, animatedStyle]} />
+      {Array.from({ length: 100 }).map((_, i) => (
+        <Text key={i} style={styles.listItem}>
+          Item {i + 1}
+        </Text>
+      ))}
+    </Animated.ScrollView>
+  );
+}

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -123,6 +123,7 @@ import RestoreStateExample from './SharedElementTransitions/RestoreState';
 import TabNavigatorExample from './SharedElementTransitions/TabNavigatorExample';
 import TransitionRestartExample from './SharedElementTransitions/TransitionRestart';
 import SharedStyleExample from './SharedStyleExample';
+import StickyHeaderExample from './StickyHeaderExample';
 import StrictDOMExample from './StrictDOMExample';
 import SvgExample from './SvgExample';
 import SwipeableListExample from './SwipeableListExample';
@@ -372,6 +373,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '𝌍',
     title: 'useScrollViewOffset',
     screen: ScrollViewOffsetExample,
+  },
+  StickyHeaderExample: {
+    icon: '🔝',
+    title: 'Sticky header',
+    screen: StickyHeaderExample,
   },
   DispatchCommandExample: {
     icon: '🫡',


### PR DESCRIPTION
## Summary

This PR adds an example with sticky header implemented using `useAnimatedScrollHandler` (although `useScrollViewOffset` is also recommended) and `useAnimatedStyle` to align the vertical translation of a view with `ScrollView` content offset.

Source code has been adapted from the repro in https://github.com/software-mansion/react-native-reanimated/issues/6992 by @Flewp.

## Test plan
