### PR TITLE
feat: add check for bridgeless in both packages

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -132,6 +132,12 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   return ![_moduleRegistry moduleIsInitialized:WorkletsModule.class];
 }
 
+- (void)checkBridgeless
+{
+  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
+  react_native_assert(isBridgeless && "[Reanimated] react-native-reanimated only supports bridgeless mode");
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 {
   REAAssertJavaScriptQueue();
@@ -144,8 +150,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   auto jsCallInvoker = _callInvoker.callInvoker;
 
   react_native_assert(self.bridge != nullptr);
-  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
-  react_native_assert(isBridgeless && "[Reanimated] react-native-reanimated only supports bridgeless mode");
+  [self checkBridgeless];
   react_native_assert(self.bridge.runtime != nullptr);
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
@@ -172,6 +177,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
+  [self checkBridgeless];
   REAAssertJavaScriptQueue();
   return std::make_shared<facebook::react::NativeReanimatedModuleSpecJSI>(params);
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -1,3 +1,4 @@
+#import <React/RCTBridge+Private.h>
 #import <React/RCTCallInvoker.h>
 #import <React/RCTScheduler.h>
 #import <React/RCTSurfacePresenter.h>
@@ -143,6 +144,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   auto jsCallInvoker = _callInvoker.callInvoker;
 
   react_native_assert(self.bridge != nullptr);
+  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
+  react_native_assert(isBridgeless && "[Reanimated] react-native-reanimated only supports bridgeless mode");
   react_native_assert(self.bridge.runtime != nullptr);
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -2,9 +2,11 @@
 #import <React/RCTEventEmitter.h>
 #import <React/RCTInvalidating.h>
 
+#import <rnworklets/rnworklets.h>
+
 #import <worklets/NativeModules/WorkletsModuleProxy.h>
 
-@interface WorkletsModule : RCTEventEmitter <RCTCallInvokerModule, RCTInvalidating>
+@interface WorkletsModule : RCTEventEmitter <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -7,6 +7,7 @@
 #import <worklets/apple/WorkletsMessageThread.h>
 #import <worklets/apple/WorkletsModule.h>
 
+#import <React/RCTBridge+Private.h>
 #import <React/RCTCallInvoker.h>
 
 using worklets::RNRuntimeWorkletDecorator;
@@ -36,10 +37,13 @@ RCT_EXPORT_MODULE(WorkletsModule);
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)valueUnpackerCode)
 {
-  AssertJavaScriptQueue();
-
   react_native_assert(self.bridge != nullptr);
   react_native_assert(self.bridge.runtime != nullptr);
+  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
+  react_native_assert(isBridgeless && "[Worklets] react-native-worklets only supports bridgeless mode");
+
+  AssertJavaScriptQueue();
+
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
   auto jsQueue = std::make_shared<WorkletsMessageThread>([NSRunLoop currentRunLoop], ^(NSError *error) {

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -31,6 +31,12 @@ using worklets::WorkletsModuleProxy;
   return workletsModuleProxy_;
 }
 
+- (void)checkBridgeless
+{
+  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
+  react_native_assert(isBridgeless && "[Worklets] react-native-worklets only supports bridgeless mode");
+}
+
 @synthesize callInvoker = _callInvoker;
 
 RCT_EXPORT_MODULE(WorkletsModule);
@@ -38,9 +44,8 @@ RCT_EXPORT_MODULE(WorkletsModule);
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)valueUnpackerCode)
 {
   react_native_assert(self.bridge != nullptr);
+  [self checkBridgeless];
   react_native_assert(self.bridge.runtime != nullptr);
-  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
-  react_native_assert(isBridgeless && "[Worklets] react-native-worklets only supports bridgeless mode");
 
   AssertJavaScriptQueue();
 
@@ -84,6 +89,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (nonnull NSString *)
   workletsModuleProxy_.reset();
 
   [super invalidate];
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  [self checkBridgeless];
+  AssertJavaScriptQueue();
+  return std::make_shared<facebook::react::NativeWorkletsModuleSpecJSI>(params);
 }
 
 @end


### PR DESCRIPTION
## Summary

There are some issues like [this](https://github.com/software-mansion/react-native-reanimated/issues/7367) where it is not obvious what was the reason of exception. It turned out to be having `bridge` which both `Reanimated` and `Worklets` do not accept. For easier problem solving, I suggest adding an explicit check for this scenario.

I also added compliance to JSI spec for `Worklets` module to be in line with `Reanimated`.

## Test plan

Run the linked repro or manually enable bridge mode e.g. [here](https://github.com/facebook/react-native/blob/7ff5db3c462c369a8210674ab53642c3f34e9c37/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm#L121) to see that it does not work.
