### PR TITLE
fix(Reanimated3): bump branch for nightly releases

### DIFF
--- a/.github/workflows/npm-reanimated-publish-nightly.yml
+++ b/.github/workflows/npm-reanimated-publish-nightly.yml
@@ -21,5 +21,6 @@ jobs:
     with:
       option: --nightly
       publish_on_npm: true
-      ref: 3.17-stable
+      # Remember to update the branch on new minor releases.
+      ref: 3.18-stable
     secrets: inherit

--- a/packages/react-native-reanimated/RELEASE.md
+++ b/packages/react-native-reanimated/RELEASE.md
@@ -41,46 +41,48 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
 
    If releasing v4, just run `yarn build` in the root directory.
 
-7. When releasing a minor version, update the minimal supported React Native version (general and New Architecture specific)
+7. When releasing v3, make sure to update the branch used for nightly releases of Reanimated 3 in [the workflow](../../.github/workflows/npm-reanimated-publish-nightly.yml).
+
+8. When releasing a minor version, update the minimal supported React Native version (general and New Architecture specific)
 
    - Android: `build.gradle`
    - iOS: `reanimated_utils.rb`
    - By default we support the last three minor versions
 
-8. Testing:
+9. Testing:
 
    - Run the examples from Reanimated app, especially those affected by release changes.
    - Test each example app on each platform (if possible, run in both **release** and **debug** mode using **Android** and **iOS**).
    - On rare cases it might be necessary to also test unusual configurations, i.e. **release** app with a **development** bundle. Please consult the team for more instructions here.
 
-9. In case of regressions, fix it in a separate PR, merge it then repeat relevant previous steps.
-10. Commit your changes:
+10. In case of regressions, fix it in a separate PR, merge it then repeat relevant previous steps.
+11. Commit your changes:
 
     - `git add --all`
     - `git commit -m "Release x.y.z"`
     - `git push --set-upstream origin <branch-name>`
 
-11. Create a PR, named "Release x.y.z" for the stable branch e.g. `3.17-stable`. Examples:
+12. Create a PR, named "Release x.y.z" for the stable branch e.g. `3.17-stable`. Examples:
 
     - patch version release [PR](https://github.com/software-mansion/react-native-reanimated/pull/6879).
     - minor version release [PR](https://github.com/software-mansion/react-native-reanimated/pull/7071).
 
-12. Run the GitHub Actions responsible for building your package:
+13. Run the GitHub Actions responsible for building your package:
 
     - [NPM Reanimated package build](https://github.com/software-mansion/react-native-reanimated/actions/workflows/npm-reanimated-package-build.yml),
     - Select your branch as the destination for the workflow:
       <img width="500" alt="upload_d3527584fe60bbd66cdd99dfbc34b118" src="https://github.com/user-attachments/assets/d25946c1-0279-430a-92b4-57a1307c1179" />
 
-13. Wait for the workflow to finish - it should take about 2 minutes.
-14. Select your workflow from the list and download artifacts.
+14. Wait for the workflow to finish - it should take about 2 minutes.
+15. Select your workflow from the list and download artifacts.
     <img width="925" alt="upload_b4eaebea327e62c1c99d44b1984066b3" src="https://github.com/user-attachments/assets/cfd54b99-2cff-4f60-b818-f92a53e62c07" />
 
-15. Unzip your artifacts:
+16. Unzip your artifacts:
 
     - `unzip react-native-reanimated-x.y.z.tgz.zip`
     - **Do not** double-click the file to extract it as it would extract it from both `zip` and `tgz` levels.
 
-16. Test the package in a clean React Native app:
+17. Test the package in a clean React Native app:
 
     - `npx @react-native-community/cli init MyApp --skip-install`
     - `cd MyApp`
@@ -91,7 +93,7 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
     - Run `open -a 'Android Studio'` and build on Android,
     - Start Metro using `yarn start --reset-cache`.
 
-17. Test the package in a clean React Native Web app:
+18. Test the package in a clean React Native Web app:
 
     - `npx create-expo-app my-app`
     - Set up using **Getting Started** tutorial from [Expo Docs](https://docs.expo.dev/workflow/web/),
@@ -103,14 +105,14 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
     - Run release: `npx expo export -p web && npx serve dist --single`.
     - Run prebuild: `npx expo prebuild` to generate native code and ensure the app works correctly.
 
-18. If something doesn't work you can fix it in this or in a separate PR (depending on the case), and repeat the steps.
-19. If everything works fine you can merge the PR.
-20. Upload the package to npm:
+19. If something doesn't work you can fix it in this or in a separate PR (depending on the case), and repeat the steps.
+20. If everything works fine you can merge the PR.
+21. Upload the package to npm:
 
     - Check package size and file list with `npm publish --dry-run react-native-reanimated-x.y.z.tgz` - see if there is anything suspicious,
     - Publish package with `npm publish react-native-reanimated-x.y.z.tgz`,
 
-21. Check that the npm tags are set correctly:
+22. Check that the npm tags are set correctly:
 
     - The version tag list can be found [here](https://www.npmjs.com/package/react-native-reanimated?activeTab=versions).
     - It should look like this:
@@ -122,14 +124,14 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
       - `reanimated3-nightly`.
     - If you see something's wrong, run `npm dist-tag`.
 
-22. After publishing briefly test if it works, when downloaded from npm:
+23. After publishing briefly test if it works, when downloaded from npm:
 
     - `yarn cache clean` (to make sure it's not downloading a local copy from the cache) ,
     - `yarn add react-native-reanimated@x.y.z`,
     - And test across platforms using [Bokeh Example](https://github.com/software-mansion/react-native-reanimated/blob/main/apps/common-app/src/apps/reanimated/examples/BokehExample.tsx),
     - You can create another clean React Native app for this, or use the one you created before.
 
-23. Create release on GitHub:
+24. Create release on GitHub:
 
     - Go to the [Releases](https://github.com/software-mansion/react-native-reanimated/releases) tab in our repo,
     - Select **Draft a new release**,
@@ -146,7 +148,7 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
       - **Set as pre-release** - select this when prereleasing (alpha, beta, rc),
       - **Set as the latest release** - check if releasing v3, don't check when dealing with v2.
 
-24. Share the good news with the team.
-25. Ask Kacper Kapuściak for a tweet informing the world about new Reanimated (patches don't count).
+25. Share the good news with the team.
+26. Ask Kacper Kapuściak for a tweet informing the world about new Reanimated (patches don't count).
 
 **Congratulations on releasing a new version of Reanimated!**


### PR DESCRIPTION
## Summary

After the release of 3.18.0 we forgot to update the branch used for releasing the nightlies of Reanimated 3.

## Test plan

🚀 
