### PR TITLE
fix: Remove unnecessary export causing web example crash

### DIFF
--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -287,7 +287,6 @@ export {
   ScreenTransition,
   startScreenTransition,
 } from './screenTransition';
-export { ReanimatedView } from './specs';
 export type { WorkletRuntime } from 'react-native-worklets';
 export {
   isWorkletFunction,


### PR DESCRIPTION
## Summary

This PR fixes web example crash caused by the export that loaded the `packages/react-native-reanimated/src/specs/NativeReanimatedModule.ts` file which calls `TurboModuleRegistry.get<Spec>('ReanimatedModule')`. Because `TurboModuleRegistry` is `undefined` on web, the app crashed just after starting.

I removed this export because it is not necessary and we will use the native `ReanimatedView` only internally for the native implementation of the `AnimatedComponent`.

## Test plan

- `yarn build` in `packages/react-native-reanimated`
- `yarn start` in `apps/web-example`