### PR TITLE
(cherry-pick) Bump react-native-is-edge-to-edge to 1.1.7 (#7346)

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -90,7 +90,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "convert-source-map": "^2.0.0",
     "invariant": "^2.2.4",
-    "react-native-is-edge-to-edge": "1.1.6"
+    "react-native-is-edge-to-edge": "1.1.7"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18084,13 +18084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:1.1.6":
-  version: 1.1.6
-  resolution: "react-native-is-edge-to-edge@npm:1.1.6"
+"react-native-is-edge-to-edge@npm:1.1.7":
+  version: 1.1.7
+  resolution: "react-native-is-edge-to-edge@npm:1.1.7"
   peerDependencies:
-    react: ">=18.2.0"
-    react-native: ">=0.73.0"
-  checksum: 10/4e07c1e34c01c8d50fd7c1d0460db06f6f0515197405230386a8ffb950cb724b10743af032310d1384df0a90059bfb8992ba2d93344ce86315315f0493feccc2
+    react: "*"
+    react-native: "*"
+  checksum: 10/4cdf2b2fb5b131f2015c26d2cb7688b4a0c5f3c8474b1bf0ddfa9eabb0263df440c87262ae8f812a6ecab0d5310df0373bddad4b51f53dabb2ffee01e9ef0f44
   languageName: node
   linkType: hard
 
@@ -18239,7 +18239,7 @@ __metadata:
     react-native: "npm:0.78.0"
     react-native-builder-bob: "patch:react-native-builder-bob@npm%3A0.33.1#~/.yarn/patches/react-native-builder-bob-npm-0.33.1-383d9e23a5.patch"
     react-native-gesture-handler: "npm:2.24.0"
-    react-native-is-edge-to-edge: "npm:1.1.6"
+    react-native-is-edge-to-edge: "npm:1.1.7"
     react-native-web: "npm:0.19.13"
     react-test-renderer: "npm:19.0.0"
     shelljs: "npm:^0.8.5"


### PR DESCRIPTION
This PR unfixes the current `react-native-is-edge-to-edge` version.

The current version has `peerDependencies` that prevents the Expo team from creating a canary release:

```
Conflicting peer dependency: react-native@0.78.2
```

npm installs this version to respect the `>=0.73.0` requirement, even if `react-native@0.79.0-rc.0` is already a project dependency.

PS: I'm on my phone and without a computer access, if someone can run yarn and fix the pipeline before merging, it would help 🙏

