### PR TITLE
fix: ensure last[propName] is defined in style updater

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -261,6 +261,9 @@ function styleUpdater(
            * states, causing abrupt transitions or 'jumps' in animation states.
            */
           if (Array.isArray(updates[propName])) {
+            if (!last[propName] || typeof last[propName] !== 'object') {
+              last[propName] = {};
+            }
             updates[propName].forEach((obj: StyleProps) => {
               for (const prop in obj) {
                 last[propName][prop] = obj[prop];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Ensure that `last[propName]` is initialised to fix an exception on web. This bug was introduced by changes in #6749.

I noticed this issue after upgrading to the latest version of react-native-reanimated. In my case, the library was trying to index `last['transform']` which didn't exist for whatever reason.

<img width="573" alt="Screenshot 2025-05-08 at 16 23 04" src="https://github.com/user-attachments/assets/1262b09a-600d-4ffb-8aa2-a02d8bc9e97e" />

<img width="676" alt="Screenshot 2025-05-08 at 16 24 29" src="https://github.com/user-attachments/assets/d17ccde5-744f-4e57-b6cd-4100a88acdae" />
