### PR TITLE
docs: Add missing information about animated styles precedence

### DIFF
--- a/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
@@ -77,6 +77,32 @@ import AnimatingStylesSrc from '!!raw-loader!@site/src/examples/AnimatingStyles'
 
 ## Remarks
 
+- Animated styles (also inline) take precedence over React Native's static styles. All values that are specified in animated styles override values from static styles.
+
+<Indent>
+
+```jsx
+function App() {
+  const animatedStyles = useAnimatedStyle(() => ({
+    width: sv.value,
+  }));
+
+  // highlight-next-line
+  return (
+    <Animated.View
+      style={[
+        animatedStyles, // ⚠️ overrides the static style width
+        { width: 100 },
+      ]}
+    />
+  );
+}
+```
+
+</Indent>
+
+- Animated styles (also inline) don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+
 - Mutating shared values in `useAnimatedStyle`'s callback is an undefined behavior which may lead to infinite loops.
 
 <Indent>

--- a/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
@@ -87,12 +87,13 @@ function App() {
     width: sv.value,
   }));
 
-  // highlight-next-line
   return (
     <Animated.View
       style={[
+        // highlight-start
         animatedStyles, // ⚠️ overrides the static style width
         { width: 100 },
+        // highlight-end
       ]}
     />
   );

--- a/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedStyle.mdx
@@ -77,7 +77,7 @@ import AnimatingStylesSrc from '!!raw-loader!@site/src/examples/AnimatingStyles'
 
 ## Remarks
 
-- Animated styles (also inline) take precedence over React Native's static styles. All values that are specified in animated styles override values from static styles.
+- Animated styles take precedence over React Native's static styles. All values specified in animated styles override values from static styles.
 
 <Indent>
 
@@ -101,7 +101,9 @@ function App() {
 
 </Indent>
 
-- Animated styles (also inline) don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+- Animated styles don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+
+- Removing the animated style from the view doesn't unset values that were applied in the animated style. To unset these values, you need to manually set them to `undefined` in the animated style.
 
 - Mutating shared values in `useAnimatedStyle`'s callback is an undefined behavior which may lead to infinite loops.
 

--- a/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
@@ -77,6 +77,32 @@ import AnimatingStylesSrc from '!!raw-loader!@site/src/examples/AnimatingStyles'
 
 ## Remarks
 
+- Animated styles (also inline) take precedence over React Native's static styles. All values that are specified in animated styles override values from static styles.
+
+<Indent>
+
+```jsx
+function App() {
+  const animatedStyles = useAnimatedStyle(() => ({
+    width: sv.value,
+  }));
+
+  // highlight-next-line
+  return (
+    <Animated.View
+      style={[
+        animatedStyles, // ⚠️ overrides the static style width
+        { width: 100 },
+      ]}
+    />
+  );
+}
+```
+
+</Indent>
+
+- Animated styles (also inline) don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+
 - Mutating shared values in `useAnimatedStyle`'s callback is an undefined behavior which may lead to infinite loops.
 
 <Indent>

--- a/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
@@ -87,12 +87,13 @@ function App() {
     width: sv.value,
   }));
 
-  // highlight-next-line
   return (
     <Animated.View
       style={[
+        // highlight-start
         animatedStyles, // ⚠️ overrides the static style width
         { width: 100 },
+        // highlight-end
       ]}
     />
   );

--- a/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/core/useAnimatedStyle.mdx
@@ -77,7 +77,7 @@ import AnimatingStylesSrc from '!!raw-loader!@site/src/examples/AnimatingStyles'
 
 ## Remarks
 
-- Animated styles (also inline) take precedence over React Native's static styles. All values that are specified in animated styles override values from static styles.
+- Animated styles take precedence over React Native's static styles. All values specified in animated styles override values from static styles.
 
 <Indent>
 
@@ -101,7 +101,9 @@ function App() {
 
 </Indent>
 
-- Animated styles (also inline) don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+- Animated styles don't follow the order in which they are specified in the style array. The last updated animated style is the one that takes effect.
+
+- Removing the animated style from the view doesn't unset values that were applied in the animated style. To unset these values, you need to manually set them to `undefined` in the animated style.
 
 - Mutating shared values in `useAnimatedStyle`'s callback is an undefined behavior which may lead to infinite loops.
 


### PR DESCRIPTION
## Summary

Refers to the issue: #7067

This PR adds missing information about animated styles behavior to the remarks section of the `useAnimatedStyle` documentation page.

We should add proper precedence support in the future, but for now, until we figure out a valid solution to this problem, we should include information about this behavior in docs.

## Screenshot

![Screenshot 2025-02-21 at 18 20 23](https://github.com/user-attachments/assets/7feed974-9ac3-406b-ba52-0eb224713b33)

## Test plan

Build docs and open the `useAnimatedStyle` hook docs.