### PR TITLE
Fix web layout transition

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationsManager.ts
@@ -233,9 +233,11 @@ export function tryActivateLayoutTransition<
     ?.presetName;
   const exitingAnimation = (props.layout as CustomConfig).exitingV?.presetName;
 
+  const deltaX = (snapshot.width - rect.width) / 2;
+  const deltaY = (snapshot.height - rect.height) / 2;
   const transitionData: TransitionData = {
-    translateX: snapshot.x - rect.x,
-    translateY: snapshot.y - rect.y,
+    translateX: snapshot.x - rect.x + deltaX,
+    translateY: snapshot.y - rect.y + deltaY,
     scaleX: snapshot.width / rect.width,
     scaleY: snapshot.height / rect.height,
     reversed: false, // This field is used only in `SequencedTransition`, so by default it will be false


### PR DESCRIPTION
## Summary

This PR fixes the transform computation for layout transitions on the web. It includes adjustments for the layout shift to the initial transform that occurs after a component's scale changes.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/2decffaf-532b-4226-a307-c8b2b1e23375" /> | <video src="https://github.com/user-attachments/assets/574de97c-b51c-456f-8036-5de66801a669" /> |

## Test plan

<details>
<summary>Test Example code</summary>

```js
import { Button } from '@/apps/css/components';
import React, { useState } from 'react';
import { StyleSheet, View } from 'react-native';
import Animated, { LinearTransition } from 'react-native-reanimated';

export default function EmptyExample() {
  const [toggle, setToggle] = useState(true);
  return (
    <View style={styles.container}>
      <Button onPress={() => setToggle(!toggle)} title="Toggle" />
      {toggle && <View style={styles.block}/>}
      <View style={{ flexDirection: 'row' }}>
        <Animated.View style={[
            { backgroundColor: 'red', borderWidth: 2, zIndex: 1 },
            toggle ? { width: 100, height: 100 } : { width: 200, height: 200 }
          ]} 
          layout={LinearTransition} />
        {toggle && <View style={styles.block}/>}
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {},
  block: {
    width: 100,
    height: 100,
    backgroundColor: 'blue',
    borderWidth: 2,
  }
});

```

</details>
