### PR TITLE
Create `NodesManager` instance in `ReanimatedModule` constructor instead of in getter method

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -11,13 +11,14 @@ import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec implements LifecycleEventListener {
-  private @Nullable NodesManager mNodesManager;
+  private final NodesManager mNodesManager;
   private final WorkletsModule mWorkletsModule;
 
   public ReanimatedModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactContext.assertOnJSQueueThread();
     mWorkletsModule = reactContext.getNativeModule(WorkletsModule.class);
+    mNodesManager = new NodesManager(reactContext, mWorkletsModule);
   }
 
   public WorkletsModule getWorkletsModule() {
@@ -50,12 +51,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     // do nothing
   }
 
-  /*package*/
   public NodesManager getNodesManager() {
-    if (mNodesManager == null) {
-      mNodesManager = new NodesManager(getReactApplicationContext(), mWorkletsModule);
-    }
-
     return mNodesManager;
   }
 
@@ -70,7 +66,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
             == 0;
 
     if (!Utils.isChromeDebugger) {
-      this.getNodesManager().initWithContext(getReactApplicationContext());
+      mNodesManager.initWithContext(getReactApplicationContext());
       return true;
     } else {
       Log.w(

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
 import com.swmansion.worklets.WorkletsModule;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec implements LifecycleEventListener {


### PR DESCRIPTION
## Summary

This PR simplifies the logic of creating and passing `NodesManager` instance on Android.

The conditional in `getNodesManager` has literally always been there 🤯 

<img width="973" alt="Screenshot 2025-03-06 at 11 08 59" src="https://github.com/user-attachments/assets/2a5b84cd-7d8a-454f-98f5-af87a5cc5a01" />

## Test plan

Build and launch fabric-example on Android.
