### PR TITLE
cherry-pick: Export some internal layout animations types (#7546)

### DIFF
--- a/packages/react-native-reanimated/src/helperTypes.ts
+++ b/packages/react-native-reanimated/src/helperTypes.ts
@@ -20,7 +20,7 @@ import type { BaseAnimationBuilder } from './layoutReanimation/animationBuilder/
 import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 import type { SharedTransition } from './layoutReanimation/sharedTransitions';
 
-type EntryOrExitLayoutType =
+export type EntryOrExitLayoutType =
   | BaseAnimationBuilder
   | typeof BaseAnimationBuilder
   | EntryExitAnimationFunction

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -50,6 +50,7 @@ export type {
   ExitAnimationsValues,
   IEntryExitAnimationBuilder,
   ILayoutAnimationBuilder,
+  KeyframeProps,
   LayoutAnimation,
   LayoutAnimationFunction,
   LayoutAnimationStartFunction,
@@ -108,6 +109,7 @@ export type {
   AnimatedProps,
   AnimatedStyleProp,
   AnimateProps,
+  EntryOrExitLayoutType,
   TransformStyleTypes,
 } from './helperTypes';
 export type {
@@ -166,6 +168,7 @@ export {
   setUpTests,
   withReanimatedTimer,
 } from './jestUtils';
+export type { ReanimatedKeyframe } from './layoutReanimation';
 export {
   BaseAnimationBuilder,
   // Bounce

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/index.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/index.ts
@@ -1,4 +1,4 @@
 'use strict';
 export { BaseAnimationBuilder } from './BaseAnimationBuilder';
 export { ComplexAnimationBuilder } from './ComplexAnimationBuilder';
-export { Keyframe } from './Keyframe';
+export { Keyframe, type ReanimatedKeyframe } from './Keyframe';


### PR DESCRIPTION
## Summary

This PR adds exports for some layout animations types that are used internally. I added exports of types that I was ask for in [this](https://github.com/software-mansion/react-native-reanimated/discussions/7537#discussioncomment-13195445) diescussion.
