### PR TITLE
Use `NPM_ACCESS_TOKEN` secret for publishing nightlies on npm

### DIFF
--- a/.github/workflows/npm-reanimated-package-build.yml
+++ b/.github/workflows/npm-reanimated-package-build.yml
@@ -129,4 +129,4 @@ jobs:
         run: npm publish $PACKAGE_NAME --tag ${{env.TAG}} --provenance
         if: ${{ inputs.publish_on_npm }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/npm-worklets-package-build.yml
+++ b/.github/workflows/npm-worklets-package-build.yml
@@ -98,4 +98,4 @@ jobs:
         run: npm publish $PACKAGE_NAME --tag nightly --provenance
         if: ${{ inputs.publish_on_npm }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.WORKLETS_NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR replaces `secrets.NODE_AUTH_TOKEN` and `secrets.WORKLETS_NODE_AUTH_TOKEN` with `secrets.NPM_ACCESS_TOKEN` in GitHub Actions workflows that publish nightly releases of react-native-reanimated and react-native-worklets on npm.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
