### PR TITLE
fix: Add `placeholderTextColor` to processColor list

### DIFF
--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -343,6 +343,7 @@ export const ColorProperties = makeShareable([
   'borderBlockStartColor',
   'color',
   'outlineColor',
+  'placeholderTextColor',
   'shadowColor',
   'textDecorationColor',
   'tintColor',


### PR DESCRIPTION

## Summary

Fixes #7198 - the color set to `placeholderTextColor` was never processed because it was not on the list. The issue persisted on Fabric and Paper.

## Test plan

Use example code from issue.
