### PR TITLE
Remove `Utils.isChromeDebugger` on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -57,22 +57,8 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule() {
     getReactApplicationContext().assertOnJSQueueThread();
-
-    // When debugging in chrome the JS context is not available.
-    // https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25
-    Utils.isChromeDebugger =
-        Objects.requireNonNull(getReactApplicationContext().getJavaScriptContextHolder()).get()
-            == 0;
-
-    if (!Utils.isChromeDebugger) {
-      mNodesManager.initWithContext(getReactApplicationContext());
-      return true;
-    } else {
-      Log.w(
-          "[REANIMATED]",
-          "Unable to create Reanimated Native Module. You can ignore this message if you are using Chrome Debugger now.");
-      return false;
-    }
+    mNodesManager.initWithContext(getReactApplicationContext());
+    return true;
   }
 
   @ReactMethod

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -1,12 +1,10 @@
 package com.swmansion.reanimated;
 
-import android.util.Log;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.module.annotations.ReactModule;
 import com.swmansion.worklets.WorkletsModule;
-import java.util.Objects;
 
 @ReactModule(name = ReanimatedModule.NAME)
 public class ReanimatedModule extends NativeReanimatedModuleSpec implements LifecycleEventListener {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/Utils.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/Utils.java
@@ -8,8 +8,6 @@ import java.util.Map;
 
 public class Utils {
 
-  public static boolean isChromeDebugger = false;
-
   public static Map<String, Integer> processMapping(ReadableMap style) {
     ReadableMapKeySetIterator iter = style.keySetIterator();
     HashMap<String, Integer> mapping = new HashMap<>();


### PR DESCRIPTION
## Summary

Chrome Debugger is now deprecated and will be removed in RN 0.79 so we don't want to support it in Reanimated 4.

This PR removes Chrome Debugger-related checks in Android codebase (we already don't have any checks on iOS).

I assume this is still a safe change in terms of error reporting since we still have `isChromeDebugger()` check in TypeScript.

## Test plan

Build and launch fabric-example on Android.
