### PR TITLE
Replace "[Reanimated]" with "[Worklets]" in react-native-worklets

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -115,7 +115,7 @@ jsi::Value WorkletsModuleProxy::createWorkletRuntime(
       true /* supportsLocking */,
       valueUnpackerCode_);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
-      rt, initializer, "[Reanimated] Initializer must be a worklet.");
+      rt, initializer, "[Worklets] Initializer must be a worklet.");
   workletRuntime->runGuarded(initializerShareable);
   return jsi::Object::createFromHostObject(rt, workletRuntime);
 }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -110,7 +110,7 @@ jsi::Value makeShareableClone(
         std::make_shared<ShareableString>(value.getSymbol(rt).toString(rt));
   } else {
     throw std::runtime_error(
-        "[Reanimated] Attempted to convert an unsupported value type.");
+        "[Worklets] Attempted to convert an unsupported value type.");
   }
   return ShareableJSRef::newHostObject(rt, shareable);
 }
@@ -125,7 +125,7 @@ std::shared_ptr<Shareable> extractShareableOrThrow(
       return object.getHostObject<ShareableJSRef>(rt)->value();
     }
     throw std::runtime_error(
-        "[Reanimated] Attempted to extract from a HostObject that wasn't converted to a Shareable.");
+        "[Worklets] Attempted to extract from a HostObject that wasn't converted to a Shareable.");
   } else if (maybeShareableValue.isUndefined()) {
     return Shareable::undefined();
   }
@@ -319,7 +319,7 @@ jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {
       return jsi::Value(data_.number);
     default:
       throw std::runtime_error(
-          "[Reanimated] Attempted to convert object that's not of a scalar type.");
+          "[Worklets] Attempted to convert object that's not of a scalar type.");
   }
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
@@ -149,14 +149,14 @@ std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,
     const std::string &errorMessage =
-        "[Reanimated] Expecting the object to be of type ShareableJSRef.");
+        "[Worklets] Expecting the object to be of type ShareableJSRef.");
 
 template <typename T>
 std::shared_ptr<T> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &shareableRef,
     const std::string &errorMessage =
