### PR TITLE
fix: undefined reference _isReanimatedSharedValue

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -38,7 +38,7 @@ const getStylesFromObject = (obj: object) => {
     : Object.fromEntries(
         Object.entries(obj).map(([property, value]) => [
           property,
-          value._isReanimatedSharedValue ? value.value : value,
+          value?._isReanimatedSharedValue ? value.value : value,
         ])
       );
 };


### PR DESCRIPTION
## Summary

This fork resolves an issue where using `.toHaveAnimatedStyle` on a component before animated styles are applied throws a `TypeError: Cannot read properties of undefined (reading '_isReanimatedSharedValue')` error. 

Specifically, I have the following test which was written under reanimated `3.15`:

```tsx
      const screen = renderWithNav(
        // A custom component that performs a style transition using Reanimated 3
        <Example
          transitions={[
            {
              property: 'opacity',
              duration,
              value: (progress) => {
                'worklet'
                return progress
              },
            },
          ]}
          animateEntrance
        />,
      )
      const transition = new StyleTransitionPageObject(
        screen.root,
        'StyleTransition',
      )
      ...
      expect(transition.container).toHaveStyle({ opacity: 0 })
      // The expectation below throws a TypeError accessing `value._isReanimatedSharedValue` in `jestUtils`
      expect(transition.container).toHaveAnimatedStyle({ opacity: 0 })

      act(() => {
        jest.advanceTimersByTime(duration * 0.5)
      })

      expect(transition.container).toHaveAnimatedStyle({ opacity: 0.5 })
      ...
```

```sh
    TypeError: Cannot read properties of undefined (reading '_isReanimatedSharedValue')

      73 |       )
      74 |       expect(transition.container).toHaveStyle({ opacity: 0 })
    > 75 |       expect(transition.container).toHaveAnimatedStyle({ opacity: 0 })
         |                                    ^
      76 |
      77 |       act(() => {
      78 |         jest.advanceTimersByTime(duration * 0.5)

      at _isReanimatedSharedValue (../node_modules/react-native-reanimated/src/jestUtils.ts:38:17)
          at Array.map (<anonymous>)
      at map (../node_modules/react-native-reanimated/src/jestUtils.ts:36:29)
      at getStylesFromObject (../node_modules/react-native-reanimated/src/jestUtils.ts:77:28)
      at getCurrentStyle (../node_modules/react-native-reanimated/src/jestUtils.ts:177:24)
      at Object.compareStyle (../node_modules/react-native-reanimated/src/jestUtils.ts:288:14)
      at __EXTERNAL_MATCHER_TRAP__ (../node_modules/expect/build/index.js:325:30)
      at Object.throwingMatcher [as toHaveAnimatedStyle] (../node_modules/expect/build/index.js:326:15
)
      at Object.toHaveAnimatedStyle (src/components/animation/style-transition/AnimatedStyleTransition
.test.tsx:75:36)
      at asyncGeneratorStep (../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
      at ../node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7
      at Object.<anonymous> (../node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12)
```

This broke between reanimated version `3.15.5` and `3.16.0`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

I haven't written a demo or a test case for this yet because I wasn't sure if this is a valid fix/issue from your perspective.
