### PR TITLE
Update react-native-is-edge-to-edge to 1.2.1

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -85,7 +85,7 @@
   },
   "homepage": "https://docs.swmansion.com/react-native-reanimated",
   "dependencies": {
-    "react-native-is-edge-to-edge": "1.1.7",
+    "react-native-is-edge-to-edge": "^1.2.1",
     "semver": "7.7.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20136,13 +20136,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:1.1.7":
-  version: 1.1.7
-  resolution: "react-native-is-edge-to-edge@npm:1.1.7"
+"react-native-is-edge-to-edge@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "react-native-is-edge-to-edge@npm:1.2.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/4cdf2b2fb5b131f2015c26d2cb7688b4a0c5f3c8474b1bf0ddfa9eabb0263df440c87262ae8f812a6ecab0d5310df0373bddad4b51f53dabb2ffee01e9ef0f44
+  checksum: 10/8fb6d8ab7b953c7d7cec8c987cef24f1c5348a293a85cb49c7c53b54ef110c0ca746736ae730e297603c8c76020df912e93915fb17518c4f2f91143757177aba
   languageName: node
   linkType: hard
 
@@ -20311,7 +20311,7 @@ __metadata:
     react-native: "patch:react-native@npm%3A0.80.0#~/.yarn/patches/react-native-npm-0.80.0-dababd395b.patch"
     react-native-builder-bob: "patch:react-native-builder-bob@npm%3A0.33.1#~/.yarn/patches/react-native-builder-bob-npm-0.33.1-383d9e23a5.patch"
     react-native-gesture-handler: "npm:2.26.0"
-    react-native-is-edge-to-edge: "npm:1.1.7"
+    react-native-is-edge-to-edge: "npm:^1.2.1"
     react-native-web: "npm:0.20.0"
     react-native-worklets: "workspace:*"
     react-test-renderer: "npm:19.1.0"


### PR DESCRIPTION
## Summary

This PR updates `react-native-is-edge-to-edge` to the latest version: `1.2.1`.

As `edgeToEdgeEnabled` will be available in the next React Native release (https://github.com/facebook/react-native/pull/52088), we need a new release of `react-native-reanimated`, as it uses a fixed version of the dependency for the moment.

To prevent this kind of issue, if it must happens again, I removed the strict requirement on the version number (for reference, `react-native-screens` doesn't fix the version https://github.com/software-mansion/react-native-screens/blob/62eb784c6457be366a2daf6d6d074b7a586fa61e/package.json#L72)
