### PR TITLE
Handle component internal animated ref

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -123,6 +123,7 @@ export interface IAnimatedComponentInternal {
    * It is not related to event handling.
    */
   getComponentViewTag: () => number;
+  hasAnimatedRef: () => boolean;
 }
 
 export type NestedArray<T> = T | NestedArray<T>[];

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -39,6 +39,7 @@ export default class AnimatedComponent<
   _viewInfo?: ViewInfo;
   _planStyle: CSSStyle = {};
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
+  _hasAnimatedRef = false;
   // Used only on web
   _componentDOMRef: HTMLElement | null = null;
 
@@ -49,6 +50,10 @@ export default class AnimatedComponent<
 
   getComponentViewTag() {
     return this._getViewInfo().viewTag as number;
+  }
+
+  hasAnimatedRef() {
+    return this._hasAnimatedRef;
   }
 
   _onSetLocalRef() {
@@ -128,6 +133,7 @@ export default class AnimatedComponent<
     // Component can specify ref which should be animated when animated version of the component is created.
     // Otherwise, we animate the component itself.
     if (componentRef && componentRef.getAnimatableRef) {
+      this._hasAnimatedRef = true;
       return componentRef.getAnimatableRef();
     }
     // Case for SVG components on Web

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -81,7 +81,7 @@ export function findHostInstance(
   resolveFindHostInstance_DEPRECATED();
   /*
     The Fabric implementation of `findHostInstance_DEPRECATED` requires a React ref as an argument
-    rather than a native ref. If a component implements the `hasAnimatedRef` method, it must use 
+    rather than a native ref. If a component implements the `getAnimatableRef` method, it must use 
     the ref provided by this method. It is the component's responsibility to ensure that this is 
     a valid React ref.
   */

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -79,10 +79,15 @@ export function findHostInstance(
   }
 
   resolveFindHostInstance_DEPRECATED();
-  // Fabric implementation of findHostInstance_DEPRECATED doesn't accept a ref as an argument
+  /*
+    The Fabric implementation of `findHostInstance_DEPRECATED` requires a React ref as an argument
+    rather than a native ref. If a component implements the `hasAnimatedRef` method, it must use 
+    the ref provided by this method. It is the component's responsibility to ensure that this is 
+    a valid React ref.
+  */
   return findHostInstance_DEPRECATED(
-    isFabric()
-      ? component
-      : (component as IAnimatedComponentInternal)._componentRef
+    !isFabric() || (component as IAnimatedComponentInternal).hasAnimatedRef()
+      ? (component as IAnimatedComponentInternal)._componentRef
+      : component
   );
 }


### PR DESCRIPTION
## Summary

A reference provided by the component via `getAnimatableRef()` should always take precedence over a reference received through `_setLocalRef()`

Fixes https://github.com/expo/expo/issues/32781

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/853e5a4c-4e8b-42cd-ab06-a26cb9db9e08" /> | <video src="https://github.com/user-attachments/assets/b87c758f-901e-488d-9ff0-7f5b44f76aac" /> |

## Test plan

Based on repro: https://github.com/jakex7/expo-32781
<details>
<summary>code</summary>

```js
import { BlurView } from "expo-blur";
import React, { useEffect } from "react";
import { Image, StyleSheet, Text, View } from "react-native";
import Animated, {
  useAnimatedProps,
  useSharedValue,
  withRepeat,
  withTiming,
} from "react-native-reanimated";

Animated.addWhitelistedNativeProps({ intensity: true });
const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);

export default function Test() {
  const animatedIntensity = useSharedValue<number | undefined>(0);

  useEffect(() => {
    animatedIntensity.value = withRepeat(
      withTiming(100, { duration: 2000 }),
      -1,
      true
      );
  }, []);

  return (
    <View style={styles.container}>
      <View style={styles.innerContainer}>
        <Image
          style={styles.image}
          source={{ uri: "https://source.unsplash.com/300x300" }}
        />
        <Text style={styles.blurredText}>This text is blurred</Text>

        <AnimatedBlurView
          style={styles.blurView}
          tint={"dark"}
          intensity={animatedIntensity}
        >
          <Text style={styles.nonBlurredText}>text</Text>
        </AnimatedBlurView>
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    alignItems: "center",
    justifyContent: "center",
    padding: 6,
  },
  innerContainer: {
    alignItems: "center",
    justifyContent: "center",
  },
  image: {
    width: 250,
    height: 250,
  },
  blurredText: {
    position: "absolute",
    padding: 10,
    backgroundColor: "rgb(120,20,20)",
    color: "white",
    fontWeight: "bold",
    fontSize: 20,
    borderRadius: 5,
  },
  blurView: {
    ...StyleSheet.absoluteFillObject,
    alignItems: "center",
    paddingTop: 20,
  },
  nonBlurredText: {
    paddingHorizontal: 10,
    paddingVertical: 4,
    backgroundColor: "rgb(120,20,20)",
    color: "white",
    fontWeight: "bold",
    fontSize: 18,
  },
});


```

</details>
