### PR TITLE
fix: add hermes debugger for all debug variants

### DIFF
--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -77,8 +77,8 @@ Pod::Spec.new do |s|
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]" => gcc_debug_definitions,
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Release]" => '$(inherited) NDEBUG=1',
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => gcc_debug_definitions,
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Release*]" => '$(inherited) NDEBUG=1',
   }
   s.compiler_flags = "#{folly_flags} #{boost_compiler_flags}"
   s.xcconfig = {

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -53,7 +53,7 @@ Pod::Spec.new do |s|
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]" => "$(inherited) #{rn79_hermes_regression_workaround_flag}",
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => "$(inherited) #{rn79_hermes_regression_workaround_flag}",
   }
   s.xcconfig = {
     "HEADER_SEARCH_PATHS" => [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
PR analogous to https://github.com/facebook/react-native/pull/50897 fixing `HERMES_ENABLE_DEBUGGER` not being added to configs that are not strictly named `Debug`. Should fix https://github.com/software-mansion/react-native-reanimated/issues/7412. Thanks @tomekzaw and @piaskowyk for helping with it.

## Test plan

Run app from https://github.com/software-mansion/react-native-reanimated/issues/7412 and see that it doesn't crash.
