### PR TITLE
Remove redundant includes on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.h
@@ -1,9 +1,7 @@
 #import <React/RCTCallInvokerModule.h>
-#import <React/RCTEventDispatcher.h>
 #import <React/RCTEventEmitter.h>
-#import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
-#import <React/RCTUIManagerUtils.h>
+
 #import <rnreanimated/rnreanimated.h>
 
 #import <reanimated/apple/REANodesManager.h>

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -1,28 +1,16 @@
-#import <React/RCTBridge+Private.h>
-
 #import <React/RCTCallInvoker.h>
-#import <React/RCTFabricSurface.h>
 #import <React/RCTScheduler.h>
-#import <React/RCTSurface.h>
 #import <React/RCTSurfacePresenter.h>
-#import <React/RCTSurfacePresenterBridgeAdapter.h>
-#import <React/RCTSurfaceView.h>
+#import <React/RCTUIManagerUtils.h>
 
 #import <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
-#import <reanimated/apple/REAUIKit.h>
 #import <reanimated/apple/native/NativeProxy.h>
 
-#import <worklets/Tools/ReanimatedJSIUtils.h>
 #import <worklets/Tools/SingleInstanceChecker.h>
-#import <worklets/WorkletRuntime/WorkletRuntime.h>
 #import <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
 #import <worklets/apple/WorkletsModule.h>
-
-#if __has_include(<UIKit/UIAccessibility.h>)
-#import <UIKit/UIAccessibility.h>
-#endif // __has_include(<UIKit/UIAccessibility.h>)
 
 using namespace facebook::react;
 using namespace reanimated;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -1,25 +1,18 @@
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcherProtocol.h>
 #import <React/RCTSurfacePresenterStub.h>
-#import <React/RCTUIManager.h>
 
 #import <reanimated/apple/READisplayLink.h>
 
 @class REAModule;
 
 typedef void (^REAOnAnimationCallback)(READisplayLink *displayLink);
-typedef void (^REANativeAnimationOp)(RCTUIManager *uiManager);
 typedef void (^REAEventHandler)(id<RCTEvent> event);
 typedef void (^CADisplayLinkOperation)(READisplayLink *displayLink);
 typedef void (^REAPerformOperations)();
 
 @interface REANodesManager : NSObject
 
-@property (nonatomic, weak, nullable) RCTUIManager *uiManager;
 @property (nonatomic, weak, nullable) REAModule *reanimatedModule;
