### PR TITLE
chore: remove apps from node_modules

### DIFF
--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -18,5 +18,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -29,6 +29,7 @@
     "node": ">=18"
   },
   "installConfig": {
-    "hoistingLimits": "workspaces"
+    "hoistingLimits": "workspaces",
+    "selfReferences": false
   }
 }

--- a/apps/next-example/package.json
+++ b/apps/next-example/package.json
@@ -31,5 +31,8 @@
     "next-compose-plugins": "^2.2.1",
     "prettier": "^3.3.3",
     "start-server-and-test": "^2.0.1"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -35,5 +35,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }

--- a/apps/web-example/package.json
+++ b/apps/web-example/package.json
@@ -22,5 +22,8 @@
     "@stylexjs/babel-plugin": "^0.10.0",
     "prettier": "^3.3.3",
     "serve": "^14.2.3"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }


### PR DESCRIPTION
## Summary

With current monorepo setup `fabric-example` etc. (not counting `common-app`) are linked in `node_modules` so they could be imported in another workspace, which is unnecessary. This doesn't really bother us, but sometimes when you need to find something in `node_modules` it's annoying that these show up.

## Test plan

🚀 
