### PR TITLE
docs: Fix typo in scroll offset example

### DIFF
--- a/packages/docs-reanimated/src/examples/AnimatedScrollHandler.tsx
+++ b/packages/docs-reanimated/src/examples/AnimatedScrollHandler.tsx
@@ -27,11 +27,11 @@ const Content = () => {
 };
 
 export default function ScrollExample() {
-  const offsetX = useSharedValue(0);
+  const offsetY = useSharedValue(0);
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
-      offsetX.value = event.contentOffset.y;
+      offsetY.value = event.contentOffset.y;
     },
     onMomentumBegin: (e) => {
       console.log('The list is moving.');
@@ -43,8 +43,8 @@ export default function ScrollExample() {
 
   const offsetAnimatedProps = useAnimatedProps(() => {
     return {
-      text: `Scroll offset: ${Math.round(offsetX.value)}px`,
-      defaultValue: `Scroll offset: ${offsetX.value}x`,
+      text: `Scroll offset: ${Math.round(offsetY.value)}px`,
+      defaultValue: `Scroll offset: ${offsetY.value}x`,
     };
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes a typo in the useAnimatedScrollHandler code example where it uses the Y coordinate but stores it in an X-named variable

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
