### PR TITLE
fix: CSS transitions glitches after upgrade to RN 0.78

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -34,6 +34,10 @@ folly::dynamic CSSTransition::getCurrentInterpolationStyle() const {
   return styleInterpolator_.interpolate(shadowNode_, progressProvider_);
 }
 
+TransitionProperties CSSTransition::getProperties() const {
+  return properties_;
+}
+
 PropertyNames CSSTransition::getAllowedProperties(
     const folly::dynamic &oldProps,
     const folly::dynamic &newProps) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -25,6 +25,7 @@ class CSSTransition {
   double getMinDelay(double timestamp) const;
   TransitionProgressState getState() const;
   folly::dynamic getCurrentInterpolationStyle() const;
+  TransitionProperties getProperties() const;
   PropertyNames getAllowedProperties(
       const folly::dynamic &oldProps,
       const folly::dynamic &newProps);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
@@ -47,8 +47,8 @@ void CSSTransitionsRegistry::updateSettings(
   // Replace style overrides with the new ones if transition properties were
   // updated (we want to keep overrides only for transitioned properties)
   if (config.properties.has_value()) {
-    const auto &currentStyle = transition->getCurrentInterpolationStyle();
-    setInUpdatesRegistry(transition->getShadowNode(), currentStyle);
+    updateInUpdatesRegistry(
+        transition, transition->getCurrentInterpolationStyle());
   }
 }
 
@@ -143,11 +143,42 @@ PropsObserver CSSTransitionsRegistry::createPropsObserver(const Tag viewTag) {
           strongThis->getUpdatesFromRegistry(shadowNode->getTag());
       const auto &transitionStartStyle = transition->run(
           changedProps, lastUpdates, strongThis->getCurrentTimestamp_());
-
-      strongThis->setInUpdatesRegistry(shadowNode, transitionStartStyle);
+      strongThis->updateInUpdatesRegistry(transition, transitionStartStyle);
       strongThis->scheduleOrActivateTransition(transition);
     }
   };
