### PR TITLE
Explicitly pass `NodesManager` to `NativeProxy` on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -52,7 +52,7 @@ public class NativeProxy {
   private final HybridData mHybridData;
 
   public @OptIn(markerClass = FrameworkAPI.class) NativeProxy(
-      ReactApplicationContext context, WorkletsModule workletsModule) {
+      ReactApplicationContext context, WorkletsModule workletsModule, NodesManager nodesManager) {
     context.assertOnJSQueueThread();
 
     mWorkletsModule = workletsModule;
@@ -72,9 +72,7 @@ public class NativeProxy {
       tempHandlerStateManager = null;
     }
     gestureHandlerStateManager = tempHandlerStateManager;
-    mNodesManager =
-        Objects.requireNonNull(mContext.get().getNativeModule(ReanimatedModule.class))
-            .getNodesManager();
+    mNodesManager = nodesManager;
 
     FabricUIManager fabricUIManager =
         (FabricUIManager) UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -72,7 +72,7 @@ public class NodesManager implements EventDispatcherListener {
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {
     reactApplicationContext.assertOnJSQueueThread();
-    mNativeProxy = new NativeProxy(reactApplicationContext, mWorkletsModule);
+    mNativeProxy = new NativeProxy(reactApplicationContext, mWorkletsModule, this);
     mFabricUIManager =
         (FabricUIManager)
             UIManagerHelper.getUIManager(reactApplicationContext, UIManagerType.FABRIC);

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -49,6 +49,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   }
 
   public NodesManager getNodesManager() {
+    // This method is called from react-native-gesture-handler.
     return mNodesManager;
   }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -48,10 +48,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     // do nothing
   }
 
-  public NodesManager getNodesManager() {
-    return mNodesManager;
-  }
-
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule() {
     getReactApplicationContext().assertOnJSQueueThread();

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -48,6 +48,10 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     // do nothing
   }
 
+  public NodesManager getNodesManager() {
+    return mNodesManager;
+  }
+
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule() {
     getReactApplicationContext().assertOnJSQueueThread();


### PR DESCRIPTION
## Summary

Currently, `NodesManager` is obtained from `ReanimatedModule` via `getNativeModule` call in `NativeProxy` constructor. This PR makes this already existing coupling a bit more apparent by explicitly passing current `NodesManager` instance (as `this`) to `NativeProxy` constructor. Ultimately, we'd like to remove two-directional referencing between Java classes such as `ReanimatedModule`, `NodesManager` and `NativeProxy`. I also removed `getNodesManager` method which became unused.

## Test plan

Build, launch and reload fabric-example on Android.
