### PR TITLE
Pass `REANodesManager` instead of `REAModule` to `createReanimatedModule`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REAModule.mm
@@ -133,7 +133,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
   auto reanimatedModuleProxy =
-      reanimated::createReanimatedModule(self, _moduleRegistry, rnRuntime, jsCallInvoker, workletsModule);
+      reanimated::createReanimatedModule(_nodesManager, _moduleRegistry, rnRuntime, jsCallInvoker, workletsModule);
 
   auto &uiRuntime = [workletsModule getWorkletsModuleProxy]->getUIWorkletRuntime() -> getJSIRuntime();
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -1,14 +1,14 @@
 #if __cplusplus
 
 #import <reanimated/NativeModules/ReanimatedModuleProxy.h>
-#import <reanimated/apple/REAModule.h>
+#import <reanimated/apple/REANodesManager.h>
 
 #import <worklets/apple/WorkletsModule.h>
 
 namespace reanimated {
 
 std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModule(
-    REAModule *reaModule,
+    REANodesManager *nodesManager,
     RCTModuleRegistry *moduleRegistry,
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -15,15 +15,13 @@ using namespace facebook;
 using namespace react;
 
 std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
-    REAModule *reaModule,
+    REANodesManager *nodesManager,
     RCTModuleRegistry *moduleRegistry,
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<CallInvoker> &jsInvoker,
     WorkletsModule *workletsModule)
 {
   REAAssertJavaScriptQueue();
-
-  auto nodesManager = reaModule.nodesManager;
 
   PlatformDepMethodsHolder platformDepMethodsHolder = makePlatformDepMethodsHolder(moduleRegistry, nodesManager);
 
@@ -35,7 +33,7 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
 
   jsi::Runtime &uiRuntime = workletsModuleProxy->getUIWorkletRuntime()->getJSIRuntime();
 
-  [reaModule.nodesManager registerEventHandler:^(id<RCTEvent> event) {
+  [nodesManager registerEventHandler:^(id<RCTEvent> event) {
     // handles RCTEvents from RNGestureHandler
     std::string eventName = [event.eventName UTF8String];
     int emitterReactTag = [event.viewTag intValue];
@@ -46,7 +44,7 @@ std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
   }];
 
   std::weak_ptr<ReanimatedModuleProxy> weakReanimatedModuleProxy = reanimatedModuleProxy; // to avoid retain cycle
-  [reaModule.nodesManager registerPerformOperations:^() {
+  [nodesManager registerPerformOperations:^() {
     if (auto reanimatedModuleProxy = weakReanimatedModuleProxy.lock()) {
       reanimatedModuleProxy->performOperations();
     }


### PR DESCRIPTION
## Summary

There's no need to pass `REAModule` to `createReanimatedModule` since only `REANodesManager` is used there. Instead of accessing `reaModule.nodesManager` in `createReanimatedModule`, let's directly pass `_nodesManager`.

## Test plan

See if CI is green.
