### PR TITLE
docs: Add neccessary CodeBlocks in TabItems

### DIFF
--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -33,13 +33,15 @@ Install `react-native-reanimated@next` and `react-native-worklets` packages from
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install react-native-reanimated@next
+    ```
 
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add react-native-reanimated@next
+    ```
 
   </TabItem>
 </Tabs>
@@ -51,14 +53,14 @@ This library requires an installation of the `react-native-worklets` dependency.
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     {/* TODO - add information about the necessity to specify a proper version of the library compatible with reanimated */}
-
+    ```bash
     npm install react-native-worklets
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add react-native-worklets
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -68,14 +70,14 @@ Run prebuild to update the native code in the `ios` and `android` directories.
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npx expo prebuild
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn expo prebuild
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -118,14 +120,14 @@ To learn more about the plugin head onto to [Reanimated babel plugin](/docs/next
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm start -- --reset-cache
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn start --reset-cache
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -149,14 +151,14 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
 </Tabs>
 

--- a/packages/docs-reanimated/docs/guides/web-support.mdx
+++ b/packages/docs-reanimated/docs/guides/web-support.mdx
@@ -15,19 +15,19 @@ Install [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs
 
 <Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
-
+    ```bash
     npx expo install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
 </Tabs>
 

--- a/packages/docs-reanimated/versioned_docs/version-3.x/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/fundamentals/getting-started.mdx
@@ -21,14 +21,14 @@ If you don't have an existing project, you can create a new Expo app using a tem
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npx create-expo-app@latest my-app -e with-reanimated
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn create expo-app my-app -e with-reanimated
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -44,19 +44,19 @@ Install `react-native-reanimated` package from npm:
 
 <Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
-
+    ```bash
     npx expo install react-native-reanimated
-
+    ```
   </TabItem>
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install react-native-reanimated
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add react-native-reanimated
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -121,19 +121,19 @@ To learn more about this feature, head onto to [Accurate Call Stacks](/docs/debu
 
 <Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
-
+    ```bash
     npx expo start -c
-
+    ```
   </TabItem>
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm start -- --reset-cache
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn start --reset-cache
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -167,19 +167,19 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
 
 <Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
-
+    ```bash
     npx expo install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
 </Tabs>
 

--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/web-support.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/web-support.mdx
@@ -15,19 +15,19 @@ Install [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs
 
 <Tabs groupId="package-managers">
   <TabItem value="expo" label="EXPO" default>
-
+    ```bash
     npx expo install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="npm" label="NPM">
-
+    ```bash
     npm install @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-
+    ```bash
     yarn add @babel/plugin-proposal-export-namespace-from
-
+    ```
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

They're needed around the fragments that we want to interpret as a code.

Before:
<img width="493" alt="image" src="https://github.com/user-attachments/assets/c4dbf609-6625-4e77-9844-efdbda9a34d2" />

After:
<img width="920" alt="image" src="https://github.com/user-attachments/assets/bab10cfb-6d5d-4117-a022-41ba596a7f2a" />


## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
