### PR TITLE
docs: correct exact -> shouldMatchAllProps

### DIFF
--- a/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/packages/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -67,7 +67,7 @@ Checking equality of selected styles with current component styles.
 - `component` - tested component.
 - `expectedStyle` - contains expected styles of testing component, for example `{ width: 100 }`.
 
-#### `expect(component).toHaveAnimatedStyle(expectedStyle, {exact: true})`
+#### `expect(component).toHaveAnimatedStyle(expectedStyle, {shouldMatchAllProps: true})`
 
 Checking equality of all current component styles with expected styles.
 


### PR DESCRIPTION
## Summary

Correct a small discrepancy in the documentation of `toHaveAnimatedStyle`.

https://github.com/software-mansion/react-native-reanimated/blob/3dd927ce8258f1459e6fbdf69e2f11bc2f4f3835/packages/react-native-reanimated/src/jestUtils.ts#L285-L287