### PR TITLE
fix: Support optional arguments in boxShadow string

### DIFF
--- a/packages/react-native-reanimated/__tests__/props.test.tsx
+++ b/packages/react-native-reanimated/__tests__/props.test.tsx
@@ -31,6 +31,21 @@ const AnimatedComponent = () => {
     };
   });
 
+  const animatedBoxShadowStripped = useAnimatedStyle(() => {
+    const blurRadius = interpolate(pressed.value, [0, 1], [10, 0]);
+    const color = interpolateColor(
+      pressed.value,
+      [0, 1],
+      ['rgba(255, 0, 0, 1)', 'rgba(0, 0, 255, 1)']
+    );
+
+    const boxShadow = `0px 4px ${blurRadius}px ${color}`;
+
+    return {
+      boxShadow,
+    };
+  });
+
   const handlePress = () => {
     pressed.value = pressed.value === 0 ? 1 : 0;
   };
@@ -53,6 +68,20 @@ const AnimatedComponent = () => {
         onPress={handlePress}>
         <Text>Button</Text>
       </AnimatedPressable>
+      <AnimatedPressable
+        testID={'strippedPressable'}
+        style={[
+          animatedBoxShadowStripped,
+          {
+            width: 100,
+            height: 100,
+            backgroundColor: 'red',
+            boxShadow: '0px 4px 10px rgba(255, 0, 0, 1)',
+          },
+        ]}
+        onPress={handlePress}>
+        <Text>Stripped</Text>
+      </AnimatedPressable>
     </View>
   );
 };
