### PR TITLE
fix: Remove doubled props passing to AnimatedComponent

### DIFF
--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -207,8 +207,7 @@ export default class AnimatedComponent<
 
     return (
       <ChildComponent
-        {...this.props}
-        {...props}
+        {...(props ?? this.props)}
         {...platformProps}
         style={filterNonCSSStyleProps(props?.style ?? this.props.style)}
         // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.


### PR DESCRIPTION
Fixes #7340 

## Summary

In css AnimatedComponent, to render function, we were passed both `props` and `this.props`, when only `props` were necessary as they have filtered props passed to a component as well as nativeID and jest styles. Knowing that, the real issue was passing `this.props`caused web error `React does not recognize the animatedProps prop on a DOM element.`, as `this.props` contained `animatedProps` (totally not needed for the component to have)

## Test plan

<details>
<summary>Code example</summary>

```tsx
import React from 'react';
import { Button } from 'react-native';
import Svg, { Path } from 'react-native-svg';
import Animated, {
  useAnimatedProps,
  useSharedValue,
  withTiming,
} from 'react-native-reanimated';
const AnimatedPath = Animated.createAnimatedComponent(Path);

export default function EmptyExample() {
  const sv = useSharedValue(10);

  const animatedProps = useAnimatedProps(() => {
    return {
      d: `M 0 0 L ${100 * sv.value} ${100 * sv.value} L 0 ${100 * sv.value} Z`,
    };
  });

  return (
    <>
      <Button
        title="Animate"
        onPress={() => {
          sv.value = withTiming(1, { duration: 1500 });
        }}
      />
      <Svg>
        <AnimatedPath
          stroke={'blue'}
          fill={'blue'}
          strokeWidth={2}
          animatedProps={animatedProps}
        />
      </Svg>
    </>
  );
}

```

</details>
