### PR TITLE
Use `react_native_assert` instead of `assert`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
+#include <react/debug/react_native_assert.h>
 
 #include <utility>
 
@@ -11,7 +12,7 @@ AnimatedSensorModule::AnimatedSensorModule(
           platformDepMethodsHolder.unregisterSensor) {}
 
 AnimatedSensorModule::~AnimatedSensorModule() {
-  assert(sensorsIds_.empty());
+  react_native_assert(sensorsIds_.empty() && "Tried to deallocate AnimatedSensorModule with registered sensors");
 }
 
 jsi::Value AnimatedSensorModule::registerSensor(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
@@ -1,5 +1,5 @@
-#include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <react/debug/react_native_assert.h>
+#include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 
 #include <utility>
 
@@ -12,7 +12,9 @@ AnimatedSensorModule::AnimatedSensorModule(
           platformDepMethodsHolder.unregisterSensor) {}
 
 AnimatedSensorModule::~AnimatedSensorModule() {
-  react_native_assert(sensorsIds_.empty() && "Tried to deallocate AnimatedSensorModule with registered sensors");
+  react_native_assert(
+      sensorsIds_.empty() &&
+      "Tried to deallocate AnimatedSensorModule with registered sensors");
 }
 
 jsi::Value AnimatedSensorModule::registerSensor(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -118,7 +118,8 @@ LayoutAnimationsManager::getConfigsForType(const LayoutAnimationType type) {
     case LAYOUT:
       return layoutAnimations_;
     default:
-      assert(false);
+      throw std::invalid_argument(
+          "[Reanimated] Unknown layout animation type");
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -118,8 +118,7 @@ LayoutAnimationsManager::getConfigsForType(const LayoutAnimationType type) {
     case LAYOUT:
       return layoutAnimations_;
     default:
-      throw std::invalid_argument(
-          "[Reanimated] Unknown layout animation type");
+      throw std::invalid_argument("[Reanimated] Unknown layout animation type");
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -735,7 +735,7 @@ void ReanimatedModuleProxy::performOperations() {
     }
     jsi::Value maybeJSPropsUpdater =
         rt.global().getProperty(rt, "updateJSProps");
-    assert(
+    react_native_assert(
         maybeJSPropsUpdater.isObject() &&
         "[Reanimated] `updateJSProps` not found");
     jsi::Function jsPropsUpdater =

--- a/packages/react-native-worklets/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Registries/WorkletRuntimeRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <react/debug/react_native_assert.h>
 
 #include <mutex>
 #include <set>
@@ -30,7 +31,7 @@ class WorkletRuntimeRegistry {
 
  public:
   static bool isRuntimeAlive(jsi::Runtime *runtime) {
-    assert(runtime != nullptr);
+    react_native_assert(runtime != nullptr && "runtime is nullptr");
     std::lock_guard<std::mutex> lock(mutex_);
     return registry_.find(runtime) != registry_.end();
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -7,7 +7,7 @@ namespace worklets {
 
 jsi::Function getValueUnpacker(jsi::Runtime &rt) {
   auto valueUnpacker = rt.global().getProperty(rt, "__valueUnpacker");
-  assert(valueUnpacker.isObject() && "valueUnpacker not found");
+  react_native_assert(valueUnpacker.isObject() && "valueUnpacker not found");
   return valueUnpacker.asObject(rt).asFunction(rt);
 }
 
@@ -352,7 +352,7 @@ jsi::Value ShareableHostFunction::toJSValue(jsi::Runtime &rt) {
 }
 
 jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
-  assert(
+  react_native_assert(
       std::any_of(
           data_.cbegin(),
           data_.cend(),

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
@@ -258,9 +258,7 @@ class ShareableHostFunction : public Shareable {
  public:
   ShareableHostFunction(jsi::Runtime &rt, jsi::Function function)
       : Shareable(HostFunctionType),
-        hostFunction_(
-            (assert(function.isHostFunction(rt)),
-             function.getHostFunction(rt))),
+        hostFunction_(function.getHostFunction(rt)),
         name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
         paramCount_(function.getProperty(rt, "length").asNumber()) {}
 

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/SingleInstanceChecker.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/SingleInstanceChecker.h
@@ -2,6 +2,8 @@
 
 #ifndef NDEBUG
 
+#include <react/debug/react_native_assert.h>
+
 #include <cxxabi.h>
 
 #include <atomic>
@@ -35,7 +37,7 @@ class SingleInstanceChecker {
 #endif
 
 #ifdef IS_REANIMATED_EXAMPLE_APP
-      assert(false);
+      react_native_assert(false && "SingleInstanceChecker failed");
 #endif
     }
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.cpp
@@ -20,7 +20,9 @@ jsi::Array convertStringToArray(
       std::istream_iterator<float>(stringStream),
       std::istream_iterator<float>(),
       std::back_inserter(transformMatrixList));
-  react_native_assert(transformMatrixList.size() == expectedSize && "Transform matrix list size is different than expected");
+  react_native_assert(
+      transformMatrixList.size() == expectedSize &&
+      "Transform matrix list size is different than expected");
   jsi::Array matrix(rt, expectedSize);
   for (unsigned int i = 0; i < expectedSize; i++) {
     matrix.setValueAtIndex(rt, i, transformMatrixList[i]);

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.cpp
@@ -1,5 +1,7 @@
 #include <worklets/Tools/WorkletsJSIUtils.h>
 
+#include <react/debug/react_native_assert.h>
+
 #include <memory>
 #include <sstream>
 #include <vector>
@@ -18,7 +20,7 @@ jsi::Array convertStringToArray(
       std::istream_iterator<float>(stringStream),
       std::istream_iterator<float>(),
       std::back_inserter(transformMatrixList));
-  assert(transformMatrixList.size() == expectedSize);
+  react_native_assert(transformMatrixList.size() == expectedSize && "Transform matrix list size is different than expected");
   jsi::Array matrix(rt, expectedSize);
   for (unsigned int i = 0; i < expectedSize; i++) {
     matrix.setValueAtIndex(rt, i, transformMatrixList[i]);

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
@@ -84,7 +84,9 @@ std::tuple<Args...> getArgsForFunction(
     jsi::Runtime &rt,
     const jsi::Value *args,
     const size_t count) {
-  react_native_assert(sizeof...(Args) == count && "Argument list has different length than expected");
+  react_native_assert(
+      sizeof...(Args) == count &&
+      "Argument list has different length than expected");
   return convertArgs<Args...>(rt, args);
 }
 
@@ -97,7 +99,9 @@ std::tuple<jsi::Runtime &, Args...> getArgsForFunction(
     jsi::Runtime &rt,
     const jsi::Value *args,
     const size_t count) {
-  react_native_assert(sizeof...(Args) == count && "Argument list has different length than expected");
+  react_native_assert(
+      sizeof...(Args) == count &&
+      "Argument list has different length than expected");
   return std::tuple_cat(std::tie(rt), convertArgs<Args...>(rt, args));
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletsJSIUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <react/debug/react_native_assert.h>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -83,7 +84,7 @@ std::tuple<Args...> getArgsForFunction(
     jsi::Runtime &rt,
     const jsi::Value *args,
     const size_t count) {
-  assert(sizeof...(Args) == count);
+  react_native_assert(sizeof...(Args) == count && "Argument list has different length than expected");
   return convertArgs<Args...>(rt, args);
 }
 
@@ -96,7 +97,7 @@ std::tuple<jsi::Runtime &, Args...> getArgsForFunction(
     jsi::Runtime &rt,
     const jsi::Value *args,
     const size_t count) {
-  assert(sizeof...(Args) == count);
+  react_native_assert(sizeof...(Args) == count && "Argument list has different length than expected");
   return std::tuple_cat(std::tie(rt), convertArgs<Args...>(rt, args));
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
@@ -10,6 +10,7 @@
 #include <hermes/hermes.h>
 #include <jsi/decorator.h>
 #include <jsi/jsi.h>
+#include <react/debug/react_native_assert.h>
 
 #include <atomic>
 #include <memory>
@@ -61,13 +62,13 @@ struct WorkletsReentrancyCheck {
       // Returns true if tid and expected were the same.  If they
       // were, then the stored tid referred to no thread, and we
       // atomically saved this thread's tid.  Now increment depth.
-      assert(depth == 0 && "[Worklets] No thread id, but depth != 0");
+      react_native_assert(depth == 0 && "[Worklets] No thread id, but depth != 0");
       ++depth;
     } else if (expected == this_id) {
       // If the stored tid referred to a thread, expected was set to
       // that value.  If that value is this thread's tid, that's ok,
       // just increment depth again.
-      assert(depth != 0 && "[Worklets] Thread id was set, but depth == 0");
+      react_native_assert(depth != 0 && "[Worklets] Thread id was set, but depth == 0");
       ++depth;
     } else {
       // The stored tid was some other thread.  This indicates a bad
@@ -79,7 +80,7 @@ struct WorkletsReentrancyCheck {
   }
 
   void after() {
-    assert(
+    react_native_assert(
         tid.load(std::memory_order_relaxed) == std::this_thread::get_id() &&
         "[Worklets] No thread id in after()");
     if (--depth == 0) {
@@ -87,7 +88,7 @@ struct WorkletsReentrancyCheck {
       std::thread::id expected = std::this_thread::get_id();
       bool didWrite = tid.compare_exchange_strong(
           expected, std::thread::id(), std::memory_order_relaxed);
-      assert(didWrite && "[Worklets] Decremented to zero, but no tid write");
+      react_native_assert(didWrite && "[Worklets] Decremented to zero, but no tid write");
     }
   }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
@@ -62,13 +62,15 @@ struct WorkletsReentrancyCheck {
       // Returns true if tid and expected were the same.  If they
       // were, then the stored tid referred to no thread, and we
       // atomically saved this thread's tid.  Now increment depth.
-      react_native_assert(depth == 0 && "[Worklets] No thread id, but depth != 0");
+      react_native_assert(
+          depth == 0 && "[Worklets] No thread id, but depth != 0");
       ++depth;
     } else if (expected == this_id) {
       // If the stored tid referred to a thread, expected was set to
       // that value.  If that value is this thread's tid, that's ok,
       // just increment depth again.
-      react_native_assert(depth != 0 && "[Worklets] Thread id was set, but depth == 0");
+      react_native_assert(
+          depth != 0 && "[Worklets] Thread id was set, but depth == 0");
       ++depth;
     } else {
       // The stored tid was some other thread.  This indicates a bad
@@ -88,7 +90,8 @@ struct WorkletsReentrancyCheck {
       std::thread::id expected = std::this_thread::get_id();
       bool didWrite = tid.compare_exchange_strong(
           expected, std::thread::id(), std::memory_order_relaxed);
-      react_native_assert(didWrite && "[Worklets] Decremented to zero, but no tid write");
+      react_native_assert(
+          didWrite && "[Worklets] Decremented to zero, but no tid write");
     }
   }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -137,7 +137,7 @@ WorkletRuntime::WorkletRuntime(
 jsi::Value WorkletRuntime::executeSync(
     jsi::Runtime &rt,
     const jsi::Value &worklet) const {
-  assert(
+  react_native_assert(
       supportsLocking_ &&
       ("[Worklets] Runtime \"" + name_ + "\" doesn't support locking.")
           .c_str());


### PR DESCRIPTION
## Summary

This PR converts all usages of `assert()` into `react_native_assert()` which offers better logging as well as adds missing error messages.

## Test plan
