### PR TITLE
fix: useScrollViewOffset not working after delayed ref initialization

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,46 +1,10 @@
-import React, { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
-import type Animated from 'react-native-reanimated';
-import {
-  useAnimatedReaction,
-  useAnimatedRef,
-  useScrollViewOffset,
-} from 'react-native-reanimated';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function EmptyExample() {
-  const [shouldRender, setShouldRender] = useState(false);
-  const scrollRef = useAnimatedRef<Animated.ScrollView>();
-  const scrollOffset = useScrollViewOffset(scrollRef);
-
-  useAnimatedReaction(
-    () => scrollOffset.value,
-    (value) => {
-      console.log('scrollOffset', value);
-    }
-  );
-
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>
-        ScrollView is {shouldRender ? 'rendered' : 'not rendered'}
-      </Text>
-      <Button
-        title={shouldRender ? 'Remove ScrollView' : 'Render ScrollView'}
-        onPress={() => setShouldRender(!shouldRender)}
-      />
-
-      {shouldRender && (
-        <ScrollView
-          ref={scrollRef}
-          scrollEventThrottle={1000 / 60}
-          style={styles.scrollView}>
-          {Array.from({ length: 20 }).map((_, index) => (
-            <View key={index} style={styles.item}>
-              <Text style={styles.itemText}>Scroll Item {index + 1}</Text>
-            </View>
-          ))}
-        </ScrollView>
-      )}
+      <Text>Hello world!</Text>
     </View>
   );
 }
@@ -48,27 +12,7 @@ export default function EmptyExample() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    padding: 20,
-  },
-  text: {
-    fontSize: 16,
-    marginBottom: 10,
-  },
-  scrollView: {
-    flex: 1,
-    marginTop: 20,
-  },
-  item: {
-    height: 100,
-    backgroundColor: '#f0f0f0',
-    marginVertical: 8,
-    borderRadius: 8,
-    justifyContent: 'center',
     alignItems: 'center',
-  },
-  itemText: {
-    fontSize: 16,
-    color: '#333',
+    justifyContent: 'center',
   },
 });

--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,10 +1,46 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type Animated from 'react-native-reanimated';
+import {
+  useAnimatedReaction,
+  useAnimatedRef,
+  useScrollViewOffset,
+} from 'react-native-reanimated';
 
 export default function EmptyExample() {
+  const [shouldRender, setShouldRender] = useState(false);
+  const scrollRef = useAnimatedRef<Animated.ScrollView>();
+  const scrollOffset = useScrollViewOffset(scrollRef);
+
+  useAnimatedReaction(
+    () => scrollOffset.value,
+    (value) => {
+      console.log('scrollOffset', value);
+    }
+  );
+
   return (
     <View style={styles.container}>
-      <Text>Hello world!</Text>
+      <Text style={styles.text}>
+        ScrollView is {shouldRender ? 'rendered' : 'not rendered'}
+      </Text>
+      <Button
+        title={shouldRender ? 'Remove ScrollView' : 'Render ScrollView'}
+        onPress={() => setShouldRender(!shouldRender)}
+      />
+
+      {shouldRender && (
+        <ScrollView
+          ref={scrollRef}
+          scrollEventThrottle={1000 / 60}
+          style={styles.scrollView}>
+          {Array.from({ length: 20 }).map((_, index) => (
+            <View key={index} style={styles.item}>
+              <Text style={styles.itemText}>Scroll Item {index + 1}</Text>
+            </View>
+          ))}
+        </ScrollView>
+      )}
     </View>
   );
 }
@@ -12,7 +48,27 @@ export default function EmptyExample() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
+    backgroundColor: '#fff',
+    padding: 20,
+  },
+  text: {
+    fontSize: 16,
+    marginBottom: 10,
+  },
+  scrollView: {
+    flex: 1,
+    marginTop: 20,
+  },
+  item: {
+    height: 100,
+    backgroundColor: '#f0f0f0',
+    marginVertical: 8,
+    borderRadius: 8,
     justifyContent: 'center',
+    alignItems: 'center',
+  },
+  itemText: {
+    fontSize: 16,
+    color: '#333',
   },
 });

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -25,13 +25,16 @@ export interface Descriptor {
   shadowNodeWrapper: ShadowNodeWrapper;
 }
 
+export type AnimatedRefObserver = (tag: number | null) => void;
+
 export type AnimatedRef<T extends Component> = {
   (component?: T):
     | number // Paper
     | ShadowNodeWrapper // Fabric
     | HTMLElement; // web
   current: T | null;
-  getTag: () => number;
+  observe: (observer: AnimatedRefObserver) => void;
+  getTag?: () => number | null;
 };
 
 // Might make that type generic if it's ever needed.

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -25,7 +25,9 @@ export interface Descriptor {
   shadowNodeWrapper: ShadowNodeWrapper;
 }
 
