### PR TITLE
feat: clangd for worklets

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -207,10 +207,10 @@ android {
                 if (!IS_REANIMATED_EXAMPLE_APP) {
                     return
                 }
-                def monorepoDir = new File("${project.projectDir}/../../..")
+                def packageDir = new File("${project.projectDir}/..")
 
                 def generated = new File("${compileTask.abi.getCxxBuildFolder()}/compile_commands.json")
-                def output = new File("${monorepoDir}/compile_commands.json")
+                def output = new File("${packageDir}/compile_commands.json")
 
                 output.text = generated.text
 

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -1,3 +1,4 @@
+import com.android.build.gradle.tasks.ExternalNativeBuildJsonTask
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -255,6 +256,22 @@ android {
                 }
             }
         }
+    }
+    tasks.withType(ExternalNativeBuildJsonTask) {
+        compileTask ->
+            compileTask.doLast {
+                if (!IS_REANIMATED_EXAMPLE_APP) {
+                    return
+                }
+                def packageDir = new File("${project.projectDir}/..")
+
+                def generated = new File("${compileTask.abi.getCxxBuildFolder()}/compile_commands.json")
+                def output = new File("${packageDir}/compile_commands.json")
+
+                output.text = generated.text
+
+                println("Generated clangd metadata.")
+            }
     }
 }
 


### PR DESCRIPTION
## Summary

Now we have two packages so `compile_commands.json` should be hoisted in the respective package directory.

## Test plan

🚀 
