### PR TITLE
Extract `AnimationFrameCallback` from NativeProxy.h

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/AnimationFrameCallback.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/AnimationFrameCallback.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace reanimated {
+
+using namespace facebook;
+using namespace facebook::jni;
+
+class AnimationFrameCallback : public HybridClass<AnimationFrameCallback> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/swmansion/reanimated/nativeProxy/AnimationFrameCallback;";
+
+  void onAnimationFrame(double timestampMs) {
+    callback_(timestampMs);
+  }
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod(
+            "onAnimationFrame", AnimationFrameCallback::onAnimationFrame),
+    });
+  }
+
+ private:
+  friend HybridBase;
+
+  explicit AnimationFrameCallback(std::function<void(double)> callback)
+      : callback_(std::move(callback)) {}
+
+  std::function<void(double)> callback_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 #include <reanimated/Tools/ReanimatedVersion.h>
+#include <reanimated/android/AnimationFrameCallback.h>
 #include <reanimated/android/NativeProxy.h>
 
 #include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -21,31 +21,6 @@ namespace reanimated {
 using namespace facebook;
 using namespace facebook::jni;
 
-class AnimationFrameCallback : public HybridClass<AnimationFrameCallback> {
- public:
-  static auto constexpr kJavaDescriptor =
-      "Lcom/swmansion/reanimated/nativeProxy/AnimationFrameCallback;";
-
-  void onAnimationFrame(double timestampMs) {
-    callback_(timestampMs);
-  }
-
-  static void registerNatives() {
-    javaClassStatic()->registerNatives({
-        makeNativeMethod(
-            "onAnimationFrame", AnimationFrameCallback::onAnimationFrame),
-    });
-  }
-
- private:
-  friend HybridBase;
-
-  explicit AnimationFrameCallback(std::function<void(double)> callback)
-      : callback_(std::move(callback)) {}
-
-  std::function<void(double)> callback_;
-};
-
 class EventHandler : public HybridClass<EventHandler> {
  public:
   static auto constexpr kJavaDescriptor =

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
@@ -1,5 +1,6 @@
 #include <fbjni/fbjni.h>
 
+#include <reanimated/android/AnimationFrameCallback.h>
 #include <reanimated/android/NativeProxy.h>
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {


### PR DESCRIPTION
## Summary

This PR extracts `AnimationFrameCallback` declaration on Android from `NativeProxy.h` to a new separate file `AnimationFrameCallback.h` as well as updates all its usages and adds necessary includes.

## Test plan

Build fabric-example for Android
