### PR TITLE
chore(ci): Set `react-native-worklets` dependency version for nightly builds.

### DIFF
--- a/packages/react-native-reanimated/scripts/set-reanimated-version.js
+++ b/packages/react-native-reanimated/scripts/set-reanimated-version.js
@@ -1,16 +1,28 @@
 const fs = require('fs');
 const path = require('path');
-const getVersion = require('../../../scripts/releasing').getVersion;
+const { getFlags, getVersion } = require('../../../scripts/releasing');
 
 const packageJsonPath = path.resolve(__dirname, '../package.json');
 
-const { currentVersion, newVersion } = getVersion(
-  process.argv,
-  packageJsonPath
-);
-
+const { argv } = process;
+const { currentVersion, newVersion } = getVersion(argv, packageJsonPath);
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
 packageJson.version = newVersion;
+
+if (getFlags(argv).flags.nightly) {
+  const workletsPackageJsonPath = path.resolve(
+    __dirname,
+    '../../react-native-worklets/package.json'
+  );
+  const { newVersion: newWorkletsVersion } = getVersion(
+    argv,
+    workletsPackageJsonPath
+  );
+
+  packageJson.peerDependencies['react-native-worklets'] = newWorkletsVersion;
+}
+
 const newPackageJson = JSON.stringify(packageJson, null, 2) + '\n';
 fs.writeFileSync(packageJsonPath, newPackageJson, 'utf-8');
 

