### PR TITLE
Merge `initWithContext` method into `NodesManager` constructor

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -2,7 +2,6 @@ package com.swmansion.reanimated;
 
 import android.os.SystemClock;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
@@ -35,7 +34,6 @@ public class NodesManager implements EventDispatcherListener {
     void onAnimationFrame(double timestampMs);
   }
 
-  private final WorkletsModule mWorkletsModule;
   private final DeviceEventManagerModule.RCTDeviceEventEmitter mEventEmitter;
   private final ReactChoreographer mReactChoreographer;
   private final GuardedFrameCallback mChoreographerCallback;
@@ -64,22 +62,12 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
-  public void initWithContext(ReactApplicationContext reactApplicationContext) {
-    reactApplicationContext.assertOnJSQueueThread();
-    mNativeProxy = new NativeProxy(reactApplicationContext, mWorkletsModule, this);
-    mFabricUIManager =
-        (FabricUIManager)
-            UIManagerHelper.getUIManager(reactApplicationContext, UIManagerType.FABRIC);
-    mFabricUIManager.getEventDispatcher().addListener(this);
-  }
-
-  public NodesManager(ReactContext context, WorkletsModule workletsModule) {
+  public NodesManager(ReactApplicationContext context, WorkletsModule workletsModule) {
     context.assertOnJSQueueThread();
 
-    mWorkletsModule = workletsModule;
-    UIManager mUIManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
-    assert mUIManager != null;
-    mCustomEventNamesResolver = mUIManager::resolveCustomDirectEventName;
+    UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+    assert uiManager != null;
+    mCustomEventNamesResolver = uiManager::resolveCustomDirectEventName;
     mEventEmitter = context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
 
     mReactChoreographer = ReactChoreographer.getInstance();
@@ -90,6 +78,10 @@ public class NodesManager implements EventDispatcherListener {
             onAnimationFrame(frameTimeNanos);
           }
         };
+
+    mNativeProxy = new NativeProxy(context, workletsModule, this);
+    mFabricUIManager = (FabricUIManager) uiManager;
+    mFabricUIManager.getEventDispatcher().addListener(this);
   }
 
   public void onHostPause() {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -16,8 +16,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
     reactContext.assertOnJSQueueThread();
     mWorkletsModule = reactContext.getNativeModule(WorkletsModule.class);
     mNodesManager = new NodesManager(reactContext, mWorkletsModule);
-    mNodesManager.initWithContext(reactContext);
-    // TODO: merge initWithContext into NodesManager constructor
   }
 
   @Override


### PR DESCRIPTION
## Summary

Since `initWithContext` method is called immediately after `NodesManager`, this PR moves all the logic of `initWithContext` method into the constructor as well as removes its usage.

## Test plan

Build, launch and reload fabric-example app.