### PR TITLE
Remove unused `convertProps` function and `REAJSIUtils` functions

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -7,7 +7,6 @@
 #import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
 #import <reanimated/apple/native/NativeMethods.h>
 #import <reanimated/apple/native/NativeProxy.h>
-#import <reanimated/apple/native/REAJSIUtils.h>
 #import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
 
 #import <React/RCTBridge+Private.h>
@@ -31,17 +30,6 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
-
-static NSSet *convertProps(jsi::Runtime &rt, const jsi::Value &props)
-{
-  NSMutableSet *propsSet = [[NSMutableSet alloc] init];
-  jsi::Array propsNames = props.asObject(rt).asArray(rt);
-  for (int i = 0; i < propsNames.size(rt); i++) {
-    NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
-    [propsSet addObject:propName];
-  }
-  return propsSet;
-}
 
 SetGestureStateFunction makeSetGestureStateFunction(RCTModuleRegistry *moduleRegistry)
 {

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/REAJSIUtils.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/REAJSIUtils.h
@@ -25,11 +25,12 @@ static jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *v
 }
 
 static jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
+
 static jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)
 {
   jsi::Object result = jsi::Object(runtime);
   for (NSString *k in value) {
-    result.setProperty(runtime, [k UTF8String], convertObjCObjectToJSIValue(runtime, value[k]));
+    result.setProperty(runtime, convertNSStringToJSIString(runtime, k), convertObjCObjectToJSIValue(runtime, value[k]));
   }
   return result;
 }
@@ -60,96 +61,4 @@ static jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
     return jsi::Value::null();
   }
   return jsi::Value::undefined();
-}
-
-// Other
-
-static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
-
-static NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value)
-{
-  return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
-}
-
-static NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value)
-{
-  jsi::Array propertyNames = value.getPropertyNames(runtime);
-  size_t size = propertyNames.size(runtime);
-  NSMutableDictionary *result = [NSMutableDictionary new];
-  for (size_t i = 0; i < size; i++) {
-    jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
-    NSString *k = convertJSIStringToNSString(runtime, name);
-    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name));
-    if (v) {
-      result[k] = v;
-    }
-  }
-  return [result copy];
-}
-
-static NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value)
-{
-  size_t size = value.size(runtime);
-  NSMutableArray *result = [NSMutableArray new];
-  for (size_t i = 0; i < size; i++) {
-    // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i)) ?: (id)kCFNull];
-  }
-  return [result copy];
-}
-
-static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value)
-{
-  if (value.isUndefined() || value.isNull()) {
-    return nil;
-  }
-  if (value.isBool()) {
-    return @(value.getBool());
-  }
-  if (value.isNumber()) {
-    return @(value.getNumber());
-  }
-  if (value.isString()) {
-    return convertJSIStringToNSString(runtime, value.getString(runtime));
-  }
-  if (value.isObject()) {
-    jsi::Object o = value.getObject(runtime);
-    if (o.isArray(runtime)) {
-      return convertJSIArrayToNSArray(runtime, o.getArray(runtime));
-    }
-    return convertJSIObjectToNSDictionary(runtime, o);
-  }
-
-  throw std::runtime_error("[Reanimated] Unsupported jsi::Value kind.");
-}
-
-static id convertDynamicToNSObject(const folly::dynamic &value)
-{
-  if (value.isNull()) {
-    return [NSNull null];
-  } else if (value.isBool()) {
-    return [NSNumber numberWithBool:value.asBool()];
-  } else if (value.isInt()) {
-    return [NSNumber numberWithLong:value.asInt()];
-  } else if (value.isDouble()) {
-    return [NSNumber numberWithDouble:value.asDouble()];
-  } else if (value.isString()) {
-    return [NSString stringWithUTF8String:value.asString().c_str()];
-  } else if (value.isArray()) {
-    NSMutableArray *array = [NSMutableArray arrayWithCapacity:value.size()];
-    for (const auto &elem : value) {
-      [array addObject:convertDynamicToNSObject(elem)];
-    }
-    return array;
-  } else if (value.isObject()) {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-    for (const auto &pair : value.items()) {
-      NSString *key = [NSString stringWithUTF8String:pair.first.c_str()];
-      id object = convertDynamicToNSObject(pair.second);
-      [dictionary setObject:object forKey:key];
-    }
-    return dictionary;
-  } else {
-    return nil;
-  }
 }


### PR DESCRIPTION
## Summary

This PR removes unused import and `convertProps` method in PlatformDepMethodsHolderImpl.mm as well as removes unused functions in REAJSIUtils.h (the rest is still used) and aligns the implementation with RCTTurboModule.mm from react-native.

## Test plan
