### PR TITLE
chore(Worklets): add missing codegen for iOS experimental bundling

### DIFF
--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -131,6 +131,13 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.swmansion.worklets"
+    },
+    "ios": {
+      "modulesConformingToProtocol": {
+        "RCTBundleConsumer": [
+          "WorkletsModule"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

It was added in https://github.com/software-mansion/react-native-reanimated/pull/7644 but I forgot about it in https://github.com/software-mansion/react-native-reanimated/pull/7657.

Without it experimental bundling won't work on iOS.

## Test plan

This codegen field has no effect with `experimentalBundling` disabled.
