### PR TITLE
feat: preworkletized target

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -30,7 +30,8 @@
     "type:check:src": "yarn tsc --noEmit",
     "type:check:app": "yarn workspace common-app type:check",
     "type:check:tests:common": "./scripts/test-ts.sh __typetests__/common",
-    "build": "yarn workspace react-native-worklets build && bob build",
+    "build": "yarn workspace react-native-worklets build && bob build && yarn build:preworkletized",
+    "build:preworkletized": "yarn babel --out-dir lib/preworkletized --config-file ../react-native-worklets/preworkletized.babel.config.js --extensions \".js,.jsx\" --source-maps true lib/module",
     "circular-dependency-check": "yarn madge --extensions js,jsx,ts,tsx --circular src lib",
     "use-strict-check": "node ../../scripts/validate-use-strict.js",
     "prepack": "cp ../../README.md ./README.md",
@@ -40,6 +41,7 @@
   "module": "lib/module/index",
   "react-native": "src/index",
   "source": "src/index",
+  "preworkletized": "lib/preworkletized/index",
   "types": "lib/typescript/index.d.ts",
   "files": [
     "Common/",

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -9,7 +9,8 @@
     "worklets"
   ],
   "scripts": {
-    "build": "bob build",
+    "build": "bob build && yarn build:preworkletized",
+    "build:preworkletized": "yarn babel --out-dir lib/preworkletized --config-file ./preworkletized.babel.config.js --extensions \".js,.jsx\" --source-maps true lib/module",
     "circular-dependency-check": "yarn madge --extensions js,jsx,ts,tsx --circular src lib",
     "find-unused-code:js": "yarn ts-prune --ignore \"index|.web.\" --error",
     "format": "yarn format:js && yarn format:plugin && yarn format:common && yarn format:android && yarn format:apple",
@@ -53,6 +54,8 @@
     "react-native": "*"
   },
   "devDependencies": {
+    "@babel/cli": "^7.20.0",
+    "@babel/core": "^7.25.2",
     "@react-native-community/cli": "15.0.1",
     "@react-native/eslint-config": "0.76.5",
     "@types/jest": "^29.5.5",
@@ -74,6 +77,7 @@
   "module": "./lib/module/index",
   "react-native": "./src/index",
   "source": "./src/index",
+  "preworkletized": "./lib/preworkletized/index",
   "types": "lib/typescript/index.d.ts",
   "files": [
     "src",

--- a/packages/react-native-worklets/preworkletized.babel.config.js
+++ b/packages/react-native-worklets/preworkletized.babel.config.js
@@ -1,0 +1,4 @@
+/** @type {import('@babel/core').TransformOptions} */
+module.exports = {
+  plugins: [['react-native-worklets/plugin', { processNestedWorklets: true }]],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -18329,6 +18329,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-worklets@workspace:packages/react-native-worklets"
   dependencies:
+    "@babel/cli": "npm:^7.20.0"
+    "@babel/core": "npm:^7.25.2"
     "@react-native-community/cli": "npm:15.0.1"
     "@react-native/eslint-config": "npm:0.76.5"
     "@types/jest": "npm:^29.5.5"


### PR DESCRIPTION
## Summary

Transpilation of Reanimated's worklets takes a significant amount of time due to Worklets Babel plugin invocation of `transformSync`. See https://github.com/byCedric/expo-babel-benchmarks for more details. Adding pre-workletized target for our libraries reduces the transpilation time for Worklets Babel plugin to effectively zero, speeding up bundling.

## Test plan

Generate new targets, in Reanimated move `src` to `src.bak`, copy `lib/preworkletized` to `src`, delete `lib/module` and see that WebExample works as expected.

You should be able to specify `metroConfig.resolver.resolverMainFields = ['preworkletized']` [LINK](https://metrobundler.dev/docs/configuration/#resolvermainfields) but it doesn't work in WebExample for some reason, cc @MatiPl01 on that.
