### PR TITLE
Infer only readonly arrays in `MaybeSharedValueRecursive`

### DIFF
--- a/packages/react-native-reanimated/__typetests__/common/AnimatedComponentTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/AnimatedComponentTest.tsx
@@ -10,11 +10,9 @@ import type { AnimatedStyle } from '../..';
 import Animated from '../..';
 
 function AnimatedStyleRecursiveReadonlyArrayTest() {
-  type TestStyleProp<T> =
-    | T
-    | ReadonlyArray<TestStyleProp<T>>
+  type TestStyleProp<T> = T | ReadonlyArray<TestStyleProp<T>>;
 
-  const style: AnimatedStyle<TestStyleProp<ViewStyle>> = {}
+  const style: AnimatedStyle<TestStyleProp<ViewStyle>> = {};
 }
 
 function AnimatedComponentPropsTest() {

--- a/packages/react-native-reanimated/__typetests__/common/AnimatedComponentTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/AnimatedComponentTest.tsx
@@ -6,7 +6,16 @@ import React from 'react';
 import type { ViewStyle } from 'react-native';
 import { FlatList, ScrollView, View } from 'react-native';
 
+import type { AnimatedStyle } from '../..';
 import Animated from '../..';
+
+function AnimatedStyleRecursiveReadonlyArrayTest() {
+  type TestStyleProp<T> =
+    | T
+    | ReadonlyArray<TestStyleProp<T>>
+
+  const style: AnimatedStyle<TestStyleProp<ViewStyle>> = {}
+}
 
 function AnimatedComponentPropsTest() {
   const RNStyle: ViewStyle = {};

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -416,7 +416,7 @@ type MaybeSharedValue<Value> =
       ? SharedValueDisableContravariance<Value>
       : never);
 
-type MaybeSharedValueRecursive<Value> = Value extends (infer Item)[]
+type MaybeSharedValueRecursive<Value> = Value extends readonly (infer Item)[]
   ?
       | SharedValueDisableContravariance<Item[]>
       | (MaybeSharedValueRecursive<Item> | Item)[]


### PR DESCRIPTION
## Summary

`MaybeSharedValueRecursive` will result in `Type installation is excessively deep and infinite` error when used with recursive read-only arrays. This PR changes the inference to readonly arrays.

## Test plan

See included test case
