### PR TITLE
Add asserts for queue during Worklets initialization on iOS

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/AssertJavaScriptQueue.h
+++ b/packages/react-native-worklets/apple/worklets/apple/AssertJavaScriptQueue.h
@@ -1,0 +1,14 @@
+#import <react/debug/react_native_assert.h>
+
+// Copied from RCTJSThreadManager.mm
+static NSString *const RCTJSThreadName = @"com.facebook.react.runtime.JavaScript";
+
+static BOOL IsJavaScriptQueue()
+{
+  return [NSThread.currentThread.name isEqualToString:RCTJSThreadName];
+}
+
+static void AssertJavaScriptQueue()
+{
+  react_native_assert(IsJavaScriptQueue() && "This function must be called on the JavaScript queue");
+}

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsMessageThread.mm
@@ -1,3 +1,4 @@
+#import <worklets/apple/AssertJavaScriptQueue.h>
 #import <worklets/apple/WorkletsMessageThread.h>
 
 namespace facebook {
@@ -21,6 +22,7 @@ struct WorkletsMessageThreadPublic {
 // the app.
 void WorkletsMessageThread::quitSynchronous()
 {
+  AssertJavaScriptQueue();
   RCTMessageThread *rctThread = static_cast<RCTMessageThread *>(this);
   WorkletsMessageThreadPublic *rctThreadPublic = reinterpret_cast<WorkletsMessageThreadPublic *>(rctThread);
   rctThreadPublic->m_shutdown = true;

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -1,6 +1,7 @@
 #import <worklets/Tools/SingleInstanceChecker.h>
 #import <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #import <worklets/apple/AnimationFrameQueue.h>
+#import <worklets/apple/AssertJavaScriptQueue.h>
 #import <worklets/apple/IOSUIScheduler.h>
 #import <worklets/apple/WorkletsMessageThread.h>
 #import <worklets/apple/WorkletsModule.h>
@@ -27,6 +28,7 @@ using worklets::WorkletsModuleProxy;
 
 - (std::shared_ptr<WorkletsModuleProxy>)getWorkletsModuleProxy
 {
+  AssertJavaScriptQueue();
   return workletsModuleProxy_;
 }
 
@@ -36,6 +38,8 @@ RCT_EXPORT_MODULE(WorkletsModule);
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)valueUnpackerCode)
 {
+  AssertJavaScriptQueue();
+
   auto *bridge = self.bridge;
   auto &rnRuntime = *(jsi::Runtime *)bridge.runtime;
   auto jsQueue = std::make_shared<WorkletsMessageThread>([NSRunLoop currentRunLoop], ^(NSError *error) {
@@ -66,6 +70,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
 
 - (void)invalidate
 {
+  // Called on com.meta.react.turbomodulemanager.queue
+
   [animationFrameQueue_ invalidate];
 
   // We have to destroy extra runtimes when invalidate is called. If we clean


### PR DESCRIPTION
## Summary

This PR adds `RCTAssertMainQueue()` and `REAAssertJavaScriptQueue()` calls in various initialization methods in `WorkletsModule`, `AnimationFrameQueue` and `WorkletsMessageThread` on iOS along with the implementation of `AssertJavaScriptQueue`. This way we can make sure that the methods are called on appropriate threads as well as track this information in the codebase.

I wasn't able to come up with an assert for "com.meta.react.turbomodulemanager.queue" in `invalidate` methods since `NSThread.currentThread.name` returns `nil` so I just added `// Called on com.meta.react.turbomodulemanager.queue` comments.

## Test plan

✅ Tested in debug and release mode