### PR TITLE
Remove `requiresMainQueueSetup` with `YES`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -44,11 +44,6 @@ using namespace reanimated;
 
 RCT_EXPORT_MODULE(ReanimatedModule);
 
-+ (BOOL)requiresMainQueueSetup
-{
-  return YES;
-}
-
 - (void)invalidate
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -44,7 +44,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (dispatch_queue_t)methodQueue
 {
-  RCTAssertMainQueue();
+  REAAssertJavaScriptQueue();
 
   // This module needs to be on the same queue as the UIManager to avoid
   // having to lock `_operations` and `_preOperations` since `uiManagerWillPerformMounting`
@@ -100,13 +100,13 @@ RCT_EXPORT_MODULE(ReanimatedModule);
  */
 - (void)setSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
-  RCTAssertMainQueue();
+  REAAssertJavaScriptQueue();
   _surfacePresenter = surfacePresenter;
 }
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  RCTAssertMainQueue();
+  REAAssertJavaScriptQueue();
   [super setBridge:bridge];
   _nodesManager = [[REANodesManager alloc] initWithModule:self bridge:bridge surfacePresenter:_surfacePresenter];
   [[self.moduleRegistry moduleForName:"EventDispatcher"] addDispatchObserver:self];

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -147,10 +147,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   REAAssertJavaScriptQueue();
 
   WorkletsModule *workletsModule = [_moduleRegistry moduleForName:"WorkletsModule"];
-  auto jsCallInvoker = _callInvoker.callInvoker;
-  auto jsiRuntime = reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
+  react_native_assert(workletsModule != nullptr);
 
-  assert(jsiRuntime != nullptr);
+  auto jsCallInvoker = _callInvoker.callInvoker;
+  react_native_assert(jsCallInvoker != nullptr);
+
+  react_native_assert(self.bridge != nullptr);
+  react_native_assert(self.bridge.runtime != nullptr);
+  auto jsiRuntime = reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
   auto reanimatedModuleProxy = reanimated::createReanimatedModule(self, _moduleRegistry, jsCallInvoker, workletsModule);
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -27,8 +27,8 @@
 
 - (void)useDisplayLinkOnMainQueue:(CADisplayLinkOperation)displayLinkOperation
 {
-  // This method is called on the main queue during initialization or on the ShadowQueue during invalidation.
-  react_native_assert(RCTIsMainQueue() || RCTIsUIManagerQueue());
+  // This method is called on the JavaScript queue during initialization or on the ShadowQueue during invalidation.
+  react_native_assert(REAIsJavaScriptQueue() || RCTIsUIManagerQueue());
 
   __weak __typeof__(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{
@@ -44,7 +44,7 @@
                                 bridge:(RCTBridge *)bridge
                       surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
-  RCTAssertMainQueue();
+  REAAssertJavaScriptQueue();
 
   if ((self = [super init])) {
     _reanimatedModule = reanimatedModule;


### PR DESCRIPTION
## Summary

⚠️ This is potentially a very breaking change in some setups!

This PR removes `requiresMainQueueSetup` method in `REAModule` that was responsible for marking that Reanimated module should be initialized on the main queue.

This method was added as a side effect 3 years ago in https://github.com/software-mansion/react-native-reanimated/pull/3555 in order to make the warning go away and to keep the identical initialization behavior.

Looks like this is a perfect moment to get rid of this chunk of the code and hopefully it should work just fine.

Please let us know immediately if you have any troubles with running Reanimated without `requiresMainQueueSetup`.

## Test plan
