### PR TITLE
feat(Worklets): add exp. bundling native apis and flags

### DIFF
--- a/apps/fabric-example/android/gradle.properties
+++ b/apps/fabric-example/android/gradle.properties
@@ -42,3 +42,6 @@ hermesEnabled=true
 # Please do not remove them.
 isReanimatedExampleApp=true
 enableReanimatedProfiling=true
+
+# Uncomment the next line to enable experimental bundling.
+# workletsExperimentalBundling=true

--- a/apps/fabric-example/babel.config.js
+++ b/apps/fabric-example/babel.config.js
@@ -2,7 +2,13 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
-    'react-native-worklets/plugin',
+    [
+      'react-native-worklets/plugin',
+      {
+        // Uncomment the next line to enable experimental bundling.
+        // experimentalBundling: true,
+      },
+    ],
     [
       'module-resolver',
       {

--- a/apps/fabric-example/ios/Podfile
+++ b/apps/fabric-example/ios/Podfile
@@ -9,6 +9,9 @@ require_relative '../../../packages/react-native-reanimated/scripts/clangd-add-x
 
 ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
 
+# Uncomment the next line to enable experimental bundling.
+# ENV['WORKLETS_EXPERIMENTAL_BUNDLING'] = '1'
+
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 

--- a/apps/fabric-example/metro.config.js
+++ b/apps/fabric-example/metro.config.js
@@ -4,6 +4,7 @@ const {
 } = require('react-native-reanimated/metro-config');
 const {
   getMetroAndroidAssetsResolutionFix,
+  // @ts-ignore react-native-monorepo-tools doesn't have types.
 } = require('react-native-monorepo-tools');
 const androidAssetsResolutionFix = getMetroAndroidAssetsResolutionFix();
 
@@ -21,6 +22,33 @@ const config = {
   transformer: {
     publicPath: androidAssetsResolutionFix.publicPath,
   },
+  // Uncomment the following to enable experimental bundling.
+  // --------------------------------------------------------
+  // serializer: {
+  //   getModulesRunBeforeMainModule() {
+  //     return [
+  //       require.resolve('react-native-worklets/src/workletRuntimeEntry.ts'),
+  //     ];
+  //   },
+  //   createModuleIdFactory() {
+  //     let nextId = 0;
+  //     const idFileMap = new Map();
+  //     return (ppath) => {
+  //       if (idFileMap.has(ppath)) {
+  //         return idFileMap.get(ppath);
+  //       }
+  //       if (ppath.includes('react-native-worklets/__generatedWorklets/')) {
+  //         const base = path.basename(ppath, '.js');
+  //         const id = Number(base);
+  //         idFileMap.set(ppath, id);
+  //         return id;
+  //       }
+  //       idFileMap.set(ppath, nextId++);
+  //       return idFileMap.get(ppath);
+  //     };
+  //   },
+  // },
+  // --------------------------------------------------------
   server: {
     enhanceMiddleware: (middleware) => {
       return androidAssetsResolutionFix.applyMiddleware(middleware);

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -57,7 +57,8 @@ target_include_directories(
           "${REACT_NATIVE_DIR}/ReactCommon"
           "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
           "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
-          "${REACT_NATIVE_DIR}/ReactCommon/runtimeexecutor")
+          "${REACT_NATIVE_DIR}/ReactCommon/runtimeexecutor"
+          "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
   target_include_directories(

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -11,7 +11,6 @@
 #include <fbjni/fbjni.h>
 #endif // __ANDROID__
 
-#include <string>
 #include <utility>
 
 using namespace facebook;
@@ -64,6 +63,8 @@ inline jsi::Value createWorkletRuntime(
     const std::shared_ptr<JSScheduler> &jsScheduler,
     std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
     const bool isDevBundle,
+    const std::shared_ptr<const BigStringBuffer> script,
+    const std::string &sourceUrl,
     jsi::Runtime &rt,
     const jsi::Value &name,
     const jsi::Value &initializer) {
@@ -74,7 +75,9 @@ inline jsi::Value createWorkletRuntime(
       jsScheduler,
       name.asString(rt).utf8(rt),
       true /* supportsLocking */,
-      isDevBundle);
+      isDevBundle,
+      script,
+      sourceUrl);
   auto initializerShareable = extractShareableOrThrow<ShareableWorklet>(
       rt, initializer, "[Worklets] Initializer must be a worklet.");
   workletRuntime->runGuarded(initializerShareable);
@@ -83,12 +86,16 @@ inline jsi::Value createWorkletRuntime(
 
 JSIWorkletsModuleProxy::JSIWorkletsModuleProxy(
     const bool isDevBundle,
+    const std::shared_ptr<const BigStringBuffer> &script,
+    const std::string &sourceUrl,
     const std::shared_ptr<MessageQueueThread> &jsQueue,
     const std::shared_ptr<JSScheduler> &jsScheduler,
     const std::shared_ptr<UIScheduler> &uiScheduler,
     std::shared_ptr<WorkletRuntime> uiWorkletRuntime)
     : jsi::HostObject(),
       isDevBundle_(isDevBundle),
+      script_(script),
+      sourceUrl_(sourceUrl),
       jsQueue_(jsQueue),
       jsScheduler_(jsScheduler),
       uiScheduler_(uiScheduler),
@@ -98,6 +105,8 @@ JSIWorkletsModuleProxy::JSIWorkletsModuleProxy(
     const JSIWorkletsModuleProxy &other)
     : jsi::HostObject(),
       isDevBundle_(other.isDevBundle_),
+      script_(other.script_),
+      sourceUrl_(other.sourceUrl_),
       jsQueue_(other.jsQueue_),
       jsScheduler_(other.jsScheduler_),
       uiScheduler_(other.uiScheduler_),
@@ -268,6 +277,8 @@ jsi::Value JSIWorkletsModuleProxy::get(
         [jsQueue = jsQueue_,
          jsScheduler = jsScheduler_,
          isDevBundle = isDevBundle_,
+         script = script_,
+         sourceUrl = sourceUrl_,
          clone](
             jsi::Runtime &rt,
             const jsi::Value &thisValue,
@@ -278,6 +289,8 @@ jsi::Value JSIWorkletsModuleProxy::get(
               jsScheduler,
               std::move(clone),
               isDevBundle,
+              script,
+              sourceUrl,
               rt,
               args[0],
               args[1]);

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
@@ -16,6 +16,7 @@
 #include <jsi/jsi.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 using namespace facebook;
@@ -26,6 +27,8 @@ class JSIWorkletsModuleProxy : public jsi::HostObject {
  public:
   explicit JSIWorkletsModuleProxy(
       const bool isDevBundle,
+      const std::shared_ptr<const BigStringBuffer> &script,
+      const std::string &sourceUrl,
       const std::shared_ptr<MessageQueueThread> &jsQueue,
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::shared_ptr<UIScheduler> &uiScheduler,
@@ -41,6 +44,8 @@ class JSIWorkletsModuleProxy : public jsi::HostObject {
 
  private:
   const bool isDevBundle_;
+  const std::shared_ptr<const BigStringBuffer> script_;
+  const std::string sourceUrl_;
   const std::shared_ptr<MessageQueueThread> jsQueue_;
   const std::shared_ptr<JSScheduler> jsScheduler_;
   const std::shared_ptr<UIScheduler> uiScheduler_;

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -26,11 +26,15 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     const std::shared_ptr<CallInvoker> &jsCallInvoker,
     const std::shared_ptr<UIScheduler> &uiScheduler,
     std::function<void(std::function<void(const double)>)>
-        &&forwardedRequestAnimationFrame)
+        &&forwardedRequestAnimationFrame,
+    std::shared_ptr<const BigStringBuffer> &&script,
+    const std::string &sourceUrl)
     : isDevBundle_(isDevBundleFromRNRuntime(rnRuntime)),
       jsQueue_(jsQueue),
       jsScheduler_(std::make_shared<JSScheduler>(rnRuntime, jsCallInvoker)),
       uiScheduler_(uiScheduler),
+      script_(std::move(script)),
+      sourceUrl_(sourceUrl),
       uiWorkletRuntime_(std::make_shared<WorkletRuntime>(
           rnRuntime,
           createJSIWorkletsModuleProxy(),
@@ -38,7 +42,9 @@ WorkletsModuleProxy::WorkletsModuleProxy(
           jsScheduler_,
           "Reanimated UI runtime",
           true /* supportsLocking */,
-          isDevBundle_)),
+          isDevBundle_,
+          script_,
+          sourceUrl_)),
       animationFrameBatchinator_(std::make_shared<AnimationFrameBatchinator>(
           uiWorkletRuntime_->getJSIRuntime(),
           std::move(forwardedRequestAnimationFrame))) {
@@ -50,7 +56,13 @@ WorkletsModuleProxy::WorkletsModuleProxy(
 std::shared_ptr<jsi::HostObject>
 WorkletsModuleProxy::createJSIWorkletsModuleProxy() const {
   return std::make_shared<JSIWorkletsModuleProxy>(
-      isDevBundle_, jsQueue_, jsScheduler_, uiScheduler_, uiWorkletRuntime_);
+      isDevBundle_,
+      script_,
+      sourceUrl_,
+      jsQueue_,
+      jsScheduler_,
+      uiScheduler_,
+      uiWorkletRuntime_);
 }
 
 WorkletsModuleProxy::~WorkletsModuleProxy() {

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.h
@@ -2,6 +2,7 @@
 
 #include <cxxreact/MessageQueueThread.h>
 #include <jsi/jsi.h>
+#include <jsireact/JSIExecutor.h>
 #include <worklets/AnimationFrameQueue/AnimationFrameBatchinator.h>
 #include <worklets/Tools/JSScheduler.h>
 #include <worklets/Tools/SingleInstanceChecker.h>
@@ -9,6 +10,7 @@
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #include <memory>
+#include <string>
 
 namespace worklets {
 
@@ -21,7 +23,9 @@ class WorkletsModuleProxy
       const std::shared_ptr<CallInvoker> &jsCallInvoker,
       const std::shared_ptr<UIScheduler> &uiScheduler,
       std::function<void(std::function<void(const double)>)>
-          &&forwardedRequestAnimationFrame);
+          &&forwardedRequestAnimationFrame,
+      std::shared_ptr<const BigStringBuffer> &&script,
+      const std::string &sourceUrl);
 
   ~WorkletsModuleProxy();
 
@@ -54,6 +58,8 @@ class WorkletsModuleProxy
   const std::shared_ptr<MessageQueueThread> jsQueue_;
   const std::shared_ptr<JSScheduler> jsScheduler_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
+  const std::shared_ptr<const BigStringBuffer> script_;
+  const std::string sourceUrl_;
   std::shared_ptr<WorkletRuntime> uiWorkletRuntime_;
   std::shared_ptr<AnimationFrameBatchinator> animationFrameBatchinator_;
 #ifndef NDEBUG

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
@@ -33,7 +33,7 @@ inline jsi::Value runOnRuntimeGuarded(
   return getCallGuard(rt).call(rt, function, args...);
 #else
   return function.asObject(rt).asFunction(rt).call(rt, args...);
-#endif
+#endif // NDEBUG
 }
 
 inline void cleanupIfRuntimeExists(

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -2,6 +2,7 @@
 
 #include <cxxreact/MessageQueueThread.h>
 #include <jsi/jsi.h>
+#include <jsireact/JSIExecutor.h>
 
 #include <worklets/SharedItems/Shareables.h>
 #include <worklets/Tools/AsyncQueue.h>
@@ -27,7 +28,9 @@ class WorkletRuntime : public jsi::HostObject,
       const std::shared_ptr<JSScheduler> &jsScheduler,
       const std::string &name,
       const bool supportsLocking,
-      const bool isDevBundle);
+      const bool isDevBundle,
+      const std::shared_ptr<const BigStringBuffer> &script,
+      const std::string &sourceUrl);
 
   jsi::Runtime &getJSIRuntime() const {
     return *runtime_;

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -43,6 +43,8 @@ Pod::Spec.new do |s|
   #   HERMESVM_PROFILER_BB
   # which shouldn't be defined in standard setups.
   hermes_debug_hidden_flags = '$(inherited) HERMES_ENABLE_DEBUGGER=1'
+
+  experimental_bundling_flag = $worklets_config[:experimental_bundling] ? 'WORKLETS_EXPERIMENTAL_BUNDLING=1' : ''
   
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
@@ -57,9 +59,9 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/Headers/Private/React-Core"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"',
     ].join(' '),
-    "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
+    "FRAMEWORK_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => hermes_debug_hidden_flags,
+    "GCC_PREPROCESSOR_DEFINITIONS[config=*Debug*]" => "#{hermes_debug_hidden_flags} #{experimental_bundling_flag}",
     "GCC_PREPROCESSOR_DEFINITIONS[config=*Release*]" => '$(inherited)',
   }
   s.xcconfig = {

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -25,6 +25,9 @@ endif()
 if(${IS_REANIMATED_EXAMPLE_APP})
   string(APPEND CMAKE_CXX_FLAGS " -DIS_REANIMATED_EXAMPLE_APP -Wpedantic")
 endif()
+if(${WORKLETS_EXPERIMENTAL_BUNDLING})
+  string(APPEND CMAKE_CXX_FLAGS " -DWORKLETS_EXPERIMENTAL_BUNDLING")
+endif()
 
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
   string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG")
@@ -75,7 +78,8 @@ target_include_directories(
           "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
           "${REACT_NATIVE_DIR}/ReactCommon/react/nativemodule/core/ReactCommon"
           "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
-          "${REACT_NATIVE_DIR}/ReactCommon/runtimeexecutor")
+          "${REACT_NATIVE_DIR}/ReactCommon/runtimeexecutor"
+          "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor")
 
 if(${IS_NEW_ARCHITECTURE_ENABLED})
   target_include_directories(

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -72,6 +72,7 @@ def REACT_NATIVE_MINOR_VERSION = getReactNativeMinorVersion()
 def WORKLETS_VERSION = getWorkletsVersion()
 def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 def IS_REANIMATED_EXAMPLE_APP = safeAppExtGet("isReanimatedExampleApp", false)
+def EXPERIMENTAL_BUNDLING = safeAppExtGet("workletsExperimentalBundling", false)
 
 // Set version for prefab
 version WORKLETS_VERSION
@@ -181,6 +182,7 @@ android {
                         "-DJS_RUNTIME_DIR=${jsRuntimeDir}",
                         "-DIS_NEW_ARCHITECTURE_ENABLED=${IS_NEW_ARCHITECTURE_ENABLED}",
                         "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
+                        "-DWORKLETS_EXPERIMENTAL_BUNDLING=${EXPERIMENTAL_BUNDLING}",
                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters (*reactNativeArchitectures())
                 targets("worklets")

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -17,7 +17,9 @@ WorkletsModule::WorkletsModule(
     jsi::Runtime *rnRuntime,
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
-    const std::shared_ptr<UIScheduler> &uiScheduler)
+    const std::shared_ptr<UIScheduler> &uiScheduler,
+    std::shared_ptr<BigStringBuffer> script,
+    std::string sourceURL)
     : javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       workletsModuleProxy_(std::make_shared<WorkletsModuleProxy>(
@@ -25,7 +27,9 @@ WorkletsModule::WorkletsModule(
           std::make_shared<JMessageQueueThread>(messageQueueThread),
           jsCallInvoker,
           uiScheduler,
-          getForwardedRequestAnimationFrame())) {
+          getForwardedRequestAnimationFrame(),
+          std::move(script),
+          sourceURL)) {
   auto jsiWorkletsModuleProxy =
       workletsModuleProxy_->createJSIWorkletsModuleProxy();
   auto optimizedJsiWorkletsModuleProxy = jsi_utils::optimizedFromHostObject(
@@ -40,13 +44,29 @@ jni::local_ref<WorkletsModule::jhybriddata> WorkletsModule::initHybrid(
     jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
     jni::alias_ref<facebook::react::CallInvokerHolder::javaobject>
         jsCallInvokerHolder,
-    jni::alias_ref<worklets::AndroidUIScheduler::javaobject>
-        androidUIScheduler) {
+    jni::alias_ref<worklets::AndroidUIScheduler::javaobject> androidUIScheduler,
+    std::string sourceFilename,
+    std::string sourceURL) {
   auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
   auto rnRuntime = reinterpret_cast<jsi::Runtime *>(jsContext);
   auto uiScheduler = androidUIScheduler->cthis()->getUIScheduler();
+
+  std::shared_ptr<BigStringBuffer> script;
+#ifdef WORKLETS_EXPERIMENTAL_BUNDLING
+  if (!sourceFilename.empty()) {
+    script = std::make_shared<BigStringBuffer>(
+        JSBigFileString::fromPath(sourceFilename));
+  }
+#endif // WORKLETS_EXPERIMENTAL_BUNDLING
+
   return makeCxxInstance(
-      jThis, rnRuntime, messageQueueThread, jsCallInvoker, uiScheduler);
+      jThis,
+      rnRuntime,
+      messageQueueThread,
+      jsCallInvoker,
+      uiScheduler,
+      script,
+      sourceURL);
 }
 
 std::function<void(std::function<void(const double)>)>

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -3,6 +3,7 @@
 #include <ReactCommon/CallInvokerHolder.h>
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
+#include <jsireact/JSIExecutor.h>
 #include <react/jni/JMessageQueueThread.h>
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
@@ -28,7 +29,9 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
       jni::alias_ref<facebook::react::CallInvokerHolder::javaobject>
           jsCallInvokerHolder,
       jni::alias_ref<worklets::AndroidUIScheduler::javaobject>
-          androidUIScheduler);
+          androidUIScheduler,
+      std::string sourceFilename,
+      std::string sourceURL);
 
   static void registerNatives();
 
@@ -42,7 +45,9 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
       jsi::Runtime *rnRuntime,
       jni::alias_ref<JavaMessageQueueThread::javaobject> messageQueueThread,
       const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
-      const std::shared_ptr<UIScheduler> &uiScheduler);
+      const std::shared_ptr<UIScheduler> &uiScheduler,
+      std::shared_ptr<BigStringBuffer> script,
+      std::string sourceURL);
 
   void invalidateCpp();
 

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/WorkletsModule.java
@@ -36,6 +36,16 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
   private final AndroidUIScheduler mAndroidUIScheduler;
   private final AnimationFrameQueue mAnimationFrameQueue;
   private boolean mSlowAnimationsEnabled;
+  private String mSourceFileName = null;
+  private String mSourceURL = null;
+
+  public void setSourceFileName(String sourceFileName) {
+    mSourceFileName = sourceFileName;
+  }
+
+  public void setSourceURL(String sourceURL) {
+    mSourceURL = sourceURL;
+  }
 
   /**
    * Invalidating concurrently could be fatal. It shouldn't happen in a normal flow, but it doesn't
@@ -48,7 +58,9 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
       long jsContext,
       MessageQueueThread messageQueueThread,
       CallInvokerHolderImpl jsCallInvokerHolder,
-      AndroidUIScheduler androidUIScheduler);
+      AndroidUIScheduler androidUIScheduler,
+      String sourceFileName,
+      String sourceURL);
 
   public WorkletsModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -67,7 +79,13 @@ public class WorkletsModule extends NativeWorkletsModuleSpec implements Lifecycl
     var jsCallInvokerHolder = JSCallInvokerResolver.getJSCallInvokerHolder(context);
 
     mHybridData =
-        initHybrid(jsContext, mMessageQueueThread, jsCallInvokerHolder, mAndroidUIScheduler);
+        initHybrid(
+            jsContext,
+            mMessageQueueThread,
+            jsCallInvokerHolder,
+            mAndroidUIScheduler,
+            mSourceFileName,
+            mSourceURL);
     return true;
   }
 

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.h
@@ -1,6 +1,7 @@
 #import <React/RCTCallInvokerModule.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTInvalidating.h>
+#import <ReactCommon/NSBigStringBuffer.h>
 
 #import <rnworklets/rnworklets.h>
 
@@ -9,5 +10,9 @@
 @interface WorkletsModule : RCTEventEmitter <NativeWorkletsModuleSpec, RCTCallInvokerModule, RCTInvalidating>
 
 - (std::shared_ptr<worklets::WorkletsModuleProxy>)getWorkletsModuleProxy;
+
+- (void)setScriptBuffer:(NSBigStringBuffer *)script;
+
+- (void)setSourceURL:(const std::string &)sourceURL;
 
 @end

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -8,6 +8,7 @@ end
 
 def worklets_find_config()
   result = {
+    :experimental_bundling => nil,
     :is_reanimated_example_app => nil,
     :react_native_version => nil,
     :react_native_minor_version => nil,
@@ -15,6 +16,8 @@ def worklets_find_config()
     :react_native_common_dir => nil,
     :dynamic_frameworks_worklets_dir => nil,
   }
+
+  result[:experimental_bundling] = ENV["WORKLETS_EXPERIMENTAL_BUNDLING"] != nil
 
   react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
   react_native_json = worklets_try_to_parse_react_native_package_json(react_native_node_modules_dir)

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -23,6 +23,7 @@ declare global {
   var _toString: (value: unknown) => string;
   var __workletsModuleProxy: WorkletsModuleProxy | undefined;
   var _WORKLET: boolean | undefined;
+  var _WORKLETS_EXPERIMENTAL_BUNDLING: boolean | undefined;
   var _makeShareableClone: <T>(
     value: T,
     nativeStateSource?: object

--- a/packages/react-native-worklets/src/threads.ts
+++ b/packages/react-native-worklets/src/threads.ts
@@ -239,10 +239,7 @@ export function runOnJS<Args extends unknown[], ReturnValue>(
       fun as
         | ((...args: Args) => ReturnValue)
         | WorkletFunction<Args, ReturnValue>,
-      args.length > 0
-        ? // TODO TYPESCRIPT this cast is terrible but will be fixed
-          (makeShareableCloneOnUIRecursive(args) as unknown as unknown[])
-        : undefined
+      args.length > 0 ? makeShareableCloneOnUIRecursive(args) : undefined
     );
   };
 }

--- a/packages/react-native-worklets/src/workletRuntimeEntry.ts
+++ b/packages/react-native-worklets/src/workletRuntimeEntry.ts
@@ -17,6 +17,7 @@ import type { ValueUnpacker } from './workletTypes';
  * This function has no effect on the RN Runtime.
  */
 export function initializeLibraryOnWorkletRuntime() {
+  globalThis._WORKLETS_EXPERIMENTAL_BUNDLING = true;
   if (globalThis._WORKLET) {
     globalThis.__valueUnpacker = bundleValueUnpacker as ValueUnpacker;
 


### PR DESCRIPTION
## Summary

This pull requests adds relevant APIs for iOS `WorkletsModule.mm` and Android `WorkletsModule.cpp` - they now can receive the bundle and the source url and forward it to Worklet Runtimes. There's no change in behavior if the feature flag for experimental bundling is not enabled.

Do not enable the experimental bundling yet, as PRs that bring more required changes will be coming shortly.

## Test plan

No runtime behavior difference.
