### PR TITLE
backport: Add suport for animatedProps

### DIFF
--- a/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
+++ b/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Button, TextInput, View } from 'react-native';
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { Circle, Svg } from 'react-native-svg';
+
+const animationDuration = 100;
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+Animated.addWhitelistedNativeProps({ r: true });
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+Animated.addWhitelistedNativeProps({ text: true });
+
+export default function AnimatedComponent() {
+  const r = useSharedValue(20);
+  const width = useSharedValue(20);
+
+  const handlePress = () => {
+    r.value += 10;
+    width.value += 10;
+  };
+
+  const animatedProps = useAnimatedProps(() => ({
+    r: withTiming(r.value, { duration: animationDuration }),
+  }));
+
+  const textAnimatedProps = useAnimatedProps(() => {
+    return {
+      text: `Box width: ${width.value}`,
+      defaultValue: `Box width: ${width.value}`,
+    };
+  });
+
+  return (
+    <View>
+      <Svg>
+        // SVG components strip our jest props and cannot be tested
+        <AnimatedCircle
+          cx="50%"
+          cy="50%"
+          fill="#b58df1"
+          testID={'circle'}
+          animatedProps={animatedProps}
+        />
+      </Svg>
+      <AnimatedTextInput testID={'text'} animatedProps={textAnimatedProps} />
+      <Button testID={'button'} onPress={handlePress} title="Click me" />
+    </View>
+  );
+}
+
+describe('animatedProps', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('SVG component cannot be tested', () => {
+    const { getByTestId } = render(<AnimatedComponent />);
+    const circle = getByTestId('circle');
+
+    expect(circle).toHaveAnimatedProps({});
+  });
+  test('Custom animated component', () => {
+    const { getByTestId } = render(<AnimatedComponent />);
+    const textInput = getByTestId('text');
+    const button = getByTestId('button');
+
+    expect(textInput).toHaveAnimatedProps({ text: 'Box width: 20' });
+
+    fireEvent.press(button);
+    jest.advanceTimersByTime(animationDuration);
+
+    expect(textInput).toHaveAnimatedProps({ text: 'Box width: 30' });
+  });
+});