-export type AnimatedRefObserver = (tag: number | null) => void;
+export type MaybeObserverCleanup = (() => void) | undefined;
+
+export type AnimatedRefObserver = (tag: number | null) => MaybeObserverCleanup;
 
 export type AnimatedRef<T extends Component> = {
   (component?: T):

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -41,9 +41,9 @@ function useAnimatedRefNative<
   TComponent extends Component,
 >(): AnimatedRef<TComponent> {
   const [tag] = useState(() => makeMutable<ShadowNodeWrapper | null>(null));
-  const [observers] = useState<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
-    () => new Map()
-  );
+  const observers = useRef<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
+    new Map()
+  ).current;
   const tagRef = useRef<ShadowNodeWrapper | null>(null);
 
   const ref = useRef<AnimatedRef<TComponent> | null>(null);
@@ -116,9 +116,9 @@ function useAnimatedRefWeb<
   TComponent extends Component,
 >(): AnimatedRef<TComponent> {
   const tagRef = useRef<ShadowNodeWrapper | null>(null);
-  const [observers] = useState<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
-    () => new Map()
-  );
+  const observers = useRef<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
+    new Map()
+  ).current;
 
   const ref = useRef<AnimatedRef<TComponent> | null>(null);
 

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -37,100 +37,140 @@ function getComponentOrScrollable(component: MaybeScrollableComponent) {
   return component;
 }
 
-function useAnimatedRefBase<TComponent extends Component>(
-  getWrapper: (component: TComponent) => ShadowNodeWrapper
-): AnimatedRef<TComponent> {
+function useAnimatedRefNative<
+  TComponent extends Component,
+>(): AnimatedRef<TComponent> {
+  const [tag] = useState(() => makeMutable<ShadowNodeWrapper | null>(null));
   const [observers] = useState<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
     () => new Map()
   );
-  const wrapperRef = useRef<ShadowNodeWrapper | null>(null);
+  const tagRef = useRef<ShadowNodeWrapper | null>(null);
 
   const ref = useRef<AnimatedRef<TComponent> | null>(null);
 
   if (!ref.current) {
+    /** Called by React when ref is attached to a component. */
     const fun: AnimatedRef<TComponent> = <AnimatedRef<TComponent>>((
       component
     ) => {
+      let initialTag: ShadowNodeWrapper | null = null;
       if (component) {
-        wrapperRef.current = getWrapper(component);
+        const getTagOrShadowNodeWrapper = () => {
+          return getShadowNodeWrapperFromRef(
+            getComponentOrScrollable(component) as Component
+          );
+        };
+
+        initialTag = getTagOrShadowNodeWrapper();
+        tag.value = initialTag;
+        tagRef.current = initialTag;
 
         // We have to unwrap the tag from the shadow node wrapper.
         fun.getTag = () =>
           findNodeHandle(getComponentOrScrollable(component) as Component)!;
-
         fun.current = component;
-
-        if (observers.size) {
-          const tag = fun?.getTag?.() ?? null;
-          observers.forEach((cleanup, observer) => {
-            // Perform the cleanup before calling the observer again.
-            // This ensures that all events that were set up in the observer
-            // are cleaned up before the observer sets up new events during
-            // the next call.
-            cleanup?.();
-            observers.set(observer, observer(tag));
-          });
-        }
       }
 
-      return wrapperRef.current;
+      if (observers.size) {
+        const currentTag = fun?.getTag?.() ?? null;
+        observers.forEach((cleanup, observer) => {
+          // Perform the cleanup before calling the observer again.
+          // This ensures that all events that were set up in the observer
+          // are cleaned up before the observer sets up new events during
+          // the next call.
+          cleanup?.();
+          observers.set(observer, observer(currentTag));
+        });
+      }
+
+      return tagRef.current;
     });
 
     fun.observe = (observer: AnimatedRefObserver) => {
-      const tag = fun?.getTag?.() ?? null;
       // Call observer immediately to get the initial value
-      observers.set(observer, observer(tag));
+      const cleanup = observer(fun?.getTag?.() ?? null);
+      observers.set(observer, cleanup);
 
       return () => {
-        const cleanup = observers.get(observer);
-        cleanup?.();
+        observers.get(observer)?.();
         observers.delete(observer);
       };
     };
 
     fun.current = null;
+
+    const animatedRefShareableHandle = makeShareableCloneRecursive({
+      __init: (): AnimatedRefOnUI => {
+        'worklet';
+        return () => tag.value;
+      },
+    });
+    shareableMappingCache.set(fun, animatedRefShareableHandle);
     ref.current = fun;
   }
 
   return ref.current;
 }
 
