### PR TITLE
Remove unused `REAModule` argument in `makePlatformDepMethodsHolder`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -26,8 +26,7 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
 
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(reaModule.bridge.runtime);
 
-  PlatformDepMethodsHolder platformDepMethodsHolder =
-      makePlatformDepMethodsHolder(moduleRegistry, nodesManager, reaModule);
+  PlatformDepMethodsHolder platformDepMethodsHolder = makePlatformDepMethodsHolder(moduleRegistry, nodesManager);
 
   const auto workletsModuleProxy = [workletsModule getWorkletsModuleProxy];
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
@@ -9,8 +9,7 @@ namespace reanimated {
 
 PlatformDepMethodsHolder makePlatformDepMethodsHolder(
     RCTModuleRegistry *moduleRegistry,
-    REANodesManager *nodesManager,
-    REAModule *reaModule);
+    REANodesManager *nodesManager);
 SetGestureStateFunction makeSetGestureStateFunction(
     RCTModuleRegistry *moduleRegistry);
 RequestRenderFunction makeRequestRender(REANodesManager *nodesManager);

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -96,8 +96,7 @@ KeyboardEventUnsubscribeFunction makeUnsubscribeFromKeyboardEventsFunction(REAKe
   return unsubscribeFromKeyboardEventsFunction;
 }
 
-PlatformDepMethodsHolder
-makePlatformDepMethodsHolder(RCTModuleRegistry *moduleRegistry, REANodesManager *nodesManager, REAModule *reaModule)
+PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleRegistry, REANodesManager *nodesManager)
 {
   auto requestRender = makeRequestRender(nodesManager);
 


### PR DESCRIPTION
## Summary

This PR removes unused argument `reaModule` in `makePlatformDepMethodsHolder` function on iOS.

## Test plan

See if CI is green.
