### PR TITLE
chore: Separate css progress updates from frame props calculation

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -40,8 +40,8 @@ double CSSAnimation::getStartTimestamp(const double timestamp) const {
   return progressProvider_->getStartTimestamp(timestamp);
 }
 
-AnimationProgressState CSSAnimation::getState(double timestamp) const {
-  return progressProvider_->getState(timestamp);
+AnimationProgressState CSSAnimation::getState() const {
+  return progressProvider_->getState();
 }
 
 bool CSSAnimation::isReversed() const {
@@ -65,42 +65,35 @@ folly::dynamic CSSAnimation::getBackwardsFillStyle() const {
                       : styleInterpolator_->getFirstKeyframeValue();
 }
 
-folly::dynamic CSSAnimation::getCurrentInterpolationStyle(
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
-  return styleInterpolator_->interpolate(
-      getUpdateContext(viewStylesRepository));
-}
-
 folly::dynamic CSSAnimation::getResetStyle(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   return styleInterpolator_->getResetStyle(
       getUpdateContext(viewStylesRepository));
 }
 
-void CSSAnimation::run(const double timestamp) {
-  if (progressProvider_->getState(timestamp) ==
-      AnimationProgressState::Finished) {
-    return;
-  }
-  progressProvider_->play(timestamp);
-}
-
-folly::dynamic CSSAnimation::update(
-    const double timestamp,
-    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
-  progressProvider_->update(timestamp);
-
+folly::dynamic CSSAnimation::getCurrentFrameProps(
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   // Check if the animation has not started yet because of the delay
   // (In general, it shouldn't be activated until the delay has passed but we
   // add this check to make sure that animation doesn't start with the negative
   // progress)
-  if (progressProvider_->getState(timestamp) ==
-      AnimationProgressState::Pending) {
+  if (progressProvider_->getState() == AnimationProgressState::Pending) {
     return hasBackwardsFillMode() ? getBackwardsFillStyle() : folly::dynamic();
   }
 
   return styleInterpolator_->interpolate(
       getUpdateContext(viewStylesRepository));
+}
+
+void CSSAnimation::run(const double timestamp) {
+  if (progressProvider_->getState() == AnimationProgressState::Finished) {
+    return;
+  }
+  progressProvider_->play(timestamp);
+}
+
+void CSSAnimation::update(const double timestamp) {
+  progressProvider_->update(timestamp);
 }
 
 void CSSAnimation::updateSettings(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -26,25 +26,23 @@ class CSSAnimation {
   ShadowNode::Shared getShadowNode() const;
 
   double getStartTimestamp(double timestamp) const;
-  AnimationProgressState getState(double timestamp) const;
+  AnimationProgressState getState() const;
   bool isReversed() const;
 
   bool hasForwardsFillMode() const;
   bool hasBackwardsFillMode() const;
 
   folly::dynamic getBackwardsFillStyle() const;
-  folly::dynamic getCurrentInterpolationStyle(
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
   folly::dynamic getResetStyle(
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
+  folly::dynamic getCurrentFrameProps(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
-  void run(double timestamp);
-  folly::dynamic update(
-      double timestamp,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
   void updateSettings(
       const PartialCSSAnimationSettings &updatedSettings,
       double timestamp);
+  void run(double timestamp);
+  void update(double timestamp);
 
  private:
   const std::string name_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -22,22 +22,19 @@ class CSSTransition {
   ShadowNode::Shared getShadowNode() const;
   double getMinDelay(double timestamp) const;
   TransitionProgressState getState() const;
-  folly::dynamic getCurrentInterpolationStyle(
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
   TransitionProperties getProperties() const;
   PropertyNames getAllowedProperties(
       const folly::dynamic &oldProps,
       const folly::dynamic &newProps);
+  folly::dynamic getCurrentFrameProps(
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
   void updateSettings(const PartialCSSTransitionConfig &config);
-  folly::dynamic run(
+  void run(
       double timestamp,
       const ChangedProps &changedProps,
-      const folly::dynamic &lastUpdateValue,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
-  folly::dynamic update(
-      double timestamp,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
+      const folly::dynamic &lastUpdateValue);
+  void update(double timestamp);
 
  private:
   const ShadowNode::Shared shadowNode_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -37,11 +37,7 @@ double AnimationProgressProvider::getGlobalProgress() const {
   return applyAnimationDirection(rawProgress_.value_or(0));
 }
 
-AnimationProgressState AnimationProgressProvider::getState(
-    const double timestamp) const {
-  if (shouldFinish(timestamp)) {
-    return AnimationProgressState::Finished;
-  }
+AnimationProgressState AnimationProgressProvider::getState() const {
   if (pauseTimestamp_ > 0) {
     return AnimationProgressState::Paused;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -41,7 +41,7 @@ AnimationProgressState AnimationProgressProvider::getState() const {
   if (pauseTimestamp_ > 0) {
     return AnimationProgressState::Paused;
   }
-  if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
+  if (!rawProgress_.has_value()) {
     return AnimationProgressState::Pending;
   }
   const auto rawProgress = rawProgress_.value();
@@ -120,21 +120,21 @@ bool AnimationProgressProvider::shouldFinish(const double timestamp) const {
 
 std::optional<double> AnimationProgressProvider::calculateRawProgress(
     const double timestamp) {
-  const double currentIterationElapsedTime = timestamp -
-      (creationTimestamp_ + delay_ + previousIterationsDuration_ +
-       getTotalPausedTime(timestamp));
+  const auto startTimestamp = getStartTimestamp(timestamp);
 
-  if (currentIterationElapsedTime < 0) {
+  if (timestamp < startTimestamp) {
     return std::nullopt;
   }
 
-  const double iterationProgress =
+  const auto currentIterationElapsedTime =
+      timestamp - (startTimestamp + previousIterationsDuration_);
+  const auto iterationProgress =
       updateIterationProgress(currentIterationElapsedTime);
 
   if (shouldFinish(timestamp)) {
     // Override current progress for the last update in the last iteration to
     // ensure that animation finishes exactly at the specified iteration
-    const double intPart = std::floor(iterationCount_);
+    const auto intPart = std::floor(iterationCount_);
     return intPart == iterationCount_ ? 1 : iterationCount_ - intPart;
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -37,7 +37,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
   AnimationDirection getDirection() const;
   double getGlobalProgress() const override;
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
-  AnimationProgressState getState(double timestamp) const;
+  AnimationProgressState getState() const;
   double getPauseTimestamp() const;
   double getTotalPausedTime(double timestamp) const;
   double getStartTimestamp(double timestamp) const;


### PR DESCRIPTION
## Summary

This PR separates CSS animation and transition progress updates from the frame props calculation. This change is needed because we don't want to update the progress of the animation/transition while reading the current frame props in our custom shadow node implementation.