### PR TITLE
Cherry-pick for 3.17.0

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -233,7 +233,7 @@ jsi::Value ReanimatedModuleProxy::createWorkletRuntime(
       workletsModuleProxy_->getJSQueue(),
       workletsModuleProxy_->getJSScheduler(),
       name.asString(rt).utf8(rt),
-      false /* supportsLocking */,
+      true /* supportsLocking */,
       valueUnpackerCode_);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
       rt, initializer, "[Reanimated] Initializer must be a worklet.");


### PR DESCRIPTION
## Summary

This PR cherry-picks the following PRs to `3.17-stable` branch:
* https://github.com/software-mansion/react-native-reanimated/pull/7033

## Test plan
