### PR TITLE
docs: fix Radon IDE banner

### DIFF
--- a/packages/docs-reanimated/src/components/RadonBanner/index.tsx
+++ b/packages/docs-reanimated/src/components/RadonBanner/index.tsx
@@ -1,3 +1,5 @@
+import React, { useRef } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import styles from './styles.module.css';
 
 import ArrowRight from '@site/static/img/arrow-right.svg';
@@ -45,21 +47,33 @@ const items = [
   },
 ];
 
-export default function RadonBanner() {
-  const item = items[Math.floor(Math.random() * items.length)];
+function RadonBannerInner(): JSX.Element {
+  const item = useRef(items[Math.floor(Math.random() * items.length)]);
 
   return (
     <a
       href="https://ide.swmansion.com/?utm_source=reanimated"
       className={styles.container}>
       <div className={styles.content}>
-        <p className={styles.text}>{item.text}</p>
+        <p className={styles.text}>{item.current.text}</p>
         <span className={styles.button}>
-          {item.button} <ArrowRight />
+          {item.current.button} <ArrowRight />
         </span>
       </div>
       <span className={styles.ellipseLeft} />
       <span className={styles.ellipseRight} />
     </a>
+  );
+}
+
+export default function RadonBanner() {
+  return (
+    <BrowserOnly fallback={<div />}>
+      {() => (
+        <>
+          <RadonBannerInner />
+        </>
+      )}
+    </BrowserOnly>
   );
 }

--- a/packages/docs-reanimated/src/components/RadonBanner/styles.module.css
+++ b/packages/docs-reanimated/src/components/RadonBanner/styles.module.css
@@ -11,7 +11,7 @@
   opacity: 0;
   animation-name: slideUpAndFade;
   animation-fill-mode: forwards;
-  animation-duration: 300ms;
+  animation-duration: 500ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
 }
@@ -19,7 +19,7 @@
 @keyframes slideUpAndFade {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(6px);
   }
   to {
     opacity: 1;

--- a/packages/docs-reanimated/src/components/RadonBanner/styles.module.css
+++ b/packages/docs-reanimated/src/components/RadonBanner/styles.module.css
@@ -8,6 +8,23 @@
   position: relative;
   overflow: hidden;
   text-decoration: none !important;
+  opacity: 0;
+  animation-name: slideUpAndFade;
+  animation-fill-mode: forwards;
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+@keyframes slideUpAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .container:hover .button svg {


### PR DESCRIPTION
In the production environment Docusaurus serves the HTML statically and then hydrates the HTML shell with React. This caused the banner to randomly pick the banner copy twice (different text was picked "on the server" and then again "on the client") causing an ugly jump/rerender. 

There was no way to catch that bug in dev mode as Docusaurus only runs the page "client side" during development.

I've fixed the problem by only running the code only on the client side and masking the hydration step with a slide and fade animation.

In the following recordings I'm repeatedly refreshing the page.

### Before


https://github.com/user-attachments/assets/7739e2f0-56d1-489d-b7ed-7442c1be4a6e


### After


https://github.com/user-attachments/assets/b5330d5f-2d7f-40f8-898d-a1c933c4cc1f



