### PR TITLE
Don't transfer reanimated updates to ReactJS

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -61,7 +61,8 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
   return shadowNode.clone(
       {mergeProps(shadowNode, propsMap, *family),
        std::make_shared<ShadowNode::ListOfShared>(children),
-       shadowNode.getState()});
+       shadowNode.getState(),
+       false});
 }
 
 RootShadowNode::Unshared cloneShadowTreeWithNewProps(


### PR DESCRIPTION
## Summary

This PR changes the way reanimated clones `ShadowNodes`. Due to the new `runtimeShadowNodeReference` mechanism, react "sees" the updates we apply in the commit hook. This is a problem, because then we are unable to remove an animation, as no one will remember the state that would be displayed without the animation. Instead an intermediate state would be displayed. To fix that, we disable transferring of ShadowNode references for when we clone them from reanimated.

## Test plan
