### PR TITLE
[0.80] Remove `folly_flags` in RNReanimated.podspec

### DIFF
--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -8,7 +8,6 @@ assert_minimal_react_native_version($config)
 $new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] != '0'
 assert_new_architecture_enabled($new_arch_enabled)
 
-folly_flags = "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32"
 boost_compiler_flags = '-Wno-documentation'
 fabric_flags = $new_arch_enabled ? '-DRCT_NEW_ARCH_ENABLED' : ''
 example_flag = $config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
@@ -73,7 +72,7 @@ Pod::Spec.new do |s|
     "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => '$(inherited)',
     "GCC_PREPROCESSOR_DEFINITIONS[config=*Release*]" => '$(inherited)',
   }
-  s.compiler_flags = "#{folly_flags} #{boost_compiler_flags}"
+  s.compiler_flags = boost_compiler_flags
   s.xcconfig = {
     "HEADER_SEARCH_PATHS" => [
       '"$(PODS_ROOT)/boost"',
@@ -90,7 +89,7 @@ Pod::Spec.new do |s|
       "\"$(PODS_ROOT)/#{$config[:dynamic_frameworks_worklets_dir]}/apple\"",
       "\"$(PODS_ROOT)/#{$config[:dynamic_frameworks_worklets_dir]}/Common/cpp\"",
     ].join(' '),
-    "OTHER_CFLAGS" => "$(inherited) #{folly_flags} #{fabric_flags} #{example_flag} #{version_flags} #{compilation_metadata_generation_flag}"
+    "OTHER_CFLAGS" => "$(inherited) #{fabric_flags} #{example_flag} #{version_flags} #{compilation_metadata_generation_flag}"
   }
   s.requires_arc = true
 


### PR DESCRIPTION
## Summary

This PR removes `folly_flags` in RNReanimated.podspec since they break compatibility with RN 0.80.0-rc.0.

Instead, `folly-config.h` file from `RCT-Folly` dependency is used which is the default way to configure Folly.

This change is backward-compatible with at least 3 previous versions of react-native.

## Test plan
