### PR TITLE
chore: Add missing CSS properties helper warnings

### DIFF
--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2131,7 +2131,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 3a01f76123e04b8b945d43e5ffccae6f90f4a26e
   ReactCommon: 59e7bd3cf331ba77a96a75e6b603abf05883b102
   RNReanimated: bdbe194b9f56a80251bdfa4c9c226c3076d2ba73
-  RNWorklets: 7c0b2d2112a61ebf57c131a2d83ab309b1eb933a
+  RNWorklets: 3791e6bdb53e34ec541094d453225a96418dbcc6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 770a077e3a222f162c2e0c8a95e7e997b7682a8e
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2131,7 +2131,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 3a01f76123e04b8b945d43e5ffccae6f90f4a26e
   ReactCommon: 59e7bd3cf331ba77a96a75e6b603abf05883b102
   RNReanimated: bdbe194b9f56a80251bdfa4c9c226c3076d2ba73
-  RNWorklets: 3791e6bdb53e34ec541094d453225a96418dbcc6
+  RNWorklets: 7c0b2d2112a61ebf57c131a2d83ab309b1eb933a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 770a077e3a222f162c2e0c8a95e7e997b7682a8e
 

--- a/packages/react-native-reanimated/src/css/constants/settings.ts
+++ b/packages/react-native-reanimated/src/css/constants/settings.ts
@@ -1,8 +1,9 @@
 'use strict';
 import type { PredefinedTimingFunction, StepsModifier } from '../easings';
-import type { CSSAnimationSettingProp, CSSTransitionProp } from '../types';
+import type { CSSAnimationProp, CSSTransitionProp } from '../types';
 
-export const ANIMATION_SETTINGS: CSSAnimationSettingProp[] = [
+export const ANIMATION_PROPS: CSSAnimationProp[] = [
+  'animationName',
   'animationDuration',
   'animationTimingFunction',
   'animationDelay',

--- a/packages/react-native-reanimated/src/css/types/animation.ts
+++ b/packages/react-native-reanimated/src/css/types/animation.ts
@@ -71,6 +71,4 @@ export type ExistingCSSAnimationProperties<S extends object = PlainStyle> =
     >;
   };
 
-export type CSSAnimationSettingProp = keyof CSSAnimationSettings;
-
 export type CSSAnimationProp = keyof CSSAnimationProperties;

--- a/packages/react-native-reanimated/src/css/utils/guards.ts
+++ b/packages/react-native-reanimated/src/css/utils/guards.ts
@@ -1,6 +1,6 @@
 'use strict';
 import {
-  ANIMATION_SETTINGS,
+  ANIMATION_PROPS,
   TRANSITION_PROPS,
   VALID_PARAMETRIZED_TIMING_FUNCTIONS,
   VALID_PREDEFINED_TIMING_FUNCTIONS,
@@ -10,7 +10,7 @@ import type { PredefinedTimingFunction, StepsModifier } from '../easings/types';
 import type {
   AnyRecord,
   CSSAnimationKeyframes,
-  CSSAnimationSettingProp,
+  CSSAnimationProp,
   CSSKeyframesRule,
   CSSStyleProp,
   CSSTransitionProp,
@@ -19,7 +19,7 @@ import type {
 } from '../types';
 import type { ConfigPropertyAlias } from '../types/config';
 
-const ANIMATION_SETTINGS_SET = new Set<string>(ANIMATION_SETTINGS);
+const ANIMATION_PROPS_SET = new Set<string>(ANIMATION_PROPS);
 const TRANSITION_PROPS_SET = new Set<string>(TRANSITION_PROPS);
 const VALID_STEPS_MODIFIERS_SET = new Set<string>(VALID_STEPS_MODIFIERS);
 
@@ -40,9 +40,8 @@ export const smellsLikeTimingFunction = (value: string) =>
   VALID_PREDEFINED_TIMING_FUNCTIONS_SET.has(value) ||
   VALID_PARAMETRIZED_TIMING_FUNCTIONS_SET.has(value.split('(')[0].trim());
 
-export const isAnimationSetting = (
-  key: string
-): key is CSSAnimationSettingProp => ANIMATION_SETTINGS_SET.has(key);
+export const isAnimationProp = (key: string): key is CSSAnimationProp =>
+  ANIMATION_PROPS_SET.has(key);
 
 export const isTransitionProp = (key: string): key is CSSTransitionProp =>
   TRANSITION_PROPS_SET.has(key);
@@ -51,7 +50,7 @@ export const isStepsModifier = (value: string): value is StepsModifier =>
   VALID_STEPS_MODIFIERS_SET.has(value);
 
 export const isCSSStyleProp = (key: string): key is CSSStyleProp =>
-  isTransitionProp(key) || isAnimationSetting(key) || key === 'animationName';
+  isTransitionProp(key) || isAnimationProp(key);
 
 export const isTimeUnit = (value: unknown): value is TimeUnit =>
   // TODO: implement more strict check

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -84,10 +84,8 @@ function validateCSSAnimationProps(props: Partial<CSSAnimationProperties>) {
   // Check if any animation properties are present but animationName is missing
   if (propertyNames.length > 0 && !('animationName' in props)) {
     logger.warn(
-      'CSS animationName property is missing while other CSS animation properties were provided.\n' +
-        'If you wanted to remove the CSS animation, either:\n' +
-        '  - Pass animationName: "none" to make it explicit\n' +
-        '  - Remove all CSS animation properties from the style'
+      'CSS animation properties were provided without specifying animationName.\n' +
+        'If unintended, add animationName or remove unnecessary animation properties.'
     );
   }
 
@@ -98,10 +96,20 @@ function validateCSSAnimationProps(props: Partial<CSSAnimationProperties>) {
     !('animationDuration' in props)
   ) {
     logger.warn(
-      'animationDuration is not specified for CSS animation. The default value is 0s.\n' +
+      'animationDuration was not specified for CSS animation. The default duration is 0s.\n' +
         'Have you forgotten to pass the animationDuration?'
     );
   }
 }
 
-function validateCSSTransitionProps(_props: Partial<CSSTransitionProperties>) {}
+function validateCSSTransitionProps(props: Partial<CSSTransitionProperties>) {
+  const propertyNames = Object.keys(props);
+
+  // Check if any transition properties are present but transitionDuration is missing
+  if (propertyNames.length > 0 && !('transitionDuration' in props)) {
+    logger.warn(
+      'transitionDuration was not specified for CSS transition. The default duration is 0s.\n' +
+        'Have you forgotten to pass the transitionDuration?'
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds helper warnings for missing CSS animation/transition properties.

## Examples

### Animations

![Screenshot 2025-06-03 at 17 42 50](https://github.com/user-attachments/assets/9109f18e-4179-4a02-9a00-9cbd40595c2e)

### Transitions

![Screenshot 2025-06-03 at 17 43 44](https://github.com/user-attachments/assets/a2c92ffc-8e64-4e35-940d-379d28db424f)
