### PR TITLE
chore(ci): Remove irrelevant workflow steps.

### DIFF
--- a/.github/workflows/npm-reanimated-package-build.yml
+++ b/.github/workflows/npm-reanimated-package-build.yml
@@ -89,24 +89,6 @@ jobs:
         run: >-
           ./createNPMPackage.sh ${{ inputs.option }}
 
-      - name: Check if any node_modules were packed
-        working-directory: ${{ env.REANIMATED_DIR }}
-        id: node_modules
-        run: >-
-          ! grep --silent -E "node_modules/.+" build.log
-
-      - name: Show build log
-        working-directory: ${{ env.REANIMATED_DIR }}
-        if: failure() && steps.build.outcome == 'failure'
-        run: >-
-          cat build.log
-
-      - name: Show packed node_modules
-        working-directory: ${{ env.REANIMATED_DIR }}
-        if: failure() && steps.node_modules.outcome == 'failure'
-        run: >-
-          ! grep -E "node_modules/.+" build.log
-
       - name: Add package name to env
         working-directory: ${{ env.REANIMATED_DIR }}
         run: echo "PACKAGE_NAME=$(ls -l | egrep -o "react-native-reanimated-(.*)(=?\.tgz)")" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

It removes obsolete steps from `NPM Reanimated package build` workflow. These steps were based on the existence of `build.log` which is no longer emitted from the build step. One of those removed steps (`id: node_modules`) was passing for the wrong reason. It was supposed to pass on failure to find given expression in `build.log` but it was passing on failure to locate that file.

## Test plan

Validate that workflow is doing its job.