### PR TITLE
Move Java and C++ version checks to `NativeProxy` constructor on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -32,10 +32,15 @@ NativeProxy::NativeProxy(
           jsCallInvoker,
           getPlatformDependentMethods(),
           getIsReducedMotion())) {
+#ifndef NDEBUG
+  checkJavaVersion();
+  injectCppVersion();
+#endif // NDEBUG
   reanimatedModuleProxy_->init(getPlatformDependentMethods());
   const auto &uiManager =
       fabricUIManager->getBinding()->getScheduler()->getUIManager();
   reanimatedModuleProxy_->initializeFabric(uiManager);
+  registerEventHandler();
   // removed temporarily, event listener mechanism needs to be fixed on RN side
   // eventListener_ = std::make_shared<EventListener>(
   //     [reanimatedModuleProxy,
@@ -76,7 +81,7 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
 }
 
 #ifndef NDEBUG
-void NativeProxy::checkJavaVersion(jsi::Runtime &rnRuntime) {
+void NativeProxy::checkJavaVersion() {
   std::string javaVersion;
   try {
     javaVersion =
@@ -121,12 +126,6 @@ void NativeProxy::installJSIBindings() {
       rnRuntime,
       workletsModuleProxy_->getUIWorkletRuntime()->getJSIRuntime(),
       reanimatedModuleProxy_);
-#ifndef NDEBUG
-  checkJavaVersion(rnRuntime);
-  injectCppVersion();
-#endif // NDEBUG
-
-  registerEventHandler();
 }
 
 bool NativeProxy::isAnyHandlerWaitingForEvent(

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -45,7 +45,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>,
   std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;
   std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy_;
 #ifndef NDEBUG
-  void checkJavaVersion(jsi::Runtime &);
+  void checkJavaVersion();
   void injectCppVersion();
 #endif // NDEBUG
   // removed temporarily, event listener mechanism needs to be fixed on RN side

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -91,6 +91,9 @@ public class NativeProxy {
             Objects.requireNonNull(context.getJavaScriptContextHolder()).get(),
             callInvokerHolder,
             fabricUIManager);
+    if (BuildConfig.DEBUG) {
+      checkCppVersion(); // injectCppVersion should be called during initHybrid above
+    }
   }
 
   @OptIn(markerClass = FrameworkAPI.class)

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/ReanimatedModule.java
@@ -49,9 +49,6 @@ public class ReanimatedModule extends NativeReanimatedModuleSpec implements Life
   public boolean installTurboModule() {
     getReactApplicationContext().assertOnJSQueueThread();
     mNodesManager.getNativeProxy().installJSIBindings();
-    if (BuildConfig.DEBUG) {
-      mNodesManager.getNativeProxy().checkCppVersion();
-    }
     return true;
   }
 


### PR DESCRIPTION
## Summary

## Test plan
