### PR TITLE
fix: separate implementation for custom errors

### DIFF
--- a/packages/react-native-reanimated/src/errors.ts
+++ b/packages/react-native-reanimated/src/errors.ts
@@ -1,12 +1,33 @@
+/* eslint-disable reanimated/use-reanimated-error */
 'use strict';
 
-import { createCustomError, registerCustomError } from 'react-native-worklets';
+function ReanimatedErrorConstructor(message: string): ReanimatedError {
+  'worklet';
+  const prefix = '[Reanimated]';
+  const errorInstance = new Error(message ? `${prefix} ${message}` : prefix);
+  errorInstance.name = 'ReanimatedError';
+  return errorInstance as ReanimatedError;
+}
 
-export const ReanimatedError = createCustomError('Reanimated');
-
-const ReanimatedErrorConstructor = ReanimatedError;
-
+/**
+ * Registers ReanimatedError in the global scope. Register only for Worklet
+ * runtimes.
+ */
 export function registerReanimatedError() {
   'worklet';
-  registerCustomError(ReanimatedErrorConstructor, 'Reanimated');
+  if (globalThis._WORKLET) {
+    globalThis.ReanimatedError =
+      ReanimatedErrorConstructor as IReanimatedErrorConstructor;
+  }
 }
+
+export const ReanimatedError =
+  ReanimatedErrorConstructor as IReanimatedErrorConstructor;
+
+export interface IReanimatedErrorConstructor extends Error {
+  new (message?: string): ReanimatedError;
+  (message?: string): ReanimatedError;
+  readonly prototype: ReanimatedError;
+}
+
+export type ReanimatedError = Error & { name: 'Reanimated' }; // signed type

--- a/packages/react-native-reanimated/src/privateGlobals.d.ts
+++ b/packages/react-native-reanimated/src/privateGlobals.d.ts
@@ -11,6 +11,7 @@ import type {
   ShadowNodeWrapper,
   StyleProps,
 } from './commonTypes';
+import type { IReanimatedErrorConstructor } from './errors';
 import type { FrameCallbackRegistryUI } from './frameCallback/FrameCallbackRegistryUI';
 import type { AnimatedStyle } from './helperTypes';
 import type { LayoutAnimationsManager } from './layoutReanimation/animationsManager';
@@ -101,4 +102,5 @@ declare global {
     value: T,
     nativeStateSource?: object
   ) => FlatShareableRef<T>;
+  var ReanimatedError: IReanimatedErrorConstructor;
 }

--- a/packages/react-native-worklets/src/WorkletsError.ts
+++ b/packages/react-native-worklets/src/WorkletsError.ts
@@ -1,13 +1,33 @@
+/* eslint-disable reanimated/use-worklets-error */
 'use strict';
 
-import { createCustomError, registerCustomError } from './errors';
+function WorkletsErrorConstructor(message?: string): WorkletsError {
+  'worklet';
+  const prefix = '[Worklets]';
+  const errorInstance = new Error(message ? `${prefix} ${message}` : prefix);
+  errorInstance.name = `{prefix}Error`;
+  return errorInstance as WorkletsError;
+}
 
-export const WorkletsError = createCustomError('Worklets');
-
-// To capture it in a the registering worklet's closure.
-const WorkletsErrorConstructor = WorkletsError;
-
+/**
+ * Registers WorkletsError in the global scope. Register only for Worklet
+ * runtimes.
+ */
 export function registerWorkletsError() {
   'worklet';
-  registerCustomError(WorkletsErrorConstructor, 'Worklets');
+  if (globalThis._WORKLET) {
+    globalThis.WorkletsError =
+      WorkletsErrorConstructor as IWorkletsErrorConstructor;
+  }
+}
+
+export const WorkletsError =
+  WorkletsErrorConstructor as IWorkletsErrorConstructor;
+
+export type WorkletsError = Error & { name: 'Worklets' }; // signed type
+
+export interface IWorkletsErrorConstructor extends Error {
+  new (message?: string): WorkletsError;
+  (message?: string): WorkletsError;
+  readonly prototype: WorkletsError;
 }

--- a/packages/react-native-worklets/src/WorkletsError.ts
+++ b/packages/react-native-worklets/src/WorkletsError.ts
@@ -5,7 +5,7 @@ function WorkletsErrorConstructor(message?: string): WorkletsError {
   'worklet';
   const prefix = '[Worklets]';
   const errorInstance = new Error(message ? `${prefix} ${message}` : prefix);
-  errorInstance.name = `{prefix}Error`;
+  errorInstance.name = `WorkletsError`;
   return errorInstance as WorkletsError;
 }
 

--- a/packages/react-native-worklets/src/errors.ts
+++ b/packages/react-native-worklets/src/errors.ts
@@ -2,46 +2,6 @@
 
 import type { WorkletStackDetails } from './workletTypes';
 
-export type CustomError<TName extends string> = Error & { name: TName }; // signed type
-
-export interface CustomErrorConstructor<TName extends string> extends Error {
-  new (message?: string): CustomError<TName>;
-  (message?: string): CustomError<TName>;
-  readonly prototype: CustomError<TName>;
-}
-
-export function createCustomError<TName extends string>(
-  name: TName
-): CustomErrorConstructor<TName> {
-  const constructor = function CustomError(message?: string) {
-    'worklet';
-    const prefix = `[${name}]`;
-    // eslint-disable-next-line reanimated/use-worklets-error
-    const errorInstance = new Error(message ? `${prefix} ${message}` : prefix);
-    errorInstance.name = `${name}Error`;
-    return errorInstance;
-  };
-
-  Object.defineProperty(constructor, 'name', { value: `${name}Error` });
-
-  return constructor as CustomErrorConstructor<TName>;
-}
-
-/** Registers custom errors in global scope. Use it only for Worklet runtimes. */
-export function registerCustomError<TName extends string>(
-  constructor: CustomErrorConstructor<TName>,
-  name: TName
-) {
-  'worklet';
-  if (!globalThis._WORKLET) {
-    // eslint-disable-next-line reanimated/use-worklets-error
-    throw new Error(
-      '[Worklets] registerCustomError() must be called on a Worklet runtime'
-    );
-  }
-  (global as Record<string, unknown>)[`${name}Error`] = constructor;
-}
-
 const _workletStackDetails = new Map<number, WorkletStackDetails>();
 
 export function registerWorkletStackDetails(

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -7,8 +7,6 @@ import { WorkletsModule } from './WorkletsModule';
 // universal source of truth for it.
 initializeUIRuntime(WorkletsModule);
 
-export type { CustomError } from './errors';
-export { createCustomError, registerCustomError } from './errors';
 export type { LoggerConfig } from './logger';
 export {
   logger,

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -5,6 +5,7 @@
 // This file works by accident - currently Builder Bob doesn't move `.d.ts` files to output types.
 // If it ever breaks, we should address it so we'd not pollute the user's global namespace.
 import type { callGuardDEV } from './initializers';
+import type { IWorkletsErrorConstructor } from './WorkletsError';
 import type { WorkletsModuleProxy } from './WorkletsModule';
 
 declare global {
@@ -40,4 +41,5 @@ declare global {
     worklet: ShareableRef<() => void>
   ) => void;
   var _microtaskQueueFinalizers: (() => void)[];
+  var WorkletsError: IWorkletsErrorConstructor;
 }


### PR DESCRIPTION
## Summary

Turns out that exporting `createCustomError` function is error-prone and sometimes the errors don't work properly. The solution to that is duplicating the code - it's quite small so it shouldn't be a problem.

## Test plan

Trigger `WorkletsError` and `ReanimatedError` and see they work properly now.
