### PR TITLE
Extract `EventHandler` from NativeProxy.h

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/EventHandler.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/EventHandler.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <reanimated/Tools/ReanimatedSystraceSection.h>
+
+#include <fbjni/fbjni.h>
+#include <react/jni/WritableNativeMap.h>
+
+namespace reanimated {
+
+using namespace facebook;
+using namespace facebook::jni;
+
+class EventHandler : public HybridClass<EventHandler> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/swmansion/reanimated/nativeProxy/EventHandler;";
+
+  void receiveEvent(
+      jni::alias_ref<JString> eventKey,
+      jint emitterReactTag,
+      jni::alias_ref<react::WritableMap> event) {
+    ReanimatedSystraceSection s("EventHandler::receiveEvent");
+    handler_(eventKey, emitterReactTag, event);
+  }
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod("receiveEvent", EventHandler::receiveEvent),
+    });
+  }
+
+ private:
+  friend HybridBase;
+
+  explicit EventHandler(std::function<void(
+                            jni::alias_ref<JString>,
+                            jint emitterReactTag,
+                            jni::alias_ref<react::WritableMap>)> handler)
+      : handler_(std::move(handler)) {}
+
+  std::function<
+      void(jni::alias_ref<JString>, jint, jni::alias_ref<react::WritableMap>)>
+      handler_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 #include <reanimated/Tools/ReanimatedVersion.h>
+#include <reanimated/android/EventHandler.h>
 #include <reanimated/android/NativeProxy.h>
 
 #include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <reanimated/NativeModules/ReanimatedModuleProxy.h>
-#include <reanimated/Tools/ReanimatedSystraceSection.h>
 
 #include <worklets/android/WorkletsModule.h>
 
@@ -44,39 +43,6 @@ class AnimationFrameCallback : public HybridClass<AnimationFrameCallback> {
       : callback_(std::move(callback)) {}
 
   std::function<void(double)> callback_;
-};
-
-class EventHandler : public HybridClass<EventHandler> {
- public:
-  static auto constexpr kJavaDescriptor =
-      "Lcom/swmansion/reanimated/nativeProxy/EventHandler;";
-
-  void receiveEvent(
-      jni::alias_ref<JString> eventKey,
-      jint emitterReactTag,
-      jni::alias_ref<react::WritableMap> event) {
-    ReanimatedSystraceSection s("EventHandler::receiveEvent");
-    handler_(eventKey, emitterReactTag, event);
-  }
-
-  static void registerNatives() {
-    javaClassStatic()->registerNatives({
-        makeNativeMethod("receiveEvent", EventHandler::receiveEvent),
-    });
-  }
-
- private:
-  friend HybridBase;
-
-  explicit EventHandler(std::function<void(
-                            jni::alias_ref<JString>,
-                            jint emitterReactTag,
-                            jni::alias_ref<react::WritableMap>)> handler)
-      : handler_(std::move(handler)) {}
-
-  std::function<
-      void(jni::alias_ref<JString>, jint, jni::alias_ref<react::WritableMap>)>
-      handler_;
 };
 
 class SensorSetter : public HybridClass<SensorSetter> {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
@@ -1,5 +1,6 @@
 #include <fbjni/fbjni.h>
 
+#include <reanimated/android/EventHandler.h>
 #include <reanimated/android/NativeProxy.h>
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {


### PR DESCRIPTION
## Summary

This PR extracts `EventHandler` declaration on Android from `NativeProxy.h` to a new separate file `EventHandler.h` as well as updates all its usages and adds necessary includes.

## Test plan

Build fabric-example for Android
