### PR TITLE
Backport changes to 3.17

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -255,7 +255,8 @@ android {
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                         "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
-                        "-DREANIMATED_VERSION=${REANIMATED_VERSION}"
+                        "-DREANIMATED_VERSION=${REANIMATED_VERSION}",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
                 targets("reanimated", "worklets")
             }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -632,7 +632,7 @@ export function createAnimatedComponent(
     Component.displayName || Component.name || 'Component'
   })`;
 
-  return React.forwardRef<Component>((props, ref) => {
+  const animatedComponent = React.forwardRef<Component>((props, ref) => {
     return (
       <AnimatedComponent
         {...props}
@@ -640,4 +640,9 @@ export function createAnimatedComponent(
       />
     );
   });
+
+  animatedComponent.displayName =
+    Component.displayName || Component.name || 'Component';
+
+  return animatedComponent;
 }

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -250,7 +250,8 @@ android {
                         "-DJS_RUNTIME=${JS_RUNTIME}",
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
-                        "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}"
+                        "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
             }
         }


### PR DESCRIPTION
## Summary

This PR contains cherry-picked commits that should be backported to 3.17

- https://github.com/software-mansion/react-native-reanimated/pull/6978
- https://github.com/software-mansion/react-native-reanimated/pull/7037
## Test plan
