### PR TITLE
fix: Add missing optional chaining operator in current react owner check

### DIFF
--- a/packages/react-native-reanimated/src/reactUtils.ts
+++ b/packages/react-native-reanimated/src/reactUtils.ts
@@ -4,7 +4,7 @@ import React from 'react';
 function getCurrentReactOwner() {
   return (
     // @ts-expect-error React secret internals aren't typed
-    React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?.A?.getOwner() ||
+    React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?.A?.getOwner?.() ||
     // @ts-expect-error React secret internals aren't typed
     React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner
       ?.current ||


### PR DESCRIPTION
## Summary

This very likely caused Next production build crashes described in the #7543 issue.
