### PR TITLE
(cherry-pick) fix: boxShadow sometimes not working on web

### DIFF
--- a/apps/common-app/src/examples/ColorExample.tsx
+++ b/apps/common-app/src/examples/ColorExample.tsx
@@ -5,6 +5,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import type { DefaultStyle } from 'react-native-reanimated/lib/typescript/hook/commonTypes';
 
 function makeColor(x: number) {
   'worklet';
@@ -31,7 +32,7 @@ export default function ColorExample() {
   const style4 = useAnimatedStyle(() => {
     return {
       boxShadow: '20px 20px 5px 0px ' + makeColor(sv.value),
-    };
+    } as DefaultStyle;
   });
 
   // TODO: textDecorationColor, tintColor, textShadowColor, overlayColor

--- a/apps/common-app/src/examples/ColorExample.tsx
+++ b/apps/common-app/src/examples/ColorExample.tsx
@@ -29,7 +29,9 @@ export default function ColorExample() {
   });
 
   const style4 = useAnimatedStyle(() => {
-    return { shadowColor: makeColor(sv.value) };
+    return {
+      boxShadow: '20px 20px 5px 0px ' + makeColor(sv.value),
+    };
   });
 
   // TODO: textDecorationColor, tintColor, textShadowColor, overlayColor

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -212,7 +212,7 @@ function styleUpdater(
   let hasAnimations = false;
   let frameTimestamp: number | undefined;
   let hasNonAnimatedValues = false;
-  if (typeof newValues.boxShadow === 'string') {
+  if (!SHOULD_BE_USE_WEB && typeof newValues.boxShadow === 'string') {
     processBoxShadow(newValues);
   }
   for (const key in newValues) {


### PR DESCRIPTION
…w sometimes not working for web (#7338)This PR fixes boxShadow sometimes not working on web. To work boxShadow in the form of string must have `offsetX`, `offsetY`, `blurRadius` and `spreadDistance`. When one of these props was missing the boxShadow wasn't being processed ergo was staying as string - that's why it sometimes **worked** on web. This PR checks if we are on web and if no we then can process the boxShadow.

Additionally I've replaced `shadow` with `boxShadow` in ColorExample.tsx

Check ColorExample on web

