### PR TITLE
Remove implementation of `UIManagerListener` and `UIManagerModuleListener` interfaces in `ReanimatedModule` on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -10,8 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
-public class ReanimatedModule extends NativeReanimatedModuleSpec
-    implements LifecycleEventListener {
+public class ReanimatedModule extends NativeReanimatedModuleSpec implements LifecycleEventListener {
   private @Nullable NodesManager mNodesManager;
   private final WorkletsModule mWorkletsModule;
   private Runnable mUnsubscribe = () -> {};

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -30,8 +30,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     ReactApplicationContext reactCtx = getReactApplicationContext();
     reactCtx.assertOnJSQueueThread();
     reactCtx.addLifecycleEventListener(this);
-    mUnsubscribe =
-        Utils.combineRunnables(mUnsubscribe, () -> reactCtx.removeLifecycleEventListener(this));
+    mUnsubscribe = () -> reactCtx.removeLifecycleEventListener(this);
   }
 
   @Override

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -10,8 +10,6 @@ import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.UIManagerModuleListener;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.swmansion.worklets.WorkletsModule;
 import java.util.ArrayList;
@@ -20,7 +18,7 @@ import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec
-    implements LifecycleEventListener, UIManagerModuleListener, UIManagerListener {
+    implements LifecycleEventListener, UIManagerListener {
 
   public void didDispatchMountItems(@NonNull UIManager uiManager) {
     // Keep: Required for UIManagerListener
@@ -114,24 +112,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec
   @Override
   public void onHostDestroy() {
     // do nothing
-  }
-
-  @Override
-  public void willDispatchViewUpdates(final UIManagerModule uiManager) {
-    // This method is called for the interface of UIManagerModuleListener on
-    // Paper. The below function with the same name won't be called.
-    if (mOperations.isEmpty()) {
-      return;
-    }
-    final ArrayList<UIThreadOperation> operations = mOperations;
-    mOperations = new ArrayList<>();
-    uiManager.addUIBlock(
-        nativeViewHierarchyManager -> {
-          NodesManager nodesManager = getNodesManager();
-          for (UIThreadOperation operation : operations) {
-            operation.execute(nodesManager);
-          }
-        });
   }
 
   /*package*/

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -6,19 +6,12 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
 import com.swmansion.worklets.WorkletsModule;
-import java.util.ArrayList;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec
     implements LifecycleEventListener {
-
-  private interface UIThreadOperation {
-    void execute(NodesManager nodesManager);
-  }
-
-  private ArrayList<UIThreadOperation> mOperations = new ArrayList<>();
   private @Nullable NodesManager mNodesManager;
   private final WorkletsModule mWorkletsModule;
   private Runnable mUnsubscribe = () -> {};

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -1,16 +1,10 @@
 package com.swmansion.reanimated;
 
 import android.util.Log;
-import androidx.annotation.NonNull;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.UIManager;
-import com.facebook.react.bridge.UIManagerListener;
-import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.common.UIManagerType;
 import com.swmansion.worklets.WorkletsModule;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -18,43 +12,7 @@ import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec
-    implements LifecycleEventListener, UIManagerListener {
-
-  public void didDispatchMountItems(@NonNull UIManager uiManager) {
-    // Keep: Required for UIManagerListener
-  }
-
-  public void didMountItems(@NonNull UIManager uiManager) {
-    // Keep: Required for UIManagerListener
-  }
-
-  public void didScheduleMountItems(@NonNull UIManager uiManager) {
-    // Keep: Required for UIManagerListener
-  }
-
-  public void willDispatchViewUpdates(@NonNull UIManager uiManager) {
-    // This method is called for the interface of UIManagerListener on Fabric.
-    // The below function with the same name won't be called.
-    if (mOperations.isEmpty()) {
-      return;
-    }
-    final ArrayList<UIThreadOperation> operations = mOperations;
-    mOperations = new ArrayList<>();
-    if (uiManager instanceof FabricUIManager) {
-      ((FabricUIManager) uiManager)
-          .addUIBlock(
-              uiBlockViewResolver -> {
-                NodesManager nodesManager = getNodesManager();
-                for (UIThreadOperation operation : operations) {
-                  operation.execute(nodesManager);
-                }
-              });
-    } else {
-      throw new RuntimeException("[Reanimated] Failed to obtain instance of FabricUIManager.");
-    }
-  }
-
-  public void willMountItems(@NonNull UIManager uiManager) {}
+    implements LifecycleEventListener {
 
   private interface UIThreadOperation {
     void execute(NodesManager nodesManager);
@@ -79,17 +37,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec
   public void initialize() {
     ReactApplicationContext reactCtx = getReactApplicationContext();
     reactCtx.assertOnJSQueueThread();
-
-    UIManager uiManager = UIManagerHelper.getUIManager(reactCtx, UIManagerType.FABRIC);
-    if (uiManager instanceof FabricUIManager) {
-      ((FabricUIManager) uiManager).addUIManagerEventListener(this);
-      mUnsubscribe =
-          Utils.combineRunnables(
-              mUnsubscribe, () -> ((FabricUIManager) uiManager).removeUIManagerEventListener(this));
-    } else {
-      throw new RuntimeException("[Reanimated] Failed to obtain instance of FabricUIManager.");
-    }
-
     reactCtx.addLifecycleEventListener(this);
     mUnsubscribe =
         Utils.combineRunnables(mUnsubscribe, () -> reactCtx.removeLifecycleEventListener(this));


### PR DESCRIPTION
## Summary

Currently, `mOperations` in `ReanimatedModule` is never populated, so it can be removed together with `UIThreadOperation` interface and `willDispatchViewUpdates` interface methods from `UIManagerModuleListener` and `UIManagerListener` interfaces, along with all the remaining methods which are currently no-ops. This means we also need to remove `addUIManagerEventListener` and `removeUIManagerEventListener`. Turns out, we don't need `FabricUIManager` as well. After all these changes there will be only one runnable to execute in `invalidate` method so I also simplified `mUnsubscribe` assignment.

## Test plan

Build, launch and play with fabric-example on Android.
