### PR TITLE
(cherry-pick) docs: Add info about animatedProps to Jest section

### DIFF
--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -71,6 +71,13 @@ Checking equality of selected styles with current component styles.
 
 Checking equality of all current component styles with expected styles.
 
+#### `expect(component).toHaveAnimatedProps(expectedProps)`
+
+Checking equality of selected props with current component props.
+
+- `component` - tested component.
+- `expectedProps` - contains expected props of testing component, for example `{ text: 'name' }`.
+
 #### `getDefaultStyle(component)`
 
 Gets all styles of tested component.
@@ -107,6 +114,7 @@ More examples from `react-native-reanimated` repository:
 ## Remarks
 
 - Tests must run with Node 16 or newer.
+- Testing `react-native-svg` props is not supported.
 - If you have custom babel configuration for testing, make sure that Reanimated's babel plugin is enabled in that environment.
 
 ## Recommended testing library


### PR DESCRIPTION
Cherry pick of #7302 

This PR adds info about new `toHaveAnimatedProps` function to our documentation and adds disclaimer about SVG props not working. Merge after: #7231

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
