### PR TITLE
feat(Worklets): improve errors in Worklets Babel Plugin

### DIFF
--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1696,7 +1696,10 @@ module.exports = function WorkletsBabelPlugin() {
     try {
       fun();
     } catch (e) {
-      throw new Error(`[Worklets] Babel plugin exception: ${e}`);
+      const error = e;
+      error.message = `[Worklets] Babel plugin exception: ${error.message}`;
+      error.name = "WorkletsBabelPluginError";
+      throw error;
     }
   }
   return {

--- a/packages/react-native-worklets/plugin/src/plugin.ts
+++ b/packages/react-native-worklets/plugin/src/plugin.ts
@@ -26,7 +26,10 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
     try {
       fun();
     } catch (e) {
-      throw new Error(`[Worklets] Babel plugin exception: ${e as string}`);
+      const error = e as Error;
+      error.message = `[Worklets] Babel plugin exception: ${error.message}`;
+      error.name = 'WorkletsBabelPluginError';
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

QoL change that makes it so we don't replace the stack traces and get an actually informative error.

Before:
![Screenshot 2025-06-25 at 18 09 03](https://github.com/user-attachments/assets/2ef9abf4-27f7-44eb-91e5-114011a5809e)

After:
![Screenshot 2025-06-25 at 18 07 08](https://github.com/user-attachments/assets/fa5b6c5f-a256-42e5-bb1d-b72139835683)

## Test plan

CI
