### PR TITLE
Remove queue asserts in `AnimationFrameQueue`

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/AnimationFrameQueue.mm
@@ -32,7 +32,6 @@ typedef void (^AnimationFrameCallback)(WorkletsDisplayLink *displayLink);
 
 - (void)requestAnimationFrame:(std::function<void(double)>)callback
 {
-  RCTAssertMainQueue();
   {
     std::lock_guard<std::mutex> lock(callbacksMutex_);
     frameCallbacks_.push_back(callback);
@@ -50,7 +49,6 @@ typedef void (^AnimationFrameCallback)(WorkletsDisplayLink *displayLink);
 
 - (void)scheduleQueueExecution
 {
-  RCTAssertMainQueue();
   [displayLink_ setPaused:FALSE];
 }
 


### PR DESCRIPTION
## Summary

This PR removes recently added queue asserts as requested by @tjzel in https://github.com/software-mansion/react-native-reanimated/pull/7137#discussion_r1977756357 and https://github.com/software-mansion/react-native-reanimated/pull/7137#discussion_r1977756948.

## Test plan

See if CI is green.
