### PR TITLE
Add asserts for `TurboModuleManager` queue

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
@@ -1,5 +1,6 @@
 #import <worklets/apple/AnimationFrameQueue.h>
 #import <worklets/apple/AssertJavaScriptQueue.h>
+#import <worklets/apple/AssertTurboModuleManagerQueue.h>
 #import <worklets/apple/SlowAnimations.h>
 
 #import <React/RCTAssert.h>
@@ -41,7 +42,7 @@ typedef void (^AnimationFrameCallback)(WorkletsDisplayLink *displayLink);
 
 - (void)invalidate
 {
-  // Called on com.meta.react.turbomodulemanager.queue
+  AssertTurboModuleManagerQueue();
   [displayLink_ invalidate];
 }
 

--- a/packages/react-native-worklets/apple/worklets/apple/AssertTurboModuleManagerQueue.h
+++ b/packages/react-native-worklets/apple/worklets/apple/AssertTurboModuleManagerQueue.h
@@ -1,0 +1,16 @@
+#import <react/debug/react_native_assert.h>
+
+constexpr auto turboModuleManagerQueueLabel =
+    "com.meta.react.turbomodulemanager.queue";
+
+static bool IsTurboModuleManagerQueue() {
+  const auto currentQueueLabel =
+      dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
+  return strcmp(currentQueueLabel, turboModuleManagerQueueLabel) == 0;
+}
+
+static void AssertTurboModuleManagerQueue() {
+  react_native_assert(
+      IsTurboModuleManagerQueue() &&
+      "This function must be called on the TurboModuleManager queue");
+}

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -2,6 +2,7 @@
 #import <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #import <worklets/apple/AnimationFrameQueue.h>
 #import <worklets/apple/AssertJavaScriptQueue.h>
+#import <worklets/apple/AssertTurboModuleManagerQueue.h>
 #import <worklets/apple/IOSUIScheduler.h>
 #import <worklets/apple/WorkletsMessageThread.h>
 #import <worklets/apple/WorkletsModule.h>
@@ -67,7 +68,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
 
 - (void)invalidate
 {
-  // Called on com.meta.react.turbomodulemanager.queue
+  AssertTurboModuleManagerQueue();
 
   [animationFrameQueue_ invalidate];
 


### PR DESCRIPTION
## Summary

This PR replaces `// Called on com.meta.react.turbomodulemanager.queue` with proper `AssertTurboModuleManagerQueue()` calls along with implementation of `AssertTurboModuleManagerQueue`.

## Test plan

Build and launch fabric-example on iOS.
