### PR TITLE
fix: Exclude deprecated, unsupported properties from style type

### DIFF
--- a/packages/react-native-reanimated/src/css/platform/native/config.ts
+++ b/packages/react-native-reanimated/src/css/platform/native/config.ts
@@ -184,12 +184,6 @@ export const PROPERTIES_CONFIG: StyleBuilderConfig<PlainStyle> = {
   // TRANSFORMS
   transformOrigin: { process: processTransformOrigin },
   transform: { process: processTransform },
-  transformMatrix: false, // deprecated
-  rotation: false, // deprecated
-  scaleX: false, // deprecated
-  scaleY: false, // deprecated
-  translateX: false, // deprecated
-  translateY: false, // deprecated
 
   // OTHERS
   backfaceVisibility: true,

--- a/packages/react-native-reanimated/src/css/platform/web/config.ts
+++ b/packages/react-native-reanimated/src/css/platform/web/config.ts
@@ -185,12 +185,6 @@ export const PROPERTIES_CONFIG: StyleBuilderConfig<PlainStyle> = {
   // TRANSFORMS
   transformOrigin: { process: processTransformOrigin },
   transform: { process: processTransform },
-  transformMatrix: false, // deprecated
-  rotation: false, // deprecated
-  scaleX: false, // deprecated
-  scaleY: false, // deprecated
-  translateX: false, // deprecated
-  translateY: false, // deprecated
 
   // OTHERS
   backfaceVisibility: true,

--- a/packages/react-native-reanimated/src/css/types/common.ts
+++ b/packages/react-native-reanimated/src/css/types/common.ts
@@ -7,7 +7,18 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-export type PlainStyle = ViewStyle & TextStyle & ImageStyle;
+type DeprecatedProps =
+  | 'transformMatrix'
+  | 'rotation'
+  | 'scaleX'
+  | 'scaleY'
+  | 'translateX'
+  | 'translateY';
+
+export type PlainStyle = Omit<
+  ViewStyle & TextStyle & ImageStyle,
+  DeprecatedProps
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyComponent = ComponentType<any>;


### PR DESCRIPTION
## Summary

This PR excludes deprecated props that aren't supported by CSS animations (and shouldn't be used in animated styles as well, as they are deprecated) from the `PlainStyle` type.

The issue was originally reported by @softwarebyze and was related to CSS transitions allowing to e.g. pass the `translateX` string for the `transitionProperty`, which is not supported and `transition` string should be used instead.

### Before

![Screenshot 2025-03-25 at 14 14 41](https://github.com/user-attachments/assets/e3be2461-66ad-4780-9d14-80b32c801d19) 

### After

![Screenshot 2025-03-25 at 14 13 28](https://github.com/user-attachments/assets/d4ea7c19-d620-480f-b1d4-7dfd418c2c0b)
