### PR TITLE
Remove unused `getAndroidUIScheduler` method

### DIFF
--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
@@ -36,10 +36,6 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
   private final AnimationFrameQueue mAnimationFrameQueue;
   private boolean mSlowAnimationsEnabled;
 
-  public AndroidUIScheduler getAndroidUIScheduler() {
-    return mAndroidUIScheduler;
-  }
-
   @OptIn(markerClass = FrameworkAPI.class)
   private native HybridData initHybrid(
       long jsContext,


### PR DESCRIPTION
## Summary

This method is no longer used (confirmed with @tjzel) so let's remove it.

## Test plan

Build fabric-example for Android.
