### PR TITLE
fix: Not working window size dependent layout animations

### DIFF
--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -16,7 +16,6 @@ import type {
   WorkletFunction,
 } from './commonTypes';
 import { ReanimatedError } from './errors';
-import { initializeUIRuntime } from './initializers';
 import { isFabric, shouldBeUseWeb } from './PlatformChecker';
 import { ReanimatedModule } from './ReanimatedModule';
 import { SensorContainer } from './SensorContainer';
@@ -169,8 +168,6 @@ export function unregisterSensor(sensorId: number): void {
   const sensorContainer = getSensorContainer();
   return sensorContainer.unregisterSensor(sensorId);
 }
-
-initializeUIRuntime(ReanimatedModule);
 
 type FeaturesConfig = {
   enableLayoutAnimations: boolean;

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -3,6 +3,10 @@
 import './publicGlobals';
 
 import * as Animated from './Animated';
+import { initializeUIRuntime } from './initializers';
+import { ReanimatedModule } from './ReanimatedModule';
+
+initializeUIRuntime(ReanimatedModule);
 
 export default Animated;
 


### PR DESCRIPTION
## Summary

Similar fix to #7681 that fixes the same issue. I just moved reanimated initialization to the `index.ts` file to ensure that it is initialized before anything from reanimated is used.