-        "[Reanimated] Provided shareable object is of an incompatible type.") {
+        "[Worklets] Provided shareable object is of an incompatible type.") {
   auto res = std::dynamic_pointer_cast<T>(
       extractShareableOrThrow(rt, shareableRef, errorMessage));
   if (!res) {

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/JSISerializer.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/JSISerializer.cpp
@@ -330,7 +330,7 @@ std::string JSISerializer::stringifyJSIValueRecursively(
     return stringifyObject(object);
   }
 
-  throw std::runtime_error("[Reanimated] Unsupported value type.");
+  throw std::runtime_error("[Worklets] Unsupported value type.");
 }
 
 std::string stringifyJSIValue(jsi::Runtime &rt, const jsi::Value &value) {

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/ReanimatedJSIUtils.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/ReanimatedJSIUtils.h
@@ -28,7 +28,7 @@ inline int get<int>(jsi::Runtime &, const jsi::Value *value) {
 template <>
 inline bool get<bool>(jsi::Runtime &, const jsi::Value *value) {
   if (!value->isBool()) {
-    throw jsi::JSINativeException("[Reanimated] Expected a boolean.");
+    throw jsi::JSINativeException("[Worklets] Expected a boolean.");
   }
   return value->getBool();
 }

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/SingleInstanceChecker.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/SingleInstanceChecker.h
@@ -30,9 +30,9 @@ class SingleInstanceChecker {
     if (!condition) {
 #ifdef ANDROID
       __android_log_print(
-          ANDROID_LOG_WARN, "Reanimated", "%s", message.c_str());
+          ANDROID_LOG_WARN, "Worklets", "%s", message.c_str());
 #else
-      std::cerr << "[Reanimated] " << message << std::endl;
+      std::cerr << "[Worklets] " << message << std::endl;
 #endif
 
 #ifdef IS_REANIMATED_EXAMPLE_APP
@@ -58,7 +58,7 @@ SingleInstanceChecker<T>::SingleInstanceChecker() {
   instanceCount_++;
   assertWithMessage(
       instanceCount_ <= 2,
-      "[Reanimated] More than two instances of " + className +
+      "[Worklets] More than two instances of " + className +
           " present. This may indicate a memory leak due to a retain cycle.");
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/ReanimatedHermesRuntime.h
@@ -61,13 +61,13 @@ struct ReanimatedReentrancyCheck {
       // Returns true if tid and expected were the same.  If they
       // were, then the stored tid referred to no thread, and we
       // atomically saved this thread's tid.  Now increment depth.
-      assert(depth == 0 && "[Reanimated] No thread id, but depth != 0");
+      assert(depth == 0 && "[Worklets] No thread id, but depth != 0");
       ++depth;
     } else if (expected == this_id) {
       // If the stored tid referred to a thread, expected was set to
       // that value.  If that value is this thread's tid, that's ok,
       // just increment depth again.
-      assert(depth != 0 && "[Reanimated] Thread id was set, but depth == 0");
+      assert(depth != 0 && "[Worklets] Thread id was set, but depth == 0");
       ++depth;
     } else {
       // The stored tid was some other thread.  This indicates a bad
@@ -81,13 +81,13 @@ struct ReanimatedReentrancyCheck {
   void after() {
     assert(
         tid.load(std::memory_order_relaxed) == std::this_thread::get_id() &&
-        "[Reanimated] No thread id in after()");
+        "[Worklets] No thread id in after()");
     if (--depth == 0) {
       // If we decremented depth to zero, store no-thread into tid.
       std::thread::id expected = std::this_thread::get_id();
       bool didWrite = tid.compare_exchange_strong(
           expected, std::thread::id(), std::memory_order_relaxed);
-      assert(didWrite && "[Reanimated] Decremented to zero, but no tid write");
+      assert(didWrite && "[Worklets] Decremented to zero, but no tid write");
     }
   }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -114,12 +114,12 @@ jsi::Value WorkletRuntime::executeSync(
     const jsi::Value &worklet) const {
   assert(
       supportsLocking_ &&
-      ("[Reanimated] Runtime \"" + name_ + "\" doesn't support locking.")
+      ("[Worklets] Runtime \"" + name_ + "\" doesn't support locking.")
           .c_str());
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
       rt,
       worklet,
-      "[Reanimated] Only worklets can be executed synchronously on UI runtime.");
+      "[Worklets] Only worklets can be executed synchronously on UI runtime.");
   auto lock = std::unique_lock<std::recursive_mutex>(*runtimeMutex_);
   jsi::Runtime &uiRuntime = getJSIRuntime();
   auto result = runGuarded(shareableWorklet);
@@ -176,7 +176,7 @@ void scheduleOnRuntime(
   auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
       rt,
       shareableWorkletValue,
-      "[Reanimated] Function passed to `_scheduleOnRuntime` is not a shareable worklet. Please make sure that `processNestedWorklets` option in Reanimated Babel plugin is enabled.");
+      "[Worklets] Function passed to `_scheduleOnRuntime` is not a shareable worklet. Please make sure that `processNestedWorklets` option in Reanimated Babel plugin is enabled.");
   workletRuntime->runAsyncGuarded(shareableWorklet);
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -106,12 +106,12 @@ void WorkletRuntimeDecorator::decorate(
             ShareableRemoteFunction>(
             rt,
             funValue,
-            "[Reanimated] Incompatible object passed to scheduleOnJS. It is only allowed to schedule worklets or functions defined on the React Native JS runtime this way.");
+            "[Worklets] Incompatible object passed to scheduleOnJS. It is only allowed to schedule worklets or functions defined on the React Native JS runtime this way.");
 
         auto shareableArgs = argsValue.isUndefined()
             ? nullptr
             : extractShareableOrThrow<ShareableArray>(
-                  rt, argsValue, "[Reanimated] Args must be an array.");
+                  rt, argsValue, "[Worklets] Args must be an array.");
 
         jsScheduler->scheduleOnJS([=](jsi::Runtime &rt) {
           auto fun =
@@ -140,7 +140,7 @@ void WorkletRuntimeDecorator::decorate(
         auto shareableArgs = argsValue.isUndefined()
             ? nullptr
             : extractShareableOrThrow<ShareableArray>(
-                  rt, argsValue, "[Reanimated] Args must be an array.");
+                  rt, argsValue, "[Worklets] Args must be an array.");
 
         jsScheduler->scheduleOnJS([=](jsi::Runtime &rt) {
           auto args = parseArgs(rt, shareableArgs);

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -32,7 +32,7 @@ def resolveReactNativeDirectory() {
     }
 
     throw new GradleException(
-        "[Reanimated] Unable to resolve react-native location in node_modules. You should set project extension property (in `app/build.gradle`) named `REACT_NATIVE_NODE_MODULES_DIR` with the path to react-native in node_modules."
+        "[Worklets] Unable to resolve react-native location in node_modules. You should set project extension property (in `app/build.gradle`) named `REACT_NATIVE_NODE_MODULES_DIR` with the path to react-native in node_modules."
     )
 }
 
@@ -263,7 +263,7 @@ task assertMinimalReactNativeVersionTask {
     def minimalReactNativeVersion = 75
     onlyIf { REACT_NATIVE_MINOR_VERSION < minimalReactNativeVersion }
     doFirst {
-        throw new GradleException("[Reanimated] Unsupported React Native version. Please use $minimalReactNativeVersion or newer.")
+        throw new GradleException("[Worklets] Unsupported React Native version. Please use $minimalReactNativeVersion or newer.")
     }
 }
 

--- a/packages/react-native-worklets/src/runtimes.ts
+++ b/packages/react-native-worklets/src/runtimes.ts
@@ -23,7 +23,7 @@ const SHOULD_BE_USE_WEB = shouldBeUseWeb();
  * @param initializer - An optional worklet that will be run synchronously on
  *   the same thread immediately after the runtime is created.
  * @returns WorkletRuntime which is a
- *   `jsi::HostObject<reanimated::WorkletRuntime>` - {@link WorkletRuntime}
+ *   `jsi::HostObject<worklets::WorkletRuntime>` - {@link WorkletRuntime}
  * @see https://docs.swmansion.com/react-native-reanimated/docs/threading/createWorkletRuntime
  */
 // @ts-expect-error Check `runOnUI` overload.
@@ -36,7 +36,7 @@ export function createWorkletRuntime(
   name: string,
   initializer?: WorkletFunction<[], void>
 ): WorkletRuntime {
-  // Assign to a different variable as __reanimatedLoggerConfig is not a captured
+  // Assign to a different variable as __workletsLoggerConfig is not a captured
   // identifier in the Worklet runtime.
   const config = __workletsLoggerConfig;
   return WorkletsModule.createWorkletRuntime(


### PR DESCRIPTION
## Summary

This PR replaces "Reanimated" with "Worklets" in error messages in react-native-worklets package.

## Test plan

See if CI is green.
