### PR TITLE
feat: Custom Reanimated ShadowNode props

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
@@ -3,7 +3,7 @@
  * file should be replaced with the actual example implementation.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -44,14 +44,6 @@ export default function Playground() {
     return transitionStyles[num % transitionStyles.length];
   };
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setState((prev) => prev + 1);
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <Screen>
       <View style={styles.container}>
@@ -67,7 +59,7 @@ export default function Playground() {
               backgroundColor: 'red',
               height: 65,
               marginTop: 60,
-              transitionDuration: 500,
+              transitionDuration: '0.5s',
               transitionProperty: 'all',
               transitionTimingFunction: 'ease-in-out',
               width: 65,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
@@ -3,7 +3,7 @@
  * file should be replaced with the actual example implementation.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ViewStyle } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -44,6 +44,14 @@ export default function Playground() {
     return transitionStyles[num % transitionStyles.length];
   };
 
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setState((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <Screen>
       <View style={styles.container}>
@@ -59,7 +67,7 @@ export default function Playground() {
               backgroundColor: 'red',
               height: 65,
               marginTop: 60,
-              transitionDuration: '0.5s',
+              transitionDuration: 500,
               transitionProperty: 'all',
               transitionTimingFunction: 'ease-in-out',
               width: 65,

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
@@ -1,0 +1,27 @@
+#include <react/renderer/components/rnreanimated/ReanimatedNodeProps.h>
+
+namespace facebook::react {
+
+ReanimatedNodeProps::ReanimatedNodeProps(
+    const PropsParserContext &context,
+    const ReanimatedNodeProps &sourceProps,
+    const RawProps &rawProps)
+    : ViewProps(context, sourceProps, rawProps),
+      jsStyle(convertRawProp(
+          context,
+          rawProps,
+          "jsStyle",
+          sourceProps.jsStyle,
+          {})) {
+  auto rawValue = const_cast<RawValue *>(rawProps.at("cssTransition", "", ""));
+  auto pair = (JsiValuePair *)rawValue;
+
+  if (pair) {
+    auto &[rt, value] = *pair;
+    if (value.isObject()) {
+      cssTransition = parseCSSTransitionConfig(*rt, value);
+    }
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
@@ -12,33 +12,48 @@ ReanimatedNodeProps::ReanimatedNodeProps(
           rawProps,
           "jsStyle",
           sourceProps.jsStyle,
-          {})) {
-  auto rawValue = const_cast<RawValue *>(rawProps.at("cssTransition", "", ""));
+          {})),
+      cssTransition(parseCSSTransition(rawProps)),
+      cssAnimations(parseCSSAnimations(rawProps)) {}
+
+std::optional<CSSTransitionConfig> ReanimatedNodeProps::parseCSSTransition(
+    const RawProps &rawProps) {
+  return parseRawProp<CSSTransitionConfig>(
+      rawProps, "cssTransition", [](jsi::Runtime &rt, const jsi::Value &value) {
+        return CSSTransitionConfig(rt, value);
+      });
+}
+
+std::vector<CSSAnimationConfig> ReanimatedNodeProps::parseCSSAnimations(
+    const RawProps &rawProps) {
+  auto parsedProp = parseRawProp<std::vector<CSSAnimationConfig>>(
+      rawProps, "cssAnimations", [](jsi::Runtime &rt, const jsi::Value &value) {
+        std::vector<CSSAnimationConfig> animations;
+        const auto animationConfigs = value.asObject(rt).asArray(rt);
+        const auto configsCount = animationConfigs.size(rt);
+
+        animations.reserve(configsCount);
+        for (size_t i = 0; i < configsCount; i++) {
+          animations.emplace_back(rt, animationConfigs.getValueAtIndex(rt, i));
+        }
+        return animations;
+      });
+  return std::move(parsedProp).value_or(std::vector<CSSAnimationConfig>{});
+}
+
+template <typename T>
+std::optional<T> ReanimatedNodeProps::parseRawProp(
+    const RawProps &rawProps,
+    const char *propName,
+    std::function<T(jsi::Runtime &, const jsi::Value &)> parser) {
+  auto rawValue = const_cast<RawValue *>(rawProps.at(propName, "", ""));
   auto pair = (JsiValuePair *)rawValue;
 
-  if (pair) {
-    auto &[rt, value] = *pair;
-    if (value.isObject()) {
-      cssTransition = CSSTransitionConfig(*rt, value);
-    }
+  if (pair && pair->second.isObject()) {
+    return parser(*pair->first, pair->second);
   }
 
-  auto rawValue2 = const_cast<RawValue *>(rawProps.at("cssAnimations", "", ""));
-  auto pair2 = (JsiValuePair *)rawValue2;
-
-  if (pair2) {
-    auto &[runtime, value] = *pair2;
-    auto &rt = *runtime;
-    if (value.isObject()) {
-      const auto animationConfigs = value.asObject(rt).asArray(rt);
-      const auto configsCount = animationConfigs.size(rt);
-
-      cssAnimations.reserve(configsCount);
-      for (size_t i = 0; i < configsCount; i++) {
-        cssAnimations.emplace_back(rt, animationConfigs.getValueAtIndex(rt, i));
-      }
-    }
-  }
+  return std::nullopt;
 }
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
@@ -19,7 +19,24 @@ ReanimatedNodeProps::ReanimatedNodeProps(
   if (pair) {
     auto &[rt, value] = *pair;
     if (value.isObject()) {
-      cssTransition = parseCSSTransitionConfig(*rt, value);
+      cssTransition = CSSTransitionConfig(*rt, value);
+    }
+  }
+
+  auto rawValue2 = const_cast<RawValue *>(rawProps.at("cssAnimations", "", ""));
+  auto pair2 = (JsiValuePair *)rawValue2;
+
+  if (pair2) {
+    auto &[runtime, value] = *pair2;
+    auto &rt = *runtime;
+    if (value.isObject()) {
+      const auto animationConfigs = value.asObject(rt).asArray(rt);
+      const auto configsCount = animationConfigs.size(rt);
+
+      cssAnimations.reserve(configsCount);
+      for (size_t i = 0; i < configsCount; i++) {
+        cssAnimations.emplace_back(rt, animationConfigs.getValueAtIndex(rt, i));
+      }
     }
   }
 }

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.cpp
@@ -13,47 +13,17 @@ ReanimatedNodeProps::ReanimatedNodeProps(
           "jsStyle",
           sourceProps.jsStyle,
           {})),
-      cssTransition(parseCSSTransition(rawProps)),
-      cssAnimations(parseCSSAnimations(rawProps)) {}
-
-std::optional<CSSTransitionConfig> ReanimatedNodeProps::parseCSSTransition(
-    const RawProps &rawProps) {
-  return parseRawProp<CSSTransitionConfig>(
-      rawProps, "cssTransition", [](jsi::Runtime &rt, const jsi::Value &value) {
-        return CSSTransitionConfig(rt, value);
-      });
-}
-
-std::vector<CSSAnimationConfig> ReanimatedNodeProps::parseCSSAnimations(
-    const RawProps &rawProps) {
-  auto parsedProp = parseRawProp<std::vector<CSSAnimationConfig>>(
-      rawProps, "cssAnimations", [](jsi::Runtime &rt, const jsi::Value &value) {
-        std::vector<CSSAnimationConfig> animations;
-        const auto animationConfigs = value.asObject(rt).asArray(rt);
-        const auto configsCount = animationConfigs.size(rt);
-
-        animations.reserve(configsCount);
-        for (size_t i = 0; i < configsCount; i++) {
-          animations.emplace_back(rt, animationConfigs.getValueAtIndex(rt, i));
-        }
-        return animations;
-      });
-  return std::move(parsedProp).value_or(std::vector<CSSAnimationConfig>{});
-}
-
-template <typename T>
-std::optional<T> ReanimatedNodeProps::parseRawProp(
-    const RawProps &rawProps,
-    const char *propName,
-    std::function<T(jsi::Runtime &, const jsi::Value &)> parser) {
-  auto rawValue = const_cast<RawValue *>(rawProps.at(propName, "", ""));
-  auto pair = (JsiValuePair *)rawValue;
-
-  if (pair && pair->second.isObject()) {
-    return parser(*pair->first, pair->second);
-  }
-
-  return std::nullopt;
-}
+      cssTransition(convertRawProp(
+          context,
+          rawProps,
+          "cssTransition",
+          sourceProps.cssTransition,
+          std::nullopt)),
+      cssAnimations(convertRawProp(
+          context,
+          rawProps,
+          "cssAnimations",
+          sourceProps.cssAnimations,
+          {})) {}
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/propsConversions.h>
+
+#include <reanimated/CSS/config/CSSAnimationConfig.h>
+#include <reanimated/CSS/config/CSSTransitionConfig.h>
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+using namespace reanimated;
+using namespace css;
+
+class ReanimatedNodeProps final : public ViewProps {
+ public:
+  ReanimatedNodeProps() = default;
+  ReanimatedNodeProps(
+      const PropsParserContext &context,
+      const ReanimatedNodeProps &sourceProps,
+      const RawProps &rawProps);
+
+#pragma mark - Props
+
+  using JsiValuePair = std::pair<jsi::Runtime *, jsi::Value>;
+
+  folly::dynamic jsStyle{};
+  std::optional<CSSTransitionConfig> cssTransition{};
+  JsiValuePair cssAnimations{};
+};
+
+} // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
@@ -29,7 +29,7 @@ class ReanimatedNodeProps final : public ViewProps {
 
   folly::dynamic jsStyle{};
   std::optional<CSSTransitionConfig> cssTransition{};
-  JsiValuePair cssAnimations{};
+  std::vector<CSSAnimationConfig> cssAnimations{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
@@ -30,6 +30,18 @@ class ReanimatedNodeProps final : public ViewProps {
   folly::dynamic jsStyle{};
   std::optional<CSSTransitionConfig> cssTransition{};
   std::vector<CSSAnimationConfig> cssAnimations{};
+
+ private:
+  std::optional<CSSTransitionConfig> parseCSSTransition(
+      const RawProps &rawProps);
+
+  std::vector<CSSAnimationConfig> parseCSSAnimations(const RawProps &rawProps);
+
+  template <typename T>
+  std::optional<T> parseRawProp(
+      const RawProps &rawProps,
+      const char *propName,
+      std::function<T(jsi::Runtime &, const jsi::Value &)> parser);
 };
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedNodeProps.h
@@ -8,7 +8,7 @@
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
 
 #include <folly/dynamic.h>
-#include <jsi/jsi.h>
+#include <vector>
 
 namespace facebook::react {
 
@@ -25,23 +25,9 @@ class ReanimatedNodeProps final : public ViewProps {
 
 #pragma mark - Props
 
-  using JsiValuePair = std::pair<jsi::Runtime *, jsi::Value>;
-
   folly::dynamic jsStyle{};
   std::optional<CSSTransitionConfig> cssTransition{};
   std::vector<CSSAnimationConfig> cssAnimations{};
-
- private:
-  std::optional<CSSTransitionConfig> parseCSSTransition(
-      const RawProps &rawProps);
-
-  std::vector<CSSAnimationConfig> parseCSSAnimations(const RawProps &rawProps);
-
-  template <typename T>
-  std::optional<T> parseRawProp(
-      const RawProps &rawProps,
-      const char *propName,
-      std::function<T(jsi::Runtime &, const jsi::Value &)> parser);
 };
 
 } // namespace facebook::react

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -12,8 +12,8 @@ ReanimatedShadowNode::ReanimatedShadowNode(
   const auto &newProps =
       static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
-  // const auto &state = getStateData();
-  // state.cssAnimationsManager->update(newProps);
+  const auto &state = getStateData();
+  state.cssAnimationsManager->update(newProps);
 }
 
 ReanimatedShadowNode::ReanimatedShadowNode(
@@ -25,19 +25,9 @@ ReanimatedShadowNode::ReanimatedShadowNode(
   const auto &newProps =
       static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
-  // TODO - optimize cloning (don't call update if props on the JS side didn't
-  // change)
-
-  if (oldProps.cssTransition != newProps.cssTransition) {
-    LOG(INFO) << "cssTransition changed";
-  }
-
-  if (oldProps.cssAnimations != newProps.cssAnimations) {
-    LOG(INFO) << "cssAnimations changed";
-  }
-
-  // const auto &state = getStateData();
-  // state.cssAnimationsManager->update(newProps);
+  const auto &state = getStateData();
+  state.cssAnimationsManager->update(newProps);
+  state.cssTransitionManager->update(oldProps, newProps);
 }
 
 void ReanimatedShadowNode::layout(LayoutContext layoutContext) {

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -13,7 +13,7 @@ ReanimatedShadowNode::ReanimatedShadowNode(
       static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
   const auto &state = getStateData();
-  state.cssAnimationsManager->update(newProps);
+  state.cssAnimationsManager->update(ReanimatedNodeProps(), newProps);
 }
 
 ReanimatedShadowNode::ReanimatedShadowNode(
@@ -26,7 +26,7 @@ ReanimatedShadowNode::ReanimatedShadowNode(
       static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
   const auto &state = getStateData();
-  state.cssAnimationsManager->update(newProps);
+  state.cssAnimationsManager->update(oldProps, newProps);
   state.cssTransitionManager->update(oldProps, newProps);
 }
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -10,7 +10,7 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     ShadowNodeTraits traits)
     : ReanimatedViewShadowNodeBase(fragment, family, traits) {
   const auto &newProps =
-      static_cast<const ReanimatedViewProps &>(*this->getProps());
+      static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
   // const auto &state = getStateData();
   // state.cssAnimationsManager->update(newProps);
@@ -21,9 +21,9 @@ ReanimatedShadowNode::ReanimatedShadowNode(
     const ShadowNodeFragment &fragment)
     : ReanimatedViewShadowNodeBase(sourceShadowNode, fragment) {
   const auto &oldProps =
-      static_cast<const ReanimatedViewProps &>(*sourceShadowNode.getProps());
+      static_cast<const ReanimatedNodeProps &>(*sourceShadowNode.getProps());
   const auto &newProps =
-      static_cast<const ReanimatedViewProps &>(*this->getProps());
+      static_cast<const ReanimatedNodeProps &>(*this->getProps());
 
   // TODO - optimize cloning (don't call update if props on the JS side didn't
   // change)

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.cpp
@@ -28,8 +28,15 @@ ReanimatedShadowNode::ReanimatedShadowNode(
   // TODO - optimize cloning (don't call update if props on the JS side didn't
   // change)
 
+  if (oldProps.cssTransition != newProps.cssTransition) {
+    LOG(INFO) << "cssTransition changed";
+  }
+
+  if (oldProps.cssAnimations != newProps.cssAnimations) {
+    LOG(INFO) << "cssAnimations changed";
+  }
+
   // const auto &state = getStateData();
-  // state.cssTransitionManager->update(oldProps, newProps);
   // state.cssAnimationsManager->update(newProps);
 }
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <react/renderer/components/rnreanimated/EventEmitters.h>
-#include <react/renderer/components/rnreanimated/Props.h>
+#include <react/renderer/components/rnreanimated/ReanimatedNodeProps.h>
 #include <react/renderer/components/rnreanimated/ReanimatedViewStateData.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
@@ -12,7 +12,7 @@ JSI_EXPORT extern const char ReanimatedViewComponentName[];
 
 using ReanimatedViewShadowNodeBase = ConcreteViewShadowNode<
     ReanimatedViewComponentName,
-    ReanimatedViewProps,
+    ReanimatedNodeProps,
     ReanimatedViewEventEmitter,
     ReanimatedViewStateData>;
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.cpp
@@ -31,7 +31,7 @@ folly::dynamic CSSAnimationsManager::getCurrentFrameProps(
   return result;
 }
 
-void CSSAnimationsManager::update(const ReanimatedViewProps &newProps) {
+void CSSAnimationsManager::update(const ReanimatedNodeProps &newProps) {
   // // Parse properties to animation config objects
   // const auto configs = parseAnimationConfigs(newProps.cssAnimations);
   // // Map current animations to their names in order to reuse the same

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/components/rnreanimated/Props.h>
+#include <react/renderer/components/rnreanimated/ReanimatedNodeProps.h>
 
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
@@ -29,7 +29,7 @@ class CSSAnimationsManager {
 
   folly::dynamic getCurrentFrameProps(const ShadowNode::Shared &shadowNode);
 
-  void update(const ReanimatedViewProps &newProps);
+  void update(const ReanimatedNodeProps &newProps);
 
  private:
   using AnimationsVector = std::vector<std::shared_ptr<CSSAnimation>>;

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSAnimationsManager.h
@@ -29,7 +29,9 @@ class CSSAnimationsManager {
 
   folly::dynamic getCurrentFrameProps(const ShadowNode::Shared &shadowNode);
 
-  void update(const ReanimatedNodeProps &newProps);
+  void update(
+      const ReanimatedNodeProps &oldProps,
+      const ReanimatedNodeProps &newProps);
 
  private:
   using AnimationsVector = std::vector<std::shared_ptr<CSSAnimation>>;
@@ -43,10 +45,8 @@ class CSSAnimationsManager {
   std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 
-  std::vector<CSSAnimationConfig> parseAnimationConfigs(
-      const folly::dynamic &cssAnimations) const;
   NameToAnimationsMap createCurrentNameToAnimationsMap() const;
-  AnimationsVector createNewAnimationsVector(
+  AnimationsVector createAndStartNewAnimations(
       NameToAnimationsMap &nameToAnimationsMap,
       const std::vector<CSSAnimationConfig> &animationConfigs);
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
@@ -29,24 +29,24 @@ folly::dynamic CSSTransitionManager::getCurrentFrameProps(
 void CSSTransitionManager::update(
     const ReanimatedNodeProps &oldProps,
     const ReanimatedNodeProps &newProps) {
-  // updateTransitionInstance(oldProps.cssTransition, newProps.cssTransition);
-  // if (transition_) {
-  //   // Run transition if at least one of transition properties has changed
-  //   runTransitionForChangedProperties(oldProps.jsStyle, newProps.jsStyle);
-  // }
+  updateTransitionInstance(oldProps.cssTransition, newProps.cssTransition);
+  if (transition_) {
+    // Run transition if at least one of transition properties has changed
+    runTransitionForChangedProperties(oldProps.jsStyle, newProps.jsStyle);
+  }
 }
 
 void CSSTransitionManager::updateTransitionInstance(
-    const folly::dynamic &oldConfig,
-    const folly::dynamic &newConfig) {
+    const std::optional<CSSTransitionConfig> &oldConfig,
+    const std::optional<CSSTransitionConfig> &newConfig) {
   if (!transition_) {
-    if (!newConfig.empty()) {
-      createTransition(newConfig);
+    if (newConfig.has_value()) {
+      transition_ = std::make_shared<CSSTransition>(newConfig.value());
     }
-  } else if (newConfig.empty()) {
+  } else if (!newConfig.has_value()) {
     removeTransition();
-  } else {
-    updateTransition(oldConfig, newConfig);
+  } else if (oldConfig != newConfig) {
+    // TODO
   }
 }
 
@@ -69,24 +69,9 @@ void CSSTransitionManager::runTransitionForChangedProperties(
   }
 }
 
-void CSSTransitionManager::createTransition(const folly::dynamic &config) {
-  //  transition_ =
-  //      std::make_shared<CSSTransition>(parseCSSTransitionConfig(config));
-}
-
 void CSSTransitionManager::removeTransition() {
   operationsLoop_->remove(operationHandle_);
   transition_ = nullptr;
-}
-
-void CSSTransitionManager::updateTransition(
-    const folly::dynamic &oldConfig,
-    const folly::dynamic &newConfig) {
-  // const auto updates =
-  //     getParsedCSSTransitionConfigUpdates(oldConfig, newConfig);
-  // if (updates.has_value()) {
-  //   transition_->updateSettings(std::move(updates.value()));
-  // }
 }
 
 void CSSTransitionManager::runTransition(ChangedProps &&changedProps) {

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
@@ -46,7 +46,7 @@ void CSSTransitionManager::updateTransitionInstance(
   } else if (!newConfig.has_value()) {
     removeTransition();
   } else if (oldConfig != newConfig) {
-    // TODO
+    transition_->updateConfig(newConfig.value());
   }
 }
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.cpp
@@ -27,8 +27,8 @@ folly::dynamic CSSTransitionManager::getCurrentFrameProps(
 }
 
 void CSSTransitionManager::update(
-    const ReanimatedViewProps &oldProps,
-    const ReanimatedViewProps &newProps) {
+    const ReanimatedNodeProps &oldProps,
+    const ReanimatedNodeProps &newProps) {
   // updateTransitionInstance(oldProps.cssTransition, newProps.cssTransition);
   // if (transition_) {
   //   // Run transition if at least one of transition properties has changed

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.h
@@ -41,17 +41,13 @@ class CSSTransitionManager {
   std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
 
   void updateTransitionInstance(
-      const folly::dynamic &oldConfig,
-      const folly::dynamic &newConfig);
+      const std::optional<CSSTransitionConfig> &oldConfig,
+      const std::optional<CSSTransitionConfig> &newConfig);
   void runTransitionForChangedProperties(
       const folly::dynamic &oldProps,
       const folly::dynamic &newProps);
 
-  void createTransition(const folly::dynamic &config);
   void removeTransition();
-  void updateTransition(
-      const folly::dynamic &oldConfig,
-      const folly::dynamic &newConfig);
   void runTransition(ChangedProps &&changedProps);
 };
 

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/managers/CSSTransitionManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/components/rnreanimated/Props.h>
+#include <react/renderer/components/rnreanimated/ReanimatedNodeProps.h>
 
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
 #include <reanimated/CSS/core/CSSTransition.h>
@@ -26,8 +26,8 @@ class CSSTransitionManager {
   folly::dynamic getCurrentFrameProps(const ShadowNode::Shared &shadowNode);
 
   void update(
-      const ReanimatedViewProps &oldProps,
-      const ReanimatedViewProps &newProps);
+      const ReanimatedNodeProps &oldProps,
+      const ReanimatedNodeProps &newProps);
 
  private:
   std::shared_ptr<CSSTransition> transition_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -3,11 +3,14 @@
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {
 
 using namespace facebook;
+
+using JsiValuePair = std::pair<jsi::Runtime *, jsi::Value>;
 
 using PropertyNames = std::vector<std::string>;
 using PropertyPath = std::vector<std::string>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
@@ -195,4 +195,42 @@ CSSAnimationUpdates parseCSSAnimationUpdates(
   return result;
 }
 
+CSSAnimationConfig::CSSAnimationConfig(
+    const std::string &name,
+    double duration,
+    std::shared_ptr<Easing> easing,
+    double delay,
+    double iterationCount,
+    AnimationDirection direction,
+    AnimationFillMode fillMode,
+    AnimationPlayState playState)
+    : CSSAnimationSettings{duration, easing, delay, iterationCount, direction, fillMode, playState},
+      name(name) {}
+
+CSSAnimationConfig::CSSAnimationConfig(
+    jsi::Runtime &rt,
+    const jsi::Value &config) {
+  const auto configObj = config.asObject(rt);
+  name = parseName(rt, configObj);
+  duration = parseDuration(rt, configObj);
+  easing = parseTimingFunction(rt, configObj);
+  delay = parseDelay(rt, configObj);
+  iterationCount = parseIterationCount(rt, configObj);
+  direction = parseDirection(rt, configObj);
+  fillMode = parseFillMode(rt, configObj);
+  playState = parsePlayState(rt, configObj);
+}
+
+bool CSSAnimationConfig::operator==(const CSSAnimationConfig &other) const {
+  // First check if it's the same object
+  if (this == &other) {
+    return true;
+  }
+
+  return duration == other.duration && easing == other.easing &&
+      delay == other.delay && iterationCount == other.iterationCount &&
+      direction == other.direction && fillMode == other.fillMode &&
+      playState == other.playState && name == other.name;
+}
+
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
@@ -207,18 +207,18 @@ CSSAnimationConfig::CSSAnimationConfig(
     : CSSAnimationSettings{duration, easing, delay, iterationCount, direction, fillMode, playState},
       name(name) {}
 
-CSSAnimationConfig::CSSAnimationConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config) {
-  const auto configObj = config.asObject(rt);
-  name = parseName(rt, configObj);
-  duration = parseDuration(rt, configObj);
-  easing = parseTimingFunction(rt, configObj);
-  delay = parseDelay(rt, configObj);
-  iterationCount = parseIterationCount(rt, configObj);
-  direction = parseDirection(rt, configObj);
-  fillMode = parseFillMode(rt, configObj);
-  playState = parsePlayState(rt, configObj);
+CSSAnimationConfig::CSSAnimationConfig(const RawValue &rawValue) {
+  parseRawValue(rawValue, [this](jsi::Runtime &rt, const jsi::Value &value) {
+    const auto configObj = value.asObject(rt);
+    name = parseName(rt, configObj);
+    duration = parseDuration(rt, configObj);
+    easing = parseTimingFunction(rt, configObj);
+    delay = parseDelay(rt, configObj);
+    iterationCount = parseIterationCount(rt, configObj);
+    direction = parseDirection(rt, configObj);
+    fillMode = parseFillMode(rt, configObj);
+    playState = parsePlayState(rt, configObj);
+  });
 }
 
 bool CSSAnimationConfig::operator==(const CSSAnimationConfig &other) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -57,6 +57,20 @@ CSSAnimationUpdates parseCSSAnimationUpdates(
 
 struct CSSAnimationConfig : public CSSAnimationSettings {
   std::string name;
+
+  CSSAnimationConfig(
+      const std::string &name,
+      double duration,
+      std::shared_ptr<Easing> easing,
+      double delay,
+      double iterationCount,
+      AnimationDirection direction,
+      AnimationFillMode fillMode,
+      AnimationPlayState playState);
+
+  CSSAnimationConfig(jsi::Runtime &rt, const jsi::Value &config);
+
+  bool operator==(const CSSAnimationConfig &other) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -58,6 +58,7 @@ CSSAnimationUpdates parseCSSAnimationUpdates(
 struct CSSAnimationConfig : public CSSAnimationSettings {
   std::string name;
 
+  // TODO - remove this constructor when refactor is finished
   CSSAnimationConfig(
       const std::string &name,
       double duration,
@@ -68,7 +69,9 @@ struct CSSAnimationConfig : public CSSAnimationSettings {
       AnimationFillMode fillMode,
       AnimationPlayState playState);
 
-  CSSAnimationConfig(jsi::Runtime &rt, const jsi::Value &config);
+  // Both constructors are needed for rawValue conversion
+  CSSAnimationConfig() = default;
+  explicit CSSAnimationConfig(const RawValue &rawValue);
 
   bool operator==(const CSSAnimationConfig &other) const;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
@@ -71,6 +71,45 @@ CSSTransitionPropertiesSettings parseCSSTransitionPropertiesSettings(
   return result;
 }
 
+bool CSSTransitionPropertySettings::operator==(
+    const CSSTransitionPropertySettings &other) const {
+  return duration == other.duration && easing == other.easing &&
+      delay == other.delay && allowDiscrete == other.allowDiscrete;
+}
+
+CSSTransitionConfig::CSSTransitionConfig(
+    TransitionProperties properties,
+    CSSTransitionPropertiesSettings settings)
+    : properties(properties), settings(settings) {}
+
+CSSTransitionConfig::CSSTransitionConfig(
+    jsi::Runtime &rt,
+    const jsi::Value &config) {
+  const auto configObj = config.asObject(rt);
+  properties = parseProperties(rt, configObj);
+  settings = parseCSSTransitionPropertiesSettings(
+      rt, configObj.getProperty(rt, "settings").asObject(rt));
+}
+
+bool CSSTransitionConfig::operator==(const CSSTransitionConfig &other) const {
+  // First check if it's the same object
+  if (this == &other) {
+    return true;
+  }
+
+  // Compare properties (optional vector of strings)
+  if (properties.has_value() != other.properties.has_value()) {
+    return false;
+  }
+  if (properties.has_value() &&
+      properties.value() != other.properties.value()) {
+    return false;
+  }
+
+  // Compare settings (unordered map mapping property names to settings)
+  return settings == other.settings;
+}
+
 CSSTransitionConfig parseCSSTransitionConfig(
     jsi::Runtime &rt,
     const jsi::Value &config) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.cpp
@@ -82,13 +82,13 @@ CSSTransitionConfig::CSSTransitionConfig(
     CSSTransitionPropertiesSettings settings)
     : properties(properties), settings(settings) {}
 
-CSSTransitionConfig::CSSTransitionConfig(
-    jsi::Runtime &rt,
-    const jsi::Value &config) {
-  const auto configObj = config.asObject(rt);
-  properties = parseProperties(rt, configObj);
-  settings = parseCSSTransitionPropertiesSettings(
-      rt, configObj.getProperty(rt, "settings").asObject(rt));
+CSSTransitionConfig::CSSTransitionConfig(const RawValue &rawValue) {
+  parseRawValue(rawValue, [this](jsi::Runtime &rt, const jsi::Value &value) {
+    const auto configObj = value.asObject(rt);
+    properties = parseProperties(rt, configObj);
+    settings = parseCSSTransitionPropertiesSettings(
+        rt, configObj.getProperty(rt, "settings").asObject(rt));
+  });
 }
 
 bool CSSTransitionConfig::operator==(const CSSTransitionConfig &other) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -20,6 +20,8 @@ struct CSSTransitionPropertySettings {
   std::shared_ptr<Easing> easing;
   double delay;
   bool allowDiscrete;
+
+  bool operator==(const CSSTransitionPropertySettings &other) const;
 };
 
 using CSSTransitionPropertiesSettings =
@@ -28,6 +30,14 @@ using CSSTransitionPropertiesSettings =
 struct CSSTransitionConfig {
   TransitionProperties properties;
   CSSTransitionPropertiesSettings settings;
+
+  CSSTransitionConfig(
+      TransitionProperties properties,
+      CSSTransitionPropertiesSettings settings);
+
+  CSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config);
+
+  bool operator==(const CSSTransitionConfig &other) const;
 };
 
 std::optional<CSSTransitionPropertySettings> getTransitionPropertySettings(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -31,11 +31,14 @@ struct CSSTransitionConfig {
   TransitionProperties properties;
   CSSTransitionPropertiesSettings settings;
 
+  // TODO - remove this constructor when refactor is finished
   CSSTransitionConfig(
       TransitionProperties properties,
       CSSTransitionPropertiesSettings settings);
 
-  CSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config);
+  // Both constructors are needed for rawValue conversion
+  CSSTransitionConfig() = default;
+  explicit CSSTransitionConfig(const RawValue &rawValue);
 
   bool operator==(const CSSTransitionConfig &other) const;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -2,6 +2,13 @@
 
 namespace reanimated::css {
 
+void parseRawValue(
+    const RawValue &rawValue,
+    std::function<void(jsi::Runtime &, const jsi::Value &)> parser) {
+  auto pair = (JsiValuePair *)(const_cast<RawValue *>(&rawValue));
+  parser(*pair->first, pair->second);
+}
+
 double parseDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -5,7 +5,8 @@ namespace reanimated::css {
 void parseRawValue(
     const RawValue &rawValue,
     std::function<void(jsi::Runtime &, const jsi::Value &)> parser) {
-  auto pair = (JsiValuePair *)(const_cast<RawValue *>(&rawValue));
+  auto pair =
+      reinterpret_cast<JsiValuePair *>(const_cast<RawValue *>(&rawValue));
   parser(*pair->first, pair->second);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -1,11 +1,19 @@
 #pragma once
 
+#include <react/renderer/core/RawValue.h>
+
 #include <reanimated/CSS/easing/utils.h>
 
 #include <jsi/jsi.h>
 #include <memory>
 
 namespace reanimated::css {
+
+using namespace facebook::react;
+
+void parseRawValue(
+    const RawValue &rawValue,
+    std::function<void(jsi::Runtime &, const jsi::Value &)> parser);
 
 double parseDuration(jsi::Runtime &rt, const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -63,6 +63,7 @@ folly::dynamic CSSTransition::getCurrentFrameProps(
       shadowNode, progressProvider_, viewStylesRepository);
 }
 
+// TODO - remove this method when CSS refactor is finished
 void CSSTransition::updateSettings(const CSSTransitionConfigUpdates &config) {
   if (config.properties.has_value()) {
     updateTransitionProperties(config.properties.value());
@@ -70,6 +71,13 @@ void CSSTransition::updateSettings(const CSSTransitionConfigUpdates &config) {
   if (config.settings.has_value()) {
     settings_ = config.settings.value();
   }
+}
+
+void CSSTransition::updateConfig(const CSSTransitionConfig &config) {
+  if (config.properties != properties_) {
+    updateTransitionProperties(config.properties);
+  }
+  settings_ = config.settings;
 }
 
 void CSSTransition::run(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -26,7 +26,9 @@ class CSSTransition {
       const ShadowNode::Shared &shadowNode,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const;
 
+  // TODO - remove this method when CSS refactor is finished
   void updateSettings(const CSSTransitionConfigUpdates &config);
+  void updateConfig(const CSSTransitionConfig &config);
   void run(
       double timestamp,
       const ChangedProps &changedProps,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -510,16 +510,15 @@ void ReanimatedModuleProxy::applyCSSAnimations(
             "[Reanimated] index is out of bounds of animationNames");
       }
 
-      CSSAnimationConfig config{
-          CSSAnimationSettings{
-              settings.duration,
-              settings.easing,
-              settings.delay,
-              settings.iterationCount,
-              settings.direction,
-              settings.fillMode,
-              settings.playState},
-          animationNames[index]};
+      const auto config = CSSAnimationConfig(
+          animationNames[index],
+          settings.duration,
+          settings.easing,
+          settings.delay,
+          settings.iterationCount,
+          settings.direction,
+          settings.fillMode,
+          settings.playState);
 
       const auto animation = std::make_shared<CSSAnimation>(
           config, cssAnimationKeyframesRegistry_, timestamp);

--- a/packages/react-native-reanimated/apple/reanimated/apple/view/ReanimatedView.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/view/ReanimatedView.mm
@@ -2,7 +2,6 @@
 
 #import <react/renderer/components/rnreanimated/ComponentDescriptors.h>
 #import <react/renderer/components/rnreanimated/EventEmitters.h>
-#import <react/renderer/components/rnreanimated/Props.h>
 #import <react/renderer/components/rnreanimated/RCTComponentViewHelpers.h>
 
 using namespace facebook::react;
@@ -16,9 +15,6 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  //  const auto &oldViewProps = *std::static_pointer_cast<ReanimatedViewProps const>(_props);
-  //  const auto &newViewProps = *std::static_pointer_cast<ReanimatedViewProps const>(props);
-
   [super updateProps:props oldProps:oldProps];
 }
 


### PR DESCRIPTION
## Summary

This PR adds custom Reanimated ShadowNode props type with direct parsing from `jsi::Value` to the desired config type.

It also adjust implementations of managers and config structs to optimize props comparison (checking if they are the same) and parsing directly from the `rawValue` (being converted to the `jsi::Runtime` and `jsi::Value` pair).