### PR TITLE
Restore `JSScheduler::scheduleOnJS` method

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.cpp
@@ -1,20 +1,10 @@
 #include <worklets/Tools/JSScheduler.h>
 
-#include <utility>
-
-using namespace facebook;
-using namespace react;
-
 namespace worklets {
 
-JSScheduler::JSScheduler(
-    jsi::Runtime &rnRuntime,
-    const std::shared_ptr<CallInvoker> &jsCallInvoker)
-    : scheduleOnJS([&](Job job) {
-        jsCallInvoker_->invokeAsync(
-            [job = std::move(job), &rt = rnRuntime_] { job(rt); });
-      }),
-      rnRuntime_(rnRuntime),
-      jsCallInvoker_(jsCallInvoker) {}
+void JSScheduler::scheduleOnJS(Job job) {
+  jsCallInvoker_->invokeAsync(
+      [job = std::move(job), &rt = rnRuntime_] { job(rt); });
+}
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ReactCommon/CallInvoker.h>
-#include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 
 #include <memory>
@@ -17,13 +16,14 @@ class JSScheduler {
  public:
   explicit JSScheduler(
       jsi::Runtime &rnRuntime,
-      const std::shared_ptr<CallInvoker> &jsCallInvoker);
+      const std::shared_ptr<CallInvoker> &jsCallInvoker)
+      : rnRuntime_(rnRuntime), jsCallInvoker_(jsCallInvoker) {}
 
-  const std::function<void(Job)> scheduleOnJS = nullptr;
+  void scheduleOnJS(std::function<void(jsi::Runtime &rt)> job);
 
  protected:
   jsi::Runtime &rnRuntime_;
-  const std::shared_ptr<CallInvoker> jsCallInvoker_ = nullptr;
+  const std::shared_ptr<CallInvoker> jsCallInvoker_;
 };
 
 } // namespace worklets


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR removes all leftovers from `JSScheduler.cpp` and `JSScheduler.h` and converts `scheduleOnJS` from `std::function` back to a regular class method.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
