### PR TITLE
Add asserts for queue during Reanimated initialization on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAAssertJavaScriptQueue.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAAssertJavaScriptQueue.h
@@ -1,0 +1,14 @@
+#import <react/debug/react_native_assert.h>
+
+// Copied from RCTJSThreadManager.mm
+static NSString *const RCTJSThreadName = @"com.facebook.react.runtime.JavaScript";
+
+static BOOL REAIsJavaScriptQueue()
+{
+  return [NSThread.currentThread.name isEqualToString:RCTJSThreadName];
+}
+
+static void REAAssertJavaScriptQueue()
+{
+  react_native_assert(REAIsJavaScriptQueue() && "This function must be called on the JavaScript queue");
+}

--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -4,6 +4,7 @@
 #import <React/RCTUIManagerUtils.h>
 
 #import <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
+#import <reanimated/apple/REAAssertJavaScriptQueue.h>
 #import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
 #import <reanimated/apple/native/NativeProxy.h>
@@ -34,11 +35,14 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 + (BOOL)requiresMainQueueSetup
 {
+  REAAssertJavaScriptQueue();
   return YES;
 }
 
 - (void)invalidate
 {
+  RCTAssertUIManagerQueue();
+
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_nodesManager invalidate];
   [super invalidate];
@@ -46,6 +50,8 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (dispatch_queue_t)methodQueue
 {
+  RCTAssertMainQueue();
+
   // This module needs to be on the same queue as the UIManager to avoid
   // having to lock `_operations` and `_preOperations` since `uiManagerWillPerformMounting`
   // will be called from that queue.
@@ -54,13 +60,19 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 - (std::shared_ptr<UIManager>)getUIManager
 {
-  react_native_assert(_surfacePresenter != nil);
+  REAAssertJavaScriptQueue();
+
+  react_native_assert(_surfacePresenter != nil && "_surfacePresenter is nil");
   RCTScheduler *scheduler = [_surfacePresenter scheduler];
+  react_native_assert(scheduler != nil && "_surfacePresenter.scheduler is nil");
+  react_native_assert(scheduler.uiManager != nil && "_surfacePresenter.scheduler.uiManager is nil");
   return scheduler.uiManager;
 }
 
 - (void)attachReactEventListener:(const std::shared_ptr<ReanimatedModuleProxy>)reanimatedModuleProxy
 {
+  REAAssertJavaScriptQueue();
+
   std::weak_ptr<ReanimatedModuleProxy> reanimatedModuleProxyWeak = reanimatedModuleProxy;
   RCTScheduler *scheduler = [_surfacePresenter scheduler];
   __weak __typeof__(self) weakSelf = self;
@@ -94,11 +106,13 @@ RCT_EXPORT_MODULE(ReanimatedModule);
  */
 - (void)setSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
+  RCTAssertMainQueue();
   _surfacePresenter = surfacePresenter;
 }
 
 - (void)setBridge:(RCTBridge *)bridge
 {
+  RCTAssertMainQueue();
   [super setBridge:bridge];
   _nodesManager = [[REANodesManager alloc] initWithModule:self bridge:bridge surfacePresenter:_surfacePresenter];
   [[self.moduleRegistry moduleForName:"EventDispatcher"] addDispatchObserver:self];
@@ -136,6 +150,8 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 {
+  REAAssertJavaScriptQueue();
+
   WorkletsModule *workletsModule = [_moduleRegistry moduleForName:"WorkletsModule"];
   auto jsCallInvoker = _callInvoker.callInvoker;
   auto jsiRuntime = reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
@@ -160,6 +176,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
+  REAAssertJavaScriptQueue();
   return std::make_shared<facebook::react::NativeReanimatedModuleSpecJSI>(params);
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -1,4 +1,5 @@
 #import <reanimated/Tools/PlatformDepMethodsHolder.h>
+#import <reanimated/apple/REAAssertJavaScriptQueue.h>
 #import <reanimated/apple/native/NativeProxy.h>
 #import <reanimated/apple/native/PlatformDepMethodsHolderImpl.h>
 #import <reanimated/apple/native/REAJSIUtils.h>
@@ -27,6 +28,8 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
     const std::shared_ptr<CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule)
 {
+  REAAssertJavaScriptQueue();
+
   auto nodesManager = reaModule.nodesManager;
 
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(reaModule.bridge.runtime);
@@ -50,6 +53,8 @@ void commonInit(
     jsi::Runtime &uiRuntime,
     std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy)
 {
+  REAAssertJavaScriptQueue();
+
   [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
     std::string eventName = [event.eventName UTF8String];


### PR DESCRIPTION
## Summary

This PR adds `RCTAssertMainQueue()`, `RCTAssertUIManagerQueue()` and `REAAssertJavaScriptQueue()` calls in various initialization methods in `REAModule`, `NativeProxy` and `NodesManager` on iOS along with the implementation of `REAAssertJavaScriptQueue`. This way we can make sure that the methods are called on appropriate threads as well as track this information in the codebase.

Analogous asserts will be added in `react-native-worklets` in a separate PR: https://github.com/software-mansion/react-native-reanimated/pull/7137

## Test plan

✅ Tested in debug and release mode