### PR TITLE
chore: Remove RCT_NEW_ARCH_ENABLED from CSS code, apply clang tidy suggestions

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/Quaternion.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/Quaternion.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/common/Quaternion.h>
 
 namespace reanimated {
@@ -54,5 +53,3 @@ Quaternion Quaternion::interpolate(const double t, const Quaternion &other)
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/Quaternion.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/Quaternion.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <cmath>
 
@@ -24,5 +23,3 @@ struct Quaternion {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/common/TransformMatrix.h>
 
 namespace reanimated {
@@ -633,5 +632,3 @@ double TransformMatrix::determinant3x3(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/Quaternion.h>
 #include <reanimated/CSS/common/definitions.h>
@@ -102,5 +101,3 @@ class TransformMatrix {
 Vector4D operator*(const Vector4D &v, const TransformMatrix &m);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <jsi/jsi.h>
 #include <memory>
@@ -25,5 +24,3 @@ using Vec16Array = std::array<double, 16>;
 using Matrix4x4 = std::array<std::array<double, 4>, 4>;
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/common/values/CSSAngle.h>
 
 namespace reanimated {
@@ -87,5 +86,3 @@ std::ostream &operator<<(std::ostream &os, const CSSAngle &angleValue) {
 #endif // NDEBUG
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
@@ -37,5 +36,3 @@ struct CSSAngle : public CSSSimpleValue<CSSAngle> {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSBoolean.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSBoolean.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/CSS/common/values/CSSBoolean.h>
 
 namespace reanimated {
@@ -48,5 +46,3 @@ std::ostream &operator<<(std::ostream &os, const CSSBoolean &boolValue) {
 #endif // NDEBUG
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSBoolean.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSBoolean.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
@@ -32,5 +31,3 @@ struct CSSBoolean : public CSSSimpleValue<CSSBoolean> {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <folly/json.h>
 #include <reanimated/CSS/common/values/CSSColor.h>
 
@@ -154,5 +153,3 @@ std::ostream &operator<<(std::ostream &os, const CSSColor &colorValue) {
 #endif // NDEBUG
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
@@ -50,5 +49,3 @@ struct CSSColor : public CSSSimpleValue<CSSColor> {
 inline const CSSColor CSSColor::Transparent(ColorType::Transparent);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDimension.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDimension.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/common/values/CSSDimension.h>
 
 namespace reanimated {
@@ -144,5 +143,3 @@ std::ostream &operator<<(std::ostream &os, const CSSDimension &dimension) {
 #endif // NDEBUG
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDimension.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDimension.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
@@ -42,5 +41,3 @@ struct CSSDimension : public CSSResolvableValue<CSSDimension, double> {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <folly/json.h>
 #include <reanimated/CSS/common/values/CSSDiscreteArray.h>
 
@@ -120,5 +118,3 @@ std::ostream &operator<<(
 template struct CSSDiscreteArray<CSSKeyword>;
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 
@@ -48,5 +47,3 @@ struct CSSDiscreteArray : public CSSSimpleValue<CSSDiscreteArray<TValue>> {
 };
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <folly/json.h>
 #include <reanimated/CSS/common/values/CSSKeyword.h>
 
@@ -104,5 +102,3 @@ template class CSSKeywordBase<CSSKeyword>;
 template class CSSKeywordBase<CSSDisplay>;
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.cpp
@@ -6,9 +6,6 @@
 namespace reanimated {
 
 template <typename TValue>
-CSSKeywordBase<TValue>::CSSKeywordBase() : value("") {}
-
-template <typename TValue>
 CSSKeywordBase<TValue>::CSSKeywordBase(const char *value) : value(value) {}
 
 template <typename TValue>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.h
@@ -15,7 +15,7 @@ class CSSKeywordBase : public CSSSimpleValue<TValue> {
  public:
   static constexpr bool is_discrete_value = true;
 
-  CSSKeywordBase();
+  CSSKeywordBase() = default;
   explicit CSSKeywordBase(const char *value);
   explicit CSSKeywordBase(jsi::Runtime &rt, const jsi::Value &jsiValue);
   explicit CSSKeywordBase(const folly::dynamic &value);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSKeyword.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
@@ -60,5 +59,3 @@ struct CSSDisplay : public CSSKeywordBase<CSSDisplay> {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <folly/json.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
 
@@ -104,5 +103,3 @@ template struct CSSNumberBase<CSSShadowRadiusAndroid, double>;
 #endif
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSNumber.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
@@ -71,5 +70,3 @@ struct CSSShadowRadiusAndroid
 #endif
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 
@@ -74,5 +73,3 @@ template <typename TCSSValue>
 concept CSSValueDerived = std::is_base_of_v<CSSValue, TCSSValue>;
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 #include <worklets/Tools/JSISerializer.h>
@@ -276,5 +275,3 @@ class CSSValueVariant final : public CSSValue {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -108,7 +108,7 @@ class CSSValueVariant final : public CSSValue {
     }
   }
 
-  CSSValueVariant(const folly::dynamic &value) {
+  explicit CSSValueVariant(const folly::dynamic &value) {
     if (!tryConstruct(value)) {
       throw std::runtime_error(
           "[Reanimated] No compatible type found for construction from: " +

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/vectors.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/vectors.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/common/vectors.h>
 
 namespace reanimated {
@@ -100,5 +99,3 @@ std::ostream &operator<<(std::ostream &os, const Vector4D &vector) {
 #endif // NDEBUG
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/vectors.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/vectors.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <array>
 #include <cmath>
@@ -55,5 +54,3 @@ struct Vector4D {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
 
 namespace reanimated {
@@ -103,5 +102,3 @@ PartialCSSAnimationSettings parsePartialCSSAnimationSettings(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
 #include <reanimated/CSS/config/common.h>
@@ -62,5 +61,3 @@ PartialCSSAnimationSettings parsePartialCSSAnimationSettings(
     const jsi::Value &partialSettings);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
 
 namespace reanimated {
@@ -51,5 +49,3 @@ CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
@@ -32,5 +31,3 @@ CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
 
 namespace reanimated {
@@ -101,5 +100,3 @@ PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/config/common.h>
@@ -49,5 +48,3 @@ PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
     const jsi::Value &partialConfig);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/PropertyInterpolatorsConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/PropertyInterpolatorsConfig.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/InterpolatorFactory.h>
 
@@ -303,5 +302,3 @@ const InterpolatorFactoriesRecord PROPERTY_INTERPOLATORS_CONFIG = []() {
 }();
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/config/common.h>
 
 namespace reanimated {
@@ -16,5 +15,3 @@ double getDelay(jsi::Runtime &rt, const jsi::Object &config) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
@@ -12,5 +11,3 @@ EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
 double getDelay(jsi::Runtime &rt, const jsi::Object &config);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -10,7 +10,6 @@ CSSAnimation::CSSAnimation(
     const unsigned index,
     const CSSKeyframesConfig &keyframesConfig,
     const CSSAnimationSettings &settings,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
     const double timestamp)
     : index_(index),
       shadowNode_(std::move(shadowNode)),

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/core/CSSAnimation.h>
 
 #include <utility>
@@ -136,5 +135,3 @@ void CSSAnimation::updateSettings(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -22,7 +22,6 @@ class CSSAnimation {
       unsigned index,
       const CSSKeyframesConfig &keyframesConfig,
       const CSSAnimationSettings &settings,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
       double timestamp);
 
   CSSAnimationId getId() const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
@@ -57,5 +56,3 @@ class CSSAnimation {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/core/CSSTransition.h>
 
 namespace reanimated {
@@ -136,5 +135,3 @@ bool CSSTransition::isAllowedProperty(const std::string &propertyName) const {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
@@ -49,5 +48,3 @@ class CSSTransition {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
 namespace reanimated {
@@ -73,5 +72,3 @@ EasingFunction createParametrizedEasingFunction(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #pragma once
 
 #include <reanimated/CSS/easing/cubicBezier.h>
@@ -27,5 +26,3 @@ EasingFunction createEasingFunction(
     const jsi::Value &easingConfig);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/easing/cubicBezier.h>
 
 namespace reanimated {
@@ -75,5 +74,3 @@ EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 
@@ -14,5 +13,3 @@ EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
 EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/easing/linear.h>
 
 namespace reanimated {
@@ -31,5 +30,3 @@ EasingFunction linear(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/util/algorithms.h>
@@ -19,5 +18,3 @@ EasingFunction linear(
     const std::vector<double> &pointsY);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/easing/steps.h>
 
 namespace reanimated {
@@ -12,5 +11,3 @@ EasingFunction steps(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/util/algorithms.h>
@@ -13,5 +12,3 @@ EasingFunction steps(
     const std::vector<double> &pointsY);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/InterpolatorFactory.h>
 
 namespace reanimated::Interpolators {
@@ -133,5 +132,3 @@ std::shared_ptr<PropertyInterpolatorFactory> transforms(
 }
 
 } // namespace reanimated::Interpolators
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 
@@ -156,5 +155,3 @@ std::shared_ptr<PropertyInterpolatorFactory> transforms(
         std::shared_ptr<TransformInterpolator>> &interpolators);
 
 } // namespace reanimated::Interpolators
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -1,5 +1,3 @@
-#if RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 
 namespace reanimated {
@@ -15,5 +13,3 @@ bool PropertyInterpolatorFactory::isDiscreteProperty() const {
 }
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -1,11 +1,13 @@
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 
+#include <utility>
+
 namespace reanimated {
 
 PropertyInterpolator::PropertyInterpolator(
-    const PropertyPath &propertyPath,
+    PropertyPath propertyPath,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : propertyPath_(propertyPath),
+    : propertyPath_(std::move(propertyPath)),
       viewStylesRepository_(viewStylesRepository) {}
 
 bool PropertyInterpolatorFactory::isDiscreteProperty() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -15,7 +15,7 @@ namespace reanimated {
 class PropertyInterpolator {
  public:
   explicit PropertyInterpolator(
-      const PropertyPath &propertyPath,
+      PropertyPath propertyPath,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
   virtual folly::dynamic getStyleValue(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
@@ -71,5 +70,3 @@ using InterpolatorFactoriesArray =
     std::vector<std::shared_ptr<PropertyInterpolatorFactory>>;
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h>
 
 namespace reanimated {
@@ -100,5 +99,3 @@ void ArrayPropertiesInterpolator::resizeInterpolators(size_t valuesCount) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -89,12 +89,11 @@ void ArrayPropertiesInterpolator::resizeInterpolators(size_t valuesCount) {
   }
 
   while (interpolators_.size() < valuesCount) {
-    const auto newInterpolator = createPropertyInterpolator(
+    interpolators_.emplace_back(createPropertyInterpolator(
         interpolators_.size(),
         propertyPath_,
         factories_,
-        viewStylesRepository_);
-    interpolators_.push_back(newInterpolator);
+        viewStylesRepository_));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h>
 #include <reanimated/CSS/util/interpolators.h>
@@ -39,5 +38,3 @@ class ArrayPropertiesInterpolator : public GroupPropertiesInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h>
 
 namespace reanimated {
@@ -48,5 +47,3 @@ folly::dynamic GroupPropertiesInterpolator::interpolate(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
@@ -34,5 +33,3 @@ class GroupPropertiesInterpolator : public PropertyInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -11,16 +11,12 @@ RecordPropertiesInterpolator::RecordPropertiesInterpolator(
 
 bool RecordPropertiesInterpolator::equalsReversingAdjustedStartValue(
     const folly::dynamic &propertyValue) const {
-  for (const auto &[propName, propValue] : propertyValue.items()) {
+  return std::ranges::all_of(propertyValue.items(), [this](const auto &item) {
+    const auto &[propName, propValue] = item;
     const auto it = interpolators_.find(propName.getString());
-
-    if (it == interpolators_.end() ||
-        !it->second->equalsReversingAdjustedStartValue(propValue)) {
-      return false;
-    }
-  }
-
-  return true;
+    return it != interpolators_.end() &&
+        it->second->equalsReversingAdjustedStartValue(propValue);
+  });
 }
 
 void RecordPropertiesInterpolator::updateKeyframes(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h>
 
 namespace reanimated {
@@ -99,5 +98,3 @@ void RecordPropertiesInterpolator::maybeCreateInterpolator(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h>
 #include <reanimated/CSS/util/interpolators.h>
@@ -40,5 +39,3 @@ class RecordPropertiesInterpolator : public GroupPropertiesInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/PropertyInterpolatorsConfig.h>
 #include <reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h>
@@ -22,5 +21,3 @@ class AnimationStyleInterpolator : public RecordPropertiesInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h>
 
 namespace reanimated {
@@ -111,5 +110,3 @@ folly::dynamic TransitionStyleInterpolator::mapInterpolators(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/config/PropertyInterpolatorsConfig.h>
@@ -48,5 +47,3 @@ class TransitionStyleInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
@@ -85,5 +84,3 @@ using TransformInterpolators = TransformInterpolator::Interpolators;
 using TransformInterpolatorUpdateContext = TransformInterpolator::UpdateContext;
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
@@ -275,7 +275,7 @@ std::string TransformOperationBase<
  */
 
 // Perspective
-PerspectiveOperation::PerspectiveOperation(double value)
+PerspectiveOperation::PerspectiveOperation(const double value)
     : TransformOperationBase<CSSDouble>(CSSDouble(value)) {}
 TransformOperationType PerspectiveOperation::type() const {
   return TransformOperationType::Perspective;
@@ -331,7 +331,7 @@ TransformMatrix RotateZOperation::toMatrix() const {
 }
 
 // Scale
-ScaleOperation::ScaleOperation(double value)
+ScaleOperation::ScaleOperation(const double value)
     : TransformOperationBase<CSSDouble>(CSSDouble(value)) {}
 TransformOperationType ScaleOperation::type() const {
   return TransformOperationType::Scale;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
 
 namespace reanimated {
@@ -570,5 +569,3 @@ template struct TransformOperationBase<
     std::variant<TransformMatrix, TransformOperations>>;
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/TransformMatrix.h>
 #include <reanimated/CSS/common/definitions.h>
@@ -214,5 +213,3 @@ struct MatrixOperation final
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h>
 
 namespace reanimated {
@@ -64,5 +62,3 @@ TransformOperationInterpolator<MatrixOperation>::matrixFromOperation(
 }
 
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 #include <reanimated/CSS/interpolation/transforms/TransformInterpolator.h>
@@ -122,5 +121,3 @@ class TransformOperationInterpolator<TOperation>
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -178,14 +178,14 @@ TransformsStyleInterpolator::parseTransformOperations(
     return std::nullopt;
   }
 
-  const auto transformsArray = values;
+  const auto& transformsArray = values;
   const auto transformsCount = transformsArray.size();
 
   TransformOperations transformOperations;
   transformOperations.reserve(transformsCount);
 
   for (size_t i = 0; i < transformsCount; ++i) {
-    const auto transform = transformsArray.at(i);
+    const auto& transform = transformsArray.at(i);
     transformOperations.emplace_back(
         TransformOperation::fromDynamic(transform));
   }
@@ -396,8 +396,8 @@ folly::dynamic TransformsStyleInterpolator::convertResultToDynamic(
     const TransformOperations &operations) {
   auto result = folly::dynamic::array();
 
-  for (size_t i = 0; i < operations.size(); ++i) {
-    result.push_back(operations[i]->toDynamic());
+  for (const auto &operation : operations) {
+    result.push_back(operation->toDynamic());
   }
 
   return result;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h>
 
 namespace reanimated {
@@ -405,5 +404,3 @@ folly::dynamic TransformsStyleInterpolator::convertResultToDynamic(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -178,14 +178,14 @@ TransformsStyleInterpolator::parseTransformOperations(
     return std::nullopt;
   }
 
-  const auto& transformsArray = values;
+  const auto &transformsArray = values;
   const auto transformsCount = transformsArray.size();
 
   TransformOperations transformOperations;
   transformOperations.reserve(transformsCount);
 
   for (size_t i = 0; i < transformsCount; ++i) {
-    const auto& transform = transformsArray.at(i);
+    const auto &transform = transformsArray.at(i);
     transformOperations.emplace_back(
         TransformOperation::fromDynamic(transform));
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 #include <reanimated/CSS/interpolation/transforms/TransformInterpolator.h>
@@ -97,5 +96,3 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSDimension.h>
 #include <reanimated/CSS/interpolation/values/ValueInterpolator.h>
@@ -50,5 +49,3 @@ class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/values/CSSValueVariant.h>
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
@@ -204,5 +203,3 @@ class ValueInterpolator : public PropertyInterpolator {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -112,24 +112,24 @@ folly::dynamic ViewStylesRepository::getPropertyValue(
 
   for (size_t i = 0; i < propertyPath.size(); ++i) {
     if (currentValue->isNull() || currentValue->empty()) {
-      return folly::dynamic();
+      return {};
     }
 
     const auto &propName = propertyPath[i];
 
     if (!currentValue->isObject()) {
-      return folly::dynamic();
+      return {};
     }
 
     if (propName == "transform") {
       auto transformIt = currentValue->find("transform");
       if (transformIt == currentValue->items().end()) {
-        return folly::dynamic();
+        return {};
       }
 
       const auto &transform = transformIt->second;
       if (!transform.isArray()) {
-        return folly::dynamic();
+        return {};
       }
 
       if (i + 1 >= propertyPath.size()) {
@@ -147,12 +147,12 @@ folly::dynamic ViewStylesRepository::getPropertyValue(
         }
       }
 
-      return folly::dynamic();
+      return {};
     }
 
     auto propIt = currentValue->find(propName);
     if (propIt == currentValue->items().end()) {
-      return folly::dynamic();
+      return {};
     }
 
     currentValue = &propIt->second;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 namespace reanimated {
@@ -163,5 +162,3 @@ folly::dynamic ViewStylesRepository::getPropertyValue(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/registry/StaticPropsRegistry.h>
@@ -63,5 +62,3 @@ class ViewStylesRepository {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 
 #include <utility>
@@ -166,5 +165,3 @@ double AnimationProgressProvider::applyAnimationDirection(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -48,9 +48,6 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
   double getGlobalProgress() const override {
     return applyAnimationDirection(rawProgress_.value_or(0));
   }
-  bool isFirstUpdate() const override {
-    return !previousRawProgress_.has_value();
-  }
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
   AnimationProgressState getState(double timestamp) const;
   double getPauseTimestamp() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
@@ -85,5 +84,3 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/KeyframeProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/KeyframeProgressProvider.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <string>
 
@@ -15,5 +14,3 @@ class KeyframeProgressProvider {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/KeyframeProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/KeyframeProgressProvider.h
@@ -7,7 +7,6 @@ namespace reanimated {
 class KeyframeProgressProvider {
  public:
   virtual double getGlobalProgress() const = 0;
-  virtual bool isFirstUpdate() const = 0;
 
   virtual double getKeyframeProgress(double fromOffset, double toOffset)
       const = 0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/progress/RawProgressProvider.h>
 
 namespace reanimated {
@@ -45,5 +44,3 @@ void RawProgressProvider::update(const double timestamp) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <chrono>
 #include <optional>
@@ -33,5 +32,3 @@ class RawProgressProvider {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/progress/TransitionProgressProvider.h>
 
 namespace reanimated {
@@ -221,5 +220,3 @@ TransitionProgressProvider::createReversingShorteningProgressProvider(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -56,10 +56,6 @@ TransitionProgressState TransitionPropertyProgressProvider::getState() const {
   return TransitionProgressState::Running;
 }
 
-bool TransitionPropertyProgressProvider::isFirstUpdate() const {
-  return !previousRawProgress_.has_value();
-}
-
 std::optional<double> TransitionPropertyProgressProvider::calculateRawProgress(
     const double timestamp) {
   if (duration_ == 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
@@ -87,5 +86,3 @@ class TransitionProgressProvider final {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -40,8 +40,6 @@ class TransitionPropertyProgressProvider final
   double getReversingShorteningFactor() const;
   TransitionProgressState getState() const;
 
-  bool isFirstUpdate() const override;
-
  protected:
   std::optional<double> calculateRawProgress(double timestamp) override;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -6,6 +6,11 @@ bool CSSAnimationsRegistry::hasUpdates() const {
   return !runningAnimationsMap_.empty() || !delayedAnimationsManager_.empty();
 }
 
+bool CSSAnimationsRegistry::isEmpty() const {
+    return UpdatesRegistry::isEmpty() && registry_.empty() &&
+           runningAnimationsMap_.empty() && animationsToRevertMap_.empty();
+}
+
 void CSSAnimationsRegistry::set(
     const ShadowNode::Shared &shadowNode,
     std::vector<std::shared_ptr<CSSAnimation>> &&animations,
@@ -269,11 +274,6 @@ bool CSSAnimationsRegistry::addStyleUpdates(
   }
 
   return hasUpdates;
-}
-
-bool CSSAnimationsRegistry::isEmpty() {
-  return UpdatesRegistry::isEmpty() && registry_.empty() &&
-      runningAnimationsMap_.empty() && animationsToRevertMap_.empty();
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/registry/CSSAnimationsRegistry.h>
 
 namespace reanimated {
@@ -278,5 +277,3 @@ bool CSSAnimationsRegistry::isEmpty() {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -7,8 +7,8 @@ bool CSSAnimationsRegistry::hasUpdates() const {
 }
 
 bool CSSAnimationsRegistry::isEmpty() const {
-    return UpdatesRegistry::isEmpty() && registry_.empty() &&
-           runningAnimationsMap_.empty() && animationsToRevertMap_.empty();
+  return UpdatesRegistry::isEmpty() && registry_.empty() &&
+      runningAnimationsMap_.empty() && animationsToRevertMap_.empty();
 }
 
 void CSSAnimationsRegistry::set(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/util/DelayedItemsManager.h>
@@ -71,5 +70,3 @@ class CSSAnimationsRegistry
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
@@ -22,6 +22,7 @@ class CSSAnimationsRegistry
       std::vector<std::pair<unsigned, PartialCSSAnimationSettings>>;
 
   bool hasUpdates() const;
+  bool isEmpty() const override;
 
   void set(
       const ShadowNode::Shared &shadowNode,
@@ -35,7 +36,6 @@ class CSSAnimationsRegistry
       double timestamp);
 
   void update(double timestamp);
-  bool isEmpty();
 
  private:
   using Registry =

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSKeyframesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSKeyframesRegistry.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/registry/CSSKeyframesRegistry.h>
 
 namespace reanimated {
@@ -25,5 +24,3 @@ void CSSKeyframesRegistry::remove(const std::string &animationName) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSKeyframesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSKeyframesRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
 
@@ -21,5 +20,3 @@ class CSSKeyframesRegistry {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
@@ -13,8 +13,8 @@ bool CSSTransitionsRegistry::hasUpdates() const {
 }
 
 bool CSSTransitionsRegistry::isEmpty() const {
-    return UpdatesRegistry::isEmpty() && registry_.empty() &&
-           runningTransitionTags_.empty();
+  return UpdatesRegistry::isEmpty() && registry_.empty() &&
+      runningTransitionTags_.empty();
 }
 
 void CSSTransitionsRegistry::add(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
@@ -12,6 +12,11 @@ bool CSSTransitionsRegistry::hasUpdates() const {
   return !runningTransitionTags_.empty() || !delayedTransitionsManager_.empty();
 }
 
+bool CSSTransitionsRegistry::isEmpty() const {
+    return UpdatesRegistry::isEmpty() && registry_.empty() &&
+           runningTransitionTags_.empty();
+}
+
 void CSSTransitionsRegistry::add(
     const std::shared_ptr<CSSTransition> &transition) {
   std::lock_guard<std::mutex> lock{mutex_};
@@ -48,11 +53,6 @@ void CSSTransitionsRegistry::removeBatch(const std::vector<Tag> &tagsToRemove) {
     runningTransitionTags_.erase(viewTag);
     registry_.erase(viewTag);
   }
-}
-
-bool CSSTransitionsRegistry::isEmpty() {
-  return UpdatesRegistry::isEmpty() && registry_.empty() &&
-      runningTransitionTags_.empty();
 }
 
 void CSSTransitionsRegistry::updateSettings(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/registry/CSSTransitionsRegistry.h>
 
 namespace reanimated {
@@ -171,5 +170,3 @@ PropsObserver CSSTransitionsRegistry::createPropsObserver(const Tag viewTag) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/core/CSSTransition.h>
 #include <reanimated/CSS/registry/StaticPropsRegistry.h>
@@ -53,5 +52,3 @@ class CSSTransitionsRegistry
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
@@ -25,11 +25,11 @@ class CSSTransitionsRegistry
       const GetAnimationTimestampFunction &getCurrentTimestamp);
 
   bool hasUpdates() const;
+  bool isEmpty() const override;
 
   void add(const std::shared_ptr<CSSTransition> &transition);
   void remove(Tag viewTag);
   void removeBatch(const std::vector<Tag> &tagsToRemove) override;
-  bool isEmpty();
   void updateSettings(Tag viewTag, const PartialCSSTransitionConfig &config);
 
   void update(double timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/registry/StaticPropsRegistry.h>
 
 namespace reanimated {
@@ -69,5 +68,3 @@ void StaticPropsRegistry::notifyObservers(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNode.h>
 
@@ -38,5 +37,3 @@ class StaticPropsRegistry {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/StaticPropsRegistry.h
@@ -22,9 +22,9 @@ class StaticPropsRegistry {
   void remove(Tag viewTag);
   void removeBatch(const std::vector<Tag> &tagsToRemove);
   bool isEmpty();
-  bool hasObservers(const Tag viewTag) const;
-  void setObserver(const Tag viewTag, PropsObserver observer);
-  void removeObserver(const Tag viewTag);
+  bool hasObservers(Tag viewTag) const;
+  void setObserver(Tag viewTag, PropsObserver observer);
+  void removeObserver(Tag viewTag);
 
  private:
   std::unordered_map<Tag, folly::dynamic> registry_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/DelayedItemsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/DelayedItemsManager.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/util/DelayedItemsManager.h>
 
 namespace reanimated {
@@ -91,5 +90,3 @@ template struct DelayedItemComparator<CSSAnimationId>;
 template struct DelayedItemComparator<Tag>;
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/DelayedItemsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/DelayedItemsManager.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/core/CSSAnimation.h>
 
@@ -52,5 +51,3 @@ class DelayedItemsManager {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/algorithms.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/algorithms.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/util/algorithms.h>
 
 namespace reanimated {
@@ -9,5 +8,3 @@ size_t firstSmallerOrEqual(const double x, const std::vector<double> &arr) {
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/algorithms.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/algorithms.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <algorithm>
 #include <vector>
@@ -9,5 +8,3 @@ namespace reanimated {
 size_t firstSmallerOrEqual(double x, const std::vector<double> &arr);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/util/interpolators.h>
 
 namespace reanimated {
@@ -35,5 +34,3 @@ std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 
@@ -22,5 +21,3 @@ std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/util/keyframes.h>
 
 namespace reanimated {
@@ -51,5 +50,3 @@ std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <jsi/jsi.h>
 #include <utility>
@@ -14,5 +13,3 @@ std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
     const jsi::Value &keyframes);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/CSS/util/props.h>
 
 namespace reanimated {
@@ -155,5 +154,3 @@ ChangedProps getChangedProps(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
@@ -130,7 +130,7 @@ ChangedProps getChangedProps(
   PropertyNames changedPropertyNames;
 
   for (const auto &propName : allowedProperties) {
-     auto [oldChangedProp, newChangedProp] =
+    auto [oldChangedProp, newChangedProp] =
         getChangedValueForProp(oldProps, newProps, propName);
 
     const auto hasOldChangedProp = !oldChangedProp.isNull();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.cpp
@@ -130,7 +130,7 @@ ChangedProps getChangedProps(
   PropertyNames changedPropertyNames;
 
   for (const auto &propName : allowedProperties) {
-    const auto [oldChangedProp, newChangedProp] =
+     auto [oldChangedProp, newChangedProp] =
         getChangedValueForProp(oldProps, newProps, propName);
 
     const auto hasOldChangedProp = !oldChangedProp.isNull();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/props.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/config/PropertyInterpolatorsConfig.h>
@@ -33,5 +32,3 @@ ChangedProps getChangedProps(
     const PropertyNames &allowedProperties);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 
 namespace reanimated {
@@ -28,6 +27,11 @@ SurfaceId AnimatedPropsRegistry::update(
   return surfaceId;
 }
 
-} // namespace reanimated
+void AnimatedPropsRegistry::removeBatch(const std::vector<Tag> &tagsToRemove) {
+  std::unique_lock<std::mutex> l(mutex_);
+  for (const auto &tag : tagsToRemove) {
+    updatesRegistry_.erase(tag);
+  }
+}
 
-#endif // RCT_NEW_ARCH_ENABLED
+} // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
 
@@ -19,9 +18,9 @@ class AnimatedPropsRegistry : public UpdatesRegistry {
 
  public:
   JSIUpdates getJSIUpdates();
+
   SurfaceId update(jsi::Runtime &rt, const jsi::Value &operations);
+  void removeBatch(const std::vector<Tag> &tagsToRemove) override;
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -3,7 +3,7 @@
 namespace reanimated {
 
 bool UpdatesRegistry::isEmpty() const {
-    return updatesRegistry_.empty();
+  return updatesRegistry_.empty();
 }
 
 folly::dynamic UpdatesRegistry::get(const Tag tag) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -1,7 +1,10 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
 
 namespace reanimated {
+
+bool UpdatesRegistry::isEmpty() const {
+    return updatesRegistry_.empty();
+}
 
 folly::dynamic UpdatesRegistry::get(const Tag tag) const {
   std::lock_guard<std::mutex> lock{mutex_};
@@ -94,17 +97,6 @@ void UpdatesRegistry::flushUpdatesToRegistry(
   }
 }
 
-void UpdatesRegistry::removeBatch(const std::vector<Tag> &tagsToRemove) {
-  std::unique_lock<std::mutex> l(mutex_);
-  for (const auto &tag : tagsToRemove) {
-    updatesRegistry_.erase(tag);
-  }
-}
-
-bool UpdatesRegistry::isEmpty() {
-  return updatesRegistry_.empty();
-}
-
 #ifdef ANDROID
 
 bool UpdatesRegistry::hasPropsToRevert() const {
@@ -164,5 +156,3 @@ void UpdatesRegistry::updatePropsToRevert(
 #endif
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 
@@ -33,7 +32,11 @@ using PropsToRevertMap = std::unordered_map<Tag, PropsToRevert>;
 
 class UpdatesRegistry {
  public:
+  virtual ~UpdatesRegistry() {}
+
   folly::dynamic get(Tag tag) const;
+
+  virtual bool isEmpty() const;
 
 #ifdef ANDROID
   bool hasPropsToRevert() const;
@@ -42,9 +45,7 @@ class UpdatesRegistry {
 
   void flushUpdates(UpdatesBatch &updatesBatch, bool merge);
   void collectProps(PropsMap &propsMap);
-  virtual void removeBatch(const std::vector<Tag> &tagsToRemove);
-  bool isEmpty();
-  virtual ~UpdatesRegistry() {}
+  virtual void removeBatch(const std::vector<Tag> &tagsToRemove) = 0;
 
  protected:
   mutable std::mutex mutex_;
@@ -72,5 +73,3 @@ class UpdatesRegistry {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -605,13 +605,7 @@ void ReanimatedModuleProxy::registerCSSAnimations(
         cssAnimationKeyframesRegistry_->get(animationName);
 
     animations.emplace_back(std::make_shared<CSSAnimation>(
-        rt,
-        shadowNode,
-        i,
-        keyframesConfig,
-        settings,
-        viewStylesRepository_,
-        timestamp));
+        rt, shadowNode, i, keyframesConfig, settings, timestamp));
   }
 
   cssAnimationsRegistry_->set(shadowNode, std::move(animations), timestamp);


### PR DESCRIPTION
## Summary

This PR removes `RCT_NEW_ARCH_ENABLED` from CSS code and applies some of clang-tidy suggestions in CSS-related files. It also cleans up code recently added in registries a bit.

## Test plan

Build the app and see that everything works
