### PR TITLE
docs: Fix sidebar link to 4.x not working

### DIFF
--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Slug for default page was not set.

Before:

<img width="944" alt="image" src="https://github.com/user-attachments/assets/67399117-4fc2-4fd3-9db8-db6a6b95f453" />


After:

<img width="964" alt="image" src="https://github.com/user-attachments/assets/b05b83da-d106-48a6-b706-9403f1e25ea2" />


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
