### PR TITLE
feat: Inject reanimated module proxy to reanimated shadow node

### DIFF
--- a/packages/react-native-reanimated/Common/NativeView/CMakeLists.txt
+++ b/packages/react-native-reanimated/Common/NativeView/CMakeLists.txt
@@ -18,6 +18,11 @@ file(
   ${CODEGEN_OVERWRITTEN_COMPONENTS_DIR}/*.cpp
 )
 
+find_package(fbjni REQUIRED CONFIG)
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(react-native-worklets REQUIRED CONFIG)
+find_package(react-native-reanimated REQUIRED CONFIG)
+
 add_library(
   react_codegen_rnreanimated
   OBJECT
@@ -32,13 +37,18 @@ target_include_directories(
   ${CODEGEN_OVERWRITTEN_COMPONENTS_DIR}
   ${CODEGEN_JNI_DIR}
   ${CODEGEN_COMPONENTS_DIR}
+  ${REACT_COMMON_DIR}
 )
 
 target_link_libraries(
   react_codegen_rnreanimated
+  log
+  ReactAndroid::jsi
+  ReactAndroid::reactnative
   fbjni
   jsi
-  reactnative
+  react-native-reanimated::reanimated
+  react-native-worklets::worklets
 )
 
 target_compile_options(

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h
@@ -4,12 +4,42 @@
 #include <react/renderer/components/rnreanimated/ReanimatedShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
+
 #include <memory>
 
 namespace facebook::react {
 
-using ReanimatedViewComponentDescriptor =
-    ConcreteComponentDescriptor<ReanimatedShadowNode>;
+using namespace reanimated;
+using namespace css;
+
+class ReanimatedViewComponentDescriptor
+    : public ConcreteComponentDescriptor<ReanimatedShadowNode> {
+ public:
+  explicit ReanimatedViewComponentDescriptor(
+      const ComponentDescriptorParameters &parameters)
+      : ConcreteComponentDescriptor<ReanimatedShadowNode>(parameters),
+        reanimatedModuleProxy_(findReanimatedModuleProxy(parameters)) {}
+
+  void adopt(ShadowNode &shadowNode) const override {
+    if (!reanimatedModuleProxy_.has_value()) {
+      return;
+    }
+    const auto &proxy = reanimatedModuleProxy_.value().lock();
+    if (!proxy) {
+      return;
+    }
+  }
+
+ private:
+  std::optional<std::weak_ptr<ReanimatedModuleProxy>> reanimatedModuleProxy_;
+
+  std::optional<std::weak_ptr<ReanimatedModuleProxy>> findReanimatedModuleProxy(
+      const ComponentDescriptorParameters &parameters) {
+    return parameters.contextContainer
+        ->find<std::weak_ptr<ReanimatedModuleProxy>>("ReanimatedModuleProxy");
+  }
+};
 
 void rnreanimated_registerComponentDescriptorsFromCodegen(
     const std::shared_ptr<const ComponentDescriptorProviderRegistry> &registry);

--- a/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.h
+++ b/packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ReanimatedShadowNode.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <jsi/jsi.h>
 #include <react/renderer/components/rnreanimated/EventEmitters.h>
 #include <react/renderer/components/rnreanimated/Props.h>
 #include <react/renderer/components/rnreanimated/ReanimatedViewState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
+
+#include <jsi/jsi.h>
 
 namespace facebook::react {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -927,6 +927,11 @@ void ReanimatedModuleProxy::initializeFabric(
       uiManager_, updatesRegistryManager_, request);
   commitHook_ = std::make_shared<ReanimatedCommitHook>(
       uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
+
+  const auto scheduler =
+      reinterpret_cast<Scheduler *>(uiManager_->getDelegate());
+  scheduler->getContextContainer()->insert(
+      "ReanimatedModuleProxy", weak_from_this());
 }
 
 void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {

--- a/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
+++ b/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
@@ -16,7 +16,7 @@ Animated.addWhitelistedNativeProps({ r: true });
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 Animated.addWhitelistedNativeProps({ text: true });
 
-export default function AnimatedComponent() {
+function AnimatedComponent() {
   const r = useSharedValue(20);
   const width = useSharedValue(20);
 

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -13,6 +13,7 @@ import type {
 import { getViewInfo } from '../../createAnimatedComponent/getViewInfo';
 import { getShadowNodeWrapperFromRef } from '../../fabricUtils';
 import { findHostInstance } from '../../platform-specific/findHostInstance';
+import { ReanimatedView } from '../../specs';
 import { CSSManager } from '../managers';
 import { markNodeAsRemovable, unmarkNodeAsRemovable } from '../platform/native';
 import type { AnyComponent, AnyRecord, CSSStyle, PlainStyle } from '../types';
@@ -201,7 +202,7 @@ export default class AnimatedComponent<
       default: { collapsable: false },
     });
 
-    return (
+    const child = (
       <ChildComponent
         {...this.props}
         {...props}
@@ -212,5 +213,17 @@ export default class AnimatedComponent<
         ref={this._setComponentRef as (ref: Component) => void}
       />
     );
+
+    if (SHOULD_BE_USE_WEB) {
+      return child;
+    }
+
+    return <ReanimatedView style={styles.container}>{child}</ReanimatedView>;
   }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'contents',
+  },
+});

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -3,6 +3,12 @@
 import './publicGlobals';
 
 import * as Animated from './Animated';
+import { initializeReanimatedModule } from './initializers';
+import { ReanimatedModule } from './ReanimatedModule';
+
+// TODO: Specify the initialization pipeline since now there's no
+// universal source of truth for it.
+initializeReanimatedModule(ReanimatedModule);
 
 export default Animated;
 

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -1,0 +1,16 @@
+'use strict';
+import { IS_WEB } from './common';
+import type { IReanimatedModule } from './ReanimatedModule';
+
+export function initializeReanimatedModule(
+  ReanimatedModule: IReanimatedModule
+) {
+  if (IS_WEB) {
+    return;
+  }
+  if (!ReanimatedModule) {
+    throw new ReanimatedError(
+      'Tried to initialize Reanimated without a valid ReanimatedModule'
+    );
+  }
+}

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -1,6 +1,7 @@
 /* eslint-disable n/no-callback-literal */
 'use strict';
 
+import type { ViewProps } from 'react-native';
 import {
   Animated as AnimatedRN,
   Image as ImageRN,
@@ -491,3 +492,18 @@ module.exports = {
   ...Reanimated,
   default: Animated,
 };
+
+// Mock ReanimatedView
+jest.mock(
+  'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
+  () => {
+    return function ReanimatedViewMock(props: ViewProps) {
+      return props.children;
+    };
+  }
+);
+jest.mock('react-native-reanimated/src/specs/ReanimatedNativeComponent', () => {
+  return function ReanimatedViewMock(props: ViewProps) {
+    return props.children;
+  };
+});


### PR DESCRIPTION
## Summary

This PR adds a possibility to access the `ReanimatedModuleProxy` from the `ReanimatedShadowNode`. It also fixes android linking issue to make it possible to access all reanimated library stuff.

## Test plan

You can open any example in the example app and see that it renders fine. 

You can also uncomment the following line in the `packages/react-native-reanimated/Common/NativeView/react/renderer/components/rnreanimated/ComponentDescriptors.h`:

```cpp
// LOG(INFO) << "We can access the proxy: " << proxy->getCssTimestamp();
```

and see that the proxy can be accessed.

## TODO

- [ ] Fix gesture handler integration - in the current implementation gestures aren't attached to AnimatedComponents because the `ReanimatedView` is not laid out (because of `display: contents`).