### PR TITLE
(v3) fix: TVOS example crashing right after launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
     "prettier": "^3.3.3",
     "prettier-plugin-jsdoc": "^1.3.0",
     "typescript": "~5.3.0"
-  },
-  "resolutions": {
-    "@react-native/gradle-plugin": "0.80.0-rc.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6118,6 +6118,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/gradle-plugin@npm:0.77.0":
+  version: 0.77.0
+  resolution: "@react-native/gradle-plugin@npm:0.77.0"
+  checksum: 10/116bb7670eb8e70837084577e69533c52d332f889d3e0b74c240707de5a0e50297076b5ebd62959d22bba6b20812ab008cd4d89e5660ca5ae000dbd95ce5995c
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.77.1":
+  version: 0.77.1
+  resolution: "@react-native/gradle-plugin@npm:0.77.1"
+  checksum: 10/4834440daf6bea824d4b77d5ffa4446afe1982a42dc75e68133529f00f0abc8d38fc26153b30c2c3df7ba044c41e359c1ed32e42e67c284d8dd3e8794d502334
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.79.0-rc.2":
+  version: 0.79.0-rc.2
+  resolution: "@react-native/gradle-plugin@npm:0.79.0-rc.2"
+  checksum: 10/14bb807e144135b341340e69caff91fcd857ba669f3fff950ae8f4161f64161140cc1dc5c767f93230b854c457b6c4b07029a4a3867bc257423515e9b00c0766
+  languageName: node
+  linkType: hard
+
 "@react-native/gradle-plugin@npm:0.80.0-rc.3":
   version: 0.80.0-rc.3
   resolution: "@react-native/gradle-plugin@npm:0.80.0-rc.3"
@@ -6919,16 +6940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-test-renderer@npm:^19.0.0":
-  version: 19.0.0
-  resolution: "@types/react-test-renderer@npm:19.0.0"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10/a22c4401e3af216a8c2cded22702bb6f928e22af7fbcaca7e0cc28447ec34bea5a94c6d6de7ed5734c527a1b53868393e67b7b4815623802e29abb1d8d378d61
-  languageName: node
-  linkType: hard
-
-"@types/react-test-renderer@npm:^19.1.0":
+"@types/react-test-renderer@npm:^19.0.0, @types/react-test-renderer@npm:^19.1.0":
   version: 19.1.0
   resolution: "@types/react-test-renderer@npm:19.1.0"
   dependencies:
@@ -6948,11 +6960,11 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:^19.0.0":
-  version: 19.1.0
-  resolution: "@types/react@npm:19.1.0"
+  version: 19.1.6
+  resolution: "@types/react@npm:19.1.6"
   dependencies:
     csstype: "npm:^3.0.2"
-  checksum: 10/bfa3bb7e2efe929bdf41bf36461f2598611a29647852b8b7ecde510e83f797caf7f290388d13e2b71055df10587b3c41fc4345c1d9cbc38b4e897b03ad11c02f
+  checksum: 10/722a8efb36dedaf5cfe226287214df0982d612ff33ebf005dbbb646279647e5987da661f2d9fe6b8a4516d3b29dd6cb3a708641265861251abb682e8e90540cf
   languageName: node
   linkType: hard
 
@@ -18878,14 +18890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^19.0.0":
-  version: 19.0.0
-  resolution: "react-is@npm:19.0.0"
-  checksum: 10/6cd3695c462ec3f0d4db98583f0c1b9a439248d60214f6c42c2b0e2951a1066339d0eefa74707f03484042e043fca87750282a35b652492c035f5f3da0d6498a
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^19.1.0":
+"react-is@npm:^19.0.0, react-is@npm:^19.1.0":
   version: 19.1.0
   resolution: "react-is@npm:19.1.0"
   checksum: 10/4aceca94492032a19411138bf68c6ca7dce4abee7ae6c7f23db9291d2dff14d6a643717b176ef9a151e8cdf6a2b71fdbc59fd998328e086a6f752512304a252b


### PR DESCRIPTION
## Summary

TVOS example was crashing because of the `resolutions` field used in the top-level `package.json`, which was overriding version of the `@react-native/gradle-plugin` dependency in all example apps to `0.80-rc.3`, whilst TVOS example still uses RN 0.79.

I tested all example apps (except the MacOS example that we don't support on fabric yet) and everything seems to work fine.

### Error log

```
import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
                                                     ^
symbol:   class LegacyArchitectureLogger
location: package com.facebook.react.common.annotations.internal
```