### PR TITLE
feat: CSS animation shorthand property

### DIFF
--- a/packages/react-native-reanimated/src/css/constants/settings.ts
+++ b/packages/react-native-reanimated/src/css/constants/settings.ts
@@ -39,3 +39,9 @@ export const VALID_PREDEFINED_TIMING_FUNCTIONS: PredefinedTimingFunction[] = [
   'step-start',
   'step-end',
 ];
+
+export const VALID_PARAMETRIZED_TIMING_FUNCTIONS: string[] = [
+  'cubic-bezier',
+  'steps',
+  'linear',
+];

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/animation/shorthand.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/animation/shorthand.ts
@@ -1,0 +1,6 @@
+'use strict';
+
+export function parseCSSAnimationShorthand(value: string) {
+  const parts = value.split(',');
+  return parts.map((part) => part.trim());
+}

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/common/index.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/common/index.ts
@@ -4,3 +4,4 @@ export {
   normalizeDuration,
   normalizeTimingFunction,
 } from './settings';
+export * from './shorthand';

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/common/shorthand.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/common/shorthand.ts
@@ -1,0 +1,75 @@
+'use strict';
+import type { ControlPoint, CSSTimingFunction } from '../../../../easings';
+import { cubicBezier, linear, steps } from '../../../../easings';
+import { ReanimatedError } from '../../../../errors';
+import {
+  isArrayOfLength,
+  isPercentage,
+  isPredefinedTimingFunction,
+  isStepsModifier,
+  splitByComma,
+  splitByWhitespace,
+} from '../../../../utils';
+
+function asControlPoint(value: string[]): ControlPoint | null {
+  const [first, ...rest] = value;
+  if (!first || isNaN(Number(first)) || !rest.every(isPercentage)) {
+    return null;
+  }
+  return [Number(first), ...rest];
+}
+
+export function parseTimingFunction(value: string): CSSTimingFunction {
+  if (isPredefinedTimingFunction(value)) {
+    return value;
+  }
+
+  // TODO: implement more strict check
+  const regex = /^(.+)\((.+)\)$/;
+  if (!regex.test(value)) {
+    throw new ReanimatedError(`Unsupported timing function: ${value}`);
+  }
+
+  const [, name, args] = value.match(regex)!;
+  const parsedArgs = splitByComma(args);
+
+  switch (name) {
+    case 'cubic-bezier': {
+      const numberArgs = parsedArgs.map(Number);
+      if (
+        isArrayOfLength(numberArgs, 4) &&
+        numberArgs.every((n) => !isNaN(n))
+      ) {
+        return cubicBezier(...numberArgs);
+      }
+      break;
+    }
+    case 'linear': {
+      const controlPoints = parsedArgs.map((arg) => {
+        const parts = splitByWhitespace(arg);
+        const controlPoint = asControlPoint(parts);
+        if (!controlPoint) {
+          throw new ReanimatedError(
+            `Invalid control point: ${arg} in ${value} timing function`
+          );
+        }
+        return controlPoint;
+      });
+      return linear(...controlPoints);
+    }
+    case 'steps': {
+      const stepsNumber = Number(parsedArgs[0]);
+      const stepsModifier = parsedArgs[1];
+      if (
+        !isNaN(stepsNumber) &&
+        stepsNumber > 0 &&
+        (stepsModifier === undefined || isStepsModifier(stepsModifier))
+      ) {
+        return steps(stepsNumber, stepsModifier);
+      }
+      break;
+    }
+  }
+
+  throw new ReanimatedError(`Invalid timing function: ${value}`);
+}

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/transition/__tests__/shorthand.test.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/transition/__tests__/shorthand.test.ts
@@ -1,10 +1,10 @@
 'use strict';
 import { cubicBezier, linear, steps } from '../../../../../easings';
-import type { ExpandedConfigProperties } from '../shorthand';
-import { parseTransitionShorthand } from '../shorthand';
+import type { ExpandedCSSTransitionConfigProperties } from '../shorthand';
+import { parseCSSTransitionShorthand } from '../shorthand';
 
