### PR TITLE
Fix possible linking error on Android due to undefined symbols from libworklets.so

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -323,4 +323,17 @@ dependencies {
     }
 }
 
+task prepareKotlinBuildScriptModel {
+  // This task is run during Gradle Sync in Android Studio.
+}
+
+// This fixes linking errors due to undefined symbols from libworklets.so.
+// During Gradle Sync, Android Gradle Plugin runs Prefab and treats worklets
+// like a header-only library. During build, config files are not regenerated
+// because the cache key does not change and AGP thinks that they are up-to-date.
+afterEvaluate {
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-reanimated:prefabDebugPackage")
+  prepareKotlinBuildScriptModel.dependsOn(":react-native-reanimated:prefabReleasePackage")
+}
+
 preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)


### PR DESCRIPTION
## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

* https://github.com/Expensify/react-native-live-markdown/pull/627

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