--- a/packages/react-native-reanimated/src/UpdateProps.ts
+++ b/packages/react-native-reanimated/src/UpdateProps.ts
@@ -45,14 +45,14 @@ if (shouldBeUseWeb()) {
 export const updatePropsJestWrapper = (
   viewDescriptors: ViewDescriptorsWrapper,
   updates: AnimatedStyle<any>,
-  animatedStyle: MutableRefObject<AnimatedStyle<any>>,
+  animatedValues: MutableRefObject<AnimatedStyle<any>>,
   adapters: ((updates: AnimatedStyle<any>) => void)[]
 ): void => {
   adapters.forEach((adapter) => {
     adapter(updates);
   });
-  animatedStyle.current.value = {
-    ...animatedStyle.current.value,
+  animatedValues.current.value = {
+    ...animatedValues.current.value,
     ...updates,
   };
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -107,6 +107,7 @@ export interface IAnimatedComponentInternal {
   _isFirstRender: boolean;
   jestInlineStyle: NestedArray<StyleProps> | undefined;
   jestAnimatedStyle: { value: StyleProps };
+  jestAnimatedProps: { value: AnimatedProps };
   _componentRef: AnimatedComponentRef | HTMLElement | null;
   _sharedElementTransition: SharedTransition | null;
   _jsPropsUpdater: IJSPropsUpdater;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { Component, Ref } from 'react';
+import type { Component, MutableRefObject, Ref } from 'react';
 
 import type {
   EntryExitAnimationFunction,
@@ -68,6 +68,7 @@ export type AnimatedComponentProps<P extends Record<string, unknown>> = P & {
   forwardedRef?: Ref<Component>;
   style?: NestedArray<StyleProps>;
   animatedProps?: Partial<AnimatedComponentProps<AnimatedProps>>;
+  jestAnimatedValues?: MutableRefObject<AnimatedProps>;
   animatedStyle?: StyleProps;
   layout?: (
     | BaseAnimationBuilder

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -141,6 +141,7 @@ export function createAnimatedComponent(
     _isFirstRender = true;
     jestInlineStyle: NestedArray<StyleProps> | undefined;
     jestAnimatedStyle: { value: StyleProps } = { value: {} };
+    jestAnimatedProps: { value: AnimatedProps } = { value: {} };
     _componentRef: AnimatedComponentRef | HTMLElement | null = null;
     _hasAnimatedRef = false;
     // Used only on web
@@ -160,6 +161,7 @@ export function createAnimatedComponent(
       super(props);
       if (IS_JEST) {
         this.jestAnimatedStyle = { value: {} };
+        this.jestAnimatedProps = { value: {} };
       }
 
       const entering = this.props.entering;
@@ -357,11 +359,12 @@ export function createAnimatedComponent(
       const styles = this.props.style
         ? onlyAnimatedStyles(flattenArray<StyleProps>(this.props.style))
         : [];
+      const animatedProps = this.props.animatedProps;
       const prevStyles = this._styles;
       this._styles = styles;
 
       const prevAnimatedProps = this._animatedProps;
-      this._animatedProps = this.props.animatedProps;
+      this._animatedProps = animatedProps;
 
       const { viewTag, viewName, shadowNodeWrapper, viewConfig } =
         this._getViewInfo();
@@ -392,6 +395,16 @@ export function createAnimatedComponent(
         }
       }
 
+      if (animatedProps && IS_JEST) {
+        this.jestAnimatedProps.value = {
+          ...this.jestAnimatedProps.value,
+          ...animatedProps?.initial?.value,
+        };
+        // @ts-ignore It tells jestAnimatedValues is unknown yet it's part of animatedProps
+        // TODO: fix this somewhat in the future
+        animatedProps.jestAnimatedValues.current = this.jestAnimatedProps;
+      }
+
       styles.forEach((style) => {
         style.viewDescriptors.add({
           tag: viewTag,
@@ -410,7 +423,7 @@ export function createAnimatedComponent(
             ...this.jestAnimatedStyle.value,
             ...style.initial.value,
           };
-          style.jestAnimatedStyle.current = this.jestAnimatedStyle;
+          style.jestAnimatedValues.current = this.jestAnimatedStyle;
         }
       });
 
@@ -615,6 +628,7 @@ export function createAnimatedComponent(
 
       if (IS_JEST) {
         filteredProps.jestAnimatedStyle = this.jestAnimatedStyle;
+        filteredProps.jestAnimatedProps = this.jestAnimatedProps;
       }
 
       // Layout animations on web are set inside `componentDidMount` method, which is called after first render.
@@ -646,6 +660,7 @@ export function createAnimatedComponent(
         ? {
             jestInlineStyle: this.props.style,
             jestAnimatedStyle: this.jestAnimatedStyle,
+            jestAnimatedProps: this.jestAnimatedProps,
           }
         : {};
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -400,9 +400,10 @@ export function createAnimatedComponent(
           ...this.jestAnimatedProps.value,
           ...animatedProps?.initial?.value,
         };
-        // @ts-ignore It tells jestAnimatedValues is unknown yet it's part of animatedProps
-        // TODO: fix this somewhat in the future
-        animatedProps.jestAnimatedValues.current = this.jestAnimatedProps;
+
+        if (animatedProps?.jestAnimatedValues) {
+          animatedProps.jestAnimatedValues.current = this.jestAnimatedProps;
+        }
       }
 
       styles.forEach((style) => {

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -15,6 +15,7 @@ import type {
   SharedValue,
   WorkletFunction,
 } from '../commonTypes';
+import type { AnimatedProps } from '../createAnimatedComponent/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import type { ViewDescriptorsSet } from '../ViewDescriptorsSet';
 
@@ -91,7 +92,7 @@ export interface IWorkletEventHandler<Event extends object> {
 }
 
 export interface AnimatedStyleHandle<
-  Style extends DefaultStyle = DefaultStyle,
+  Style extends DefaultStyle | AnimatedProps = DefaultStyle,
 > {
   viewDescriptors: ViewDescriptorsSet;
   initial: {
@@ -101,9 +102,11 @@ export interface AnimatedStyleHandle<
 }
 
 export interface JestAnimatedStyleHandle<
-  Style extends DefaultStyle = DefaultStyle,
+  Style extends DefaultStyle | AnimatedProps = DefaultStyle,
 > extends AnimatedStyleHandle<Style> {
-  jestAnimatedStyle: MutableRefObject<AnimatedStyle<Style>>;
+  jestAnimatedValues:
+    | MutableRefObject<AnimatedStyle<Style>>
+    | MutableRefObject<AnimatedProps>;
 }
 
 export type UseAnimatedStyleInternal<Style extends DefaultStyle> = (

--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -5,6 +5,7 @@ import type { ReactTestInstance } from 'react-test-renderer';
 
 import type {
   AnimatedComponentProps,
+  AnimatedProps,
   IAnimatedComponentInternal,
   InitialComponentProps,
 } from './createAnimatedComponent/commonTypes';
@@ -21,6 +22,7 @@ declare global {
           shouldMatchAllProps?: boolean;
         }
       ): R;
+      toHaveAnimatedProps(props: Record<string, unknown>): R;
     }
   }
 }
@@ -49,6 +51,14 @@ type JestInlineStyle =
     }
   | ArrayLike<StyleValue>;
 
+const getCurrentProps = (
+  component: TestComponent
+): Partial<AnimatedComponentProps<AnimatedProps>> => {
+  const propsObject = component.props.jestAnimatedProps?.value;
+
+  return propsObject ? { ...propsObject } : {};
+};
+
 const getCurrentStyle = (component: TestComponent): DefaultStyle => {
   const styleObject = component.props.style;
 
@@ -72,7 +82,7 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
 
   if (Array.isArray(jestInlineStyles)) {
     for (const obj of jestInlineStyles) {
-      if ('jestAnimatedStyle' in obj) {
+      if ('jestAnimatedValues' in obj) {
         continue;
       }
 
@@ -128,8 +138,8 @@ const checkEqual = <Value>(current: Value, expected: Value) => {
 };
 
 const findStyleDiff = (
-  current: DefaultStyle,
-  expected: DefaultStyle,
+  current: DefaultStyle | Partial<AnimatedComponentProps<AnimatedProps>>,
+  expected: DefaultStyle | Partial<AnimatedComponentProps<AnimatedProps>>,
   shouldMatchAllProps?: boolean
 ) => {
   const diffs = [];
@@ -167,6 +177,53 @@ const findStyleDiff = (
   return { isEqual, diffs };
 };
 
+const compareAndFormatDifferences = (
+  currentValues: Partial<AnimatedComponentProps<AnimatedProps>> | DefaultStyle,
+  expectedValues: Partial<AnimatedComponentProps<AnimatedProps>> | DefaultStyle,
+  shouldMatchAllProps: boolean = false
+): { message: () => string; pass: boolean } => {
+  const { isEqual, diffs } = findStyleDiff(
+    currentValues,
+    expectedValues,
+    shouldMatchAllProps
+  );
+
+  if (isEqual) {
+    return { message: () => 'ok', pass: true };
+  }
+
+  const currentValuesStr = JSON.stringify(currentValues);
+  const expectedValuesStr = JSON.stringify(expectedValues);
+  const differences = diffs
+    .map(
+      (diff) =>
+        `- '${diff.property}' should be ${JSON.stringify(diff.expect)}, but is ${JSON.stringify(diff.current)}`
+    )
+    .join('\n');
+
+  return {
+    message: () =>
+      `Expected: ${expectedValuesStr}\nReceived: ${currentValuesStr}\n\nDifferences:\n${differences}`,
+    pass: false,
+  };
+};
+
+const compareProps = (
+  component: TestComponent,
+  expectedProps: Partial<AnimatedComponentProps<AnimatedProps>>
+) => {
+  if (
+    component.props.jestAnimatedProps &&
+    Object.keys(component.props.jestAnimatedProps.value).length === 0
+  ) {
+    return { message: () => `Component doesn't have props.`, pass: false };
+  }
+
+  const currentProps = getCurrentProps(component);
+
+  return compareAndFormatDifferences(currentProps, expectedProps);
+};
+
 const compareStyle = (
   component: TestComponent,
   expectedStyle: DefaultStyle,
@@ -177,32 +234,12 @@ const compareStyle = (
   }
   const { shouldMatchAllProps } = config;
   const currentStyle = getCurrentStyle(component);
-  const { isEqual, diffs } = findStyleDiff(
+
+  return compareAndFormatDifferences(
     currentStyle,
     expectedStyle,
     shouldMatchAllProps
   );
-
-  if (isEqual) {
-    return { message: () => 'ok', pass: true };
-  }
-
-  const currentStyleStr = JSON.stringify(currentStyle);
-  const expectedStyleStr = JSON.stringify(expectedStyle);
-  const differences = diffs
-    .map(
-      (diff) =>
-        `- '${diff.property}' should be ${JSON.stringify(
-          diff.expect
-        )}, but is ${JSON.stringify(diff.current)}`
-    )
-    .join('\n');
-
-  return {
-    message: () =>
-      `Expected: ${expectedStyleStr}\nReceived: ${currentStyleStr}\n\nDifferences:\n${differences}`,
-    pass: false,
-  };
 };
 
 let frameTime = Math.round(1000 / defaultFramerateConfig.fps);
@@ -279,6 +316,18 @@ export const setUpTests = (userFramerateConfig = {}) => {
   frameTime = Math.round(1000 / framerateConfig.fps);
 
   expect.extend({
+    toHaveAnimatedProps(
+      component: React.Component<
+        AnimatedComponentProps<InitialComponentProps>
+      > &
+        IAnimatedComponentInternal,
+      expectedProps: Partial<AnimatedComponentProps<AnimatedProps>>
+    ) {
+      return compareProps(component, expectedProps);
+    },
+  });
+
+  expect.extend({
     toHaveAnimatedStyle(
       component: React.Component<
         AnimatedComponentProps<InitialComponentProps>
@@ -295,6 +344,9 @@ export const setUpTests = (userFramerateConfig = {}) => {
 type TestComponent = React.Component<
   AnimatedComponentProps<InitialComponentProps> & {
     jestAnimatedStyle?: { value: DefaultStyle };
+    jestAnimatedProps?: {
+      value: Partial<AnimatedComponentProps<AnimatedProps>>;
+    };
   }
 >;
 


### PR DESCRIPTION
## Summary

It turned out animated props when tested in Jest kept their initial value. It was caused by lack of support for animatedProps, which this PR adds.

## Test plan
