### PR TITLE
docs: Update compatibility table in docs, add 3.17.4

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -13,16 +13,17 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 
 <div className="compatibility">
 
-|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
-| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1 – 3.17.2"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   |
+| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.17.4"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>

--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
@@ -9,24 +9,25 @@ sidebar_label: Compatibility
 
 <div className="compatibility">
 
-|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
-| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1 – 3.17.2"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.17.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.7"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.0 – 3.16.6"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   |
+| ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.17.4"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1 – 3.17.3"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.17.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.7"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.0 – 3.16.6"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.15.x"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.5.x"/>           | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.3.x – 3.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x – 3.2.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 | <Spacer/>                            |        |        |        |        |        |        |        |        |        |        |        |        |        |        |        |        |
-| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.14.x – 2.17.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.11.x – 2.13.x"/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.10.x"/>          | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.5.x – 2.9.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="2.3.x – 2.4.x"/>   | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>
 
@@ -42,16 +43,17 @@ Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-nativ
 
 <div className="compatibility">
 
-|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   |
-| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.17.1 – 3.17.2"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   |
+| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="3.17.4"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>


### PR DESCRIPTION
## Summary

This PR adds missing `3.17.3` version and the new `3.17.4` version to compatibility tables in docs.

I decided to mark only `3.17.4` as supporting RN 0.79 because of the issue with some layout animations using rotation values without units which stopped working on RN 0.79. Here is a PR with the fix: #7400

## Example recordings

https://github.com/user-attachments/assets/8d83fccf-3413-4384-95e6-f95ec375c3d3

https://github.com/user-attachments/assets/96893a75-3f2d-4dff-b314-8f6acb02553d
