### PR TITLE
[Fabric LA] Add progress batching

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DurationZero.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DurationZero.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+import Animated, { withTiming } from 'react-native-reanimated';
+
+const customEntering = () => {
+  'worklet';
+  const animations = {
+    width: withTiming(100, { duration: 0 }),
+  };
+  const initialValues = {
+    width: 0,
+  };
+  return {
+    initialValues,
+    animations,
+  };
+};
+
+export default function DurationZeroExample() {
+  const [show, setShow] = React.useState(false);
+  return (
+    <View style={styles.container}>
+      <Button title="Click me" onPress={() => setShow(!show)} />
+      {show && (
+        <Animated.View
+          entering={customEntering}
+          style={{ width: 100, height: 100, backgroundColor: 'blue' }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -53,6 +53,7 @@ import CombinedTest from './LayoutAnimations/Combined';
 import CustomLayoutAnimationScreen from './LayoutAnimations/CustomLayout';
 import DefaultAnimations from './LayoutAnimations/DefaultAnimations';
 import DeleteAncestorOfExiting from './LayoutAnimations/DeleteAncestorOfExiting';
+import DurationZeroExample from './LayoutAnimations/DurationZero';
 import FlatListSkipEnteringExiting from './LayoutAnimations/FlatListSkipEnteringExiting';
 import HabitsExample from './LayoutAnimations/HabitsExample';
 import KeyframeAnimation from './LayoutAnimations/KeyframeAnimation';
@@ -728,5 +729,9 @@ export const EXAMPLES: Record<string, Example> = {
   MoveWithExiting: {
     title: '[LA] Move with exiting',
     screen: MoveWithExiting,
+  },
+  DurationZeroExample: {
+    title: '[LA] Duration zero',
+    screen: DurationZeroExample,
   },
 } as const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -5,6 +5,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
 #include <set>
+#include <utility>
 
 namespace reanimated {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -42,6 +42,7 @@ struct LayoutAnimationsProxy
   mutable SurfaceManager surfaceManager;
   mutable std::unordered_set<std::shared_ptr<MutationNode>> deadNodes;
   mutable std::unordered_map<Tag, int> leastRemoved;
+  mutable std::vector<Tag> finishedAnimationTags_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
   ContextContainer::Shared contextContainer_;
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -133,7 +133,7 @@ void ReanimatedModuleProxy::init(
         strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
       };
 
-  auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double d) {
+  auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double) {
     auto strongThis = weakThis.lock();
     if (!strongThis) {
       return;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -132,8 +132,8 @@ void ReanimatedModuleProxy::init(
         }
         strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
       };
-  
-  auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double d){
+
+  auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double d) {
     auto strongThis = weakThis.lock();
     if (!strongThis) {
       return;
@@ -142,7 +142,8 @@ void ReanimatedModuleProxy::init(
   };
 
   EndLayoutAnimationFunction endLayoutAnimation =
-      [weakThis = weak_from_this(), requestLayoutAnimationRender](int tag, bool shouldRemove) {
+      [weakThis = weak_from_this(), requestLayoutAnimationRender](
+          int tag, bool shouldRemove) {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
@@ -150,14 +151,15 @@ void ReanimatedModuleProxy::init(
 
         auto surfaceId = strongThis->layoutAnimationsProxy_->endLayoutAnimation(
             tag, shouldRemove);
-        
-        if (!strongThis->layoutAnimationRenderRequested_){
+
+        if (!strongThis->layoutAnimationRenderRequested_) {
           strongThis->layoutAnimationRenderRequested_ = true;
-          // if an animation has duration 0, performOperations would not get called for it
-          // so we call requestRender to have it called in the next frame
+          // if an animation has duration 0, performOperations would not get
+          // called for it so we call requestRender to have it called in the
+          // next frame
           strongThis->requestRender_(requestLayoutAnimationRender);
         }
-        
+
         if (!surfaceId) {
           return;
         }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -132,9 +132,17 @@ void ReanimatedModuleProxy::init(
         }
         strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
       };
+  
+  auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double d){
+    auto strongThis = weakThis.lock();
+    if (!strongThis) {
+      return;
+    }
+    strongThis->layoutAnimationRenderRequested_ = false;
+  };
 
   EndLayoutAnimationFunction endLayoutAnimation =
-      [weakThis = weak_from_this()](int tag, bool shouldRemove) {
+      [weakThis = weak_from_this(), requestLayoutAnimationRender](int tag, bool shouldRemove) {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
@@ -142,6 +150,14 @@ void ReanimatedModuleProxy::init(
 
         auto surfaceId = strongThis->layoutAnimationsProxy_->endLayoutAnimation(
             tag, shouldRemove);
+        
+        if (!strongThis->layoutAnimationRenderRequested_){
+          strongThis->layoutAnimationRenderRequested_ = true;
+          // if an animation has duration 0, performOperations would not get called for it
+          // so we call requestRender to have it called in the next frame
+          strongThis->requestRender_(requestLayoutAnimationRender);
+        }
+        
         if (!surfaceId) {
           return;
         }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -241,6 +241,7 @@ class ReanimatedModuleProxy
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
   std::set<SurfaceId> layoutAnimationFlushRequests_;
+  bool layoutAnimationRenderRequested_;
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -29,6 +29,7 @@
 #include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -239,6 +240,7 @@ class ReanimatedModuleProxy
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
+  std::set<SurfaceId> layoutAnimationFlushRequests_;
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;


### PR DESCRIPTION
## Summary
This PR changes the way we apply layout animations. Now we call the `notifyDelegateOfUpdates` method only once per frame, instead of doing that for every updated component separately. This improves performance, fixes animations with `duration=0` and possibly helps with some timing issues, when the view could be updated before it's mounted (#7493 - but it's probably not fully solved by this PR).

## Test plan

Checks all LA related examples.
