### PR TITLE
fix(Reanimated): Worklets version validation scripts failing in runtime

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -66,7 +66,7 @@ def toPlatformFileString(String path) {
 def validateWorkletsVersion() {
     def result = providers.exec {
         workingDir(projectDir.path)
-        commandLine("node", "./../scripts/validate-worklets-version.js")
+        commandLine("node", "./../scripts/validate-worklets-build.js")
         ignoreExitValue = true
     }
 

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -52,6 +52,7 @@
     "apple/",
     "RNReanimated.podspec",
     "scripts/reanimated_utils.rb",
+    "scripts/validate-worklets-build.js",
     "scripts/validate-worklets-version.js",
     "scripts/worklets-version.json",
     "mock.js",

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -31,7 +31,7 @@ def find_config()
     raise '[Reanimated] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
   end
 
-  validate_worklets_script = File.expand_path(File.join(__dir__, 'validate-worklets-version.js'))
+  validate_worklets_script = File.expand_path(File.join(__dir__, 'validate-worklets-build.js'))
   unless system("node \"#{validate_worklets_script}\"")
     abort("[Reanimated] Failed to validate worklets version")
   end

--- a/packages/react-native-reanimated/scripts/validate-worklets-build.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-build.js
@@ -7,6 +7,6 @@ const validateVersion = require('./validate-worklets-version');
 const result = validateVersion();
 if (!result.ok) {
   // eslint-disable-next-line reanimated/use-logger
-  console.error('[Reanimated]' + result.message);
+  console.error('[Reanimated] ' + result.message);
   process.exit(1);
 }

--- a/packages/react-native-reanimated/scripts/validate-worklets-build.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-build.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// We don't use this script in runtime since `process` might not be available.
+
+const validateVersion = require('./validate-worklets-version');
+
+const result = validateVersion();
+if (!result.ok) {
+  // eslint-disable-next-line reanimated/use-logger
+  console.error('[Reanimated]' + result.message);
+  process.exit(1);
+}

--- a/packages/react-native-reanimated/scripts/validate-worklets-version.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-version.js
@@ -1,26 +1,26 @@
-/* eslint-disable reanimated/use-logger */
 'use strict';
 
 const semverSatisfies = require('semver/functions/satisfies');
 const semverPrerelease = require('semver/functions/prerelease');
 const expectedVersion = require('./worklets-version.json');
-const { exit } = require('process');
 
-function assertWorkletsVersion() {
+/** @returns {{ ok: boolean; message?: string }} */
+function validateVersion() {
   let workletsVersion;
 
   try {
     const { version } = require('react-native-worklets/package.json');
     workletsVersion = version;
   } catch (_e) {
-    console.error(
-      "[Reanimated] react-native-worklets package isn't installed. Please install a version between " +
+    return {
+      ok: false,
+      message:
+        "react-native-worklets package isn't installed. Please install a version between " +
         expectedVersion.min +
         ' and ' +
         expectedVersion.max +
-        ' to use Reanimated 4.'
-    );
-    exit(1);
+        ' to use Reanimated 4.',
+    };
   }
 
   if (semverPrerelease(workletsVersion)) {
@@ -28,17 +28,21 @@ function assertWorkletsVersion() {
      * Don't perform any checks for pre-release versions, like nightlies or
      * feature previews. The user knows what they're doing.
      */
-    return;
+    return { ok: true };
   }
 
   const acceptedRange = `${expectedVersion.min} - ${expectedVersion.max}`;
 
   if (!semverSatisfies(workletsVersion, acceptedRange)) {
-    console.error(
-      `[Reanimated] Invalid version of \`react-native-worklets\`: "${workletsVersion}". Expected the version to be in inclusive range "${acceptedRange}". Please install a compatible version of \`react-native-worklets\`.`
-    );
-    exit(2);
+    return {
+      ok: false,
+      message: `Invalid version of \`react-native-worklets\`: "${workletsVersion}". Expected the version to be in inclusive range "${acceptedRange}". Please install a compatible version of \`react-native-worklets\`.`,
+    };
   }
+
+  return {
+    ok: true,
+  };
 }
 
-assertWorkletsVersion();
+module.exports = validateVersion;

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-//@ts-expect-error There's no types for this script.
+// @ts-expect-error There's no types for this script.
 import validateWorkletsVersion from 'react-native-reanimated/scripts/validate-worklets-version';
 
 import { ReanimatedError } from '../common/errors';

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -1,6 +1,15 @@
+/* eslint-disable n/no-missing-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 'use strict';
 
+import { ReanimatedError } from '../common/errors';
+
 export function assertWorkletsVersion() {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, n/no-missing-require
-  require('react-native-reanimated/scripts/validate-worklets-version');
+  const result =
+    require('react-native-reanimated/scripts/validate-worklets-version')();
+
+  if (!result.ok) {
+    throw new ReanimatedError(result.message);
+  }
 }

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -1,13 +1,12 @@
-/* eslint-disable n/no-missing-require */
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-require-imports */
 'use strict';
+
+//@ts-expect-error There's no types for this script.
+import validateWorkletsVersion from 'react-native-reanimated/scripts/validate-worklets-version';
 
 import { ReanimatedError } from '../common/errors';
 
 export function assertWorkletsVersion() {
-  const result =
-    require('react-native-reanimated/scripts/validate-worklets-version')();
+  const result = validateWorkletsVersion();
 
   if (!result.ok) {
     throw new ReanimatedError(result.message);


### PR DESCRIPTION
## Summary

`process.exit` function can be unavailable in runtime. Therefore runtime script must not use it.

## Test plan

@tomekzaw 🚊 🚋 🚌 
