### PR TITLE
Remove `RCT_NEW_ARCH_ENABLED` macros and unused functions in Common C++

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/Fabric/ReanimatedCommitHook.h>
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
@@ -99,5 +97,3 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
@@ -45,5 +44,3 @@ class ReanimatedCommitHook
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitShadowNode.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitShadowNode.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/ShadowNode.h>
 
@@ -45,5 +44,3 @@ class ReanimatedCommitShadowNode : public ShadowNode {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
@@ -47,5 +45,3 @@ void ReanimatedMountHook::shadowTreeDidMount(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
@@ -31,5 +30,3 @@ class ReanimatedMountHook : public UIManagerMountHook {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
@@ -106,5 +104,3 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -26,5 +25,3 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(
     std::vector<Tag> &tagsToRemove);
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 
 namespace reanimated {
@@ -132,5 +130,3 @@ void UpdatesRegistryManager::clearPropsToRevert(const SurfaceId surfaceId) {
 #endif
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/CSS/config/PropertyInterpolatorsConfig.h>
 #include <reanimated/CSS/registry/StaticPropsRegistry.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
@@ -63,5 +61,3 @@ class UpdatesRegistryManager {
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -19,12 +19,10 @@ void LayoutAnimationsManager::configureAnimationBatch(
       clearSharedTransitionConfig(tag);
       sharedTransitionConfigs.push_back(std::move(layoutAnimationConfig));
     } else {
-#ifdef RCT_NEW_ARCH_ENABLED
       if (type == ENTERING) {
         enteringAnimationsForNativeID_[tag] = config;
         continue;
       }
-#endif
       if (config == nullptr) {
         getConfigsForType(type).erase(tag);
       } else {
@@ -173,7 +171,6 @@ const std::vector<int> &LayoutAnimationsManager::getSharedGroup(
   return sharedTransitionGroups_[groupSharedTag];
 }
 
-#ifdef RCT_NEW_ARCH_ENABLED
 void LayoutAnimationsManager::transferConfigFromNativeID(
     const int nativeId,
     const int tag) {
@@ -184,7 +181,6 @@ void LayoutAnimationsManager::transferConfigFromNativeID(
   }
   enteringAnimationsForNativeID_.erase(nativeId);
 }
-#endif
 
 #ifndef NDEBUG
 std::string LayoutAnimationsManager::getScreenSharedTagPairString(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -44,9 +44,7 @@ class LayoutAnimationsManager {
   void clearLayoutAnimationConfig(const int tag);
   void clearSharedTransitionConfig(const int tag);
   void cancelLayoutAnimation(jsi::Runtime &rt, const int tag) const;
-#ifdef RCT_NEW_ARCH_ENABLED
   void transferConfigFromNativeID(const int nativeId, const int tag);
-#endif
   int findPrecedingViewTagForTransition(const int tag);
   const std::vector<int> &getSharedGroup(const int viewTag);
 #ifndef NDEBUG
@@ -69,10 +67,8 @@ class LayoutAnimationsManager {
   std::unordered_map<int, std::string> viewsScreenSharedTagMap_;
 #endif
 
-#ifdef RCT_NEW_ARCH_ENABLED
   std::unordered_map<int, std::shared_ptr<Shareable>>
       enteringAnimationsForNativeID_;
-#endif
   std::unordered_map<int, std::shared_ptr<Shareable>> enteringAnimations_;
   std::unordered_map<int, std::shared_ptr<Shareable>> exitingAnimations_;
   std::unordered_map<int, std::shared_ptr<Shareable>> layoutAnimations_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -1,5 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
 #include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
@@ -867,5 +865,3 @@ void LayoutAnimationsProxy::maybeUpdateWindowDimensions(
 }
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsUtils.h>
@@ -142,5 +141,3 @@ struct LayoutAnimationsProxy
 };
 
 } // namespace reanimated
-
-#endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
@@ -1,4 +1,3 @@
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/LayoutAnimations/LayoutAnimationsUtils.h>
 
 namespace reanimated {
@@ -87,5 +86,3 @@ bool MutationNode::isMutationMode() {
   return true;
 }
 } // namespace reanimated
-
-#endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -19,11 +19,11 @@
 #include <react/renderer/uimanager/primitives.h>
 
 #include <functional>
-#include <unordered_map>
-#include <utility>
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -1,11 +1,6 @@
 #pragma once
 
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
-#include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
-#include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
-#include <reanimated/Tools/PlatformDepMethodsHolder.h>
-#include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
-#include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/CSSTransition.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
@@ -14,10 +9,15 @@
 #include <reanimated/CSS/registry/CSSTransitionsRegistry.h>
 #include <reanimated/CSS/registry/StaticPropsRegistry.h>
 #include <reanimated/Fabric/ReanimatedCommitHook.h>
+#include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
+#include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
+#include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
+#include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/Registries/EventHandlerRegistry.h>
@@ -25,8 +25,8 @@
 #include <worklets/Tools/SingleInstanceChecker.h>
 #include <worklets/Tools/UIScheduler.h>
 
-#include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
 #include <string>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -4,11 +4,8 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
-
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
-
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/CSSTransition.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
@@ -21,7 +18,6 @@
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
-#endif // RCT_NEW_ARCH_ENABLED
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/Registries/EventHandlerRegistry.h>
@@ -29,10 +25,7 @@
 #include <worklets/Tools/SingleInstanceChecker.h>
 #include <worklets/Tools/UIScheduler.h>
 
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <react/renderer/uimanager/UIManager.h>
-#endif // RCT_NEW_ARCH_ENABLED
-
 #include <react/renderer/core/ShadowNode.h>
 
 #include <memory>
@@ -76,11 +69,7 @@ class ReanimatedModuleProxy
 
   jsi::Value getViewProp(
       jsi::Runtime &rt,
-#ifdef RCT_NEW_ARCH_ENABLED
       const jsi::Value &shadowNodeWrapper,
-#else
-      const jsi::Value &viewTag,
-#endif
       const jsi::Value &propName,
       const jsi::Value &callback) override;
 
@@ -116,7 +105,6 @@ class ReanimatedModuleProxy
     return jsLogger_;
   }
 
-#ifdef RCT_NEW_ARCH_ENABLED
   bool handleRawEvent(const RawEvent &rawEvent, double currentTime);
 
   void maybeRunCSSLoop();
@@ -181,7 +169,6 @@ class ReanimatedModuleProxy
       jsi::Runtime &rt,
       const std::string &propName,
       const ShadowNode::Shared &shadowNode);
-#endif
 
   jsi::Value registerSensor(
       jsi::Runtime &rt,
@@ -221,11 +208,9 @@ class ReanimatedModuleProxy
  private:
   void commitUpdates(jsi::Runtime &rt, const UpdatesBatch &updatesBatch);
 
-#ifdef RCT_NEW_ARCH_ENABLED
   jsi::Value filterNonAnimatableProps(
       jsi::Runtime &rt,
       const jsi::Value &props);
-#endif // RCT_NEW_ARCH_ENABLED
 
   const bool isReducedMotion_;
   bool shouldFlushRegistry_ = false;
@@ -242,7 +227,6 @@ class ReanimatedModuleProxy
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
   GetAnimationTimestampFunction getAnimationTimestamp_;
 
-#ifdef RCT_NEW_ARCH_ENABLED
   bool cssLoopRunning_{false};
   bool shouldUpdateCssAnimations_{true};
   double currentCssTimestamp_{0};
@@ -261,11 +245,6 @@ class ReanimatedModuleProxy
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
-#else
-  const ObtainPropFunction obtainPropFunction_;
-  const ConfigurePropsFunction configurePropsPlatformFunction_;
-  const UpdatePropsFunction updatePropsFunction_;
-#endif
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -121,8 +121,6 @@ static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)(
   return jsi::Value::undefined();
 }
 
-#ifdef RCT_NEW_ARCH_ENABLED
-
 static jsi::Value REANIMATED_SPEC_PREFIX(setViewStyle)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -223,8 +221,6 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unregisterCSSTransition)(
   return jsi::Value::undefined();
 }
 
-#endif // RCT_NEW_ARCH_ENABLED
-
 ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
     const std::shared_ptr<CallInvoker> &jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
@@ -253,8 +249,6 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
   methodMap_["setShouldAnimateExitingForTag"] =
       MethodMetadata{2, REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)};
 
-#ifdef RCT_NEW_ARCH_ENABLED
-
   methodMap_["setViewStyle"] =
       MethodMetadata{2, REANIMATED_SPEC_PREFIX(setViewStyle)};
   methodMap_["removeViewStyle"] =
@@ -278,7 +272,6 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
       MethodMetadata{2, REANIMATED_SPEC_PREFIX(updateCSSTransition)};
   methodMap_["unregisterCSSTransition"] =
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(unregisterCSSTransition)};
-
-#endif
 }
+
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -31,11 +31,7 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
   // views
   virtual jsi::Value getViewProp(
       jsi::Runtime &rt,
-#ifdef RCT_NEW_ARCH_ENABLED
       const jsi::Value &shadowNodeWrapper,
-#else
-      const jsi::Value &viewTag,
-#endif
       const jsi::Value &propName,
       const jsi::Value &callback) = 0;
 
@@ -79,8 +75,6 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
       const jsi::Value &viewTag,
       const jsi::Value &shouldAnimate) = 0;
 
-#ifdef RCT_NEW_ARCH_ENABLED
-
   // JS View style
   virtual void setViewStyle(
       jsi::Runtime &rt,
@@ -121,7 +115,6 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &viewTag) = 0;
 
-#endif // RCT_NEW_ARCH_ENABLED
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -114,7 +114,6 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
   virtual void unregisterCSSTransition(
       jsi::Runtime &rt,
       const jsi::Value &viewTag) = 0;
-
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
@@ -24,12 +24,12 @@ void RNRuntimeDecorator::decorate(
   checkJSVersion(rnRuntime, reanimatedModuleProxy->getJSLogger());
 #endif // NDEBUG
 
-#if defined(IS_REANIMATED_EXAMPLE_APP) && defined(RCT_NEW_ARCH_ENABLED)
+#ifdef IS_REANIMATED_EXAMPLE_APP
   jsi_utils::installJsiFunction(
       rnRuntime,
       "_registriesLeakCheck",
       reanimatedModuleProxy->createRegistriesLeakCheck());
-#endif // defined(IS_REANIMATED_EXAMPLE_APP) && defined(RCT_NEW_ARCH_ENABLED)
+#endif // IS_REANIMATED_EXAMPLE_APP
   injectReanimatedCppVersion(rnRuntime);
 
   rnRuntime.global().setProperty(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
@@ -7,11 +7,6 @@ using namespace worklets;
 
 void UIRuntimeDecorator::decorate(
     jsi::Runtime &uiRuntime,
-#ifdef RCT_NEW_ARCH_ENABLED
-// nothing
-#else
-    const ScrollToFunction scrollTo,
-#endif
     const ObtainPropFunction obtainPropFunction,
     const UpdatePropsFunction updateProps,
     const MeasureFunction measure,
@@ -21,30 +16,10 @@ void UIRuntimeDecorator::decorate(
     const ProgressLayoutAnimationFunction progressLayoutAnimation,
     const EndLayoutAnimationFunction endLayoutAnimation,
     const MaybeFlushUIUpdatesQueueFunction maybeFlushUIUpdatesQueue) {
-#ifdef RCT_NEW_ARCH_ENABLED
   jsi_utils::installJsiFunction(uiRuntime, "_updatePropsFabric", updateProps);
   jsi_utils::installJsiFunction(
       uiRuntime, "_dispatchCommandFabric", dispatchCommand);
   jsi_utils::installJsiFunction(uiRuntime, "_measureFabric", measure);
-#else
-  jsi_utils::installJsiFunction(uiRuntime, "_updatePropsPaper", updateProps);
-  jsi_utils::installJsiFunction(
-      uiRuntime, "_dispatchCommandPaper", dispatchCommand);
-  jsi_utils::installJsiFunction(uiRuntime, "_scrollToPaper", scrollTo);
-  jsi_utils::installJsiFunction(
-      uiRuntime,
-      "_measurePaper",
-      [measure](jsi::Runtime &rt, int viewTag) -> jsi::Value {
-        auto result = measure(viewTag);
-        jsi::Object resultObject(rt);
-        for (const auto &item : result) {
-          resultObject.setProperty(rt, item.first.c_str(), item.second);
-        }
-        return resultObject;
-      });
-  jsi_utils::installJsiFunction(
-      uiRuntime, "_obtainPropPaper", obtainPropFunction);
-#endif // RCT_NEW_ARCH_ENABLED
 
   jsi_utils::installJsiFunction(
       uiRuntime, "_getAnimationTimestamp", getAnimationTimestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.h
@@ -12,11 +12,6 @@ class UIRuntimeDecorator {
  public:
   static void decorate(
       jsi::Runtime &uiRuntime,
-#ifdef RCT_NEW_ARCH_ENABLED
-// nothing
-#else
-      const ScrollToFunction scrollTo,
-#endif
       const ObtainPropFunction obtainPropFunction,
       const UpdatePropsFunction updateProps,
       const MeasureFunction measure,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -1,25 +1,17 @@
 #pragma once
 
 #include <jsi/jsi.h>
-
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <folly/dynamic.h>
 #include <react/renderer/core/ReactPrimitives.h>
-#endif
 
 #include <string>
 #include <utility>
 #include <vector>
 
 using namespace facebook;
-
-#ifdef RCT_NEW_ARCH_ENABLED
 using namespace react;
-#endif
 
 namespace reanimated {
-
-#ifdef RCT_NEW_ARCH_ENABLED
 
 using UpdatePropsFunction =
     std::function<void(jsi::Runtime &rt, const jsi::Value &operations)>;
@@ -34,23 +26,6 @@ using DispatchCommandFunction = std::function<void(
     const jsi::Value &argsValue)>;
 using MeasureFunction = std::function<
     jsi::Value(jsi::Runtime &rt, const jsi::Value &shadowNodeValue)>;
-
-#else
-
-using UpdatePropsFunction =
-    std::function<void(jsi::Runtime &rt, const jsi::Value &operations)>;
-using ScrollToFunction = std::function<void(int, double, double, bool)>;
-using DispatchCommandFunction = std::function<void(
-    jsi::Runtime &rt,
-    const int viewTag,
-    const jsi::Value &commandNameValue,
-    const jsi::Value &argsValue)>;
-using MeasureFunction =
-    std::function<std::vector<std::pair<std::string, double>>(int)>;
-using ObtainPropFunction =
-    std::function<jsi::Value(jsi::Runtime &, const int, const jsi::Value &)>;
-
-#endif // RCT_NEW_ARCH_ENABLED
 
 using RequestRenderFunction =
     std::function<void(std::function<void(const double)>)>;
@@ -75,16 +50,6 @@ using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 
 struct PlatformDepMethodsHolder {
   RequestRenderFunction requestRender;
-#ifdef RCT_NEW_ARCH_ENABLED
-  // nothing
-#else
-  UpdatePropsFunction updatePropsFunction;
-  ScrollToFunction scrollToFunction;
-  DispatchCommandFunction dispatchCommandFunction;
-  MeasureFunction measureFunction;
-  ConfigurePropsFunction configurePropsFunction;
-  ObtainPropFunction obtainPropFunction;
-#endif
   GetAnimationTimestampFunction getAnimationTimestamp;
   ProgressLayoutAnimationFunction progressLayoutAnimation;
   EndLayoutAnimationFunction endLayoutAnimation;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <jsi/jsi.h>
 #include <folly/dynamic.h>
+#include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>
 
 #include <string>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -2,10 +2,8 @@
 #include <string>
 #include <utility>
 
-#ifdef RCT_NEW_ARCH_ENABLED
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/primitives.h>
-#endif // RCT_NEW_ARCH_ENABLED
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/SharedItems/Shareables.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
@@ -9,12 +9,7 @@ void RNRuntimeWorkletDecorator::decorate(
 
   // TODO: Remove _IS_FABRIC sometime in the future
   // react-native-screens 4.9.0 depends on it
-#ifdef RCT_NEW_ARCH_ENABLED
-  constexpr auto isFabric = true;
-#else
-  constexpr auto isFabric = false;
-#endif // RCT_NEW_ARCH_ENABLED
-  rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", isFabric);
+  rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", true);
 
   rnRuntime.global().setProperty(
       rnRuntime,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -49,12 +49,7 @@ void WorkletRuntimeDecorator::decorate(
 
   // TODO: Remove _IS_FABRIC sometime in the future
   // react-native-screens 4.9.0 depends on it
-#ifdef RCT_NEW_ARCH_ENABLED
-  constexpr auto isFabric = true;
-#else
-  constexpr auto isFabric = false;
-#endif // RCT_NEW_ARCH_ENABLED
-  rt.global().setProperty(rt, "_IS_FABRIC", isFabric);
+  rt.global().setProperty(rt, "_IS_FABRIC", true);
 
 #ifndef NDEBUG
   auto evalWithSourceUrl = [](jsi::Runtime &rt,


### PR DESCRIPTION
Co-authored-by: Krzysztof Piaskowy <krzysztof.piaskowy@swmansion.com>

## Summary

This PR removes all `#ifdef RCT_NEW_ARCH_ENABLED` in Reanimated C++ codebase common for all native platforms.

## Test plan

See if CI is green.
