### PR TITLE
release(Worklets): 0.3.0

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2629,7 +2629,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.3.0):
+  - RNWorklets (0.4.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2656,10 +2656,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.3.0)
+    - RNWorklets/worklets (= 0.4.0)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.3.0):
+  - RNWorklets/worklets (0.4.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2686,10 +2686,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.3.0)
+    - RNWorklets/worklets/apple (= 0.4.0)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.3.0):
+  - RNWorklets/worklets/apple (0.4.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3063,7 +3063,7 @@ SPEC CHECKSUMS:
   RNReanimated: e769e1c19d706c84370241e26e1d152bccf5bd0b
   RNScreens: 10ca32b82794369e5857df3c8ca5937c415fbfd3
   RNSVG: 341f555dbcd83a34d1f058e88df387de7bbc3347
-  RNWorklets: 5e13081978d725e355af50932e040d9d27faa80c
+  RNWorklets: 8cd71c6d3aa2d7269b03d8df379eabb09a3b20b9
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 1cf315b6f6373fa6118b88bf0c7a2c6dd760706c
 

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -1716,7 +1716,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNWorklets (0.3.0):
+  - RNWorklets (0.4.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -1736,9 +1736,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.3.0)
+    - RNWorklets/worklets (= 0.4.0)
     - Yoga
-  - RNWorklets/worklets (0.3.0):
+  - RNWorklets/worklets (0.4.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -1758,9 +1758,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.3.0)
+    - RNWorklets/worklets/apple (= 0.4.0)
     - Yoga
-  - RNWorklets/worklets/apple (0.3.0):
+  - RNWorklets/worklets/apple (0.4.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -2061,7 +2061,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c6b441559fe02f0c07fe2720c9103a8532552ce1
   RNReanimated: efe7c51833bb691c9ffed07f0528d5d0a08c4d6f
   RNSVG: 5b1c237fa3de0db25fe4ba12add0a72b65d6a40e
-  RNWorklets: c645e3010bf971948ba80fdbb9cc0cb6ff340f0c
+  RNWorklets: a3794f1ad204f8cdaa635b2299f696bc05dcdb7d
   SocketRocket: 9ee265c4b5ae2382d18e4ee1d2dd2d7af0ff1ab5
   Yoga: 446e6f351a519539ff00a1159fe41e589aab1b94
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1756,7 +1756,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNWorklets
     - Yoga
-  - RNWorklets (0.3.0):
+  - RNWorklets (0.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1779,9 +1779,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.3.0)
+    - RNWorklets/worklets (= 0.4.0)
     - Yoga
-  - RNWorklets/worklets (0.3.0):
+  - RNWorklets/worklets (0.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1804,9 +1804,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.3.0)
+    - RNWorklets/worklets/apple (= 0.4.0)
     - Yoga
-  - RNWorklets/worklets/apple (0.3.0):
+  - RNWorklets/worklets/apple (0.4.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2131,7 +2131,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 3a01f76123e04b8b945d43e5ffccae6f90f4a26e
   ReactCommon: 59e7bd3cf331ba77a96a75e6b603abf05883b102
   RNReanimated: 946c1ce8910b1b1d4e3fea5d7c177c57ff33b86a
-  RNWorklets: e75d899ced7333caea90d88b52d512602efa2701
+  RNWorklets: 3791e6bdb53e34ec541094d453225a96418dbcc6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 770a077e3a222f162c2e0c8a95e7e997b7682a8e
 

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-worklets",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The React Native multithreading library",
   "keywords": [
     "react-native",


### PR DESCRIPTION
## Summary

Releasing `react-native-worklets` 0.3.0 for the upcoming beta of Reanimated. For the time being I decided not to draft any GitHub releases. We have to brainstorm how do we release `react-native-reanimated` and `react-native-worklets` in parallel.

<img width="426" alt="Screenshot 2025-05-20 at 13 18 17" src="https://github.com/user-attachments/assets/cf1fe596-e246-43e7-9493-1f37e7a841bb" />

## Test plan

I tested the release within the repo and on a bare RN app.
