### PR TITLE
fix: Move check of last state inside loop

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -261,11 +261,11 @@ function styleUpdater(
            * states, causing abrupt transitions or 'jumps' in animation states.
            */
           if (Array.isArray(updates[propName])) {
-            if (!last[propName] || typeof last[propName] !== 'object') {
-              last[propName] = {};
-            }
             updates[propName].forEach((obj: StyleProps) => {
               for (const prop in obj) {
+                if (!last[propName] || typeof last[propName] !== 'object') {
+                  last[propName] = {};
+                }
                 last[propName][prop] = obj[prop];
               }
             });


### PR DESCRIPTION
## Summary

After interal conversation with @piaskowyk we decided to move this check inside the for loop. It modifies code from #7485, and ensures the initial state is guaranteed and guarded.

## Test plan

<details>
<summary>Both, commented and no, styles should work</summary>

```tsx
import { transform } from "@babel/core";
import { MotiView } from "moti";
import { useState } from "react";
import { Button, StyleSheet, View } from "react-native";
import Animated, {withSpring,useAnimatedStyle} from "react-native-reanimated";

export default function App() {
  const [doAnimate, setDoAnimate] = useState(false);
  const handlePress = () => setDoAnimate(prev => !prev);

  const animatedStylez = useAnimatedStyle(() => {
return (
  {
  transform: [{translateX: doAnimate ? withSpring(100) : 0}],

  }
)
  })

  // return (
  //   <View style={styles.container}>
  //     <MotiView
  //       style={styles.box}
  //       animate={{
  //         backgroundColor: "red",
  //         translateX: doAnimate ? 100 : undefined,
  //       }}
  //     />
  //     <Button title="move" onPress={handlePress} />
  //   </View>
  // );
  return (
    <View style={styles.container}>
      <Animated.View style={[styles.box, animatedStylez]}/>
       <Button title="move" onPress={handlePress} />
      </View>
  )
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    flexDirection: "column",
    alignItems: "center",
  },
  box: {
    width: 50,
    height: 50,
    margin: 10,
    borderRadius: 15,
    borderWidth: 2,
    backgroundColor: "#b58df1",
  },
});
```
</details>
