### PR TITLE
Convert `WorkletsModule` to a local variable in `ReanimatedModule` constructor

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -13,8 +13,8 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   public ReanimatedModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactContext.assertOnJSQueueThread();
-    WorkletsModule mWorkletsModule = reactContext.getNativeModule(WorkletsModule.class);
-    mNodesManager = new NodesManager(reactContext, mWorkletsModule);
+    WorkletsModule workletsModule = reactContext.getNativeModule(WorkletsModule.class);
+    mNodesManager = new NodesManager(reactContext, workletsModule);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Turns out, we don't use `mWorkletsModule` in `ReanimatedModule` class so let's convert it to a local variable. This means that the lifetime of `WorkletsModule` will not longer be affected by the lifetime of `ReanimatedModule`.

## Test plan

Build, launch and reload fabric-example on Android.