--- a/scripts/releasing.js
+++ b/scripts/releasing.js
@@ -1,70 +1,32 @@
 const { cat, exec } = require('shelljs');
 
 /**
+ * @typedef {object} Arg
+ * @property {string} value - argument value
+ * @property {boolean} handled - is argument known
+ */
+
+/**
+ * @typedef {object} Flags
+ * @property {boolean} help - whether help option was passed
+ * @property {boolean} nightly - whether nightly option was passed
+ * @property {boolean} fresh - whether fresh option was passed
+ * @property {boolean} custom - whether custom version was passed
+ */
+
+/**
  * @param {string[]} rawArgs
  * @param {string} packageJsonPath
  * @returns {{ currentVersion: string; newVersion: string }}
  */
 function getVersion(rawArgs, packageJsonPath) {
-  const args = rawArgs.slice(2).map((arg) => ({
-    value: arg,
-    handled: false,
-  }));
-
-  let IS_HELP = false;
-  let IS_NIGHTLY = false;
-  let IS_FRESH = false;
-  let IS_SET_CUSTOM = false;
-
-  let customVersion = '';
-
-  args.forEach((arg) => {
-    if (arg.value === '--help' || arg.value === '-h') {
-      IS_HELP = true;
-      arg.handled = true;
-    } else if (arg.value === '--nightly' || arg.value === '-n') {
-      IS_NIGHTLY = true;
-      arg.handled = true;
-    } else if (arg.value === '--fresh' || arg.value === '-f') {
-      IS_FRESH = true;
-      arg.handled = true;
-    } else if (!IS_SET_CUSTOM) {
-      customVersion = arg.value;
-      IS_SET_CUSTOM = true;
-      arg.handled = true;
-    }
-  });
-
-  const unknownArgs = args.filter((arg) => !arg.handled);
-  if (unknownArgs.length > 0) {
-    console.error('Unknown arguments: ', unknownArgs);
-    process.exit(1);
-  }
-
-  if (IS_HELP) {
-    console.warn(
-      'Use --nightly or -n to set nightly version.\nUse --fresh or -f to set fresh version.\nElse pass the version as an argument.'
-    );
-    process.exit(1);
-  }
-
-  if (IS_NIGHTLY && IS_FRESH) {
-    throw new Error('Cannot set nightly and fresh version at the same time.');
-  }
-
-  if ((IS_NIGHTLY || IS_FRESH) && IS_SET_CUSTOM) {
-    throw new Error('Cannot set nightly or fresh version with custom version.');
-  }
-
-  if (!IS_SET_CUSTOM && !IS_NIGHTLY && !IS_FRESH) {
-    throw new Error('Version not set.');
-  }
-
+  const { flags: { custom, nightly, fresh }, customVersion } = getFlags(rawArgs)
   const packageJson = JSON.parse(cat(packageJsonPath));
   const currentVersion = packageJson.version;
 
   let newVersion = currentVersion;
-  if (IS_SET_CUSTOM) {
+
+  if (custom) {
     newVersion = customVersion;
   } else {
     let dateIdentifier = new Date()
@@ -72,7 +34,7 @@ function getVersion(rawArgs, packageJsonPath) {
       .slice(0, -5)
       .replace(/[-:T]/g, '');
 
-    if (IS_NIGHTLY) {
+    if (nightly) {
       if (currentVersion.includes('nightly')) {
         throw new Error('Cannot set nightly version on a nightly version');
       }
@@ -84,7 +46,7 @@ function getVersion(rawArgs, packageJsonPath) {
       const shortCommit = currentCommit.slice(0, 9);
 
       newVersion = `${currentVersion.split('-')[0]}-nightly-${dateIdentifier}-${shortCommit}`;
-    } else if (IS_FRESH) {
+    } else if (fresh) {
       newVersion = `${currentVersion}-${dateIdentifier}`;
     }
   }
@@ -95,6 +57,93 @@ function getVersion(rawArgs, packageJsonPath) {
   };
 }
 
+/**
+ * @param {string[]} rawArgs
+ * @returns {Arg[]}
+ */
+function buildArgs(rawArgs) {
+  return rawArgs.slice(2).map((arg) => ({ value: arg, handled: false }));
+}
+
+/**
+ * @param {Arg[]} args
+ * @returns {{ flags: Flags; customVersion: string }}
+ */
+function processArgs(args) {
+  const flags = {
+    help: false,
+    nightly: false,
+    fresh: false,
+    custom: false,
+  }
+
+  let customVersion = '';
+
+  args.forEach((arg) => {
+    if (arg.value === '--help' || arg.value === '-h') {
+      flags.help = true;
+      arg.handled = true;
+    } else if (arg.value === '--nightly' || arg.value === '-n') {
+      flags.nightly = true;
+      arg.handled = true;
+    } else if (arg.value === '--fresh' || arg.value === '-f') {
+      flags.fresh = true;
+      arg.handled = true;
+    } else if (!flags.custom) {
+      customVersion = arg.value;
+      flags.custom = true;
+      arg.handled = true;
+    }
+  });
+
+  const unknownArgs = args.filter((arg) => !arg.handled);
+
+  if (unknownArgs.length > 0) {
+    console.error('Unknown arguments: ', unknownArgs);
+    process.exit(1);
+  }
+
+  return { flags, customVersion };
+}
+
+/**
+ * @param {Flags} flags
+ */
+function processFlags({ help, nightly, fresh, custom }) {
+  if (help) {
+    console.warn(
+      'Use --nightly or -n to set nightly version.\nUse --fresh or -f to set fresh version.\nElse pass the version as an argument.'
+    );
+    process.exit(1);
+  }
+
+  if (nightly && fresh) {
+    throw new Error('Cannot set nightly and fresh version at the same time.');
+  }
+
+  if ((nightly || fresh) && custom) {
+    throw new Error('Cannot set nightly or fresh version with custom version.');
+  }
+
+  if (!custom && !nightly && !fresh) {
+    throw new Error('Version not set.');
+  }
+}
+
+/**
+ * @param {string[]} rawArgs
+ * @returns {{ flags: Flags; customVersion: string }}
+ */
+function getFlags(rawArgs) {
+  const args = buildArgs(rawArgs);
+  const argsResult = processArgs(args)
+
+  processFlags(argsResult.flags)
+
+  return argsResult
+}
+
 module.exports = {
+  getFlags,
   getVersion,
 };


### PR DESCRIPTION
## Summary

Nightly build will set the `react-native-worklets` peer dependency version to its nightly value.

## Test plan
Can be tested by running `set-animated-version` script with `--nightly` option.