### PR TITLE
Extract `SensorSetter` from NativeProxy.h

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 #include <reanimated/Tools/ReanimatedVersion.h>
+#include <reanimated/android/SensorSetter.h>
 #include <reanimated/android/NativeProxy.h>
 
 #include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -79,36 +79,6 @@ class EventHandler : public HybridClass<EventHandler> {
       handler_;
 };
 
-class SensorSetter : public HybridClass<SensorSetter> {
- public:
-  static auto constexpr kJavaDescriptor =
-      "Lcom/swmansion/reanimated/nativeProxy/SensorSetter;";
-
-  void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
-    size_t size = value->size();
-    auto elements = value->getRegion(0, size);
-    double array[7];
-    for (size_t i = 0; i < size; i++) {
-      array[i] = elements[i];
-    }
-    callback_(array, orientationDegrees);
-  }
-
-  static void registerNatives() {
-    javaClassStatic()->registerNatives({
-        makeNativeMethod("sensorSetter", SensorSetter::sensorSetter),
-    });
-  }
-
- private:
-  friend HybridBase;
-
-  explicit SensorSetter(std::function<void(double[], int)> callback)
-      : callback_(std::move(callback)) {}
-
-  std::function<void(double[], int)> callback_;
-};
-
 class KeyboardWorkletWrapper : public HybridClass<KeyboardWorkletWrapper> {
  public:
   static auto constexpr kJavaDescriptor =

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/OnLoad.cpp
@@ -1,5 +1,6 @@
 #include <fbjni/fbjni.h>
 
+#include <reanimated/android/SensorSetter.h>
 #include <reanimated/android/NativeProxy.h>
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace reanimated {
+
+using namespace facebook;
+using namespace facebook::jni;
+
+class SensorSetter : public HybridClass<SensorSetter> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lcom/swmansion/reanimated/nativeProxy/SensorSetter;";
+
+  void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
+    size_t size = value->size();
+    auto elements = value->getRegion(0, size);
+    double array[7];
+    for (size_t i = 0; i < size; i++) {
+      array[i] = elements[i];
+    }
+    callback_(array, orientationDegrees);
+  }
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod("sensorSetter", SensorSetter::sensorSetter),
+    });
+  }
+
+ private:
+  friend HybridBase;
+
+  explicit SensorSetter(std::function<void(double[], int)> callback)
+      : callback_(std::move(callback)) {}
+
+  std::function<void(double[], int)> callback_;
+};
+
+} // namespace reanimated


### PR DESCRIPTION
## Summary

This PR extracts `SensorSetter` declaration on Android from `NativeProxy.h` to a new separate file `SensorSetter.h` as well as updates all its usages and adds necessary includes.

## Test plan

Build fabric-example for Android
