### PR TITLE
[Fabric LA] Mark deleted nodes as DELETED

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -262,6 +262,7 @@ void LayoutAnimationsProxy::handleRemovals(
         filteredMutations.push_back(ShadowViewMutation::DeleteMutation(
             node->mutation.oldChildShadowView));
         nodeForTag_.erase(node->tag);
+        node->state = DELETED;
 #ifdef LAYOUT_ANIMATIONS_LOGS
         LOG(INFO) << "delete " << node->tag << std::endl;
 #endif
@@ -466,6 +467,7 @@ void LayoutAnimationsProxy::maybeDropAncestors(
     nodeForTag_.erase(node->tag);
     cleanupMutations.push_back(node->mutation);
     maybeCancelAnimation(node->tag);
+    node->state = DELETED;
 #ifdef LAYOUT_ANIMATIONS_LOGS
     LOG(INFO) << "delete " << node->tag << std::endl;
 #endif


### PR DESCRIPTION
## Summary

This PR fixes crashes that became apparent after #7798. The issue is that we would add DELETE mutations for some views multiple times, because in some code-paths we were not marking deleted views as DELETED. I think that the issue was not manifesting before #7798 because then we would handle removals separately for each view.

## Test plan

Spam the `[LA] Entering and Exiting with Layout` example and check for crashes.
