### PR TITLE
Pass runtime reference from `REAModule` to `NativeProxy` on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -132,7 +132,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   react_native_assert(self.bridge.runtime != nullptr);
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
-  auto reanimatedModuleProxy = reanimated::createReanimatedModule(self, _moduleRegistry, jsCallInvoker, workletsModule);
+  auto reanimatedModuleProxy = reanimated::createReanimatedModule(self, _moduleRegistry, rnRuntime, jsCallInvoker, workletsModule);
 
   auto &uiRuntime = [workletsModule getWorkletsModuleProxy]->getUIWorkletRuntime() -> getJSIRuntime();
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -10,6 +10,7 @@ namespace reanimated {
 std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModule(
     REAModule *reaModule,
     RCTModuleRegistry *moduleRegistry,
+    jsi::Runtime &rnRuntime,
     const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule);
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -17,14 +17,13 @@ using namespace react;
 std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
     REAModule *reaModule,
     RCTModuleRegistry *moduleRegistry,
+    jsi::Runtime &rnRuntime,
     const std::shared_ptr<CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule)
 {
   REAAssertJavaScriptQueue();
 
   auto nodesManager = reaModule.nodesManager;
-
-  jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(reaModule.bridge.runtime);
 
   PlatformDepMethodsHolder platformDepMethodsHolder =
       makePlatformDepMethodsHolder(moduleRegistry, nodesManager, reaModule);


### PR DESCRIPTION
## Summary

Currently, in Reanimated we obtain runtime reference twice – once in `installTurboModule` in `REAModule` and then in `createReanimatedModule` in `NativeProxy`. This PR removes the second `reinterpret_cast` in favor of passing `rnRuntime` as `createReanimatedModule` argument.

## Test plan

See if CI is green.
