### PR TITLE
chore: amend compatibility table

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -15,7 +15,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 
 |                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
 | ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |

--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
@@ -11,7 +11,7 @@ sidebar_label: Compatibility
 
 |                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
 | ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.17.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.7"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.0 – 3.16.6"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
@@ -38,13 +38,11 @@ Reanimated 2 won't receive support for newest React Native versions. To get the 
 
 To use Reanimated with [the experimental New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page), update the package to at least version 3.0.0. Due to the vast number of breaking-changes related to the New Architecture in each React Native version, as a rule of thumb Reanimated supports the latest stable version of React Native.
 
-Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-native-new-architecture/discussions/154).
-
 <div className="compatibility">
 
 |                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
 | ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |


### PR DESCRIPTION
## Summary

Reanimated 3.17 actually doesn't support 0.75.

## Test plan

🚀 
