### PR TITLE
Fix dynamic updates of layout animations

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -30,6 +30,7 @@ import type {
   IAnimatedComponentInternal,
   INativeEventsManager,
   InitialComponentProps,
+  LayoutAnimationOrBuilder,
   NestedArray,
 } from './commonTypes';
 import { InlinePropManager } from './InlinePropManager';
@@ -86,20 +87,10 @@ export default class AnimatedComponent
       this.jestAnimatedProps = { value: {} };
     }
 
-    const entering = this.props.entering;
     const skipEntering = this.context?.current;
-    if (
-      !entering ||
-      getReducedMotionFromConfig(entering as CustomConfig) ||
-      skipEntering
-    ) {
-      return;
-    }
-    // This call is responsible for configuring entering animations on Fabric.
-    updateLayoutAnimations(
-      this.reanimatedID,
+    this._configureTransition(
       LayoutAnimationType.ENTERING,
-      maybeBuild(entering, this.props?.style, displayName)
+      skipEntering ? this.props.entering : undefined
     );
   }
 
@@ -117,10 +108,8 @@ export default class AnimatedComponent
       jsPropsUpdater.registerComponent(this, this._options.jsProps);
     }
 
-    const layout = this.props.layout;
-    if (layout) {
-      this._configureLayoutTransition();
-    }
+    this._configureTransition(LayoutAnimationType.LAYOUT, this.props.layout);
+    this._configureTransition(LayoutAnimationType.EXITING, this.props.exiting);
 
     if (IS_WEB) {
       if (this.props.exiting && this._componentDOMRef) {
@@ -281,11 +270,17 @@ export default class AnimatedComponent
     _prevState: Readonly<unknown>,
     snapshot: DOMRect | null
   ) {
-    const layout = this.props.layout;
-    const oldLayout = prevProps.layout;
-    if (layout !== oldLayout) {
-      this._configureLayoutTransition();
-    }
+    this._configureTransition(
+      LayoutAnimationType.LAYOUT,
+      this.props.layout,
+      prevProps.layout
+    );
+    this._configureTransition(
+      LayoutAnimationType.EXITING,
+      this.props.exiting,
+      prevProps.exiting
+    );
+
     this._NativeEventsManager?.updateEvents(prevProps);
     this._attachAnimatedStyles();
     this._InlinePropManager.attachInlineProps(this, this._getViewInfo());
@@ -315,47 +310,45 @@ export default class AnimatedComponent
     this._cssStyle = filtered.cssStyle;
   }
 
-  _configureLayoutTransition() {
-    if (IS_WEB) {
+  _configureTransition(
+    type: LayoutAnimationType,
+    currentConfig: LayoutAnimationOrBuilder | undefined,
+    previousConfig?: LayoutAnimationOrBuilder
+  ) {
+    if (IS_WEB || currentConfig === previousConfig) {
       return;
     }
 
-    const layout = this.props.layout;
-    if (layout && getReducedMotionFromConfig(layout as CustomConfig)) {
-      return;
+    if (this._isReducedMotion(currentConfig)) {
+      if (previousConfig) {
+        currentConfig = undefined;
+      } else {
+        return;
+      }
     }
+
     updateLayoutAnimations(
-      this.getComponentViewTag(),
-      LayoutAnimationType.LAYOUT,
-      layout &&
+      type == LayoutAnimationType.ENTERING
+        ? this.getComponentViewTag()
+        : this.reanimatedID,
+      type,
+      currentConfig &&
         maybeBuild(
-          layout,
-          undefined /* We don't have to warn user if style has common properties with animation for LAYOUT */,
+          currentConfig,
+          type == LayoutAnimationType.LAYOUT
+            ? undefined /* We don't have to warn user if style has common properties with animation for LAYOUT */
+            : this.props?.style,
           this._displayName
         )
     );
   }
 
-  _onSetLocalRef() {
-    const tag = this.getComponentViewTag();
-
-    const { layout, entering, exiting } = this.props;
-    if (layout || entering || exiting) {
-      if (exiting) {
-        const reduceMotionInExiting =
-          'getReduceMotion' in exiting &&
-          typeof exiting.getReduceMotion === 'function'
-            ? getReduceMotionFromConfig(exiting.getReduceMotion())
-            : getReduceMotionFromConfig();
-        if (!reduceMotionInExiting) {
-          updateLayoutAnimations(
-            tag,
-            LayoutAnimationType.EXITING,
-            maybeBuild(exiting, this.props?.style, this._displayName)
-          );
-        }
-      }
-    }
+  _isReducedMotion(config?: LayoutAnimationOrBuilder): boolean {
+    return config &&
+      'getReduceMotion' in config &&
+      typeof config.getReduceMotion === 'function'
+      ? getReduceMotionFromConfig(config.getReduceMotion())
+      : getReduceMotionFromConfig();
   }
 
   // This is a component lifecycle method from React, therefore we are not calling it directly.

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -328,14 +328,14 @@ export default class AnimatedComponent
     }
 
     updateLayoutAnimations(
-      type == LayoutAnimationType.ENTERING
-        ? this.getComponentViewTag()
-        : this.reanimatedID,
+      type === LayoutAnimationType.ENTERING
+        ? this.reanimatedID
+        : this.getComponentViewTag(),
       type,
       currentConfig &&
         maybeBuild(
           currentConfig,
-          type == LayoutAnimationType.LAYOUT
+          type === LayoutAnimationType.LAYOUT
             ? undefined /* We don't have to warn user if style has common properties with animation for LAYOUT */
             : this.props?.style,
           this._displayName

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -98,6 +98,15 @@ export type AnimatedComponentProps<
     LayoutAnimationStaticContext;
 };
 
+export type LayoutAnimationOrBuilder = (
+  | BaseAnimationBuilder
+  | typeof BaseAnimationBuilder
+  | EntryExitAnimationFunction
+  | Keyframe
+  | ILayoutAnimationBuilder
+) &
+  LayoutAnimationStaticContext;
+
 export interface AnimatedComponentRef extends Component {
   setNativeProps?: (props: Record<string, unknown>) => void;
   getScrollableNode?: () => AnimatedComponentRef;


### PR DESCRIPTION
## Summary

This PR adds handling for removing or changing layout animations over a component's lifecycle. In the previous approach, we saved the layout animation during mounting and never changed it.
Note that this only makes sense for layout and exiting animations - we can't change the entering animation during a component's lifetime.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/7763

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ed51b466-4702-4d8e-b1a5-44f1c9528e0a" /> | <video src="https://github.com/user-attachments/assets/ef1cf798-5954-4ba2-82c1-ca2a97c19901" /> |

## Test plan

<details>
<summary>code</summary>

```js
import { useState } from 'react';
import {
  Button,
  SafeAreaView,
  StyleSheet,
  Text,
} from 'react-native';
import Animated, {
  FadeOutLeft,
} from 'react-native-reanimated';

export default function App() {
  const [isVisible, setIsVisible] = useState(true);
  const [toggleAnimation, setToggleAnimation] = useState(true);

  return (
    <SafeAreaView style={styles.container}>
      <Button
        title={'Toggle Animation'}
        onPress={() => setToggleAnimation(!toggleAnimation)}
      />
      <Button
        title={isVisible ? 'Hide' : 'Show'}
        onPress={() => setIsVisible(prev => !prev)}
      />
      <Text>Has Exiting?: {toggleAnimation ? 'YES' : 'NO'}</Text>
      {isVisible ? (
        <Animated.View
          exiting={toggleAnimation ? FadeOutLeft : undefined}
          style={{ width: 150, height: 150, backgroundColor: 'green' }}
        />
      ) : null}
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  center: {
    alignItems: 'center',
  },
});
```

</details>
