### PR TITLE
chore: Use [] operator instead of .at() when possible

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/TransformMatrix.cpp
@@ -54,7 +54,7 @@ TransformMatrix::TransformMatrix(const folly::dynamic &array) {
   }
 
   for (size_t i = 0; i < 16; ++i) {
-    matrix_[i / 4][i % 4] = array.at(i).getDouble();
+    matrix_[i / 4][i % 4] = array[i].getDouble();
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
@@ -40,7 +40,7 @@ CSSDiscreteArray<TValue>::CSSDiscreteArray(const folly::dynamic &value) {
   values.reserve(array.size());
 
   for (size_t i = 0; i < array.size(); i++) {
-    values.emplace_back(array.at(i));
+    values.emplace_back(array[i]);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -64,9 +64,9 @@ void ArrayPropertiesInterpolator::updateKeyframesFromStyleChange(
     // These index checks ensure that interpolation works between 2 arrays
     // with different lengths
     interpolators_[i]->updateKeyframesFromStyleChange(
-        i < oldSize ? oldStyleArray.at(i) : empty,
-        i < newSize ? newStyleArray.at(i) : empty,
-        i < valuesCount ? lastUpdateArray.at(i) : empty);
+        i < oldSize ? oldStyleArray[i] : empty,
+        i < newSize ? newStyleArray[i] : empty,
+        i < valuesCount ? lastUpdateArray[i] : empty);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -36,7 +36,7 @@ void RecordPropertiesInterpolator::updateKeyframes(
         rt, jsi::PropNameID::forUtf8(rt, propertyName));
 
     maybeCreateInterpolator(propertyName);
-    interpolators_.at(propertyName)->updateKeyframes(rt, propertyKeyframes);
+    interpolators_[propertyName]->updateKeyframes(rt, propertyKeyframes);
   }
 }
 
@@ -64,11 +64,10 @@ void RecordPropertiesInterpolator::updateKeyframesFromStyleChange(
 
   for (const auto &propertyName : propertyNamesSet) {
     maybeCreateInterpolator(propertyName);
-    interpolators_.at(propertyName)
-        ->updateKeyframesFromStyleChange(
-            oldStyleObject.getDefault(propertyName, empty),
-            newStyleObject.getDefault(propertyName, empty),
-            lastUpdateObject.getDefault(propertyName, empty));
+    interpolators_[propertyName]->updateKeyframesFromStyleChange(
+        oldStyleObject.getDefault(propertyName, empty),
+        newStyleObject.getDefault(propertyName, empty),
+        lastUpdateObject.getDefault(propertyName, empty));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -73,7 +73,7 @@ folly::dynamic TransformsStyleInterpolator::interpolate(
   const auto currentIndex = getIndexOfCurrentKeyframe(progressProvider);
 
   // Get or create the current keyframe
-  auto keyframe = keyframes_.at(currentIndex);
+  auto keyframe = keyframes_[currentIndex];
   if (!keyframe->fromOperations.has_value() ||
       !keyframe->toOperations.has_value()) {
     // If the value is nullopt, we would have to read it from the view style
@@ -185,7 +185,7 @@ TransformsStyleInterpolator::parseTransformOperations(
   transformOperations.reserve(transformsCount);
 
   for (size_t i = 0; i < transformsCount; ++i) {
-    const auto &transform = transformsArray.at(i);
+    const auto &transform = transformsArray[i];
     transformOperations.emplace_back(
         TransformOperation::fromDynamic(transform));
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -125,8 +125,8 @@ class ValueInterpolator : public PropertyInterpolator {
     const auto toIndex = getToKeyframeIndex(progressProvider);
     const auto fromIndex = toIndex - 1;
 
-    const auto &fromKeyframe = keyframes_.at(fromIndex);
-    const auto &toKeyframe = keyframes_.at(toIndex);
+    const auto &fromKeyframe = keyframes_[fromIndex];
+    const auto &toKeyframe = keyframes_[toIndex];
 
     std::optional<ValueType> fromValue = fromKeyframe.value;
     std::optional<ValueType> toValue = toKeyframe.value;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -83,7 +83,7 @@ void CSSAnimationsRegistry::update(const double timestamp) {
         it->second.begin(), it->second.end()};
     updateViewAnimations(viewTag, animationIndices, timestamp, true);
 
-    if (runningAnimationIndicesMap_.at(viewTag).empty()) {
+    if (runningAnimationIndicesMap_[viewTag].empty()) {
       it = runningAnimationIndicesMap_.erase(it);
     } else {
       ++it;
@@ -352,7 +352,7 @@ bool CSSAnimationsRegistry::addStyleUpdates(
   bool hasUpdates = false;
   for (const auto &[propertyName, propertyValue] : updates.items()) {
     if (shouldOverride || !target.count(propertyName) ||
-        target.at(propertyName).isNull()) {
+        target[propertyName].isNull()) {
       target[propertyName] = propertyValue;
       hasUpdates = true;
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.cpp
@@ -50,7 +50,7 @@ void CSSTransitionsRegistry::updateSettings(
     const PartialCSSTransitionConfig &config) {
   std::lock_guard<std::mutex> lock{mutex_};
 
-  const auto &transition = registry_.at(viewTag);
+  const auto &transition = registry_[viewTag];
   transition->updateSettings(config);
 
   // Replace style overrides with the new ones if transition properties were
@@ -71,7 +71,7 @@ void CSSTransitionsRegistry::update(const double timestamp) {
   for (auto it = runningTransitionTags_.begin();
        it != runningTransitionTags_.end();) {
     const auto &viewTag = *it;
-    const auto &transition = registry_.at(viewTag);
+    const auto &transition = registry_[viewTag];
 
     const folly::dynamic &updates = transition->update(timestamp);
     if (!updates.empty()) {
@@ -141,7 +141,7 @@ PropsObserver CSSTransitionsRegistry::createPropsObserver(const Tag viewTag) {
       return;
     }
 
-    const auto &transition = strongThis->registry_.at(viewTag);
+    const auto &transition = strongThis->registry_[viewTag];
     const auto allowedProperties =
         transition->getAllowedProperties(oldProps, newProps);
 


### PR DESCRIPTION
## Summary

This PR replaces `.at()` vector/map access with the `[]` operator when possible. The `[]` operator doesn't perform unnecessary range bounds checks, which may have a slight impact on performance.