### PR TITLE
Remove `combineTransition`

### DIFF
--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -188,7 +188,6 @@ export {
   BounceOutLeft,
   BounceOutRight,
   BounceOutUp,
-  combineTransition,
   ComplexAnimationBuilder,
   CurvedTransition,
   EntryExitTransition,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/EntryExitTransition.ts
@@ -246,15 +246,3 @@ export class EntryExitTransition
     };
   };
 }
-
-/**
- * @deprecated Please use
- *   `EntryExitTransition.entering(entering).exiting(exiting)` instead.
- * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions
- */
-export function combineTransition(
-  exiting: BaseAnimationBuilder | typeof BaseAnimationBuilder,
-  entering: BaseAnimationBuilder | typeof BaseAnimationBuilder
-): EntryExitTransition {
-  return EntryExitTransition.entering(entering).exiting(exiting);
-}


### PR DESCRIPTION
## Summary

Some time ago, we've decided to remove `combineTransition` function for Reanimated 4. We've already taken it out of the documentation.

The `combineTransition` function isn't necessary; you can achieve the same effect using the syntax below.
```js
EntryExitTransition.entering(entering).exiting(exiting);
```
More details here: https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions#entryexit-transition
