### PR TITLE
Move `JSScheduler` creation to `WorkletsModuleProxy` constructor

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -26,19 +26,18 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<MessageQueueThread> &jsQueue,
     const std::shared_ptr<CallInvoker> &jsCallInvoker,
-    const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::shared_ptr<UIScheduler> &uiScheduler,
     std::function<void(std::function<void(const double)>)>
         &&forwardedRequestAnimationFrame)
     : WorkletsModuleProxySpec(jsCallInvoker),
       isDevBundle_(isDevBundleFromRNRuntime(rnRuntime)),
       jsQueue_(jsQueue),
-      jsScheduler_(jsScheduler),
+      jsScheduler_(std::make_shared<JSScheduler>(rnRuntime, jsCallInvoker)),
       uiScheduler_(uiScheduler),
       uiWorkletRuntime_(std::make_shared<WorkletRuntime>(
           rnRuntime,
           jsQueue,
-          jsScheduler,
+          jsScheduler_,
           "Reanimated UI runtime",
           true /* supportsLocking */,
           isDevBundle_)),

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -21,7 +21,6 @@ class WorkletsModuleProxy
       jsi::Runtime &rnRuntime,
       const std::shared_ptr<MessageQueueThread> &jsQueue,
       const std::shared_ptr<CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler,
       std::function<void(std::function<void(const double)>)>
           &&forwardedRequestAnimationFrame);

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -40,11 +40,7 @@ jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(
   auto rnRuntime = reinterpret_cast<jsi::Runtime *>(jsContext);
   auto uiScheduler = androidUIScheduler->cthis()->getUIScheduler();
   return makeCxxInstance(
-      jThis,
-      rnRuntime,
-      messageQueueThread,
-      jsCallInvoker,
-      uiScheduler);
+      jThis, rnRuntime, messageQueueThread, jsCallInvoker, uiScheduler);
 }
 
 std::function<void(std::function<void(const double)>)>

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -16,7 +16,6 @@ WorkletsModule::WorkletsModule(
     jsi::Runtime *rnRuntime,
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
-    const std::shared_ptr<worklets::JSScheduler> &jsScheduler,
     const std::shared_ptr<UIScheduler> &uiScheduler)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
@@ -24,7 +23,6 @@ WorkletsModule::WorkletsModule(
           *rnRuntime,
           std::make_shared<JMessageQueueThread>(messageQueueThread),
           jsCallInvoker,
-          jsScheduler,
           uiScheduler,
           getForwardedRequestAnimationFrame())) {
   RNRuntimeWorkletDecorator::decorate(*rnRuntime_, workletsModuleProxy_);
@@ -40,15 +38,12 @@ jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(
         androidUIScheduler) {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
   auto rnRuntime = reinterpret_cast<jsi::Runtime *>(jsContext);
-  auto jsScheduler =
-      std::make_shared<worklets::JSScheduler>(*rnRuntime, jsCallInvoker);
   auto uiScheduler = androidUIScheduler->cthis()->getUIScheduler();
   return makeCxxInstance(
       jThis,
       rnRuntime,
       messageQueueThread,
       jsCallInvoker,
-      jsScheduler,
       uiScheduler);
 }
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -42,7 +42,6 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
       jsi::Runtime *rnRuntime,
       jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
       const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<worklets::JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler);
 
   void invalidateCpp();

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -56,7 +56,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   });
 
   auto jsCallInvoker = _callInvoker.callInvoker;
-  auto jsScheduler = std::make_shared<worklets::JSScheduler>(rnRuntime, jsCallInvoker);
   auto uiScheduler = std::make_shared<worklets::IOSUIScheduler>();
   animationFrameQueue_ = [AnimationFrameQueue new];
   auto forwardedRequestAnimationFrame = std::function<void(std::function<void(const double)>)>(
@@ -64,7 +63,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
         [animationFrameQueue requestAnimationFrame:callback];
       });
   workletsModuleProxy_ = std::make_shared<WorkletsModuleProxy>(
-      rnRuntime, jsQueue, jsCallInvoker, jsScheduler, uiScheduler, std::move(forwardedRequestAnimationFrame));
+      rnRuntime, jsQueue, jsCallInvoker, uiScheduler, std::move(forwardedRequestAnimationFrame));
   RNRuntimeWorkletDecorator::decorate(rnRuntime, workletsModuleProxy_);
 
   return @YES;


### PR DESCRIPTION
## Summary

Currently, we instantiate `worklets::JSScheduler` in platform-specific Android/iOS code.

This PR moves `std::make_shared<worklets::JSScheduler>(...)` call to `WorkletsModuleProxy` constructor initializer list to avoid code duplication.

As a result, we only need to pass `jsCallInvoker` (which is still necessary for `NativeWorkletsModuleSpec`) instead of both `jsCallInvoker` and `jsScheduler`.

## Test plan
