### PR TITLE
fix: Issues after RN 0.80 upgrade

### DIFF
--- a/apps/fabric-example/android/app/src/main/java/com/fabricexample/MainApplication.kt
+++ b/apps/fabric-example/android/app/src/main/java/com/fabricexample/MainApplication.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.common.assets.ReactFontManager
 
 class MainApplication : Application(), ReactApplication {
 
@@ -34,5 +35,8 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     loadReactNative(this)
+
+    ReactFontManager.getInstance().addCustomFont(this, "Poppins", R.font.poppins)
+    ReactFontManager.getInstance().addCustomFont(this, "Ubuntu Mono", R.font.ubuntumono)
   }
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/view/ReanimatedView.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/view/ReanimatedView.mm
@@ -23,3 +23,8 @@ using namespace facebook::react;
 }
 
 @end
+
+Class<RCTComponentViewProtocol> ReanimatedViewCls(void)
+{
+  return ReanimatedView.class;
+}


### PR DESCRIPTION
## Summary

This PR fixes 2 issues introduced by the RN 0.80 upgrade in the #7497 PR.

1. Fixes codegen not working on iOS - the native implementation of the `ReanimatedView` wasn't bound to JS and the native view didn't work (I didn't receive any updates in the custom shadow node, etc.)
2. Adds mistakenly removed custom font in the fabric example on Android.