### PR TITLE
(cherry-pick) fix: cleanup sensors in invalidate and make nativeProxy not leak (#7515)

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -77,11 +77,6 @@ void NativeProxy::commonInit(
 NativeProxy::~NativeProxy() {
   // removed temporary, new event listener mechanism need fix on the RN side
   // reactScheduler_->removeEventListener(eventListener_);
-
-  // cleanup all animated sensors here, since NativeProxy
-  // has already been destroyed when AnimatedSensorModule's
-  // destructor is ran
-  reanimatedModuleProxy_->cleanupSensors();
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
@@ -593,7 +588,11 @@ void NativeProxy::setupLayoutAnimations() {
 
 void NativeProxy::invalidateCpp() {
   layoutAnimations_->cthis()->invalidate();
+  // cleanup all animated sensors here, since the next line resets
+  // the pointer and it will be too late after it
+  reanimatedModuleProxy_->cleanupSensors();
   reanimatedModuleProxy_.reset();
+  javaPart_ = nullptr;
 }
 
 } // namespace reanimated


### PR DESCRIPTION
There are essentially 2 changes in the PR. Right now when you do a reload in a simple app with reanimated installed, you will see in AS profiler that instances of all `NativeProxy`s are still in the memory. It is caused by `javaPart_` never being released thus keeping java part after reload.Due to this destructor of `NativeProxy` is not called ever. After adding `javaPart_ = nullptr` in `invalidateCpp`, it works and destructor is called. But calling `reanimatedModuleProxy_->cleanupSensors();` there makes the app crash since we already reset the `reanimatedModuleProxy_` in `invalidateCpp`.

We can go other way probably and move

```
  reanimatedModuleProxy_->cleanupSensors();
  reanimatedModuleProxy_.reset();
```
to destructor but seems like `invalidateCpp` is the cleanup method now.

Side note:
I am a bit worried that some code regarding sensors might still run after the `invalidateCpp` method is run, but maybe that would be prohibited state?

Make simple app with reanimated and do a couple of reloads and check in profiler if the `NativeProxy` leaks.

## Summary

## Test plan
