### PR TITLE
fix: scrollTo not working on web

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -72,7 +72,7 @@ export function useAnimatedRef<
 
         fun.current = component;
       }
-      return initialTag;
+      return initialTag ?? tag.value;
     });
 
     fun.current = null;


### PR DESCRIPTION
## Summary

It turns out that the #7452 PR broke `animatedRef()` calls on web. After changes introduced in the mentioned PR, this call always returned `null` instead of a correct reference to the component.

This was caused by the fact that the function was called without the `component` argument and the entire `if` statement that assigned a value to the `initialTag` was not executed. As a result, we always returned `initialTag` with the `null` value.