### PR TITLE
fix: `skipExiting` not working on Android

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,18 +1,32 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  FadeOut,
+  LayoutAnimationConfig,
+} from 'react-native-reanimated';
 
-export default function EmptyExample() {
+export default function App() {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShow(false);
+    }, 1000);
+  }, []);
+
   return (
-    <View style={styles.container}>
-      <Text>Hello world!</Text>
-    </View>
+    show && (
+      <LayoutAnimationConfig skipEntering skipExiting>
+        <Animated.View exiting={FadeOut} style={styles.box} />
+      </LayoutAnimationConfig>
+    )
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  box: {
+    width: 200,
+    height: 200,
+    backgroundColor: 'red',
   },
 });

--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,18 +1,40 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  FadeOut,
+  LayoutAnimationConfig,
+} from 'react-native-reanimated';
 
-export default function EmptyExample() {
+export default function App() {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShow(false);
+    }, 1000);
+  }, []);
+
   return (
-    <View style={styles.container}>
-      <Text>Hello world!</Text>
+    <View style={{ backgroundColor: 'blue', padding: 10 }}>
+      <View style={{ backgroundColor: 'green', padding: 10 }}>
+        <View style={{ backgroundColor: 'yellow', padding: 10 }}>
+          <View style={{ backgroundColor: 'red', padding: 10 }}>
+            {show && (
+              <LayoutAnimationConfig skipEntering skipExiting>
+                <Animated.View exiting={FadeOut} style={styles.box} />
+              </LayoutAnimationConfig>
+            )}
+          </View>
+        </View>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  box: {
+    width: 200,
+    height: 200,
+    backgroundColor: 'red',
   },
 });

