### PR TITLE
docs: update aRef typing description to animatedRef in getRelativeCoords page

### DIFF
--- a/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/packages/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -26,7 +26,7 @@ const Comp = () => {
   });
 
   return (
-    <View ref={aref}>
+    <View ref={animatedRef}>
       <PanGestureHandler onGestureEvent={gestureHandler}>
         <Animated.View style={[styles.box]} />
       </PanGestureHandler>

--- a/packages/docs-reanimated/versioned_docs/version-3.x/utilities/getRelativeCoords.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/utilities/getRelativeCoords.mdx
@@ -26,7 +26,7 @@ const Comp = () => {
   });
 
   return (
-    <View ref={aref}>
+    <View ref={animatedRef}>
       <PanGestureHandler onGestureEvent={gestureHandler}>
         <Animated.View style={[styles.box]} />
       </PanGestureHandler>


### PR DESCRIPTION
## Summary

This PR fixes a typing mistake in the `getRelativeCoords` page.

The `aRef` variable was brought over from a previous v2 implementation, but its type was not updated correctly. This PR updates the type to `animatedRef`, which aligns with the current Reanimated v3 usage.


## Test plan
No changes in functionality.
