### PR TITLE
[Android] Add support for 16KB page size

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -263,7 +263,8 @@ android {
                         "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
                         "-DREANIMATED_PROFILING=${REANIMATED_PROFILING}",
                         "-DREANIMATED_VERSION=${REANIMATED_VERSION}",
-                        "-DHAS_EXTERNAL_WORKLETS=${hasExternalWorklets}"
+                        "-DHAS_EXTERNAL_WORKLETS=${hasExternalWorklets}",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
                 if(hasExternalWorklets){
                     targets("reanimated")

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -250,7 +250,8 @@ android {
                         "-DJS_RUNTIME=${JS_RUNTIME}",
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
-                        "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}"
+                        "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
                 targets("worklets")
             }


### PR DESCRIPTION
## Description

Starting from Android 15 devices can use 16KB page size instead of 4KB. Apps that take advantage of this require additional linker flag.

This PR adds aforementioned flag so that apps that use Reanimated don't crash.

>[!NOTE]
> More info can be found [here](https://developer.android.com/guide/practices/page-sizes)

## Test plan

Tested on fabric-example on AVD with 16KB page size.