### PR TITLE
chore: Change updateKeyframes to work with folly::dynamic instead of jsi::Value

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/CSSKeyframesConfig.cpp
@@ -10,7 +10,7 @@ std::shared_ptr<AnimationStyleInterpolator> getStyleInterpolator(
       std::make_shared<AnimationStyleInterpolator>(viewStylesRepository);
 
   const auto keyframes = config.getProperty(rt, "keyframesStyle");
-  styleInterpolator->updateKeyframes(rt, keyframes);
+  styleInterpolator->updateKeyframes(dynamicFromValue(rt, keyframes));
 
   return styleInterpolator;
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -27,9 +27,7 @@ class PropertyInterpolator {
   virtual bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const = 0;
 
-  virtual void updateKeyframes(
-      jsi::Runtime &rt,
-      const jsi::Value &keyframes) = 0;
+  virtual void updateKeyframes(const folly::dynamic &keyframes) = 0;
   virtual void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -31,16 +31,13 @@ bool ArrayPropertiesInterpolator::equalsReversingAdjustedStartValue(
 }
 
 void ArrayPropertiesInterpolator::updateKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
-  const jsi::Array keyframesArray = keyframes.asObject(rt).asArray(rt);
-  const size_t valuesCount = keyframesArray.size(rt);
+    const folly::dynamic &keyframes) {
+  const size_t valuesCount = keyframes.size();
 
   resizeInterpolators(valuesCount);
 
   for (size_t i = 0; i < valuesCount; ++i) {
-    interpolators_[i]->updateKeyframes(
-        rt, keyframesArray.getValueAtIndex(rt, i));
+    interpolators_[i]->updateKeyframes(keyframes[i]);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
@@ -19,7 +19,7 @@ class ArrayPropertiesInterpolator : public GroupPropertiesInterpolator {
   bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -20,23 +20,15 @@ bool RecordPropertiesInterpolator::equalsReversingAdjustedStartValue(
 }
 
 void RecordPropertiesInterpolator::updateKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
-  // TODO - maybe add a possibility to remove interpolators that are no longer
-  // used  (for now, for simplicity, we only add new ones)
-  const jsi::Object keyframesObject = keyframes.asObject(rt);
+    const folly::dynamic &keyframes) {
+  // TODO - maybe add a possibility to remove interpolators that are no
+  // longer used  (for now, for simplicity, we only add new ones)
+  for (const auto &item : keyframes.items()) {
+    const auto &propName = item.first.getString();
+    const auto &propValue = item.second;
 
-  jsi::Array propertyNames = keyframesObject.getPropertyNames(rt);
-  size_t propertiesCount = propertyNames.size(rt);
-
-  for (size_t i = 0; i < propertiesCount; ++i) {
-    const std::string propertyName =
-        propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const jsi::Value &propertyKeyframes = keyframesObject.getProperty(
-        rt, jsi::PropNameID::forUtf8(rt, propertyName));
-
-    maybeCreateInterpolator(propertyName);
-    interpolators_[propertyName]->updateKeyframes(rt, propertyKeyframes);
+    maybeCreateInterpolator(propName);
+    interpolators_[propName]->updateKeyframes(propValue);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
@@ -20,7 +20,7 @@ class RecordPropertiesInterpolator : public GroupPropertiesInterpolator {
   bool equalsReversingAdjustedStartValue(
       const folly::dynamic &propertyValue) const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.cpp
@@ -88,79 +88,6 @@ bool TransformOperation::isRelative() const {
   return false;
 }
 
-std::shared_ptr<TransformOperation> TransformOperation::fromJSIValue(
-    jsi::Runtime &rt,
-    const jsi::Value &value) {
-  if (!value.isObject()) {
-    throw std::invalid_argument(
-        "[Reanimated] TransformOperation must be an object.");
-  }
-
-  jsi::Object obj = value.asObject(rt);
-  auto propertyNames = obj.getPropertyNames(rt);
-
-  if (propertyNames.size(rt) != 1) {
-    throw std::invalid_argument(
-        "[Reanimated] TransformOperation must have exactly one property.");
-  }
-
-  const auto propertyName =
-      propertyNames.getValueAtIndex(rt, 0).asString(rt).utf8(rt);
-  const auto propertyValue =
-      obj.getProperty(rt, jsi::PropNameID::forUtf8(rt, propertyName));
-  TransformOperationType operationType =
-      getTransformOperationType(propertyName);
-
-  switch (operationType) {
-    case TransformOperationType::Perspective:
-      return std::make_shared<PerspectiveOperation>(propertyValue.asNumber());
-    case TransformOperationType::Rotate:
-      return std::make_shared<RotateOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateX:
-      return std::make_shared<RotateXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateY:
-      return std::make_shared<RotateYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::RotateZ:
-      return std::make_shared<RotateZOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::Scale:
-      return std::make_shared<ScaleOperation>(propertyValue.asNumber());
-    case TransformOperationType::ScaleX:
-      return std::make_shared<ScaleXOperation>(propertyValue.asNumber());
-    case TransformOperationType::ScaleY:
-      return std::make_shared<ScaleYOperation>(propertyValue.asNumber());
-    case TransformOperationType::TranslateX: {
-      if (propertyValue.isNumber()) {
-        return std::make_shared<TranslateXOperation>(propertyValue.asNumber());
-      }
-      return std::make_shared<TranslateXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    }
-    case TransformOperationType::TranslateY: {
-      if (propertyValue.isNumber()) {
-        return std::make_shared<TranslateYOperation>(propertyValue.asNumber());
-      }
-      return std::make_shared<TranslateYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    }
-    case TransformOperationType::SkewX:
-      return std::make_shared<SkewXOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::SkewY:
-      return std::make_shared<SkewYOperation>(
-          propertyValue.asString(rt).utf8(rt));
-    case TransformOperationType::Matrix:
-      return std::make_shared<MatrixOperation>(
-          TransformMatrix(rt, propertyValue));
-    default:
-      throw std::invalid_argument(
-          "[Reanimated] Unknown transform operation: " + propertyName);
-  }
-}
-
 std::shared_ptr<TransformOperation> TransformOperation::fromDynamic(
     const folly::dynamic &value) {
   if (!value.isObject()) {
@@ -549,7 +476,7 @@ bool MatrixOperation::operator==(const TransformOperation &other) const {
 folly::dynamic MatrixOperation::valueToDynamic() const {
   if (!std::holds_alternative<TransformMatrix>(value)) {
     throw std::invalid_argument(
-        "[Reanimated] Cannot convert unprocessed transform operations to the JSI value.");
+        "[Reanimated] Cannot convert unprocessed transform operations to the dynamic value.");
   }
   return std::get<TransformMatrix>(value).toDynamic();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperation.h
@@ -8,6 +8,7 @@
 
 #include <react/renderer/core/ShadowNode.h>
 
+#include <folly/dynamic.h>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -57,9 +58,6 @@ struct TransformOperation {
   virtual TransformOperationType type() const = 0;
   virtual bool isRelative() const;
 
-  static std::shared_ptr<TransformOperation> fromJSIValue(
-      jsi::Runtime &rt,
-      const jsi::Value &value);
   static std::shared_ptr<TransformOperation> fromDynamic(
       const folly::dynamic &value);
   folly::dynamic toDynamic() const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -44,7 +44,7 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
       const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
       const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
+  void updateKeyframes(const folly::dynamic &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,
@@ -57,9 +57,6 @@ class TransformsStyleInterpolator final : public PropertyInterpolator {
   std::vector<std::shared_ptr<TransformKeyframe>> keyframes_;
   std::optional<TransformOperations> reversingAdjustedStartValue_;
 
-  static std::optional<TransformOperations> parseTransformOperations(
-      jsi::Runtime &rt,
-      const jsi::Value &values);
   static std::optional<TransformOperations> parseTransformOperations(
       const folly::dynamic &values);
   std::shared_ptr<TransformKeyframe> createTransformKeyframe(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -74,17 +74,17 @@ class ValueInterpolator : public PropertyInterpolator {
     return reversingAdjustedStartValue_.value() == ValueType(propertyValue);
   }
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override {
-    const auto parsedKeyframes = parseJSIKeyframes(rt, keyframes);
+  void updateKeyframes(const folly::dynamic &keyframes) override {
+    const auto parsedKeyframes = parseDynamicKeyframes(keyframes);
 
     keyframes_.clear();
     keyframes_.reserve(parsedKeyframes.size());
 
     for (const auto &[offset, value] : parsedKeyframes) {
-      if (value.isUndefined()) {
+      if (value.isNull()) {
         keyframes_.push_back(KeyframeType{offset, std::nullopt});
       } else {
-        keyframes_.push_back(KeyframeType{offset, ValueType(rt, value)});
+        keyframes_.push_back(KeyframeType{offset, ValueType(value)});
       }
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.cpp
@@ -2,48 +2,36 @@
 
 namespace reanimated::css {
 
-std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes) {
-  if (!keyframes.isObject() || !keyframes.asObject(rt).isArray(rt)) {
+std::vector<std::pair<double, folly::dynamic>> parseDynamicKeyframes(
+    const folly::dynamic &keyframes) {
+  if (!keyframes.isArray()) {
     throw std::invalid_argument(
         "[Reanimated] Keyframes must be an array of keyframe objects");
   }
 
-  const auto keyframeArray = keyframes.asObject(rt).asArray(rt);
-  const auto keyframesCount = keyframeArray.size(rt);
+  const auto keyframesCount = keyframes.size();
+  const bool hasOffset0 = keyframes[0]["offset"].asDouble() == 0;
+  const bool hasOffset1 =
+      keyframes[keyframesCount - 1]["offset"].asDouble() == 1;
 
-  const auto getKeyframeAtIndexOffset = [&](size_t index) -> double {
-    return keyframeArray.getValueAtIndex(rt, index)
-        .asObject(rt)
-        .getProperty(rt, "offset")
-        .asNumber();
-  };
-
-  const bool hasOffset0 = getKeyframeAtIndexOffset(0) == 0;
-  const bool hasOffset1 = getKeyframeAtIndexOffset(keyframesCount - 1) == 1;
-
-  std::vector<std::pair<double, jsi::Value>> result;
+  std::vector<std::pair<double, folly::dynamic>> result;
   result.reserve(keyframesCount + (hasOffset0 ? 0 : 1) + (hasOffset1 ? 0 : 1));
 
   // Insert the keyframe without value at offset 0 if it is not present
   if (!hasOffset0) {
-    result.emplace_back(0.0, jsi::Value::undefined());
+    result.emplace_back(0.0, folly::dynamic());
   }
 
   // Insert all provided keyframes
   for (size_t i = 0; i < keyframesCount; ++i) {
-    jsi::Object keyframeObject =
-        keyframeArray.getValueAtIndex(rt, i).asObject(rt);
-    double offset = keyframeObject.getProperty(rt, "offset").asNumber();
-    jsi::Value value = keyframeObject.getProperty(rt, "value");
-
-    result.emplace_back(offset, std::move(value));
+    const auto &keyframeObject = keyframes[i];
+    double offset = keyframeObject["offset"].asDouble();
+    result.emplace_back(offset, std::move(keyframeObject["value"]));
   }
 
   // Insert the keyframe without value at offset 1 if it is not present
   if (!hasOffset1) {
-    result.emplace_back(1.0, jsi::Value::undefined());
+    result.emplace_back(1.0, folly::dynamic());
   }
 
   return result;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/util/keyframes.h
@@ -1,15 +1,12 @@
 #pragma once
 
-#include <jsi/jsi.h>
+#include <folly/dynamic.h>
 #include <utility>
 #include <vector>
 
 namespace reanimated::css {
 
-using namespace facebook;
-
-std::vector<std::pair<double, jsi::Value>> parseJSIKeyframes(
-    jsi::Runtime &rt,
-    const jsi::Value &keyframes);
+std::vector<std::pair<double, folly::dynamic>> parseDynamicKeyframes(
+    const folly::dynamic &keyframes);
 
 } // namespace reanimated::css


### PR DESCRIPTION
## Summary

This PR is necessary to add support for component-specific interpolators. I would have to store keyframes config object as a `folly::dynamic` instead of creating the style interpolator right away, because I cannot determine on which component type the animation will be attached.

Only after attaching the animation to the view, I can pick the right interpolators config object and create the style interpolator from the persisted keyframes (I cannot persist a `jsi::Value`, so that's why I need this change to `folly::dynamic`).

This PR is a part of PRs set that will add support for CSS animations used on `react-native-svg` components.