### PR TITLE
fix(mock): add mock for useScrollViewOffset

### DIFF
--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -118,7 +118,7 @@ const hook = {
   }),
   // useFrameCallback: ADD ME IF NEEDED
   useAnimatedKeyboard: () => ({ height: 0, state: 0 }),
-  // useScrollViewOffset: ADD ME IF NEEDED
+  useScrollViewOffset: () => ({ value: 0 }),
 };
 
 const animation = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This adds a basic mock for `useScrollViewOffset` to the existing provided mocks for the library as documented for use here: https://docs.swmansion.com/react-native-reanimated/docs/guides/testing/#setup

The reason I think this is worth adding is because upon following this Expo documentation for jest setup to Expo's default tab template, the test will fail calling out this hook. With so many people starting with the Expo tabs template today, I think it's important that following that documentation results in a minimal test passing

## Test plan

Here is a reproducer with the patch applied already: https://github.com/frankcalise/jest-mock-dev-menu

If you want to see it fail, you can remove the patch or restore the mock source so that `useScrollViewOffset` is commented out.
