### PR TITLE
[Web] Do not call `getBoundingClientRect` on every update

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -274,8 +274,6 @@ export default class AnimatedComponent
   componentDidUpdate(
     prevProps: AnimatedComponentProps<InitialComponentProps>,
     _prevState: Readonly<unknown>,
-    // This type comes straight from React
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     snapshot: DOMRect | null
   ) {
     const layout = this.props.layout;
@@ -291,10 +289,9 @@ export default class AnimatedComponent
       saveSnapshot(this._componentDOMRef);
     }
 
-    // Snapshot won't be undefined because it comes from getSnapshotBeforeUpdate method
     if (
       IS_WEB &&
-      snapshot !== null &&
+      snapshot &&
       this.props.layout &&
       !getReducedMotionFromConfig(this.props.layout as CustomConfig)
     ) {
@@ -364,11 +361,9 @@ export default class AnimatedComponent
   // It is called before the component gets rerendered. This way we can access components' position before it changed
   // and later on, in componentDidUpdate, calculate translation for layout transition.
   getSnapshotBeforeUpdate() {
-    if (IS_WEB && this._componentDOMRef?.getBoundingClientRect !== undefined) {
-      return this._componentDOMRef.getBoundingClientRect();
+    if (IS_WEB && this.props.layout) {
+      return this._componentDOMRef?.getBoundingClientRect?.();
     }
-
-    return null;
   }
 
   render() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In `AnimatedComponent` we use lifecycle function called `getSnapshotBeforeUpdate` to prepare snapshot used in layout transitions. In that context snapshot is `DOMRect`, obtained by calling `getBoundingClientRect` function. The problem here is that it is called on every component update, even if it doesn't have any layout transition specified. This PR changes this behavior.

## Test plan

Tested that `getBoundingClientRect` is called only when component has layout transition, i.e.:

```jsx
<Animated.View layout={...} ... />
```