### PR TITLE
Move `AroundLock` class to separate header file

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/AroundLock.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/AroundLock.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace worklets {
+    
+class AroundLock {
+    const std::shared_ptr<std::recursive_mutex> mutex_;
+  
+   public:
+    explicit AroundLock(const std::shared_ptr<std::recursive_mutex> &mutex)
+        : mutex_(mutex) {}
+  
+    void before() const {
+      mutex_->lock();
+    }
+  
+    void after() const {
+      mutex_->unlock();
+    }
+  };
+
+} // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -1,4 +1,5 @@
 #include <worklets/Tools/JSISerializer.h>
+#include <worklets/WorkletRuntime/AroundLock.h>
 #include <worklets/WorkletRuntime/ReanimatedRuntime.h>
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 #include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
@@ -7,22 +8,6 @@
 #include <jsi/decorator.h>
 
 namespace worklets {
-
-class AroundLock {
-  const std::shared_ptr<std::recursive_mutex> mutex_;
-
- public:
-  explicit AroundLock(const std::shared_ptr<std::recursive_mutex> &mutex)
-      : mutex_(mutex) {}
-
-  void before() const {
-    mutex_->lock();
-  }
-
-  void after() const {
-    mutex_->unlock();
-  }
-};
 
 class LockableRuntime : public jsi::WithRuntimeDecorator<AroundLock> {
   AroundLock aroundLock_;


### PR DESCRIPTION
## Summary

This PR moves `AroundLock` class from `WorkletRuntime.cpp` to a separate new file `AroundLock.h` for easier maintenance.

## Test plan
