### PR TITLE
fix: Temporary fix for CSS issues on RN 0.78+

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -58,6 +58,8 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
     }
   }
 
+  shadowNode.setUseRuntimeShadowNodeReferenceUpdateOnThread(false);
+
   return shadowNode.clone(
       {mergeProps(shadowNode, propsMap, *family),
        std::make_shared<ShadowNode::ListOfShared>(children),


### PR DESCRIPTION
## Summary

This PR just adds one line that disables props transferring from the native to the JS shadow node. This is a temporary fix for the breaking change introduced in RN 0.78 which started causing a lot of issues with our current CSS animations and transitions implementation approach.
