### PR TITLE
Remove JS runtime logic from Reanimated build.gradle

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -16,8 +16,7 @@ string(
   CMAKE_CXX_FLAGS
   " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}\
     -DREANIMATED_PROFILING=${REANIMATED_PROFILING}\
-    -DREANIMATED_VERSION=${REANIMATED_VERSION}\
-    -DHERMES_ENABLE_DEBUGGER=${HERMES_ENABLE_DEBUGGER}")
+    -DREANIMATED_VERSION=${REANIMATED_VERSION}")
 
 string(APPEND CMAKE_CXX_FLAGS
        " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all\
@@ -34,21 +33,6 @@ endif()
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
   string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG")
 endif()
-
-if(${JS_RUNTIME} STREQUAL "hermes")
-  string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_HERMES=1")
-elseif(${JS_RUNTIME} STREQUAL "jsc")
-  string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_JSC=1")
-elseif(${JS_RUNTIME} STREQUAL "v8")
-  string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_V8=1")
-else()
-  message(FATAL_ERROR "Unknown JS runtime ${JS_RUNTIME}.")
-endif()
-
-# Resolves "CMake Warning: Manually-specified variables were not used by the
-# project" when any of the following variables is not used in some build
-# configuration.
-set(IGNORE_ME "${JS_RUNTIME_DIR}")
 
 set(BUILD_DIR "${CMAKE_SOURCE_DIR}/build")
 set(ANDROID_CPP_DIR "${CMAKE_SOURCE_DIR}/src/main/cpp")

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -79,38 +79,6 @@ version REANIMATED_VERSION
 
 def reanimatedPrefabHeadersDir = project.file("$buildDir/prefab-headers/reanimated")
 
-def JS_RUNTIME = {
-    // Override JS runtime with environment variable
-    if (System.getenv("JS_RUNTIME")) {
-        return System.getenv("JS_RUNTIME")
-    }
-
-    // Enable V8 runtime if react-native-v8 is installed
-    def v8Project = rootProject.getSubprojects().find { project -> project.name == "react-native-v8" }
-    if (v8Project != null) {
-        return "v8"
-    }
-
-    // Check if Hermes is enabled in app setup
-    def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
-    if (appProject?.hermesEnabled?.toBoolean() || appProject?.ext?.react?.enableHermes?.toBoolean()) {
-        return "hermes"
-    }
-
-    // Use JavaScriptCore (JSC) by default
-    return "jsc"
-}.call()
-
-def jsRuntimeDir = {
-    if (JS_RUNTIME == "hermes") {
-        return Paths.get(reactNativeRootDir.path, "sdks", "hermes")
-    } else if (JS_RUNTIME == "v8") {
-        return findProject(":react-native-v8").getProjectDir().getParent()
-    } else {
-        return Paths.get(reactNativeRootDir.path, "ReactCommon", "jsi")
-    }
-}.call()
-
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -179,8 +147,6 @@ android {
                         "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeRootDir.path)}",
-                        "-DJS_RUNTIME=${JS_RUNTIME}",
-                        "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                         "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
                         "-DREANIMATED_PROFILING=${REANIMATED_PROFILING}",
@@ -201,24 +167,8 @@ android {
     }
     buildTypes {
         debug {
-            externalNativeBuild {
-                cmake {
-                    if (JS_RUNTIME == "hermes") {
-                        arguments "-DHERMES_ENABLE_DEBUGGER=1"
-                    } else {
-                        arguments "-DHERMES_ENABLE_DEBUGGER=0"
-                    }
-                }
-            }
             packagingOptions {
                 doNotStrip "**/**/*.so"
-            }
-        }
-        release {
-            externalNativeBuild {
-                cmake {
-                    arguments "-DHERMES_ENABLE_DEBUGGER=0"
-                }
             }
         }
     }
@@ -334,9 +284,6 @@ dependencies {
     implementation "androidx.core:core:1.6.0"
 
     implementation "com.facebook.react:react-android" // version substituted by RNGP
-    if (JS_RUNTIME == "hermes") {
-        implementation "com.facebook.react:hermes-android" // version substituted by RNGP
-    }
  
     if (project != rootProject) {
         // This is needed for linting in Reanimated's repo.
@@ -344,15 +291,4 @@ dependencies {
     }
 }
 
-afterEvaluate {
-    preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)
-
-    if (JS_RUNTIME == "v8") {
-        def buildTasks = tasks.findAll({ task ->
-            !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake") || task.name.startsWith("generateJsonModel")) })
-        buildTasks.forEach { task ->
-            def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
-            task.dependsOn(":react-native-v8:copy${buildType}JniLibsProjectOnly")
-        }
-    }
-}
+preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/CMakeLists.txt
@@ -12,10 +12,6 @@ find_package(react-native-worklets REQUIRED CONFIG)
 add_library(reanimated SHARED ${REANIMATED_COMMON_CPP_SOURCES}
                               ${REANIMATED_ANDROID_CPP_SOURCES})
 
-if(${JS_RUNTIME} STREQUAL "hermes")
-  find_package(hermes-engine REQUIRED CONFIG)
-endif()
-
 target_include_directories(
   reanimated
   PRIVATE "${COMMON_CPP_DIR}"

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -72,7 +72,6 @@ def REACT_NATIVE_MINOR_VERSION = getReactNativeMinorVersion()
 def WORKLETS_VERSION = getWorkletsVersion()
 def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 def IS_REANIMATED_EXAMPLE_APP = safeAppExtGet("isReanimatedExampleApp", false)
-def REANIMATED_PROFILING = safeAppExtGet("enableReanimatedProfiling", false)
 
 // Set version for prefab
 version WORKLETS_VERSION

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -308,9 +308,9 @@ dependencies {
     }
 }
 
-afterEvaluate {
-    preBuild.dependsOn(prepareWorkletsHeadersForPrefabs)
+preBuild.dependsOn(prepareWorkletsHeadersForPrefabs)
 
+afterEvaluate {
     if (JS_RUNTIME == "v8") {
         def buildTasks = tasks.findAll({ task ->
             !task.name.contains("Clean") && (task.name.contains("externalNative") || task.name.contains("CMake") || task.name.startsWith("generateJsonModel")) })


### PR DESCRIPTION
## Summary

This PR removes logic related to JS runtime (including Hermes dependency) from build.gradle in react-native-reanimated.

I also moved dependency on `preBuild` task outside of `afterEvaluate` to align it with React Native and other third-party libraries.

## Test plan
