### PR TITLE
Use `WorkletsModule` instance from `NativeProxy` constructor arguments instead of using `getNativeModule` call

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -55,8 +55,7 @@ public class NativeProxy {
       ReactApplicationContext context, WorkletsModule workletsModule) {
     context.assertOnJSQueueThread();
 
-    mWorkletsModule =
-        Objects.requireNonNull(context.getNativeModule(ReanimatedModule.class)).getWorkletsModule();
+    mWorkletsModule = workletsModule;
     mContext = new WeakReference<>(context);
     reanimatedSensorContainer = new ReanimatedSensorContainer(mContext);
     keyboardAnimationManager = new KeyboardAnimationManager(mContext);


### PR DESCRIPTION
## Summary

There's no need to use `ReactApplicationContext#getNativeModule` because we already have `workletsModule` passed in the arguments.

## Test plan

Build and launch fabric-example on Android.
