### PR TITLE
Fix iOS build with `USE_FRAMEWORKS=dynamic`

### DIFF
--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -153,4 +153,9 @@ Pod::Spec.new do |s|
   else
     install_modules_dependencies_legacy(s)
   end
+  s.dependency 'React-jsi'
+  using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
+  if using_hermes && !$config[:is_tvos_target]
+    s.dependency 'React-hermes'
+  end
 end


### PR DESCRIPTION
## Summary

This PR fixes the following iOS build errors reported by @kkafar when `USE_FRAMEWORKS=dynamic` is set:

![Screenshot 2025-02-14 at 10 56 53](https://github.com/user-attachments/assets/5ae47679-b488-4011-bc00-93fc6a7d53dc)

```
Undefined symbol: facebook::jsi::dynamicFromValue(facebook::jsi::Runtime&, facebook::jsi::Value const&, std::__1::function<bool (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)> const&)
```

This is just the minimal fix, I will remove `install_modules_dependencies_legacy` in an upcoming PR.

## Test plan

1. Add `ENV['USE_FRAMEWORKS'] = 'dynamic'` in `fabric-example/ios/Podfile`
2. Run `bundle install && bundle exec pod install`
3. Open fabric-example in Xcode using `xed ios`
4. Build fabric-example app
