### PR TITLE
fix: useAnimatedRef returns wrong tag on ref attach

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -49,10 +49,11 @@ export function useAnimatedRef<
   const ref = useRef<AnimatedRef<TComponent> | null>(null);
 
   if (!ref.current) {
+    /** Called by React when ref is attached to a component. */
     const fun: AnimatedRef<TComponent> = <AnimatedRef<TComponent>>((
       component
     ) => {
-      // enters when ref is set by attaching to a component
+      let initialTag: ShadowNodeWrapper | null = null;
       if (component) {
         const getTagOrShadowNodeWrapper = () => {
           return IS_WEB
@@ -62,16 +63,16 @@ export function useAnimatedRef<
               );
         };
 
-        tag.value = getTagOrShadowNodeWrapper() as ShadowNodeWrapper;
+        initialTag = getTagOrShadowNodeWrapper();
+        tag.value = initialTag;
 
-        // On Fabric we have to unwrap the tag from the shadow node wrapper
-        // TODO: remove casting
+        // We have to unwrap the tag from the shadow node wrapper.
         fun.getTag = () =>
           findNodeHandle(getComponentOrScrollable(component) as Component)!;
 
         fun.current = component;
       }
-      return tag.value;
+      return initialTag;
     });
 
     fun.current = null;


### PR DESCRIPTION
## Summary

Fixing a bug where `useAnimatedRef` would return `null` tag even though the tag was obtained, reported in #7449. The issue probably stems from Shared Value read/write refactor where this change should be included.

Also fixing unnecessary reads of `.value`.

## Test plan

Run examples that use `useAnimatedRef`, like PinExample and see that they work properly.
