### PR TITLE
Move `WorkletRuntimeCollector::install` from Reanimated to Worklets

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -7,8 +7,6 @@
 #include <reanimated/android/NativeProxy.h>
 #include <reanimated/android/SensorSetter.h>
 
-#include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
-
 #include <react/fabric/Binding.h>
 
 namespace reanimated {
@@ -121,7 +119,6 @@ void NativeProxy::injectCppVersion() {
 
 void NativeProxy::installJSIBindings() {
   jsi::Runtime &rnRuntime = *rnRuntime_;
-  WorkletRuntimeCollector::install(rnRuntime);
   RNRuntimeDecorator::decorate(
       rnRuntime,
       workletsModuleProxy_->getUIWorkletRuntime()->getJSIRuntime(),

--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -11,7 +11,6 @@
 #import <reanimated/apple/native/NativeProxy.h>
 
 #import <worklets/Tools/SingleInstanceChecker.h>
-#import <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
 #import <worklets/apple/WorkletsModule.h>
 
 using namespace facebook::react;
@@ -159,7 +158,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 
   auto &uiRuntime = [workletsModule getWorkletsModuleProxy]->getUIWorkletRuntime() -> getJSIRuntime();
 
-  WorkletRuntimeCollector::install(rnRuntime);
   RNRuntimeDecorator::decorate(rnRuntime, uiRuntime, reanimatedModuleProxy);
   [self attachReactEventListener:reanimatedModuleProxy];
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RNRuntimeWorkletDecorator.cpp
@@ -1,4 +1,5 @@
 #include <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
+#include <worklets/WorkletRuntime/WorkletRuntimeCollector.h>
 
 namespace worklets {
 
@@ -15,6 +16,8 @@ void RNRuntimeWorkletDecorator::decorate(
       rnRuntime,
       "__workletsModuleProxy",
       jsi::Object::createFromHostObject(rnRuntime, workletsModuleProxy));
+
+  WorkletRuntimeCollector::install(rnRuntime);
 }
 
 } // namespace worklets


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR moves `WorkletRuntimeCollector::install` call from `react-native-reanimated` platform-specific code to C++ codebase in `react-native-worklets` since `WorkletRuntimeCollector` is still required when `react-native-worklets` is installed without `react-native-reanimated`. I've decided to call it from `RNRuntimeWorkletDecorator::decorate` which is already platform-agnostic so there's no code duplication.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
