### PR TITLE
Fix sticky header

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -51,7 +51,8 @@ void ReanimatedCommitHook::maybeInitializeLayoutAnimations(
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
-    RootShadowNode::Unshared const &newRootShadowNode) noexcept {
+    RootShadowNode::Unshared const &newRootShadowNode,
+    const ShadowTreeCommitOptions& commitOptions) noexcept {
   ReanimatedSystraceSection s("ReanimatedCommitHook::shadowTreeWillCommit");
 
   maybeInitializeLayoutAnimations(newRootShadowNode->getSurfaceId());
@@ -86,8 +87,11 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     // props will be applied in ReanimatedCommitHook by UpdatesRegistryManager
     // This is very important, since if we didn't pause Reanimated commits,
     // it could lead to RN commits being delayed until the animation is finished
-    // (very bad).
-    updatesRegistryManager_->pauseReanimatedCommits();
+    // (very bad). We don't pause Reanimated commits for state updates coming from
+    // React Native as this would break sticky header animations.
+    if (commitOptions.source == ShadowTreeCommitSource::React) {
+      updatesRegistryManager_->pauseReanimatedCommits();
+    }
   }
 
   return rootNode;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -87,8 +87,8 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     // props will be applied in ReanimatedCommitHook by UpdatesRegistryManager
     // This is very important, since if we didn't pause Reanimated commits,
     // it could lead to RN commits being delayed until the animation is finished
-    // (very bad). We don't pause Reanimated commits for state updates coming from
-    // React Native as this would break sticky header animations.
+    // (very bad). We don't pause Reanimated commits for state updates coming
+    // from React Native as this would break sticky header animations.
     if (commitOptions.source == ShadowTreeCommitSource::React) {
       updatesRegistryManager_->pauseReanimatedCommits();
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -52,7 +52,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
     RootShadowNode::Unshared const &newRootShadowNode
-#if REACT_NATIVE_MINOR_VERSION > 80
+#if REACT_NATIVE_MINOR_VERSION >= 80
     ,
     const ShadowTreeCommitOptions &commitOptions
 #endif
@@ -93,7 +93,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     // it could lead to RN commits being delayed until the animation is finished
     // (very bad). We don't pause Reanimated commits for state updates coming
     // from React Native as this would break sticky header animations.
-#if REACT_NATIVE_MINOR_VERSION > 80
+#if REACT_NATIVE_MINOR_VERSION >= 80
     if (commitOptions.source == ShadowTreeCommitSource::React) {
       updatesRegistryManager_->pauseReanimatedCommits();
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -52,7 +52,10 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
     RootShadowNode::Unshared const &newRootShadowNode,
-    const ShadowTreeCommitOptions& commitOptions) noexcept {
+#if REACT_NATIVE_MINOR_VERSION > 80
+    const ShadowTreeCommitOptions &commitOptions
+#endif
+    ) noexcept {
   ReanimatedSystraceSection s("ReanimatedCommitHook::shadowTreeWillCommit");
 
   maybeInitializeLayoutAnimations(newRootShadowNode->getSurfaceId());
@@ -89,9 +92,13 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     // it could lead to RN commits being delayed until the animation is finished
     // (very bad). We don't pause Reanimated commits for state updates coming
     // from React Native as this would break sticky header animations.
+#if REACT_NATIVE_MINOR_VERSION > 80
     if (commitOptions.source == ShadowTreeCommitSource::React) {
       updatesRegistryManager_->pauseReanimatedCommits();
     }
+#else
+    updatesRegistryManager_->pauseReanimatedCommits();
+#endif
   }
 
   return rootNode;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -51,8 +51,9 @@ void ReanimatedCommitHook::maybeInitializeLayoutAnimations(
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     ShadowTree const &,
     RootShadowNode::Shared const &,
-    RootShadowNode::Unshared const &newRootShadowNode,
+    RootShadowNode::Unshared const &newRootShadowNode
 #if REACT_NATIVE_MINOR_VERSION > 80
+    ,
     const ShadowTreeCommitOptions &commitOptions
 #endif
     ) noexcept {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -32,7 +32,7 @@ class ReanimatedCommitHook
       ShadowTree const &shadowTree,
       RootShadowNode::Shared const &oldRootShadowNode,
       RootShadowNode::Unshared const &newRootShadowNode
-#if REACT_NATIVE_MINOR_VERSION > 80
+#if REACT_NATIVE_MINOR_VERSION >= 80
       ,
       const ShadowTreeCommitOptions &commitOptions
 #endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -31,8 +31,9 @@ class ReanimatedCommitHook
   RootShadowNode::Unshared shadowTreeWillCommit(
       ShadowTree const &shadowTree,
       RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode,
+      RootShadowNode::Unshared const &newRootShadowNode
 #if REACT_NATIVE_MINOR_VERSION > 80
+      ,
       const ShadowTreeCommitOptions &commitOptions
 #endif
       ) noexcept override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -32,7 +32,10 @@ class ReanimatedCommitHook
       ShadowTree const &shadowTree,
       RootShadowNode::Shared const &oldRootShadowNode,
       RootShadowNode::Unshared const &newRootShadowNode,
-      const ShadowTreeCommitOptions &commitOptions) noexcept override;
+#if REACT_NATIVE_MINOR_VERSION > 80
+      const ShadowTreeCommitOptions &commitOptions
+#endif
+      ) noexcept override;
 
  private:
   std::shared_ptr<UIManager> uiManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -31,7 +31,8 @@ class ReanimatedCommitHook
   RootShadowNode::Unshared shadowTreeWillCommit(
       ShadowTree const &shadowTree,
       RootShadowNode::Shared const &oldRootShadowNode,
-      RootShadowNode::Unshared const &newRootShadowNode) noexcept override;
+      RootShadowNode::Unshared const &newRootShadowNode,
+      const ShadowTreeCommitOptions &commitOptions) noexcept override;
 
  private:
   std::shared_ptr<UIManager> uiManager_;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes sticky header on both Android and iOS.

Together with @bartlomiejbloniarz we found out that sticky header issue can be fixed by commenting out `// isPaused_ = true;` line. However, this can lead to starvation of commits coming from React. So the best workaround so far is to pause Reanimated commits only in `ReanimatedCommitHook` only for commits coming from React and skip pausing them for other commits like state updates after scroll.

Note that this PR uses the new signature of `shadowTreeWillCommit` method which is available from RN 0.80.

<video src="https://github.com/user-attachments/assets/ad36b502-88c5-4215-9ee6-51c26e9bb05c" alt="after" />

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
