### PR TITLE
fix: use jest if it is available

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -14,14 +14,16 @@ import type { DefaultStyle } from './hook/commonTypes';
 import { isJest } from './PlatformChecker';
 
 // Mock ReanimatedView
-jest.mock(
-  'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
-  () => ({})
-);
-jest.mock(
-  'react-native-reanimated/src/specs/ReanimatedNativeComponent',
-  () => ({})
-);
+if (isJest()) {
+  jest.mock(
+    'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
+    () => ({})
+  );
+  jest.mock(
+    'react-native-reanimated/src/specs/ReanimatedNativeComponent',
+    () => ({})
+  );
+}
 
 declare global {
   namespace jest {

--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -13,18 +13,6 @@ import { ReanimatedError } from './errors';
 import type { DefaultStyle } from './hook/commonTypes';
 import { isJest } from './PlatformChecker';
 
-// Mock ReanimatedView
-if (isJest()) {
-  jest.mock(
-    'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
-    () => ({})
-  );
-  jest.mock(
-    'react-native-reanimated/src/specs/ReanimatedNativeComponent',
-    () => ({})
-  );
-}
-
 declare global {
   namespace jest {
     interface Matchers<R> {
@@ -300,6 +288,15 @@ type ToHaveAnimatedStyleConfig = {
 };
 
 export const setUpTests = (userFramerateConfig = {}) => {
+  // Mock ReanimatedView
+  jest.mock(
+    'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
+    () => ({})
+  );
+  jest.mock(
+    'react-native-reanimated/src/specs/ReanimatedNativeComponent',
+    () => ({})
+  );
   let expect: jest.Expect = (global as typeof global & { expect: jest.Expect })
     .expect;
   if (expect === undefined) {


### PR DESCRIPTION
## Summary

`jest` was used in the global scope and it failed when using that code with Expo SDK 53, probably their setup does not expose `jest` in basic configuration.

## Test plan
