### PR TITLE
Remove unused methods from `NativeMethods` on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeMethods.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeMethods.h
@@ -1,21 +1,7 @@
-#import <Foundation/Foundation.h>
-#import <React/RCTUIManager.h>
 #import <reanimated/apple/RNGestureHandlerStateManager.h>
-#import <string>
-#import <utility>
-#import <vector>
 
 namespace reanimated {
 
-std::vector<std::pair<std::string, double>> measure(
-    int viewTag,
-    RCTUIManager *uiManager);
-void scrollTo(
-    int scrollViewTag,
-    RCTUIManager *uiManager,
-    double x,
-    double y,
-    bool animated);
 void setGestureState(
     id<RNGestureHandlerStateManager> gestureHandlerStateManager,
     int handlerTag,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeMethods.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeMethods.mm
@@ -1,47 +1,6 @@
-#import <React/RCTEventDispatcher.h>
-#import <React/RCTScrollView.h>
-#import <reanimated/apple/REAUIKit.h>
 #import <reanimated/apple/native/NativeMethods.h>
 
 namespace reanimated {
-
-std::vector<std::pair<std::string, double>> measure(int viewTag, RCTUIManager *uiManager)
-{
-  REAUIView *view = [uiManager viewForReactTag:@(viewTag)];
-
-  REAUIView *rootView = view;
-
-  if (view == nil) {
-    return std::vector<std::pair<std::string, double>>(1, std::make_pair("x", -1234567.0));
-  }
-
-  while (rootView.superview && ![rootView isReactRootView]) {
-    rootView = rootView.superview;
-  }
-
-  if (rootView == nil) {
-    return std::vector<std::pair<std::string, double>>(1, std::make_pair("x", -1234567.0));
-  }
-
-  CGRect frame = view.frame;
-  CGRect globalBounds = [view convertRect:view.bounds toView:rootView];
-
-  return {
-      {"x", frame.origin.x},
-      {"y", frame.origin.y},
-      {"width", globalBounds.size.width},
-      {"height", globalBounds.size.height},
-      {"pageX", globalBounds.origin.x},
-      {"pageY", globalBounds.origin.y},
-  };
-}
-
-void scrollTo(int scrollViewTag, RCTUIManager *uiManager, double x, double y, bool animated)
-{
-  REAUIView *view = [uiManager viewForReactTag:@(scrollViewTag)];
-  RCTScrollView *scrollView = (RCTScrollView *)view;
-  [scrollView scrollToOffset:(CGPoint){(CGFloat)x, (CGFloat)y} animated:animated];
-}
 
 void setGestureState(id<RNGestureHandlerStateManager> gestureHandlerStateManager, int handlerTag, int newState)
 {


### PR DESCRIPTION
## Summary

This PR removes unused methods `measure` and `scrollTo` from `NativeMethods` on iOS since they are now implemented in C++.

## Test plan

See if CI is green.