### PR TITLE
fix: timestamp on physical device in s instead of ms

### DIFF
--- a/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/SlowAnimations.mm
@@ -37,11 +37,9 @@ CFTimeInterval calculateTimestampWithSlowAnimations(CFTimeInterval currentTimest
   if (areSlowAnimationsEnabled) {
     currentTimestamp = (dragCoefChangedTimestamp + (currentTimestamp - dragCoefChangedTimestamp) / dragCoef);
   }
+#endif // TARGET_IPHONE_SIMULATOR
   currentTimestamp *= MILLISECONDS_IN_SECOND;
   return currentTimestamp;
-#else // TARGET_IPHONE_SIMULATOR
-  return currentTimestamp;
-#endif // TARGET_IPHONE_SIMULATOR
 }
 
 } // namespace worklets


### PR DESCRIPTION
## Summary
During recent changes, multiplying the `currentTimestamp` value by `MILLISECONDS_IN_SECOND` on physical device was lost. Restoring the correct behavior.

## Test plan

Run any app examples on simulator and physical device and see no difference with this PR.