+}
+
+void CSSTransitionsRegistry::updateInUpdatesRegistry(
+    const std::shared_ptr<CSSTransition> &transition,
+    const folly::dynamic &updates) {
+  const auto &shadowNode = transition->getShadowNode();
+  const auto &lastUpdates = getUpdatesFromRegistry(shadowNode->getTag());
+  const auto &transitionProperties = transition->getProperties();
+
+  folly::dynamic filteredUpdates = folly::dynamic::object;
+
+  if (!transitionProperties.has_value()) {
+    // If transitionProperty is set to 'all' (optional has no value), we have
+    // to keep the result of the previous transition updated with the new
+    // transition starting values
+    if (!lastUpdates.empty()) {
+      filteredUpdates = lastUpdates;
+    }
+  } else if (!lastUpdates.empty()) {
+    // Otherwise, we keep only allowed properties from the last updates
+    // and update the object with the new transition starting values
+    for (const auto &prop : transitionProperties.value()) {
+      if (lastUpdates.count(prop)) {
+        filteredUpdates[prop] = lastUpdates[prop];
+      }
+    }
+  }
+
+  // updates object contains only allowed properties so we don't need
+  // to do additional filtering here
+  filteredUpdates.update(updates);
+  setInUpdatesRegistry(shadowNode, filteredUpdates);
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
@@ -30,7 +30,6 @@ class CSSTransitionsRegistry
   void add(const std::shared_ptr<CSSTransition> &transition);
   void remove(Tag viewTag);
   void updateSettings(Tag viewTag, const PartialCSSTransitionConfig &config);
-  void collectProps(PropsMap &propsMap) override;
 
   void update(double timestamp);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
@@ -30,6 +30,7 @@ class CSSTransitionsRegistry
   void add(const std::shared_ptr<CSSTransition> &transition);
   void remove(Tag viewTag);
   void updateSettings(Tag viewTag, const PartialCSSTransitionConfig &config);
+  void collectProps(PropsMap &propsMap) override;
 
   void update(double timestamp);
 
@@ -48,6 +49,9 @@ class CSSTransitionsRegistry
   void scheduleOrActivateTransition(
       const std::shared_ptr<CSSTransition> &transition);
   PropsObserver createPropsObserver(Tag viewTag);
+  void updateInUpdatesRegistry(
+      const std::shared_ptr<CSSTransition> &transition,
+      const folly::dynamic &updates);
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -13,16 +13,14 @@ folly::dynamic UpdatesRegistry::get(const Tag tag) const {
   return it->second.second;
 }
 
-void UpdatesRegistry::flushUpdates(
-    UpdatesBatch &updatesBatch,
-    const bool merge) {
+void UpdatesRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
   std::lock_guard<std::mutex> lock{mutex_};
 
   auto copiedUpdatesBatch = std::move(updatesBatch_);
   updatesBatch_.clear();
 
   // Store all updates in the registry for later use in the commit hook
-  flushUpdatesToRegistry(copiedUpdatesBatch, merge);
+  flushUpdatesToRegistry(copiedUpdatesBatch);
   // Flush the updates to the updatesBatch used to apply current changes
   for (auto &[shadowNode, props] : copiedUpdatesBatch) {
     updatesBatch.emplace_back(shadowNode, std::move(props));
@@ -81,14 +79,12 @@ void UpdatesRegistry::removeFromUpdatesRegistry(const Tag tag) {
   updatesRegistry_.erase(tag);
 }
 
-void UpdatesRegistry::flushUpdatesToRegistry(
-    const UpdatesBatch &updatesBatch,
-    const bool merge) {
+void UpdatesRegistry::flushUpdatesToRegistry(const UpdatesBatch &updatesBatch) {
   for (auto &[shadowNode, props] : updatesBatch) {
     const auto tag = shadowNode->getTag();
     auto it = updatesRegistry_.find(tag);
 
-    if (it == updatesRegistry_.cend() || !merge) {
+    if (it == updatesRegistry_.cend()) {
       updatesRegistry_[tag] = std::make_pair(shadowNode, props);
     } else {
       it->second.second.update(props);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
@@ -40,12 +40,13 @@ class UpdatesRegistry {
   void collectPropsToRevert(PropsToRevertMap &propsToRevertMap);
 #endif
 
-  void flushUpdates(UpdatesBatch &updatesBatch, bool merge);
-  void collectProps(PropsMap &propsMap);
+  void flushUpdates(UpdatesBatch &updatesBatch);
+  virtual void collectProps(PropsMap &propsMap);
 
  protected:
   mutable std::mutex mutex_;
   std::unordered_set<Tag> tagsToRemove_;
+  RegistryMap updatesRegistry_;
 
   void addUpdatesToBatch(
       const ShadowNode::Shared &shadowNode,
@@ -58,9 +59,8 @@ class UpdatesRegistry {
 
  private:
   UpdatesBatch updatesBatch_;
-  RegistryMap updatesRegistry_;
 
-  void flushUpdatesToRegistry(const UpdatesBatch &updatesBatch, bool merge);
+  void flushUpdatesToRegistry(const UpdatesBatch &updatesBatch);
   void runMarkedRemovals();
 
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
@@ -41,7 +41,7 @@ class UpdatesRegistry {
 #endif
 
   void flushUpdates(UpdatesBatch &updatesBatch);
-  virtual void collectProps(PropsMap &propsMap);
+  void collectProps(PropsMap &propsMap);
 
  protected:
   mutable std::mutex mutex_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -852,16 +852,16 @@ void ReanimatedModuleProxy::performOperations() {
 
       // Update CSS transitions and flush updates
       cssTransitionsRegistry_->update(currentCssTimestamp_);
-      cssTransitionsRegistry_->flushUpdates(updatesBatch, false);
+      cssTransitionsRegistry_->flushUpdates(updatesBatch);
     }
 
     // Flush all animated props updates
-    animatedPropsRegistry_->flushUpdates(updatesBatch, true);
+    animatedPropsRegistry_->flushUpdates(updatesBatch);
 
     if (shouldUpdateCssAnimations_) {
       // Update CSS animations and flush updates
       cssAnimationsRegistry_->update(currentCssTimestamp_);
-      cssAnimationsRegistry_->flushUpdates(updatesBatch, true);
+      cssAnimationsRegistry_->flushUpdates(updatesBatch);
     }
 
     shouldUpdateCssAnimations_ = false;


### PR DESCRIPTION
## Summary

This PR fixes:

> 4. [CSS] Transitions aren't triggered / run between invalid states (it is strange as transitions on the transition routes screen work but they are triggered by the state change from the setInterval. Only transitions triggered manually don't work)

from the #7065 PR.

### What caused the issue?

(I am not sure about the exact cause but I deduced that based on my observations)

It looks like the Shadow Tree committing logic changed in RN and, when we prevented react from committing its changes to the Shadow Tree (which is what we actually do to prevent applying changes before the CSS transition starts), it was unaware of which values are were passed in the view props on the JS side. Because of that, when the next commit from React was triggered, it included old props (not props that were last passed as the view style but some previous values from the last React commit that weren't modified by us).

It worked in a different way before (in RN 0.77) and React was able to include last style values in its commit, even though we prevented it from committing them before.

### How this PR fixes the issue?

Instead of keeping only the currently transitioned style value in the CSS transitions updates registry we now store all properties that were transitioned before and are transitioned now. We only remove these props from the registry that cannot be transitioned (aren't listed in the `transitionProperty` vector). All other props are kept as long as the view exists and has CSS transition attached.

Since these props are transitioned, we don't have to remove them. Keeping it longer makes it possible to override invalid props in the RN's commit by the last values of the previous transition instead of some old invalid props that RN is trying to commit.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/297c54b2-eb49-41a5-8472-81cb301f7a99" /> | <video src="https://github.com/user-attachments/assets/a8e8a655-373f-4a01-8129-9d4268597e45" /> |

## Test plan

Open transition examples, such as the **App Settings** screen and observe the difference.