### PR TITLE
Add `createLock` method in `WorkletRuntime`

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -52,6 +52,7 @@ class WorkletRuntime : public jsi::HostObject,
         return;
       }
 
+      const auto lock = strongThis->createLock();
       strongThis->runGuarded(shareableWorklet);
     });
   }
@@ -65,6 +66,10 @@ class WorkletRuntime : public jsi::HostObject,
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propName) override;
 
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+
+  std::unique_lock<std::recursive_mutex> createLock() const {
+    return std::unique_lock<std::recursive_mutex>(*runtimeMutex_);
+  }
 
  private:
   const std::shared_ptr<std::recursive_mutex> runtimeMutex_;


### PR DESCRIPTION
## Summary

Currently, `runOnRuntime` does not implement any synchronization. This leads to crashes when worklet runtime is used directly (as `jsi::Runtime`) on another thread via `->getJSIRuntime()` and `runOnRuntime` is invoked from another thread.

This PR adds `createLock` method that returns a recursive lock. This lock is meant to be kept by each party that uses `jsi::Runtime`, including `runOnRuntime` in react-native-reanimated.

Fixes https://github.com/Expensify/react-native-live-markdown/issues/616.

## Test plan
