### PR TITLE
Remove `NodesManager` null checks on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -27,16 +27,12 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
 
   @Override
   public void onHostPause() {
-    if (mNodesManager != null) {
-      mNodesManager.onHostPause();
-    }
+    mNodesManager.onHostPause();
   }
 
   @Override
   public void onHostResume() {
-    if (mNodesManager != null) {
-      mNodesManager.onHostResume();
-    }
+    mNodesManager.onHostResume();
   }
 
   @Override
@@ -69,11 +65,7 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   @Override
   public void invalidate() {
     super.invalidate();
-
-    if (mNodesManager != null) {
-      mNodesManager.invalidate();
-    }
-
+    mNodesManager.invalidate();
     ReactApplicationContext reactContext = getReactApplicationContext();
     reactContext.removeLifecycleEventListener(this);
   }


### PR DESCRIPTION
## Summary

In https://github.com/software-mansion/react-native-reanimated/pull/7186 we moved `NodesManager` creation in `ReanimatedModule` from `getNodesManager` getter method to `ReanimatedModule` constructor. This means that `mNodesManager` will be always initialized with a non-null value so we can remove the checks in other methods.

## Test plan

Build, launch and reload fabric-example on Android.