### PR TITLE
Call `NodesManager.initWithContext` and thus create `NativeProxy` in `ReanimatedModule` constructor

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -84,11 +84,6 @@ public class NativeProxy {
             Objects.requireNonNull(context.getJavaScriptContextHolder()).get(),
             callInvokerHolder,
             fabricUIManager);
-
-    installJSIBindings();
-    if (BuildConfig.DEBUG) {
-      checkCppVersion();
-    }
   }
 
   @OptIn(markerClass = FrameworkAPI.class)

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -16,6 +16,8 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     reactContext.assertOnJSQueueThread();
     mWorkletsModule = reactContext.getNativeModule(WorkletsModule.class);
     mNodesManager = new NodesManager(reactContext, mWorkletsModule);
+    mNodesManager.initWithContext(reactContext);
+    // TODO: merge initWithContext into NodesManager constructor
   }
 
   @Override
@@ -48,7 +50,10 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   @ReactMethod(isBlockingSynchronousMethod = true)
   public boolean installTurboModule() {
     getReactApplicationContext().assertOnJSQueueThread();
-    mNodesManager.initWithContext(getReactApplicationContext());
+    mNodesManager.getNativeProxy().installJSIBindings();
+    if (BuildConfig.DEBUG) {
+      mNodesManager.getNativeProxy().checkCppVersion();
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary

Currently, we first create `ReanimatedModule` and `NodesManager` in its constructor. Then, calling `ReanimatedModule.installTurboModule` invokes `NodesManager.initWithContext` which creates `NativeProxy` and injects JSI bindings in its constructor. The part I don't like here is that `NodesManager` stays unconfigured for some time (between constructor and `initWithContext` calls). Also, there's some time period when `ReanimatedModule` exists but `NativeProxy` doesn't exist yet, even though it will be necessary, so why don't we just instantiate it earlier?

After this change, all three `ReanimatedModule`, `NodesManager` and `NativeProxy` instances will be created at the same time (but without injecting JSI bindings). Then, calling `installTurboModule` will delegate the call to already existing `NativeProxy` which will inject the bindings at the right time.

## Test plan

Build, launch and reload fabric-example on Android.
