### PR TITLE
Remove `isFabric()`, `viewName`, `getScrollableNode` along with all usages

### DIFF
--- a/apps/common-app/src/App.tsx
+++ b/apps/common-app/src/App.tsx
@@ -12,7 +12,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { colors, flex, radius, text } from '@/theme';
-import { IS_MACOS, IS_WEB, isFabric, noop } from '@/utils';
+import { IS_MACOS, IS_WEB, noop } from '@/utils';
 
 import { CSSApp, ReanimatedApp } from './apps';
 
@@ -85,7 +85,7 @@ function Navigator() {
   }
 
   const Drawer = createDrawerNavigator();
-  const screens = isFabric() || IS_WEB ? SCREENS : SCREENS.reverse();
+  const screens = IS_WEB ? SCREENS : SCREENS.reverse();
 
   return (
     <Drawer.Navigator

--- a/apps/common-app/src/apps/reanimated/App.tsx
+++ b/apps/common-app/src/apps/reanimated/App.tsx
@@ -15,7 +15,7 @@ import { RectButton } from 'react-native-gesture-handler';
 import { useReducedMotion } from 'react-native-reanimated';
 
 import { BackButton, DrawerButton } from '@/components';
-import { createStack, IS_MACOS, isFabric } from '@/utils';
+import { createStack, IS_MACOS } from '@/utils';
 
 import { EXAMPLES } from './examples';
 
@@ -103,7 +103,7 @@ function Item({
   missingOnFabric,
   wasClicked,
 }: ItemProps) {
-  const isDisabled = missingOnFabric && isFabric();
+  const isDisabled = missingOnFabric;
   const Button = IS_MACOS ? Pressable : RectButton;
   return (
     <Button

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/AnimationUpdatesRecorder.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/AnimationUpdatesRecorder.ts
@@ -15,7 +15,7 @@ export class AnimationUpdatesRecorder {
 
     await this._syncUIRunner.runOnUIBlocking(() => {
       'worklet';
-      const originalUpdateProps = global._IS_FABRIC ? global._updatePropsFabric : global._updatePropsPaper;
+      const originalUpdateProps = global._updatePropsFabric;
       global.originalUpdateProps = originalUpdateProps;
 
       const mockedUpdateProps = (operations: Operation[]) => {
@@ -23,11 +23,7 @@ export class AnimationUpdatesRecorder {
         originalUpdateProps(operations);
       };
 
-      if (global._IS_FABRIC) {
-        global._updatePropsFabric = mockedUpdateProps;
-      } else {
-        global._updatePropsPaper = mockedUpdateProps;
-      }
+      global._updatePropsFabric = mockedUpdateProps;
 
       const originalNotifyAboutProgress = global._notifyAboutProgress;
       global.originalNotifyAboutProgress = originalNotifyAboutProgress;
@@ -43,11 +39,7 @@ export class AnimationUpdatesRecorder {
     await this._syncUIRunner.runOnUIBlocking(() => {
       'worklet';
       if (global.originalUpdateProps) {
-        if (global._IS_FABRIC) {
-          global._updatePropsFabric = global.originalUpdateProps;
-        } else {
-          global._updatePropsPaper = global.originalUpdateProps;
-        }
+        global._updatePropsFabric = global.originalUpdateProps;
         global.originalUpdateProps = undefined;
       }
       if (global.originalNotifyAboutProgress) {

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/UpdatesContainer.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/UpdatesContainer.ts
@@ -27,7 +27,6 @@ export function createUpdatesContainer() {
 
   function _updateNativeSnapshot(updateInfos: JsUpdate[], jsUpdateIndex: number): void {
     'worklet';
-    const isFabric = global._IS_FABRIC;
     nativeSnapshots.modify(values => {
       'worklet';
       for (const updateInfo of updateInfos) {
@@ -35,9 +34,7 @@ export function createUpdatesContainer() {
         const updatedProps = Object.keys(updateInfo.update);
         const propsToUpdate = updatedProps.filter(propName => isValidPropName(propName));
         for (const prop of propsToUpdate) {
-          snapshot[prop] = isFabric
-            ? global._obtainPropFabric(updateInfo?.shadowNodeWrapper, prop)
-            : global._obtainPropPaper(updateInfo?.tag, prop);
+          snapshot[prop] = global._obtainPropFabric(updateInfo?.shadowNodeWrapper, prop);
         }
         values.push({
           tag: updateInfo.tag,
@@ -83,10 +80,6 @@ export function createUpdatesContainer() {
 
   function pushLayoutAnimationUpdates(tag: number, update: Record<string, unknown>) {
     'worklet';
-    if (global._IS_FABRIC) {
-      // layout animation doesn't work on Fabric yet
-      return;
-    }
     // Deep Copy, works with nested objects, but doesn't copy functions (which should be fine here)
     const updatesCopy = JSON.parse(JSON.stringify(update));
     if ('backgroundColor' in updatesCopy) {

--- a/apps/common-app/src/utils/platform.ts
+++ b/apps/common-app/src/utils/platform.ts
@@ -4,8 +4,3 @@ export const IS_WEB = Platform.OS === 'web';
 export const IS_ANDROID = Platform.OS === 'android';
 export const IS_IOS = Platform.OS === 'ios';
 export const IS_MACOS = Platform.OS === 'macos';
-
-export function isFabric(): boolean {
-  // eslint-disable-next-line no-underscore-dangle
-  return !!(global as Record<string, unknown>)._IS_FABRIC;
-}

--- a/packages/docs-reanimated/docs/scroll/scrollTo.mdx
+++ b/packages/docs-reanimated/docs/scroll/scrollTo.mdx
@@ -74,7 +74,7 @@ import ScrollToSrc from '!!raw-loader!@site/src/examples/ScrollTo';
 - The `scrollTo` function can only be called from [the UI thread](/docs/fundamentals/glossary#ui-thread).
 - Supports `Animated.FlatList`.
 - Usually works with other ScrollView-like and FlatList-like components if they use a `ScrollView` under the hood and are [made animated](/docs/core/createAnimatedComponent#reference).
-- Scrollable components must implement `getScrollableNode` method (and `getNativeScrollRef` method for the New Architecture) to be compatible with `scrollTo`.
+- Scrollable components must implement `getNativeScrollRef` method to be compatible with `scrollTo`.
 
 ## Platform compatibility
 

--- a/packages/react-native-reanimated/src/AnimatedPropsRegistry.ts
+++ b/packages/react-native-reanimated/src/AnimatedPropsRegistry.ts
@@ -1,9 +1,6 @@
 'use strict';
 import { runOnUI } from 'react-native-worklets';
 
-import { ReanimatedError } from './errors';
-import { isFabric } from './PlatformChecker';
-
 let VIEW_TAGS: number[] = [];
 
 export function removeFromPropsRegistry(viewTag: number) {
@@ -13,14 +10,7 @@ export function removeFromPropsRegistry(viewTag: number) {
   }
 }
 
-const IS_FABRIC = isFabric();
-
 function flush() {
-  if (__DEV__ && !IS_FABRIC) {
-    throw new ReanimatedError(
-      'AnimatedPropsRegistry is only available on Fabric.'
-    );
-  }
   runOnUI(removeFromPropsRegistryOnUI)(VIEW_TAGS);
   VIEW_TAGS = [];
 }

--- a/packages/react-native-reanimated/src/PlatformChecker.ts
+++ b/packages/react-native-reanimated/src/PlatformChecker.ts
@@ -34,10 +34,6 @@ export function shouldBeUseWeb() {
   return isJest() || isChromeDebugger() || isWeb() || isWindows();
 }
 
-export function isFabric() {
-  return !!globalThis.RN$Bridgeless;
-}
-
 export function isWindowAvailable() {
   // the window object is unavailable when building the server portion of a site that uses SSG
   // this function shouldn't be used to conditionally render components

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -23,7 +23,7 @@ import { ReanimatedError, registerReanimatedError } from '../errors';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import { checkCppVersion } from '../platform-specific/checkCppVersion';
 import { jsVersion } from '../platform-specific/jsVersion';
-import { isFabric, shouldBeUseWeb } from '../PlatformChecker';
+import { shouldBeUseWeb } from '../PlatformChecker';
 import { setupRequestAnimationFrame } from '../requestAnimationFrame';
 import { ReanimatedTurboModule } from '../specs';
 import type {
@@ -32,7 +32,6 @@ import type {
 } from './reanimatedModuleProxy';
 
 const IS_WEB = shouldBeUseWeb();
-const IS_FABRIC = isFabric();
 
 export function createNativeReanimatedModule(): IReanimatedModule {
   return new NativeReanimatedModule();
@@ -74,7 +73,7 @@ class NativeReanimatedModule implements IReanimatedModule {
 See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#native-part-of-reanimated-doesnt-seem-to-be-initialized for more details.`
       );
     }
-    if (!IS_FABRIC && !IS_WEB) {
+    if (!globalThis.RN$Bridgeless && !IS_WEB) {
       throw new ReanimatedError(
         'Reanimated 4 supports only the React Native New Architecture and web.'
       );
@@ -130,19 +129,14 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     component: React.Component | undefined, // required on Fabric
     callback?: (result: T) => void
   ) {
-    let shadowNodeWrapper;
-    if (IS_FABRIC) {
-      shadowNodeWrapper = getShadowNodeWrapperFromRef(
-        component as React.Component
-      );
-      return this.#reanimatedModuleProxy.getViewProp(
-        shadowNodeWrapper,
-        propName,
-        callback
-      );
-    }
-
-    return this.#reanimatedModuleProxy.getViewProp(viewTag, propName, callback);
+    const shadowNodeWrapper = getShadowNodeWrapperFromRef(
+      component as React.Component
+    );
+    return this.#reanimatedModuleProxy.getViewProp(
+      shadowNodeWrapper,
+      propName,
+      callback
+    );
   }
 
   configureLayoutAnimationBatch(

--- a/packages/react-native-reanimated/src/UpdateLayoutAnimations.ts
+++ b/packages/react-native-reanimated/src/UpdateLayoutAnimations.ts
@@ -10,9 +10,7 @@ import {
   configureLayoutAnimationBatch,
   makeShareableCloneRecursive,
 } from './core';
-import { isFabric, shouldBeUseWeb } from './PlatformChecker';
-
-const IS_FABRIC = isFabric();
+import { shouldBeUseWeb } from './PlatformChecker';
 
 function createUpdateManager() {
   const animations: LayoutAnimationBatchItem[] = [];
@@ -29,7 +27,7 @@ function createUpdateManager() {
         animations.push(batchItem);
       }
       if (animations.length + deferredAnimations.length === 1) {
-        IS_FABRIC ? this.flush() : setImmediate(this.flush);
+        this.flush();
       }
     },
     flush(this: void) {

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -16,7 +16,7 @@ import type {
   ValueRotation,
 } from './commonTypes';
 import { ReanimatedError } from './errors';
-import { isFabric, shouldBeUseWeb } from './PlatformChecker';
+import { shouldBeUseWeb } from './PlatformChecker';
 import { ReanimatedModule } from './ReanimatedModule';
 import { SensorContainer } from './SensorContainer';
 
@@ -34,7 +34,6 @@ export {
 
 const EDGE_TO_EDGE = isEdgeToEdge();
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
-const IS_FABRIC = isFabric();
 
 /** @returns `true` in Reanimated 3, doesn't exist in Reanimated 2 or 1 */
 export const isReanimated3 = () => true;
@@ -54,7 +53,7 @@ export function getViewProp<T>(
   propName: string,
   component?: React.Component // required on Fabric
 ): Promise<T> {
-  if (IS_FABRIC && !component) {
+  if (!component) {
     throw new ReanimatedError(
       'Function `getViewProp` requires a component to be passed as an argument on Fabric.'
     );

--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -142,7 +142,7 @@ export class InlinePropManager implements IInlinePropManager {
       if (!this._inlinePropsViewDescriptors) {
         this._inlinePropsViewDescriptors = makeViewDescriptorsSet();
 
-        const { viewTag, viewName, shadowNodeWrapper, viewConfig } = viewInfo;
+        const { viewTag, shadowNodeWrapper, viewConfig } = viewInfo;
 
         if (Object.keys(newInlineProps).length && viewConfig) {
           adaptViewConfig(viewConfig);
@@ -150,7 +150,6 @@ export class InlinePropManager implements IInlinePropManager {
 
         this._inlinePropsViewDescriptors.add({
           tag: viewTag as number,
-          name: viewName!,
           shadowNodeWrapper: shadowNodeWrapper!,
         });
       }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -1,11 +1,7 @@
 'use strict';
-import type { NativeModule } from 'react-native';
-import { NativeEventEmitter, Platform } from 'react-native';
 import { runOnJS, runOnUIImmediately } from 'react-native-worklets';
 
-import type { StyleProps } from '../commonTypes';
-import { isFabric, shouldBeUseWeb } from '../PlatformChecker';
-import NativeReanimatedModule from '../specs/NativeReanimatedModule';
+import { shouldBeUseWeb } from '../PlatformChecker';
 import type {
   AnimatedComponentProps,
   IAnimatedComponentInternal,
@@ -13,73 +9,17 @@ import type {
   InitialComponentProps,
 } from './commonTypes';
 
-interface ListenerData {
-  viewTag: number;
-  props: StyleProps;
-}
-
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
-class JSPropsUpdaterPaper implements IJSPropsUpdater {
-  private static _tagToComponentMapping = new Map();
-  _reanimatedEventEmitter: NativeEventEmitter;
-
-  constructor() {
-    this._reanimatedEventEmitter = new NativeEventEmitter(
-      // NativeEventEmitter only uses this parameter on iOS and macOS.
-      Platform.OS === 'ios' || Platform.OS === 'macos'
-        ? (NativeReanimatedModule as unknown as NativeModule)
-        : undefined
-    );
-  }
-
-  public addOnJSPropsChangeListener(
-    animatedComponent: React.Component<
-      AnimatedComponentProps<InitialComponentProps>
-    > &
-      IAnimatedComponentInternal
-  ) {
-    const viewTag = animatedComponent.getComponentViewTag();
-    JSPropsUpdaterPaper._tagToComponentMapping.set(viewTag, animatedComponent);
-    if (JSPropsUpdaterPaper._tagToComponentMapping.size === 1) {
-      const listener = (data: ListenerData) => {
-        const component = JSPropsUpdaterPaper._tagToComponentMapping.get(
-          data.viewTag
-        );
-        component?._updateFromNative(data.props);
-      };
-      this._reanimatedEventEmitter.addListener(
-        'onReanimatedPropsChange',
-        listener
-      );
-    }
-  }
-
-  public removeOnJSPropsChangeListener(
-    animatedComponent: React.Component<
-      AnimatedComponentProps<InitialComponentProps>
-    > &
-      IAnimatedComponentInternal
-  ) {
-    const viewTag = animatedComponent.getComponentViewTag();
-    JSPropsUpdaterPaper._tagToComponentMapping.delete(viewTag);
-    if (JSPropsUpdaterPaper._tagToComponentMapping.size === 0) {
-      this._reanimatedEventEmitter.removeAllListeners(
-        'onReanimatedPropsChange'
-      );
-    }
-  }
-}
-
-class JSPropsUpdaterFabric implements IJSPropsUpdater {
+class JSPropsUpdaterNative implements IJSPropsUpdater {
   private static _tagToComponentMapping = new Map();
   private static isInitialized = false;
 
   constructor() {
-    if (!JSPropsUpdaterFabric.isInitialized) {
+    if (!JSPropsUpdaterNative.isInitialized) {
       const updater = (viewTag: number, props: unknown) => {
         const component =
-          JSPropsUpdaterFabric._tagToComponentMapping.get(viewTag);
+          JSPropsUpdaterNative._tagToComponentMapping.get(viewTag);
         component?._updateFromNative(props);
       };
       runOnUIImmediately(() => {
@@ -88,7 +28,7 @@ class JSPropsUpdaterFabric implements IJSPropsUpdater {
           runOnJS(updater)(viewTag, props);
         };
       })();
-      JSPropsUpdaterFabric.isInitialized = true;
+      JSPropsUpdaterNative.isInitialized = true;
     }
   }
 
@@ -98,11 +38,11 @@ class JSPropsUpdaterFabric implements IJSPropsUpdater {
     > &
       IAnimatedComponentInternal
   ) {
-    if (!JSPropsUpdaterFabric.isInitialized) {
+    if (!JSPropsUpdaterNative.isInitialized) {
       return;
     }
     const viewTag = animatedComponent.getComponentViewTag();
-    JSPropsUpdaterFabric._tagToComponentMapping.set(viewTag, animatedComponent);
+    JSPropsUpdaterNative._tagToComponentMapping.set(viewTag, animatedComponent);
   }
 
   public removeOnJSPropsChangeListener(
@@ -111,11 +51,11 @@ class JSPropsUpdaterFabric implements IJSPropsUpdater {
     > &
       IAnimatedComponentInternal
   ) {
-    if (!JSPropsUpdaterFabric.isInitialized) {
+    if (!JSPropsUpdaterNative.isInitialized) {
       return;
     }
     const viewTag = animatedComponent.getComponentViewTag();
-    JSPropsUpdaterFabric._tagToComponentMapping.delete(viewTag);
+    JSPropsUpdaterNative._tagToComponentMapping.delete(viewTag);
   }
 }
 
@@ -141,16 +81,13 @@ class JSPropsUpdaterWeb implements IJSPropsUpdater {
 
 type JSPropsUpdaterOptions =
   | typeof JSPropsUpdaterWeb
-  | typeof JSPropsUpdaterFabric
-  | typeof JSPropsUpdaterPaper;
+  | typeof JSPropsUpdaterNative;
 
 let JSPropsUpdater: JSPropsUpdaterOptions;
 if (SHOULD_BE_USE_WEB) {
   JSPropsUpdater = JSPropsUpdaterWeb;
-} else if (isFabric()) {
-  JSPropsUpdater = JSPropsUpdaterFabric;
 } else {
-  JSPropsUpdater = JSPropsUpdaterPaper;
+  JSPropsUpdater = JSPropsUpdaterNative;
 }
 
 export default JSPropsUpdater;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -23,7 +23,6 @@ export interface AnimatedProps extends Record<string, unknown> {
 
 export interface ViewInfo {
   viewTag: number | AnimatedComponentRef | HTMLElement | null;
-  viewName: string | null;
   shadowNodeWrapper: ShadowNodeWrapper | null;
   viewConfig: ViewConfig;
   DOMElement?: HTMLElement | null;

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -13,15 +13,13 @@ import { getViewInfo } from '../../createAnimatedComponent/getViewInfo';
 import setAndForwardRef from '../../createAnimatedComponent/setAndForwardRef';
 import { getShadowNodeWrapperFromRef } from '../../fabricUtils';
 import { findHostInstance } from '../../platform-specific/findHostInstance';
-import { isFabric, isWeb, shouldBeUseWeb } from '../../PlatformChecker';
+import { shouldBeUseWeb } from '../../PlatformChecker';
 import { ReanimatedError } from '../errors';
 import { CSSManager } from '../managers';
 import type { AnyComponent, AnyRecord, CSSStyle, PlainStyle } from '../types';
 import { filterNonCSSStyleProps } from './utils';
 
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
-const IS_WEB = isWeb();
-const IS_FABRIC = isFabric();
 
 export type AnimatedComponentProps = Record<string, unknown> & {
   ref?: Ref<Component>;
@@ -68,7 +66,6 @@ export default class AnimatedComponent<
     }
 
     let viewTag: number | typeof this._componentRef;
-    let viewName: string | null;
     let shadowNodeWrapper: ShadowNodeWrapper | null = null;
     let viewConfig;
     let DOMElement: HTMLElement | null = null;
@@ -79,7 +76,6 @@ export default class AnimatedComponent<
       // TODO - implement a valid solution later on - this is a temporary fix
       viewTag = this._componentRef;
       DOMElement = this._componentDOMRef;
-      viewName = null;
       shadowNodeWrapper = null;
       viewConfig = null;
     } else {
@@ -97,13 +93,10 @@ export default class AnimatedComponent<
 
       const viewInfo = getViewInfo(hostInstance);
       viewTag = viewInfo.viewTag;
-      viewName = viewInfo.viewName;
       viewConfig = viewInfo.viewConfig;
-      shadowNodeWrapper = IS_FABRIC
-        ? getShadowNodeWrapperFromRef(this, hostInstance)
-        : null;
+      shadowNodeWrapper = getShadowNodeWrapperFromRef(this, hostInstance);
     }
-    this._viewInfo = { viewTag, viewName, shadowNodeWrapper, viewConfig };
+    this._viewInfo = { viewTag, shadowNodeWrapper, viewConfig };
     if (DOMElement) {
       this._viewInfo.DOMElement = DOMElement;
     }
@@ -156,10 +149,8 @@ export default class AnimatedComponent<
   componentDidMount() {
     this._updateStyles(this.props);
 
-    if (IS_FABRIC || IS_WEB) {
-      this._CSSManager = new CSSManager(this._getViewInfo());
-      this._CSSManager?.attach(this._cssStyle);
-    }
+    this._CSSManager = new CSSManager(this._getViewInfo());
+    this._CSSManager?.attach(this._cssStyle);
   }
 
   componentWillUnmount() {

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -13,7 +13,6 @@ import type {
   AnimatedPropsAdapterFunction,
   AnimatedStyle,
   ShadowNodeWrapper,
-  SharedValue,
 } from '../commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import type { ViewDescriptorsSet } from '../ViewDescriptorsSet';
@@ -22,7 +21,6 @@ export type DependencyList = Array<unknown> | undefined;
 
 export interface Descriptor {
   tag: number | ReanimatedHTMLElement;
-  name: string;
   shadowNodeWrapper: ShadowNodeWrapper;
 }
 
@@ -41,12 +39,6 @@ export type AnimatedRefOnJS = AnimatedRef<Component>;
 /** `AnimatedRef` is mapped to this type on the UI thread via a shareable handle. */
 export type AnimatedRefOnUI = {
   (): number | ShadowNodeWrapper | null;
-  /**
-   * @remarks
-   *   `viewName` is required only on iOS with Paper and it's value is null on
-   *   other platforms.
-   */
-  viewName: SharedValue<string | null>;
 };
 
 type ReanimatedPayload = {

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -1,8 +1,7 @@
 'use strict';
 import type { Component } from 'react';
 import { useRef } from 'react';
-import type { FlatList, ScrollView } from 'react-native';
-import { Platform } from 'react-native';
+import type { FlatList } from 'react-native';
 import {
   makeShareableCloneRecursive,
   shareableMappingCache,
@@ -10,29 +9,23 @@ import {
 
 import type { ShadowNodeWrapper } from '../commonTypes';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
-import { isFabric, isWeb } from '../PlatformChecker';
+import { isWeb } from '../PlatformChecker';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
 import type { AnimatedRef, AnimatedRefOnUI } from './commonTypes';
 import { useSharedValue } from './useSharedValue';
 
 const IS_WEB = isWeb();
-const IS_FABRIC = isFabric();
 
 interface MaybeScrollableComponent extends Component {
   getNativeScrollRef?: FlatList['getNativeScrollRef'];
-  getScrollableNode?:
-    | ScrollView['getScrollableNode']
-    | FlatList['getScrollableNode'];
   viewConfig?: {
     uiViewClassName?: string;
   };
 }
 
 function getComponentOrScrollable(component: MaybeScrollableComponent) {
-  if (IS_FABRIC && component.getNativeScrollRef) {
+  if (component.getNativeScrollRef) {
     return component.getNativeScrollRef();
-  } else if (!IS_FABRIC && component.getScrollableNode) {
-    return component.getScrollableNode();
   }
   return component;
 }
@@ -47,8 +40,7 @@ function getComponentOrScrollable(component: MaybeScrollableComponent) {
 export function useAnimatedRef<
   TComponent extends Component,
 >(): AnimatedRef<TComponent> {
-  const tag = useSharedValue<number | ShadowNodeWrapper | null>(-1);
-  const viewName = useSharedValue<string | null>(null);
+  const tag = useSharedValue<ShadowNodeWrapper | null>(null);
 
   const ref = useRef<AnimatedRef<TComponent>>();
 
@@ -58,30 +50,22 @@ export function useAnimatedRef<
     ) => {
       // enters when ref is set by attaching to a component
       if (component) {
-        const getTagValueFunction = IS_FABRIC
-          ? getShadowNodeWrapperFromRef
-          : findNodeHandle;
-
         const getTagOrShadowNodeWrapper = () => {
           return IS_WEB
             ? getComponentOrScrollable(component)
-            : getTagValueFunction(getComponentOrScrollable(component));
+            : getShadowNodeWrapperFromRef(
+                getComponentOrScrollable(component) as Component
+              );
         };
 
-        tag.value = getTagOrShadowNodeWrapper();
+        tag.value = getTagOrShadowNodeWrapper() as ShadowNodeWrapper;
 
         // On Fabric we have to unwrap the tag from the shadow node wrapper
-        fun.getTag = IS_FABRIC
-          ? () => findNodeHandle(getComponentOrScrollable(component))
-          : getTagOrShadowNodeWrapper;
+        // TODO: remove casting
+        fun.getTag = () =>
+          findNodeHandle(getComponentOrScrollable(component) as Component)!;
 
         fun.current = component;
-        // viewName is required only on iOS with Paper
-        if (Platform.OS === 'ios' && !IS_FABRIC) {
-          viewName.value =
-            (component as MaybeScrollableComponent)?.viewConfig
-              ?.uiViewClassName || 'RCTView';
-        }
       }
       return tag.value;
     });
@@ -89,11 +73,9 @@ export function useAnimatedRef<
     fun.current = null;
 
     const animatedRefShareableHandle = makeShareableCloneRecursive({
-      __init: () => {
+      __init: (): AnimatedRefOnUI => {
         'worklet';
-        const f: AnimatedRefOnUI = () => tag.value;
-        f.viewName = viewName;
-        return f;
+        return () => tag.value;
       },
     });
     shareableMappingCache.set(fun, animatedRefShareableHandle);

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -3,7 +3,6 @@
 
 import type { IAnimatedComponentInternal } from '../createAnimatedComponent/commonTypes';
 import { ReanimatedError } from '../errors';
-import { isFabric } from '../PlatformChecker';
 
 type HostInstanceFabric = {
   __internalInstanceHandle?: Record<string, unknown>;
@@ -39,32 +38,19 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   return undefined;
 }
 
-const IS_FABRIC = isFabric();
-
 function resolveFindHostInstance_DEPRECATED() {
   if (findHostInstance_DEPRECATED !== undefined) {
     return;
   }
-  if (IS_FABRIC) {
-    try {
-      const ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
-      // Since RN 0.77 ReactFabric exports findHostInstance_DEPRECATED in default object so we're trying to
-      // access it first, then fallback on named export
-      findHostInstance_DEPRECATED =
-        ReactFabric?.default?.findHostInstance_DEPRECATED ??
-        ReactFabric?.findHostInstance_DEPRECATED;
-    } catch (e) {
-      throw new ReanimatedError(
-        'Failed to resolve findHostInstance_DEPRECATED'
-      );
-    }
-  } else {
-    const ReactNative = require('react-native/Libraries/Renderer/shims/ReactNative');
+  try {
+    const ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
     // Since RN 0.77 ReactFabric exports findHostInstance_DEPRECATED in default object so we're trying to
     // access it first, then fallback on named export
     findHostInstance_DEPRECATED =
-      ReactNative?.default?.findHostInstance_DEPRECATED ??
-      ReactNative?.findHostInstance_DEPRECATED;
+      ReactFabric?.default?.findHostInstance_DEPRECATED ??
+      ReactFabric?.findHostInstance_DEPRECATED;
+  } catch (e) {
+    throw new ReanimatedError('Failed to resolve findHostInstance_DEPRECATED');
   }
 }
 
@@ -88,7 +74,7 @@ export function findHostInstance(
     a valid React ref.
   */
   return findHostInstance_DEPRECATED(
-    !IS_FABRIC || (component as IAnimatedComponentInternal).hasAnimatedRef()
+    (component as IAnimatedComponentInternal).hasAnimatedRef()
       ? (component as IAnimatedComponentInternal)._componentRef
       : component
   );

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -8,12 +8,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import {
-  isChromeDebugger,
-  isFabric,
-  isJest,
-  shouldBeUseWeb,
-} from '../PlatformChecker';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type DispatchCommand = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -34,7 +29,7 @@ type DispatchCommand = <T extends Component>(
  */
 export let dispatchCommand: DispatchCommand;
 
-function dispatchCommandFabric(
+function dispatchCommandNative(
   animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
   commandName: string,
   args: Array<unknown> = []
@@ -46,20 +41,6 @@ function dispatchCommandFabric(
 
   const shadowNodeWrapper = animatedRef() as ShadowNodeWrapper;
   global._dispatchCommandFabric!(shadowNodeWrapper, commandName, args);
-}
-
-function dispatchCommandPaper(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
-  commandName: string,
-  args: Array<unknown> = []
-) {
-  'worklet';
-  if (!_WORKLET) {
-    return;
-  }
-
-  const viewTag = animatedRef() as number;
-  global._dispatchCommandPaper!(viewTag, commandName, args);
 }
 
 function dispatchCommandJest() {
@@ -78,11 +59,7 @@ if (!shouldBeUseWeb()) {
   // Those assertions are actually correct since on Native platforms `AnimatedRef` is
   // mapped as a different function in `shareableMappingCache` and
   // TypeScript is not able to infer that.
-  if (isFabric()) {
-    dispatchCommand = dispatchCommandFabric as unknown as DispatchCommand;
-  } else {
-    dispatchCommand = dispatchCommandPaper as unknown as DispatchCommand;
-  }
+  dispatchCommand = dispatchCommandNative as unknown as DispatchCommand;
 } else if (isJest()) {
   dispatchCommand = dispatchCommandJest;
 } else if (isChromeDebugger()) {

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -8,12 +8,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import {
-  isChromeDebugger,
-  isFabric,
-  isJest,
-  shouldBeUseWeb,
-} from '../PlatformChecker';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type Measure = <T extends Component>(
   animatedRef: AnimatedRef<T>
@@ -32,7 +27,7 @@ type Measure = <T extends Component>(
  */
 export let measure: Measure;
 
-function measureFabric(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
+function measureNative(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
   'worklet';
   if (!_WORKLET) {
     return null;
@@ -67,47 +62,6 @@ function measureFabric(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
   }
 }
 
-function measurePaper(animatedRef: AnimatedRefOnJS | AnimatedRefOnUI) {
-  'worklet';
-  if (!_WORKLET) {
-    return null;
-  }
-
-  const viewTag = animatedRef();
-  if (viewTag === -1) {
-    logger.warn(
-      `The view with tag ${viewTag} is not a valid argument for measure(). This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
-    );
-    return null;
-  }
-
-  const measured = global._measurePaper!(viewTag as number);
-  if (measured === null) {
-    logger.warn(
-      `The view with tag ${
-        viewTag as number
-      } has some undefined, not-yet-computed or meaningless value of \`LayoutMetrics\` type. This may be because the view is not currently rendered, which may not be a bug (e.g. an off-screen FlatList item).`
-    );
-    return null;
-  } else if (measured.x === -1234567) {
-    logger.warn(
-      `The view with tag ${
-        viewTag as number
-      } returned an invalid measurement response. Please make sure the view is currently rendered.`
-    );
-    return null;
-  } else if (isNaN(measured.x)) {
-    logger.warn(
-      `The view with tag ${
-        viewTag as number
-      } gets view-flattened on Android. To disable view-flattening, set \`collapsable={false}\` on this component.`
-    );
-    return null;
-  } else {
-    return measured;
-  }
-}
-
 function measureJest() {
   logger.warn('measure() cannot be used with Jest.');
   return null;
@@ -127,11 +81,7 @@ if (!shouldBeUseWeb()) {
   // Those assertions are actually correct since on Native platforms `AnimatedRef` is
   // mapped as a different function in `shareableMappingCache` and
   // TypeScript is not able to infer that.
-  if (isFabric()) {
-    measure = measureFabric as unknown as Measure;
-  } else {
-    measure = measurePaper as unknown as Measure;
-  }
+  measure = measureNative as unknown as Measure;
 } else if (isJest()) {
   measure = measureJest;
 } else if (isChromeDebugger()) {

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -7,12 +7,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import {
-  isChromeDebugger,
-  isFabric,
-  isJest,
-  shouldBeUseWeb,
-} from '../PlatformChecker';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 import { dispatchCommand } from './dispatchCommand';
 
 type ScrollTo = <T extends Component>(
@@ -35,7 +30,7 @@ type ScrollTo = <T extends Component>(
  */
 export let scrollTo: ScrollTo;
 
-function scrollToFabric(
+function scrollToNative(
   animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
   x: number,
   y: number,
@@ -48,21 +43,6 @@ function scrollToFabric(
     'scrollTo',
     [x, y, animated]
   );
-}
-
-function scrollToPaper(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
-  x: number,
-  y: number,
-  animated: boolean
-) {
-  'worklet';
-  if (!_WORKLET) {
-    return;
-  }
-
-  const viewTag = animatedRef() as number;
-  global._scrollToPaper!(viewTag, x, y, animated);
 }
 
 function scrollToJest() {
@@ -81,11 +61,7 @@ if (!shouldBeUseWeb()) {
   // Those assertions are actually correct since on Native platforms `AnimatedRef` is
   // mapped as a different function in `shareableMappingCache` and
   // TypeScript is not able to infer that.
-  if (isFabric()) {
-    scrollTo = scrollToFabric as unknown as ScrollTo;
-  } else {
-    scrollTo = scrollToPaper as unknown as ScrollTo;
-  }
+  scrollTo = scrollToNative as unknown as ScrollTo;
 } else if (isJest()) {
   scrollTo = scrollToJest;
 } else if (isChromeDebugger()) {

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -9,12 +9,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import {
-  isChromeDebugger,
-  isFabric,
-  isJest,
-  shouldBeUseWeb,
-} from '../PlatformChecker';
+import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type SetNativeProps = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -36,7 +31,7 @@ type SetNativeProps = <T extends Component>(
  */
 export let setNativeProps: SetNativeProps;
 
-function setNativePropsFabric(
+function setNativePropsNative(
   animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
   updates: StyleProps
 ) {
@@ -48,21 +43,6 @@ function setNativePropsFabric(
   const shadowNodeWrapper = animatedRef() as ShadowNodeWrapper;
   processColorsInProps(updates);
   global._updatePropsFabric!([{ shadowNodeWrapper, updates }]);
-}
-
-function setNativePropsPaper(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
-  updates: StyleProps
-) {
-  'worklet';
-  if (!_WORKLET) {
-    logger.warn('setNativeProps() can only be used on the UI runtime.');
-    return;
-  }
-  const tag = animatedRef() as number;
-  const name = (animatedRef as AnimatedRefOnUI).viewName.value;
-  processColorsInProps(updates);
-  global._updatePropsPaper!([{ tag, name, updates }]);
 }
 
 function setNativePropsJest() {
@@ -81,11 +61,7 @@ if (!shouldBeUseWeb()) {
   // Those assertions are actually correct since on Native platforms `AnimatedRef` is
   // mapped as a different function in `shareableMappingCache` and
   // TypeScript is not able to infer that.
-  if (isFabric()) {
-    setNativeProps = setNativePropsFabric as unknown as SetNativeProps;
-  } else {
-    setNativeProps = setNativePropsPaper as unknown as SetNativeProps;
-  }
+  setNativeProps = setNativePropsNative as unknown as SetNativeProps;
 } else if (isJest()) {
   setNativeProps = setNativePropsJest;
 } else if (isChromeDebugger()) {

--- a/packages/react-native-reanimated/src/screenTransition/styleUpdater.ts
+++ b/packages/react-native-reanimated/src/screenTransition/styleUpdater.ts
@@ -1,26 +1,16 @@
 'use strict';
 import type { ShadowNodeWrapper } from '../commonTypes';
 import type { Descriptor } from '../hook/commonTypes';
-import { isFabric } from '../PlatformChecker';
 import updateProps from '../UpdateProps';
 import type {
   PanGestureHandlerEventPayload,
   ScreenTransitionConfig,
 } from './commonTypes';
 
-const IS_FABRIC = isFabric();
-
-function createViewDescriptorPaper(screenId: number | ShadowNodeWrapper) {
-  'worklet';
-  return { tag: screenId, name: 'RCTView' };
-}
-function createViewDescriptorFabric(screenId: number | ShadowNodeWrapper) {
+function createViewDescriptor(screenId: number | ShadowNodeWrapper) {
   'worklet';
   return { shadowNodeWrapper: screenId };
 }
-const createViewDescriptor = IS_FABRIC
-  ? createViewDescriptorFabric
-  : createViewDescriptorPaper;
 
 function applyStyleForTopScreen(
   screenTransitionConfig: ScreenTransitionConfig,

--- a/packages/react-native-worklets/src/worklets/PlatformChecker.ts
+++ b/packages/react-native-worklets/src/worklets/PlatformChecker.ts
@@ -34,10 +34,6 @@ export function shouldBeUseWeb() {
   return isJest() || isChromeDebugger() || isWeb() || isWindows();
 }
 
-export function isFabric() {
-  return !!globalThis.RN$Bridgeless;
-}
-
 export function isWindowAvailable() {
   // the window object is unavailable when building the server portion of a site that uses SSG
   // this function shouldn't be used to conditionally render components


### PR DESCRIPTION
Co-authored-with: Krzysztof Piaskowy <krzysztof.piaskowy@swmansion.com>

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR replaces all `isFabric()`, `IS_FABRIC` and `global._IS_FABRIC` checks with `true` (as well as optimizes the expressions and removes dead code).

Turns out, `getScrollableNode` call was inside `!IS_FABRIC` so we also removed that.

We also removed `viewName` from `ViewDescriptor` as it was used only on Paper.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
