### PR TITLE
chore(Reanimated): accept all pre-release versions of Worklets

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -86,7 +86,7 @@
   "homepage": "https://docs.swmansion.com/react-native-reanimated",
   "dependencies": {
     "react-native-is-edge-to-edge": "1.1.7",
-    "semver": "^7.7.1"
+    "semver": "7.7.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/react-native-reanimated/scripts/validate-worklets-version.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-version.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const semverSatisfies = require('semver/functions/satisfies');
+const semverPrerelease = require('semver/functions/prerelease');
 const expectedVersion = require('./worklets-version.json');
 const { exit } = require('process');
 
@@ -22,8 +23,11 @@ function assertWorkletsVersion() {
     exit(1);
   }
 
-  if (workletsVersion.includes('nightly')) {
-    // Don't perform any checks for nightly versions, the user knows what they're doing.
+  if (semverPrerelease(workletsVersion)) {
+    /**
+     * Don't perform any checks for pre-release versions, like nightlies or
+     * feature previews. The user knows what they're doing.
+     */
     return;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20315,7 +20315,7 @@ __metadata:
     react-native-web: "npm:0.20.0"
     react-native-worklets: "workspace:*"
     react-test-renderer: "npm:19.1.0"
-    semver: "npm:^7.7.1"
+    semver: "npm:7.7.2"
     shelljs: "npm:^0.8.5"
     typescript: "npm:~5.3.0"
   peerDependencies:
@@ -21399,6 +21399,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.7.2, semver@npm:^7.7.2":
+  version: 7.7.2
+  resolution: "semver@npm:7.7.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/7a24cffcaa13f53c09ce55e05efe25cd41328730b2308678624f8b9f5fc3093fc4d189f47950f0b811ff8f3c3039c24a2c36717ba7961615c682045bf03e1dda
+  languageName: node
+  linkType: hard
+
 "semver@npm:^5.5.0, semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -21432,15 +21441,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/4cfa1eb91ef3751e20fc52e47a935a0118d56d6f15a837ab814da0c150778ba2ca4f1a4d9068b33070ea4273629e615066664c2cfcd7c272caf7a8a0f6518b2c
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.2":
-  version: 7.7.2
-  resolution: "semver@npm:7.7.2"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/7a24cffcaa13f53c09ce55e05efe25cd41328730b2308678624f8b9f5fc3093fc4d189f47950f0b811ff8f3c3039c24a2c36717ba7961615c682045bf03e1dda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

When releasing `react-native-worklets-0.4.0-bundle-mode-preview-1` I realized the validation script in Reanimated wouldn't allow it.

I'm also locking semver package version since I forgot to do that previously.

## Test plan

Installed `react-native-worklets-0.4.0-bundle-mode-preview-1` is accepted after this change.
