### PR TITLE
fix: Cubes example invalid matrix transform usage error

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/CubesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/CubesExample.tsx
@@ -221,8 +221,10 @@ function CubeWithEulerAngles() {
       multiplyInto(matrix, matrix, it);
       transformOrigin(matrix, origin);
 
+      matrix[11] = -1 / 1000; // Apply perspective
+
       return {
-        transform: [{ perspective: 1000 }, { matrix }],
+        transform: [{ matrix }],
         backgroundColor: sidesColors[i],
       };
     })
@@ -260,8 +262,10 @@ function CubeWithQuaternions() {
       const matrix = quaternionToMatrix(q);
       transformOrigin(matrix, origin);
 
+      matrix[11] = -1 / 1000; // Apply perspective
+
       return {
-        transform: [{ perspective: 1000 }, { matrix }],
+        transform: [{ matrix }],
         backgroundColor: sidesColors[i],
       };
     })


### PR DESCRIPTION
## Summary

Fixes https://github.com/orgs/software-mansion/projects/45?pane=issue&itemId=99380895

## Example recording

You can see that everything works

https://github.com/user-attachments/assets/c5a152b7-e3e0-48ac-9c42-2f6941406228

