### PR TITLE
fix: FlashList scroll from UI on web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Platform, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
-import { PanGestureHandler } from 'react-native-gesture-handler';
+import {
+  Gesture,
+  GestureDetector,
+  PanGestureHandler,
+} from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   scrollTo,
@@ -69,7 +73,7 @@ function Digit({ number, index }: DigitProps) {
   useDerivedValue(() => {
     if (Platform.OS === 'web') {
       if (aref && aref.current) {
-        aref.current.getNode().scrollTo({ y: digit.value * 200 });
+        aref.current.scrollTo({ y: digit.value * 200 });
       }
     } else {
       // TODO fix this
@@ -79,7 +83,7 @@ function Digit({ number, index }: DigitProps) {
 
   return (
     <View style={styles.scrollContainer}>
-      <Animated.ScrollView ref={aref}>
+      <Animated.ScrollView ref={aref} showsVerticalScrollIndicator={false}>
         {digits.map((i) => {
           return (
             <View style={styles.digitContainer} key={i}>
@@ -94,25 +98,22 @@ function Digit({ number, index }: DigitProps) {
 
 function ProgressBar({ progress }: { progress: Animated.SharedValue<number> }) {
   const x = useSharedValue(0);
+  const startX = useSharedValue(0);
   const max = useSharedValue(0);
 
-  const handler = useAnimatedGestureHandler<
-    PanGestureHandlerGestureEvent,
-    { x: number }
-  >({
-    onStart: (_, ctx) => {
-      ctx.x = x.value;
-    },
-    onActive: (e, ctx) => {
-      let newVal = ctx.x + e.translationX;
+  const gesture = Gesture.Pan()
+    .onStart(() => {
+      startX.value = x.value;
+    })
+    .onUpdate((e) => {
+      let newVal = startX.value + e.translationX;
       newVal = Math.min(max.value, newVal);
       newVal = Math.max(0, newVal);
       x.value = newVal;
-    },
-    onEnd: (_) => {
+    })
+    .onEnd(() => {
       progress.value = x.value / max.value;
-    },
-  });
+    });
 
   const stylez = useAnimatedStyle(() => {
     return {
@@ -125,6 +126,7 @@ function ProgressBar({ progress }: { progress: Animated.SharedValue<number> }) {
       width: max.value,
     };
   });
+
   return (
     <View style={styles.container}>
       <View
@@ -143,9 +145,9 @@ function ProgressBar({ progress }: { progress: Animated.SharedValue<number> }) {
             barStyle,
           ]}
         />
-        <PanGestureHandler onGestureEvent={handler}>
+        <GestureDetector gesture={gesture}>
           <Animated.View style={[styles.dot, stylez]} />
-        </PanGestureHandler>
+        </GestureDetector>
       </View>
     </View>
   );

--- a/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/PinExample.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { Platform, SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
-import {
-  Gesture,
-  GestureDetector,
-  PanGestureHandler,
-} from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   scrollTo,
-  useAnimatedGestureHandler,
   useAnimatedRef,
   useAnimatedStyle,
   useDerivedValue,

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -18,6 +18,7 @@ const IS_WEB = isWeb();
 
 interface MaybeScrollableComponent extends Component {
   getNativeScrollRef?: FlatList['getNativeScrollRef'];
+  getScrollableNode?: FlatList['getScrollableNode'];
   viewConfig?: {
     uiViewClassName?: string;
   };
@@ -26,6 +27,9 @@ interface MaybeScrollableComponent extends Component {
 function getComponentOrScrollable(component: MaybeScrollableComponent) {
   if (component.getNativeScrollRef) {
     return component.getNativeScrollRef();
+  }
+  if (component.getScrollableNode) {
+    return component.getScrollableNode();
   }
   return component;
 }


### PR DESCRIPTION
## Summary

Fixes scrollable node obtaining in the `useAnimatedRef` and 2 related examples on web.

## Example recordings

### scrollTo example

#### Before

https://github.com/user-attachments/assets/6b4f0c95-d387-4849-8cf5-9979c9515fb7

#### After

https://github.com/user-attachments/assets/aa90e070-1140-4f4e-b3f6-5efeeb57ba2b

### PIN example

#### Before

<img width="1079" alt="Screenshot 2025-04-03 at 20 21 04" src="https://github.com/user-attachments/assets/2fe3ca8f-5081-4b87-ac75-69047e547449" />

#### After

https://github.com/user-attachments/assets/164b7dc3-7e14-4fce-9491-bb05921a08ba
