### PR TITLE
docs: update analytics id

### DIFF
--- a/packages/docs-reanimated/docusaurus.config.js
+++ b/packages/docs-reanimated/docusaurus.config.js
@@ -61,8 +61,8 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/index.css'),
         },
-        googleAnalytics: {
-          trackingID: 'UA-41044622-6',
+        gtag: {
+          trackingID: 'G-RNYQG9GVFJ',
           anonymizeIP: true,
         },
         blog: {


### PR DESCRIPTION
Updated according to [this docusaurus docs page](https://docusaurus.io/docs/2.x/api/plugins/@docusaurus/plugin-google-gtag#:~:text=gtag%3A%20%7B,%7D%2C)

`plugin-google-gtag` comes preinstalled with docusaurus so no need to install a new package