### PR TITLE
Remove leftover `removeObserver` call in `ReanimatedModule` on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -37,7 +37,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 {
   REAAssertTurboModuleManagerQueue();
 
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_nodesManager invalidate];
   [super invalidate];
 }


### PR DESCRIPTION
## Summary

This PR removes leftover `[[NSNotificationCenter defaultCenter] removeObserver:]` call.

The original `addObserver:` call was removed in https://github.com/software-mansion/react-native-reanimated/pull/6837.

## Test plan

Build, launch and reload fabric-example on iOS.
