### PR TITLE
Obtain `jsCallInvoker` using `RCTCallInvokerModule` in Worklets on iOS

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,9 +1,9 @@
-#import <React/RCTBridgeModule.h>
+#import <React/RCTCallInvokerModule.h>
 #import <React/RCTEventEmitter.h>
 
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-@interface WorkletsModule : RCTEventEmitter <RCTBridgeModule>
+@interface WorkletsModule : RCTEventEmitter <RCTCallInvokerModule>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -5,16 +5,13 @@
 #import <worklets/apple/WorkletsMessageThread.h>
 #import <worklets/apple/WorkletsModule.h>
 
+#import <React/RCTCallInvoker.h>
+
 using worklets::RNRuntimeWorkletDecorator;
 using worklets::WorkletsModuleProxy;
 
 @interface RCTBridge (JSIRuntime)
 - (void *)runtime;
-@end
-
-@interface RCTBridge (RCTTurboModule)
-- (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker;
-- (void)_tryAndHandleError:(dispatch_block_t)block;
 @end
 
 @implementation WorkletsModule {
@@ -30,7 +27,7 @@ using worklets::WorkletsModuleProxy;
   return workletsModuleProxy_;
 }
 
-@synthesize moduleRegistry = _moduleRegistry;
+@synthesize callInvoker = _callInvoker;
 
 RCT_EXPORT_MODULE(WorkletsModule);
 
@@ -43,7 +40,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
   });
 
   std::string valueUnpackerCodeStr = [valueUnpackerCode UTF8String];
-  auto jsCallInvoker = bridge.jsCallInvoker;
+  auto jsCallInvoker = _callInvoker.callInvoker;
   auto jsScheduler = std::make_shared<worklets::JSScheduler>(rnRuntime, jsCallInvoker);
   auto uiScheduler = std::make_shared<worklets::IOSUIScheduler>();
   animationFrameQueue_ = [AnimationFrameQueue new];


### PR DESCRIPTION
## Summary

This PR aligns the logic of getting `JSCallInvoker` in Worklets with the current implementation in Reanimated. The key line of code here is `@synthesize callInvoker = _callInvoker;`.

Additionally, I removed `@synthesize moduleRegistry = _moduleRegistry;` which is unused.

## Test plan
