### PR TITLE
Remove unnecessary `registerJSProps` for `G` component from react-native-svg in ThirdPartyComponentsExample

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ThirdPartyComponentsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ThirdPartyComponentsExample.tsx
@@ -4,7 +4,6 @@ import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   Easing,
   interpolateColor,
-  registerJSProps,
   useAnimatedProps,
   useSharedValue,
   withRepeat,
@@ -109,13 +108,12 @@ function SvgPathDemo({ sv }: { sv: SharedValue<number> }) {
 
 const AnimatedG = Animated.createAnimatedComponent(G);
 
-registerJSProps('RNSVGGroup', ['x', 'y']);
-
 function SvgGDemo({ sv }: { sv: SharedValue<number> }) {
   const animatedProps = useAnimatedProps(() => {
     return {
       x: sv.value * 200,
       y: Math.sin(sv.value * Math.PI) * 200,
+      opacity: sv.value,
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Turns out `x` and `y` props of `G` component from `react-native-svg` can be animated as native props.

Thanks @jakex7 for finding that out!

## Test plan
