### PR TITLE
Avoid storing `ReactApplicationContext` in cleanup lambda capture in `ReanimatedModule`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -13,7 +13,6 @@ import javax.annotation.Nullable;
 public class ReanimatedModule extends NativeReanimatedModuleSpec implements LifecycleEventListener {
   private @Nullable NodesManager mNodesManager;
   private final WorkletsModule mWorkletsModule;
-  private Runnable mUnsubscribe = () -> {};
 
   public ReanimatedModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -27,10 +26,9 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
 
   @Override
   public void initialize() {
-    ReactApplicationContext reactCtx = getReactApplicationContext();
-    reactCtx.assertOnJSQueueThread();
-    reactCtx.addLifecycleEventListener(this);
-    mUnsubscribe = () -> reactCtx.removeLifecycleEventListener(this);
+    ReactApplicationContext reactContext = getReactApplicationContext();
+    reactContext.assertOnJSQueueThread();
+    reactContext.addLifecycleEventListener(this);
   }
 
   @Override
@@ -100,6 +98,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
       mNodesManager.invalidate();
     }
 
-    mUnsubscribe.run();
+    ReactApplicationContext reactContext = getReactApplicationContext();
+    reactContext.removeLifecycleEventListener(this);
   }
 }


### PR DESCRIPTION
## Summary

This PR removes `mUnsubscribe` member field that is populate with a `Runnable` that holds `ReactApplicationContext` in its closure. Instead, we obtain `ReactApplicationContext` via `getReactApplicationContext()` directly in `invalidate` method.

Besides, I've renamed `reactCtx` to `reactContext` for the sake of readability and consistency.

I've also confirmed that the `ReactApplicationContext` instance in `initialize` is the same one as in `invalidate`:

| `initialize` | `invalidate` |
|:-:|:-:|
| <img width="648" alt="Screenshot 2025-03-05 at 13 22 35" src="https://github.com/user-attachments/assets/f2ce7754-a24e-416f-b270-f7255ff74d56" /> | <img width="655" alt="Screenshot 2025-03-05 at 13 22 47" src="https://github.com/user-attachments/assets/be56b94b-f987-4cdd-b6a1-f1f845084835" /> |

## Test plan

Build, launch and reload fabric-example on Android.