### PR TITLE
Performance Monitor: Guard Frame Rate

### DIFF
--- a/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
+++ b/packages/react-native-reanimated/src/component/PerformanceMonitor.tsx
@@ -72,7 +72,7 @@ function getFps(renderTimeInMs: number): number {
 
 function completeBufferRoutine(
   buffer: CircularBuffer,
-  timestamp: number
+  timestamp: number,
 ): number {
   'worklet';
   timestamp = Math.round(timestamp);
@@ -81,7 +81,14 @@ function completeBufferRoutine(
 
   const measuredRangeDuration = timestamp - droppedTimestamp;
 
-  return getFps(measuredRangeDuration / buffer.count);
+  // Protect against unrealistic frame times
+  const avgFrameTime = measuredRangeDuration / buffer.count;
+  if (avgFrameTime < 16) {
+    // minimum realistic frame time in ms
+    return 60; // cap at 60fps
+  }
+
+  return getFps(avgFrameTime);
 }
 
 function JsPerformance({ smoothingFrames }: { smoothingFrames: number }) {


### PR DESCRIPTION
## Summary

I noticed that when fast-scrolling sometimes the UI frame rate would over-shoot significantly up to 200 FPS. This can happen when `const measuredRangeDuration = timestamp - droppedTimestamp;` drops below 100ms.  On a 120HZ screen frames are 8ms ~

For example if it calculated frames 100ms apart would lead to 100/20 (smoothingFrames) = 1000 / 5 => 200 FPS
The maximum should be 120 FPS / 60 FPS.

I wasn't sure if we should guard or remove the division by smoothingFrames.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
