### PR TITLE
fix: Restore accidentally removed builder bob patch

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -148,7 +148,7 @@
     "prettier": "^3.3.3",
     "react": "19.0.0",
     "react-native": "0.79.0",
-    "react-native-builder-bob": "0.33.1",
+    "react-native-builder-bob": "patch:react-native-builder-bob@npm%3A0.33.1#~/.yarn/patches/react-native-builder-bob-npm-0.33.1-383d9e23a5.patch",
     "react-native-gesture-handler": "2.25.0",
     "react-native-web": "0.20.0",
     "react-native-worklets": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18149,7 +18149,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     react: "npm:19.0.0"
     react-native: "npm:0.79.0"
-    react-native-builder-bob: "npm:0.33.1"
+    react-native-builder-bob: "patch:react-native-builder-bob@npm%3A0.33.1#~/.yarn/patches/react-native-builder-bob-npm-0.33.1-383d9e23a5.patch"
     react-native-gesture-handler: "npm:2.25.0"
     react-native-is-edge-to-edge: "npm:1.1.7"
     react-native-web: "npm:0.20.0"


### PR DESCRIPTION
## Summary

Patch was accidentally removed in [this](https://github.com/software-mansion/react-native-reanimated/commit/47701784d77a063e4a569f7797bc95f74bd9b7f6#r155405465) PR.