--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,32 +1,18 @@
-import { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
-import Animated, {
-  FadeOut,
-  LayoutAnimationConfig,
-} from 'react-native-reanimated';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 
-export default function App() {
-  const [show, setShow] = useState(true);
-
-  useEffect(() => {
-    setTimeout(() => {
-      setShow(false);
-    }, 1000);
-  }, []);
-
+export default function EmptyExample() {
   return (
-    show && (
-      <LayoutAnimationConfig skipEntering skipExiting>
-        <Animated.View exiting={FadeOut} style={styles.box} />
-      </LayoutAnimationConfig>
-    )
+    <View style={styles.container}>
+      <Text>Hello world!</Text>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  box: {
-    width: 200,
-    height: 200,
-    backgroundColor: 'red',
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <reanimated/LayoutAnimations/LayoutAnimationType.h>
+#include <reanimated/LayoutAnimations/LayoutAnimationsUtils.h>
 
 #include <worklets/SharedItems/Shareables.h>
 #include <worklets/Tools/JSLogger.h>
@@ -32,8 +33,10 @@ class LayoutAnimationsManager {
       : jsLogger_(jsLogger) {}
   void configureAnimationBatch(
       const std::vector<LayoutAnimationConfig> &layoutAnimationsBatch);
-  void setShouldAnimateExiting(const int tag, const bool value);
-  bool shouldAnimateExiting(const int tag, const bool shouldAnimate);
+  void setShouldAnimateExitingForSubtree(const int rootTag, const bool value);
+  bool shouldAnimateExitingForSubtree(
+      const std::shared_ptr<MutationNode> node,
+      const bool parentShouldAnimate);
   bool hasLayoutAnimation(const int tag, const LayoutAnimationType type);
   void startLayoutAnimation(
       jsi::Runtime &rt,
@@ -55,7 +58,7 @@ class LayoutAnimationsManager {
   std::unordered_map<int, std::shared_ptr<Shareable>> enteringAnimations_;
   std::unordered_map<int, std::shared_ptr<Shareable>> exitingAnimations_;
   std::unordered_map<int, std::shared_ptr<Shareable>> layoutAnimations_;
-  std::unordered_map<int, bool> shouldAnimateExitingForTag_;
+  std::unordered_map<int, bool> shouldAnimateExitingForSubtree_;
   mutable std::recursive_mutex
       animationsMutex_; // Protects `enteringAnimations_`, `exitingAnimations_`,
   // `layoutAnimations_` and `shouldAnimateExitingForTag_`.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -26,6 +26,11 @@ std::optional<MountingTransaction> LayoutAnimationsProxy::pullTransaction(
   LOG(INFO) << "pullTransaction " << std::this_thread::get_id() << " "
             << surfaceId << std::endl;
 #endif
+  LOG(INFO) << "Mutations";
+  for (auto mutation: mutations) {
+    LOG(INFO) << "Mutation: " << mutation.parentTag;
+  }
+
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   PropsParserContext propsParserContext{surfaceId, *contextContainer_};
   ShadowViewMutationList filteredMutations;
@@ -33,7 +38,25 @@ std::optional<MountingTransaction> LayoutAnimationsProxy::pullTransaction(
   std::vector<std::shared_ptr<MutationNode>> roots;
   std::unordered_map<Tag, ShadowView> movedViews;
 
+
   parseRemoveMutations(movedViews, mutations, roots);
+  
+  if (roots.size() > 0) {
+      LOG(INFO) << "Roots: ";
+      for (auto root: roots) {
+        LOG(INFO) << "root: " << root->tag;
+      }
+      roots.pop_back();
+  }
+  
+  for (auto mutation : mutations) {
+    if (mutation.parentTag == 4 || mutation.oldChildShadowView.tag == 4 ||
+        mutation.oldChildShadowView.tag == 2) {
+      LOG(INFO) << "parentTag " << mutation.parentTag << " old child "
+                << mutation.oldChildShadowView.tag << " new child "
+                << mutation.newChildShadowView.tag;
+    }
+  }
 
   handleRemovals(filteredMutations, roots);
 
@@ -240,7 +263,7 @@ void LayoutAnimationsProxy::handleRemovals(
     std::vector<std::shared_ptr<MutationNode>> &roots) const {
   // iterate from the end, so that children
   // with higher indices appear first in the mutations list
-  for (auto it = roots.rbegin(); it != roots.rend(); it++) {
+  for (auto it = roots.begin(); it != roots.end(); it++) {
     auto &node = *it;
     if (!startAnimationsRecursively(
             node, true, true, false, filteredMutations)) {
@@ -248,8 +271,9 @@ void LayoutAnimationsProxy::handleRemovals(
       node->unflattenedParent->removeChildFromUnflattenedTree(node); //???
       if (node->state != MOVED) {
         maybeCancelAnimation(node->tag);
-        filteredMutations.push_back(ShadowViewMutation::DeleteMutation(
-            node->mutation.oldChildShadowView));
+        filteredMutations.push_back(
+            ShadowViewMutation::DeleteMutation(
+                node->mutation.oldChildShadowView));
         nodeForTag_.erase(node->tag);
 #ifdef LAYOUT_ANIMATIONS_LOGS
         LOG(INFO) << "delete " << node->tag << std::endl;
@@ -305,10 +329,11 @@ void LayoutAnimationsProxy::handleUpdatesAndEnterings(
           auto layoutAnimationIt = layoutAnimations_.find(tag);
           if (layoutAnimationIt == layoutAnimations_.end()) {
             if (oldShadowViewsForReparentings.contains(tag)) {
-              filteredMutations.push_back(ShadowViewMutation::InsertMutation(
-                  mutationParent,
-                  oldShadowViewsForReparentings[tag],
-                  mutation.index));
+              filteredMutations.push_back(
+                  ShadowViewMutation::InsertMutation(
+                      mutationParent,
+                      oldShadowViewsForReparentings[tag],
+                      mutation.index));
             } else {
               filteredMutations.push_back(mutation);
             }
@@ -316,8 +341,9 @@ void LayoutAnimationsProxy::handleUpdatesAndEnterings(
           }
 
           auto oldView = *layoutAnimationIt->second.currentView;
-          filteredMutations.push_back(ShadowViewMutation::InsertMutation(
-              mutationParent, oldView, mutation.index));
+          filteredMutations.push_back(
+              ShadowViewMutation::InsertMutation(
+                  mutationParent, oldView, mutation.index));
           continue;
         }
 
@@ -336,8 +362,9 @@ void LayoutAnimationsProxy::handleUpdatesAndEnterings(
         std::shared_ptr<ShadowView> newView =
             cloneViewWithoutOpacity(mutation, propsParserContext);
 
-        filteredMutations.push_back(ShadowViewMutation::UpdateMutation(
-            mutation.newChildShadowView, *newView, mutationParent));
+        filteredMutations.push_back(
+            ShadowViewMutation::UpdateMutation(
+                mutation.newChildShadowView, *newView, mutationParent));
         break;
       }
 
@@ -394,15 +421,16 @@ void LayoutAnimationsProxy::addOngoingAnimations(
     newView->props = updateValues.newProps;
     updateLayoutMetrics(newView->layoutMetrics, updateValues.frame);
 
-    mutations.push_back(ShadowViewMutation::UpdateMutation(
-        *layoutAnimation.currentView,
-        *newView,
+    mutations.push_back(
+        ShadowViewMutation::UpdateMutation(
+            *layoutAnimation.currentView,
+            *newView,
 #if REACT_NATIVE_MINOR_VERSION >= 78
-        layoutAnimation.parentTag
+            layoutAnimation.parentTag
 #else
-        *layoutAnimation.parentView
+            *layoutAnimation.parentView
 #endif // REACT_NATIVE_MINOR_VERSION >= 78
-        ));
+            ));
     layoutAnimation.currentView = newView;
   }
   updateMap.clear();
@@ -471,9 +499,21 @@ bool LayoutAnimationsProxy::startAnimationsRecursively(
   if (isRNSScreen(node)) {
     isScreenPop = true;
   }
+  
+
 
   shouldAnimate = !isScreenPop &&
-      layoutAnimationsManager_->shouldAnimateExiting(node->tag, shouldAnimate);
+      layoutAnimationsManager_->shouldAnimateExitingForSubtree(
+          node, shouldAnimate);
+          
+            LOG(INFO) << "Process node tag " << node->tag << " with parent " << node->parent->tag << " and children:";
+   for (auto it = node->unflattenedChildren.rbegin();
+       it != node->unflattenedChildren.rend();
+       it++) {
+    auto &subNode = *it;
+    LOG(INFO) << "> " << subNode->tag << " parent " << subNode->parent->tag;
+  }
+  LOG(INFO) << "and shouldAnimate? " << shouldAnimate;
 
   bool hasExitAnimation = shouldAnimate &&
       layoutAnimationsManager_->hasLayoutAnimation(
@@ -525,8 +565,9 @@ bool LayoutAnimationsProxy::startAnimationsRecursively(
 #ifdef LAYOUT_ANIMATIONS_LOGS
       LOG(INFO) << "delete " << subNode->tag << std::endl;
 #endif
-      mutations.push_back(ShadowViewMutation::DeleteMutation(
-          subNode->mutation.oldChildShadowView));
+      mutations.push_back(
+          ShadowViewMutation::DeleteMutation(
+              subNode->mutation.oldChildShadowView));
     } else {
       subNode->state = WAITING;
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
-
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowView.h>
 
@@ -10,8 +8,12 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <jsi/jsi.h>
 
 namespace reanimated {
+
+using namespace facebook;
+using namespace react;
 
 struct Rect {
   double width, height;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -48,12 +48,14 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>()),
-      cssTransitionsRegistry_(std::make_shared<CSSTransitionsRegistry>(
-          staticPropsRegistry_,
-          getAnimationTimestamp_)),
-      viewStylesRepository_(std::make_shared<ViewStylesRepository>(
-          staticPropsRegistry_,
-          animatedPropsRegistry_)),
+      cssTransitionsRegistry_(
+          std::make_shared<CSSTransitionsRegistry>(
+              staticPropsRegistry_,
+              getAnimationTimestamp_)),
+      viewStylesRepository_(
+          std::make_shared<ViewStylesRepository>(
+              staticPropsRegistry_,
+              animatedPropsRegistry_)),
       subscribeForKeyboardEventsFunction_(
           platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(
@@ -284,9 +286,10 @@ std::string ReanimatedModuleProxy::obtainPropFromShadowNode(
     }
   }
 
-  throw std::runtime_error(std::string(
-      "Getting property `" + propName +
-      "` with function `getViewProp` is not supported"));
+  throw std::runtime_error(
+      std::string(
+          "Getting property `" + propName +
+          "` with function `getViewProp` is not supported"));
 }
 
 jsi::Value ReanimatedModuleProxy::getViewProp(
@@ -363,12 +366,12 @@ jsi::Value ReanimatedModuleProxy::configureLayoutAnimationBatch(
   return jsi::Value::undefined();
 }
 
-void ReanimatedModuleProxy::setShouldAnimateExiting(
+void ReanimatedModuleProxy::setShouldAnimateExitingForSubtree(
     jsi::Runtime &rt,
-    const jsi::Value &viewTag,
+    const jsi::Value &rootTag,
     const jsi::Value &shouldAnimate) {
-  layoutAnimationsManager_->setShouldAnimateExiting(
-      viewTag.asNumber(), shouldAnimate.getBool());
+  layoutAnimationsManager_->setShouldAnimateExitingForSubtree(
+      rootTag.asNumber(), shouldAnimate.getBool());
 }
 
 bool ReanimatedModuleProxy::isAnyHandlerWaitingForEvent(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -82,9 +82,9 @@ class ReanimatedModuleProxy
   jsi::Value configureLayoutAnimationBatch(
       jsi::Runtime &rt,
       const jsi::Value &layoutAnimationsBatch) override;
-  void setShouldAnimateExiting(
+  void setShouldAnimateExitingForSubtree(
       jsi::Runtime &rt,
-      const jsi::Value &viewTag,
+      const jsi::Value &rootTag,
       const jsi::Value &shouldAnimate) override;
 
   void onRender(double timestampMs);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -101,13 +101,14 @@ static jsi::Value REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)(
       ->configureLayoutAnimationBatch(rt, std::move(args[0]));
 }
 
-static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)(
+static jsi::Value REANIMATED_SPEC_PREFIX(setShouldAnimateExitingForSubtree)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
     size_t) {
   static_cast<ReanimatedModuleProxySpec *>(&turboModule)
-      ->setShouldAnimateExiting(rt, std::move(args[0]), std::move(args[1]));
+      ->setShouldAnimateExitingForSubtree(
+          rt, std::move(args[0]), std::move(args[1]));
   return jsi::Value::undefined();
 }
 
@@ -234,8 +235,8 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
 
   methodMap_["configureLayoutAnimationBatch"] =
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(configureLayoutAnimationBatch)};
-  methodMap_["setShouldAnimateExitingForTag"] =
-      MethodMetadata{2, REANIMATED_SPEC_PREFIX(setShouldAnimateExiting)};
+  methodMap_["setShouldAnimateExitingForSubtree"] = MethodMetadata{
+      2, REANIMATED_SPEC_PREFIX(setShouldAnimateExitingForSubtree)};
 
   methodMap_["setViewStyle"] =
       MethodMetadata{2, REANIMATED_SPEC_PREFIX(setViewStyle)};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -67,9 +67,9 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &layoutAnimationsBatch) = 0;
 
-  virtual void setShouldAnimateExiting(
+  virtual void setShouldAnimateExitingForSubtree(
       jsi::Runtime &rt,
-      const jsi::Value &viewTag,
+      const jsi::Value &rootTag,
       const jsi::Value &shouldAnimate) = 0;
 
   // JS View style

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -155,9 +155,9 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     );
   }
 
-  setShouldAnimateExitingForTag(viewTag: number, shouldAnimate: boolean) {
-    this.#reanimatedModuleProxy.setShouldAnimateExitingForTag(
-      viewTag,
+  setShouldAnimateExitingForSubtree(rootTag: number, shouldAnimate: boolean) {
+    this.#reanimatedModuleProxy.setShouldAnimateExitingForSubtree(
+      rootTag,
       shouldAnimate
     );
   }
@@ -246,7 +246,7 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
 
 class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
   configureLayoutAnimationBatch(): void {}
-  setShouldAnimateExitingForTag(): void {}
+  setShouldAnimateExitingForSubtree(): void {}
   registerJSProps(): void {}
   subscribeForKeyboardEvents(): number {
     return -1;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -62,7 +62,7 @@ class JSReanimated implements IReanimatedModule {
     // no-op
   }
 
-  setShouldAnimateExitingForTag() {
+  setShouldAnimateExitingForSubtree() {
     // no-op
   }
 

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -54,7 +54,10 @@ export interface ReanimatedModuleProxy {
     layoutAnimationsBatch: LayoutAnimationBatchItem[]
   ): void;
 
-  setShouldAnimateExitingForTag(viewTag: number, shouldAnimate: boolean): void;
+  setShouldAnimateExitingForSubtree(
+    rootTag: number,
+    shouldAnimate: boolean
+  ): void;
 
   setViewStyle(viewTag: number, style: StyleProps): void;
 

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -70,10 +70,23 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
     }
   }
 
-  componentWillUnmount(): void {
-    if (this.props.skipExiting !== undefined) {
+  componentDidMount(): void {
+    if (this.props.skipExiting) {
       this.setShouldAnimateExiting();
     }
+  }
+
+  shouldComponentUpdate(
+    nextProps: Readonly<LayoutAnimationConfigProps>
+  ): boolean {
+    if (nextProps.skipExiting !== this.props.skipExiting) {
+      this.setShouldAnimateExiting();
+    }
+
+    return (
+      nextProps.skipExiting !== this.props.skipExiting ||
+      nextProps.skipEntering !== this.props.skipEntering
+    );
   }
 
   render(): ReactNode {

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -61,18 +61,18 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
       : this.props.children;
   }
 
-  setShouldAnimateExiting() {
+  setShouldAnimateExiting(shouldAnimate: boolean) {
     if (Children.count(this.props.children) === 1) {
       const tag = findNodeHandle(this);
       if (tag) {
-        setShouldAnimateExitingForTag(tag, !this.props.skipExiting);
+        setShouldAnimateExitingForTag(tag, shouldAnimate);
       }
     }
   }
 
   componentDidMount(): void {
     if (this.props.skipExiting) {
-      this.setShouldAnimateExiting();
+      this.setShouldAnimateExiting(false);
     }
   }
 
@@ -80,7 +80,7 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
     nextProps: Readonly<LayoutAnimationConfigProps>
   ): boolean {
     if (nextProps.skipExiting !== this.props.skipExiting) {
-      this.setShouldAnimateExiting();
+      this.setShouldAnimateExiting(!nextProps.skipExiting);
     }
 
     return true;

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -83,10 +83,7 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
       this.setShouldAnimateExiting();
     }
 
-    return (
-      nextProps.skipExiting !== this.props.skipExiting ||
-      nextProps.skipEntering !== this.props.skipEntering
-    );
+    return true;
   }
 
   render(): ReactNode {

--- a/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
+++ b/packages/react-native-reanimated/src/component/LayoutAnimationConfig.tsx
@@ -8,8 +8,9 @@ import React, {
   useRef,
 } from 'react';
 
-import { setShouldAnimateExitingForTag } from '../core';
+import { setShouldAnimateExitingForSubtree } from '../core';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
+import { View } from 'react-native';
 
 export const SkipEnteringContext =
   createContext<React.RefObject<boolean> | null>(null);
@@ -53,19 +54,12 @@ function SkipEntering(props: { shouldSkip: boolean; children: ReactNode }) {
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-animation-config/
  */
 export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps> {
-  getMaybeWrappedChildren() {
-    return Children.count(this.props.children) > 1 && this.props.skipExiting
-      ? Children.map(this.props.children, (child) => (
-          <LayoutAnimationConfig skipExiting>{child}</LayoutAnimationConfig>
-        ))
-      : this.props.children;
-  }
-
   setShouldAnimateExiting(shouldAnimate: boolean) {
     if (Children.count(this.props.children) === 1) {
-      const tag = findNodeHandle(this);
-      if (tag) {
-        setShouldAnimateExitingForTag(tag, shouldAnimate);
+      const rootTag = findNodeHandle(this);
+      console.log('rootTag', rootTag);
+      if (rootTag) {
+        setShouldAnimateExitingForSubtree(rootTag, shouldAnimate);
       }
     }
   }
@@ -87,15 +81,19 @@ export class LayoutAnimationConfig extends Component<LayoutAnimationConfigProps>
   }
 
   render(): ReactNode {
-    const children = this.getMaybeWrappedChildren();
-
     if (this.props.skipEntering === undefined) {
-      return children;
+      return (
+        <View style={{ backgroundColor: 'blue', padding: 10 }}>
+          {this.props.children}
+        </View>
+      );
     }
 
     return (
       <SkipEntering shouldSkip={this.props.skipEntering}>
-        {children}
+        <View style={{ backgroundColor: 'blue', padding: 10 }}>
+          {this.props.children}
+        </View>
       </SkipEntering>
     );
   }

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -191,12 +191,12 @@ export function configureLayoutAnimationBatch(
   ReanimatedModule.configureLayoutAnimationBatch(layoutAnimationsBatch);
 }
 
-export function setShouldAnimateExitingForTag(
-  viewTag: number | HTMLElement,
+export function setShouldAnimateExitingForSubtree(
+  rootTag: number | HTMLElement,
   shouldAnimate: boolean
 ) {
-  ReanimatedModule.setShouldAnimateExitingForTag(
-    viewTag as number,
+  ReanimatedModule.setShouldAnimateExitingForSubtree(
+    rootTag as number,
     shouldAnimate
   );
 }

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -84,6 +84,7 @@ export default class AnimatedComponent<
 
       const viewInfo = getViewInfo(hostInstance);
       viewTag = viewInfo.viewTag ?? -1;
+      console.log('viewTag', viewTag);
       shadowNodeWrapper = getShadowNodeWrapperFromRef(this, hostInstance);
     }
     this._viewInfo = { viewTag, shadowNodeWrapper };


### PR DESCRIPTION
## Summary

### Issue description

For some reason, `componentWillUnmount` was called too late on android and the `ShadowNode` removal mutation triggered the exiting layout animation before the `componentWillUnmount` was called. Since we used `componentWillUnmount` to disable exiting animations for `LayoutAnimationConfig`s on which the `skipExiting` prop was used, the disabled flag was set in CPP layout animations config object after the exiting animation started.

### How it was fixed?

The fix is not perfect, but I think that it is sufficient, at least for most cases, because people don't usually modify `skipExiting` prop at all.

Instead of waiting until the component unmounts, I mark exiting animations as disabled just after the component mounts (only if `skipExiting` is set to `true`) and then update it every time that the `skipExiting` value changes. In most cases it doesn't change at all, so in effect I set the `skipExiting` value in CPP only once.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/432ee396-5b57-430a-bba9-e4ece460c733" /> | <video src="https://github.com/user-attachments/assets/5fb96cc2-044c-4d55-b239-410b06aa2165" /> |

## Test plan

Copy this code and paste to the `EmptyExample` to see how it works.

<details>
<summary>Code snippet</summary>

```tsx
import { useEffect, useState } from 'react';
import { StyleSheet } from 'react-native';
import Animated, {
  FadeOut,
  LayoutAnimationConfig,
} from 'react-native-reanimated';

export default function App() {
  const [show, setShow] = useState(true);

  useEffect(() => {
    setTimeout(() => {
      setShow(false);
    }, 1000);
  }, []);

  return (
    show && (
      <LayoutAnimationConfig skipEntering skipExiting>
        <Animated.View exiting={FadeOut} style={styles.box} />
      </LayoutAnimationConfig>
    )
  );
}

const styles = StyleSheet.create({
  box: {
    width: 200,
    height: 200,
    backgroundColor: 'red',
  },
});
```
</details>