### PR TITLE
Remove unused `mUnsubscribe` in `NodesManager`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -46,7 +46,6 @@ public class NodesManager implements EventDispatcherListener {
   private ConcurrentLinkedQueue<CopiedEvent> mEventQueue = new ConcurrentLinkedQueue<>();
   private double lastFrameTimeMs;
   private FabricUIManager mFabricUIManager;
-  private @Nullable Runnable mUnsubscribe = null;
 
   public NativeProxy getNativeProxy() {
     return mNativeProxy;
@@ -62,11 +61,6 @@ public class NodesManager implements EventDispatcherListener {
 
     if (mFabricUIManager != null) {
       mFabricUIManager.getEventDispatcher().removeListener(this);
-    }
-
-    if (mUnsubscribe != null) {
-      mUnsubscribe.run();
-      mUnsubscribe = null;
     }
   }
 


### PR DESCRIPTION
## Summary

Turns out, we no longer need `mUnsubscribe` in `NodesManager` since we never register any cleanup lambdas so let's safely remove it.

## Test plan

Build, launch and reload fabric-example app.