### PR TITLE
Remove unused `REANIMATED_VERSION` in react-native-worklets CMakeLists.txt

### DIFF
--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -12,8 +12,7 @@ include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
 string(APPEND CMAKE_CXX_FLAGS
-       " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION} \
-  -DREANIMATED_VERSION=${REANIMATED_VERSION}")
+       " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}")
 
 string(APPEND CMAKE_CXX_FLAGS
        " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all \


### PR DESCRIPTION
## Summary

This PR removes unused and uninitialized `REANIMATED_VERSION` macro in `react-native-worklets/android/CMakeLists.txt`.

## Test plan