-@property (nonatomic, readonly) CFTimeInterval currentAnimationTimestamp;
-
-@property (nonatomic, nullable) NSSet<NSString *> *uiProps;
-@property (nonatomic, nullable) NSSet<NSString *> *nativeProps;
 
 - (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
                                 bridge:(RCTBridge *)bridge

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -1,16 +1,6 @@
-#import <React/RCTConvert.h>
-#import <reanimated/apple/READisplayLink.h>
-#import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
-#import <reanimated/apple/REAUIKit.h>
 
-#import <React/RCTComponentViewRegistry.h>
-#import <React/RCTMountingManager.h>
-#import <React/RCTSurfacePresenter.h>
-#import <react/renderer/core/ShadowNode.h>
-#import <react/renderer/uimanager/UIManager.h>
-
-using namespace facebook::react;
+#import <React/RCTUtils.h>
 
 @implementation REANodesManager {
   READisplayLink *_displayLink;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REASlowAnimations.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REASlowAnimations.mm
@@ -1,5 +1,7 @@
 #import <QuartzCore/QuartzCore.h>
+
 #import <reanimated/apple/REASlowAnimations.h>
+
 #if TARGET_IPHONE_SIMULATOR
 #import <dlfcn.h>
 #endif

--- a/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h
@@ -1,5 +1,3 @@
-#import <React/RCTEventDispatcher.h>
-
 typedef void (^KeyboardEventListenerBlock)(int keyboardState, int height);
 
 @interface REAKeyboardEventObserver : NSObject

--- a/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <React/RCTDefines.h>
-#import <React/RCTUIManager.h>
+
+#import <React/RCTAssert.h>
+#import <React/RCTBridgeConstants.h>
+#import <React/RCTUtils.h>
+
 #import <reanimated/apple/READisplayLink.h>
 #import <reanimated/apple/REASlowAnimations.h>
 #import <reanimated/apple/REAUIKit.h>

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -1,13 +1,9 @@
 #if __cplusplus
 
-#import <React/RCTEventDispatcher.h>
 #import <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #import <reanimated/apple/REAModule.h>
-#import <reanimated/apple/REANodesManager.h>
-#import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
-#import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
+
 #import <worklets/apple/WorkletsModule.h>
-#import <memory>
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -1,28 +1,7 @@
-#import <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #import <reanimated/Tools/PlatformDepMethodsHolder.h>
-#import <reanimated/apple/READisplayLink.h>
-#import <reanimated/apple/REAModule.h>
-#import <reanimated/apple/REANodesManager.h>
-#import <reanimated/apple/REASlowAnimations.h>
-#import <reanimated/apple/RNGestureHandlerStateManager.h>
-#import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
-#import <reanimated/apple/native/NativeMethods.h>
 #import <reanimated/apple/native/NativeProxy.h>
 #import <reanimated/apple/native/PlatformDepMethodsHolderImpl.h>
 #import <reanimated/apple/native/REAJSIUtils.h>
-#import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
-
-#import <React/RCTBridge+Private.h>
-#import <React/RCTScheduler.h>
-#import <React/RCTSurfacePresenter.h>
-#import <react/renderer/core/ShadowNode.h>
-#import <react/renderer/uimanager/primitives.h>
-
-#import <React/RCTUIManager.h>
-
-#if TARGET_IPHONE_SIMULATOR
-#import <dlfcn.h>
-#endif
 
 @interface RCTBridge (JSIRuntime)
 - (void *)runtime;

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
@@ -1,12 +1,9 @@
 #if __cplusplus
 
-#import <REAKeyboardEventObserver.h>
-#import <REAModule.h>
-#import <REANodesManager.h>
-#import <React/RCTEventDispatcher.h>
-#import <reanimated/NativeModules/ReanimatedModuleProxy.h>
+#import <reanimated/apple/REAModule.h>
+#import <reanimated/apple/REANodesManager.h>
+#import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
 #import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
-#import <memory>
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -1,30 +1,11 @@
 #import <reanimated/Tools/PlatformDepMethodsHolder.h>
 #import <reanimated/apple/READisplayLink.h>
-#import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
 #import <reanimated/apple/REASlowAnimations.h>
 #import <reanimated/apple/RNGestureHandlerStateManager.h>
 #import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
 #import <reanimated/apple/native/NativeMethods.h>
-#import <reanimated/apple/native/NativeProxy.h>
 #import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
-
-#import <React/RCTBridge+Private.h>
-#import <React/RCTScheduler.h>
-#import <React/RCTSurfacePresenter.h>
-#import <React/RCTUIManager.h>
-#import <react/renderer/core/ShadowNode.h>
-#import <react/renderer/uimanager/primitives.h>
-
-#if TARGET_IPHONE_SIMULATOR
-#import <dlfcn.h>
-#endif
-
-@interface RCTUIManager (DispatchCommand)
-- (void)dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
-                         commandID:(id /*(NSString or NSNumber) */)commandID
-                       commandArgs:(NSArray<id> *)commandArgs;
-@end
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/sensor/ReanimatedSensor.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/sensor/ReanimatedSensor.h
@@ -1,6 +1,7 @@
 #if !TARGET_OS_TV && !TARGET_OS_OSX
 #import <CoreMotion/CoreMotion.h>
 #endif
+
 #import <reanimated/apple/sensor/ReanimatedSensorType.h>
 
 @interface ReanimatedSensor : NSObject {

--- a/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.h
+++ b/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.h
@@ -1,10 +1,5 @@
 #import <worklets/Tools/UIScheduler.h>
 
-#import <React/RCTUIManager.h>
-#import <ReactCommon/CallInvoker.h>
-
-#import <memory>
-
 namespace worklets {
 
 using namespace facebook;

--- a/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
@@ -1,5 +1,7 @@
 #import <QuartzCore/QuartzCore.h>
+
 #import <worklets/apple/SlowAnimations.h>
+
 #if TARGET_IPHONE_SIMULATOR
 #import <dlfcn.h>
 #endif

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.h
@@ -1,11 +1,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
-#import <React/RCTJavaScriptExecutor.h>
 #import <React/RCTMessageThread.h>
-#import <cxxreact/MessageQueueThread.h>
-#import <memory>
-#import <string>
 
 namespace facebook {
 namespace react {

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.mm
@@ -1,20 +1,12 @@
 #import <worklets/apple/WorkletsMessageThread.h>
 
-#import <condition_variable>
-#import <mutex>
-
-#import <React/RCTCxxUtils.h>
-#import <React/RCTMessageThread.h>
-#import <React/RCTUtils.h>
-
 namespace facebook {
 namespace react {
 
 // Essentially the same as RCTMessageThread, but with public fields.
 struct WorkletsMessageThreadPublic {
-  // I don't know why we need three vtables (if you know then feel free to#import
-  // <worklets/apple/WorkletsMessageThread.h> explain it instead of this message), but this is what makes the casts
-  // in quitSynchronous() work correctly.
+  // I don't know why we need three vtables (if you know then feel free to explain it instead of this message),
+  // but this is what makes the casts in quitSynchronous() work correctly.
   void *vtable1;
   void *vtable2;
   void *vtable3;

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,5 +1,6 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
 @interface WorkletsModule : RCTEventEmitter <RCTBridgeModule>

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -1,4 +1,3 @@
-#import <React/RCTBridge+Private.h>
 #import <worklets/Tools/SingleInstanceChecker.h>
 #import <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #import <worklets/apple/AnimationFrameQueue.h>


### PR DESCRIPTION
## Summary

This PR removes unnecessary imports on iOS as well as some unused typedefs and class member fields.

## Test plan

See if the CI is green.