### PR TITLE
Merge `commonInit` function into `createReanimatedModule` function in NativeProxy on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -40,16 +40,8 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
       workletsModuleProxy, rnRuntime, jsInvoker, platformDepMethodsHolder, getIsReducedMotion());
   reanimatedModuleProxy->init(platformDepMethodsHolder);
 
-  commonInit(reaModule, workletsModuleProxy->getUIWorkletRuntime()->getJSIRuntime(), reanimatedModuleProxy);
+  jsi::Runtime &uiRuntime = workletsModuleProxy->getUIWorkletRuntime()->getJSIRuntime();
 
-  return reanimatedModuleProxy;
-}
-
-void commonInit(
-    REAModule *reaModule,
-    jsi::Runtime &uiRuntime,
-    std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy)
-{
   [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
     std::string eventName = [event.eventName UTF8String];
@@ -66,6 +58,8 @@ void commonInit(
       reanimatedModuleProxy->performOperations();
     }
   }];
+
+  return reanimatedModuleProxy;
 }
 
 } // namespace reanimated


### PR DESCRIPTION
## Summary

We used to have multiple versions of `createReanimatedModule` function and the common logic was moved to `commonInit` function. Now there's only one version so we can merge `commonInit` logic back to `createReanimatedModule` function.

## Test plan

See if CI is green and make sure that fabric-example works correctly.
