### PR TITLE
Add build from source snippet in fabric-example on Android

### DIFF
--- a/apps/fabric-example/android/settings.gradle
+++ b/apps/fabric-example/android/settings.gradle
@@ -4,3 +4,14 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autoli
 rootProject.name = 'FabricExample'
 include ':app'
 includeBuild('../../../node_modules/@react-native/gradle-plugin')
+
+// Build from source (https://reactnative.dev/contributing/how-to-build-from-source)
+// NOTE: Please do not remove these lines even though they are commented out.
+// includeBuild('../../../node_modules/react-native') {
+//     dependencySubstitution {
+//         substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
+//         substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
+//         substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+//         substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
+//     }
+// }


### PR DESCRIPTION
## Summary

This PR adds a comment in `fabric-example/android/settings.gradle` with code snippet that enables building React Native from source copied from [React Native docs](https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source).

## Test plan