@@ -61,6 +90,13 @@ const getDefaultStyle = () => ({
   padding: 16,
   backgroundColor: 'red',
   boxShadow: '0px 4px 10px 0px rgba(255, 0, 0, 1)',
+});
+
+const getStrippedStyle = () => ({
+  width: 100,
+  height: 100,
+  backgroundColor: 'red',
+  boxShadow: '0px 4px 10px rgba(255, 0, 0, 1)',
 });
 
 const getMultipleBoxShadowStyle = () => ({
@@ -97,6 +133,26 @@ describe('Test of boxShadow prop', () => {
     jest.advanceTimersByTime(600);
     style.boxShadow = '0px 4px 0px 0px rgba(0, 0, 255, 1)';
     expect(pressable).toHaveAnimatedStyle(style);
+  });
+
+  test('boxShadow string without spread', () => {
+    const style = getStrippedStyle();
+
+    const { getByTestId } = render(<AnimatedComponent />);
+    const strippedPressable = getByTestId('strippedPressable');
+
+    expect(strippedPressable.props.style).toEqual([
+      {
+        boxShadow: '0px 4px 10px rgba(255, 0, 0, 1)',
+      },
+      getStrippedStyle(),
+    ]);
+
+    expect(strippedPressable).toHaveAnimatedStyle(style);
+    fireEvent.press(strippedPressable);
+    jest.advanceTimersByTime(600);
+    style.boxShadow = '0px 4px 0px rgba(0, 0, 255, 1)';
+    expect(strippedPressable).toHaveAnimatedStyle(style);
   });
 
   test('boxShadow prop animation, get animated style', () => {

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -212,7 +212,7 @@ function styleUpdater(
   let hasAnimations = false;
   let frameTimestamp: number | undefined;
   let hasNonAnimatedValues = false;
-  if (!SHOULD_BE_USE_WEB && typeof newValues.boxShadow === 'string') {
+  if (!SHOULD_BE_USE_WEB && newValues.boxShadow) {
     processBoxShadow(newValues);
   }
   for (const key in newValues) {

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -71,7 +71,7 @@ function parseBoxShadowString(rawBoxShadows: string): Array<BoxShadowValue> {
             return [];
         }
       } else if (arg === 'inset') {
-        if (boxShadow.inset != null) {
+        if (boxShadow.inset) {
           return [];
         }
         if (offsetX !== null) {
@@ -80,7 +80,7 @@ function parseBoxShadowString(rawBoxShadows: string): Array<BoxShadowValue> {
         boxShadow.inset = true;
         continue;
       } else {
-        if (boxShadow.color != null) {
+        if (boxShadow.color) {
           return [];
         }
         if (offsetX != null) {

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -40,8 +40,6 @@ function parseBoxShadowString(rawBoxShadows: string): Array<BoxShadowValue> {
     // split rawBoxShadow string by all whitespaces that are not in parenthesis
     const args = rawBoxShadow.split(/\s+(?![^(]*\))/);
     for (const arg of args) {
-      // check if arg is a color, and if so end parsing
-
       if (isLength(arg)) {
         switch (lengthCount) {
           case 0:

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -131,7 +131,7 @@ export function processBoxShadow(props: StyleProps) {
 
   const rawBoxShadows = props.boxShadow;
 
-  if (rawBoxShadows == null) {
+  if (rawBoxShadows === null) {
     return result;
   }
 

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -71,7 +71,7 @@ function parseBoxShadowString(rawBoxShadows: string): Array<BoxShadowValue> {
             return [];
         }
       } else if (arg === 'inset') {
-        if (boxShadow.inset !== null) {
+        if (boxShadow.inset != null) {
           return [];
         }
         if (offsetX !== null) {

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -12,6 +12,7 @@
 import type { BoxShadowValue, OpaqueColorValue } from 'react-native';
 
 import type { StyleProps } from '.';
+import { ReanimatedError } from './errors';
 
 export const isLength = (value: string) => {
   'worklet';
@@ -132,14 +133,21 @@ export function processBoxShadow(props: StyleProps) {
 
   const rawBoxShadows = props.boxShadow;
 
-  if (rawBoxShadows === '' || rawBoxShadows == null) {
+  if (rawBoxShadows == null) {
     return result;
   }
 
-  const boxShadowList =
-    typeof rawBoxShadows === 'string'
-      ? parseBoxShadowString(rawBoxShadows.replace(/\n/g, ' '))
-      : rawBoxShadows;
+  let boxShadowList: Array<BoxShadowValue>;
+
+  if (typeof rawBoxShadows === 'string') {
+    boxShadowList = parseBoxShadowString(rawBoxShadows.replace(/\n/g, ' '));
+  } else if (Array.isArray(rawBoxShadows)) {
+    boxShadowList = rawBoxShadows;
+  } else {
+    throw new ReanimatedError(
+      `Box shadow value must be an array of shadow objects or a string. Received: ${JSON.stringify(rawBoxShadows)}`
+    );
+  }
 
   for (const rawBoxShadow of boxShadowList) {
     const parsedBoxShadow: ParsedBoxShadow = {

--- a/packages/react-native-reanimated/src/processBoxShadow.ts
+++ b/packages/react-native-reanimated/src/processBoxShadow.ts
@@ -14,7 +14,7 @@ import type { BoxShadowValue, OpaqueColorValue } from 'react-native';
 import type { StyleProps } from '.';
 import { ReanimatedError } from './errors';
 
-export const isLength = (value: string) => {
+const isLength = (value: string) => {
   'worklet';
   return value.endsWith('px') || !isNaN(Number(value));
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR updates the `parseBoxShadowString` function to handle `boxShadow` strings with missing optional arguments (`blurRadius`, `spreadDistance`, `color`).

It now gracefully handles input like:

- `10px 10px white` (defaults `blurRadius` and `spreadDistance` to `0px`)

- `10px 10px 5px white` (defaults `spreadDistance` to `0px`)

- `10px 10px` (defaults remaining values, uses black as color)

The default happen on Native side where RN process it and defaults the missing values. 

I've also added unit test with stripped string that make sure styles behave correctly.

I've also moved the string type check into the `processBoxShadow.js` file, since we want to support `boxShadow` values that are arrays of objects where individual properties can be strings with units. (The possibility to support this was already implemented but `typeof newValue.boxShadow === 'string'` prevented it from existing)
 
 ```
       boxShadow: [
        {
         // before that's how value had been provided
          offsetX: 10
          // now they can be provided also as strings with units
          offsetY: '4px',
          blurRadius,
          color,
        },
      ],
 ```
 
 
 Possible TO-DO:
 - [ ] Add additional warning for wrong color format (not sure if it's needed as it doesn't break the app)

## Test plan

<details>
<summary>Example Code</summary>

```tsx
import React from 'react';
import { Pressable, Text, View } from 'react-native';
import Animated, {
  interpolate,
  interpolateColor,
  useAnimatedProps,
  useAnimatedStyle,
  useSharedValue,
} from 'react-native-reanimated';
import { DefaultStyle } from 'react-native-reanimated/lib/typescript/hook/commonTypes';

const AnimatedPressable = Animated.createAnimatedComponent(Pressable);

export default function EmptyExample() {
  const pressed = useSharedValue(0);

  const animatedBoxShadow = useAnimatedStyle(() => {
    const blurRadius = interpolate(pressed.value, [0, 1], [10, 0]);
    const color = interpolateColor(
      pressed.value,
      [0, 1],
      ['rgba(255, 0, 0, 1)', 'rgba(0, 0, 255, 1)']
    );

    return {
      boxShadow: `0px 4px ${blurRadius}px ${color}`,
    };
  });

  const handlePress = () => {
    pressed.value = pressed.value === 0 ? 1 : 0;
  };

  return (
    <View
      style={{
        padding: 24,
      }}>
      <AnimatedPressable
        testID={'pressable'}
        style={[
          animatedBoxShadow,
          {
            backgroundColor: 'red',
            padding: 16,
            boxShadow: '0px 4px 10px rgba(255, 0, 0, 1)',
          },
        ]}
        onPress={handlePress}>
        <Text>Button</Text>
      </AnimatedPressable>
    </View>
  );
}


```

</details>
