### PR TITLE
fix: Quick fix for getSnapshotBeforeUpdate error

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -359,6 +359,7 @@ export default class AnimatedComponent
     if (IS_WEB && this.props.layout) {
       return this._componentDOMRef?.getBoundingClientRect?.();
     }
+    return null;
   }
 
   render() {

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -356,9 +356,14 @@ export default class AnimatedComponent
   // It is called before the component gets rerendered. This way we can access components' position before it changed
   // and later on, in componentDidUpdate, calculate translation for layout transition.
   getSnapshotBeforeUpdate() {
-    if (IS_WEB && this.props.layout) {
-      return this._componentDOMRef?.getBoundingClientRect?.();
+    if (
+      IS_WEB &&
+      this.props.layout &&
+      this._componentDOMRef?.getBoundingClientRect
+    ) {
+      return this._componentDOMRef.getBoundingClientRect();
     }
+
     return null;
   }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -364,6 +364,7 @@ export default class AnimatedComponent
       return this._componentDOMRef.getBoundingClientRect();
     }
 
+    // `getSnapshotBeforeUpdate` has to return value which is not `undefined`.
     return null;
   }
 


### PR DESCRIPTION
## Summary

Just a fix for an error shown when any animated component was rendered.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/efd41da1-5076-4f57-a3ab-9ada738655f5" /> | <video src="https://github.com/user-attachments/assets/a38957bf-fabb-4813-bc62-19b171f6ad57" /> | 
