### PR TITLE
Add `RCTInvalidating` protocol in `ReanimatedModule` and `WorkletsModule` on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
@@ -1,7 +1,7 @@
 #import <React/RCTCallInvokerModule.h>
 #import <React/RCTEventEmitter.h>
-#import <React/RCTUIManagerObserverCoordinator.h>
 #import <React/RCTInvalidating.h>
+#import <React/RCTUIManagerObserverCoordinator.h>
 
 #import <rnreanimated/rnreanimated.h>
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.h
@@ -1,13 +1,14 @@
 #import <React/RCTCallInvokerModule.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
+#import <React/RCTInvalidating.h>
 
 #import <rnreanimated/rnreanimated.h>
 
 #import <reanimated/apple/REANodesManager.h>
 
 @interface ReanimatedModule
-    : RCTEventEmitter <NativeReanimatedModuleSpec, RCTCallInvokerModule, RCTEventDispatcherObserver>
+    : RCTEventEmitter <NativeReanimatedModuleSpec, RCTCallInvokerModule, RCTEventDispatcherObserver, RCTInvalidating>
 
 @property (nonatomic, readonly) REANodesManager *nodesManager;
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,9 +1,10 @@
 #import <React/RCTCallInvokerModule.h>
 #import <React/RCTEventEmitter.h>
+#import <React/RCTInvalidating.h>
 
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-@interface WorkletsModule : RCTEventEmitter <RCTCallInvokerModule>
+@interface WorkletsModule : RCTEventEmitter <RCTCallInvokerModule, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 


### PR DESCRIPTION
## Summary

This PR adds `RCTInvalidating` protocol in `ReanimatedModule` and `WorkletsModule` since they both already implement `invalidate` methods with custom cleanup code on iOS according to the suggestion in https://reactnative.dev/docs/next/the-new-architecture/native-modules-lifecycle.

I haven't noticed any major changes after this change, here's the stack trace before and after:

<img width="514" alt="Screenshot 2025-04-10 at 17 25 35" src="https://github.com/user-attachments/assets/726ff4b8-914c-4e70-8c28-99053339064f" />

<img width="512" alt="Screenshot 2025-04-10 at 17 24 38" src="https://github.com/user-attachments/assets/e5766852-80dc-47e7-bc03-001dea369a52" />

## Test plan

Reload app during bokeh example a few times.