### PR TITLE
chore: Adjust CSS config parsers implementation to work with folly::dynamic

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/config/common.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
+#include <folly/dynamic.h>
 #include <memory>
 #include <optional>
 #include <string>
@@ -48,8 +49,6 @@ struct CSSAnimationUpdates {
   CSSAnimationSettingsUpdatesMap settingsUpdates;
 };
 
-CSSAnimationUpdates parseCSSAnimationUpdates(
-    jsi::Runtime &rt,
-    const jsi::Value &config);
+CSSAnimationUpdates parseCSSAnimationUpdates(const folly::dynamic &config);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -3,49 +3,38 @@
 namespace reanimated::css {
 
 std::shared_ptr<AnimationStyleInterpolator> getStyleInterpolator(
-    jsi::Runtime &rt,
-    const jsi::Object &config,
+    const folly::dynamic &config,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   const auto styleInterpolator =
       std::make_shared<AnimationStyleInterpolator>(viewStylesRepository);
 
-  const auto keyframes = config.getProperty(rt, "keyframesStyle");
-  styleInterpolator->updateKeyframes(rt, keyframes);
+  styleInterpolator->updateKeyframes(config["keyframesStyle"]);
 
   return styleInterpolator;
 }
 
 std::shared_ptr<KeyframeEasingFunctions> getKeyframeTimingFunctions(
-    jsi::Runtime &rt,
-    const jsi::Object &config) {
+    const folly::dynamic &config) {
   KeyframeEasingFunctions result;
-  const auto &keyframeTimingFunctions =
-      config.getProperty(rt, "keyframeTimingFunctions").asObject(rt);
-  const auto timingFunctionOffsets =
-      keyframeTimingFunctions.getPropertyNames(rt);
-  const auto timingFunctionsCount = timingFunctionOffsets.size(rt);
 
-  for (size_t i = 0; i < timingFunctionsCount; ++i) {
-    const auto offset =
-        timingFunctionOffsets.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const auto easingFunction = createEasingFunction(
-        rt, keyframeTimingFunctions.getProperty(rt, offset.c_str()));
+  const auto &keyframeTimingFunctions = config["keyframeTimingFunctions"];
 
-    result[std::stod(offset)] = easingFunction;
+  for (const auto &pair : keyframeTimingFunctions.items()) {
+    const std::string offset = pair.first.asString();
+    const auto &easingFunctionConfig = pair.second;
+
+    result[std::stod(offset)] = createEasingFunction(easingFunctionConfig);
   }
 
   return std::make_shared<KeyframeEasingFunctions>(result);
 }
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config,
+    const folly::dynamic &config,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
-  const auto &configObj = config.asObject(rt);
-
   return {
-      getStyleInterpolator(rt, configObj, viewStylesRepository),
-      getKeyframeTimingFunctions(rt, configObj)};
+      getStyleInterpolator(config, viewStylesRepository),
+      getKeyframeTimingFunctions(config)};
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 
+#include <folly/dynamic.h>
 #include <memory>
 #include <unordered_map>
 
@@ -17,17 +18,14 @@ struct CSSKeyframesConfig {
 };
 
 std::shared_ptr<AnimationStyleInterpolator> getStyleInterpolator(
-    jsi::Runtime &rt,
-    const jsi::Object &config,
+    const folly::dynamic &config,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
 std::shared_ptr<KeyframeEasingFunctions> getKeyframeTimingFunctions(
-    jsi::Runtime &rt,
-    const jsi::Object &config);
+    const folly::dynamic &config);
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config,
+    const folly::dynamic &config,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -6,6 +6,7 @@
 
 #include <folly/dynamic.h>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 namespace reanimated::css {
@@ -16,13 +17,6 @@ struct CSSKeyframesConfig {
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator;
   std::shared_ptr<KeyframeEasingFunctions> keyframeEasingFunctions;
 };
-
-std::shared_ptr<AnimationStyleInterpolator> getStyleInterpolator(
-    const folly::dynamic &config,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
-
-std::shared_ptr<KeyframeEasingFunctions> getKeyframeTimingFunctions(
-    const folly::dynamic &config);
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
     const folly::dynamic &config,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
@@ -65,16 +65,15 @@ CSSTransitionConfig parseCSSTransitionConfig(const folly::dynamic &config) {
 }
 
 PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
-    const folly::dynamic &oldConfig,
-    const folly::dynamic &newConfig) {
+    const folly::dynamic &partialConfig) {
   PartialCSSTransitionConfig result;
 
-  if (newConfig.count("properties")) {
-    result.properties = getProperties(newConfig);
+  if (partialConfig.count("properties")) {
+    result.properties = getProperties(partialConfig);
   }
-  if (newConfig.count("settings")) {
+  if (partialConfig.count("settings")) {
     result.settings =
-        parseCSSTransitionPropertiesSettings(newConfig["settings"]);
+        parseCSSTransitionPropertiesSettings(partialConfig["settings"]);
   }
 
   return result;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
@@ -19,19 +19,13 @@ std::optional<CSSTransitionPropertySettings> getTransitionPropertySettings(
   return std::nullopt;
 }
 
-TransitionProperties getProperties(
-    jsi::Runtime &rt,
-    const jsi::Object &config) {
-  const auto transitionProperty = config.getProperty(rt, "properties");
-
-  if (transitionProperty.isObject()) {
+TransitionProperties getProperties(const folly::dynamic &config) {
+  if (config["properties"].isArray()) {
     PropertyNames properties;
+    const auto &propertiesArray = config["properties"];
 
-    const auto propertiesArray = transitionProperty.asObject(rt).asArray(rt);
-    const auto propertiesCount = propertiesArray.size(rt);
-    for (size_t i = 0; i < propertiesCount; ++i) {
-      properties.emplace_back(
-          propertiesArray.getValueAtIndex(rt, i).asString(rt).utf8(rt));
+    for (const auto &property : propertiesArray) {
+      properties.emplace_back(property.asString());
     }
 
     return properties;
@@ -40,60 +34,47 @@ TransitionProperties getProperties(
   return std::nullopt;
 }
 
-bool getAllowDiscrete(jsi::Runtime &rt, const jsi::Object &config) {
-  return config.getProperty(rt, "allowDiscrete").asBool();
+bool getAllowDiscrete(const folly::dynamic &config) {
+  return config["allowDiscrete"].asBool();
 }
 
 CSSTransitionPropertiesSettings parseCSSTransitionPropertiesSettings(
-    jsi::Runtime &rt,
-    const jsi::Object &settings) {
+    const folly::dynamic &settings) {
   CSSTransitionPropertiesSettings result;
 
-  const auto propertyNames = settings.getPropertyNames(rt);
-  const auto propertiesCount = propertyNames.size(rt);
-
-  for (size_t i = 0; i < propertiesCount; ++i) {
-    const auto propertyName =
-        propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const auto propertySettings =
-        settings.getProperty(rt, jsi::PropNameID::forUtf8(rt, propertyName))
-            .asObject(rt);
+  for (const auto &pair : settings.items()) {
+    const std::string propertyName = pair.first.asString();
+    const auto &propertySettings = pair.second;
 
     result.emplace(
         propertyName,
         CSSTransitionPropertySettings{
-            getDuration(rt, propertySettings),
-            getTimingFunction(rt, propertySettings),
-            getDelay(rt, propertySettings),
-            getAllowDiscrete(rt, propertySettings)});
+            getDuration(propertySettings),
+            getTimingFunction(propertySettings),
+            getDelay(propertySettings),
+            getAllowDiscrete(propertySettings)});
   }
 
   return result;
 }
 
-CSSTransitionConfig parseCSSTransitionConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config) {
-  const auto configObj = config.asObject(rt);
+CSSTransitionConfig parseCSSTransitionConfig(const folly::dynamic &config) {
   return CSSTransitionConfig{
-      getProperties(rt, configObj),
-      parseCSSTransitionPropertiesSettings(
-          rt, configObj.getProperty(rt, "settings").asObject(rt))};
+      getProperties(config),
+      parseCSSTransitionPropertiesSettings(config["settings"])};
 }
 
 PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &partialConfig) {
-  const auto partialObj = partialConfig.asObject(rt);
-
+    const folly::dynamic &oldConfig,
+    const folly::dynamic &newConfig) {
   PartialCSSTransitionConfig result;
 
-  if (partialObj.hasProperty(rt, "properties")) {
-    result.properties = getProperties(rt, partialObj);
+  if (newConfig.count("properties")) {
+    result.properties = getProperties(newConfig);
   }
-  if (partialObj.hasProperty(rt, "settings")) {
-    result.settings = parseCSSTransitionPropertiesSettings(
-        rt, partialObj.getProperty(rt, "settings").asObject(rt));
+  if (newConfig.count("settings")) {
+    result.settings =
+        parseCSSTransitionPropertiesSettings(newConfig["settings"]);
   }
 
   return result;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/config/common.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
+#include <folly/dynamic.h>
 #include <string>
 #include <unordered_map>
 
@@ -33,18 +34,10 @@ std::optional<CSSTransitionPropertySettings> getTransitionPropertySettings(
     const CSSTransitionPropertiesSettings &propertiesSettings,
     const std::string &propName);
 
-TransitionProperties getProperties(jsi::Runtime &rt, const jsi::Object &config);
-
-CSSTransitionPropertiesSettings parseCSSTransitionPropertiesSettings(
-    jsi::Runtime &rt,
-    const jsi::Object &settings);
-
-CSSTransitionConfig parseCSSTransitionConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config);
+CSSTransitionConfig parseCSSTransitionConfig(const folly::dynamic &config);
 
 PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &partialConfig);
+    const folly::dynamic &oldConfig,
+    const folly::dynamic &newConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -37,7 +37,6 @@ std::optional<CSSTransitionPropertySettings> getTransitionPropertySettings(
 CSSTransitionConfig parseCSSTransitionConfig(const folly::dynamic &config);
 
 PartialCSSTransitionConfig parsePartialCSSTransitionConfig(
-    const folly::dynamic &oldConfig,
-    const folly::dynamic &newConfig);
+    const folly::dynamic &partialConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -2,16 +2,16 @@
 
 namespace reanimated::css {
 
-double getDuration(jsi::Runtime &rt, const jsi::Object &config) {
-  return config.getProperty(rt, "duration").asNumber();
+double getDuration(const folly::dynamic &config) {
+  return config["duration"].asDouble();
 }
 
-EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config) {
-  return createEasingFunction(rt, config.getProperty(rt, "timingFunction"));
+EasingFunction getTimingFunction(const folly::dynamic &config) {
+  return createEasingFunction(config["timingFunction"]);
 }
 
-double getDelay(jsi::Runtime &rt, const jsi::Object &config) {
-  return config.getProperty(rt, "delay").asNumber();
+double getDelay(const folly::dynamic &config) {
+  return config["delay"].asDouble();
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -2,12 +2,14 @@
 
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
+#include <folly/dynamic.h>
+
 namespace reanimated::css {
 
-double getDuration(jsi::Runtime &rt, const jsi::Object &config);
+double getDuration(const folly::dynamic &config);
 
-EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
+EasingFunction getTimingFunction(const folly::dynamic &config);
 
-double getDelay(jsi::Runtime &rt, const jsi::Object &config);
+double getDelay(const folly::dynamic &config);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -46,13 +46,9 @@ EasingFunction createParametrizedEasingFunction(
   std::vector<double> pointsX;
   std::vector<double> pointsY;
 
-  const auto points = easingConfig["points"];
-  const auto pointsCount = points.size();
-
-  for (size_t i = 0; i < pointsCount; i++) {
-    const auto pointObj = points[i];
-    pointsX.push_back(pointObj["x"].asDouble());
-    pointsY.push_back(pointObj["y"].asDouble());
+  for (const auto &point : easingConfig["points"]) {
+    pointsX.push_back(point["x"].asDouble());
+    pointsY.push_back(point["y"].asDouble());
   }
 
   if (easingName == "linear") {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -13,13 +13,11 @@ inline const std::unordered_map<std::string, EasingFunction>
         {"step-end",
          steps(std::vector<double>{0, 1}, std::vector<double>{0, 1})}};
 
-EasingFunction createEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Value &easingConfig) {
+EasingFunction createEasingFunction(const folly::dynamic &easingConfig) {
   if (easingConfig.isString()) {
-    return getPredefinedEasingFunction(easingConfig.asString(rt).utf8(rt));
+    return getPredefinedEasingFunction(easingConfig.asString());
   } else if (easingConfig.isObject()) {
-    return createParametrizedEasingFunction(rt, easingConfig.asObject(rt));
+    return createParametrizedEasingFunction(easingConfig);
   } else {
     throw std::runtime_error(
         std::string("[Reanimated] Invalid easing function"));
@@ -38,26 +36,23 @@ EasingFunction getPredefinedEasingFunction(const std::string &name) {
 }
 
 EasingFunction createParametrizedEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Object &easingConfig) {
-  const auto easingName =
-      easingConfig.getProperty(rt, "name").asString(rt).utf8(rt);
+    const folly::dynamic &easingConfig) {
+  const auto easingName = easingConfig["name"].asString();
 
   if (easingName == "cubicBezier") {
-    return cubicBezier(rt, easingConfig);
+    return cubicBezier(easingConfig);
   }
 
   std::vector<double> pointsX;
   std::vector<double> pointsY;
 
-  const auto points =
-      easingConfig.getProperty(rt, "points").asObject(rt).asArray(rt);
-  const auto pointsCount = points.size(rt);
+  const auto points = easingConfig["points"];
+  const auto pointsCount = points.size();
 
   for (size_t i = 0; i < pointsCount; i++) {
-    const auto pointObj = points.getValueAtIndex(rt, i).asObject(rt);
-    pointsX.push_back(pointObj.getProperty(rt, "x").asNumber());
-    pointsY.push_back(pointObj.getProperty(rt, "y").asNumber());
+    const auto pointObj = points[i];
+    pointsX.push_back(pointObj["x"].asDouble());
+    pointsY.push_back(pointObj["y"].asDouble());
   }
 
   if (easingName == "linear") {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
@@ -4,7 +4,7 @@
 #include <reanimated/CSS/easing/linear.h>
 #include <reanimated/CSS/easing/steps.h>
 
-#include <jsi/jsi.h>
+#include <folly/dynamic.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -18,11 +18,8 @@ extern const std::unordered_map<std::string, EasingFunction>
 
 EasingFunction getPredefinedEasingFunction(const std::string &name);
 EasingFunction createParametrizedEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Object &easingConfig);
+    const folly::dynamic &easingConfig);
 
-EasingFunction createEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Value &easingConfig);
+EasingFunction createEasingFunction(const folly::dynamic &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -65,12 +65,12 @@ EasingFunction cubicBezier(
   };
 }
 
-EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig) {
-  const auto x1 = easingConfig.getProperty(rt, "x1").asNumber();
-  const auto y1 = easingConfig.getProperty(rt, "y1").asNumber();
-  const auto x2 = easingConfig.getProperty(rt, "x2").asNumber();
-  const auto y2 = easingConfig.getProperty(rt, "y2").asNumber();
-  return cubicBezier(x1, y1, x2, y2);
+EasingFunction cubicBezier(const folly::dynamic &easingConfig) {
+  return cubicBezier(
+      easingConfig["x1"].asDouble(),
+      easingConfig["y1"].asDouble(),
+      easingConfig["x2"].asDouble(),
+      easingConfig["y2"].asDouble());
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -2,6 +2,8 @@
 
 #include <reanimated/CSS/common/definitions.h>
 
+#include <folly/dynamic.h>
+
 namespace reanimated::css {
 
 double sampleCurveX(double t, double x1, double x2);
@@ -10,6 +12,6 @@ double sampleCurveDerivativeX(double t, double x1, double x2);
 double solveCurveX(double x, double x1, double x2, double epsilon = 1e-6);
 
 EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
-EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);
+EasingFunction cubicBezier(const folly::dynamic &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -27,9 +27,7 @@ class PropertyInterpolator {
   virtual bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const = 0;
 
-  virtual void updateKeyframes(
-      jsi::Runtime &rt,
-      const jsi::Value &keyframes) = 0;
+  virtual void updateKeyframes(const folly::dynamic &keyframes) = 0;
   virtual void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -31,16 +31,13 @@ bool ArrayPropertiesInterpolator::equalsReversingAdjustedStartValue(
 }
 
 void ArrayPropertiesInterpolator::updateKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
-  const jsi::Array keyframesArray = keyframes.asObject(rt).asArray(rt);
-  const size_t valuesCount = keyframesArray.size(rt);
+    const folly::dynamic &keyframes) {
+  const size_t valuesCount = keyframes.size();
 
   resizeInterpolators(valuesCount);
 
   for (size_t i = 0; i < valuesCount; ++i) {
-    interpolators_[i]->updateKeyframes(
-        rt, keyframesArray.getValueAtIndex(rt, i));
+    interpolators_[i]->updateKeyframes(keyframes[i]);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
@@ -19,7 +19,7 @@ class ArrayPropertiesInterpolator : public GroupPropertiesInterpolator {
   bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -20,23 +20,15 @@ bool RecordPropertiesInterpolator::equalsReversingAdjustedStartValue(
 }
 
 void RecordPropertiesInterpolator::updateKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
+    const folly::dynamic &keyframes) {
   // TODO - maybe add a possibility to remove interpolators that are no longer
   // used  (for now, for simplicity, we only add new ones)
-  const jsi::Object keyframesObject = keyframes.asObject(rt);
+  for (const auto &item : keyframes.items()) {
+    const auto &propName = item.first.getString();
+    const auto &propValue = item.second;
 
-  jsi::Array propertyNames = keyframesObject.getPropertyNames(rt);
-  size_t propertiesCount = propertyNames.size(rt);
-
-  for (size_t i = 0; i < propertiesCount; ++i) {
-    const std::string propertyName =
-        propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const jsi::Value &propertyKeyframes = keyframesObject.getProperty(
-        rt, jsi::PropNameID::forUtf8(rt, propertyName));
-
-    maybeCreateInterpolator(propertyName);
-    interpolators_[propertyName]->updateKeyframes(rt, propertyKeyframes);
+    maybeCreateInterpolator(propName);
+    interpolators_[propName]->updateKeyframes(propValue);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
@@ -20,7 +20,7 @@ class RecordPropertiesInterpolator : public GroupPropertiesInterpolator {
   bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
@@ -88,79 +88,6 @@ bool TransformOperation::isRelative() const {
   return false;
 }
 
-std::shared_ptr<TransformOperation> TransformOperation::fromJSIValue(
-    jsi::Runtime &rt,
-    const jsi::Value &value) {
-  if (!value.isObject()) {
-    throw std::invalid_argument(
-        "[Reanimated] TransformOperation must be an object.");
-  }
-
-  jsi::Object obj = value.asObject(rt);
-  auto propertyNames = obj.getPropertyNames(rt);
-
-  if (propertyNames.size(rt) != 1) {
-    throw std::invalid_argument(
-        "[Reanimated] TransformOperation must have exactly one property.");
-  }
-
-  const auto propertyName =
-      propertyNames.getValueAtIndex(rt, 0).asString(rt).utf8(rt);
-  const auto propertyValue =
-      obj.getProperty(rt, jsi::PropNameID::forUtf8(rt, propertyName));
-  TransformOperationType operationType =
-      getTransformOperationType(propertyName);
-
-  switch (operationType) {
-    case TransformOperationType::Perspective:
-      return std::make_shared<PerspectiveOperation>(propertyValue.asNumber());
-    case TransformOperationType::Rotate:
-      return std::make_shared<RotateOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateX:
-      return std::make_shared<RotateXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateY:
-      return std::make_shared<RotateYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateZ:
-      return std::make_shared<RotateZOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::Scale:
-      return std::make_shared<ScaleOperation>(propertyValue.asNumber());
-    case TransformOperationType::ScaleX:
-      return std::make_shared<ScaleXOperation>(propertyValue.asNumber());
-    case TransformOperationType::ScaleY:
-      return std::make_shared<ScaleYOperation>(propertyValue.asNumber());
-    case TransformOperationType::TranslateX: {
-      if (propertyValue.isNumber()) {
-        return std::make_shared<TranslateXOperation>(propertyValue.asNumber());
-      }
-      return std::make_shared<TranslateXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    }
-    case TransformOperationType::TranslateY: {
-      if (propertyValue.isNumber()) {
-        return std::make_shared<TranslateYOperation>(propertyValue.asNumber());
-      }
-      return std::make_shared<TranslateYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    }
-    case TransformOperationType::SkewX:
-      return std::make_shared<SkewXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::SkewY:
-      return std::make_shared<SkewYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::Matrix:
-      return std::make_shared<MatrixOperation>(
-          TransformMatrix(rt, propertyValue));
-    default:
-      throw std::invalid_argument(
-          "[Reanimated] Unknown transform operation: " + propertyName);
-  }
-}
-
 std::shared_ptr<TransformOperation> TransformOperation::fromDynamic(
     const folly::dynamic &value) {
   if (!value.isObject()) {
@@ -549,7 +476,7 @@ bool MatrixOperation::operator==(const TransformOperation &other) const {
 folly::dynamic MatrixOperation::valueToDynamic() const {
   if (!std::holds_alternative<TransformMatrix>(value)) {
     throw std::invalid_argument(
-        "[Reanimated] Cannot convert unprocessed transform operations to the JSI value.");
+        "[Reanimated] Cannot convert unprocessed transform operations to the dynamic value.");
   }
   return std::get<TransformMatrix>(value).toDynamic();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
@@ -8,6 +8,7 @@
 
 #include <react/renderer/core/ShadowNode.h>
 
+#include <folly/dynamic.h>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -57,9 +58,6 @@ struct TransformOperation {
   virtual TransformOperationType type() const = 0;
   virtual bool isRelative() const;
 
-  static std::shared_ptr<TransformOperation> fromJSIValue(
-      jsi::Runtime &rt,
-      const jsi::Value &value);
   static std::shared_ptr<TransformOperation> fromDynamic(
       const folly::dynamic &value);
   folly::dynamic toDynamic() const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -44,7 +44,7 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
       const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
       const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -74,17 +74,17 @@ class ValueInterpolator : public PropertyInterpolator {
     return reversingAdjustedStartValue_.value() == ValueType(propertyValue);
   }
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override {
-    const auto parsedKeyframes = parseJSIKeyframes(rt, keyframes);
+  void updateKeyframes(const folly::dynamic &keyframes) override {
+    const auto parsedKeyframes = parseDynamicKeyframes(keyframes);
 
     keyframes_.clear();
     keyframes_.reserve(parsedKeyframes.size());
 
     for (const auto &[offset, value] : parsedKeyframes) {
-      if (value.isUndefined()) {
+      if (value.empty()) {
         keyframes_.push_back(KeyframeType{offset, std::nullopt});
       } else {
-        keyframes_.push_back(KeyframeType{offset, ValueType(rt, value)});
+        keyframes_.push_back(KeyframeType{offset, ValueType(value)});
       }
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -81,7 +81,7 @@ class ValueInterpolator : public PropertyInterpolator {
     keyframes_.reserve(parsedKeyframes.size());
 
     for (const auto &[offset, value] : parsedKeyframes) {
-      if (value.empty()) {
+      if (value.isNull()) {
         keyframes_.push_back(KeyframeType{offset, std::nullopt});
       } else {
         keyframes_.push_back(KeyframeType{offset, ValueType(value)});

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
@@ -2,48 +2,36 @@
 
 namespace reanimated::css {
 
-std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
-  if (!keyframes.isObject() || !keyframes.asObject(rt).isArray(rt)) {
+std::vector<std::pair<double, folly::dynamic>> parseDynamicKeyframes(
+    const folly::dynamic &keyframes) {
+  if (!keyframes.isArray()) {
     throw std::invalid_argument(
         "[Reanimated] Keyframes must be an array of keyframe objects");
   }
 
-  const auto keyframeArray = keyframes.asObject(rt).asArray(rt);
-  const auto keyframesCount = keyframeArray.size(rt);
+  const auto keyframesCount = keyframes.size();
+  const bool hasOffset0 = keyframes[0]["offset"].asDouble() == 0;
+  const bool hasOffset1 =
+      keyframes[keyframesCount - 1]["offset"].asDouble() == 1;
 
-  const auto getKeyframeAtIndexOffset = [&](size_t index) -> double {
-    return keyframeArray.getValueAtIndex(rt, index)
-        .asObject(rt)
-        .getProperty(rt, "offset")
-        .asNumber();
-  };
-
-  const bool hasOffset0 = getKeyframeAtIndexOffset(0) == 0;
-  const bool hasOffset1 = getKeyframeAtIndexOffset(keyframesCount - 1) == 1;
-
-  std::vector<std::pair<double, jsi::Value>> result;
+  std::vector<std::pair<double, folly::dynamic>> result;
   result.reserve(keyframesCount + (hasOffset0 ? 0 : 1) + (hasOffset1 ? 0 : 1));
 
   // Insert the keyframe without value at offset 0 if it is not present
   if (!hasOffset0) {
-    result.emplace_back(0.0, jsi::Value::undefined());
+    result.emplace_back(0.0, folly::dynamic());
   }
 
   // Insert all provided keyframes
   for (size_t i = 0; i < keyframesCount; ++i) {
-    jsi::Object keyframeObject =
-        keyframeArray.getValueAtIndex(rt, i).asObject(rt);
-    double offset = keyframeObject.getProperty(rt, "offset").asNumber();
-    jsi::Value value = keyframeObject.getProperty(rt, "value");
-
-    result.emplace_back(offset, std::move(value));
+    const auto &keyframeObject = keyframes[i];
+    double offset = keyframeObject["offset"].asDouble();
+    result.emplace_back(offset, std::move(keyframeObject["value"]));
   }
 
   // Insert the keyframe without value at offset 1 if it is not present
   if (!hasOffset1) {
-    result.emplace_back(1.0, jsi::Value::undefined());
+    result.emplace_back(1.0, folly::dynamic());
   }
 
   return result;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
@@ -1,15 +1,12 @@
 #pragma once
 
-#include <jsi/jsi.h>
+#include <folly/dynamic.h>
 #include <utility>
 #include <vector>
 
 namespace reanimated::css {
 
-using namespace facebook;
-
-std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes);
+std::vector<std::pair<double, folly::dynamic>> parseDynamicKeyframes(
+    const folly::dynamic &keyframes);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -459,10 +459,11 @@ void ReanimatedModuleProxy::registerCSSKeyframes(
     jsi::Runtime &rt,
     const jsi::Value &animationName,
     const jsi::Value &keyframesConfig) {
+  auto dynamic = dynamicFromValue(rt, keyframesConfig);
+  auto keyframes =
+      parseCSSAnimationKeyframesConfig(dynamic, viewStylesRepository_);
   cssAnimationKeyframesRegistry_->add(
-      animationName.asString(rt).utf8(rt),
-      parseCSSAnimationKeyframesConfig(
-          dynamicFromValue(rt, keyframesConfig), viewStylesRepository_));
+      animationName.asString(rt).utf8(rt), std::move(keyframes));
 }
 
 void ReanimatedModuleProxy::unregisterCSSKeyframes(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -462,7 +462,7 @@ void ReanimatedModuleProxy::registerCSSKeyframes(
   cssAnimationKeyframesRegistry_->add(
       animationName.asString(rt).utf8(rt),
       parseCSSAnimationKeyframesConfig(
-          rt, keyframesConfig, viewStylesRepository_));
+          dynamicFromValue(rt, keyframesConfig), viewStylesRepository_));
 }
 
 void ReanimatedModuleProxy::unregisterCSSKeyframes(
@@ -478,7 +478,8 @@ void ReanimatedModuleProxy::applyCSSAnimations(
   cssAnimationsRegistry_->lock();
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
   const auto timestamp = getCssTimestamp();
-  const auto updates = parseCSSAnimationUpdates(rt, animationUpdates);
+  const auto updates =
+      parseCSSAnimationUpdates(dynamicFromValue(rt, animationUpdates));
 
   CSSAnimationsMap newAnimations;
 
@@ -531,7 +532,7 @@ void ReanimatedModuleProxy::registerCSSTransition(
 
   auto transition = std::make_shared<CSSTransition>(
       std::move(shadowNode),
-      parseCSSTransitionConfig(rt, transitionConfig),
+      parseCSSTransitionConfig(dynamicFromValue(rt, transitionConfig)),
       viewStylesRepository_);
 
   cssTransitionsRegistry_->add(transition);
@@ -544,7 +545,8 @@ void ReanimatedModuleProxy::updateCSSTransition(
     const jsi::Value &configUpdates) {
   cssTransitionsRegistry_->lock();
   cssTransitionsRegistry_->updateSettings(
-      viewTag.asNumber(), parsePartialCSSTransitionConfig(rt, configUpdates));
+      viewTag.asNumber(),
+      parsePartialCSSTransitionConfig(dynamicFromValue(rt, configUpdates)));
   maybeRunCSSLoop();
 }
 


### PR DESCRIPTION
## Summary

Since we are moving implementation to a custom shadow node which gets `folly::dynamic` object in props, we no longer can create CSS transition/animation configs from a `jsi::Value`. Because of that, I needed to adjust the implementation of all config parsers and the `updateKeyframes` method in interpolators.