### PR TITLE
fix(Worklets): restore backwards compatibility with external flushAnimationFrame calls

### DIFF
--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -88,6 +88,7 @@ export function registerEventHandler<T>(
 ): number {
   function handleAndFlushAnimationFrame(eventTimestamp: number, event: T) {
     'worklet';
+    // TODO: Fix this and don't call `__flushAnimationFrame` here.
     global.__frameTimestamp = eventTimestamp;
     eventHandler(event);
     global.__flushAnimationFrame(eventTimestamp);
@@ -114,6 +115,7 @@ export function subscribeForKeyboardEvents(
   // via registerEventHandler. For now we are copying the code from there.
   function handleAndFlushAnimationFrame(state: number, height: number) {
     'worklet';
+    // TODO: Fix this and don't call `__flushAnimationFrame` here.
     const now = global._getAnimationTimestamp();
     global.__frameTimestamp = now;
     eventHandler(state, height);


### PR DESCRIPTION
## Summary

Fixes regressions done in #7738. I really wish I didn't have to do this.

## Test plan

Scroll event example works as previously.
