### PR TITLE
Restore original value of `canOverrideExistingModule`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java
@@ -46,7 +46,7 @@ public class ReanimatedPackage extends BaseReactPackage implements ReactPackage 
           new ReactModuleInfo(
               reactModule.name(),
               moduleClass.getName(),
-              true, // override UIManagerModule
+              reactModule.canOverrideExistingModule(),
               reactModule.needsEagerInit(),
               reactModule.isCxxModule(),
               true));

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsPackage.java
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsPackage.java
@@ -38,7 +38,7 @@ public class WorkletsPackage extends BaseReactPackage implements ReactPackage {
           new ReactModuleInfo(
               reactModule.name(),
               moduleClass.getName(),
-              true,
+              reactModule.canOverrideExistingModule(),
               reactModule.needsEagerInit(),
               reactModule.isCxxModule(),
               BuildConfig.IS_NEW_ARCHITECTURE_ENABLED));


### PR DESCRIPTION
## Summary

We used to pass `true` as `canOverrideExistingModule` argument because of the fact that we used to overwrite `UIManagerModule` to handle layout animations. Since we no longer need to do that, this PR restores the recommended value for `canOverrideExistingModule`.

## Test plan
