### PR TITLE
fix: Filter out null values from the CSS animation style

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -78,7 +78,10 @@ folly::dynamic RecordPropertiesInterpolator::mapInterpolators(
   folly::dynamic result = folly::dynamic::object;
 
   for (const auto &[propertyName, interpolator] : interpolators_) {
-    result[propertyName] = callback(*interpolator);
+    const auto value = callback(*interpolator);
+    if (!value.isNull()) {
+      result[propertyName] = value;
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

Quick fix for invalid props in the CSS animation style object.
Issue was introduced during `jsi::Value` to `folly::dynamic` refactor by mistake.

## Example recordings

You can see that before this change the blue box was initially missing (because its width was set to `null`). Afterwards, everything seems to work fine.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/d8981633-0368-46d3-bc8d-14907cc524b6" /> | <video src="https://github.com/user-attachments/assets/cc5ef663-1901-4016-836e-a2adff6fba33" /> |
