### PR TITLE
fix: CSS animation and transition removal issue on web

### DIFF
--- a/packages/react-native-reanimated/src/css/managers/CSSManager.web.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSManager.web.ts
@@ -21,16 +21,11 @@ export default class CSSManager implements ICSSManager {
   }
 
   update(style: CSSStyle): void {
-    const [animationConfig, transitionConfig] =
+    const [animationProperties, transitionProperties] =
       filterCSSAndStyleProperties(style);
 
-    if (animationConfig) {
-      this.animationsManager.update(animationConfig);
-    }
-
-    if (transitionConfig) {
-      this.transitionsManager.update(transitionConfig);
-    }
+    this.animationsManager.update(animationProperties);
+    this.transitionsManager.update(transitionProperties);
   }
 
   unmountCleanup(): void {


### PR DESCRIPTION
## Summary

There were invalid `if` statements that din't call the `update` method on the `CSSAnimationsManager` and `CSSTransitionManager` making it impossible to remove the animation/transition attached to the view.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/37285c63-4d38-46ad-886a-37b5aed9aa94" /> | <video src="https://github.com/user-attachments/assets/4cc9f5cb-7779-408c-86d9-8f02433633ca" /> |
