### PR TITLE
fix: Incorrect fill mode in alternate animations

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -61,17 +61,12 @@ bool CSSAnimation::hasBackwardsFillMode() const {
 }
 
 folly::dynamic CSSAnimation::getCurrentInterpolationStyle() const {
-  return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
+    return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
 }
 
 folly::dynamic CSSAnimation::getBackwardsFillStyle() const {
   return isReversed() ? styleInterpolator_->getLastKeyframeValue()
                       : styleInterpolator_->getFirstKeyframeValue();
-}
-
-folly::dynamic CSSAnimation::getForwardsFillStyle() const {
-  return isReversed() ? styleInterpolator_->getFirstKeyframeValue()
-                      : styleInterpolator_->getLastKeyframeValue();
 }
 
 folly::dynamic CSSAnimation::getResetStyle() const {
@@ -104,6 +99,8 @@ folly::dynamic CSSAnimation::update(const double timestamp) {
 void CSSAnimation::updateSettings(
     const PartialCSSAnimationSettings &updatedSettings,
     const double timestamp) {
+  progressProvider_->resetProgress();
+
   if (updatedSettings.duration.has_value()) {
     progressProvider_->setDuration(updatedSettings.duration.value());
   }
@@ -131,6 +128,8 @@ void CSSAnimation::updateSettings(
       progressProvider_->play(timestamp);
     }
   }
+
+  progressProvider_->update(timestamp);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -61,7 +61,7 @@ bool CSSAnimation::hasBackwardsFillMode() const {
 }
 
 folly::dynamic CSSAnimation::getCurrentInterpolationStyle() const {
-    return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
+  return styleInterpolator_->interpolate(shadowNode_, progressProvider_);
 }
 
 folly::dynamic CSSAnimation::getBackwardsFillStyle() const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -34,7 +34,6 @@ class CSSAnimation {
 
   folly::dynamic getCurrentInterpolationStyle() const;
   folly::dynamic getBackwardsFillStyle() const;
-  folly::dynamic getForwardsFillStyle() const;
   folly::dynamic getResetStyle() const;
 
   void run(double timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -18,6 +18,27 @@ AnimationProgressProvider::AnimationProgressProvider(
       easingFunction_(std::move(easingFunction)),
       keyframeEasingFunctions_(keyframeEasingFunctions) {}
 
+void AnimationProgressProvider::setIterationCount(double iterationCount) {
+  iterationCount_ = iterationCount;
+}
+
+void AnimationProgressProvider::setDirection(AnimationDirection direction) {
+  direction_ = direction;
+}
+
+void AnimationProgressProvider::setEasingFunction(
+    const EasingFunction &easingFunction) {
+  easingFunction_ = easingFunction;
+}
+
+AnimationDirection AnimationProgressProvider::getDirection() const {
+  return direction_;
+}
+
+double AnimationProgressProvider::getGlobalProgress() const {
+  return applyAnimationDirection(rawProgress_.value_or(0));
+}
+
 AnimationProgressState AnimationProgressProvider::getState(
     const double timestamp) const {
   if (shouldFinish(timestamp)) {
@@ -34,6 +55,10 @@ AnimationProgressState AnimationProgressProvider::getState(
     return AnimationProgressState::Finished;
   }
   return AnimationProgressState::Running;
+}
+
+double AnimationProgressProvider::getPauseTimestamp() const {
+  return pauseTimestamp_;
 }
 
 double AnimationProgressProvider::getTotalPausedTime(
@@ -137,7 +162,9 @@ double AnimationProgressProvider::updateIterationProgress(
 
   if (deltaIterations > 0) {
     // Return 1 if the current iteration is the last one
-    if (currentIteration_ == iterationCount_) {
+    if (iterationCount_ != -1 &&
+        currentIteration_ + deltaIterations > iterationCount_) {
+      currentIteration_ = iterationCount_;
       return 1;
     }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -47,7 +47,7 @@ AnimationProgressState AnimationProgressProvider::getState(
   if (pauseTimestamp_ > 0) {
     return AnimationProgressState::Paused;
   }
-  if (!rawProgress_.has_value()) {
+  if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
     return AnimationProgressState::Pending;
   }
   const auto rawProgress = rawProgress_.value();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -29,30 +29,15 @@ class AnimationProgressProvider final : public KeyframeProgressProvider,
       EasingFunction easingFunction,
       const std::shared_ptr<KeyframeEasingFunctions> &keyframeEasingFunctions);
 
-  void setIterationCount(double iterationCount) {
-    resetProgress();
-    iterationCount_ = iterationCount;
-  }
-  void setDirection(AnimationDirection direction) {
-    resetProgress();
-    direction_ = direction;
-  }
-  void setEasingFunction(const EasingFunction &easingFunction) {
-    resetProgress();
-    easingFunction_ = easingFunction;
-  }
+  void setIterationCount(double iterationCount);
+  void setDirection(AnimationDirection direction);
+  void setEasingFunction(const EasingFunction &easingFunction);
 
-  AnimationDirection getDirection() const {
-    return direction_;
-  }
-  double getGlobalProgress() const override {
-    return applyAnimationDirection(rawProgress_.value_or(0));
-  }
+  AnimationDirection getDirection() const;
+  double getGlobalProgress() const override;
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
   AnimationProgressState getState(double timestamp) const;
-  double getPauseTimestamp() const {
-    return pauseTimestamp_;
-  }
+  double getPauseTimestamp() const;
   double getTotalPausedTime(double timestamp) const;
   double getStartTimestamp(double timestamp) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
@@ -9,12 +9,10 @@ RawProgressProvider::RawProgressProvider(
     : duration_(duration), delay_(delay), creationTimestamp_(timestamp) {}
 
 void RawProgressProvider::setDuration(double duration) {
-  resetProgress();
   duration_ = duration;
 }
 
 void RawProgressProvider::setDelay(double delay) {
-  resetProgress();
   delay_ = delay;
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -274,15 +274,14 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(
 
     folly::dynamic style;
     const auto &currentState = animation->getState(timestamp);
-    if (currentState == AnimationProgressState::Finished) {
-      if (animation->hasForwardsFillMode()) {
-        style = animation->getForwardsFillStyle();
-      }
-    } else if (
-        startTimestamp == timestamp ||
+    if (startTimestamp == timestamp ||
         (startTimestamp > timestamp && animation->hasBackwardsFillMode())) {
       style = animation->getBackwardsFillStyle();
-    } else if (currentState != AnimationProgressState::Pending) {
+    } else if (
+        currentState == AnimationProgressState::Running ||
+        currentState == AnimationProgressState::Paused ||
+        (currentState == AnimationProgressState::Finished &&
+         animation->hasForwardsFillMode())) {
       style = animation->getCurrentInterpolationStyle();
     }
 
@@ -293,6 +292,8 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(
       updatedStyle.update(style);
     }
   }
+
+  LOG(INFO) << "updatedStyle: " << updatedStyle;
 
   setInUpdatesRegistry(shadowNode, updatedStyle);
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -279,7 +279,10 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(
       style = animation->getBackwardsFillStyle();
     } else if (
         currentState == AnimationProgressState::Running ||
-        currentState == AnimationProgressState::Paused ||
+        // Animation is paused after start (was running before)
+        (currentState == AnimationProgressState::Paused &&
+         timestamp >= animation->getStartTimestamp(timestamp)) ||
+        // Animation is finished and has fill forwards fill mode
         (currentState == AnimationProgressState::Finished &&
          animation->hasForwardsFillMode())) {
       style = animation->getCurrentInterpolationStyle();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registry/CSSAnimationsRegistry.cpp
@@ -293,8 +293,6 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(
     }
   }
 
-  LOG(INFO) << "updatedStyle: " << updatedStyle;
-
   setInUpdatesRegistry(shadowNode, updatedStyle);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes incorrect fill mode being applied in alternate animations. The previous implementation didn't take it into account that the every second animation iteration in alternate animations is revered. As a result, the animation was either treated like the animation with the `normal` direction (for `alternate`) or `reverse` (for `alternate-reverse`).

I removed the forwards fill mode getter and fixed the progress calculation after resetting animation progress when its settings change. As a result, if the animation is finished, I can just read the progress from the progress provider, without assuming that it is always 1 for finished animations as it might be 0 for alternate ones.

## Example recordings

When `animationDirection` is set to `alternate` or `alternate-reverse` and the animation has the `forwards` fill mode, the appearance of the box should change when the iteration count is changed between 1 and 2. It didn't work in the old implementation.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/0002dee1-58bc-474c-b3a2-021241937394" /> | <video src="https://github.com/user-attachments/assets/ab606c64-d12b-44a6-a294-b1d025db1a7a" /> |
