### PR TITLE
chore: Optimize css keyframes registration in the keyframes registry

### DIFF
--- a/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.ts
@@ -115,7 +115,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
       createSingleCSSAnimationProperties(animationProperties);
 
     const processedAnimations = singleAnimationPropertiesArray.map(
-      (properties, i) => {
+      (properties) => {
         const keyframes = properties.animationName;
         let keyframesRule: CSSKeyframesRuleImpl;
 
@@ -125,22 +125,20 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
           // to preserve the same animation. If used inline, it will restart the animation
           // on every component re-render)
           keyframesRule = keyframes;
-        } else if (
-          this.attachedAnimations[i]?.keyframesRule.cssText !==
-          JSON.stringify(keyframes)
-        ) {
+        } else {
           // If the keyframes are not an instance of the CSSKeyframesRule class (e.g. someone
           // passes a keyframes object inline in the component's style without using css.keyframes()
           // function), we don't want to restart the animation on every component re-render.
-          // In this case, we need to compare the stringified keyframes of the old and the new
-          // animation configuration object to determine if the animation has changed.
-          keyframesRule = new CSSKeyframesRuleImpl(
-            keyframes as CSSAnimationKeyframes
-          );
-        } else {
-          // Otherwise, if keyframes are the same, we can just use the existing keyframes rule
-          // instance
-          keyframesRule = this.attachedAnimations[i]?.keyframesRule;
+          // In this case, we need to check if the animation with the same keyframes is already
+          // registered in the registry. If it is, we can just use the existing keyframes rule.
+          // Otherwise, we need to create a new keyframes rule.
+          const cssText = JSON.stringify(keyframes);
+          keyframesRule =
+            CSSAnimationsManager.animationKeyframesRegistry.get(cssText) ??
+            new CSSKeyframesRuleImpl(
+              keyframes as CSSAnimationKeyframes,
+              cssText
+            );
         }
 
         return {

--- a/packages/react-native-reanimated/src/css/models/CSSKeyframesRule.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSKeyframesRule.ts
@@ -9,8 +9,8 @@ export default class CSSKeyframesRuleImpl<
 > extends CSSKeyframesRuleBase<S> {
   private normalizedKeyframes_: NormalizedCSSAnimationKeyframesConfig;
 
-  constructor(keyframes: CSSAnimationKeyframes<S>) {
-    super(keyframes);
+  constructor(keyframes: CSSAnimationKeyframes<S>, cssText?: string) {
+    super(keyframes, cssText);
     this.normalizedKeyframes_ = normalizeAnimationKeyframes(keyframes);
   }
 

--- a/packages/react-native-reanimated/src/css/models/CSSKeyframesRuleBase.ts
+++ b/packages/react-native-reanimated/src/css/models/CSSKeyframesRuleBase.ts
@@ -17,9 +17,9 @@ export default abstract class CSSKeyframesRuleBase<S extends PlainStyle>
   private readonly length_: number;
   private readonly name_: string;
 
-  constructor(keyframes: CSSAnimationKeyframes<S>) {
+  constructor(keyframes: CSSAnimationKeyframes<S>, cssText?: string) {
     this.cssRules_ = keyframes;
-    this.cssText_ = JSON.stringify(keyframes);
+    this.cssText_ = cssText ?? JSON.stringify(keyframes);
     this.length_ = Object.keys(keyframes).length;
     this.name_ = CSSKeyframesRuleBase.generateNextKeyframeName();
   }


### PR DESCRIPTION
## Summary

This implementation brings a few optimizations related to the CSS keyframes registration:

1. Allows passing `cssText` (stringified keyframes) to the `CSSKeyframesRule` constructor to prevent converting keyframes object to string twice
2. Improves the JS side `CSSKeyframesRegistry` to allow keyframes selection by the `cssText` (useful for inline CSS keyframes - we can just reuse existing keyframes object from the registry if `cssText` matches)
3. Modifies the `CSSAnimationsManager` to check for inline keyframes existence in the `CSSKeyframesRegistry` by checking if the keyframes with the particular `cssText` exist in this registry instead of just comparing the current keyframes object with the previous one at the same index (the one in the previous CSS animation keyframes array passed to the view).
