### PR TITLE
chore: move publicGlobals

### DIFF
--- a/packages/react-native-reanimated/src/publicGlobals.ts
+++ b/packages/react-native-reanimated/src/publicGlobals.ts
@@ -1,27 +1,5 @@
 'use strict';
 
-/* eslint-disable reanimated/use-global-this */
 export {};
 
-declare global {
-  /**
-   * This global variable is a diagnostic/development tool.
-   *
-   * It is `true` on the UI thread and `false` on the JS thread.
-   *
-   * It used to be necessary in the past for some of the functionalities of
-   * react-native-reanimated to work properly but it's no longer the case. Your
-   * code shouldn't depend on it, we keep it here mainly for backward
-   * compatibility for our users.
-   */
-  var _WORKLET: boolean | undefined;
-
-  /**
-   * This ArrayBuffer contains the memory address of `jsi::Runtime` which is the
-   * Reanimated UI runtime.
-   */
-  var _WORKLET_RUNTIME: ArrayBuffer;
-
-  /** @deprecated Don't use. */
-  var _IS_FABRIC: boolean | undefined;
-}
+declare global {}

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import './publicGlobals';
+
 import { init } from './initializers';
 import { experimentalBundlingInit } from './workletRuntimeEntry';
 

--- a/packages/react-native-worklets/src/publicGlobals.ts
+++ b/packages/react-native-worklets/src/publicGlobals.ts
@@ -1,0 +1,26 @@
+'use strict';
+/* eslint-disable reanimated/use-global-this */
+export {};
+
+declare global {
+  /**
+   * This global variable is a diagnostic/development tool.
+   *
+   * It is `true` on the UI thread and `false` on the JS thread.
+   *
+   * It used to be necessary in the past for some of the functionalities of
+   * react-native-reanimated to work properly but it's no longer the case. Your
+   * code shouldn't depend on it, we keep it here mainly for backward
+   * compatibility for our users.
+   */
+  var _WORKLET: boolean | undefined;
+
+  /**
+   * This ArrayBuffer contains the memory address of `jsi::Runtime` which is the
+   * Reanimated UI runtime.
+   */
+  var _WORKLET_RUNTIME: ArrayBuffer;
+
+  /** @deprecated Don't use. */
+  var _IS_FABRIC: boolean | undefined;
+}


### PR DESCRIPTION
## Summary

These globals are defined by Worklets so it makes sense to move them.

I retained the `publicGlobals.ts` file in Reanimated in case we need it in the future.

## Test plan

🚀 
