### PR TITLE
fix: Reanimated Component Descriptor initialization on reloads

### DIFF
--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.cpp
@@ -4,27 +4,29 @@ namespace facebook::react {
 
 ReanimatedViewComponentDescriptor::ReanimatedViewComponentDescriptor(
     const ComponentDescriptorParameters &parameters)
-    : ConcreteComponentDescriptor<ReanimatedShadowNode>(parameters) {
-  const auto &reanimatedModuleProxy =
-      parameters.contextContainer->find<std::weak_ptr<ReanimatedModuleProxy>>(
-          "ReanimatedModuleProxy");
-
-  if (reanimatedModuleProxy.has_value()) {
-    const auto &proxy = reanimatedModuleProxy.value().lock();
-    if (proxy) {
-      proxy_ = proxy;
-    }
-  }
-}
+    : ConcreteComponentDescriptor<ReanimatedShadowNode>(parameters) {}
 
 void ReanimatedViewComponentDescriptor::adopt(ShadowNode &shadowNode) const {}
 
 State::Shared ReanimatedViewComponentDescriptor::createInitialState(
     const Props::Shared & /*props*/,
     const ShadowNodeFamily::Shared &family) const {
-  auto state = std::make_shared<ReanimatedViewStateData>();
-  state->initialize(proxy_);
-  return std::make_shared<ConcreteState>(state, family);
+  return std::make_shared<const ConcreteState>(
+      std::make_shared<ReanimatedViewStateData>(getProxy()), family);
+}
+
+std::shared_ptr<ReanimatedModuleProxy>
+ReanimatedViewComponentDescriptor::getProxy() const {
+  // Sometimes ReanimatedModuleProxy is initialized before
+  // ReanimatedViewComponentDescriptor and sometimes after it. Because of that,
+  // we cannot get the proxy instance in the constructor and need to use this
+  // getter function. Each of ReanimatedViewComponentDescriptor methods is
+  // called after ReanimatedModuleProxy is already added to the context
+  // container, so we can safely call this getter function anywhere in the
+  // component descriptor except for the constructor.
+  return contextContainer_
+      ->at<std::weak_ptr<ReanimatedModuleProxy>>("ReanimatedModuleProxy")
+      .lock();
 }
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
@@ -28,9 +28,7 @@ class ReanimatedViewComponentDescriptor
       const ShadowNodeFamily::Shared &family) const override;
 
  private:
-  std::shared_ptr<ReanimatedModuleProxy> proxy_;
-
-  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
+  std::shared_ptr<ReanimatedModuleProxy> getProxy() const;
 };
 
 void rnreanimated_registerComponentDescriptorsFromCodegen(

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -9,13 +9,10 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : ReanimatedViewShadowNodeBase(fragment, family, traits) {
-  const auto &state = getStateData();
-  if (!state.isInitialized()) {
-    return;
-  }
-
   const auto &newProps =
       static_cast<const ReanimatedViewProps &>(*this->getProps());
+
+  const auto &state = getStateData();
   state.cssAnimationsManager->update(newProps);
 }
 
@@ -23,23 +20,15 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNode &sourceShadowNode,
     const ShadowNodeFragment &fragment)
     : ReanimatedViewShadowNodeBase(sourceShadowNode, fragment) {
-  const auto &state = getStateData();
-  if (!state.isInitialized()) {
-    return;
-  }
-
   const auto &oldProps =
       static_cast<const ReanimatedViewProps &>(*sourceShadowNode.getProps());
   const auto &newProps =
       static_cast<const ReanimatedViewProps &>(*this->getProps());
 
-  // Check if props object is the same first - it will be the same e.g. if
-  // commit to the ShadowTree was made from reanimated and props on the JS side
-  // didn't change
-  if (&oldProps == &newProps) {
-    return;
-  }
+  // TODO - optimize cloning (don't call update if props on the JS side didn't
+  // change)
 
+  const auto &state = getStateData();
   state.cssTransitionManager->update(oldProps, newProps);
   state.cssAnimationsManager->update(newProps);
 }

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.cpp
@@ -2,16 +2,20 @@
 
 namespace facebook::react {
 
-bool ReanimatedViewStateData::isInitialized() const {
-  return initialized_;
+ReanimatedViewStateData::ReanimatedViewStateData() {
+  // We throw an error here, because we cannot create ReanimatedViewStateData
+  // without proxy. React Native requires this constructor to be present.
+  throw std::runtime_error(
+      "[Reanimated] Cannot create ReanimatedViewStateData without proxy");
+}
+
+ReanimatedViewStateData::ReanimatedViewStateData(
+    const std::shared_ptr<ReanimatedModuleProxy> &proxy) {
+  initialize(proxy);
 }
 
 void ReanimatedViewStateData::initialize(
     const std::shared_ptr<ReanimatedModuleProxy> &proxy) {
-  if (!proxy) {
-    return;
-  }
-
   const auto operationsLoop = proxy->getOperationsLoop();
   const auto cssAnimationKeyframesRegistry =
       proxy->getCssAnimationKeyframesRegistry();

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedViewStateData.h
@@ -24,14 +24,12 @@ class ReanimatedViewStateData {
   std::shared_ptr<CSSTransitionManager> cssTransitionManager;
   std::shared_ptr<CSSAnimationsManager> cssAnimationsManager;
 
-  ReanimatedViewStateData() = default;
-
-  bool isInitialized() const;
-  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
+  ReanimatedViewStateData();
+  ReanimatedViewStateData(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
 
 #ifdef ANDROID
   ReanimatedViewStateData(
-      ReanimatedViewStateData const &previousState,
+      const ReanimatedViewStateData &sourceData,
       folly::dynamic data) {}
   folly::dynamic getDynamic() const {
     return {};
@@ -39,7 +37,7 @@ class ReanimatedViewStateData {
 #endif
 
  private:
-  bool initialized_ = false;
+  void initialize(const std::shared_ptr<ReanimatedModuleProxy> &proxy);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary

- fixes the initialization of the `ReanimatedViewComponentDescriptor` (it used some strange initialization logic pulling the `proxy` instance from the context container before, which didn't sometimes work. In general, the `ReanimatedModuleProxy` is usually initialized first, but it is not the case during hot reloads, when the order of initialization of `ReanimatedViewComponentDescriptor` and `ReanimatedModuleProxy` can be different. Because of that, we ended up with an uninitialized `ReanimatedModuleProxy` instance with invalid shadow nodes without properly initialized state object that depends on the `proxy`)