### PR TITLE
Remove redundant includes on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -3,18 +3,9 @@
 #include <reanimated/Tools/ReanimatedVersion.h>
 #include <reanimated/android/NativeProxy.h>
 
-#include <worklets/Tools/ReanimatedJSIUtils.h>
-#include <worklets/WorkletRuntime/WorkletRuntime.h>
 #include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
-#include <worklets/android/AndroidUIScheduler.h>
 
-#include <android/log.h>
-#include <fbjni/fbjni.h>
-#include <jsi/JSIDynamic.h>
-#include <jsi/jsi.h>
 #include <react/fabric/Binding.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <react/jni/ReadableNativeMap.h>
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -9,17 +9,12 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <react/fabric/JFabricUIManager.h>
-#include <react/jni/CxxModuleWrapper.h>
-#include <react/jni/JRuntimeExecutor.h>
-#include <react/jni/JavaScriptExecutorHolder.h>
 #include <react/jni/WritableNativeMap.h>
 #include <react/renderer/scheduler/Scheduler.h>
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
-#include <vector>
 
 namespace reanimated {
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -1,9 +1,5 @@
 #include <worklets/android/AndroidUIScheduler.h>
 
-#include <android/log.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
 namespace worklets {
 
 using namespace facebook;

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.h
@@ -3,12 +3,7 @@
 #include <worklets/Tools/UIScheduler.h>
 
 #include <fbjni/fbjni.h>
-#include <jni.h>
 #include <jsi/jsi.h>
-#include <react/jni/CxxModuleWrapper.h>
-#include <react/jni/JMessageQueueThread.h>
-
-#include <memory>
 
 namespace worklets {
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AnimationFrameCallback.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AnimationFrameCallback.h
@@ -2,8 +2,6 @@
 
 #include <fbjni/fbjni.h>
 
-#include <utility>
-
 namespace worklets {
 
 class AnimationFrameCallback

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -1,17 +1,8 @@
-#include <android/log.h>
-#include <fbjni/fbjni.h>
-#include <jsi/JSIDynamic.h>
-#include <jsi/jsi.h>
 #include <react/jni/JMessageQueueThread.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <react/jni/ReadableNativeMap.h>
 
 #include <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #include <worklets/android/AnimationFrameCallback.h>
 #include <worklets/android/WorkletsModule.h>
-
-#include <functional>
-#include <utility>
 
 namespace worklets {
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -1,18 +1,12 @@
 #pragma once
 
-#include <fbjni/detail/References.h>
 #include <ReactCommon/CallInvokerHolder.h>
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
-#include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JMessageQueueThread.h>
-#include <react/jni/WritableNativeMap.h>
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/android/AndroidUIScheduler.h>
-
-#include <memory>
-#include <string>
 
 namespace worklets {
 


### PR DESCRIPTION
## Summary

This PR removes unnecessary `#include` macros on Android.

## Test plan

See if CI is green.
