### PR TITLE
fix: Expandable card items resizing in the example app

### DIFF
--- a/apps/common-app/src/apps/css/components/examples/ExampleCard.tsx
+++ b/apps/common-app/src/apps/css/components/examples/ExampleCard.tsx
@@ -66,7 +66,7 @@ export default function ExampleCard({
   const itemWrapperStyle: StyleProp<ViewStyle> = [
     styles.itemWrapper,
     {
-      flexBasis: isExpanded ? undefined : '50%',
+      width: isExpanded ? undefined : '50%',
     },
   ];
 


### PR DESCRIPTION
## Summary

It worked before with the `flexBasis` change instead of `width` but must have stopped working after one of the latest RN upgrades.

It is not our issue as the same problem was happening on plain `View` components without any layout animations.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/9246b356-5923-4eea-a6f0-d805eae48fe3" /> | <video src="https://github.com/user-attachments/assets/56294362-9f79-48b5-8edf-00963ecf74fb" /> |
