### PR TITLE
fix: unitialized shared_ptr on android

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -30,18 +30,20 @@ WorkletsModuleProxy::WorkletsModuleProxy(
     : isDevBundle_(isDevBundleFromRNRuntime(rnRuntime)),
       jsQueue_(jsQueue),
       jsScheduler_(std::make_shared<JSScheduler>(rnRuntime, jsCallInvoker)),
-      uiScheduler_(uiScheduler),
-      uiWorkletRuntime_(std::make_shared<WorkletRuntime>(
-          rnRuntime,
-          createJSIWorkletsModuleProxy(),
-          jsQueue,
-          jsScheduler_,
-          "Reanimated UI runtime",
-          true /* supportsLocking */,
-          isDevBundle_)),
-      animationFrameBatchinator_(std::make_shared<AnimationFrameBatchinator>(
-          uiWorkletRuntime_->getJSIRuntime(),
-          std::move(forwardedRequestAnimationFrame))) {
+      uiScheduler_(uiScheduler) {
+  uiWorkletRuntime_ = std::make_shared<WorkletRuntime>(
+      rnRuntime,
+      createJSIWorkletsModuleProxy(),
+      jsQueue_,
+      jsScheduler_,
+      "Reanimated UI runtime",
+      true /* supportsLocking */,
+      isDevBundle_);
+
+  animationFrameBatchinator_ = std::make_shared<AnimationFrameBatchinator>(
+      uiWorkletRuntime_->getJSIRuntime(),
+      std::move(forwardedRequestAnimationFrame));
+
   UIRuntimeDecorator::decorate(
       uiWorkletRuntime_->getJSIRuntime(),
       animationFrameBatchinator_->getJsiRequestAnimationFrame());


### PR DESCRIPTION
## Summary

In #7486 I made the function `createJSIWorkletsModuleProxy` which uses uninitialized shared_ptr on first invocation - it was intentional, but turns out that this uninitialized shared_ptr was the inteded `nullptr` on iOS but a garbage memory on Android. I'm moving the line to the constructor outside of initializer list to fix this.

## Test plan

I tested Android in both debug and release and it didn't crash anymore.
