### PR TITLE
Add thread asserts during initialization on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -8,6 +8,7 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
@@ -52,6 +53,8 @@ public class NativeProxy {
 
   public @OptIn(markerClass = FrameworkAPI.class) NativeProxy(
       ReactApplicationContext context, WorkletsModule workletsModule) {
+    context.assertOnJSQueueThread();
+
     mWorkletsModule =
         Objects.requireNonNull(context.getNativeModule(ReanimatedModule.class)).getWorkletsModule();
     mContext = new WeakReference<>(context);
@@ -130,6 +133,7 @@ public class NativeProxy {
 
   @DoNotStrip
   public void requestRender(AnimationFrameCallback callback) {
+    UiThreadUtil.assertOnUiThread();
     mNodesManager.postOnAnimation(callback);
   }
 
@@ -223,6 +227,7 @@ public class NativeProxy {
 
   @DoNotStrip
   void maybeFlushUIUpdatesQueue() {
+    UiThreadUtil.assertOnUiThread();
     if (!mNodesManager.isAnimationRunning()) {
       mNodesManager.performOperations();
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -70,12 +70,15 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {
+    reactApplicationContext.assertOnJSQueueThread();
     mNativeProxy = new NativeProxy(reactApplicationContext, mWorkletsModule);
     compatibility = new ReaCompatibility(reactApplicationContext);
     compatibility.registerFabricEventListener(this);
   }
 
   public NodesManager(ReactContext context, WorkletsModule workletsModule) {
+    context.assertOnJSQueueThread();
+
     mWorkletsModule = workletsModule;
     UIManager mUIManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
     assert mUIManager != null;
@@ -124,12 +127,15 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   public void performOperations() {
+    UiThreadUtil.assertOnUiThread();
     if (mNativeProxy != null) {
       mNativeProxy.performOperations();
     }
   }
 
   private void onAnimationFrame(long frameTimeNanos) {
+    UiThreadUtil.assertOnUiThread();
+
     try {
       if (BuildConfig.REANIMATED_PROFILING) {
         Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "onAnimationFrame");

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -69,6 +69,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec
 
   public ReanimatedModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    reactContext.assertOnJSQueueThread();
     mWorkletsModule = reactContext.getNativeModule(WorkletsModule.class);
   }
 
@@ -79,6 +80,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec
   @Override
   public void initialize() {
     ReactApplicationContext reactCtx = getReactApplicationContext();
+    reactCtx.assertOnJSQueueThread();
 
     UIManager uiManager = UIManagerHelper.getUIManager(reactCtx, UIManagerType.FABRIC);
     if (uiManager instanceof FabricUIManager) {
@@ -143,6 +145,8 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule() {
+    getReactApplicationContext().assertOnJSQueueThread();
+
     // When debugging in chrome the JS context is not available.
     // https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25
     Utils.isChromeDebugger =

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
@@ -50,6 +50,7 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
 
   public WorkletsModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    reactContext.assertOnJSQueueThread();
     mAndroidUIScheduler = new AndroidUIScheduler(reactContext);
     mAnimationFrameQueue = new AnimationFrameQueue(reactContext);
   }
@@ -58,6 +59,8 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule(String valueUnpackerCode) {
     var context = getReactApplicationContext();
+    context.assertOnJSQueueThread();
+  
     var jsContext = Objects.requireNonNull(context.getJavaScriptContextHolder()).get();
     var jsCallInvokerHolder = JSCallInvokerResolver.getJSCallInvokerHolder(context);
 

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
@@ -60,7 +60,7 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
   public boolean installTurboModule(String valueUnpackerCode) {
     var context = getReactApplicationContext();
     context.assertOnJSQueueThread();
-  
+
     var jsContext = Objects.requireNonNull(context.getJavaScriptContextHolder()).get();
     var jsCallInvokerHolder = JSCallInvokerResolver.getJSCallInvokerHolder(context);
 


### PR DESCRIPTION
## Summary

This PR adds assertions for JS and UI threads in initialization methods of Reanimated and Worklets on Android.

## Test plan

Build and launch fabric-example on Android.
