### PR TITLE
chore: Bump min required version of worklets to 0.4.0

### DIFF
--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -11,7 +11,7 @@ export const jsVersion = '4.0.0-beta.4';
  * if the App compiles there could be ABI mismatches.
  */
 export const acceptedWorkletsVersion = {
-  min: '0.3.0' satisfies ValidVersion,
+  min: '0.4.0' satisfies ValidVersion,
   // TODO: Placeholding "infinity" version for now.
   // Set it to a proper value when releasing stable Reanimated 4.
   max: '1000.0.0' satisfies ValidVersion,


### PR DESCRIPTION
## Summary

Just an update of the min required version of `react-native-worklets` as asked by @tjzel in [this](https://github.com/software-mansion/react-native-reanimated/pull/7560#discussion_r2097997884) commend.