-function useAnimatedRefNative<
-  TComponent extends Component,
->(): AnimatedRef<TComponent> {
-  const [sharedWrapper] = useState(() =>
-    makeMutable<ShadowNodeWrapper | null>(null)
-  );
-
-  const ref = useAnimatedRefBase<TComponent>((component) => {
-    const currentWrapper = getShadowNodeWrapperFromRef(
-      getComponentOrScrollable(component) as Component
-    );
-
-    sharedWrapper.value = currentWrapper;
-
-    return currentWrapper;
-  });
-
-  if (!shareableMappingCache.get(ref)) {
-    const animatedRefShareableHandle = makeShareableCloneRecursive({
-      __init: (): AnimatedRefOnUI => {
-        'worklet';
-        return () => sharedWrapper.value;
-      },
-    });
-    shareableMappingCache.set(ref, animatedRefShareableHandle);
-  }
-
-  return ref;
-}
-
 function useAnimatedRefWeb<
   TComponent extends Component,
 >(): AnimatedRef<TComponent> {
-  return useAnimatedRefBase<TComponent>((component) =>
-    getComponentOrScrollable(component)
+  const tagRef = useRef<ShadowNodeWrapper | null>(null);
+  const [observers] = useState<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
+    () => new Map()
   );
+
+  const ref = useRef<AnimatedRef<TComponent> | null>(null);
+
+  if (!ref.current) {
+    /** Called by React when ref is attached to a component. */
+    const fun: AnimatedRef<TComponent> = <AnimatedRef<TComponent>>((
+      component
+    ) => {
+      if (component) {
+        const getTagOrShadowNodeWrapper = () => {
+          return getComponentOrScrollable(component);
+        };
+
+        tagRef.current = getTagOrShadowNodeWrapper();
+
+        // We have to unwrap the tag from the shadow node wrapper.
+        fun.getTag = () =>
+          findNodeHandle(getComponentOrScrollable(component) as Component)!;
+        fun.current = component;
+      }
+
+      if (observers.size) {
+        const currentTag = fun?.getTag?.() ?? null;
+        observers.forEach((cleanup, observer) => {
+          // Perform the cleanup before calling the observer again.
+          // This ensures that all events that were set up in the observer
+          // are cleaned up before the observer sets up new events during
+          // the next call.
+          cleanup?.();
+          observers.set(observer, observer(currentTag));
+        });
+      }
+
+      return tagRef.current;
+    });
+
+    fun.observe = (observer: AnimatedRefObserver) => {
+      const cleanup = observer(fun?.getTag?.() ?? null);
+      observers.set(observer, cleanup);
+
+      return () => {
+        observers.get(observer)?.();
+        observers.delete(observer);
+      };
+    };
+
+    fun.current = null;
+
+    ref.current = fun;
+  }
+
+  return ref.current;
 }
 
 /**

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -14,6 +14,9 @@ import type { EventHandlerInternal } from './useEvent';
 import { useEvent } from './useEvent';
 import { useSharedValue } from './useSharedValue';
 
+const NOT_INITIALIZED_WARNING =
+  'animatedRef is not initialized in useScrollViewOffset. Make sure to pass the animated ref to the scrollable component to get scroll offset updates.';
+
 /**
  * Lets you synchronously get the current offset of a `ScrollView`.
  *
@@ -42,27 +45,27 @@ function useScrollViewOffsetWeb(
       offset.value =
         element.scrollLeft === 0 ? element.scrollTop : element.scrollLeft;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef?.current]);
+  }, [animatedRef, offset]);
 
   useEffect(() => {
-    const element = animatedRef?.current
-      ? getWebScrollableElement(animatedRef.current)
-      : null;
-
-    if (element) {
-      element.addEventListener('scroll', eventHandler);
+    if (!animatedRef) {
+      return;
     }
-    return () => {
-      if (element) {
-        element.removeEventListener('scroll', eventHandler);
+
+    return animatedRef.observe((tag) => {
+      if (!tag) {
+        logger.warn(NOT_INITIALIZED_WARNING);
+        return;
       }
-    };
-    // React here has a problem with `animatedRef.current` since a Ref .current
-    // field shouldn't be used as a dependency. However, in this case we have
-    // to do it this way.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef?.current, eventHandler]);
+
+      const element = getWebScrollableElement(animatedRef.current);
+      element.addEventListener('scroll', eventHandler);
+
+      return () => {
+        element.removeEventListener('scroll', eventHandler);
+      };
+    });
+  }, [animatedRef, eventHandler]);
 
   return offset;
 }
@@ -94,9 +97,7 @@ function useScrollViewOffsetNative(
 
     return animatedRef.observe((tag) => {
       if (!tag) {
-        logger.warn(
-          'animatedRef is not initialized in useScrollViewOffset. Make sure to pass the animated ref to the scrollable component to get scroll offset updates.'
-        );
+        logger.warn(NOT_INITIALIZED_WARNING);
         return;
       }
 

--- a/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollViewOffset.ts
@@ -92,27 +92,20 @@ function useScrollViewOffsetNative(
       return;
     }
 
-    if (!animatedRef.getTag) {
-      logger.warn(
-        'animatedRef is not initialized. Please make sure to pass the animated ref to the scrollable component if you want to use useScrollViewOffset.'
-      );
-      return;
-    }
+    return animatedRef.observe((tag) => {
+      if (!tag) {
+        logger.warn(
+          'animatedRef is not initialized in useScrollViewOffset. Make sure to pass the animated ref to the scrollable component to get scroll offset updates.'
+        );
+        return;
+      }
 
-    const elementTag = animatedRef.getTag();
-
-    if (elementTag) {
-      eventHandler.workletEventHandler.registerForEvents(elementTag);
+      eventHandler.workletEventHandler.registerForEvents(tag);
       return () => {
-        eventHandler.workletEventHandler.unregisterFromEvents(elementTag);
+        eventHandler.workletEventHandler.unregisterFromEvents(tag);
       };
-    }
-
-    // React here has a problem with `animatedRef.current` since a Ref .current
-    // field shouldn't be used as a dependency. However, in this case we have
-    // to do it this way.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animatedRef, animatedRef?.current, eventHandler]);
+    });
+  }, [animatedRef, eventHandler]);
 
   return offset;
 }


### PR DESCRIPTION
## Summary

This PR fixes `useScrollViewOffset` hook not updating the returned SharedValue if the scrollable to which the ref is attached is rendered with some delay.

The previous implementation didn't work because the `animatedRef` was uninitialized when the `useEffect` hook in the `useScrollViewOffset` was called if the ref wasn't passed to any component. The `useEffect` was not triggered after the ref was passed to the component later on, even though (at least as I understand) the `animatedRef?.current` in the `useEffect` dependencies changed, because this change happened after hook dependencies were recalculated.

Since the code od the component executes from the top to the bottom during render, the `useEffect` hook dependencies array was created before the `animatedRef.current` was set in the function created within the `useAnimatedRef` hook (it is set as soon as the ref function is called with the exiting component argument, which happened after `useEffect` hook dependencies were recalculated).

## Example recordings

### Mobile

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/16b2d7dd-ec29-45be-ab7e-44007e922204" /> | <video src="https://github.com/user-attachments/assets/9e6f4475-4f66-4b46-a42b-2322a3cdb301" /> |

### Web

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/4e8f02af-5aee-498a-a738-a674db062bbc" /> | <video src="https://github.com/user-attachments/assets/cd0965da-7e2c-4281-ac3b-f3f58c97e153" /> |

## Test plan

Copy-paste the following code snippet and see how it works.

<details>
<summary>Code snippet</summary>

```tsx
import React, { useState } from 'react';
import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
import type Animated from 'react-native-reanimated';
import {
  useAnimatedReaction,
  useAnimatedRef,
  useScrollViewOffset,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const [shouldRender, setShouldRender] = useState(false);
  const scrollRef = useAnimatedRef<Animated.ScrollView>();
  const scrollOffset = useScrollViewOffset(scrollRef);

  useAnimatedReaction(
    () => scrollOffset.value,
    (value) => {
      console.log('scrollOffset', value);
    }
  );

  return (
    <View style={styles.container}>
      <Text style={styles.text}>
        ScrollView is {shouldRender ? 'rendered' : 'not rendered'}
      </Text>
      <Button
        title={shouldRender ? 'Remove ScrollView' : 'Render ScrollView'}
        onPress={() => setShouldRender(!shouldRender)}
      />

      {shouldRender && (
        <ScrollView
          ref={scrollRef}
          scrollEventThrottle={1000 / 60}
          style={styles.scrollView}>
          {Array.from({ length: 20 }).map((_, index) => (
            <View key={index} style={styles.item}>
              <Text style={styles.itemText}>Scroll Item {index + 1}</Text>
            </View>
          ))}
        </ScrollView>
      )}
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    padding: 20,
  },
  text: {
    fontSize: 16,
    marginBottom: 10,
  },
  scrollView: {
    flex: 1,
    marginTop: 20,
  },
  item: {
    height: 100,
    backgroundColor: '#f0f0f0',
    marginVertical: 8,
    borderRadius: 8,
    justifyContent: 'center',
    alignItems: 'center',
  },
  itemText: {
    fontSize: 16,
    color: '#333',
  },
});
```
</details>

I also checked if the following examples in the example app still work (on mobile and web):

- useAnimatedScrollHandler
- scrollTo
- useScrollViewOffset