### PR TITLE
fix: TVOS example crashing right after launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "prettier": "^3.3.3",
     "prettier-plugin-jsdoc": "^1.3.0",
     "typescript": "~5.3.0"
-  },
-  "resolutions": {
-    "@react-native/gradle-plugin": "0.80.0-rc.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5812,6 +5812,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/gradle-plugin@npm:0.75.4":
+  version: 0.75.4
+  resolution: "@react-native/gradle-plugin@npm:0.75.4"
+  checksum: 10/7fe648705740703186d9f90408521cdcc46af2c0a11d50e6baca39d1ea6d4d57a30701ee8902ddc5fea93aa8d1a4b6efd2651eb280f5b7555375b7c6f8562026
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.79.1":
+  version: 0.79.1
+  resolution: "@react-native/gradle-plugin@npm:0.79.1"
+  checksum: 10/694fa5ef8f9206810547851ed869f3aa28c9b7191be6655faa9aa51960c6172aedc918d64ecb44c115b5044e40a2110c32c5c66ddb99e3449299cce5c134a7b4
+  languageName: node
+  linkType: hard
+
 "@react-native/gradle-plugin@npm:0.80.0-rc.3":
   version: 0.80.0-rc.3
   resolution: "@react-native/gradle-plugin@npm:0.80.0-rc.3"


### PR DESCRIPTION
## Summary

TVOS example was crashing because of the `resolutions` field used in the top-level `package.json`, which was overriding version of the `@react-native/gradle-plugin` dependency in all example apps to `0.80-rc.3`, whilst TVOS example still uses RN 0.79.

I tested all example apps (except the MacOS example that we don't support on fabric yet) and everything seems to work fine.

### Error log

```
import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
                                                     ^
symbol:   class LegacyArchitectureLogger
location: package com.facebook.react.common.annotations.internal
```