### PR TITLE
Set compile options using `target_compile_reactnative_options` from `react-native-flags.cmake`

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -19,9 +19,14 @@ string(
     -DREANIMATED_VERSION=${REANIMATED_VERSION}\
     -DREANIMATED_FEATURE_FLAGS=\"${REANIMATED_FEATURE_FLAGS}\"")
 
-string(APPEND CMAKE_CXX_FLAGS
-       " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all\
-   -std=c++${CMAKE_CXX_STANDARD} -Wall -Werror")
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  include("${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")
+  target_compile_reactnative_options(reanimated PUBLIC)
+else()
+  string(APPEND CMAKE_CXX_FLAGS " -fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall -Werror")
+endif()
+
+string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fstack-protector-all")
 
 if(${IS_REANIMATED_EXAMPLE_APP})
   string(APPEND CMAKE_CXX_FLAGS " -DIS_REANIMATED_EXAMPLE_APP -Wpedantic")

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -14,9 +14,14 @@ add_compile_options(${folly_FLAGS})
 string(APPEND CMAKE_CXX_FLAGS
        " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}")
 
-string(APPEND CMAKE_CXX_FLAGS
-       " -fexceptions -fno-omit-frame-pointer -frtti -fstack-protector-all \
-  -std=c++${CMAKE_CXX_STANDARD} -Wall -Werror")
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  include("${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")
+  target_compile_reactnative_options(reanimated PUBLIC)
+else()
+  string(APPEND CMAKE_CXX_FLAGS " -fexceptions -frtti -std=c++${CMAKE_CXX_STANDARD} -Wall -Werror")
+endif()
+
+string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fstack-protector-all")
 
 if(${IS_REANIMATED_EXAMPLE_APP})
   string(APPEND CMAKE_CXX_FLAGS " -DIS_REANIMATED_EXAMPLE_APP -Wpedantic")


### PR DESCRIPTION
## Summary

This PR includes `react-native-flags.cmake`and calls `target_compile_reactnative_options` in CMakeLists.txt  which sets necessary flags and definitions instead of setting them manually.

## Test plan
