### PR TITLE
cherry-pick: fix: Crash caused by passing animated ref to the animate component

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -109,6 +109,7 @@ export interface IAnimatedComponentInternal {
   jestAnimatedStyle: { value: StyleProps };
   _componentRef: AnimatedComponentRef | HTMLElement | null;
   _sharedElementTransition: SharedTransition | null;
+  _hasAnimatedRef: boolean;
   _jsPropsUpdater: IJSPropsUpdater;
   _InlinePropManager: IInlinePropManager;
   _PropsFilter: IPropsFilter;
@@ -121,7 +122,6 @@ export interface IAnimatedComponentInternal {
    * It is not related to event handling.
    */
   getComponentViewTag: () => number;
-  hasAnimatedRef: () => boolean;
 }
 
 export type NestedArray<T> = T | NestedArray<T>[];

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -276,10 +276,6 @@ export function createAnimatedComponent(
       return this._getViewInfo().viewTag as number;
     }
 
-    hasAnimatedRef() {
-      return this._hasAnimatedRef;
-    }
-
     _detachStyles() {
       const viewTag = this.getComponentViewTag();
       if (viewTag !== -1 && this._styles !== null) {

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -86,7 +86,7 @@ export function findHostInstance(
     a valid React ref.
   */
   return findHostInstance_DEPRECATED(
-    !isFabric() || (component as IAnimatedComponentInternal).hasAnimatedRef()
+    !isFabric() || (component as IAnimatedComponentInternal)._hasAnimatedRef
       ? (component as IAnimatedComponentInternal)._componentRef
       : component
   );


### PR DESCRIPTION
## Summary

Cherry-pick of the #7158 PR