### PR TITLE
Remove unused `getWorkletsModule` method

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -18,10 +18,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     mNodesManager = new NodesManager(reactContext, mWorkletsModule);
   }
 
-  public WorkletsModule getWorkletsModule() {
-    return mWorkletsModule;
-  }
-
   @Override
   public void initialize() {
     ReactApplicationContext reactContext = getReactApplicationContext();


### PR DESCRIPTION
## Summary

Once we merged https://github.com/software-mansion/react-native-reanimated/pull/7188 this method is no longer used (confirmed with @tjzel) so let's remove it.

## Test plan

Build fabric-example for Android.