-describe(parseTransitionShorthand, () => {
-  const emptyResult: ExpandedConfigProperties = {
+describe(parseCSSTransitionShorthand, () => {
+  const emptyResult: ExpandedCSSTransitionConfigProperties = {
     transitionProperty: [],
     transitionDuration: [],
     transitionTimingFunction: [],
@@ -13,8 +13,8 @@ describe(parseTransitionShorthand, () => {
   };
 
   const withDefaults = (
-    result: Partial<ExpandedConfigProperties>
-  ): ExpandedConfigProperties => ({
+    result: Partial<ExpandedCSSTransitionConfigProperties>
+  ): ExpandedCSSTransitionConfigProperties => ({
     ...emptyResult,
     ...result,
   });
@@ -88,10 +88,12 @@ describe(parseTransitionShorthand, () => {
           transitionTimingFunction: ['ease-out'],
         },
       ],
-    ] satisfies [string, Partial<ExpandedConfigProperties>][])(
+    ] satisfies [string, Partial<ExpandedCSSTransitionConfigProperties>][])(
       '%p',
       (input, expected) => {
-        expect(parseTransitionShorthand(input)).toEqual(withDefaults(expected));
+        expect(parseCSSTransitionShorthand(input)).toEqual(
+          withDefaults(expected)
+        );
       }
     );
   });
@@ -148,10 +150,12 @@ describe(parseTransitionShorthand, () => {
           transitionBehavior: ['allow-discrete', undefined, 'allow-discrete'],
         },
       ],
-    ] satisfies [string, Partial<ExpandedConfigProperties>][])(
+    ] satisfies [string, Partial<ExpandedCSSTransitionConfigProperties>][])(
       '%p',
       (input, expected) => {
-        expect(parseTransitionShorthand(input)).toEqual(withDefaults(expected));
+        expect(parseCSSTransitionShorthand(input)).toEqual(
+          withDefaults(expected)
+        );
       }
     );
   });
@@ -234,10 +238,12 @@ describe(parseTransitionShorthand, () => {
           transitionBehavior: ['allow-discrete', undefined],
         },
       ],
-    ] satisfies [string, Partial<ExpandedConfigProperties>][])(
+    ] satisfies [string, Partial<ExpandedCSSTransitionConfigProperties>][])(
       '%p',
       (input, expected) => {
-        expect(parseTransitionShorthand(input)).toEqual(withDefaults(expected));
+        expect(parseCSSTransitionShorthand(input)).toEqual(
+          withDefaults(expected)
+        );
       }
     );
   });

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/transition/config.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/transition/config.ts
@@ -21,8 +21,8 @@ import {
   normalizeTimingFunction,
 } from '../common';
 import { normalizeTransitionBehavior } from './settings';
