### PR TITLE
cherry-pick: Fix getAnimatedStyle error when called with component that doesn't have animated styles #6746

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -29,7 +29,8 @@ const defaultFramerateConfig = {
   fps: 60,
 };
 
-const isEmpty = (obj: object) => Object.keys(obj).length === 0;
+const isEmpty = (obj: object | undefined) =>
+  !obj || Object.keys(obj).length === 0;
 const getStylesFromObject = (obj: object) => {
   return obj === undefined
     ? {}
@@ -94,7 +95,7 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
 
   const inlineStyles = getStylesFromObject(jestInlineStyles);
 
-  currentStyle = isEmpty(jestAnimatedStyleValue as object)
+  currentStyle = isEmpty(jestAnimatedStyleValue as object | undefined)
     ? { ...styleObject, ...inlineStyles }
     : { ...styleObject, ...jestAnimatedStyleValue };
 


### PR DESCRIPTION
cherry-pick: https://github.com/software-mansion/react-native-reanimated/pull/6746