### PR TITLE
cherry-pick: Add missing optional chaining operator in current react owner check

### DIFF
--- a/packages/react-native-reanimated/src/reactUtils.tsx
+++ b/packages/react-native-reanimated/src/reactUtils.tsx
@@ -14,7 +14,7 @@ const IS_REACT_19 = isReact19();
 function getCurrentReactOwner() {
   return (
     // @ts-expect-error React secret internals aren't typed
-    React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?.A?.getOwner() ||
+    React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?.A?.getOwner?.() ||
     // @ts-expect-error React secret internals aren't typed
     React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner
       ?.current ||


### PR DESCRIPTION
## Summary

This caused Next production build crashes described in the #7543 issue.
