### PR TITLE
(chery-pick) feat: prevent flattening style arrays

### DIFF
--- a/packages/react-native-reanimated/__tests__/Animation.test.tsx
+++ b/packages/react-native-reanimated/__tests__/Animation.test.tsx
@@ -67,7 +67,7 @@ describe('Tests of animations', () => {
     const { getByTestId } = render(<AnimatedComponent />);
     const view = getByTestId('view');
     const button = getByTestId('button');
-    expect(view.props.style.width).toBe(0);
+    expect(view.props.style).toEqual([getDefaultStyle(), { width: 0 }]);
     expect(view).toHaveAnimatedStyle(style);
     fireEvent.press(button);
     jest.advanceTimersByTime(600);
@@ -92,7 +92,7 @@ describe('Tests of animations', () => {
     const view = getByTestId('view');
     const button = getByTestId('button');
 
-    expect(view.props.style.width).toBe(0);
+    expect(view.props.style).toEqual([getDefaultStyle(), { width: 0 }]);
     expect(view).toHaveAnimatedStyle(style);
 
     fireEvent.press(button);

--- a/packages/react-native-reanimated/__tests__/props.test.tsx
+++ b/packages/react-native-reanimated/__tests__/props.test.tsx
@@ -3,12 +3,12 @@ import type { ViewStyle } from 'react-native';
 import { Pressable, Text, View } from 'react-native';
 
 import Animated, {
+  getAnimatedStyle,
   interpolate,
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
 } from '../src';
-import { getAnimatedStyle } from '../src/jestUtils';
 import { processBoxShadow } from '../src/processBoxShadow';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -86,9 +86,12 @@ describe('Test of boxShadow prop', () => {
     const { getByTestId } = render(<AnimatedComponent />);
     const pressable = getByTestId('pressable');
 
-    expect(pressable.props.style.boxShadow).toBe(
-      '0px 4px 10px 0px rgba(255, 0, 0, 1)'
-    );
+    expect(pressable.props.style).toEqual([
+      {
+        boxShadow: '0px 4px 10px 0px rgba(255, 0, 0, 1)',
+      },
+      getDefaultStyle(),
+    ]);
     expect(pressable).toHaveAnimatedStyle(style);
     fireEvent.press(pressable);
     jest.advanceTimersByTime(600);
@@ -112,13 +115,18 @@ describe('Test of boxShadow prop', () => {
     const { getByTestId } = render(<AnimatedComponent />);
     const pressable = getByTestId('pressable');
 
-    expect(pressable.props.style.boxShadow).toBe(
-      '0px 4px 10px 0px rgba(255, 0, 0, 1)'
-    );
+    expect(pressable.props.style).toEqual([
+      {
+        boxShadow: '0px 4px 10px 0px rgba(255, 0, 0, 1)',
+      },
+      getDefaultStyle(),
+    ]);
 
-    processBoxShadow(pressable.props.style);
+    const unprocessedStyle = getAnimatedStyle(pressable) as ViewStyle;
 
-    expect(pressable.props.style.boxShadow).toEqual([
+    processBoxShadow(unprocessedStyle);
+
+    expect(unprocessedStyle.boxShadow).toEqual([
       {
         offsetX: 0,
         offsetY: 4,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
@@ -1,7 +1,5 @@
 'use strict';
 
-import { StyleSheet } from 'react-native';
-
 import { initialUpdaterRun } from '../animation';
 import type { StyleProps } from '../commonTypes';
 import { isSharedValue } from '../isSharedValue';
@@ -53,7 +51,9 @@ export class PropsFilter implements IPropsFilter {
             return style;
           }
         });
-        props[key] = StyleSheet.flatten(processedStyle);
+        // keep styles as they were passed by the user
+        // it will help other libs to interpret styles correctly
+        props[key] = processedStyle;
       } else if (key === 'animatedProps') {
         const animatedProp = inputProps.animatedProps as Partial<
           AnimatedComponentProps<AnimatedProps>

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -642,10 +642,12 @@ export function createAnimatedComponent(
         filteredProps.entering &&
         !getReducedMotionFromConfig(filteredProps.entering as CustomConfig)
       ) {
-        filteredProps.style = {
-          ...(filteredProps.style ?? {}),
-          visibility: 'hidden', // Hide component until `componentDidMount` triggers
-        };
+        filteredProps.style = Array.isArray(filteredProps.style)
+          ? filteredProps.style.concat([{ visibility: 'hidden' }])
+          : {
+              ...(filteredProps.style ?? {}),
+              visibility: 'hidden', // Hide component until `componentDidMount` triggers
+            };
       }
 
       const platformProps = Platform.select({

--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -73,8 +73,6 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
         ...style,
       };
     });
-
-    return currentStyle;
   }
 
   const jestInlineStyles = component.props.jestInlineStyle as JestInlineStyle;

--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -93,7 +93,6 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
     }
 
     currentStyle = {
-      ...styleObject,
       ...currentStyle,
       ...jestAnimatedStyleValue,
     };
@@ -104,8 +103,8 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
   const inlineStyles = getStylesFromObject(jestInlineStyles);
 
   currentStyle = isEmpty(jestAnimatedStyleValue as object | undefined)
-    ? { ...styleObject, ...inlineStyles }
-    : { ...styleObject, ...jestAnimatedStyleValue };
+    ? { ...inlineStyles }
+    : { ...jestAnimatedStyleValue };
 
   return currentStyle;
 };


### PR DESCRIPTION
## Summary

Cherry pick of #7021. Main reason for it was that the early return of `currentStyles` (if `style` is an array) caused to not apply `jestAnimatedStyle`. Becasue of that execution of tests using `style` arrays would fail.

I decided to cherry-pick whole PR not only desired fragments to keep integrity between `main` and `3.17-stable`.

## Test plan
