### PR TITLE
refactor: remove runOnUIImmediately

### DIFF
--- a/packages/react-native-reanimated/src/UpdateProps.ts
+++ b/packages/react-native-reanimated/src/UpdateProps.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 'use strict';
 import type { MutableRefObject } from 'react';
-import { runOnUIImmediately } from 'react-native-worklets';
+import { runOnUI } from 'react-native-worklets';
 
 import { processColorsInProps } from './Colors';
 import type {
@@ -107,7 +107,7 @@ if (shouldBeUseWeb()) {
     },
   });
 } else {
-  runOnUIImmediately(() => {
+  runOnUI(() => {
     'worklet';
     global.UpdatePropsManager = createUpdatePropsManager();
   })();

--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { runOnJS, runOnUIImmediately } from 'react-native-worklets';
+import { runOnJS, runOnUI } from 'react-native-worklets';
 
 import { shouldBeUseWeb } from '../PlatformChecker';
 import type {
@@ -22,7 +22,7 @@ class JSPropsUpdaterNative implements IJSPropsUpdater {
           JSPropsUpdaterNative._tagToComponentMapping.get(viewTag);
         component?._updateFromNative(props);
       };
-      runOnUIImmediately(() => {
+      runOnUI(() => {
         'worklet';
         global.updateJSProps = (viewTag: number, props: unknown) => {
           runOnJS(updater)(viewTag, props);

--- a/packages/react-native-reanimated/src/frameCallback/FrameCallbackRegistryUI.ts
+++ b/packages/react-native-reanimated/src/frameCallback/FrameCallbackRegistryUI.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { runOnUIImmediately } from 'react-native-worklets';
+import { runOnUI } from 'react-native-worklets';
 
 type CallbackDetails = {
   callback: (frameInfo: FrameInfo) => void;
@@ -26,7 +26,7 @@ export interface FrameCallbackRegistryUI {
   manageStateFrameCallback: (callbackId: number, state: boolean) => void;
 }
 
-export const prepareUIRegistry = runOnUIImmediately(() => {
+export const prepareUIRegistry = runOnUI(() => {
   'worklet';
 
   const frameCallbackRegistry: FrameCallbackRegistryUI = {

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { runOnUIImmediately } from 'react-native-worklets';
+import { runOnUI } from 'react-native-worklets';
 
 import { withStyleAnimation } from '../animation/styleAnimation';
 import type {
@@ -99,7 +99,7 @@ function createLayoutAnimationManager(): {
   };
 }
 
-runOnUIImmediately(() => {
+runOnUI(() => {
   'worklet';
   global.LayoutAnimationsManager = createLayoutAnimationManager();
 })();

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -28,7 +28,6 @@ export {
   executeOnUIRuntimeSync,
   runOnJS,
   runOnUI,
-  runOnUIImmediately,
 } from './threads';
 export { isWorkletFunction } from './workletFunction';
 export type { IWorkletsModule, WorkletsModuleProxy } from './WorkletsModule';

--- a/packages/react-native-worklets/src/threads.ts
+++ b/packages/react-native-worklets/src/threads.ts
@@ -158,35 +158,6 @@ export function executeOnUIRuntimeSync<Args extends unknown[], ReturnValue>(
   };
 }
 
-// @ts-expect-error Check `runOnUI` overload above.
-export function runOnUIImmediately<Args extends unknown[], ReturnValue>(
-  worklet: (...args: Args) => ReturnValue
-): WorkletFunction<Args, ReturnValue>;
-/** Schedule a worklet to execute on the UI runtime skipping batching mechanism. */
-export function runOnUIImmediately<Args extends unknown[], ReturnValue>(
-  worklet: WorkletFunction<Args, ReturnValue>
-): (...args: Args) => void {
-  'worklet';
-  if (__DEV__ && !SHOULD_BE_USE_WEB && _WORKLET) {
-    throw new WorkletsError(
-      '`runOnUIImmediately` cannot be called on the UI runtime. Please call the function synchronously or use `queueMicrotask` or `requestAnimationFrame` instead.'
-    );
-  }
-  if (__DEV__ && !SHOULD_BE_USE_WEB && !isWorkletFunction(worklet)) {
-    throw new WorkletsError(
-      '`runOnUIImmediately` can only be used with worklets.'
-    );
-  }
-  return (...args) => {
-    WorkletsModule.scheduleOnUI(
-      makeShareableCloneRecursive(() => {
-        'worklet';
-        worklet(...args);
-      })
-    );
-  };
-}
-
 type ReleaseRemoteFunction<Args extends unknown[], ReturnValue> = {
   (...args: Args): ReturnValue;
 };


### PR DESCRIPTION
## Summary

`runOnUIImmediately` is not conforming with a well defined event loop model of the UI Runtime, so we should remove it.

I considered that we can replace it with:
1. `runOnUI`
2. `executeOnUIRuntimeSync`
3. Additional batching mechanism on the side of Reanimated, using `runOnUI`.

Of those I went for **1.** for the sake of simplicity and didn't notice any regressions. **2.** would be the second choice since it actually preserves the logic but could be potentially slowing down the initialization process.

Please submit any suggestions on how to test this change more thoroughly. 

## Test plan

Run an example and see that all animations run well 🚀 
