### PR TITLE
Remove `isChromeDebugger` completely

### DIFF
--- a/packages/react-native-reanimated/src/PlatformChecker.ts
+++ b/packages/react-native-reanimated/src/PlatformChecker.ts
@@ -1,10 +1,6 @@
 'use strict';
 import { Platform } from 'react-native';
 
-// This type is necessary since some libraries tend to do a lib check
-// and this file causes type errors on `global` access.
-type localGlobal = typeof global & Record<string, unknown>;
-
 export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }

--- a/packages/react-native-reanimated/src/PlatformChecker.ts
+++ b/packages/react-native-reanimated/src/PlatformChecker.ts
@@ -9,15 +9,6 @@ export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }
 
-// `isChromeDebugger` also returns true in Jest environment, so `isJest()` check should always be performed first
-export function isChromeDebugger(): boolean {
-  return (
-    (!(global as localGlobal).nativeCallSyncHook ||
-      !!(global as localGlobal).__REMOTEDEV__) &&
-    !(global as localGlobal).RN$Bridgeless
-  );
-}
-
 export function isWeb(): boolean {
   return Platform.OS === 'web';
 }
@@ -31,7 +22,7 @@ function isWindows(): boolean {
 }
 
 export function shouldBeUseWeb() {
-  return isJest() || isChromeDebugger() || isWeb() || isWindows();
+  return isJest() || isWeb() || isWindows();
 }
 
 export function isWindowAvailable() {

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -20,7 +20,6 @@ import type {
 } from '../../css/platform/native';
 import { ReanimatedError } from '../../errors';
 import {
-  isChromeDebugger,
   isJest,
   isWeb,
   isWindowAvailable,
@@ -63,8 +62,6 @@ class JSReanimated implements IReanimatedModule {
       logger.warn('Layout Animations are not supported on web yet.');
     } else if (isJest()) {
       logger.warn('Layout Animations are no-ops when using Jest.');
-    } else if (isChromeDebugger()) {
-      logger.warn('Layout Animations are no-ops when using Chrome Debugger.');
     } else {
       logger.warn('Layout Animations are not supported on this configuration.');
     }
@@ -195,10 +192,6 @@ class JSReanimated implements IReanimatedModule {
       logger.warn('useAnimatedKeyboard is not available on web yet.');
     } else if (isJest()) {
       logger.warn('useAnimatedKeyboard is not available when using Jest.');
-    } else if (isChromeDebugger()) {
-      logger.warn(
-        'useAnimatedKeyboard is not available when using Chrome Debugger.'
-      );
     } else {
       logger.warn(
         'useAnimatedKeyboard is not available on this configuration.'

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -19,11 +19,7 @@ import type {
   NormalizedCSSTransitionConfig,
 } from '../../css/platform/native';
 import { ReanimatedError } from '../../errors';
-import {
-  isJest,
-  isWeb,
-  isWindowAvailable,
-} from '../../PlatformChecker';
+import { isJest, isWeb, isWindowAvailable } from '../../PlatformChecker';
 import type { IReanimatedModule } from '../reanimatedModuleProxy';
 import type { WebSensor } from './WebSensor';
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
@@ -4,7 +4,6 @@ import { initialUpdaterRun } from '../animation';
 import type { StyleProps } from '../commonTypes';
 import type { AnimatedStyleHandle } from '../hook/commonTypes';
 import { isSharedValue } from '../isSharedValue';
-import { isChromeDebugger } from '../PlatformChecker';
 import { WorkletEventHandler } from '../WorkletEventHandler';
 import type {
   AnimatedComponentProps,
@@ -87,7 +86,7 @@ export class PropsFilter implements IPropsFilter {
         if (component._isFirstRender) {
           props[key] = value.value;
         }
-      } else if (key !== 'onGestureHandlerStateChange' || !isChromeDebugger()) {
+      } else {
         props[key] = value;
       }
     }

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -8,7 +8,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type DispatchCommand = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -47,10 +47,6 @@ function dispatchCommandJest() {
   logger.warn('dispatchCommand() is not supported with Jest.');
 }
 
-function dispatchCommandChromeDebugger() {
-  logger.warn('dispatchCommand() is not supported with Chrome Debugger.');
-}
-
 function dispatchCommandDefault() {
   logger.warn('dispatchCommand() is not supported on this configuration.');
 }
@@ -62,8 +58,6 @@ if (!shouldBeUseWeb()) {
   dispatchCommand = dispatchCommandNative as unknown as DispatchCommand;
 } else if (isJest()) {
   dispatchCommand = dispatchCommandJest;
-} else if (isChromeDebugger()) {
-  dispatchCommand = dispatchCommandChromeDebugger;
 } else {
   dispatchCommand = dispatchCommandDefault;
 }

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -8,7 +8,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type Measure = <T extends Component>(
   animatedRef: AnimatedRef<T>
@@ -67,11 +67,6 @@ function measureJest() {
   return null;
 }
 
-function measureChromeDebugger() {
-  logger.warn('measure() cannot be used with Chrome Debugger.');
-  return null;
-}
-
 function measureDefault() {
   logger.warn('measure() is not supported on this configuration.');
   return null;
@@ -84,8 +79,6 @@ if (!shouldBeUseWeb()) {
   measure = measureNative as unknown as Measure;
 } else if (isJest()) {
   measure = measureJest;
-} else if (isChromeDebugger()) {
-  measure = measureChromeDebugger;
 } else {
   measure = measureDefault;
 }

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -7,7 +7,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 import { dispatchCommand } from './dispatchCommand';
 
 type ScrollTo = <T extends Component>(
@@ -49,10 +49,6 @@ function scrollToJest() {
   logger.warn('scrollTo() is not supported with Jest.');
 }
 
-function scrollToChromeDebugger() {
-  logger.warn('scrollTo() is not supported with Chrome Debugger.');
-}
-
 function scrollToDefault() {
   logger.warn('scrollTo() is not supported on this configuration.');
 }
@@ -64,8 +60,6 @@ if (!shouldBeUseWeb()) {
   scrollTo = scrollToNative as unknown as ScrollTo;
 } else if (isJest()) {
   scrollTo = scrollToJest;
-} else if (isChromeDebugger()) {
-  scrollTo = scrollToChromeDebugger;
 } else {
   scrollTo = scrollToDefault;
 }

--- a/packages/react-native-reanimated/src/platformFunctions/setGestureState.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setGestureState.ts
@@ -2,7 +2,7 @@
 
 import { logger } from 'react-native-worklets';
 
-import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type SetGestureState = (handlerTag: number, newState: number) => void;
 
@@ -21,10 +21,6 @@ function setGestureStateJest() {
   logger.warn('setGestureState() cannot be used with Jest.');
 }
 
-function setGestureStateChromeDebugger() {
-  logger.warn('setGestureState() cannot be used with Chrome Debugger.');
-}
-
 function setGestureStateDefault() {
   logger.warn('setGestureState() is not supported on this configuration.');
 }
@@ -33,8 +29,6 @@ if (!shouldBeUseWeb()) {
   setGestureState = setGestureStateNative;
 } else if (isJest()) {
   setGestureState = setGestureStateJest;
-} else if (isChromeDebugger()) {
-  setGestureState = setGestureStateChromeDebugger;
 } else {
   setGestureState = setGestureStateDefault;
 }

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -9,7 +9,7 @@ import type {
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
-import { isChromeDebugger, isJest, shouldBeUseWeb } from '../PlatformChecker';
+import { isJest, shouldBeUseWeb } from '../PlatformChecker';
 
 type SetNativeProps = <T extends Component>(
   animatedRef: AnimatedRef<T>,
@@ -49,10 +49,6 @@ function setNativePropsJest() {
   logger.warn('setNativeProps() is not supported with Jest.');
 }
 
-function setNativePropsChromeDebugger() {
-  logger.warn('setNativeProps() is not supported with Chrome Debugger.');
-}
-
 function setNativePropsDefault() {
   logger.warn('setNativeProps() is not supported on this configuration.');
 }
@@ -64,8 +60,6 @@ if (!shouldBeUseWeb()) {
   setNativeProps = setNativePropsNative as unknown as SetNativeProps;
 } else if (isJest()) {
   setNativeProps = setNativePropsJest;
-} else if (isChromeDebugger()) {
-  setNativeProps = setNativePropsChromeDebugger;
 } else {
   setNativeProps = setNativePropsDefault;
 }

--- a/packages/react-native-worklets/src/PlatformChecker.ts
+++ b/packages/react-native-worklets/src/PlatformChecker.ts
@@ -1,10 +1,6 @@
 'use strict';
 import { Platform } from 'react-native';
 
-// This type is necessary since some libraries tend to do a lib check
-// and this file causes type errors on `global` access.
-type localGlobal = typeof global & Record<string, unknown>;
-
 export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }

--- a/packages/react-native-worklets/src/PlatformChecker.ts
+++ b/packages/react-native-worklets/src/PlatformChecker.ts
@@ -9,15 +9,6 @@ export function isJest(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }
 
-// `isChromeDebugger` also returns true in Jest environment, so `isJest()` check should always be performed first
-export function isChromeDebugger(): boolean {
-  return (
-    (!(global as localGlobal).nativeCallSyncHook ||
-      !!(global as localGlobal).__REMOTEDEV__) &&
-    !(global as localGlobal).RN$Bridgeless
-  );
-}
-
 export function isWeb(): boolean {
   return Platform.OS === 'web';
 }
@@ -31,7 +22,7 @@ function isWindows(): boolean {
 }
 
 export function shouldBeUseWeb() {
-  return isJest() || isChromeDebugger() || isWeb() || isWindows();
+  return isJest() || isWeb() || isWindows();
 }
 
 export function isWindowAvailable() {

--- a/packages/react-native-worklets/src/initializers.ts
+++ b/packages/react-native-worklets/src/initializers.ts
@@ -9,12 +9,7 @@ import {
   registerLoggerConfig,
   replaceLoggerImplementation,
 } from './logger';
-import {
-  isChromeDebugger,
-  isJest,
-  isWeb,
-  shouldBeUseWeb,
-} from './PlatformChecker';
+import { isJest, isWeb, shouldBeUseWeb } from './PlatformChecker';
 import { executeOnUIRuntimeSync, runOnJS, setupMicrotasks } from './threads';
 import { isWorkletFunction } from './workletFunction';
 import { registerWorkletsError, WorkletsError } from './WorkletsError';
@@ -22,7 +17,6 @@ import type { IWorkletsModule } from './WorkletsModule';
 
 const IS_JEST = isJest();
 const SHOULD_BE_USE_WEB = shouldBeUseWeb();
-const IS_CHROME_DEBUGGER = isChromeDebugger();
 
 // Override the logFunction implementation with the one that adds logs
 // with better stack traces to the LogBox (need to override it after `runOnJS`
@@ -140,19 +134,17 @@ const capturableConsole = createMemorySafeCapturableConsole();
 
 export function setupConsole() {
   'worklet';
-  if (!IS_CHROME_DEBUGGER) {
-    // @ts-ignore TypeScript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtime console version
-    global.console = {
-      /* eslint-disable @typescript-eslint/unbound-method */
-      assert: runOnJS(capturableConsole.assert),
-      debug: runOnJS(capturableConsole.debug),
-      log: runOnJS(capturableConsole.log),
-      warn: runOnJS(capturableConsole.warn),
-      error: runOnJS(capturableConsole.error),
-      info: runOnJS(capturableConsole.info),
-      /* eslint-enable @typescript-eslint/unbound-method */
-    };
-  }
+  // @ts-ignore TypeScript doesn't like that there are missing methods in console object, but we don't provide all the methods for the UI runtime console version
+  global.console = {
+    /* eslint-disable @typescript-eslint/unbound-method */
+    assert: runOnJS(capturableConsole.assert),
+    debug: runOnJS(capturableConsole.debug),
+    log: runOnJS(capturableConsole.log),
+    warn: runOnJS(capturableConsole.warn),
+    error: runOnJS(capturableConsole.error),
+    info: runOnJS(capturableConsole.info),
+    /* eslint-enable @typescript-eslint/unbound-method */
+  };
 }
 
 export function initializeUIRuntime(WorkletsModule: IWorkletsModule) {

--- a/packages/react-native-worklets/src/shareables.ts
+++ b/packages/react-native-worklets/src/shareables.ts
@@ -15,7 +15,7 @@ import type {
   WorkletFunction,
 } from './workletTypes';
 
-// for web/chrome debugger/jest environments this file provides a stub implementation
+// for web and jest environments this file provides a stub implementation
 // where no shareable references are used. Instead, the objects themselves are used
 // instead of shareable references, because of the fact that we don't have to deal with
 // running the code on separate VMs.


### PR DESCRIPTION
## Summary

React Native New Architecture itself doesn't support **Chrome Debugger** (not to be confused with **Chrome DevTools** which is the recommended to debug React Native apps way now) so we can finally get rid of all its traces in our codebase.

## Test plan
