### PR TITLE
fix: createNPMPackage.sh not working without parameters

### DIFF
--- a/packages/react-native-reanimated/createNPMPackage.sh
+++ b/packages/react-native-reanimated/createNPMPackage.sh
@@ -2,14 +2,18 @@
 
 yarn install --immutable
 
-if ! CURRENT_VERSION=$(node scripts/set-reanimated-version.js "$@"); then
-  exit 1
+if [ $# -gt 1 ]; then
+  if ! CURRENT_VERSION=$(node scripts/set-reanimated-version.js "$@"); then
+    exit 1
+  fi
 fi
 
 yarn build
 
 npm pack
 
-node scripts/set-reanimated-version.js "$CURRENT_VERSION" >/dev/null
+if [ $# -gt 1 ]; then
+  node scripts/set-reanimated-version.js "$CURRENT_VERSION" >/dev/null
+fi
 
 echo "Done!"

--- a/packages/react-native-worklets/createNPMPackage.sh
+++ b/packages/react-native-worklets/createNPMPackage.sh
@@ -2,14 +2,18 @@
 
 yarn install --immutable
 
-if ! CURRENT_VERSION=$(node scripts/set-worklets-version.js "$@"); then
-  exit 1
+if [ $# -gt 1 ]; then
+  if ! CURRENT_VERSION=$(node scripts/set-worklets-version.js "$@"); then
+    exit 1
+  fi
 fi
 
 yarn build
 
 npm pack
 
-node scripts/set-worklets-version.js "$CURRENT_VERSION" >/dev/null
+if [ $# -gt 1 ]; then
+  node scripts/set-worklets-version.js "$CURRENT_VERSION" >/dev/null
+fi
 
 echo "Done!"


### PR DESCRIPTION
## Summary

After the changes to the releasing scripts I introduced a regression where calling `createNPMPackage.sh` without parameters would result in an error.

#7107 

## Test plan

🚀