### PR TITLE
fix: 

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -8,6 +8,7 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowView.h>
+#include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
 #include <string>
@@ -43,17 +44,20 @@ struct LayoutAnimationsProxy
   mutable std::unordered_set<std::shared_ptr<MutationNode>> deadNodes;
   mutable std::unordered_map<Tag, int> leastRemoved;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
+  std::shared_ptr<UIManager> uiManager_;
   ContextContainer::Shared contextContainer_;
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   jsi::Runtime &uiRuntime_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
   LayoutAnimationsProxy(
       std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager,
+      std::shared_ptr<UIManager> uiManager,
       SharedComponentDescriptorRegistry componentDescriptorRegistry,
       ContextContainer::Shared contextContainer,
       jsi::Runtime &uiRuntime,
       const std::shared_ptr<UIScheduler> uiScheduler)
       : layoutAnimationsManager_(layoutAnimationsManager),
+        uiManager_(uiManager),
         contextContainer_(contextContainer),
         componentDescriptorRegistry_(componentDescriptorRegistry),
         uiRuntime_(uiRuntime),

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
@@ -21,12 +21,12 @@ void SurfaceManager::updateWindow(
   windows_.insert_or_assign(surfaceId, Rect{windowWidth, windowHeight});
 }
 
+bool SurfaceManager::hasWindow(SurfaceId surfaceId) {
+  return windows_.find(surfaceId) != windows_.end();
+}
+
 Rect SurfaceManager::getWindow(SurfaceId surfaceId) {
-  auto windowIt = windows_.find(surfaceId);
-  if (windowIt != windows_.end()) {
-    return windowIt->second;
-  }
-  return Rect{0, 0};
+  return hasWindow(surfaceId) ? windows_[surfaceId] : Rect{0, 0};
 }
 
 void Node::applyMutationToIndices(ShadowViewMutation mutation) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.h
@@ -113,6 +113,7 @@ struct SurfaceManager {
   std::unordered_map<Tag, UpdateValues> &getUpdateMap(SurfaceId surfaceId);
   void
   updateWindow(SurfaceId surfaceId, double windowWidth, double windowHeight);
+  bool hasWindow(SurfaceId surfaceId);
   Rect getWindow(SurfaceId surfaceId);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -959,6 +959,7 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
   if (componentDescriptorRegistry) {
     layoutAnimationsProxy_ = std::make_shared<LayoutAnimationsProxy>(
         layoutAnimationsManager_,
+        uiManager_,
         componentDescriptorRegistry,
         scheduler->getContextContainer(),
         workletsModuleProxy_->getUIWorkletRuntime()->getJSIRuntime(),


### PR DESCRIPTION
## Summary



## Test plan

Paste the following code in the `apps/common-app/src/App.tsx` file to make sure that it is the only one component rendered on the screen and Reanimated won't be initialized because of other calls to `ReanimatedModule` methods.

<details>
<summary>Code snippet</summary>

```tsx

```
</details>
