### PR TITLE
feat: Convert CSS easing functions to easing objects

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -18,7 +18,6 @@ using PropertyPath = std::vector<std::string>;
  */
 using TransitionProperties = std::optional<PropertyNames>;
 
-using EasingFunction = std::function<double(double)>;
 using ColorChannels = std::array<uint8_t, 4>;
 using Vec16Array = std::array<double, 16>;
 using Matrix4x4 = std::array<std::array<double, 4>, 4>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.cpp
@@ -84,7 +84,7 @@ PartialCSSAnimationSettings parsePartialCSSAnimationSettings(
     result.duration = parseDuration(rt, partialObj);
   }
   if (partialObj.hasProperty(rt, "timingFunction")) {
-    result.easingFunction = parseTimingFunction(rt, partialObj);
+    result.easing = parseTimingFunction(rt, partialObj);
   }
   if (partialObj.hasProperty(rt, "delay")) {
     result.delay = parseDelay(rt, partialObj);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -20,7 +20,7 @@ enum class AnimationPlayState { Running, Paused };
 
 struct CSSAnimationSettings {
   double duration;
-  EasingFunction easingFunction;
+  Easing easing;
   double delay;
   double iterationCount;
   AnimationDirection direction;
@@ -30,7 +30,7 @@ struct CSSAnimationSettings {
 
 struct PartialCSSAnimationSettings {
   std::optional<double> duration;
-  std::optional<EasingFunction> easingFunction;
+  std::optional<Easing> easing;
   std::optional<double> delay;
   std::optional<double> iterationCount;
   std::optional<AnimationDirection> direction;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSAnimationConfig.h
@@ -2,7 +2,7 @@
 
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
 #include <reanimated/CSS/config/common.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 
 #include <folly/dynamic.h>
 #include <memory>
@@ -20,7 +20,7 @@ enum class AnimationPlayState { Running, Paused };
 
 struct CSSAnimationSettings {
   double duration;
-  Easing easing;
+  std::shared_ptr<Easing> easing;
   double delay;
   double iterationCount;
   AnimationDirection direction;
@@ -30,7 +30,7 @@ struct CSSAnimationSettings {
 
 struct PartialCSSAnimationSettings {
   std::optional<double> duration;
-  std::optional<Easing> easing;
+  std::optional<std::shared_ptr<Easing>> easing;
   std::optional<double> delay;
   std::optional<double> iterationCount;
   std::optional<AnimationDirection> direction;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<KeyframeEasings> parseKeyframeTimingFunctions(
   for (size_t i = 0; i < timingFunctionsCount; ++i) {
     const auto offset =
         timingFunctionOffsets.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const auto easing = createEasingFunction(
+    const auto easing = createEasing(
         rt, keyframeTimingFunctions.getProperty(rt, offset.c_str()));
 
     result[std::stod(offset)] = easing;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -13,10 +13,10 @@ std::shared_ptr<AnimationStyleInterpolator> createStyleInterpolator(
   return styleInterpolator;
 }
 
-std::shared_ptr<KeyframeEasingFunctions> parseKeyframeTimingFunctions(
+std::shared_ptr<KeyframeEasings> parseKeyframeTimingFunctions(
     jsi::Runtime &rt,
     const jsi::Object &config) {
-  KeyframeEasingFunctions result;
+  KeyframeEasings result;
   const auto &keyframeTimingFunctions =
       config.getProperty(rt, "keyframeTimingFunctions").asObject(rt);
   const auto timingFunctionOffsets =
@@ -26,13 +26,13 @@ std::shared_ptr<KeyframeEasingFunctions> parseKeyframeTimingFunctions(
   for (size_t i = 0; i < timingFunctionsCount; ++i) {
     const auto offset =
         timingFunctionOffsets.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const auto easingFunction = createEasingFunction(
+    const auto easing = createEasingFunction(
         rt, keyframeTimingFunctions.getProperty(rt, offset.c_str()));
 
-    result[std::stod(offset)] = easingFunction;
+    result[std::stod(offset)] = easing;
   }
 
-  return std::make_shared<KeyframeEasingFunctions>(result);
+  return std::make_shared<KeyframeEasings>(result);
 }
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -9,18 +9,18 @@
 
 namespace reanimated::css {
 
-using KeyframeEasingFunctions = std::unordered_map<double, EasingFunction>;
+using KeyframeEasings = std::unordered_map<double, Easing>;
 
 struct CSSKeyframesConfig {
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator;
-  std::shared_ptr<KeyframeEasingFunctions> keyframeEasingFunctions;
+  std::shared_ptr<KeyframeEasings> keyframeEasingFunctions;
 };
 
 std::shared_ptr<AnimationStyleInterpolator> createStyleInterpolator(
     jsi::Runtime &rt,
     const jsi::Object &config);
 
-std::shared_ptr<KeyframeEasingFunctions> parseKeyframeTimingFunctions(
+std::shared_ptr<KeyframeEasings> parseKeyframeTimingFunctions(
     jsi::Runtime &rt,
     const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 
@@ -9,11 +9,11 @@
 
 namespace reanimated::css {
 
-using KeyframeEasings = std::unordered_map<double, Easing>;
+using KeyframeEasings = std::unordered_map<double, std::shared_ptr<Easing>>;
 
 struct CSSKeyframesConfig {
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator;
-  std::shared_ptr<KeyframeEasings> keyframeEasingFunctions;
+  std::shared_ptr<KeyframeEasings> keyframeEasings;
 };
 
 std::shared_ptr<AnimationStyleInterpolator> createStyleInterpolator(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -7,6 +7,7 @@
 #include <reanimated/CSS/easing/utils.h>
 
 #include <folly/dynamic.h>
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSTransitionConfig.h
@@ -4,7 +4,7 @@
 
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/config/common.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 
 #include <folly/dynamic.h>
 #include <string>
@@ -16,7 +16,7 @@ using namespace facebook::react;
 
 struct CSSTransitionPropertySettings {
   double duration;
-  EasingFunction easingFunction;
+  std::shared_ptr<Easing> easing;
   double delay;
   bool allowDiscrete;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -6,8 +6,10 @@ double parseDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
 }
 
-Easing parseTimingFunction(jsi::Runtime &rt, const jsi::Object &config) {
-  return createEasingFunction(rt, config.getProperty(rt, "timingFunction"));
+std::shared_ptr<Easing> parseTimingFunction(
+    jsi::Runtime &rt,
+    const jsi::Object &config) {
+  return createEasing(rt, config.getProperty(rt, "timingFunction"));
 }
 
 double parseDelay(jsi::Runtime &rt, const jsi::Object &config) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.cpp
@@ -6,9 +6,7 @@ double parseDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
 }
 
-EasingFunction parseTimingFunction(
-    jsi::Runtime &rt,
-    const jsi::Object &config) {
+Easing parseTimingFunction(jsi::Runtime &rt, const jsi::Object &config) {
   return createEasingFunction(rt, config.getProperty(rt, "timingFunction"));
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -8,7 +8,7 @@ namespace reanimated::css {
 
 double parseDuration(jsi::Runtime &rt, const jsi::Object &config);
 
-EasingFunction parseTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
+Easing parseTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
 
 double parseDelay(jsi::Runtime &rt, const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 
 #include <jsi/jsi.h>
 
@@ -8,7 +8,9 @@ namespace reanimated::css {
 
 double parseDuration(jsi::Runtime &rt, const jsi::Object &config);
 
-Easing parseTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
+std::shared_ptr<Easing> parseTimingFunction(
+    jsi::Runtime &rt,
+    const jsi::Object &config);
 
 double parseDelay(jsi::Runtime &rt, const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/common.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/easing/utils.h>
 
 #include <jsi/jsi.h>
+#include <memory>
 
 namespace reanimated::css {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -16,7 +16,7 @@ CSSAnimation::CSSAnimation(
       config.iterationCount,
       config.direction,
       config.easing,
-      keyframesConfig.keyframeEasingFunctions);
+      keyframesConfig.keyframeEasings);
 
   styleInterpolator_ = keyframesConfig.styleInterpolator;
 
@@ -103,7 +103,7 @@ void CSSAnimation::updateSettings(
     progressProvider_->setDuration(updatedSettings.duration.value());
   }
   if (updatedSettings.easing.has_value()) {
-    progressProvider_->setEasingFunction(updatedSettings.easing.value());
+    progressProvider_->setEasing(updatedSettings.easing.value());
   }
   if (updatedSettings.delay.has_value()) {
     progressProvider_->setDelay(updatedSettings.delay.value());
@@ -134,7 +134,7 @@ bool CSSAnimation::updateSettings(
   const auto oldState = progressProvider_->getState();
 
   progressProvider_->setDuration(settings.duration);
-  progressProvider_->setEasingFunction(settings.easing);
+  progressProvider_->setEasing(settings.easing);
   progressProvider_->setDelay(settings.delay);
   progressProvider_->setIterationCount(settings.iterationCount);
   progressProvider_->setDirection(settings.direction);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -15,7 +15,7 @@ CSSAnimation::CSSAnimation(
       config.delay,
       config.iterationCount,
       config.direction,
-      config.easingFunction,
+      config.easing,
       keyframesConfig.keyframeEasingFunctions);
 
   styleInterpolator_ = keyframesConfig.styleInterpolator;
@@ -102,9 +102,8 @@ void CSSAnimation::updateSettings(
   if (updatedSettings.duration.has_value()) {
     progressProvider_->setDuration(updatedSettings.duration.value());
   }
-  if (updatedSettings.easingFunction.has_value()) {
-    progressProvider_->setEasingFunction(
-        updatedSettings.easingFunction.value());
+  if (updatedSettings.easing.has_value()) {
+    progressProvider_->setEasingFunction(updatedSettings.easing.value());
   }
   if (updatedSettings.delay.has_value()) {
     progressProvider_->setDelay(updatedSettings.delay.value());
@@ -135,7 +134,7 @@ bool CSSAnimation::updateSettings(
   const auto oldState = progressProvider_->getState();
 
   progressProvider_->setDuration(settings.duration);
-  progressProvider_->setEasingFunction(settings.easingFunction);
+  progressProvider_->setEasingFunction(settings.easing);
   progressProvider_->setDelay(settings.delay);
   progressProvider_->setIterationCount(settings.iterationCount);
   progressProvider_->setDirection(settings.direction);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 #include <reanimated/CSS/registry/CSSKeyframesRegistry.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <reanimated/CSS/config/CSSTransitionConfig.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 #include <reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h>
 #include <reanimated/CSS/progress/TransitionProgressProvider.h>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -2,20 +2,17 @@
 
 namespace reanimated::css {
 
-inline const std::unordered_map<std::string, EasingFunction>
-    PREDEFINED_EASING_MAP = {
-        {"linear", [](double x) { return x; }},
-        {"ease", cubicBezier(0.25, 0.1, 0.25, 0.1)},
-        {"ease-in", cubicBezier(0.42, 0.0, 1.0, 1.0)},
-        {"ease-out", cubicBezier(0.0, 0.0, 0.58, 1.0)},
-        {"ease-in-out", cubicBezier(0.42, 0.0, 0.58, 1.0)},
-        {"step-start", steps(std::vector<double>{0}, std::vector<double>{1})},
-        {"step-end",
-         steps(std::vector<double>{0, 1}, std::vector<double>{0, 1})}};
+inline const std::unordered_map<std::string, Easing> PREDEFINED_EASING_MAP = {
+    {"linear", [](double x) { return x; }},
+    {"ease", CubicBezierEasing(0.25, 0.1, 0.25, 0.1)},
+    {"ease-in", CubicBezierEasing(0.42, 0.0, 1.0, 1.0)},
+    {"ease-out", CubicBezierEasing(0.0, 0.0, 0.58, 1.0)},
+    {"ease-in-out", CubicBezierEasing(0.42, 0.0, 0.58, 1.0)},
+    {"step-start", StepsEasing(std::vector<double>{0}, std::vector<double>{1})},
+    {"step-end",
+     StepsEasing(std::vector<double>{0, 1}, std::vector<double>{0, 1})}};
 
-EasingFunction createEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Value &easingConfig) {
+Easing createEasingFunction(jsi::Runtime &rt, const jsi::Value &easingConfig) {
   if (easingConfig.isString()) {
     return getPredefinedEasingFunction(easingConfig.asString(rt).utf8(rt));
   } else if (easingConfig.isObject()) {
@@ -26,25 +23,25 @@ EasingFunction createEasingFunction(
   }
 }
 
-EasingFunction getPredefinedEasingFunction(const std::string &name) {
+Easing getPredefinedEasingFunction(const std::string &name) {
   auto it = PREDEFINED_EASING_MAP.find(name);
   if (it != PREDEFINED_EASING_MAP.end()) {
     return it->second;
   } else {
     throw std::runtime_error(std::string(
-        "[Reanimated] Easing function with name '" + name +
+        "[Reanimated] EasingBase function with name '" + name +
         "' is not defined."));
   }
 }
 
-EasingFunction createParametrizedEasingFunction(
+Easing createParametrizedEasingFunction(
     jsi::Runtime &rt,
     const jsi::Object &easingConfig) {
   const auto easingName =
       easingConfig.getProperty(rt, "name").asString(rt).utf8(rt);
 
   if (easingName == "cubicBezier") {
-    return cubicBezier(rt, easingConfig);
+    return CubicBezierEasing(rt, easingConfig);
   }
 
   std::vector<double> pointsX;
@@ -61,9 +58,9 @@ EasingFunction createParametrizedEasingFunction(
   }
 
   if (easingName == "linear") {
-    return linear(pointsX, pointsY);
+    return LinearEasing(pointsX, pointsY);
   } else if (easingName == "steps") {
-    return steps(pointsX, pointsY);
+    return StepsEasing(pointsX, pointsY);
   } else {
     throw std::runtime_error(std::string(
         "[Reanimated] Parametrized easing function with name '" + easingName +

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
@@ -13,16 +13,13 @@ namespace reanimated::css {
 
 using namespace facebook;
 
-extern const std::unordered_map<std::string, EasingFunction>
-    PREDEFINED_EASING_MAP;
+extern const std::unordered_map<std::string, Easing> PREDEFINED_EASING_MAP;
 
-EasingFunction getPredefinedEasingFunction(const std::string &name);
-EasingFunction createParametrizedEasingFunction(
+Easing getPredefinedEasingFunction(const std::string &name);
+Easing createParametrizedEasingFunction(
     jsi::Runtime &rt,
     const jsi::Object &easingConfig);
 
-EasingFunction createEasingFunction(
-    jsi::Runtime &rt,
-    const jsi::Value &easingConfig);
+Easing createEasingFunction(jsi::Runtime &rt, const jsi::Value &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/common.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace reanimated::css {
+
+enum class EasingType { Linear, CubicBezier, Steps };
+
+class Easing {
+ public:
+  virtual ~Easing() = default;
+
+  virtual double calculate(double x) const = 0;
+
+  virtual bool operator==(const Easing &other) const = 0;
+  virtual EasingType getType() const = 0;
+};
+
+template <EasingType Type>
+class EasingBase : public Easing {
+ public:
+  virtual ~EasingBase() = default;
+
+  EasingType getType() const override {
+    return Type;
+  }
+
+  bool operator==(const Easing &other) const override {
+    if (other.getType() != Type) {
+      return false;
+    }
+    return *this == static_cast<const EasingBase<Type> &>(other);
+  }
+
+  virtual bool operator==(const EasingBase<Type> &other) const = 0;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -2,34 +2,42 @@
 
 namespace reanimated::css {
 
-double sampleCurveX(const double t, const double x1, const double x2) {
-  return 3 * (1 - t) * (1 - t) * t * x1 + 3 * (1 - t) * t * t * x2 + t * t * t;
+CubicBezierEasing::CubicBezierEasing(double x1, double y1, double x2, double y2)
+    : x1_(x1), y1_(y1), x2_(x2), y2_(y2) {}
+
+CubicBezierEasing::CubicBezierEasing(
+    jsi::Runtime &rt,
+    const jsi::Object &easingConfig)
+    : x1_(easingConfig.getProperty(rt, "x1").asNumber()),
+      y1_(easingConfig.getProperty(rt, "y1").asNumber()),
+      x2_(easingConfig.getProperty(rt, "x2").asNumber()),
+      y2_(easingConfig.getProperty(rt, "y2").asNumber()) {}
+
+double CubicBezierEasing::sampleCurveX(double t) const {
+  return 3 * (1 - t) * (1 - t) * t * x1_ + 3 * (1 - t) * t * t * x2_ +
+      t * t * t;
 }
 
-double sampleCurveY(const double t, const double y1, const double y2) {
-  return 3 * (1 - t) * (1 - t) * t * y1 + 3 * (1 - t) * t * t * y2 + t * t * t;
+double CubicBezierEasing::sampleCurveY(double t) const {
+  return 3 * (1 - t) * (1 - t) * t * y1_ + 3 * (1 - t) * t * t * y2_ +
+      t * t * t;
 }
 
-double
-sampleCurveDerivativeX(const double t, const double x1, const double x2) {
-  return -6 * (1 - t) * t * x1 + 3 * (1 - t) * (1 - t) * x1 +
-      6 * (1 - t) * t * x2 - 6 * t * t * x2 + 3 * t * t;
+double CubicBezierEasing::sampleCurveDerivativeX(double t) const {
+  return -6 * (1 - t) * t * x1_ + 3 * (1 - t) * (1 - t) * x1_ +
+      6 * (1 - t) * t * x2_ - 6 * t * t * x2_ + 3 * t * t;
 }
 
-double solveCurveX(
-    const double x,
-    const double x1,
-    const double x2,
-    const double epsilon) {
+double CubicBezierEasing::solveCurveX(double x, double epsilon) const {
   double t0 = 0.0, t1 = 1.0, t2 = x, xValue, dX;
   int iterations = 0;
 
   while (iterations < 8) {
-    xValue = sampleCurveX(t2, x1, x2) - x;
+    xValue = sampleCurveX(t2) - x;
     if (std::abs(xValue) < epsilon) {
       return t2;
     }
-    dX = sampleCurveDerivativeX(t2, x1, x2);
+    dX = sampleCurveDerivativeX(t2);
     if (std::abs(dX) < epsilon) {
       break;
     }
@@ -40,7 +48,7 @@ double solveCurveX(
   // Fallback: Use binary search
   while (t0 < t1) {
     t2 = (t0 + t1) / 2.0;
-    xValue = sampleCurveX(t2, x1, x2);
+    xValue = sampleCurveX(t2);
     if (std::abs(xValue - x) < epsilon) {
       return t2;
     }
@@ -54,23 +62,16 @@ double solveCurveX(
   return t2;
 }
 
-EasingFunction cubicBezier(
-    const double x1,
-    const double y1,
-    const double x2,
-    const double y2) {
-  return [=](double x) {
-    double t = solveCurveX(x, x1, x2);
-    return sampleCurveY(t, y1, y2);
-  };
+double CubicBezierEasing::calculate(double x) const {
+  double t = solveCurveX(x);
+  return sampleCurveY(t);
 }
 
-EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig) {
-  return cubicBezier(
-      easingConfig.getProperty(rt, "x1").asNumber(),
-      easingConfig.getProperty(rt, "y1").asNumber(),
-      easingConfig.getProperty(rt, "x2").asNumber(),
-      easingConfig.getProperty(rt, "y2").asNumber());
+bool CubicBezierEasing::operator==(
+    const EasingBase<EasingType::CubicBezier> &other) const {
+  const auto &otherCubic = static_cast<const CubicBezierEasing &>(other);
+  return x1_ == otherCubic.x1_ && y1_ == otherCubic.y1_ &&
+      x2_ == otherCubic.x2_ && y2_ == otherCubic.y2_;
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -2,7 +2,11 @@
 
 namespace reanimated::css {
 
-CubicBezierEasing::CubicBezierEasing(double x1, double y1, double x2, double y2)
+CubicBezierEasing::CubicBezierEasing(
+    const double x1,
+    const double y1,
+    const double x2,
+    const double y2)
     : x1_(x1), y1_(y1), x2_(x2), y2_(y2) {}
 
 CubicBezierEasing::CubicBezierEasing(
@@ -13,22 +17,23 @@ CubicBezierEasing::CubicBezierEasing(
       x2_(easingConfig.getProperty(rt, "x2").asNumber()),
       y2_(easingConfig.getProperty(rt, "y2").asNumber()) {}
 
-double CubicBezierEasing::sampleCurveX(double t) const {
+double CubicBezierEasing::sampleCurveX(const double t) const {
   return 3 * (1 - t) * (1 - t) * t * x1_ + 3 * (1 - t) * t * t * x2_ +
       t * t * t;
 }
 
-double CubicBezierEasing::sampleCurveY(double t) const {
+double CubicBezierEasing::sampleCurveY(const double t) const {
   return 3 * (1 - t) * (1 - t) * t * y1_ + 3 * (1 - t) * t * t * y2_ +
       t * t * t;
 }
 
-double CubicBezierEasing::sampleCurveDerivativeX(double t) const {
+double CubicBezierEasing::sampleCurveDerivativeX(const double t) const {
   return -6 * (1 - t) * t * x1_ + 3 * (1 - t) * (1 - t) * x1_ +
       6 * (1 - t) * t * x2_ - 6 * t * t * x2_ + 3 * t * t;
 }
 
-double CubicBezierEasing::solveCurveX(double x, double epsilon) const {
+double CubicBezierEasing::solveCurveX(const double x, const double epsilon)
+    const {
   double t0 = 0.0, t1 = 1.0, t2 = x, xValue, dX;
   int iterations = 0;
 
@@ -62,9 +67,8 @@ double CubicBezierEasing::solveCurveX(double x, double epsilon) const {
   return t2;
 }
 
-double CubicBezierEasing::calculate(double x) const {
-  double t = solveCurveX(x);
-  return sampleCurveY(t);
+double CubicBezierEasing::calculate(const double t) const {
+  return sampleCurveY(solveCurveX(t));
 }
 
 bool CubicBezierEasing::operator==(
@@ -72,6 +76,20 @@ bool CubicBezierEasing::operator==(
   const auto &otherCubic = static_cast<const CubicBezierEasing &>(other);
   return x1_ == otherCubic.x1_ && y1_ == otherCubic.y1_ &&
       x2_ == otherCubic.x2_ && y2_ == otherCubic.y2_;
+}
+
+std::shared_ptr<CubicBezierEasing> cubicBezier(
+    const double x1,
+    const double y1,
+    const double x2,
+    const double y2) {
+  return std::make_shared<CubicBezierEasing>(x1, y1, x2, y2);
+}
+
+std::shared_ptr<CubicBezierEasing> cubicBezier(
+    jsi::Runtime &rt,
+    const jsi::Object &easingConfig) {
+  return std::make_shared<CubicBezierEasing>(rt, easingConfig);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -3,6 +3,9 @@
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/easing/common.h>
 
+#include <jsi/jsi.h>
+#include <memory>
+
 namespace reanimated::css {
 
 class CubicBezierEasing : public EasingBase<EasingType::CubicBezier> {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -10,8 +10,9 @@ class CubicBezierEasing : public EasingBase<EasingType::CubicBezier> {
   CubicBezierEasing(double x1, double y1, double x2, double y2);
   CubicBezierEasing(jsi::Runtime &rt, const jsi::Object &easingConfig);
 
-  double calculate(double t) const override;
-  bool operator==(const EasingBase<EasingType::CubicBezier> &other) const;
+  double calculate(double x) const override;
+  bool operator==(
+      const EasingBase<EasingType::CubicBezier> &other) const override;
 
  private:
   const double x1_, y1_, x2_, y2_;
@@ -21,5 +22,12 @@ class CubicBezierEasing : public EasingBase<EasingType::CubicBezier> {
   double sampleCurveDerivativeX(double t) const;
   double solveCurveX(double x, double epsilon = 1e-6) const;
 };
+
+std::shared_ptr<CubicBezierEasing>
+cubicBezier(double x1, double y1, double x2, double y2);
+
+std::shared_ptr<CubicBezierEasing> cubicBezier(
+    jsi::Runtime &rt,
+    const jsi::Object &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -1,17 +1,25 @@
 #pragma once
 
 #include <reanimated/CSS/common/definitions.h>
-
-#include <folly/dynamic.h>
+#include <reanimated/CSS/easing/common.h>
 
 namespace reanimated::css {
 
-double sampleCurveX(double t, double x1, double x2);
-double sampleCurveY(double t, double y1, double y2);
-double sampleCurveDerivativeX(double t, double x1, double x2);
-double solveCurveX(double x, double x1, double x2, double epsilon = 1e-6);
+class CubicBezierEasing : public EasingBase<EasingType::CubicBezier> {
+ public:
+  CubicBezierEasing(double x1, double y1, double x2, double y2);
+  CubicBezierEasing(jsi::Runtime &rt, const jsi::Object &easingConfig);
 
-EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
-EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);
+  double calculate(double t) const override;
+  bool operator==(const EasingBase<EasingType::CubicBezier> &other) const;
+
+ private:
+  const double x1_, y1_, x2_, y2_;
+
+  double sampleCurveX(double t) const;
+  double sampleCurveY(double t) const;
+  double sampleCurveDerivativeX(double t) const;
+  double solveCurveX(double x, double epsilon = 1e-6) const;
+};
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
@@ -7,7 +7,8 @@ LinearEasing::LinearEasing(
     std::vector<double> pointsY)
     : pointsX_(std::move(pointsX)), pointsY_(std::move(pointsY)) {}
 
-double LinearEasing::interpolateValue(double x, std::size_t leftIdx) const {
+double LinearEasing::interpolateValue(const double x, const std::size_t leftIdx)
+    const {
   if (leftIdx == pointsX_.size() - 1) {
     // We are exactly on the last point of the curve, we just return its y
     // coordinate
@@ -21,15 +22,21 @@ double LinearEasing::interpolateValue(double x, std::size_t leftIdx) const {
   return pointsY_[leftIdx] + a * (x - pointsX_[leftIdx]);
 }
 
-double LinearEasing::calculate(double x) const {
-  size_t leftIdx = firstSmallerOrEqual(x, pointsX_);
-  return interpolateValue(x, leftIdx);
+double LinearEasing::calculate(const double t) const {
+  const auto leftIdx = firstSmallerOrEqual(t, pointsX_);
+  return interpolateValue(t, leftIdx);
 }
 
 bool LinearEasing::operator==(
     const EasingBase<EasingType::Linear> &other) const {
   const auto &otherLinear = static_cast<const LinearEasing &>(other);
   return pointsX_ == otherLinear.pointsX_ && pointsY_ == otherLinear.pointsY_;
+}
+
+std::shared_ptr<LinearEasing> linear(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY) {
+  return std::make_shared<LinearEasing>(std::move(pointsX), std::move(pointsY));
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.cpp
@@ -2,31 +2,34 @@
 
 namespace reanimated::css {
 
-double interpolateValue(
-    double x,
-    size_t leftIdx,
-    const std::vector<double> &pointsX,
-    const std::vector<double> &pointsY) {
-  if (leftIdx == pointsX.size() - 1) {
+LinearEasing::LinearEasing(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY)
+    : pointsX_(std::move(pointsX)), pointsY_(std::move(pointsY)) {}
+
+double LinearEasing::interpolateValue(double x, std::size_t leftIdx) const {
+  if (leftIdx == pointsX_.size() - 1) {
     // We are exactly on the last point of the curve, we just return its y
     // coordinate
-    return pointsY[leftIdx];
+    return pointsY_[leftIdx];
   }
   const auto rightIdx = leftIdx + 1;
   // Calculate the line equation for the line between leftIdx and rightIdx
   // points
-  const auto a = (pointsY[rightIdx] - pointsY[leftIdx]) /
-      (pointsX[rightIdx] - pointsX[leftIdx]);
-  return pointsY[leftIdx] + a * (x - pointsX[leftIdx]);
+  const auto a = (pointsY_[rightIdx] - pointsY_[leftIdx]) /
+      (pointsX_[rightIdx] - pointsX_[leftIdx]);
+  return pointsY_[leftIdx] + a * (x - pointsX_[leftIdx]);
 }
 
-EasingFunction linear(
-    const std::vector<double> &pointsX,
-    const std::vector<double> &pointsY) {
-  return [=](double x) {
-    size_t leftIdx = firstSmallerOrEqual(x, pointsX);
-    return interpolateValue(x, leftIdx, pointsX, pointsY);
-  };
+double LinearEasing::calculate(double x) const {
+  size_t leftIdx = firstSmallerOrEqual(x, pointsX_);
+  return interpolateValue(x, leftIdx);
+}
+
+bool LinearEasing::operator==(
+    const EasingBase<EasingType::Linear> &other) const {
+  const auto &otherLinear = static_cast<const LinearEasing &>(other);
+  return pointsX_ == otherLinear.pointsX_ && pointsY_ == otherLinear.pointsY_;
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
@@ -1,20 +1,25 @@
 #pragma once
 
 #include <reanimated/CSS/common/definitions.h>
+#include <reanimated/CSS/easing/common.h>
 #include <reanimated/CSS/util/algorithms.h>
 
 #include <vector>
 
 namespace reanimated::css {
 
-double interpolateValue(
-    double x,
-    std::size_t leftIdx,
-    const std::vector<double> &arrX,
-    const std::vector<double> &arrY);
+class LinearEasing : public EasingBase<EasingType::Linear> {
+ public:
+  LinearEasing(std::vector<double> pointsX, std::vector<double> pointsY);
 
-EasingFunction linear(
-    const std::vector<double> &pointsX,
-    const std::vector<double> &pointsY);
+  double calculate(double t) const override;
+  bool operator==(const EasingBase<EasingType::Linear> &other) const;
+
+ private:
+  const std::vector<double> pointsX_;
+  const std::vector<double> pointsY_;
+
+  double interpolateValue(double x, std::size_t leftIdx) const;
+};
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
@@ -4,6 +4,8 @@
 #include <reanimated/CSS/easing/common.h>
 #include <reanimated/CSS/util/algorithms.h>
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/linear.h
@@ -12,8 +12,8 @@ class LinearEasing : public EasingBase<EasingType::Linear> {
  public:
   LinearEasing(std::vector<double> pointsX, std::vector<double> pointsY);
 
-  double calculate(double t) const override;
-  bool operator==(const EasingBase<EasingType::Linear> &other) const;
+  double calculate(double x) const override;
+  bool operator==(const EasingBase<EasingType::Linear> &other) const override;
 
  private:
   const std::vector<double> pointsX_;
@@ -21,5 +21,9 @@ class LinearEasing : public EasingBase<EasingType::Linear> {
 
   double interpolateValue(double x, std::size_t leftIdx) const;
 };
+
+std::shared_ptr<LinearEasing> linear(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
@@ -1,13 +1,20 @@
 #include <reanimated/CSS/easing/steps.h>
 
 namespace reanimated::css {
-EasingFunction steps(
-    const std::vector<double> &pointsX,
-    const std::vector<double> &pointsY) {
-  return [=](double x) {
-    size_t stepIdx = firstSmallerOrEqual(x, pointsX);
-    return pointsY[stepIdx];
-  };
+
+StepsEasing::StepsEasing(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY)
+    : pointsX_(std::move(pointsX)), pointsY_(std::move(pointsY)) {}
+
+double StepsEasing::calculate(double x) const {
+  size_t stepIdx = firstSmallerOrEqual(x, pointsX_);
+  return pointsY_[stepIdx];
+}
+
+bool StepsEasing::operator==(const EasingBase<EasingType::Steps> &other) const {
+  const auto &otherSteps = static_cast<const StepsEasing &>(other);
+  return pointsX_ == otherSteps.pointsX_ && pointsY_ == otherSteps.pointsY_;
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.cpp
@@ -7,14 +7,20 @@ StepsEasing::StepsEasing(
     std::vector<double> pointsY)
     : pointsX_(std::move(pointsX)), pointsY_(std::move(pointsY)) {}
 
-double StepsEasing::calculate(double x) const {
-  size_t stepIdx = firstSmallerOrEqual(x, pointsX_);
+double StepsEasing::calculate(const double t) const {
+  const auto stepIdx = firstSmallerOrEqual(t, pointsX_);
   return pointsY_[stepIdx];
 }
 
 bool StepsEasing::operator==(const EasingBase<EasingType::Steps> &other) const {
   const auto &otherSteps = static_cast<const StepsEasing &>(other);
   return pointsX_ == otherSteps.pointsX_ && pointsY_ == otherSteps.pointsY_;
+}
+
+std::shared_ptr<StepsEasing> steps(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY) {
+  return std::make_shared<StepsEasing>(std::move(pointsX), std::move(pointsY));
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
@@ -4,6 +4,8 @@
 #include <reanimated/CSS/easing/common.h>
 #include <reanimated/CSS/util/algorithms.h>
 
+#include <memory>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
@@ -1,14 +1,23 @@
 #pragma once
 
 #include <reanimated/CSS/common/definitions.h>
+#include <reanimated/CSS/easing/common.h>
 #include <reanimated/CSS/util/algorithms.h>
 
 #include <vector>
 
 namespace reanimated::css {
 
-EasingFunction steps(
-    const std::vector<double> &pointsX,
-    const std::vector<double> &pointsY);
+class StepsEasing : public EasingBase<EasingType::Steps> {
+ public:
+  StepsEasing(std::vector<double> pointsX, std::vector<double> pointsY);
+
+  double calculate(double t) const override;
+  bool operator==(const EasingBase<EasingType::Steps> &other) const;
+
+ private:
+  const std::vector<double> pointsX_;
+  const std::vector<double> pointsY_;
+};
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/steps.h
@@ -12,12 +12,16 @@ class StepsEasing : public EasingBase<EasingType::Steps> {
  public:
   StepsEasing(std::vector<double> pointsX, std::vector<double> pointsY);
 
-  double calculate(double t) const override;
-  bool operator==(const EasingBase<EasingType::Steps> &other) const;
+  double calculate(double x) const override;
+  bool operator==(const EasingBase<EasingType::Steps> &other) const override;
 
  private:
   const std::vector<double> pointsX_;
   const std::vector<double> pointsY_;
 };
+
+std::shared_ptr<StepsEasing> steps(
+    std::vector<double> pointsX,
+    std::vector<double> pointsY);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/utils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/utils.h
@@ -13,13 +13,16 @@ namespace reanimated::css {
 
 using namespace facebook;
 
-extern const std::unordered_map<std::string, Easing> PREDEFINED_EASING_MAP;
+extern const std::unordered_map<std::string, std::shared_ptr<Easing>>
+    PREDEFINED_EASING_MAP;
 
-Easing getPredefinedEasingFunction(const std::string &name);
-Easing createParametrizedEasingFunction(
+std::shared_ptr<Easing> getPredefinedEasing(const std::string &name);
+std::shared_ptr<Easing> createParametrizedEasing(
     jsi::Runtime &rt,
     const jsi::Object &easingConfig);
 
-Easing createEasingFunction(jsi::Runtime &rt, const jsi::Value &easingConfig);
+std::shared_ptr<Easing> createEasing(
+    jsi::Runtime &rt,
+    const jsi::Value &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/utils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/utils.h
@@ -5,6 +5,7 @@
 #include <reanimated/CSS/easing/steps.h>
 
 #include <jsi/jsi.h>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -1,7 +1,5 @@
 #include <reanimated/CSS/progress/AnimationProgressProvider.h>
 
-#include <utility>
-
 namespace reanimated::css {
 
 AnimationProgressProvider::AnimationProgressProvider(
@@ -10,13 +8,13 @@ AnimationProgressProvider::AnimationProgressProvider(
     const double delay,
     const double iterationCount,
     const AnimationDirection direction,
-    Easing easing,
-    const std::shared_ptr<KeyframeEasings> &keyframeEasingFunctions)
+    std::shared_ptr<Easing> easing,
+    std::shared_ptr<KeyframeEasings> keyframeEasings)
     : RawProgressProvider(timestamp, duration, delay),
       iterationCount_(iterationCount),
       direction_(direction),
       easing_(std::move(easing)),
-      keyframeEasingFunctions_(keyframeEasingFunctions) {}
+      keyframeEasings_(std::move(keyframeEasings)) {}
 
 AnimationProgressState AnimationProgressProvider::getState() const {
   if (pauseTimestamp_ > 0) {
@@ -59,12 +57,12 @@ double AnimationProgressProvider::getKeyframeProgress(
 
   // Use the overridden easing function if it was overridden for the
   // current keyframe
-  const auto easingFunctionIt = keyframeEasingFunctions_->find(fromOffset);
-  if (easingFunctionIt != keyframeEasingFunctions_->end()) {
-    return easingFunctionIt->second(keyframeProgress);
+  const auto it = keyframeEasings_->find(fromOffset);
+  if (it != keyframeEasings_->end()) {
+    return it->second->calculate(keyframeProgress);
   }
 
-  return easing_.calculate(keyframeProgress);
+  return easing_->calculate(keyframeProgress);
 }
 
 void AnimationProgressProvider::pause(const double timestamp) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -10,12 +10,12 @@ AnimationProgressProvider::AnimationProgressProvider(
     const double delay,
     const double iterationCount,
     const AnimationDirection direction,
-    EasingFunction easingFunction,
-    const std::shared_ptr<KeyframeEasingFunctions> &keyframeEasingFunctions)
+    Easing easing,
+    const std::shared_ptr<KeyframeEasings> &keyframeEasingFunctions)
     : RawProgressProvider(timestamp, duration, delay),
       iterationCount_(iterationCount),
       direction_(direction),
-      easingFunction_(std::move(easingFunction)),
+      easing_(std::move(easing)),
       keyframeEasingFunctions_(keyframeEasingFunctions) {}
 
 AnimationProgressState AnimationProgressProvider::getState() const {
@@ -64,7 +64,7 @@ double AnimationProgressProvider::getKeyframeProgress(
     return easingFunctionIt->second(keyframeProgress);
   }
 
-  return easingFunction_(keyframeProgress);
+  return easing_.calculate(keyframeProgress);
 }
 
 void AnimationProgressProvider::pause(const double timestamp) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -26,8 +26,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
       double delay,
       double iterationCount,
       AnimationDirection direction,
-      EasingFunction easingFunction,
-      const std::shared_ptr<KeyframeEasingFunctions> &keyframeEasingFunctions);
+      Easing easing,
+      const std::shared_ptr<KeyframeEasings> &keyframeEasingFunctions);
 
   void setIterationCount(double iterationCount) {
     resetProgress();
@@ -37,9 +37,9 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
     resetProgress();
     direction_ = direction;
   }
-  void setEasingFunction(const EasingFunction &easingFunction) {
+  void setEasingFunction(const Easing &easing) {
     resetProgress();
-    easingFunction_ = easingFunction;
+    easing_ = easing;
   }
 
   AnimationDirection getDirection() const {
@@ -66,8 +66,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
  private:
   double iterationCount_;
   AnimationDirection direction_;
-  EasingFunction easingFunction_;
-  std::shared_ptr<KeyframeEasingFunctions> keyframeEasingFunctions_;
+  Easing easing_;
+  std::shared_ptr<KeyframeEasings> keyframeEasingFunctions_;
 
   unsigned currentIteration_ = 1;
   double previousIterationsDuration_ = 0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -2,11 +2,12 @@
 
 #include <reanimated/CSS/config/CSSAnimationConfig.h>
 #include <reanimated/CSS/config/CSSKeyframesConfig.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/utils.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 #include <reanimated/CSS/progress/RawProgressProvider.h>
 
 #include <memory>
+#include <utility>
 
 namespace reanimated::css {
 
@@ -26,8 +27,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
       double delay,
       double iterationCount,
       AnimationDirection direction,
-      Easing easing,
-      const std::shared_ptr<KeyframeEasings> &keyframeEasingFunctions);
+      std::shared_ptr<Easing> easing,
+      std::shared_ptr<KeyframeEasings> keyframeEasings);
 
   void setIterationCount(double iterationCount) {
     resetProgress();
@@ -37,9 +38,9 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
     resetProgress();
     direction_ = direction;
   }
-  void setEasingFunction(const Easing &easing) {
+  void setEasing(std::shared_ptr<Easing> easing) {
     resetProgress();
-    easing_ = easing;
+    easing_ = std::move(easing);
   }
 
   AnimationDirection getDirection() const {
@@ -66,8 +67,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
  private:
   double iterationCount_;
   AnimationDirection direction_;
-  Easing easing_;
-  std::shared_ptr<KeyframeEasings> keyframeEasingFunctions_;
+  std::shared_ptr<Easing> easing_;
+  std::shared_ptr<KeyframeEasings> keyframeEasings_;
 
   unsigned currentIteration_ = 1;
   double previousIterationsDuration_ = 0;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -8,17 +8,18 @@ TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double timestamp,
     const double duration,
     const double delay,
-    const Easing &easing)
-    : RawProgressProvider(timestamp, duration, delay), easing_(easing) {}
+    std::shared_ptr<Easing> easing)
+    : RawProgressProvider(timestamp, duration, delay),
+      easing_(std::move(easing)) {}
 
 TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double timestamp,
     const double duration,
     const double delay,
-    const Easing &easing,
+    std::shared_ptr<Easing> easing,
     const double reversingShorteningFactor)
     : RawProgressProvider(timestamp, duration, delay),
-      easing_(easing),
+      easing_(std::move(easing)),
       reversingShorteningFactor_(reversingShorteningFactor) {}
 
 double TransitionPropertyProgressProvider::getGlobalProgress() const {
@@ -31,7 +32,7 @@ double TransitionPropertyProgressProvider::getKeyframeProgress(
   if (fromOffset == toOffset) {
     return 1;
   }
-  return easing_.calculate(getGlobalProgress());
+  return easing_->calculate(getGlobalProgress());
 }
 
 double TransitionPropertyProgressProvider::getRemainingDelay(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -8,18 +8,17 @@ TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double timestamp,
     const double duration,
     const double delay,
-    const EasingFunction &easingFunction)
-    : RawProgressProvider(timestamp, duration, delay),
-      easingFunction_(easingFunction) {}
+    const Easing &easing)
+    : RawProgressProvider(timestamp, duration, delay), easing_(easing) {}
 
 TransitionPropertyProgressProvider::TransitionPropertyProgressProvider(
     const double timestamp,
     const double duration,
     const double delay,
-    const EasingFunction &easingFunction,
+    const Easing &easing,
     const double reversingShorteningFactor)
     : RawProgressProvider(timestamp, duration, delay),
-      easingFunction_(easingFunction),
+      easing_(easing),
       reversingShorteningFactor_(reversingShorteningFactor) {}
 
 double TransitionPropertyProgressProvider::getGlobalProgress() const {
@@ -32,7 +31,7 @@ double TransitionPropertyProgressProvider::getKeyframeProgress(
   if (fromOffset == toOffset) {
     return 1;
   }
-  return easingFunction_(getGlobalProgress());
+  return easing_.calculate(getGlobalProgress());
 }
 
 double TransitionPropertyProgressProvider::getRemainingDelay(
@@ -176,7 +175,7 @@ void TransitionProgressProvider::runProgressProviders(
             timestamp,
             propertySettings.duration,
             propertySettings.delay,
-            propertySettings.easingFunction));
+            propertySettings.easing));
   }
 }
 
@@ -211,7 +210,7 @@ TransitionProgressProvider::createReversingShorteningProgressProvider(
       propertySettings.delay < 0
           ? newReversingShorteningFactor * propertySettings.delay
           : propertySettings.delay,
-      propertySettings.easingFunction,
+      propertySettings.easing,
       newReversingShorteningFactor);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -26,12 +26,12 @@ class TransitionPropertyProgressProvider final
       double timestamp,
       double duration,
       double delay,
-      const EasingFunction &easingFunction);
+      const Easing &easing);
   TransitionPropertyProgressProvider(
       double timestamp,
       double duration,
       double delay,
-      const EasingFunction &easingFunction,
+      const Easing &easing,
       double reversingShorteningFactor);
 
   double getGlobalProgress() const override;
@@ -44,7 +44,7 @@ class TransitionPropertyProgressProvider final
   std::optional<double> calculateRawProgress(double timestamp) override;
 
  private:
-  EasingFunction easingFunction_;
+  Easing easing_;
   double reversingShorteningFactor_ = 1;
 
   double getElapsedTime(double timestamp) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -26,12 +26,12 @@ class TransitionPropertyProgressProvider final
       double timestamp,
       double duration,
       double delay,
-      const Easing &easing);
+      std::shared_ptr<Easing> easing);
   TransitionPropertyProgressProvider(
       double timestamp,
       double duration,
       double delay,
-      const Easing &easing,
+      std::shared_ptr<Easing> easing,
       double reversingShorteningFactor);
 
   double getGlobalProgress() const override;
@@ -44,7 +44,7 @@ class TransitionPropertyProgressProvider final
   std::optional<double> calculateRawProgress(double timestamp) override;
 
  private:
-  Easing easing_;
+  std::shared_ptr<Easing> easing_;
   double reversingShorteningFactor_ = 1;
 
   double getElapsedTime(double timestamp) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -513,7 +513,7 @@ void ReanimatedModuleProxy::applyCSSAnimations(
       CSSAnimationConfig config{
           CSSAnimationSettings{
               settings.duration,
-              settings.easingFunction,
+              settings.easing,
               settings.delay,
               settings.iterationCount,
               settings.direction,


### PR DESCRIPTION
## Summary

This PR converts easing functions to classes. I made this change for these reasons:

1. I need to make easings comparable after being created (I cannot compare 2 instances of lambdas, even if they were created with the same params in the closure)
2. I wanted to encapsulate all helper easing methods in the easing object instead of keeping them global