### PR TITLE
feat: inject __DEV__ to worklet runtimes

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -30,7 +30,7 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     std::function<void(std::function<void(const double)>)>
         &&forwardedRequestAnimationFrame)
     : WorkletsModuleProxySpec(jsCallInvoker),
-      bundleFlavor_(
+      isDevBundle_(
           rnRuntime.global().getProperty(rnRuntime, "__DEV__").asBool()),
       valueUnpackerCode_(valueUnpackerCode),
       jsQueue_(jsQueue),
@@ -42,7 +42,7 @@ WorkletsModuleProxy::WorkletsModuleProxy(
           jsScheduler,
           "Reanimated UI runtime",
           true /* supportsLocking */,
-          bundleFlavor_,
+          isDevBundle_,
           valueUnpackerCode_)),
       animationFrameBatchinator_(std::make_shared<AnimationFrameBatchinator>(
           uiWorkletRuntime_->getJSIRuntime(),
@@ -116,7 +116,7 @@ jsi::Value WorkletsModuleProxy::createWorkletRuntime(
       jsScheduler_,
       name.asString(rt).utf8(rt),
       true /* supportsLocking */,
-      bundleFlavor_,
+      isDevBundle_,
       valueUnpackerCode_);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
       rt, initializer, "[Worklets] Initializer must be a worklet.");

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -30,6 +30,8 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     std::function<void(std::function<void(const double)>)>
         &&forwardedRequestAnimationFrame)
     : WorkletsModuleProxySpec(jsCallInvoker),
+      bundleFlavor_(
+          rnRuntime.global().getProperty(rnRuntime, "__DEV__").asBool()),
       valueUnpackerCode_(valueUnpackerCode),
       jsQueue_(jsQueue),
       jsScheduler_(jsScheduler),
