### PR TITLE
fix: hwb color parsing on web

### DIFF
--- a/packages/react-native-reanimated/src/css/platform/web/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/css/platform/web/style/processors/colors.ts
@@ -9,7 +9,7 @@ export const processColor: ValueProcessor<ColorValue> = (value) => {
   }
 
   if (value.startsWith('hwb')) {
-    return value.replace(/,/g, '');
+    return value.replace(/\s*,\s*/g, ' ');
   }
 
   return value;


### PR DESCRIPTION
## Summary

This PR fixes incorrect `hwb` color parsing in the web CSS color parser implementation. The previous implementation just removed `,`, which didn't work right when there was no whitespace in the color string.

e.g. `hwb(311,15%,15%)` was converted to `hwb(31115%15%)` instead of `hwb(311 15% 15%)`

## Comparison

| Before* | After |
|-|-|
| <img width="621" height="980" alt="Screenshot 2025-07-15 at 00 14 03" src="https://github.com/user-attachments/assets/ce261616-408d-469f-ab67-71e192f2b255" /> | <video src="https://github.com/user-attachments/assets/53c1539c-4839-4684-9005-41417fd1478d" /> |

*I attached a screenshot as there was no animation at all because of the invalid color format

<details>
<summary>
Code snippet
</summary>

```tsx
import Animated from 'react-native-reanimated';

export default function Playground() {
  return (
    <Animated.View
      style={{
        flex: 1,
        animationName: {
          from: { backgroundColor: 'hwb(311,15%,15%)' },
          to: { backgroundColor: 'hwb(221,25%,42%)' },
        },
        animationDuration: '1s',
        animationTimingFunction: 'ease-in-out',
        animationIterationCount: 'infinite',
        animationDirection: 'alternate',
      }}
    />
  );
}
```
</details>