### PR TITLE
Remove unused arguments in `REANodesManager` initializer

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -98,7 +98,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 {
   REAAssertJavaScriptQueue();
   [super setBridge:bridge];
-  _nodesManager = [[REANodesManager alloc] initWithModule:self bridge:bridge surfacePresenter:_surfacePresenter];
+  _nodesManager = [[REANodesManager alloc] initWithModule:self];
   [[self.moduleRegistry moduleForName:"EventDispatcher"] addDispatchObserver:self];
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -1,5 +1,4 @@
 #import <React/RCTEventDispatcherProtocol.h>
-#import <React/RCTSurfacePresenterStub.h>
 
 #import <reanimated/apple/READisplayLink.h>
 
@@ -14,9 +13,7 @@ typedef void (^REAPerformOperations)();
 
 @property (nonatomic, weak, nullable) REAModule *reanimatedModule;
 
-- (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
-                                bridge:(RCTBridge *)bridge
-                      surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter;
+- (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule;
 - (void)invalidate;
 
 - (void)postOnAnimation:(REAOnAnimationCallback)clb;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -41,8 +41,6 @@
 }
 
 - (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
-                                bridge:(RCTBridge *)bridge
-                      surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
   REAAssertJavaScriptQueue();
 


### PR DESCRIPTION
## Summary

This PR removes `bridge` and `surfacePresenter` arguments in `[REANodesManager initWithModule:]` as they are unused.

## Test plan

See if CI is green.
