### PR TITLE
backport: Add warning for unsupported layout animation props (#7135)

### DIFF
--- a/packages/react-native-reanimated/src/animation/styleAnimation.ts
+++ b/packages/react-native-reanimated/src/animation/styleAnimation.ts
@@ -12,7 +12,7 @@ import type {
 import { logger } from '../logger';
 import type { StyleLayoutAnimation } from './commonTypes';
 import { withTiming } from './timing';
-import { defineAnimation } from './util';
+import { defineAnimation, isValidLayoutAnimationProp } from './util';
 
 // resolves path to value for nested objects
 // if path cannot be resolved returns undefined
@@ -185,12 +185,23 @@ export function withStyleAnimation(
           if (prevAnimation && !prevVal) {
             prevVal = (prevAnimation as any).current;
           }
-          if (prevVal === undefined) {
-            logger.warn(
-              `Initial values for animation are missing for property ${currentEntry.path.join(
-                '.'
-              )}`
-            );
+          if (__DEV__) {
+            if (prevVal === undefined) {
+              logger.warn(
+                `Initial values for animation are missing for property ${currentEntry.path.join(
+                  '.'
+                )}`
+              );
+            }
+            const propName = currentEntry.path[0];
+            if (
+              typeof propName === 'string' &&
+              !isValidLayoutAnimationProp(propName.trim())
+            ) {
+              logger.warn(
+                `'${propName}' property is not officially supported for layout animations. It may not work as expected.`
+              );
+            }
           }
           setPath(animation.current, currentEntry.path, prevVal);
           let currentAnimation: AnimationObject;

--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -44,6 +44,25 @@ import {
 let IN_STYLE_UPDATER = false;
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
 
+const LAYOUT_ANIMATION_SUPPORTED_PROPS = {
+  originX: true,
+  originY: true,
+  width: true,
+  heigth: true,
+  borderRadius: true,
+  globalOriginX: true,
+  globalOriginY: true,
+  opacity: true,
+  transform: true,
+};
+
+type LayoutAnimationProp = keyof typeof LAYOUT_ANIMATION_SUPPORTED_PROPS;
+
+export function isValidLayoutAnimationProp(prop: string) {
+  'worklet';
+  return (prop as LayoutAnimationProp) in LAYOUT_ANIMATION_SUPPORTED_PROPS;
+}
+
 if (__DEV__ && ReducedMotionManager.jsValue) {
   logger.warn(
     `Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#reduced-motion-setting-is-enabled-on-this-device.`


### PR DESCRIPTION
This PR aims to help users avoid confusion by warning them when using layout animation properties that are not officially supported. It was motivated by arising amount of issues related to "X prop not working in custom layout animation" - we want to make it clear for users c:

Related to: #7042 

## Test plan

<details>
<summary>example code</summary>

```tsx
import React, { useState } from 'react';
import { View, Button, StyleSheet, SafeAreaView } from 'react-native';
import Animated, { withTiming, withDelay } from 'react-native-reanimated';

const WIDTH = 200;

const customEntering = (targetValues) => {
  'worklet';
  const animations = {
    originX: withTiming(targetValues.targetOriginX, { duration: 3000 }),
    opacity: withTiming(1, { duration: 2000 }),
    borderRadius: withDelay(1500, withTiming(40, { duration: 3000 })),
    transform: [
      { rotate: withTiming('0deg', { duration: 4000 }) },
      { scale: withTiming(1, { duration: 3500 }) },
    ],
    maxWidth: withTiming(200, { duration: 3000 }),
  };
  const initialValues = {
    originX: -WIDTH,
    opacity: 0,
    borderRadius: 10,
    transform: [{ rotate: '90deg' }, { scale: 0.2 }],
    maxWidth: 10,
  };
  return {
    initialValues,
    animations,
  };
};

const customExiting = (values) => {
  'worklet';
  const animations = {
    originX: withTiming(2 * WIDTH, { duration: 3000 }),
    opacity: withTiming(0, { duration: 2000 }),
    transform: [{ scale: withTiming(0.2, { duration: 3500 }) }],
    minWidth: withTiming(10, { duration: 3000 }),
  };
  const initialValues = {
    originX: values.currentOriginX,
    opacity: 1,
    transform: [{ scale: 1 }],
    minWidth: 0,
  };
  return {
    initialValues,
    animations,
  };
};

export default function EnteringExample() {
  const [show, setShow] = useState(false);

  return (
    <SafeAreaView>
      <View style={styles.container}>
        <Button title="Click me" onPress={() => setShow(!show)} />
        {show && (
          <Animated.View
            style={styles.card}
            entering={customEntering}
            exiting={customExiting}
          />
        )}
      </View>
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    display: 'flex',
    padding: 128,
    justifyContent: 'space-between',
    alignItems: 'center',
    height: '100%',
  },
  card: {
    width: WIDTH,
    height: 300,
    backgroundColor: '#b58df1',
    justifyContent: 'center',
    alignItems: 'center',
    margin: 20,
  },
});
```
</details>

---------

## Summary

## Test plan
