### PR TITLE
chore: Remove ViewStylesRepository from CSS constructors

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -16,10 +16,10 @@ enum class RelativeTo {
 };
 
 struct CSSResolvableValueInterpolationContext {
-  const ShadowNode::Shared &node;
-  const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
+  ShadowNode::Shared node;
+  std::shared_ptr<ViewStylesRepository> viewStylesRepository;
+  RelativeTo relativeTo;
   const std::string &relativeProperty;
-  const RelativeTo relativeTo;
 };
 
 struct CSSValue {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -3,10 +3,8 @@
 namespace reanimated::css {
 
 std::shared_ptr<AnimationStyleInterpolator> getStyleInterpolator(
-    const folly::dynamic &config,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
-  const auto styleInterpolator =
-      std::make_shared<AnimationStyleInterpolator>(viewStylesRepository);
+    const folly::dynamic &config) {
+  const auto styleInterpolator = std::make_shared<AnimationStyleInterpolator>();
 
   styleInterpolator->updateKeyframes(config["keyframesStyle"]);
 
@@ -30,11 +28,8 @@ std::shared_ptr<KeyframeEasingFunctions> getKeyframeTimingFunctions(
 }
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
-    const folly::dynamic &config,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
-  return {
-      getStyleInterpolator(config, viewStylesRepository),
-      getKeyframeTimingFunctions(config)};
+    const folly::dynamic &config) {
+  return {getStyleInterpolator(config), getKeyframeTimingFunctions(config)};
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -2,7 +2,6 @@
 
 #include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <folly/dynamic.h>
 #include <memory>
@@ -19,7 +18,6 @@ struct CSSKeyframesConfig {
 };
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
-    const folly::dynamic &config,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+    const folly::dynamic &config);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -143,8 +143,8 @@ PropertyInterpolatorUpdateContext CSSAnimation::getUpdateContext(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   return PropertyInterpolatorUpdateContext{
       .node = shadowNode_,
-      .viewStylesRepository = viewStylesRepository,
       .progressProvider = progressProvider_,
+      .viewStylesRepository = viewStylesRepository,
   };
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -60,17 +60,21 @@ bool CSSAnimation::hasBackwardsFillMode() const {
       fillMode_ == AnimationFillMode::Both;
 }
 
-folly::dynamic CSSAnimation::getCurrentInterpolationStyle() const {
-  return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
-}
-
 folly::dynamic CSSAnimation::getBackwardsFillStyle() const {
   return isReversed() ? styleInterpolator_->getLastKeyframeValue()
                       : styleInterpolator_->getFirstKeyframeValue();
 }
 
-folly::dynamic CSSAnimation::getResetStyle() const {
-  return styleInterpolator_->getResetStyle(shadowNode_);
+folly::dynamic CSSAnimation::getCurrentInterpolationStyle(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return styleInterpolator_->interpolate(
+      getUpdateContext(viewStylesRepository));
+}
+
+folly::dynamic CSSAnimation::getResetStyle(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return styleInterpolator_->getResetStyle(
+      getUpdateContext(viewStylesRepository));
 }
 
 void CSSAnimation::run(const double timestamp) {
@@ -81,7 +85,9 @@ void CSSAnimation::run(const double timestamp) {
   progressProvider_->play(timestamp);
 }
 
-folly::dynamic CSSAnimation::update(const double timestamp) {
+folly::dynamic CSSAnimation::update(
+    const double timestamp,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   progressProvider_->update(timestamp);
 
   // Check if the animation has not started yet because of the delay
@@ -93,7 +99,8 @@ folly::dynamic CSSAnimation::update(const double timestamp) {
     return hasBackwardsFillMode() ? getBackwardsFillStyle() : folly::dynamic();
   }
 
-  return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
+  return styleInterpolator_->interpolate(
+      getUpdateContext(viewStylesRepository));
 }
 
 void CSSAnimation::updateSettings(
@@ -130,6 +137,15 @@ void CSSAnimation::updateSettings(
   }
 
   progressProvider_->update(timestamp);
+}
+
+PropertyInterpolatorUpdateContext CSSAnimation::getUpdateContext(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return PropertyInterpolatorUpdateContext{
+      .node = shadowNode_,
+      .viewStylesRepository = viewStylesRepository,
+      .progressProvider = progressProvider_,
+  };
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -32,12 +32,16 @@ class CSSAnimation {
   bool hasForwardsFillMode() const;
   bool hasBackwardsFillMode() const;
 
-  folly::dynamic getCurrentInterpolationStyle() const;
   folly::dynamic getBackwardsFillStyle() const;
-  folly::dynamic getResetStyle() const;
+  folly::dynamic getCurrentInterpolationStyle(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
+  folly::dynamic getResetStyle(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
   void run(double timestamp);
-  folly::dynamic update(double timestamp);
+  folly::dynamic update(
+      double timestamp,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
   void updateSettings(
       const PartialCSSAnimationSettings &updatedSettings,
       double timestamp);
@@ -49,6 +53,9 @@ class CSSAnimation {
 
   std::shared_ptr<AnimationProgressProvider> progressProvider_;
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator_;
+
+  PropertyInterpolatorUpdateContext getUpdateContext(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -27,8 +27,10 @@ TransitionProgressState CSSTransition::getState() const {
   return progressProvider_.getState();
 }
 
-folly::dynamic CSSTransition::getCurrentInterpolationStyle() const {
-  return styleInterpolator_.interpolate(shadowNode_, progressProvider_);
+folly::dynamic CSSTransition::getCurrentInterpolationStyle(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return styleInterpolator_.interpolate(
+      shadowNode_, progressProvider_, viewStylesRepository);
 }
 
 TransitionProperties CSSTransition::getProperties() const {
@@ -81,9 +83,10 @@ void CSSTransition::updateSettings(const PartialCSSTransitionConfig &config) {
 }
 
 folly::dynamic CSSTransition::run(
+    const double timestamp,
     const ChangedProps &changedProps,
     const folly::dynamic &lastUpdateValue,
-    const double timestamp) {
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   progressProvider_.runProgressProviders(
       timestamp,
       settings_,
@@ -91,12 +94,15 @@ folly::dynamic CSSTransition::run(
       styleInterpolator_.getReversedPropertyNames(changedProps.newProps));
   styleInterpolator_.updateInterpolatedProperties(
       changedProps, lastUpdateValue);
-  return update(timestamp);
+  return update(timestamp, viewStylesRepository);
 }
 
-folly::dynamic CSSTransition::update(const double timestamp) {
+folly::dynamic CSSTransition::update(
+    const double timestamp,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
   progressProvider_.update(timestamp);
-  auto result = styleInterpolator_.interpolate(shadowNode_, progressProvider_);
+  auto result = styleInterpolator_.interpolate(
+      shadowNode_, progressProvider_, viewStylesRepository);
   // Remove interpolators for which interpolation has finished
   // (we won't need them anymore in the current transition)
   styleInterpolator_.discardFinishedInterpolators(progressProvider_);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -4,14 +4,12 @@ namespace reanimated::css {
 
 CSSTransition::CSSTransition(
     ShadowNode::Shared shadowNode,
-    const CSSTransitionConfig &config,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
+    const CSSTransitionConfig &config)
     : shadowNode_(std::move(shadowNode)),
-      viewStylesRepository_(viewStylesRepository),
       properties_(config.properties),
       settings_(config.settings),
       progressProvider_(TransitionProgressProvider()),
-      styleInterpolator_(TransitionStyleInterpolator(viewStylesRepository)) {}
+      styleInterpolator_(TransitionStyleInterpolator()) {}
 
 Tag CSSTransition::getViewTag() const {
   return shadowNode_->getTag();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -22,7 +22,8 @@ class CSSTransition {
   ShadowNode::Shared getShadowNode() const;
   double getMinDelay(double timestamp) const;
   TransitionProgressState getState() const;
-  folly::dynamic getCurrentInterpolationStyle() const;
+  folly::dynamic getCurrentInterpolationStyle(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
   TransitionProperties getProperties() const;
   PropertyNames getAllowedProperties(
       const folly::dynamic &oldProps,
@@ -30,10 +31,13 @@ class CSSTransition {
 
   void updateSettings(const PartialCSSTransitionConfig &config);
   folly::dynamic run(
+      double timestamp,
       const ChangedProps &changedProps,
       const folly::dynamic &lastUpdateValue,
-      double timestamp);
-  folly::dynamic update(double timestamp);
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+  folly::dynamic update(
+      double timestamp,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
  private:
   const ShadowNode::Shared shadowNode_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -16,8 +16,7 @@ class CSSTransition {
  public:
   CSSTransition(
       ShadowNode::Shared shadowNode,
-      const CSSTransitionConfig &config,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+      const CSSTransitionConfig &config);
 
   Tag getViewTag() const;
   ShadowNode::Shared getShadowNode() const;
@@ -38,7 +37,6 @@ class CSSTransition {
 
  private:
   const ShadowNode::Shared shadowNode_;
-  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   TransitionProperties properties_;
   CSSTransitionPropertiesSettings settings_;
   TransitionProgressProvider progressProvider_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
@@ -14,11 +14,9 @@ class RecordInterpolatorFactory : public PropertyInterpolatorFactory {
   }
 
   std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const override {
+      const PropertyPath &propertyPath) const override {
     return std::make_shared<RecordPropertiesInterpolator>(
-        factories_, propertyPath, viewStylesRepository);
+        factories_, propertyPath);
   }
 
  private:
@@ -47,11 +45,9 @@ class ArrayInterpolatorFactory : public PropertyInterpolatorFactory {
   }
 
   std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const override {
+      const PropertyPath &propertyPath) const override {
     return std::make_shared<ArrayPropertiesInterpolator>(
-        factories_, propertyPath, viewStylesRepository);
+        factories_, propertyPath);
   }
 
  private:
@@ -81,11 +77,9 @@ class TransformsInterpolatorFactory : public PropertyInterpolatorFactory {
   }
 
   std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const override {
+      const PropertyPath &propertyPath) const override {
     return std::make_shared<TransformsStyleInterpolator>(
-        propertyPath, interpolators_, viewStylesRepository);
+        propertyPath, interpolators_);
   }
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -37,11 +37,9 @@ class ValueInterpolatorFactory : public PropertyInterpolatorFactory {
   }
 
   std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const override {
+      const PropertyPath &propertyPath) const override {
     return std::make_shared<ValueInterpolator<AllowedTypes...>>(
-        propertyPath, defaultValue_, viewStylesRepository);
+        propertyPath, defaultValue_);
   }
 
  private:
@@ -66,15 +64,9 @@ class ResolvableValueInterpolatorFactory : public PropertyInterpolatorFactory {
   }
 
   std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const override {
+      const PropertyPath &propertyPath) const override {
     return std::make_shared<ResolvableValueInterpolator<AllowedTypes...>>(
-        propertyPath,
-        defaultValue_,
-        viewStylesRepository,
-        relativeTo_,
-        relativeProperty_);
+        propertyPath, defaultValue_, relativeTo_, relativeProperty_);
   }
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -1,7 +1,5 @@
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
 
-#include <utility>
-
 namespace reanimated::css {
 
 PropertyInterpolator::PropertyInterpolator(PropertyPath propertyPath)

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.cpp
@@ -4,11 +4,8 @@
 
 namespace reanimated::css {
 
-PropertyInterpolator::PropertyInterpolator(
-    PropertyPath propertyPath,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : propertyPath_(std::move(propertyPath)),
-      viewStylesRepository_(viewStylesRepository) {}
+PropertyInterpolator::PropertyInterpolator(PropertyPath propertyPath)
+    : propertyPath_(std::move(propertyPath)) {}
 
 bool PropertyInterpolatorFactory::isDiscreteProperty() const {
   return false;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -2,23 +2,31 @@
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {
+
+struct PropertyInterpolatorUpdateContext {
+  const ShadowNode::Shared &node;
+  const std::shared_ptr<KeyframeProgressProvider> &progressProvider;
+  const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
+};
 
 class PropertyInterpolator {
  public:
   explicit PropertyInterpolator(PropertyPath propertyPath);
 
   virtual folly::dynamic getStyleValue(
-      const ShadowNode::Shared &shadowNode) const = 0;
+      const PropertyInterpolatorUpdateContext &context) const = 0;
   virtual folly::dynamic getResetStyle(
-      const ShadowNode::Shared &shadowNode) const = 0;
+      const PropertyInterpolatorUpdateContext &context) const = 0;
   virtual folly::dynamic getFirstKeyframeValue() const = 0;
   virtual folly::dynamic getLastKeyframeValue() const = 0;
   virtual bool equalsReversingAdjustedStartValue(
@@ -31,9 +39,7 @@ class PropertyInterpolator {
       const folly::dynamic &lastUpdateValue) = 0;
 
   virtual folly::dynamic interpolate(
-      const ShadowNode::Shared &shadowNode,
-      const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
-      const = 0;
+      const PropertyInterpolatorUpdateContext &context) const = 0;
 
  protected:
   const PropertyPath propertyPath_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -14,9 +14,9 @@
 namespace reanimated::css {
 
 struct PropertyInterpolatorUpdateContext {
-  const ShadowNode::Shared &node;
-  const std::shared_ptr<KeyframeProgressProvider> &progressProvider;
-  const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
+  ShadowNode::Shared node;
+  std::shared_ptr<KeyframeProgressProvider> progressProvider;
+  std::shared_ptr<ViewStylesRepository> viewStylesRepository;
 };
 
 class PropertyInterpolator {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -2,7 +2,6 @@
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 
 #include <memory>
@@ -14,9 +13,7 @@ namespace reanimated::css {
 
 class PropertyInterpolator {
  public:
-  explicit PropertyInterpolator(
-      PropertyPath propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+  explicit PropertyInterpolator(PropertyPath propertyPath);
 
   virtual folly::dynamic getStyleValue(
       const ShadowNode::Shared &shadowNode) const = 0;
@@ -40,7 +37,6 @@ class PropertyInterpolator {
 
  protected:
   const PropertyPath propertyPath_;
-  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 };
 
 class PropertyInterpolatorFactory {
@@ -52,9 +48,7 @@ class PropertyInterpolatorFactory {
   virtual const CSSValue &getDefaultValue() const = 0;
 
   virtual std::shared_ptr<PropertyInterpolator> create(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      const = 0;
+      const PropertyPath &propertyPath) const = 0;
 };
 
 using PropertyInterpolatorsRecord =

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -4,10 +4,8 @@ namespace reanimated::css {
 
 ArrayPropertiesInterpolator::ArrayPropertiesInterpolator(
     const InterpolatorFactoriesArray &factories,
-    const PropertyPath &propertyPath,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : GroupPropertiesInterpolator(propertyPath, viewStylesRepository),
-      factories_(factories) {}
+    const PropertyPath &propertyPath)
+    : GroupPropertiesInterpolator(propertyPath), factories_(factories) {}
 
 bool ArrayPropertiesInterpolator::equalsReversingAdjustedStartValue(
     const folly::dynamic &propertyValue) const {
@@ -87,10 +85,7 @@ void ArrayPropertiesInterpolator::resizeInterpolators(size_t valuesCount) {
 
   while (interpolators_.size() < valuesCount) {
     interpolators_.emplace_back(createPropertyInterpolator(
-        interpolators_.size(),
-        propertyPath_,
-        factories_,
-        viewStylesRepository_));
+        interpolators_.size(), propertyPath_, factories_));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
@@ -12,8 +12,7 @@ class ArrayPropertiesInterpolator : public GroupPropertiesInterpolator {
  public:
   ArrayPropertiesInterpolator(
       const InterpolatorFactoriesArray &factories,
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+      const PropertyPath &propertyPath);
   virtual ~ArrayPropertiesInterpolator() = default;
 
   bool equalsReversingAdjustedStartValue(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
@@ -3,9 +3,8 @@
 namespace reanimated::css {
 
 GroupPropertiesInterpolator::GroupPropertiesInterpolator(
-    const PropertyPath &propertyPath,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : PropertyInterpolator(propertyPath, viewStylesRepository) {}
+    const PropertyPath &propertyPath)
+    : PropertyInterpolator(propertyPath) {}
 
 folly::dynamic GroupPropertiesInterpolator::getStyleValue(
     const ShadowNode::Shared &shadowNode) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.cpp
@@ -7,18 +7,18 @@ GroupPropertiesInterpolator::GroupPropertiesInterpolator(
     : PropertyInterpolator(propertyPath) {}
 
 folly::dynamic GroupPropertiesInterpolator::getStyleValue(
-    const ShadowNode::Shared &shadowNode) const {
+    const PropertyInterpolatorUpdateContext &context) const {
   return mapInterpolators(
       [&](PropertyInterpolator &interpolator) -> folly::dynamic {
-        return interpolator.getStyleValue(shadowNode);
+        return interpolator.getStyleValue(context);
       });
 }
 
 folly::dynamic GroupPropertiesInterpolator::getResetStyle(
-    const ShadowNode::Shared &shadowNode) const {
+    const PropertyInterpolatorUpdateContext &context) const {
   return mapInterpolators(
       [&](PropertyInterpolator &interpolator) -> folly::dynamic {
-        return interpolator.getResetStyle(shadowNode);
+        return interpolator.getResetStyle(context);
       });
 }
 
@@ -37,11 +37,10 @@ folly::dynamic GroupPropertiesInterpolator::getLastKeyframeValue() const {
 }
 
 folly::dynamic GroupPropertiesInterpolator::interpolate(
-    const ShadowNode::Shared &shadowNode,
-    const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const {
+    const PropertyInterpolatorUpdateContext &context) const {
   return mapInterpolators(
       [&](PropertyInterpolator &interpolator) -> folly::dynamic {
-        return interpolator.interpolate(shadowNode, progressProvider);
+        return interpolator.interpolate(context);
       });
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <reanimated/CSS/interpolation/PropertyInterpolator.h>
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 
 #include <memory>
@@ -10,9 +9,7 @@ namespace reanimated::css {
 
 class GroupPropertiesInterpolator : public PropertyInterpolator {
  public:
-  GroupPropertiesInterpolator(
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+  GroupPropertiesInterpolator(const PropertyPath &propertyPath);
 
   folly::dynamic getStyleValue(
       const ShadowNode::Shared &shadowNode) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/GroupPropertiesInterpolator.h
@@ -9,19 +9,17 @@ namespace reanimated::css {
 
 class GroupPropertiesInterpolator : public PropertyInterpolator {
  public:
-  GroupPropertiesInterpolator(const PropertyPath &propertyPath);
+  explicit GroupPropertiesInterpolator(const PropertyPath &propertyPath);
 
   folly::dynamic getStyleValue(
-      const ShadowNode::Shared &shadowNode) const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
   folly::dynamic getResetStyle(
-      const ShadowNode::Shared &shadowNode) const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
   folly::dynamic getFirstKeyframeValue() const override;
   folly::dynamic getLastKeyframeValue() const override;
 
   folly::dynamic interpolate(
-      const ShadowNode::Shared &shadowNode,
-      const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
-      const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
 
  protected:
   virtual folly::dynamic mapInterpolators(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -4,10 +4,8 @@ namespace reanimated::css {
 
 RecordPropertiesInterpolator::RecordPropertiesInterpolator(
     const InterpolatorFactoriesRecord &factories,
-    const PropertyPath &propertyPath,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : GroupPropertiesInterpolator(propertyPath, viewStylesRepository),
-      factories_(factories) {}
+    const PropertyPath &propertyPath)
+    : GroupPropertiesInterpolator(propertyPath), factories_(factories) {}
 
 bool RecordPropertiesInterpolator::equalsReversingAdjustedStartValue(
     const folly::dynamic &propertyValue) const {
@@ -81,8 +79,8 @@ folly::dynamic RecordPropertiesInterpolator::mapInterpolators(
 void RecordPropertiesInterpolator::maybeCreateInterpolator(
     const std::string &propertyName) {
   if (interpolators_.find(propertyName) == interpolators_.end()) {
-    const auto newInterpolator = createPropertyInterpolator(
-        propertyName, propertyPath_, factories_, viewStylesRepository_);
+    const auto newInterpolator =
+        createPropertyInterpolator(propertyName, propertyPath_, factories_);
     interpolators_.emplace(propertyName, newInterpolator);
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
@@ -13,8 +13,7 @@ class RecordPropertiesInterpolator : public GroupPropertiesInterpolator {
  public:
   RecordPropertiesInterpolator(
       const InterpolatorFactoriesRecord &factories,
-      const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+      const PropertyPath &propertyPath);
   virtual ~RecordPropertiesInterpolator() = default;
 
   bool equalsReversingAdjustedStartValue(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
@@ -12,7 +12,7 @@ namespace reanimated::css {
 // same as interpolating record properties
 class AnimationStyleInterpolator : public RecordPropertiesInterpolator {
  public:
-  explicit AnimationStyleInterpolator()
+  AnimationStyleInterpolator()
       : RecordPropertiesInterpolator(PROPERTY_INTERPOLATORS_CONFIG, {}) {}
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h
@@ -12,12 +12,8 @@ namespace reanimated::css {
 // same as interpolating record properties
 class AnimationStyleInterpolator : public RecordPropertiesInterpolator {
  public:
-  explicit AnimationStyleInterpolator(
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      : RecordPropertiesInterpolator(
-            PROPERTY_INTERPOLATORS_CONFIG,
-            {},
-            viewStylesRepository) {}
+  explicit AnimationStyleInterpolator()
+      : RecordPropertiesInterpolator(PROPERTY_INTERPOLATORS_CONFIG, {}) {}
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -27,12 +27,17 @@ TransitionStyleInterpolator::getReversedPropertyNames(
 
 folly::dynamic TransitionStyleInterpolator::interpolate(
     const ShadowNode::Shared &shadowNode,
-    const TransitionProgressProvider &transitionProgressProvider) const {
+    const TransitionProgressProvider &transitionProgressProvider,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   return mapInterpolators(
       transitionProgressProvider,
       [&](const std::shared_ptr<PropertyInterpolator> &interpolator,
           const std::shared_ptr<KeyframeProgressProvider> &progressProvider) {
-        return interpolator->interpolate(shadowNode, progressProvider);
+        return interpolator->interpolate({
+            .node = shadowNode,
+            .viewStylesRepository = viewStylesRepository,
+            .progressProvider = progressProvider,
+        });
       });
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -2,10 +2,6 @@
 
 namespace reanimated::css {
 
-TransitionStyleInterpolator::TransitionStyleInterpolator(
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : viewStylesRepository_(viewStylesRepository) {}
-
 std::unordered_set<std::string>
 TransitionStyleInterpolator::getReversedPropertyNames(
     const folly::dynamic &newPropertyValues) const {
@@ -76,10 +72,7 @@ void TransitionStyleInterpolator::updateInterpolatedProperties(
 
     if (shouldCreateInterpolator) {
       const auto newInterpolator = createPropertyInterpolator(
-          propertyName,
-          {},
-          PROPERTY_INTERPOLATORS_CONFIG,
-          viewStylesRepository_);
+          propertyName, {}, PROPERTY_INTERPOLATORS_CONFIG);
       it = interpolators_.emplace(propertyName, newInterpolator).first;
     }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -35,8 +35,8 @@ folly::dynamic TransitionStyleInterpolator::interpolate(
           const std::shared_ptr<KeyframeProgressProvider> &progressProvider) {
         return interpolator->interpolate({
             .node = shadowNode,
-            .viewStylesRepository = viewStylesRepository,
             .progressProvider = progressProvider,
+            .viewStylesRepository = viewStylesRepository,
         });
       });
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
@@ -19,7 +19,8 @@ class TransitionStyleInterpolator {
 
   folly::dynamic interpolate(
       const ShadowNode::Shared &shadowNode,
-      const TransitionProgressProvider &transitionProgressProvider) const;
+      const TransitionProgressProvider &transitionProgressProvider,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
   void discardFinishedInterpolators(
       const TransitionProgressProvider &transitionProgressProvider);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
@@ -14,9 +14,6 @@ namespace reanimated::css {
 
 class TransitionStyleInterpolator {
  public:
-  TransitionStyleInterpolator(
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
-
   std::unordered_set<std::string> getReversedPropertyNames(
       const folly::dynamic &newPropertyValues) const;
 
@@ -36,8 +33,6 @@ class TransitionStyleInterpolator {
   using MapInterpolatorsCallback = std::function<folly::dynamic(
       const std::shared_ptr<PropertyInterpolator> &,
       const std::shared_ptr<KeyframeProgressProvider> &)>;
-
-  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 
   PropertyInterpolatorsRecord interpolators_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <memory>
 #include <unordered_map>
@@ -16,7 +15,6 @@ class TransformInterpolator {
 
   struct UpdateContext {
     const ShadowNode::Shared &node;
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
     const std::shared_ptr<Interpolators> &interpolators;
   };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformInterpolator.h
@@ -16,6 +16,7 @@ class TransformInterpolator {
   struct UpdateContext {
     const ShadowNode::Shared &node;
     const std::shared_ptr<Interpolators> &interpolators;
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
   };
 
   virtual ~TransformInterpolator() = default;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/common/values/CSSValue.h>
 #include <reanimated/CSS/interpolation/transforms/TransformInterpolator.h>
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <memory>
 #include <string>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h
@@ -115,8 +115,8 @@ class TransformOperationInterpolator<TOperation>
     return {
         .node = context.node,
         .viewStylesRepository = context.viewStylesRepository,
-        .relativeProperty = relativeProperty_,
         .relativeTo = relativeTo_,
+        .relativeProperty = relativeProperty_,
     };
   }
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -7,10 +7,8 @@ const TransformOperations TransformsStyleInterpolator::defaultStyleValue_ = {
 
 TransformsStyleInterpolator::TransformsStyleInterpolator(
     const PropertyPath &propertyPath,
-    const std::shared_ptr<TransformInterpolators> &interpolators,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-    : PropertyInterpolator(propertyPath, viewStylesRepository),
-      interpolators_(interpolators) {}
+    const std::shared_ptr<TransformInterpolators> &interpolators)
+    : PropertyInterpolator(propertyPath), interpolators_(interpolators) {}
 
 folly::dynamic TransformsStyleInterpolator::getStyleValue(
     const ShadowNode::Shared &shadowNode) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -11,14 +11,14 @@ TransformsStyleInterpolator::TransformsStyleInterpolator(
     : PropertyInterpolator(propertyPath), interpolators_(interpolators) {}
 
 folly::dynamic TransformsStyleInterpolator::getStyleValue(
-    const ShadowNode::Shared &shadowNode) const {
-  return viewStylesRepository_->getStyleProp(
-      shadowNode->getTag(), propertyPath_);
+    const PropertyInterpolatorUpdateContext &context) const {
+  return context.viewStylesRepository->getStyleProp(
+      context.node->getTag(), propertyPath_);
 }
 
 folly::dynamic TransformsStyleInterpolator::getResetStyle(
-    const ShadowNode::Shared &shadowNode) const {
-  auto styleValue = getStyleValue(shadowNode);
+    const PropertyInterpolatorUpdateContext &context) const {
+  auto styleValue = getStyleValue(context);
 
   if (!styleValue.isArray()) {
     return convertResultToDynamic(defaultStyleValue_);
@@ -66,9 +66,8 @@ bool TransformsStyleInterpolator::equalsReversingAdjustedStartValue(
 }
 
 folly::dynamic TransformsStyleInterpolator::interpolate(
-    const ShadowNode::Shared &shadowNode,
-    const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const {
-  const auto currentIndex = getIndexOfCurrentKeyframe(progressProvider);
+    const PropertyInterpolatorUpdateContext &context) const {
+  const auto currentIndex = getIndexOfCurrentKeyframe(context.progressProvider);
 
   // Get or create the current keyframe
   auto keyframe = keyframes_[currentIndex];
@@ -76,7 +75,7 @@ folly::dynamic TransformsStyleInterpolator::interpolate(
       !keyframe->toOperations.has_value()) {
     // If the value is nullopt, we would have to read it from the view style
     // and build the keyframe again
-    const auto fallbackValue = getFallbackValue(shadowNode);
+    const auto fallbackValue = getFallbackValue(context);
     keyframe = createTransformKeyframe(
         keyframe->fromOffset,
         keyframe->toOffset,
@@ -86,11 +85,11 @@ folly::dynamic TransformsStyleInterpolator::interpolate(
 
   // Interpolate the current keyframe
   TransformOperations result = interpolateOperations(
-      shadowNode,
-      progressProvider->getKeyframeProgress(
+      context.progressProvider->getKeyframeProgress(
           keyframe->fromOffset, keyframe->toOffset),
       keyframe->fromOperations.value(),
-      keyframe->toOperations.value());
+      keyframe->toOperations.value(),
+      context);
 
   return convertResultToDynamic(result);
 }
@@ -333,8 +332,8 @@ size_t TransformsStyleInterpolator::getIndexOfCurrentKeyframe(
 }
 
 TransformOperations TransformsStyleInterpolator::getFallbackValue(
-    const ShadowNode::Shared &shadowNode) const {
-  const auto &styleValue = getStyleValue(shadowNode);
+    const PropertyInterpolatorUpdateContext &context) const {
+  const auto &styleValue = getStyleValue(context);
   return parseTransformOperations(styleValue).value_or(TransformOperations{});
 }
 
@@ -345,14 +344,14 @@ TransformsStyleInterpolator::getDefaultOperationOfType(
 }
 
 TransformOperations TransformsStyleInterpolator::interpolateOperations(
-    const ShadowNode::Shared &shadowNode,
     const double keyframeProgress,
     const TransformOperations &fromOperations,
-    const TransformOperations &toOperations) const {
+    const TransformOperations &toOperations,
+    const PropertyInterpolatorUpdateContext &context) const {
   TransformOperations result;
   result.reserve(fromOperations.size());
   const auto transformUpdateContext = TransformInterpolatorUpdateContext{
-      shadowNode, viewStylesRepository_, interpolators_};
+      context.node, interpolators_, context.viewStylesRepository};
 
   for (size_t i = 0; i < fromOperations.size(); ++i) {
     const auto &fromOperation = fromOperations[i];

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -27,8 +27,7 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
  public:
   TransformsStyleInterpolator(
       const PropertyPath &propertyPath,
-      const std::shared_ptr<TransformInterpolators> &interpolators,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+      const std::shared_ptr<TransformInterpolators> &interpolators);
 
   folly::dynamic getStyleValue(
       const ShadowNode::Shared &shadowNode) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -30,18 +30,16 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
       const std::shared_ptr<TransformInterpolators> &interpolators);
 
   folly::dynamic getStyleValue(
-      const ShadowNode::Shared &shadowNode) const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
   folly::dynamic getResetStyle(
-      const ShadowNode::Shared &shadowNode) const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
   folly::dynamic getFirstKeyframeValue() const override;
   folly::dynamic getLastKeyframeValue() const override;
   bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const override;
 
   folly::dynamic interpolate(
-      const ShadowNode::Shared &shadowNode,
-      const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
-      const override;
+      const PropertyInterpolatorUpdateContext &context) const override;
 
   void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
@@ -81,17 +79,15 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
   size_t getIndexOfCurrentKeyframe(
       const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const;
   TransformOperations getFallbackValue(
-      const ShadowNode::Shared &shadowNode) const;
+      const PropertyInterpolatorUpdateContext &context) const;
   TransformOperations interpolateOperations(
-      const ShadowNode::Shared &shadowNode,
       double keyframeProgress,
       const TransformOperations &fromOperations,
-      const TransformOperations &toOperations) const;
+      const TransformOperations &toOperations,
+      const PropertyInterpolatorUpdateContext &context) const;
 
   static folly::dynamic convertResultToDynamic(
       const TransformOperations &operations);
-  TransformInterpolatorUpdateContext createUpdateContext(
-      const ShadowNode::Shared &shadowNode) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
@@ -33,10 +33,12 @@ class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
     return fromValue.interpolate(
         progress,
         toValue,
-        {.node = context.node,
-         .viewStylesRepository = context.viewStylesRepository,
-         .relativeProperty = relativeProperty_,
-         .relativeTo = relativeTo_});
+        {
+            .node = context.node,
+            .viewStylesRepository = context.viewStylesRepository,
+            .relativeTo = relativeTo_,
+            .relativeProperty = relativeProperty_,
+        });
   }
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
@@ -29,7 +29,7 @@ class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
       double progress,
       const ValueType &fromValue,
       const ValueType &toValue,
-      const ValueInterpolatorUpdateContext &context) const override {
+      const PropertyInterpolatorUpdateContext &context) const override {
     return fromValue.interpolate(
         progress,
         toValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
@@ -17,13 +17,9 @@ class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
   ResolvableValueInterpolator(
       const PropertyPath &propertyPath,
       const ValueType &defaultStyleValue,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
       RelativeTo relativeTo,
       std::string relativeProperty)
-      : ValueInterpolator<AllowedTypes...>(
-            propertyPath,
-            defaultStyleValue,
-            viewStylesRepository),
+      : ValueInterpolator<AllowedTypes...>(propertyPath, defaultStyleValue),
         relativeTo_(relativeTo),
         relativeProperty_(std::move(relativeProperty)) {}
   virtual ~ResolvableValueInterpolator() = default;
@@ -38,7 +34,7 @@ class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
         progress,
         toValue,
         {.node = context.node,
-         .viewStylesRepository = this->viewStylesRepository_,
+         .viewStylesRepository = context.viewStylesRepository,
          .relativeProperty = relativeProperty_,
          .relativeTo = relativeTo_});
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -12,6 +12,7 @@ namespace reanimated::css {
 
 struct ValueInterpolatorUpdateContext {
   const ShadowNode::Shared &node;
+  const std::shared_ptr<ViewStylesRepository> &viewStylesRepository;
 };
 
 template <typename TValue>
@@ -35,9 +36,8 @@ class ValueInterpolator : public PropertyInterpolator {
 
   explicit ValueInterpolator(
       const PropertyPath &propertyPath,
-      const ValueType &defaultStyleValue,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      : PropertyInterpolator(propertyPath, viewStylesRepository),
+      const ValueType &defaultStyleValue)
+      : PropertyInterpolator(propertyPath),
         defaultStyleValue_(defaultStyleValue) {}
   virtual ~ValueInterpolator() = default;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -2,6 +2,10 @@
 
 namespace reanimated::css {
 
+CSSAnimationsRegistry::CSSAnimationsRegistry(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
+    : viewStylesRepository_(viewStylesRepository) {}
+
 bool CSSAnimationsRegistry::isEmpty() const {
   // The registry is empty if has no registered animations and no updates
   // stored in the updates registry
@@ -186,7 +190,7 @@ void CSSAnimationsRegistry::updateViewAnimations(
     }
 
     bool updatesAddedToBatch = false;
-    const auto updates = animation->update(timestamp);
+    const auto updates = animation->update(timestamp, viewStylesRepository_);
     const auto newState = animation->getState(timestamp);
 
     if (newState == AnimationProgressState::Finished) {
@@ -195,8 +199,10 @@ void CSSAnimationsRegistry::updateViewAnimations(
       if (addToBatch && !animation->hasForwardsFillMode()) {
         //  We also have to manually commit style values
         // reverting the changes applied by the animation.
-        hasUpdates =
-            addStyleUpdates(result, animation->getResetStyle(), false) ||
+        hasUpdates = addStyleUpdates(
+                         result,
+                         animation->getResetStyle(viewStylesRepository_),
+                         false) ||
             hasUpdates;
         updatesAddedToBatch = true;
         // We want to remove style changes applied by the animation that is
@@ -284,7 +290,7 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(
         // Animation is finished and has fill forwards fill mode
         (currentState == AnimationProgressState::Finished &&
          animation->hasForwardsFillMode())) {
-      style = animation->getCurrentInterpolationStyle();
+      style = animation->getCurrentInterpolationStyle(viewStylesRepository_);
     }
 
     if (!shadowNode) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
@@ -24,6 +24,9 @@ class CSSAnimationsRegistry
     : public UpdatesRegistry,
       std::enable_shared_from_this<CSSAnimationsRegistry> {
  public:
+  CSSAnimationsRegistry(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+
   using SettingsUpdates =
       std::vector<std::pair<size_t, PartialCSSAnimationSettings>>;
 
@@ -59,6 +62,8 @@ class CSSAnimationsRegistry
   RunningAnimationIndicesMap runningAnimationIndicesMap_;
   AnimationsToRevertMap animationsToRevertMap_;
   DelayedItemsManager<std::shared_ptr<CSSAnimation>> delayedAnimationsManager_;
+
+  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 
   CSSAnimationsVector buildAnimationsVector(
       jsi::Runtime &rt,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSTransitionsRegistry.h
@@ -22,6 +22,7 @@ class CSSTransitionsRegistry
  public:
   CSSTransitionsRegistry(
       const std::shared_ptr<StaticPropsRegistry> &staticPropsRegistry,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
       const GetAnimationTimestampFunction &getCurrentTimestamp);
 
   bool isEmpty() const override;
@@ -38,7 +39,7 @@ class CSSTransitionsRegistry
 
   const GetAnimationTimestampFunction &getCurrentTimestamp_;
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
-
+  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   Registry registry_;
 
   std::unordered_set<Tag> runningTransitionTags_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.cpp
@@ -5,8 +5,7 @@ namespace reanimated::css {
 std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     const std::string &propertyName,
     const PropertyPath &propertyPath,
-    const InterpolatorFactoriesRecord &factories,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
+    const InterpolatorFactoriesRecord &factories) {
   auto it = factories.find(propertyName);
 
   if (it == factories.cend()) {
@@ -18,19 +17,17 @@ std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
   PropertyPath newPath = propertyPath;
   newPath.emplace_back(propertyName);
 
-  return it->second->create(newPath, viewStylesRepository);
+  return it->second->create(newPath);
 }
 
 std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     size_t arrayIndex,
     const PropertyPath &propertyPath,
-    const InterpolatorFactoriesArray &factories,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
+    const InterpolatorFactoriesArray &factories) {
   PropertyPath newPath = propertyPath;
   newPath.emplace_back(std::to_string(arrayIndex));
 
-  return factories[arrayIndex % factories.size()]->create(
-      newPath, viewStylesRepository);
+  return factories[arrayIndex % factories.size()]->create(newPath);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/interpolators.h
@@ -11,13 +11,11 @@ namespace reanimated::css {
 std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     const std::string &propertyName,
     const PropertyPath &propertyPath,
-    const InterpolatorFactoriesRecord &factories,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+    const InterpolatorFactoriesRecord &factories);
 
 std::shared_ptr<PropertyInterpolator> createPropertyInterpolator(
     size_t arrayIndex,
     const PropertyPath &propertyPath,
-    const InterpolatorFactoriesArray &factories,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+    const InterpolatorFactoriesArray &factories);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -234,11 +234,11 @@ class ReanimatedModuleProxy
 
   const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
+  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;
   const std::shared_ptr<CSSTransitionsRegistry> cssTransitionsRegistry_;
-  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<OperationsLoop> operationsLoop_;
 
   std::unordered_set<std::string>


### PR DESCRIPTION
## Summary

This PR removes `ViewStylesRepository` from constructor parameters lists in `CSSTransition` and `CSSAnimation`. I want to get rid of the `ViewStylesRepository` entirely in the future and replace it with the custom shadow node usage. All the necessary methods to get node/style prop should be available via the `ReanimatedShadowNode`. 