### PR TITLE
fix: Misspelt height prop name in supported layout animation props

### DIFF
--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -48,7 +48,7 @@ const LAYOUT_ANIMATION_SUPPORTED_PROPS = {
   originX: true,
   originY: true,
   width: true,
-  heigth: true,
+  height: true,
   borderRadius: true,
   globalOriginX: true,
   globalOriginY: true,


### PR DESCRIPTION
## Summary

Quick fix for incorrect `height` prop spelling which resulted in this warning being shown in the console:

```
[Worklets] 'height' property is not officially supported for layout animations. It may not work as expected.
```