### PR TITLE
Remove `RCTUIManagerObserver` protocol from `REAModule`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.h
@@ -6,11 +6,7 @@
 
 #import <reanimated/apple/REANodesManager.h>
 
-@interface REAModule : RCTEventEmitter <
-                           NativeReanimatedModuleSpec,
-                           RCTCallInvokerModule,
-                           RCTEventDispatcherObserver,
-                           RCTUIManagerObserver>
+@interface REAModule : RCTEventEmitter <NativeReanimatedModuleSpec, RCTCallInvokerModule, RCTEventDispatcherObserver>
 
 @property (nonatomic, readonly) REANodesManager *nodesManager;
 


### PR DESCRIPTION
## Summary

This PR removes `RCTUIManagerObserver` protocol from `REAModule` class since `REAModule` no longer implements any of the interface methods.

This change was suggested by @piaskowyk.

## Test plan

See if CI is green.
