### PR TITLE
docs: Add AvailableFrom flag to `toHaveAnimatedProps`

### DIFF
--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -71,7 +71,7 @@ Checking equality of selected styles with current component styles.
 
 Checking equality of all current component styles with expected styles.
 
-#### `expect(component).toHaveAnimatedProps(expectedProps)` <AvailableFrom version={'3.17.2'} />
+#### `expect(component).toHaveAnimatedProps(expectedProps)`
 
 Checking equality of selected props with current component props.
 

--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -71,7 +71,7 @@ Checking equality of selected styles with current component styles.
 
 Checking equality of all current component styles with expected styles.
 
-#### `expect(component).toHaveAnimatedProps(expectedProps)`
+#### `expect(component).toHaveAnimatedProps(expectedProps)` <AvailableFrom version={'3.17.2'} />
 
 Checking equality of selected props with current component props.
 

--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/testing-with-jest.mdx
@@ -71,7 +71,7 @@ Checking equality of selected styles with current component styles.
 
 Checking equality of all current component styles with expected styles.
 
-#### `expect(component).toHaveAnimatedProps(expectedProps)`
+#### `expect(component).toHaveAnimatedProps(expectedProps)` <AvailableFrom version={'3.17.2'} />
 
 Checking equality of selected props with current component props.
 


### PR DESCRIPTION
## Summary

Thanks to @tjzel suggestion and my remembering about AvailableFrom flag I've added it to `toHaveAnimatedProps` that will be available from `3.17.2`
<img width="716" alt="image" src="https://github.com/user-attachments/assets/5a501352-dae2-43f6-8be3-afa284d790a8" />

## Test plan
