### PR TITLE
docs: fix animationName "to" keyword

### DIFF
--- a/packages/docs-reanimated/docs/css-animations/animation-name.mdx
+++ b/packages/docs-reanimated/docs/css-animations/animation-name.mdx
@@ -59,7 +59,7 @@ A JavaScript object with offset values used as keys and corresponding style prop
 
 - `<percentage>` - a string which is a number between `0` and `100` followed by `%`,
 - `from` - an alias for `0%` offset,
-- `end`- an alias for `100%` offset.
+- `to`- an alias for `100%` offset.
 - `<number>` - a floating-point number between `0` and `1`.
 
 Keyframes can be defined inline (and provided directly to `animationName` property) or as a separate variable:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This is just a mistake in docs. `to` is the correct keyword https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes#to

## Test plan

`end` just doesn't work. `to` works like a charm.