### PR TITLE
Add opacity and transform example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/OpacityTransformExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/OpacityTransformExample.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
+
+const ROWS = 25;
+const COLS = 15;
+const SIZE = 25;
+
+export default function OpacityTransformExample() {
+  const sv = useSharedValue(0);
+
+  useEffect(() => {
+    sv.value = 0;
+    sv.value = withRepeat(withTiming(1, { duration: 500 }), -1, true);
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: sv.value,
+    transform: [{ scale: sv.value }, { rotate: `${sv.value * 90}deg` }],
+  }));
+
+  return (
+    <View style={styles.container}>
+      {[...new Array(ROWS)].map((_, i) => (
+        <View key={i} style={styles.row}>
+          {[...new Array(COLS)].map((_, j) => (
+            <Animated.View key={j} style={[styles.box, animatedStyle]} />
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  box: {
+    backgroundColor: 'navy',
+    width: SIZE,
+    height: SIZE,
+  }
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -84,6 +84,7 @@ import NewestShadowNodesRegistryRemoveExample from './NewestShadowNodesRegistryR
 import NonLayoutPropAndRenderExample from './NonLayoutPropAndRenderExample';
 import OldAnimatedSensorExample from './OldAnimatedSensorExample';
 import OldMeasureExample from './OldMeasureExample';
+import OpacityTransformExample from './OpacityTransformExample';
 import OverlappingBoxesExample from './OverlappingBoxesExample';
 import PendulumExample from './PendulumExample';
 import PerformanceMonitorExample from './PerfomanceMonitorExample';
@@ -211,6 +212,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🫧',
     title: 'Bubbles',
     screen: BubblesExample,
+  },
+  OpacityTransformExample: {
+    icon: '🌀',
+    title: 'opacity & transform',
+    screen: OpacityTransformExample,
   },
   IPodExample: {
     icon: '🎧',


### PR DESCRIPTION
## Summary

This PR adds "opacity & transform" example which is a benchmark for animating `opacity` and `transform` styles.

<table>
<thead>
<tr>
<th>Android</th>
<th>iOS</th>
</tr>
</thead>
<tbody>
<tr>
<td><video src="https://github.com/user-attachments/assets/5f2cb9c3-463e-454f-9a06-6042429aa445" /></td>
<td><video src="https://github.com/user-attachments/assets/1d02f4f0-d796-479f-ae91-2d586bf608e8" /></td>
</tr>
</tbody>
</table>

## Test plan
