### PR TITLE
Fix zombie view when parent is moved

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/MoveWithExiting.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/MoveWithExiting.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+
+import Animated, { FadeOut } from 'react-native-reanimated';
+
+export default function MoveWithExiting() {
+  const [collapsable, setCollapsable] = React.useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Toggle Collapsable"
+        onPress={() => setCollapsable(!collapsable)}
+      />
+      <View
+        collapsable={collapsable}
+        style={{
+          width: 200,
+          height: 200,
+          backgroundColor: collapsable ? 'transparent' : 'red',
+        }}>
+        <Animated.View
+          exiting={FadeOut}
+          style={{ width: 100, height: 100, backgroundColor: 'blue' }}>
+          {!collapsable && (
+            <View style={{ width: 50, height: 50, backgroundColor: 'green' }} />
+          )}
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -61,6 +61,7 @@ import ListItemLayoutAnimation from './LayoutAnimations/ListItemLayoutAnimation'
 import Modal from './LayoutAnimations/Modal';
 import ModalNewAPI from './LayoutAnimations/ModalNewAPI';
 import MountingUnmounting from './LayoutAnimations/MountingUnmounting';
+import MoveWithExiting from './LayoutAnimations/MoveWithExiting';
 import NativeModals from './LayoutAnimations/NativeModals';
 import NestedTest from './LayoutAnimations/Nested';
 import NestedLayoutAnimationConfig from './LayoutAnimations/NestedLayoutAnimationConfig';
@@ -718,5 +719,9 @@ export const EXAMPLES: Record<string, Example> = {
   ModalExitingExample: {
     title: '[LA] Modal exiting example',
     screen: ModalExitingExample,
+  },
+  MoveWithExiting: {
+    title: '[LA] Move with exiting',
+    screen: MoveWithExiting,
   },
 } as const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -481,7 +481,8 @@ bool LayoutAnimationsProxy::startAnimationsRecursively(
   bool hasAnimatedChildren = false;
 
   shouldRemoveSubviewsWithoutAnimations =
-      shouldRemoveSubviewsWithoutAnimations && (!hasExitAnimation || node->state == MOVED);
+      shouldRemoveSubviewsWithoutAnimations &&
+      (!hasExitAnimation || node->state == MOVED);
   std::vector<std::shared_ptr<MutationNode>> toBeRemoved;
 
   // iterate from the end, so that children

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -481,7 +481,7 @@ bool LayoutAnimationsProxy::startAnimationsRecursively(
   bool hasAnimatedChildren = false;
 
   shouldRemoveSubviewsWithoutAnimations =
-      shouldRemoveSubviewsWithoutAnimations && !hasExitAnimation;
+      shouldRemoveSubviewsWithoutAnimations && (!hasExitAnimation || node->state == MOVED);
   std::vector<std::shared_ptr<MutationNode>> toBeRemoved;
 
   // iterate from the end, so that children


### PR DESCRIPTION
## Summary

This PR fixes how we handle the case when a view is supposed to be removed but its parent is being moved due to view flattening, and has an exiting animation configured. Currently this scenario would lead to a state where the children are not removed (because there is an exiting animation configured), but the animation would not start (because the view is not deleted- it's only moved). This would lead to the children being left on the screen forever.

## Test plan

Test the `[LA] Move with exiting` example.