### PR TITLE
refactor(Worklets)(makeShareableClone): add makeShareableString

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
@@ -9,12 +9,12 @@ export default function ShareablesExample() {
     <View style={styles.container}>
       <View style={styles.statusInfoBox}>
         <View style={styles.statusInfoRow}>
-          <Text style={styles.statusInfoText}>🟢 - ok</Text>
-          <Text style={styles.statusInfoText}>🚫 - error</Text>
+          <Text style={styles.statusInfoText}>🟢 - Ok</Text>
+          <Text style={styles.statusInfoText}>🚫 - Throws</Text>
         </View>
         <View style={styles.statusInfoRow}>
-          <Text style={styles.statusInfoText}>🔴 - not_ok</Text>
-          <Text style={styles.statusInfoText}>⚪ - not_checked</Text>
+          <Text style={styles.statusInfoText}>🔴 - Failed</Text>
+          <Text style={styles.statusInfoText}>⚪ - Pending</Text>
         </View>
       </View>
 

--- a/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
@@ -97,10 +97,10 @@ function StringDemo() {
   const expectedStatus: Status = 'ok';
 
   const handlePress = () => {
+    const testString = 'test';
     runOnUI(() => {
       'worklet';
       try {
-        const testString = 'test';
         if (testString === 'test') {
           runOnJS(isOk)();
         } else {

--- a/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ShareablesExample.tsx
@@ -1,10 +1,32 @@
-import React from 'react';
-import { Button, StyleSheet, View } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { runOnJS, runOnUI } from 'react-native-reanimated';
+
+type Status = 'ok' | 'not_ok' | 'error' | undefined;
 
 export default function ShareablesExample() {
   return (
     <View style={styles.container}>
+      <View style={styles.statusInfoBox}>
+        <View style={styles.statusInfoRow}>
+          <Text style={styles.statusInfoText}>🟢 - ok</Text>
+          <Text style={styles.statusInfoText}>🚫 - error</Text>
+        </View>
+        <View style={styles.statusInfoRow}>
+          <Text style={styles.statusInfoText}>🔴 - not_ok</Text>
+          <Text style={styles.statusInfoText}>⚪ - not_checked</Text>
+        </View>
+      </View>
+
+      <View style={styles.headerRow}>
+        <Text style={[styles.headerText, styles.columnTestCase]}>
+          Test Case
+        </Text>
+        <Text style={[styles.headerText, styles.columnExpected]}>Expected</Text>
+        <Text style={[styles.headerText, styles.columnActual]}>Actual</Text>
+      </View>
+
+      <StringDemo />
       <CyclicObjectDemo />
       <InaccessibleObjectDemo />
       <RemoteNamedFunctionSyncCallDemo />
@@ -19,93 +41,279 @@ export default function ShareablesExample() {
   );
 }
 
-function CyclicObjectDemo() {
+function useStatus() {
+  const [status, setStatus] = useState<Status>(undefined);
+  const isOk = () => setStatus('ok');
+  const isNotOk = () => setStatus('not_ok');
+  const isError = () => setStatus('error');
+  return { status, isOk, isNotOk, isError };
+}
+
+interface DemoItemRowProps {
+  title: string;
+  onPress: () => void;
+  status: Status;
+  expected: Status;
+}
+
+const DemoItemRow: React.FC<DemoItemRowProps> = ({
+  title,
+  onPress,
+  status,
+  expected,
+}) => {
+  return (
+    <View style={styles.demoRow}>
+      <TouchableOpacity
+        onPress={onPress}
+        style={styles.clickableTitleContainer}>
+        <Text style={styles.titleText}>{title}</Text>
+      </TouchableOpacity>
+      <View style={styles.expectedContainer}>
+        <Status status={expected} />
+      </View>
+      <View style={styles.statusContainer}>
+        <Status status={status} />
+      </View>
+    </View>
+  );
+};
+
+function Status({ status }: { status: Status }) {
+  const emoji =
+    status === 'ok'
+      ? '🟢'
+      : status === 'not_ok'
+        ? '🔴'
+        : status === 'error'
+          ? '🚫'
+          : '⚪';
+  return <Text style={styles.statusTextIcon}>{emoji}</Text>;
+}
+
+function StringDemo() {
+  const title = 'String';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
-    type RecursiveArray = (number | RecursiveArray)[];
-    const x: RecursiveArray = [];
-    x.push(1);
-    x.push(x);
     runOnUI(() => {
-      console.log(x);
+      'worklet';
+      try {
+        const testString = 'test';
+        if (testString === 'test') {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
+}
 
-  return <Button title="Cyclic object" onPress={handlePress} />;
+function CyclicObjectDemo() {
+  const title = 'Cyclic object';
+  const { status, isOk, isError } = useStatus();
+  const expectedStatus: Status = 'error';
+
+  const handlePress = () => {
+    try {
+      type RecursiveArray = (number | RecursiveArray)[];
+      const x: RecursiveArray = [];
+      x.push(1);
+      x.push(x);
+      runOnUI(() => {
+        'worklet';
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const _test = x[1];
+          runOnJS(isOk)();
+        } catch (e) {
+          runOnJS(isError)();
+        }
+      })();
+    } catch (e) {
+      runOnJS(isError)();
+    }
+  };
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function InaccessibleObjectDemo() {
+  const title = 'Inaccessible object';
+  const { status, isOk, isError } = useStatus();
+  const expectedStatus: Status = 'error';
+
   const handlePress = () => {
     const x = new Set();
     runOnUI(() => {
-      console.log(x);
-      console.log(x instanceof Set); // returns false
-      console.log(x.has(42)); // should throw error
+      'worklet';
+      try {
+        x.has(42);
+        runOnJS(isOk)();
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="Inaccessible object" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function RemoteNamedFunctionSyncCallDemo() {
+  const title = 'Remote named function sync call';
+  const { status, isOk, isError } = useStatus();
+  const expectedStatus: Status = 'error';
+
   const handlePress = () => {
     function foo() {}
     runOnUI(() => {
-      foo();
+      'worklet';
+      try {
+        foo();
+        runOnJS(isOk)();
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
   return (
-    <Button title="Remote named function sync call" onPress={handlePress} />
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
   );
 }
 
 function RemoteAnonymousFunctionSyncCallDemo() {
+  const title = 'Remote anonymous function sync call';
+  const { status, isOk, isError } = useStatus();
+  const expectedStatus: Status = 'error';
+
   const handlePress = () => {
-    // eslint-disable-next-line no-constant-condition
-    const foo = true ? () => {} : () => {};
+    const foo = () => {};
     runOnUI(() => {
-      foo();
+      'worklet';
+      try {
+        foo();
+        runOnJS(isOk)();
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
   return (
-    <Button title="Remote anonymous function sync call" onPress={handlePress} />
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
   );
 }
 
 function BigIntDemo() {
+  const title = 'BigInt';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const bigint = BigInt('1234567890');
     runOnUI(() => {
-      console.log(bigint === BigInt('1234567890'));
-      console.log(typeof bigint === 'bigint');
+      'worklet';
+      try {
+        const checks = [
+          bigint === BigInt('1234567890'),
+          typeof bigint === 'bigint',
+        ];
+        if (checks.every(Boolean)) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="BigInt" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function ArrayBufferDemo() {
+  const title = 'ArrayBuffer';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const ab = new ArrayBuffer(8);
     const ta = new Uint8Array(ab);
     ta[7] = 42;
-    function after() {
-      console.log(ta[7] === 42);
-    }
+
     runOnUI(() => {
-      console.log(ab instanceof ArrayBuffer);
-      const ta = new Uint8Array(ab);
-      console.log(ta[7] === 42);
-      ta[7] = 123;
-      runOnJS(after)();
+      'worklet';
+      try {
+        const isArrayBufferInstance = ab instanceof ArrayBuffer;
+        const taUi = new Uint8Array(ab);
+        const initialValueCheck = taUi[7] === 42;
+        taUi[7] = 123;
+
+        if (isArrayBufferInstance && initialValueCheck) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="ArrayBuffer" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function TypedArrayDemo() {
+  const title = 'TypedArray';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const ta1 = new Int8Array(100);
     const ta2 = new Uint8Array(100);
@@ -116,7 +324,6 @@ function TypedArrayDemo() {
     const ta7 = new Uint32Array(100);
     const ta8 = new Float32Array(100);
     const ta9 = new Float64Array(100);
-
     ta1[99] = -123;
     ta2[99] = 123;
     ta3[99] = 999;
@@ -128,86 +335,242 @@ function TypedArrayDemo() {
     ta9[99] = 12345.6789;
 
     runOnUI(() => {
-      console.log(ta1 instanceof Int8Array);
-      console.log(ta2 instanceof Uint8Array);
-      console.log(ta3 instanceof Uint8ClampedArray);
-      console.log(ta4 instanceof Int16Array);
-      console.log(ta5 instanceof Uint16Array);
-      console.log(ta6 instanceof Int32Array);
-      console.log(ta7 instanceof Uint32Array);
-      console.log(ta8 instanceof Float32Array);
-      console.log(ta9 instanceof Float64Array);
-
-      console.log(ta1[99] === -123);
-      console.log(ta2[99] === 123);
-      console.log(ta3[99] === 255);
-      console.log(ta4[99] === -12345);
-      console.log(ta5[99] === 12345);
-      console.log(ta6[99] === -123456789);
-      console.log(ta7[99] === 123456789);
-      console.log(Math.abs(ta8[99] - 123.45) < 1e-5);
-      console.log(Math.abs(ta9[99] - 12345.6789) < 1e-5);
+      'worklet';
+      try {
+        const checks = [
+          ta1 instanceof Int8Array,
+          ta2 instanceof Uint8Array,
+          ta3 instanceof Uint8ClampedArray,
+          ta4 instanceof Int16Array,
+          ta5 instanceof Uint16Array,
+          ta6 instanceof Int32Array,
+          ta7 instanceof Uint32Array,
+          ta8 instanceof Float32Array,
+          ta9 instanceof Float64Array,
+          ta1[99] === -123,
+          ta2[99] === 123,
+          ta3[99] === 255,
+          ta4[99] === -12345,
+          ta5[99] === 12345,
+          ta6[99] === -123456789,
+          ta7[99] === 123456789,
+          Math.abs(ta8[99] - 123.45) < 1e-5,
+          Math.abs(ta9[99] - 12345.6789) < 1e-5,
+        ];
+        if (checks.every(Boolean)) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="TypedArray" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function BigIntTypedArrayDemo() {
+  const title = 'BigIntTypedArray';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const ta1 = new BigInt64Array(100);
     const ta2 = new BigUint64Array(100);
-
-    // BigInt literals are not available when targeting lower than ES2020
     ta1[99] = BigInt('-1234567890');
     ta2[99] = BigInt('1234567890');
 
     runOnUI(() => {
-      console.log(ta1 instanceof BigInt64Array);
-      console.log(ta2 instanceof BigUint64Array);
-
-      console.log(ta1[99] === BigInt('-1234567890'));
-      console.log(ta2[99] === BigInt('1234567890'));
+      'worklet';
+      try {
+        const checks = [
+          ta1 instanceof BigInt64Array,
+          ta2 instanceof BigUint64Array,
+          ta1[99] === BigInt('-1234567890'),
+          ta2[99] === BigInt('1234567890'),
+        ];
+        if (checks.every(Boolean)) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="BigIntTypedArray" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function DataViewDemo() {
+  const title = 'DataView';
+  const { status, isOk, isNotOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const buffer = new ArrayBuffer(16);
     const dv = new DataView(buffer);
     dv.setInt16(7, 12345);
+
     runOnUI(() => {
-      console.log(dv instanceof DataView);
-      console.log(dv.getInt16(7) === 12345);
+      'worklet';
+      try {
+        const checks = [dv instanceof DataView, dv.getInt16(7) === 12345];
+        if (checks.every(Boolean)) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isNotOk)();
+        }
+      } catch (e) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="DataView" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 function ErrorDemo() {
+  const title = 'Error';
+  const { status, isOk, isError } = useStatus();
+  const expectedStatus: Status = 'ok';
+
   const handlePress = () => {
     const e = new Error('error message');
-    console.log(_WORKLET ? 'UI' : 'RN', e instanceof Error);
-    console.log(_WORKLET ? 'UI' : 'RN', String(e));
-    console.log(_WORKLET ? 'UI' : 'RN', e.stack?.length);
     runOnUI(() => {
-      console.log(_WORKLET ? 'UI' : 'RN', e instanceof Error);
-      console.log(_WORKLET ? 'UI' : 'RN', String(e));
-      console.log(_WORKLET ? 'UI' : 'RN', e.stack?.length);
+      'worklet';
+      try {
+        const checks = [
+          e instanceof Error,
+          String(e).includes('error message'),
+          global._WORKLET,
+        ];
+        if (checks.every(Boolean)) {
+          runOnJS(isOk)();
+        } else {
+          runOnJS(isError)();
+        }
+      } catch (err) {
+        runOnJS(isError)();
+      }
     })();
   };
-
-  return <Button title="Error" onPress={handlePress} />;
+  return (
+    <DemoItemRow
+      title={title}
+      onPress={handlePress}
+      status={status}
+      expected={expectedStatus}
+    />
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    padding: 10,
+  },
+  statusInfoBox: {
+    justifyContent: 'center',
+    gap: 5,
+    flexDirection: 'column',
+    padding: 10,
+    borderWidth: 1,
+    borderColor: 'black',
+    borderRadius: 10,
+    marginBottom: 20,
+  },
+  statusInfoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    width: '100%',
+  },
+  statusInfoText: {
+    fontSize: 18,
+    textAlign: 'left',
+    width: '50%',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    paddingVertical: 8,
+    paddingHorizontal: 5,
+    borderBottomWidth: 2,
+    borderBottomColor: '#333',
+    backgroundColor: '#f0f0f0',
+    marginBottom: 5,
+  },
+  headerText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    textAlign: 'left',
+  },
+  demoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    paddingVertical: 12,
+    paddingHorizontal: 5,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  columnTestCase: {
+    width: '60%',
+    paddingRight: 5,
+  },
+  columnExpected: {
+    width: '20%',
+    textAlign: 'center',
+  },
+  columnActual: {
+    width: '20%',
+    textAlign: 'center',
+  },
+  clickableTitleContainer: {
+    width: '60%',
+    justifyContent: 'center',
+    paddingRight: 5,
+  },
+  titleText: {
+    fontSize: 16,
+    color: '#007AFF',
+    textAlign: 'left',
+  },
+  expectedContainer: {
+    width: '20%',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  statusContainer: {
+    width: '20%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusTextIcon: {
+    fontSize: 20,
+    fontWeight: 'bold',
   },
 });

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -66,6 +66,12 @@ jsi::Value WorkletsModuleProxy::makeShareableClone(
       rt, value, shouldRetainRemote, nativeStateSource);
 }
 
+jsi::Value WorkletsModuleProxy::makeShareableString(
+    jsi::Runtime &rt,
+    const jsi::String &string) {
+  return worklets::makeShareableString(rt, string);
+}
+
 void WorkletsModuleProxy::scheduleOnUI(
     jsi::Runtime &rt,
     const jsi::Value &worklet) {

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -35,6 +35,9 @@ class WorkletsModuleProxy
       const jsi::Value &shouldRetainRemote,
       const jsi::Value &nativeStateSource) override;
 
+  jsi::Value makeShareableString(jsi::Runtime &rt, const jsi::String &string)
+      override;
+
   void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) override;
 
   jsi::Value executeOnUIRuntimeSync(jsi::Runtime &rt, const jsi::Value &worklet)

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.cpp
@@ -1,3 +1,4 @@
+#include <jsi/jsi.h>
 #include <worklets/NativeModules/WorkletsModuleProxySpec.h>
 
 #include <utility>
@@ -15,6 +16,15 @@ static jsi::Value WORKLETS_SPEC_PREFIX(makeShareableClone)(
   return static_cast<WorkletsModuleProxySpec *>(&turboModule)
       ->makeShareableClone(
           rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+}
+
+static jsi::Value WORKLETS_SPEC_PREFIX(makeShareableString)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<WorkletsModuleProxySpec *>(&turboModule)
+      ->makeShareableString(rt, std::move(args[0]).asString(rt));
 }
 
 static jsi::Value WORKLETS_SPEC_PREFIX(scheduleOnUI)(
@@ -59,6 +69,8 @@ WorkletsModuleProxySpec::WorkletsModuleProxySpec(
     : TurboModule("NativeWorklets", jsInvoker) {
   methodMap_["makeShareableClone"] =
       MethodMetadata{2, WORKLETS_SPEC_PREFIX(makeShareableClone)};
+  methodMap_["makeShareableString"] =
+      MethodMetadata{1, WORKLETS_SPEC_PREFIX(makeShareableString)};
   methodMap_["scheduleOnUI"] =
       MethodMetadata{1, WORKLETS_SPEC_PREFIX(scheduleOnUI)};
   methodMap_["executeOnUIRuntimeSync"] =

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
@@ -22,6 +22,10 @@ class JSI_EXPORT WorkletsModuleProxySpec : public TurboModule {
       const jsi::Value &shouldRetainRemote,
       const jsi::Value &nativeStateSource) = 0;
 
+  virtual jsi::Value makeShareableString(
+      jsi::Runtime &rt,
+      const jsi::String &string) = 0;
+
   // Scheduling
   virtual void scheduleOnUI(jsi::Runtime &rt, const jsi::Value &worklet) = 0;
 

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxySpec.h
@@ -3,6 +3,7 @@
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/TurboModule.h>
 #include <memory>
+#include <string>
 
 using namespace facebook;
 using namespace react;

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -115,6 +115,11 @@ jsi::Value makeShareableClone(
   return ShareableJSRef::newHostObject(rt, shareable);
 }
 
+jsi::Value makeShareableString(jsi::Runtime &rt, const jsi::String &string) {
+  auto shareable = std::make_shared<ShareableString>(string.utf8(rt));
+  return ShareableJSRef::newHostObject(rt, shareable);
+}
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
@@ -145,6 +145,8 @@ jsi::Value makeShareableClone(
     const jsi::Value &shouldRetainRemote,
     const jsi::Value &nativeStateSource);
 
+jsi::Value makeShareableString(jsi::Runtime &rt, const jsi::String &string);
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -97,6 +97,13 @@ void WorkletRuntimeDecorator::decorate(
 
   jsi_utils::installJsiFunction(
       rt,
+      "_makeShareableString",
+      [](jsi::Runtime &rt, const jsi::Value &value) {
+        return makeShareableString(rt, value.asString(rt));
+      });
+
+  jsi_utils::installJsiFunction(
+      rt,
       "_scheduleRemoteFunctionOnJS",
       [jsScheduler](
           jsi::Runtime &rt,

--- a/packages/react-native-worklets/src/WorkletsModule/JSWorklets.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/JSWorklets.ts
@@ -26,6 +26,12 @@ class JSWorklets implements IWorkletsModule {
     );
   }
 
+  makeShareableString(_string: string): ShareableRef<string> {
+    throw new WorkletsError(
+      'makeShareableString should never be called in JSWorklets.'
+    );
+  }
+
   scheduleOnUI<TValue>(worklet: ShareableRef<TValue>) {
     // TODO: `requestAnimationFrame` should be used exclusively in Reanimated
 

--- a/packages/react-native-worklets/src/WorkletsModule/JSWorklets.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/JSWorklets.ts
@@ -26,7 +26,7 @@ class JSWorklets implements IWorkletsModule {
     );
   }
 
-  makeShareableString(_string: string): ShareableRef<string> {
+  makeShareableString(): ShareableRef<string> {
     throw new WorkletsError(
       'makeShareableString should never be called in JSWorklets.'
     );

--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.ts
@@ -51,8 +51,8 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     );
   }
 
-  makeShareableString(string: string) {
-    return this.#workletsModuleProxy.makeShareableString(string);
+  makeShareableString(str: string) {
+    return this.#workletsModuleProxy.makeShareableString(str);
   }
 
   scheduleOnUI<TValue>(shareable: ShareableRef<TValue>) {

--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.ts
@@ -35,6 +35,7 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
         global.__workletsModuleProxy.executeOnUIRuntimeSync,
       createWorkletRuntime: global.__workletsModuleProxy.createWorkletRuntime,
       makeShareableClone: global.__workletsModuleProxy.makeShareableClone,
+      makeShareableString: global.__workletsModuleProxy.makeShareableString,
     };
   }
 
@@ -48,6 +49,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
       shouldPersistRemote,
       nativeStateSource
     );
+  }
+
+  makeShareableString(string: string) {
+    return this.#workletsModuleProxy.makeShareableString(string);
   }
 
   scheduleOnUI<TValue>(shareable: ShareableRef<TValue>) {

--- a/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
@@ -10,6 +10,8 @@ export interface WorkletsModuleProxy {
     nativeStateSource?: object
   ): ShareableRef<TValue>;
 
+  makeShareableString(string: string): ShareableRef<string>;
+
   scheduleOnUI<TValue>(shareable: ShareableRef<TValue>): void;
 
   executeOnUIRuntimeSync<TValue, TReturn>(

--- a/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
@@ -10,7 +10,7 @@ export interface WorkletsModuleProxy {
     nativeStateSource?: object
   ): ShareableRef<TValue>;
 
-  makeShareableString(string: string): ShareableRef<string>;
+  makeShareableString(str: string): ShareableRef<string>;
 
   scheduleOnUI<TValue>(shareable: ShareableRef<TValue>): void;
 

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -24,6 +24,7 @@ declare global {
     value: T,
     nativeStateSource?: object
   ) => FlatShareableRef<T>;
+  var _makeShareableString: (value: string) => FlatShareableRef<string>;
   var __callMicrotasks: () => void;
   var _scheduleHostFunctionOnJS: (fun: (...args: A) => R, args?: A) => void;
   var _scheduleRemoteFunctionOnJS: (fun: (...args: A) => R, args?: A) => void;

--- a/packages/react-native-worklets/src/shareables.ts
+++ b/packages/react-native-worklets/src/shareables.ts
@@ -123,6 +123,10 @@ function makeShareableCloneRecursiveNative<T>(
   const isObject = typeof value === 'object';
   const isFunction = typeof value === 'function';
 
+  if (typeof value === 'string') {
+    return cloneString(value) as ShareableRef<T>;
+  }
+
   if ((!isObject && !isFunction) || value === null) {
     return clonePrimitive(value, shouldPersistRemote);
   }
@@ -198,6 +202,10 @@ function clonePrimitive<T>(
   shouldPersistRemote: boolean
 ): ShareableRef<T> {
   return WorkletsModule.makeShareableClone(value, shouldPersistRemote);
+}
+
+function cloneString(value: string): ShareableRef<string> {
+  return WorkletsModule.makeShareableString(value);
 }
 
 function cloneArray<T extends unknown[]>(

--- a/packages/react-native-worklets/src/shareables.ts
+++ b/packages/react-native-worklets/src/shareables.ts
@@ -551,6 +551,11 @@ export function makeShareableCloneOnUIRecursive<T>(
       }
       return global._makeShareableClone(toAdapt, value) as FlatShareableRef<T>;
     }
+
+    if (typeof value === 'string') {
+      return global._makeShareableString(value);
+    }
+
     return global._makeShareableClone(value, undefined);
   }
   return cloneRecursive(value);


### PR DESCRIPTION
## Summary
The first in a series of PRs that are intended to refactor the logic of the `makeShareableClone` function.
The current implementation does not have a single source of truth, as we have two type checking logics for the passed value, one on the `JS` side and one on the `Cpp` side.
The idea of the refactor is to implement one source of truth on the `JS` side and call the corresponding method on the `Cpp` side e.g:
```js
if (typeof value === ‘string’) {
  return global._makeShareableString(value);
}
```

In addition, in this PR I have rewritten the `Shareables` example to make it more readable and easier to use.
## Test plan
`Shareables` example
<video src="https://github.com/user-attachments/assets/5d61009d-e31b-44fc-b4fd-c21a8c417612" />

