### PR TITLE
fix: Crash in useScrollViewOffset if animatedRef is not initialized

### DIFF
--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -100,11 +100,14 @@ function useScrollViewOffsetNative(
     }
 
     const elementTag = animatedRef.getTag();
-    eventHandler.workletEventHandler.registerForEvents(elementTag);
 
-    return () => {
-      eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
-    };
+    if (elementTag) {
+      eventHandler.workletEventHandler.registerForEvents(elementTag);
+      return () => {
+        eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
+      };
+    }
+
     // React here has a problem with `animatedRef.current` since a Ref .current
     // field shouldn't be used as a dependency. However, in this case we have
     // to do it this way.

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -87,8 +87,18 @@ function useScrollViewOffsetNative(
   ) as unknown as EventHandlerInternal<ReanimatedScrollEvent>;
 
   useEffect(() => {
-    const elementTag = animatedRef?.getTag() ?? null;
+    if (!animatedRef) {
+      return;
+    }
 
+    if (!animatedRef.getTag) {
+      console.warn(
+        'animatedRef is not initialized. Please make sure to pass the animated ref to the animated component if you want to use useScrollViewOffset.'
+      );
+      return;
+    }
+
+    const elementTag = animatedRef.getTag();
     if (elementTag) {
       eventHandler.workletEventHandler.registerForEvents(elementTag);
     }

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -93,7 +93,7 @@ function useScrollViewOffsetNative(
 
     if (!animatedRef.getTag) {
       console.warn(
-        'animatedRef is not initialized. Please make sure to pass the animated ref to the animated component if you want to use useScrollViewOffset.'
+        'animatedRef is not initialized. Please make sure to pass the animated ref to the scrollable component if you want to use useScrollViewOffset.'
       );
       return;
     }

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -1,5 +1,6 @@
 'use strict';
 import { useCallback, useEffect, useRef } from 'react';
+import { logger } from 'react-native-worklets';
 
 import { IS_WEB } from '../common';
 import type { SharedValue } from '../commonTypes';
@@ -92,7 +93,7 @@ function useScrollViewOffsetNative(
     }
 
     if (!animatedRef.getTag) {
-      console.warn(
+      logger.warn(
         'animatedRef is not initialized. Please make sure to pass the animated ref to the scrollable component if you want to use useScrollViewOffset.'
       );
       return;

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -100,13 +100,10 @@ function useScrollViewOffsetNative(
     }
 
     const elementTag = animatedRef.getTag();
-    if (elementTag) {
-      eventHandler.workletEventHandler.registerForEvents(elementTag);
-    }
+    eventHandler.workletEventHandler.registerForEvents(elementTag);
+
     return () => {
-      if (elementTag) {
-        eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
-      }
+      eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
     };
     // React here has a problem with `animatedRef.current` since a Ref .current
     // field shouldn't be used as a dependency. However, in this case we have


### PR DESCRIPTION
## Summary

This PR fixes an old [issue](https://github.com/software-mansion/react-native-reanimated/issues/7170) related to the `useScrollViewOffset` throwing error on the `getTag()` call when the `animatedRef` is not initialized (wasn't passed to the component).

## Examples

<details>
<summary>Source code</summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import Animated, {
  useAnimatedReaction,
  useAnimatedRef,
  useScrollViewOffset,
} from 'react-native-reanimated';

type BoxProps = {
  color: string;
};

function Box({ color }: BoxProps) {
  return <View style={[styles.box, { backgroundColor: color }]} />;
}

export default function EmptyExample() {
  const aref = useAnimatedRef<Animated.ScrollView>();
  const x = useScrollViewOffset(aref);

  useAnimatedReaction(
    () => x.value,
    (value) => {
      console.log('value', value);
    }
  );

  return (
    <Animated.ScrollView contentContainerStyle={styles.container}>
      <Box color="red" />
      <Box color="blue" />
      <Box color="green" />
      <Box color="yellow" />
      <Box color="purple" />
      <Box color="orange" />
      <Box color="pink" />
    </Animated.ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    gap: 50,
    alignItems: 'center',
  },
  box: {
    width: 100,
    height: 100,
  },
});
```
</details>

### Before

https://github.com/user-attachments/assets/1290e4ee-4aee-45ef-88c6-44dbfcd21e90

### After

https://github.com/user-attachments/assets/970f65be-4b43-4a91-8e46-780c171b9ce6
