### PR TITLE
Replace `REANIMATED_EXAMPLE_APP_NAME` with `IS_REANIMATED_EXAMPLE_APP` on iOS

### DIFF
--- a/apps/fabric-example/ios/Podfile
+++ b/apps/fabric-example/ios/Podfile
@@ -8,7 +8,7 @@ require Pod::Executable.execute_command('node', ['-p',
 require_relative '../../../packages/react-native-reanimated/scripts/clangd-add-xcode-step.rb'
 
 ENV['RCT_NEW_ARCH_ENABLED'] = '1'
-ENV['REANIMATED_EXAMPLE_APP_NAME'] = 'FabricExample'
+ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!

--- a/apps/macos-example/macos/Podfile
+++ b/apps/macos-example/macos/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native-macos/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-ENV['REANIMATED_EXAMPLE_APP_NAME'] = 'MacOSExample-macos'
+ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
 
 require_relative '../../../packages/react-native-reanimated/scripts/clangd-add-xcode-step.rb'
 

--- a/apps/tvos-example/ios/Podfile
+++ b/apps/tvos-example/ios/Podfile
@@ -7,7 +7,7 @@ require Pod::Executable.execute_command('node', ['-p',
 
 require_relative '../../../packages/react-native-reanimated/scripts/clangd-add-xcode-step.rb'
 
-ENV['REANIMATED_EXAMPLE_APP_NAME'] = 'TVOSExample'
+ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
 
 platform :tvos, min_ios_version_supported
 prepare_react_native_project!

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -30,7 +30,7 @@ def find_config()
     raise '[Reanimated] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
   end
 
-  result[:is_reanimated_example_app] = ENV["REANIMATED_EXAMPLE_APP_NAME"] != nil
+  result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
   result[:is_tvos_target] = react_native_json['name'] == 'react-native-tvos'
   result[:react_native_version] = react_native_json['version']
   result[:react_native_minor_version] = react_native_json['version'].split('.')[1].to_i

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -28,7 +28,7 @@ def worklets_find_config()
     raise '[Worklets] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
   end
 
-  result[:is_reanimated_example_app] = ENV["REANIMATED_EXAMPLE_APP_NAME"] != nil
+  result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
   result[:react_native_version] = react_native_json['version']
   result[:react_native_minor_version] = react_native_json['version'].split('.')[1].to_i
   if result[:react_native_minor_version] == 0 # nightly


### PR DESCRIPTION
## Summary

We don't use example apps names so I thought it would be better to set `IS_REANIMATED_EXAMPLE_APP` environmental variable instead of `REANIMATED_EXAMPLE_APP_NAME` to align the naming with `isReanimatedExampleApp` setting used on Android.

## Test plan
