### PR TITLE
fix: Crashes by adding missing worklet directive to plain object check

### DIFF
--- a/packages/react-native-worklets/src/shareables.ts
+++ b/packages/react-native-worklets/src/shareables.ts
@@ -34,6 +34,7 @@ function isHostObject(value: NonNullable<object>) {
 }
 
 function isPlainJSObject(object: object): object is Record<string, unknown> {
+  'worklet';
   return Object.getPrototypeOf(object) === Object.prototype;
 }
 


### PR DESCRIPTION
## Summary

Quick fix for the issue introduced in the #7548 PR.

## Test plan

Open the drawer navigator in the fabric example app and see this crash when there is no `'worklet'` directive.

![Screenshot 2025-05-23 at 17 08 53](https://github.com/user-attachments/assets/75c33c35-a55b-4fc2-a290-c3710dbac239)

