### PR TITLE
Merge `commonInit` function into `NativeProxy` constructor in NativeProxy on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -29,12 +29,6 @@ NativeProxy::NativeProxy(
           getPlatformDependentMethods(),
           getIsReducedMotion())) {
   reanimatedModuleProxy_->init(getPlatformDependentMethods());
-  commonInit(fabricUIManager);
-}
-
-void NativeProxy::commonInit(
-    jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-        &fabricUIManager) {
   const auto &uiManager =
       fabricUIManager->getBinding()->getScheduler()->getUIManager();
   reanimatedModuleProxy_->initializeFabric(uiManager);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -223,9 +223,6 @@ class NativeProxy : public jni::HybridClass<NativeProxy>,
       jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
           fabricUIManager);
 
-  void commonInit(jni::alias_ref<facebook::react::JFabricUIManager::javaobject>
-                      &fabricUIManager);
-
   void invalidateCpp();
 };
 


### PR DESCRIPTION
## Summary

Since `commonInit` is now used only once, I've merged it into `NativeProxy` constructor on Android analogously to https://github.com/software-mansion/react-native-reanimated/pull/7139 for iOS.

## Test plan

Build fabric-example for Android
