### PR TITLE
chore(Reanimated3): cherry-pick #7428

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2453,7 +2453,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: ae521efb1c6c2b183ae0f8479487db03c826184c
   RNFlashList: 7ad51f0d0d51a3b7b1d1bb07947b927cb352afc4
   RNGestureHandler: ebef699ea17e7c0006c1074e1e423ead60ce0121
-  RNReanimated: f34e7f7daf8e2cf3ba0de6b9976b7b2b9d89de9c
+  RNReanimated: 5d5eac2113b3b62b0ee3968f7f7bf2a3802c2b52
   RNScreens: b6320de0f7e7b7bc1a782a2fb6213a4d98c30b88
   RNSVG: 794f269526df9ddc1f79b3d1a202b619df0368e3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -1875,7 +1875,7 @@ SPEC CHECKSUMS:
   ReactCommon: 7490617e54cc60ef0aecee2beaa1f44d4b413e61
   RNCAsyncStorage: c91d753ede6dc21862c4922cd13f98f7cfde578e
   RNGestureHandler: 3aebdd5727d76b567572472b9e52c29536ee0eef
-  RNReanimated: 8339401089607d70471849bb56af2f76e29dd230
+  RNReanimated: bea62941075e67f082b170bb3779c1dde9507ea3
   RNSVG: 67de7abef81f367387b708ba6d2acefe7d4f5895
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: b84121efc79fe86699a15c8ae59e5a6a8bca05c8

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2074,7 +2074,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ec07a48c499f7f1420c872ba3347ce7937000960
   ReactCodegen: a9e644a22d3ef480d4973dd117c9458da936d12b
   ReactCommon: 975c24e76b57544fa910b0caee34f4adbfe90abb
-  RNReanimated: d29042c429a85fcf0b0013c26ce8f873bc2398b8
+  RNReanimated: 5c0ec62982c666cad3a49857357d88520507f94d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: d4280c1f5bc3aef681cf28421e3a988c2d77ba31
 

--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -83,8 +83,8 @@ Pod::Spec.new do |s|
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]" => hermes_debug_hidden_flags,
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Release]" => '$(inherited)',
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => hermes_debug_hidden_flags,
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Release*]" => '$(inherited)',
   }
   s.compiler_flags = "#{folly_flags} #{boost_compiler_flags}"
   s.xcconfig = {

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -56,8 +56,8 @@ Pod::Spec.new do |s|
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]" => hermes_debug_hidden_flags,
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Release]" => '$(inherited)',
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => hermes_debug_hidden_flags,
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Release*]" => '$(inherited)',
   }
   
 end


### PR DESCRIPTION
PR analogous to https://github.com/facebook/react-native/pull/50897 fixing `HERMES_ENABLE_DEBUGGER` not being added to configs that are not strictly named `Debug`. Should fix https://github.com/software-mansion/react-native-reanimated/issues/7412. Thanks @tomekzaw and @piaskowyk for helping with it.

Run app from https://github.com/software-mansion/react-native-reanimated/issues/7412 and see that it doesn't crash.
