### PR TITLE
fix: Prevent uninitialized scrollview warning from showing up on unmount

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -55,18 +55,18 @@ function useAnimatedRefBase<TComponent extends Component>(
         fun.getTag = () =>
           findNodeHandle(getComponentOrScrollable(component) as Component)!;
         fun.current = component;
-      }
 
-      if (observers.size) {
-        const currentTag = fun?.getTag?.() ?? null;
-        observers.forEach((cleanup, observer) => {
-          // Perform the cleanup before calling the observer again.
-          // This ensures that all events that were set up in the observer
-          // are cleaned up before the observer sets up new events during
-          // the next call.
-          cleanup?.();
-          observers.set(observer, observer(currentTag));
-        });
+        if (observers.size) {
+          const currentTag = fun?.getTag?.() ?? null;
+          observers.forEach((cleanup, observer) => {
+            // Perform the cleanup before calling the observer again.
+            // This ensures that all events that were set up in the observer
+            // are cleaned up before the observer sets up new events during
+            // the next call.
+            cleanup?.();
+            observers.set(observer, observer(currentTag));
+          });
+        }
       }
 
       return wrapperRef.current;


### PR DESCRIPTION
## Summary

This PR fixes warning that was shown when the component using `useScrollOffset` hook was unmounted. In the new approach, the warning won't be shown when the component, to which the ref was attached, is unmounted.

This is a double-edged sword:
- on the one hand, it fixes invalid warning shown when the scrollable component and its parent get unmounted at the same time
- on the other hand, it won't show the warning when the scrollable component was initially available and then it was unmounted without unmounting its parent, in which the animated ref is created

Nonetheless, I think that it is the best what we can do and it's better not to show too many warnings. The implementation after changes will still show warning when the component mounts and the ref is not initialized after component, in which `useScrollOffset` hook with such a ref is used, mounts.

## Example recordings

## Test plan

<details>
<summary>Code snippet</summary>

```tsx
import React, { useEffect } from 'react';
import { ScrollView, StyleSheet, Text } from 'react-native';
import type Animated from 'react-native-reanimated';
import { useAnimatedRef, useScrollOffset } from 'react-native-reanimated';

export default function EmptyExample() {
  const aref = useAnimatedRef<Animated.ScrollView>();
  const offset = useScrollOffset(aref);

  useEffect(() => {
    console.log('offset', offset.value);
  }, [offset]);

  return (
    <ScrollView ref={aref} contentContainerStyle={styles.container}>
      <Text>Hello world!</Text>
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```
</details>