### PR TITLE
chore: Add reanimatedMajorVersion variable instead of isReanimated3

### DIFF
--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -33,8 +33,20 @@ export {
 
 const EDGE_TO_EDGE = isEdgeToEdge();
 
-/** @returns `true` in Reanimated 3, doesn't exist in Reanimated 2 or 1 */
-export const isReanimated3 = () => true;
+/**
+ * @deprecated Please use the exported variable `reanimatedMajorVersion`
+ *   instead.
+ * @returns `true` in Reanimated 3, doesn't exist in Reanimated 2 or 1
+ */
+export const isReanimated3 = () => {
+  logger.warn(
+    'The `isReanimated3` function is deprecated. Please use the exported variable `reanimatedMajorVersion` instead.'
+  );
+  return true;
+};
+
+/** @returns Reanimated major version, doesn't exist before Reanimated 4 */
+export const reanimatedMajorVersion = 4;
 
 // Superseded by check in `/src/threads.ts`.
 // Used by `react-navigation` to detect if using Reanimated 2 or 3.

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -95,6 +95,7 @@ export {
   isReanimated3,
   makeMutable,
   makeShareableCloneRecursive,
+  reanimatedMajorVersion,
   runOnJS,
   runOnRuntime,
   runOnUI,

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -312,6 +312,12 @@ const core = {
   makeMutable: ID,
   makeShareableCloneRecursive: ID,
   isReanimated3: () => true,
+  get reanimatedMajorVersion() {
+    logger.warn(
+      '[reanimated] The core.reanimatedMajorVersion property is deprecated. Please use the exported variable reanimatedMajorVersion instead.'
+    );
+    return 4;
+  },
   // isConfigured: ADD ME IF NEEDED
   enableLayoutAnimations: NOOP,
   // getViewProp: ADD ME IF NEEDED


### PR DESCRIPTION
## Summary

This PR adds more future-proof check for the reanimated version and deprecates the old `isReanimated3` check.