### PR TITLE
chore: Remove ShadowNode from CSSAnimation dependencies

### DIFF
--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -12,7 +12,7 @@ ReanimatedShadowNode::ReanimatedShadowNode(
   const auto &newProps =
       static_cast<const ReanimatedViewProps &>(*this->getProps());
   const auto &state = getStateData();
-  state.cssAnimationsManager->update(ReanimatedViewProps(), newProps);
+  state.cssAnimationsManager->update(newProps);
 }
 
 ReanimatedShadowNode::ReanimatedShadowNode(
@@ -33,7 +33,7 @@ ReanimatedShadowNode::ReanimatedShadowNode(
 
   const auto &state = getStateData();
   state.cssTransitionManager->update(oldProps, newProps);
-  state.cssAnimationsManager->update(oldProps, newProps);
+  state.cssAnimationsManager->update(newProps);
 }
 
 void ReanimatedShadowNode::layout(LayoutContext layoutContext) {

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.cpp
@@ -18,9 +18,7 @@ folly::dynamic CSSAnimationsManager::getCurrentFrameProps(
   return folly::dynamic::object();
 }
 
-void CSSAnimationsManager::update(
-    const ReanimatedViewProps &oldProps,
-    const ReanimatedViewProps &newProps) {
+void CSSAnimationsManager::update(const ReanimatedViewProps &newProps) {
   // TODO - implement
   // LOG(INFO) << "CSSAnimationsManager::update: " << oldProps.cssAnimations <<
   // " "

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
@@ -2,8 +2,8 @@
 
 #include <react/renderer/components/rnreanimated/Props.h>
 
-#include <reanimated/CSS/config/CSSTransitionConfig.h>
-#include <reanimated/CSS/core/CSSTransition.h>
+#include <reanimated/CSS/config/CSSAnimationConfig.h>
+#include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/Fabric/operations/OperationsLoop.h>
 
 #include <folly/dynamic.h>
@@ -24,11 +24,11 @@ class CSSAnimationsManager {
 
   folly::dynamic getCurrentFrameProps(const ShadowNode::Shared &shadowNode);
 
-  void update(
-      const ReanimatedViewProps &oldProps,
-      const ReanimatedViewProps &newProps);
+  void update(const ReanimatedViewProps &newProps);
 
  private:
+  std::vector<CSSAnimation> animations_;
+
   std::shared_ptr<OperationsLoop> operationsLoop_;
   std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 };

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
@@ -8,6 +8,8 @@
 
 #include <folly/dynamic.h>
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace facebook::react {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -6,13 +6,11 @@ namespace reanimated::css {
 
 CSSAnimation::CSSAnimation(
     jsi::Runtime &rt,
-    ShadowNode::Shared shadowNode,
     std::string name,
     const CSSKeyframesConfig &keyframesConfig,
     const CSSAnimationSettings &settings,
     const double timestamp)
     : name_(std::move(name)),
-      shadowNode_(std::move(shadowNode)),
       fillMode_(settings.fillMode),
       progressProvider_(std::make_shared<AnimationProgressProvider>(
           timestamp,
@@ -30,10 +28,6 @@ CSSAnimation::CSSAnimation(
 
 const std::string &CSSAnimation::getName() const {
   return name_;
-}
-
-ShadowNode::Shared CSSAnimation::getShadowNode() const {
-  return shadowNode_;
 }
 
 double CSSAnimation::getStartTimestamp(const double timestamp) const {
@@ -66,12 +60,14 @@ folly::dynamic CSSAnimation::getBackwardsFillStyle() const {
 }
 
 folly::dynamic CSSAnimation::getResetStyle(
+    const ShadowNode::Shared &shadowNode,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   return styleInterpolator_->getResetStyle(
-      getUpdateContext(viewStylesRepository));
+      getUpdateContext(shadowNode, viewStylesRepository));
 }
 
 folly::dynamic CSSAnimation::getCurrentFrameProps(
+    const ShadowNode::Shared &shadowNode,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   // Check if the animation has not started yet because of the delay
   // (In general, it shouldn't be activated until the delay has passed but we
@@ -82,7 +78,7 @@ folly::dynamic CSSAnimation::getCurrentFrameProps(
   }
 
   return styleInterpolator_->interpolate(
-      getUpdateContext(viewStylesRepository));
+      getUpdateContext(shadowNode, viewStylesRepository));
 }
 
 void CSSAnimation::run(const double timestamp) {
@@ -133,9 +129,10 @@ void CSSAnimation::updateSettings(
 }
 
 PropertyInterpolatorUpdateContext CSSAnimation::getUpdateContext(
+    const ShadowNode::Shared &shadowNode,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
   return PropertyInterpolatorUpdateContext{
-      .node = shadowNode_,
+      .node = shadowNode,
       .progressProvider = progressProvider_,
       .viewStylesRepository = viewStylesRepository,
   };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -16,14 +16,12 @@ class CSSAnimation {
  public:
   CSSAnimation(
       jsi::Runtime &rt,
-      ShadowNode::Shared shadowNode,
       std::string name,
       const CSSKeyframesConfig &keyframesConfig,
       const CSSAnimationSettings &settings,
       double timestamp);
 
   const std::string &getName() const;
-  ShadowNode::Shared getShadowNode() const;
 
   double getStartTimestamp(double timestamp) const;
   AnimationProgressState getState() const;
@@ -34,8 +32,10 @@ class CSSAnimation {
 
   folly::dynamic getBackwardsFillStyle() const;
   folly::dynamic getResetStyle(
+      const ShadowNode::Shared &shadowNode,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
   folly::dynamic getCurrentFrameProps(
+      const ShadowNode::Shared &shadowNode,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
   void updateSettings(
@@ -46,13 +46,13 @@ class CSSAnimation {
 
  private:
   const std::string name_;
-  const ShadowNode::Shared shadowNode_;
   AnimationFillMode fillMode_;
 
   std::shared_ptr<AnimationProgressProvider> progressProvider_;
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator_;
 
   PropertyInterpolatorUpdateContext getUpdateContext(
+      const ShadowNode::Shared &shadowNode,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.h
@@ -53,6 +53,7 @@ class CSSAnimationsRegistry
   struct RegistryEntry {
     const CSSAnimationsVector animationsVector;
     const AnimationToIndexMap animationToIndexMap;
+    const ShadowNode::Shared shadowNode;
   };
 
   using Registry = std::unordered_map<Tag, RegistryEntry>;
@@ -61,7 +62,8 @@ class CSSAnimationsRegistry
 
   RunningAnimationIndicesMap runningAnimationIndicesMap_;
   AnimationsToRevertMap animationsToRevertMap_;
-  DelayedItemsManager<std::shared_ptr<CSSAnimation>> delayedAnimationsManager_;
+  DelayedItemsManager<std::shared_ptr<CSSAnimation>, Tag>
+      delayedAnimationsManager_;
 
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 
@@ -78,16 +80,19 @@ class CSSAnimationsRegistry
       double timestamp);
 
   void updateViewAnimations(
-      Tag viewTag,
+      const ShadowNode::Shared &shadowNode,
       const std::vector<size_t> &animationIndices,
       double timestamp,
       bool addToBatch);
   void scheduleOrActivateAnimation(
+      Tag viewTag,
       size_t animationIndex,
       const std::shared_ptr<CSSAnimation> &animation,
       double timestamp);
   void removeViewAnimations(Tag viewTag);
-  void applyViewAnimationsStyle(Tag viewTag, double timestamp);
+  void applyViewAnimationsStyle(
+      const ShadowNode::Shared &shadowNode,
+      double timestamp);
   void activateDelayedAnimations(double timestamp);
   void handleAnimationsToRevert(double timestamp);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -509,7 +509,6 @@ void ReanimatedModuleProxy::applyCSSAnimations(
       const auto &name = animationNames[index];
       const auto animation = std::make_shared<CSSAnimation>(
           rt,
-          shadowNode,
           name,
           cssAnimationKeyframesRegistry_->get(name),
           settings,


### PR DESCRIPTION
## Summary

This PR removes the shadow node instance stored in the `CSSAnimation` props. This is needed as we won't store the shadow node in the animation itself anymore. We are getting this instance when the node is cloned and can simply pass it via props to calculate the current animation frame.