### PR TITLE
Rename `REAModule` to `ReanimatedModule` and `createReanimatedModule` to `createReanimatedModuleProxy`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -2,7 +2,7 @@
 
 #import <reanimated/apple/READisplayLink.h>
 
-@class REAModule;
+@class ReanimatedModule;
 
 typedef void (^REAOnAnimationCallback)(READisplayLink *displayLink);
 typedef void (^REAEventHandler)(id<RCTEvent> event);
@@ -11,9 +11,9 @@ typedef void (^REAPerformOperations)();
 
 @interface REANodesManager : NSObject
 
-@property (nonatomic, weak, nullable) REAModule *reanimatedModule;
+@property (nonatomic, weak, nullable) ReanimatedModule *reanimatedModule;
 
-- (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule;
+- (nonnull instancetype)initWithModule:(ReanimatedModule *)reanimatedModule;
 - (void)invalidate;
 
 - (void)postOnAnimation:(REAOnAnimationCallback)clb;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -40,7 +40,7 @@
   });
 }
 
-- (nonnull instancetype)initWithModule:(REAModule *)reanimatedModule
+- (nonnull instancetype)initWithModule:(ReanimatedModule *)reanimatedModule
 {
   REAAssertJavaScriptQueue();
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
@@ -6,7 +6,8 @@
 
 #import <reanimated/apple/REANodesManager.h>
 
-@interface REAModule : RCTEventEmitter <NativeReanimatedModuleSpec, RCTCallInvokerModule, RCTEventDispatcherObserver>
+@interface ReanimatedModule
+    : RCTEventEmitter <NativeReanimatedModuleSpec, RCTCallInvokerModule, RCTEventDispatcherObserver>
 
 @property (nonatomic, readonly) REANodesManager *nodesManager;
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -133,7 +133,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
   auto reanimatedModuleProxy =
-      reanimated::createReanimatedModule(_nodesManager, _moduleRegistry, rnRuntime, jsCallInvoker, workletsModule);
+      reanimated::createReanimatedModuleProxy(_nodesManager, _moduleRegistry, rnRuntime, jsCallInvoker, workletsModule);
 
   auto &uiRuntime = [workletsModule getWorkletsModuleProxy]->getUIWorkletRuntime() -> getJSIRuntime();
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -5,8 +5,8 @@
 #import <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #import <reanimated/apple/REAAssertJavaScriptQueue.h>
 #import <reanimated/apple/REAAssertTurboModuleManagerQueue.h>
-#import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
+#import <reanimated/apple/ReanimatedModule.h>
 #import <reanimated/apple/native/NativeProxy.h>
 
 #import <worklets/Tools/SingleInstanceChecker.h>
@@ -20,10 +20,10 @@ using namespace reanimated;
 - (void *)runtime;
 @end
 
-@implementation REAModule {
+@implementation ReanimatedModule {
   __weak RCTSurfacePresenter *_surfacePresenter;
 #ifndef NDEBUG
-  SingleInstanceChecker<REAModule> singleInstanceChecker_;
+  SingleInstanceChecker<ReanimatedModule> singleInstanceChecker_;
 #endif // NDEBUG
   bool hasListeners;
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.h
@@ -7,7 +7,7 @@
 
 namespace reanimated {
 
-std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModule(
+std::shared_ptr<reanimated::ReanimatedModuleProxy> createReanimatedModuleProxy(
     REANodesManager *nodesManager,
     RCTModuleRegistry *moduleRegistry,
     jsi::Runtime &rnRuntime,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/NativeProxy.mm
@@ -14,7 +14,7 @@ namespace reanimated {
 using namespace facebook;
 using namespace react;
 
-std::shared_ptr<ReanimatedModuleProxy> createReanimatedModule(
+std::shared_ptr<ReanimatedModuleProxy> createReanimatedModuleProxy(
     REANodesManager *nodesManager,
     RCTModuleRegistry *moduleRegistry,
     jsi::Runtime &rnRuntime,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.h
@@ -1,7 +1,7 @@
 #if __cplusplus
 
-#import <reanimated/apple/REAModule.h>
 #import <reanimated/apple/REANodesManager.h>
+#import <reanimated/apple/ReanimatedModule.h>
 #import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
 #import <reanimated/apple/sensor/ReanimatedSensorContainer.h>
 

--- a/packages/react-native-reanimated/scripts/validate-apple.sh
+++ b/packages/react-native-reanimated/scripts/validate-apple.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if grep -Rn apple -e '^#include '; then
-    echo 'Found `#include` in `apple/` directory. Convert it to `#import`, e.g. `#import <reanimated/apple/REAModule.h>`.'
+    echo 'Found `#include` in `apple/` directory. Convert it to `#import`, e.g. `#import <reanimated/apple/ReanimatedModule.h>`.'
     exit 1
 fi
 
 if grep -Rn apple -e '^#import "'; then
-    echo 'Found `#import "..."` in `apple/` directory. Convert it to `#import <...>`, e.g. `#import <reanimated/apple/REAModule.h>`.'
+    echo 'Found `#import "..."` in `apple/` directory. Convert it to `#import <...>`, e.g. `#import <reanimated/apple/ReanimatedModule.h>`.'
     exit 1
 fi
 
 if grep -Rn apple -e '^#import <RNReanimated\/'; then
-    echo 'Found `#import <RNReanimated/...>` in `apple/` directory. Convert it to `#import <reanimated/...>`, e.g. `#import <reanimated/apple/REAModule.h>`.'
+    echo 'Found `#import <RNReanimated/...>` in `apple/` directory. Convert it to `#import <reanimated/...>`, e.g. `#import <reanimated/apple/ReanimatedModule.h>`.'
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

This PR renames `REAModule` to `ReanimatedModule` in order to align its name with already existing `WorkletsModule`.

Additionally, I renamed `createReanimatedModule` to `createReanimatedModuleProxy` since the function returns a `std::shared_ptr<ReanimatedModuleProxy>`.

## Test plan

Build and launch fabric-example on iOS.
