### PR TITLE
fix: Layout animations with rotation not working in RN 0.79

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -44,7 +44,7 @@ export class PinwheelIn
               scale: delayFunction(delay, animation(1, config)),
             },
             {
-              rotate: delayFunction(delay, animation('0', config)),
+              rotate: delayFunction(delay, animation('0rad', config)),
             },
           ],
         },
@@ -55,7 +55,7 @@ export class PinwheelIn
               scale: 0,
             },
             {
-              rotate: '5',
+              rotate: '5rad',
             },
           ],
           ...initialValues,
@@ -104,7 +104,7 @@ export class PinwheelOut
               scale: delayFunction(delay, animation(0, config)),
             },
             {
-              rotate: delayFunction(delay, animation('5', config)),
+              rotate: delayFunction(delay, animation('5rad', config)),
             },
           ],
         },
@@ -115,7 +115,7 @@ export class PinwheelOut
               scale: 1,
             },
             {
-              rotate: '0',
+              rotate: '0rad',
             },
           ],
           ...initialValues,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
@@ -95,7 +95,7 @@ export class ZoomInRotate
           ],
         },
         initialValues: {
-          transform: [{ scale: 0 }, { rotate }],
+          transform: [{ scale: 0 }, { rotate: `${rotate}rad` }],
           ...initialValues,
         },
         callback,
@@ -469,7 +469,7 @@ export class ZoomOutRotate
           ],
         },
         initialValues: {
-          transform: [{ scale: 1 }, { rotate: '0' }],
+          transform: [{ scale: 1 }, { rotate: '0rad' }],
           ...initialValues,
         },
         callback,


### PR DESCRIPTION
## Summary

This PR fixes issues with rotation transformation after RN upgrade to 0.79. Rotation strings without units are no longer supported so the `rad` unit must me specified explicitly for them to work.

## Example recordings

### ZoomInRotate / ZoomOutRotate

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/93e0fbdc-519c-4b69-b710-045be29a991c" /> | <video src="https://github.com/user-attachments/assets/6752842f-8e07-4fb9-831a-33c0978a92bf" /> |

### PinwheelIn / PinwheelOut

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/cb43cbb3-bb54-4a46-8014-22f0db3ba58d" /> | <video src="https://github.com/user-attachments/assets/dc45f65f-cc93-41a3-b4a9-b0e06e75143c" /> |

<details>
<summary>Code snippet</summary>

```tsx
import React, { useState } from 'react';
import { Button, StyleSheet, View } from 'react-native';
import Animated, { PinwheelIn, PinwheelOut } from 'react-native-reanimated';

export default function DeleteAncestorOfExiting() {
  const [shown, setShown] = useState(true);

  return (
    <View style={styles.container}>
      <Button
        onPress={() => {
          setShown(!shown);
        }}
        title="Toggle"
      />
      {shown && (
        <Animated.View
          style={styles.box}
          exiting={PinwheelOut}
          entering={PinwheelIn}
        />
      )}
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    marginTop: 300,
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'red',
  },
});
```
</details>
