### PR TITLE
feat: Set display to contents from native, fix component descriptor initialization

### DIFF
--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.cpp
@@ -9,15 +9,37 @@ ReanimatedViewComponentDescriptor::ReanimatedViewComponentDescriptor(
       parameters.contextContainer->find<std::weak_ptr<ReanimatedModuleProxy>>(
           "ReanimatedModuleProxy");
 
-  if (reanimatedModuleProxy.has_value()) {
-    const auto &proxy = reanimatedModuleProxy.value().lock();
-    if (proxy) {
-      proxy_ = proxy;
-    }
+  if (!reanimatedModuleProxy.has_value()) {
+    return;
   }
+  const auto &proxy = reanimatedModuleProxy.value().lock();
+  if (!proxy) {
+    return;
+  }
+
+  proxy_ = proxy;
+  reanimatedNodeProps_ = cloneProps(
+      // cloneProps needs PropsParserContext to be passed. It can be anything
+      // here as it is not used while parsing the display: contents prop, so we
+      // use the mandatory 0 value for the surfaceId
+      PropsParserContext(0, *parameters.contextContainer),
+      ShadowNodeFragment::propsPlaceholder(),
+      RawProps(folly::dynamic::object("display", "contents")));
 }
 
-void ReanimatedViewComponentDescriptor::adopt(ShadowNode &shadowNode) const {}
+std::shared_ptr<ShadowNode> ReanimatedViewComponentDescriptor::createShadowNode(
+    const ShadowNodeFragment &fragment,
+    const ShadowNodeFamily::Shared &family) const {
+  return ConcreteComponentDescriptor::createShadowNode(
+      createShadowNodeFragment(fragment), family);
+}
+
+ShadowNode::Unshared ReanimatedViewComponentDescriptor::cloneShadowNode(
+    const ShadowNode &sourceShadowNode,
+    const ShadowNodeFragment &fragment) const {
+  return ConcreteComponentDescriptor::cloneShadowNode(
+      sourceShadowNode, createShadowNodeFragment(fragment));
+}
 
 State::Shared ReanimatedViewComponentDescriptor::createInitialState(
     const Props::Shared & /*props*/,
@@ -25,6 +47,16 @@ State::Shared ReanimatedViewComponentDescriptor::createInitialState(
   auto state = std::make_shared<ReanimatedViewStateData>();
   state->initialize(proxy_);
   return std::make_shared<ConcreteState>(state, family);
+}
+
+ShadowNodeFragment ReanimatedViewComponentDescriptor::createShadowNodeFragment(
+    const ShadowNodeFragment &fragment) const {
+  return ShadowNodeFragment{
+      .props = reanimatedNodeProps_,
+      .children = fragment.children,
+      .state = fragment.state,
+      .runtimeShadowNodeReference = fragment.runtimeShadowNodeReference,
+  };
 }
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
@@ -2,6 +2,7 @@
 
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/rnreanimated/ReanimatedShadowNode.h>
+#include <react/renderer/components/rnreanimated/ReanimatedViewStateData.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
@@ -33,13 +34,17 @@ class ReanimatedViewComponentDescriptor
       const Props::Shared & /*props*/,
       const ShadowNodeFamily::Shared &family) const override;
 
+ protected:
+  virtual void adopt(ShadowNode &shadowNode) const override;
+
  private:
-  std::shared_ptr<ReanimatedModuleProxy> proxy_;
   Props::Shared reanimatedNodeProps_;
 
-  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
-  ShadowNodeFragment createShadowNodeFragment(
-      const ShadowNodeFragment &fragment) const;
+  std::shared_ptr<ReanimatedModuleProxy> getProxy() const;
+
+  ShadowNodeFragment createReanimatedNodeFragment(
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily &family) const;
 };
 
 void rnreanimated_registerComponentDescriptorsFromCodegen(

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
@@ -21,7 +21,13 @@ class ReanimatedViewComponentDescriptor
   explicit ReanimatedViewComponentDescriptor(
       const ComponentDescriptorParameters &parameters);
 
-  void adopt(ShadowNode &shadowNode) const override;
+  std::shared_ptr<ShadowNode> createShadowNode(
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family) const override;
+
+  ShadowNode::Unshared cloneShadowNode(
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment) const override;
 
   State::Shared createInitialState(
       const Props::Shared & /*props*/,
@@ -29,8 +35,11 @@ class ReanimatedViewComponentDescriptor
 
  private:
   std::shared_ptr<ReanimatedModuleProxy> proxy_;
+  Props::Shared reanimatedNodeProps_;
 
   void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
+  ShadowNodeFragment createShadowNodeFragment(
+      const ShadowNodeFragment &fragment) const;
 };
 
 void rnreanimated_registerComponentDescriptorsFromCodegen(

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -9,14 +9,14 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : ReanimatedViewShadowNodeBase(fragment, family, traits) {
-  const auto &state = getStateData();
-  if (!state.isInitialized()) {
-    return;
-  }
+  // const auto &state = getStateData();
+  // if (!state.isInitialized()) {
+  //   return;
+  // }
 
-  const auto &newProps =
-      static_cast<const ReanimatedViewProps &>(*this->getProps());
-  state.cssAnimationsManager->update(newProps);
+  // const auto &newProps =
+  //     static_cast<const ReanimatedViewProps &>(*this->getProps());
+  // state.cssAnimationsManager->update(newProps);
 }
 
 ReanimatedShadowNode::ReanimatedShadowNode(
@@ -24,24 +24,25 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNodeFragment &fragment)
     : ReanimatedViewShadowNodeBase(sourceShadowNode, fragment) {
   const auto &state = getStateData();
-  if (!state.isInitialized()) {
-    return;
-  }
+  // if (!state.isInitialized()) {
+  //   return;
+  // }
 
-  const auto &oldProps =
-      static_cast<const ReanimatedViewProps &>(*sourceShadowNode.getProps());
-  const auto &newProps =
-      static_cast<const ReanimatedViewProps &>(*this->getProps());
+  // const auto &oldProps =
+  //     static_cast<const ReanimatedViewProps &>(*sourceShadowNode.getProps());
+  // const auto &newProps =
+  //     static_cast<const ReanimatedViewProps &>(*this->getProps());
 
-  // Check if props object is the same first - it will be the same e.g. if
-  // commit to the ShadowTree was made from reanimated and props on the JS side
-  // didn't change
-  if (&oldProps == &newProps) {
-    return;
-  }
+  // // Check if props object is the same first - it will be the same e.g. if
+  // // commit to the ShadowTree was made from reanimated and props on the JS
+  // side
+  // // didn't change
+  // if (&oldProps == &newProps) {
+  //   return;
+  // }
 
-  state.cssTransitionManager->update(oldProps, newProps);
-  state.cssAnimationsManager->update(newProps);
+  // state.cssTransitionManager->update(oldProps, newProps);
+  // state.cssAnimationsManager->update(newProps);
 }
 
 void ReanimatedShadowNode::layout(LayoutContext layoutContext) {

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -9,40 +9,43 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : ReanimatedViewShadowNodeBase(fragment, family, traits) {
-  // const auto &state = getStateData();
-  // if (!state.isInitialized()) {
-  //   return;
-  // }
-
-  // const auto &newProps =
-  //     static_cast<const ReanimatedViewProps &>(*this->getProps());
-  // state.cssAnimationsManager->update(newProps);
+  // TODO - fix state updates later
+  //  const auto &stateData = getStateData();
+  //  if (!stateData.isInitialized()) {
+  //    return;
+  //  }
+  //
+  //  const auto &newProps =
+  //      static_cast<const ReanimatedViewProps &>(*this->getProps());
+  //  stateData.cssAnimationsManager->update(newProps);
 }
 
 ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNode &sourceShadowNode,
     const ShadowNodeFragment &fragment)
     : ReanimatedViewShadowNodeBase(sourceShadowNode, fragment) {
-  const auto &state = getStateData();
-  // if (!state.isInitialized()) {
-  //   return;
-  // }
-
-  // const auto &oldProps =
-  //     static_cast<const ReanimatedViewProps &>(*sourceShadowNode.getProps());
-  // const auto &newProps =
-  //     static_cast<const ReanimatedViewProps &>(*this->getProps());
-
-  // // Check if props object is the same first - it will be the same e.g. if
-  // // commit to the ShadowTree was made from reanimated and props on the JS
-  // side
-  // // didn't change
-  // if (&oldProps == &newProps) {
-  //   return;
-  // }
-
-  // state.cssTransitionManager->update(oldProps, newProps);
-  // state.cssAnimationsManager->update(newProps);
+  // TODO - fix state updates later
+  //  const auto &stateData = getStateData();
+  //  if (!stateData.isInitialized()) {
+  //    return;
+  //  }
+  //
+  //  const auto &oldProps =
+  //      static_cast<const ReanimatedViewProps
+  //      &>(*sourceShadowNode.getProps());
+  //  const auto &newProps =
+  //      static_cast<const ReanimatedViewProps &>(*this->getProps());
+  //
+  //  // Check if props object is the same first - it will be the same e.g. if
+  //  // commit to the ShadowTree was made from reanimated and props on the JS
+  //  side
+  //  // didn't change
+  //  if (&oldProps == &newProps) {
+  //    return;
+  //  }
+  //
+  //  stateData.cssTransitionManager->update(oldProps, newProps);
+  //  stateData.cssAnimationsManager->update(newProps);
 }
 
 void ReanimatedShadowNode::layout(LayoutContext layoutContext) {

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.cpp
@@ -2,16 +2,20 @@
 
 namespace facebook::react {
 
-bool ReanimatedViewStateData::isInitialized() const {
-  return initialized_;
+ReanimatedViewStateData::ReanimatedViewStateData() {
+  // We throw an error here, because we cannot create ReanimatedViewStateData
+  // without proxy. React Native requires this constructor to be present.
+  throw std::runtime_error(
+      "[Reanimated] Cannot create ReanimatedViewStateData without proxy");
+}
+
+ReanimatedViewStateData::ReanimatedViewStateData(
+    const std::shared_ptr<ReanimatedModuleProxy> &proxy) {
+  initialize(proxy);
 }
 
 void ReanimatedViewStateData::initialize(
     const std::shared_ptr<ReanimatedModuleProxy> &proxy) {
-  if (!proxy) {
-    return;
-  }
-
   const auto operationsLoop = proxy->getOperationsLoop();
   const auto cssAnimationKeyframesRegistry =
       proxy->getCssAnimationKeyframesRegistry();

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.h
@@ -19,19 +19,16 @@ namespace facebook::react {
 using namespace reanimated;
 using namespace css;
 
-class ReanimatedViewStateData {
- public:
+struct ReanimatedViewStateData final {
   std::shared_ptr<CSSTransitionManager> cssTransitionManager;
   std::shared_ptr<CSSAnimationsManager> cssAnimationsManager;
 
-  ReanimatedViewStateData() = default;
-
-  bool isInitialized() const;
-  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
+  ReanimatedViewStateData(); // This constructor is required by React Native
+  ReanimatedViewStateData(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
 
 #ifdef ANDROID
   ReanimatedViewStateData(
-      ReanimatedViewStateData const &previousState,
+      const ReanimatedViewStateData &sourceData,
       folly::dynamic data) {}
   folly::dynamic getDynamic() const {
     return {};
@@ -39,7 +36,7 @@ class ReanimatedViewStateData {
 #endif
 
  private:
-  bool initialized_ = false;
+  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
 };
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -241,17 +241,9 @@ export default class AnimatedComponent<
     }
 
     return (
-      <ReanimatedView
-        {...this._CSSManagerNew?.getProps()}
-        style={styles.container}>
+      <ReanimatedView {...this._CSSManagerNew?.getProps()}>
         {child}
       </ReanimatedView>
     );
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    display: 'contents',
-  },
-});

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -2,7 +2,7 @@
 import type { ComponentProps, Ref } from 'react';
 import React, { Component } from 'react';
 import type { StyleProp } from 'react-native';
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import type { ShadowNodeWrapper } from '../../commonTypes';
 import type {
@@ -211,27 +211,15 @@ export default class AnimatedComponent<
 
   render(props?: ComponentProps<AnyComponent>) {
     const { ChildComponent } = this;
+    const { style, ...restProps } = props ?? this.props;
+    const filteredStyle = filterNonCSSStyleProps(style);
 
-    const platformProps = Platform.select({
-      web: {},
-      default: { collapsable: false },
-    });
-
-    const style = props?.style ?? this.props.style;
-
-    const child = (
-      <ChildComponent
-        {...(props ?? this.props)}
-        {...platformProps}
-        style={filterNonCSSStyleProps(style)}
-        // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
-        // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
-        ref={this._setComponentRef as (ref: Component) => void}
-      />
-    );
+    // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
+    // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
+    const ref = this._setComponentRef as (ref: Component) => void;
 
     if (IS_WEB) {
-      return child;
+      return <ChildComponent {...restProps} style={filteredStyle} ref={ref} />;
     }
 
     if (!this._CSSManagerNew) {
@@ -242,7 +230,12 @@ export default class AnimatedComponent<
 
     return (
       <ReanimatedView {...this._CSSManagerNew?.getProps()}>
-        {child}
+        <ChildComponent
+          {...restProps}
+          collapsable={false}
+          ref={ref}
+          style={filteredStyle}
+        />
       </ReanimatedView>
     );
   }


### PR DESCRIPTION
## Summary

- add shared and reusable `reanimatedNodeProps_` props object for all reanimated shadow nodes containing `display` property set to `contents` (since reanimated Shadow Nodes should be "transparent", we don't need any props except `display: 'contents'`. Thanks to this PR, we no longer have to pass `display: 'contents'` style prop in JS),
- fixes the initialization of the `ReanimatedViewComponentDescriptor` (it used some strange initialization logic pulling the `proxy` instance from the context container before, which didn't sometimes work. In general, the `ReanimatedModuleProxy` is usually initialized first, but it is not the case during hot reloads, when the order of initialization of `ReanimatedViewComponentDescriptor` and `ReanimatedModuleProxy` can be different. Because of that, we ended up with an uninitialized `ReanimatedModuleProxy` instance with invalid shadow nodes without properly initialized state object that depends on the `proxy`)