-import type { ExpandedConfigProperties } from './shorthand';
-import { parseTransitionShorthand } from './shorthand';
+import type { ExpandedCSSTransitionConfigProperties } from './shorthand';
+import { parseCSSTransitionShorthand } from './shorthand';
 
 export const ERROR_MESSAGES = {
   invalidTransitionProperty: (
@@ -32,13 +32,13 @@ export const ERROR_MESSAGES = {
 
 function getExpandedConfigProperties(
   config: CSSTransitionProperties
-): ExpandedConfigProperties {
+): ExpandedCSSTransitionConfigProperties {
   const configEntries = Object.entries(config);
   const shorthandIndex = config.transition
     ? configEntries.findIndex(([key]) => key === 'transition')
     : -1;
   const result: AnyRecord = config.transition
-    ? parseTransitionShorthand(config.transition)
+    ? parseCSSTransitionShorthand(config.transition)
     : {};
   // If there is a shorthand `transition` property, all properties specified
   // before are ignored and only these specified later are taken into account
@@ -51,11 +51,11 @@ function getExpandedConfigProperties(
     result[key] = convertPropertyToArray(value);
   }
 
-  return result as ExpandedConfigProperties;
+  return result as ExpandedCSSTransitionConfigProperties;
 }
 
 const hasTransitionProperties = (
-  transitionProperty: ExpandedConfigProperties['transitionProperty']
+  transitionProperty: ExpandedCSSTransitionConfigProperties['transitionProperty']
 ): transitionProperty is string[] =>
   !!transitionProperty?.length &&
   transitionProperty.some((prop) => prop !== 'none');

--- a/packages/react-native-reanimated/src/css/platform/native/normalization/transition/shorthand.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/normalization/transition/shorthand.ts
@@ -1,6 +1,4 @@
 'use strict';
-import type { ControlPoint, CSSTimingFunction } from '../../../../easings';
-import { cubicBezier, linear, steps } from '../../../../easings';
 import { ReanimatedError } from '../../../../errors';
 import type {
   ConvertValuesToArraysWithUndefined,
@@ -9,21 +7,14 @@ import type {
 } from '../../../../types';
 import {
   camelizeKebabCase,
-  isArrayOfLength,
-  isPercentage,
-  isPredefinedTimingFunction,
-  isStepsModifier,
   isTimeUnit,
-  VALID_PREDEFINED_TIMING_FUNCTIONS_SET,
+  smellsLikeTimingFunction,
+  splitByComma,
+  splitByWhitespace,
 } from '../../../../utils';
+import { parseTimingFunction } from '../common';
 
-const VALID_PARAMETRIZED_TIMING_FUNCTIONS_SET = new Set<string>([
-  'cubic-bezier',
-  'steps',
-  'linear',
-]);
-
-export type ExpandedConfigProperties = Required<
+export type ExpandedCSSTransitionConfigProperties = Required<
   ConvertValuesToArraysWithUndefined<
     Omit<CSSTransitionProperties, 'transition' | 'transitionProperty'>
   >
@@ -31,8 +22,8 @@ export type ExpandedConfigProperties = Required<
   transitionProperty: string[];
 };
 
-export function parseTransitionShorthand(value: string) {
-  return splitByComma(value).reduce<ExpandedConfigProperties>(
+export function parseCSSTransitionShorthand(value: string) {
+  return splitByComma(value).reduce<ExpandedCSSTransitionConfigProperties>(
     (acc, part) => {
       const result = parseSingleTransitionShorthand(part);
       acc.transitionProperty.push(result.transitionProperty ?? 'all');
@@ -100,100 +91,4 @@ function parseSingleTransitionShorthand(
   }
 
   return result;
-}
-
-function splitByComma(str: string) {
-  // split by comma not enclosed in parentheses
-  const parts: string[] = [];
-  let current = '';
-  let depth = 0;
-  for (const char of str) {
-    if (char === '(') {
-      depth++;
-    } else if (char === ')') {
-      depth--;
-    } else if (char === ',' && depth === 0) {
-      parts.push(current.trim());
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-  parts.push(current.trim());
-  return parts;
-}
-
-function splitByWhitespace(str: string) {
-  // split by whitespace not enclosed in parentheses
-  return str.split(/\s+(?![^()]*\))/);
-}
-
-function smellsLikeTimingFunction(value: string) {
-  return (
-    VALID_PREDEFINED_TIMING_FUNCTIONS_SET.has(value) ||
-    VALID_PARAMETRIZED_TIMING_FUNCTIONS_SET.has(value.split('(')[0].trim())
-  );
-}
-
-function asControlPoint(value: string[]): ControlPoint | null {
-  const [first, ...rest] = value;
-  if (!first || isNaN(Number(first)) || !rest.every(isPercentage)) {
-    return null;
-  }
-  return [Number(first), ...rest];
-}
-
-function parseTimingFunction(value: string): CSSTimingFunction {
-  if (isPredefinedTimingFunction(value)) {
-    return value;
-  }
-
-  // TODO: implement more strict check
-  const regex = /^(.+)\((.+)\)$/;
-  if (!regex.test(value)) {
-    throw new ReanimatedError(`Unsupported timing function: ${value}`);
-  }
-
-  const [, name, args] = value.match(regex)!;
-  const parsedArgs = splitByComma(args);
-
-  switch (name) {
-    case 'cubic-bezier': {
-      const numberArgs = parsedArgs.map(Number);
-      if (
-        isArrayOfLength(numberArgs, 4) &&
-        numberArgs.every((n) => !isNaN(n))
-      ) {
-        return cubicBezier(...numberArgs);
-      }
-      break;
-    }
-    case 'linear': {
-      const controlPoints = parsedArgs.map((arg) => {
-        const parts = splitByWhitespace(arg);
-        const controlPoint = asControlPoint(parts);
-        if (!controlPoint) {
-          throw new ReanimatedError(
-            `Invalid control point: ${arg} in ${value} timing function`
-          );
-        }
-        return controlPoint;
-      });
-      return linear(...controlPoints);
-    }
-    case 'steps': {
-      const stepsNumber = Number(parsedArgs[0]);
-      const stepsModifier = parsedArgs[1];
-      if (
-        !isNaN(stepsNumber) &&
-        stepsNumber > 0 &&
-        (stepsModifier === undefined || isStepsModifier(stepsModifier))
-      ) {
-        return steps(stepsNumber, stepsModifier);
-      }
-      break;
-    }
-  }
-
-  throw new ReanimatedError(`Invalid timing function: ${value}`);
 }

--- a/packages/react-native-reanimated/src/css/utils/guards.ts
+++ b/packages/react-native-reanimated/src/css/utils/guards.ts
@@ -2,6 +2,7 @@
 import {
   ANIMATION_SETTINGS,
   TRANSITION_PROPS,
+  VALID_PARAMETRIZED_TIMING_FUNCTIONS,
   VALID_PREDEFINED_TIMING_FUNCTIONS,
   VALID_STEPS_MODIFIERS,
 } from '../constants';
@@ -25,10 +26,18 @@ export const VALID_PREDEFINED_TIMING_FUNCTIONS_SET = new Set<string>(
   VALID_PREDEFINED_TIMING_FUNCTIONS
 );
 
+export const VALID_PARAMETRIZED_TIMING_FUNCTIONS_SET = new Set<string>(
+  VALID_PARAMETRIZED_TIMING_FUNCTIONS
+);
+
 export const isPredefinedTimingFunction = (
   value: string
 ): value is PredefinedTimingFunction =>
   VALID_PREDEFINED_TIMING_FUNCTIONS_SET.has(value);
+
+export const smellsLikeTimingFunction = (value: string) =>
+  VALID_PREDEFINED_TIMING_FUNCTIONS_SET.has(value) ||
+  VALID_PARAMETRIZED_TIMING_FUNCTIONS_SET.has(value.split('(')[0].trim());
 
 export const isAnimationSetting = (
   key: string

--- a/packages/react-native-reanimated/src/css/utils/parsers.ts
+++ b/packages/react-native-reanimated/src/css/utils/parsers.ts
@@ -42,3 +42,29 @@ export function parseBoxShadowString(value: string) {
     return result;
   });
 }
+
+export function splitByComma(str: string) {
+  // split by comma not enclosed in parentheses
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (const char of str) {
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+    } else if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+export function splitByWhitespace(str: string) {
+  // split by whitespace not enclosed in parentheses
+  return str.split(/\s+(?![^()]*\))/);
+}


### PR DESCRIPTION
## Summary

This PR adds `CSSAnimationKeyframesRegistry` to store animation configuration objects that may be used by multiple views. 

In the previous implementation we created separate style interpolators for each `CSSAnimation` object in CPP, which is created separately for every animation on different views. 

The new implementation registers animation keyframes in the native side just once for the animation, so when the user creates an animation with `css.keyframes` and reuses it on multiple views, the same `AnimationStyleInterpolator` instance will be reused for each of views where the same animation is used.

Inline animation keyframes still work in the same way as before, so even if the same keyframes are used for multiple views, separate animations will be created for these views.

## Test plan

Open the example app and see that everything still works
