### PR TITLE
Remove unused `reanimatedModule` property in `REANodesManager`

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -2,8 +2,6 @@
 
 #import <reanimated/apple/READisplayLink.h>
 
-@class ReanimatedModule;
-
 typedef void (^REAOnAnimationCallback)(READisplayLink *displayLink);
 typedef void (^REAEventHandler)(id<RCTEvent> event);
 typedef void (^CADisplayLinkOperation)(READisplayLink *displayLink);
@@ -11,9 +9,7 @@ typedef void (^REAPerformOperations)();
 
 @interface REANodesManager : NSObject
 
-@property (nonatomic, weak, nullable) ReanimatedModule *reanimatedModule;
-
-- (nonnull instancetype)initWithModule:(ReanimatedModule *)reanimatedModule;
+- (nonnull instancetype)init;
 - (void)invalidate;
 
 - (void)postOnAnimation:(REAOnAnimationCallback)clb;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -40,12 +40,11 @@
   });
 }
 
-- (nonnull instancetype)initWithModule:(ReanimatedModule *)reanimatedModule
+- (nonnull instancetype)init
 {
   REAAssertJavaScriptQueue();
 
   if ((self = [super init])) {
-    _reanimatedModule = reanimatedModule;
     _onAnimationCallbacks = [NSMutableArray new];
     _eventHandler = ^(id<RCTEvent> event) {
       // no-op

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -87,7 +87,7 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 {
   REAAssertJavaScriptQueue();
   [super setBridge:bridge];
-  _nodesManager = [[REANodesManager alloc] initWithModule:self];
+  _nodesManager = [[REANodesManager alloc] init];
   [[self.moduleRegistry moduleForName:"EventDispatcher"] addDispatchObserver:self];
 }
 


### PR DESCRIPTION
## Summary

This PR removes unused `@property ReanimatedModule *reanimatedModule` in `REANodesManager` as well as removes unused argument in its initializer method.

## Test plan

Build and launch fabric-example on iOS.
