### PR TITLE
fix: ColorsExample shadow color animation on web and android

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
@@ -6,6 +6,8 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { IS_WEB } from '@/utils';
+
 function makeColor(x: number) {
   'worklet';
   return `hsl(${Math.round(x * 240)}, 100%, 50%)`;
@@ -29,7 +31,9 @@ export default function ColorExample() {
   });
 
   const style4 = useAnimatedStyle(() => {
-    return { shadowColor: makeColor(sv.value) };
+    return IS_WEB
+      ? { boxShadow: `20px 20px 5px ${makeColor(sv.value)}` } // Use boxShadow for web
+      : { shadowColor: makeColor(sv.value) };
   });
 
   // TODO: textDecorationColor, tintColor, textShadowColor, overlayColor
@@ -88,6 +92,7 @@ const styles = StyleSheet.create({
     shadowRadius: 5,
     shadowOpacity: 1,
     shadowColor: 'black',
+    elevation: 20,
   },
   buttons: {
     marginTop: 50,


### PR DESCRIPTION
## Summary

Fixes ColorsExample:
- we cannot animate just `shadowColor` on web; `boxShadow` works fine instead (we can replace `shadowColor` with `boxShadow` for all platforms in the future),
- shadow properties don't work on Android, we have to use `elevation`

## Example recordings

| iOS | Android | Web |
|-|-|-|
| <video src="https://github.com/user-attachments/assets/9fb6f4a1-bbe7-4334-a585-2aefb1fe5871" /> | <video src="https://github.com/user-attachments/assets/51c7d15d-daf4-4c5d-82be-2bd4c18f5fd4" /> | <video src="https://github.com/user-attachments/assets/d20fe4ba-54fd-4c8a-971a-18bc3f350cc6" /> |
