### PR TITLE
Replace `react-native-reanimated/plugin` with `react-native-worklets/plugin`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
         Before you proceed:
 
         - Make sure to check whether there are similar issues in the repository
-        - Make sure `'react-native-reanimated/plugin'` is listed in your `babel.config.js`
+        - Make sure that either `'react-native-reanimated/plugin'` or `'react-native-worklets/plugin'` is listed in your `babel.config.js`
         - Make sure to clean cache in your project. Depending on your setup this could be done by:
           - `yarn start --reset-cache` or
           - `npm start -- --reset-cache` or

--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -82,7 +82,7 @@ And that's it! Reanimated 4 is now configured in your Expo project.
 
 ### React Native Community CLI
 
-When using [React Native Community CLI](https://github.com/react-native-community/cli), you also need to manually add the `react-native-reanimated/plugin` plugin to your `babel.config.js`.
+When using [React Native Community CLI](https://github.com/react-native-community/cli), you also need to manually add the `react-native-worklets/plugin` plugin to your `babel.config.js`.
 
 ```js {7}
   module.exports = {
@@ -91,14 +91,14 @@ When using [React Native Community CLI](https://github.com/react-native-communit
     ],
     plugins: [
       ...
-      'react-native-reanimated/plugin',
+      'react-native-worklets/plugin',
     ],
   };
 ```
 
 :::caution
 
-`react-native-reanimated/plugin` has to be listed last.
+`react-native-worklets/plugin` has to be listed last.
 
 :::
 
@@ -167,11 +167,11 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
       plugins: [
           ...
           '@babel/plugin-proposal-export-namespace-from',
-          'react-native-reanimated/plugin',
+          'react-native-worklets/plugin',
       ],
   };
 ```
 
-Make sure to list `react-native-reanimated/plugin` last.
+Make sure to list `react-native-worklets/plugin` last.
 
 More advanced use cases such as running Reanimated with `webpack` or with `Next.js` are explained in a separate [Web Support](/docs/next/guides/web-support) guide.

--- a/packages/docs-reanimated/docs/guides/web-support.mdx
+++ b/packages/docs-reanimated/docs/guides/web-support.mdx
@@ -43,14 +43,14 @@ Add `@babel/plugin-proposal-export-namespace-from` and Reanimated Babel plugin t
       plugins: [
           ...
           '@babel/plugin-proposal-export-namespace-from',
-          'react-native-reanimated/plugin',
+          'react-native-worklets/plugin',
       ],
   };
 ```
 
 :::caution
 
-Make sure to list `react-native-reanimated/plugin` last.
+Make sure to list `react-native-worklets/plugin` last.
 
 :::
 
@@ -122,7 +122,7 @@ module.exports = {
 
 ## Web without the Babel plugin
 
-It is possible to use Reanimated without the Babel plugin (`react-native-reanimated/plugin` on the Web, with some additional configuration.
+It is possible to use Reanimated without the Babel plugin (`react-native-worklets/plugin` on the Web, with some additional configuration.
 
 Reanimated hooks all accept optional dependency arrays. Under the hood, the Reanimated Babel plugin inserts these for you.
 

--- a/packages/docs-reanimated/docs/reanimated-babel-plugin/options.md
+++ b/packages/docs-reanimated/docs/reanimated-babel-plugin/options.md
@@ -39,7 +39,7 @@ module.exports = {
   plugins: [
     ...
     [
-      'react-native-reanimated/plugin',
+      'react-native-worklets/plugin',
       {
         relativeSourceLocation: true,
         disableInlineStylesWarning: true,
@@ -188,7 +188,7 @@ JS THREAD
 
 This output occurs because the entire `global` object (!) would be copied to the UI thread for it to be assigned by `setOnUI`. Then, `readOnUI` would again copy the `global` object and read from this copy.
 
-There is a [huge list of identifiers whitelisted by default](https://github.com/software-mansion/react-native-reanimated/blob/3.14.0/packages/react-native-reanimated/plugin/src/globals.ts).
+There is a [huge list of identifiers whitelisted by default](https://github.com/software-mansion/react-native-reanimated/blob/4.0.0-beta.3/packages/react-native-worklets/plugin/src/globals.ts).
 
 ### substituteWebPlatformChecks
 


### PR DESCRIPTION
## Summary

This PR replaces `react-native-reanimated/plugin` with `react-native-worklets/plugin` in some places.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