@@ -40,6 +42,7 @@ WorkletsModuleProxy::WorkletsModuleProxy(
           jsScheduler,
           "Reanimated UI runtime",
           true /* supportsLocking */,
+          bundleFlavor_,
           valueUnpackerCode_)),
       animationFrameBatchinator_(std::make_shared<AnimationFrameBatchinator>(
           uiWorkletRuntime_->getJSIRuntime(),
@@ -113,6 +116,7 @@ jsi::Value WorkletsModuleProxy::createWorkletRuntime(
       jsScheduler_,
       name.asString(rt).utf8(rt),
       true /* supportsLocking */,
+      bundleFlavor_,
       valueUnpackerCode_);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
       rt, initializer, "[Worklets] Initializer must be a worklet.");

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -158,11 +158,8 @@ jsi::Value WorkletsModuleProxy::scheduleOnRuntime(
 }
 
 auto isDevBundleFromRNRuntime(jsi::Runtime &rnRuntime) -> bool {
-  auto rtDev = rnRuntime.global().getProperty(rnRuntime, "__DEV__");
-  if (rtDev.isBool()) {
-    return rtDev.asBool();
-  }
-  return false;
+  const auto rtDev = rnRuntime.global().getProperty(rnRuntime, "__DEV__");
+  return rtDev.isBool() && rtDev.asBool();
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -20,6 +20,8 @@ using namespace facebook;
 
 namespace worklets {
 
+auto isDevBundleFromRNRuntime(jsi::Runtime &rnRuntime) -> bool;
+
 WorkletsModuleProxy::WorkletsModuleProxy(
     jsi::Runtime &rnRuntime,
     const std::string &valueUnpackerCode,
@@ -30,8 +32,7 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     std::function<void(std::function<void(const double)>)>
         &&forwardedRequestAnimationFrame)
     : WorkletsModuleProxySpec(jsCallInvoker),
-      isDevBundle_(
-          rnRuntime.global().getProperty(rnRuntime, "__DEV__").asBool()),
+      isDevBundle_(isDevBundleFromRNRuntime(rnRuntime)),
       valueUnpackerCode_(valueUnpackerCode),
       jsQueue_(jsQueue),
       jsScheduler_(jsScheduler),
@@ -130,6 +131,14 @@ jsi::Value WorkletsModuleProxy::scheduleOnRuntime(
     const jsi::Value &shareableWorkletValue) {
   worklets::scheduleOnRuntime(rt, workletRuntimeValue, shareableWorkletValue);
   return jsi::Value::undefined();
+}
+
+auto isDevBundleFromRNRuntime(jsi::Runtime &rnRuntime) -> bool {
+  auto rtDev = rnRuntime.global().getProperty(rnRuntime, "__DEV__");
+  if (rtDev.isBool()) {
+    return rtDev.asBool();
+  }
+  return false;
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -67,7 +67,12 @@ class WorkletsModuleProxy
     return uiWorkletRuntime_;
   }
 
+  [[nodiscard]] inline bool getBundleFlavor() const {
+    return bundleFlavor_;
+  }
+
  private:
+  const bool bundleFlavor_;
   const std::string valueUnpackerCode_;
   const std::shared_ptr<MessageQueueThread> jsQueue_;
   const std::shared_ptr<JSScheduler> jsScheduler_;

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -67,12 +67,12 @@ class WorkletsModuleProxy
     return uiWorkletRuntime_;
   }
 
-  [[nodiscard]] inline bool getBundleFlavor() const {
-    return bundleFlavor_;
+  [[nodiscard]] inline bool isDevBundle() const {
+    return isDevBundle_;
   }
 
  private:
-  const bool bundleFlavor_;
+  const bool isDevBundle_;
   const std::string valueUnpackerCode_;
   const std::shared_ptr<MessageQueueThread> jsQueue_;
   const std::shared_ptr<JSScheduler> jsScheduler_;

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -85,7 +85,7 @@ WorkletRuntime::WorkletRuntime(
     const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::string &name,
     const bool supportsLocking,
-    const bool bundleFlavor,
+    const bool isDevBundle,
     const std::string &valueUnpackerCode)
     : runtimeMutex_(std::make_shared<std::recursive_mutex>()),
       runtime_(makeRuntime(
@@ -100,7 +100,7 @@ WorkletRuntime::WorkletRuntime(
       name_(name) {
   jsi::Runtime &rt = *runtime_;
   WorkletRuntimeCollector::install(rt);
-  WorkletRuntimeDecorator::decorate(rt, name, jsScheduler, bundleFlavor);
+  WorkletRuntimeDecorator::decorate(rt, name, jsScheduler, isDevBundle);
 
   auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
       "(" + valueUnpackerCode + "\n)");

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -85,6 +85,7 @@ WorkletRuntime::WorkletRuntime(
     const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::string &name,
     const bool supportsLocking,
+    const bool bundleFlavor,
     const std::string &valueUnpackerCode)
     : runtimeMutex_(std::make_shared<std::recursive_mutex>()),
       runtime_(makeRuntime(
@@ -99,7 +100,7 @@ WorkletRuntime::WorkletRuntime(
       name_(name) {
   jsi::Runtime &rt = *runtime_;
   WorkletRuntimeCollector::install(rt);
-  WorkletRuntimeDecorator::decorate(rt, name, jsScheduler);
+  WorkletRuntimeDecorator::decorate(rt, name, jsScheduler, bundleFlavor);
 
   auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
       "(" + valueUnpackerCode + "\n)");

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -26,6 +26,7 @@ class WorkletRuntime : public jsi::HostObject,
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::string &name,
       const bool supportsLocking,
+      const bool bundleFlavor,
       const std::string &valueUnpackerCode);
 
   jsi::Runtime &getJSIRuntime() const {

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -26,7 +26,7 @@ class WorkletRuntime : public jsi::HostObject,
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::string &name,
       const bool supportsLocking,
-      const bool bundleFlavor,
+      const bool isDevBundle,
       const std::string &valueUnpackerCode);
 
   jsi::Runtime &getJSIRuntime() const {

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -39,7 +39,8 @@ static inline std::vector<jsi::Value> parseArgs(
 void WorkletRuntimeDecorator::decorate(
     jsi::Runtime &rt,
     const std::string &name,
-    const std::shared_ptr<JSScheduler> &jsScheduler) {
+    const std::shared_ptr<JSScheduler> &jsScheduler,
+    const bool bundleFlavor) {
   // resolves "ReferenceError: Property 'global' doesn't exist at ..."
   rt.global().setProperty(rt, "global", rt.global());
 
@@ -50,6 +51,8 @@ void WorkletRuntimeDecorator::decorate(
   // TODO: Remove _IS_FABRIC sometime in the future
   // react-native-screens 4.9.0 depends on it
   rt.global().setProperty(rt, "_IS_FABRIC", true);
+
+  rt.global().setProperty(rt, "__DEV__", bundleFlavor);
 
 #ifndef NDEBUG
   auto evalWithSourceUrl = [](jsi::Runtime &rt,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -40,7 +40,7 @@ void WorkletRuntimeDecorator::decorate(
     jsi::Runtime &rt,
     const std::string &name,
     const std::shared_ptr<JSScheduler> &jsScheduler,
-    const bool bundleFlavor) {
+    const bool isDevBundle) {
   // resolves "ReferenceError: Property 'global' doesn't exist at ..."
   rt.global().setProperty(rt, "global", rt.global());
 
@@ -52,7 +52,7 @@ void WorkletRuntimeDecorator::decorate(
   // react-native-screens 4.9.0 depends on it
   rt.global().setProperty(rt, "_IS_FABRIC", true);
 
-  rt.global().setProperty(rt, "__DEV__", bundleFlavor);
+  rt.global().setProperty(rt, "__DEV__", isDevBundle);
 
 #ifndef NDEBUG
   auto evalWithSourceUrl = [](jsi::Runtime &rt,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
@@ -17,7 +17,7 @@ class WorkletRuntimeDecorator {
       jsi::Runtime &rt,
       const std::string &name,
       const std::shared_ptr<JSScheduler> &jsScheduler,
-      const bool bundleFlavor);
+      const bool isDevBundle);
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.h
@@ -16,7 +16,8 @@ class WorkletRuntimeDecorator {
   static void decorate(
       jsi::Runtime &rt,
       const std::string &name,
-      const std::shared_ptr<JSScheduler> &jsScheduler);
+      const std::shared_ptr<JSScheduler> &jsScheduler,
+      const bool bundleFlavor);
 };
 
 } // namespace worklets


### PR DESCRIPTION
## Summary

In the new bundling method we won't copy implicit global identifiers. However, Reanimated & Worklets still depend on copying `__DEV__` from the global object. This PR injects `__DEV__` to Worklet Runtimes while maintaining previous behavior, it's needed for future PRs of worklets.

## Test plan

Run an app in dev & prod and see that it works properly.
