### PR TITLE
Remove redundant `commonInit` declaration in NativeProxy.h

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -13,11 +13,6 @@ std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModule(
     const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule);
 
-void commonInit(
-    REAModule *reaModule,
-    jsi::Runtime &uiRuntime,
-    std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy);
-
 } // namespace reanimated
 
 #endif //__cplusplus


### PR DESCRIPTION
## Summary

This PR removes `commonInit` function in `NativeProxy.h` that I forgot to remove in https://github.com/software-mansion/react-native-reanimated/pull/7139.

## Test plan

See if CI is green.
