### PR TITLE
feat(Reanimated): react-native-worklets compatibility assertions

### DIFF
--- a/packages/eslint-plugin-reanimated/package.json
+++ b/packages/eslint-plugin-reanimated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-reanimated",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "types": "lib",

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -93,13 +93,14 @@
     "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
     "@babel/preset-typescript": "^7.16.7",
     "convert-source-map": "^2.0.0",
-    "react-native-is-edge-to-edge": "1.1.7"
+    "react-native-is-edge-to-edge": "1.1.7",
+    "semver": "^7.7.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",
     "react": "*",
     "react-native": "*",
-    "react-native-worklets": "0.1.0"
+    "react-native-worklets": ">=0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.0",
@@ -121,6 +122,7 @@
     "@types/node": "^18.0.0",
     "@types/react": "^19.0.10",
     "@types/react-test-renderer": "^19.0.0",
+    "@types/semver": "^7",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "@typescript-eslint/rule-tester": "^6.21.0",

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -23,6 +23,7 @@ import { ReanimatedError, registerReanimatedError } from '../errors';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import { checkCppVersion } from '../platform-specific/checkCppVersion';
 import { jsVersion } from '../platform-specific/jsVersion';
+import { assertWorkletsVersion } from '../platform-specific/workletsVersion';
 import { shouldBeUseWeb } from '../PlatformChecker';
 import { ReanimatedTurboModule } from '../specs';
 import type {
@@ -61,6 +62,7 @@ class NativeReanimatedModule implements IReanimatedModule {
     // These checks have to split since version checking depend on the execution order
     if (__DEV__) {
       assertSingleReanimatedInstance();
+      assertWorkletsVersion();
     }
     global._REANIMATED_VERSION_JS = jsVersion;
     if (global.__reanimatedModuleProxy === undefined && ReanimatedTurboModule) {

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -5,6 +5,7 @@
  * keep this in sync with the version declared in `package.json`
  */
 export const jsVersion = '4.0.0-beta.3';
+
 /**
  * Extra checks for comforming with the version of `react-native-worklets`. Even
  * if the App compiles there could be ABI mismatches.

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -7,10 +7,10 @@
 export const jsVersion = '4.0.0-beta.3';
 
 /**
- * Extra checks for comforming with the version of `react-native-worklets`. Even
+ * Extra checks for conforming with the version of `react-native-worklets`. Even
  * if the App compiles there could be ABI mismatches.
  */
-export const acceptedWorkletsVerison = {
+export const acceptedWorkletsVersion = {
   min: '0.3.0' satisfies ValidVersion,
   // TODO: Placeholding "infinity" version for now.
   // Set it to a proper value when releasing stable Reanimated 4.

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -5,3 +5,15 @@
  * keep this in sync with the version declared in `package.json`
  */
 export const jsVersion = '4.0.0-beta.3';
+/**
+ * Extra checks for comforming with the version of `react-native-worklets`. Even
+ * if the App compiles there could be ABI mismatches.
+ */
+export const acceptedWorkletsVerison = {
+  min: '0.3.0' satisfies ValidVersion,
+  // TODO: Placeholding "infinity" version for now.
+  // Set it to a proper value when releasing stable Reanimated 4.
+  max: '1000.0.0' satisfies ValidVersion,
+};
+
+type ValidVersion = `${number}.${number}.${number}`;

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -1,0 +1,35 @@
+'use strict';
+
+import semverSatisfies from 'semver/functions/satisfies';
+
+import { ReanimatedError } from '../errors';
+import { acceptedWorkletsVerison } from './jsVersion';
+
+export function assertWorkletsVersion() {
+  let workletsVersion: string | undefined;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { version } = require('react-native-worklets/package.json');
+    workletsVersion = version;
+  } catch (e) {
+    throw new ReanimatedError(
+      "react-native-worklets package isn't installed. Please install it to use Reanimated."
+    );
+  }
+
+  workletsVersion = workletsVersion!;
+
+  if (workletsVersion?.includes('nightly')) {
+    // Don't perform any checks for nightly versions, the user knows what they're doing.
+    return;
+  }
+
+  const acceptedRange = `${acceptedWorkletsVerison.min} - ${acceptedWorkletsVerison.max}`;
+
+  if (!semverSatisfies(workletsVersion, acceptedRange)) {
+    throw new ReanimatedError(
+      `Invalid version of react-native-worklets: ${workletsVersion}. Expected the version to be in inclusive range ${acceptedRange}. Please install a compatible version of react-native-worklets.`
+    );
+  }
+}

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -3,7 +3,7 @@
 import semverSatisfies from 'semver/functions/satisfies';
 
 import { ReanimatedError } from '../errors';
-import { acceptedWorkletsVerison } from './jsVersion';
+import { acceptedWorkletsVersion } from './jsVersion';
 
 export function assertWorkletsVersion() {
   let workletsVersion: string | undefined;
@@ -25,7 +25,7 @@ export function assertWorkletsVersion() {
     return;
   }
 
-  const acceptedRange = `${acceptedWorkletsVerison.min} - ${acceptedWorkletsVerison.max}`;
+  const acceptedRange = `${acceptedWorkletsVersion.min} - ${acceptedWorkletsVersion.max}`;
 
   if (!semverSatisfies(workletsVersion, acceptedRange)) {
     throw new ReanimatedError(

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -20,7 +20,7 @@ export function assertWorkletsVersion() {
 
   workletsVersion = workletsVersion!;
 
-  if (workletsVersion?.includes('nightly')) {
+  if (workletsVersion.includes('nightly')) {
     // Don't perform any checks for nightly versions, the user knows what they're doing.
     return;
   }

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-worklets",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The React Native multithreading library",
   "keywords": [
     "react-native",

--- a/packages/react-native-worklets/plugin/package.json
+++ b/packages/react-native-worklets/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-worklets",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
   "devDependencies": {
     "@babel/cli": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6481,6 +6481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7":
+  version: 7.7.0
+  resolution: "@types/semver@npm:7.7.0"
+  checksum: 10/ee4514c6c852b1c38f951239db02f9edeea39f5310fad9396a00b51efa2a2d96b3dfca1ae84c88181ea5b7157c57d32d7ef94edacee36fbf975546396b85ba5b
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
@@ -18121,6 +18128,7 @@ __metadata:
     "@types/node": "npm:^18.0.0"
     "@types/react": "npm:^19.0.10"
     "@types/react-test-renderer": "npm:^19.0.0"
+    "@types/semver": "npm:^7"
     "@typescript-eslint/eslint-plugin": "npm:^6.19.0"
     "@typescript-eslint/parser": "npm:^6.19.0"
     "@typescript-eslint/rule-tester": "npm:^6.21.0"
@@ -18155,6 +18163,7 @@ __metadata:
     react-native-web: "npm:0.20.0"
     react-native-worklets: "workspace:*"
     react-test-renderer: "npm:19.0.0"
+    semver: "npm:^7.7.1"
     shelljs: "npm:^0.8.5"
     ts-prune: "npm:^0.10.3"
     typescript: "npm:~5.3.0"
@@ -18162,7 +18171,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-    react-native-worklets: 0.1.0
+    react-native-worklets: ">=0.3.0"
   languageName: unknown
   linkType: soft
 
@@ -19140,6 +19149,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/36b1fbe1a2b6f873559cd57b238f1094a053dbfd997ceeb8757d79d1d2089c56d1321b9f1069ce263dc64cfa922fa1d2ad566b39426fe1ac6c723c1487589e10
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/4cfa1eb91ef3751e20fc52e47a935a0118d56d6f15a837ab814da0c150778ba2ca4f1a4d9068b33070ea4273629e615066664c2cfcd7c272caf7a8a0f6518b2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Extra QoL assertions for the user if they had installed the wrong version of `react-native-worklets` with Reanimated 4.

## Test plan

Try downgrading the version of `react-native-worklets` in its `package.json` and see that relevant error is thrown.
