### PR TITLE
fix: boxShadow sometimes not working for web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
@@ -31,9 +31,9 @@ export default function ColorExample() {
   });
 
   const style4 = useAnimatedStyle(() => {
-    return IS_WEB
-      ? { boxShadow: `20px 20px 5px ${makeColor(sv.value)}` } // Use boxShadow for web
-      : { shadowColor: makeColor(sv.value) };
+    return {
+      boxShadow: '20px 20px 5px 0px ' + makeColor(sv.value),
+    };
   });
 
   // TODO: textDecorationColor, tintColor, textShadowColor, overlayColor

--- a/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ColorExample.tsx
@@ -6,8 +6,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { IS_WEB } from '@/utils';
-
 function makeColor(x: number) {
   'worklet';
   return `hsl(${Math.round(x * 240)}, 100%, 50%)`;

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -212,7 +212,7 @@ function styleUpdater(
   let hasAnimations = false;
   let frameTimestamp: number | undefined;
   let hasNonAnimatedValues = false;
-  if (typeof newValues.boxShadow === 'string') {
+  if (!SHOULD_BE_USE_WEB && typeof newValues.boxShadow === 'string') {
     processBoxShadow(newValues);
   }
   for (const key in newValues) {

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -1,6 +1,12 @@
 /* based on:
  * https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
  */
+
+/* TODO: In Reanimated 4, we have another parser for boxShadow in CSS files
+ * - it's much shorter and same as effective as this one
+ * When there is a decision about extracting CSS Animations to separate package,
+ * we need to unify those two parsers or at least make sure that they are consistent
+ */
 'use strict';
 
 import type { BoxShadowValue, OpaqueColorValue } from 'react-native';


### PR DESCRIPTION
## Summary

This PR fixes boxShadow sometimes not working on web. To work boxShadow in the form of string must have `offsetX`, `offsetY`, `blurRadius` and `spreadDistance`. When one of these props was missing the boxShadow wasn't being processed ergo was staying as string - that's why it sometimes **worked** on web. This PR checks if we are on web and if no we then can process the boxShadow.

Additionally I've replaced `shadow` with `boxShadow` in ColorExample.tsx

## Test plan

Check ColorExample on web
