### PR TITLE
Improve minimal React Native version error message

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -263,7 +263,7 @@ task assertMinimalReactNativeVersionTask {
     def minimalReactNativeVersion = 75
     onlyIf { REACT_NATIVE_MINOR_VERSION < minimalReactNativeVersion }
     doFirst {
-        throw new GradleException("[Reanimated] Unsupported React Native version. Please use $minimalReactNativeVersion or newer.")
+        throw new GradleException("[Reanimated] Unsupported React Native version. Please use React Native 0.$minimalReactNativeVersion or newer.")
     }
 }
 

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -67,7 +67,7 @@ def assert_minimal_react_native_version(config)
       # If you change the minimal React Native version remember to update Compatibility Table in docs
   minimalReactNativeVersion = 75
   if config[:react_native_minor_version] < minimalReactNativeVersion
-    raise "[Reanimated] Unsupported React Native version. Please use #{minimalReactNativeVersion} or newer."
+    raise "[Reanimated] Unsupported React Native version. Please use React Native 0.#{minimalReactNativeVersion} or newer."
   end
 end
 

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -291,7 +291,7 @@ task assertMinimalReactNativeVersionTask {
     def minimalReactNativeVersion = 75
     onlyIf { REACT_NATIVE_MINOR_VERSION < minimalReactNativeVersion }
     doFirst {
-        throw new GradleException("[Worklets] Unsupported React Native version. Please use $minimalReactNativeVersion or newer.")
+        throw new GradleException("[Worklets] Unsupported React Native version. Please use React Native 0.$minimalReactNativeVersion or newer.")
     }
 }
 

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -56,7 +56,7 @@ def worklets_assert_minimal_react_native_version(config)
       # If you change the minimal React Native version remember to update Compatibility Table in docs
   minimalReactNativeVersion = 75
   if config[:react_native_minor_version] < minimalReactNativeVersion
-    raise "[Worklets] Unsupported React Native version. Please use #{minimalReactNativeVersion} or newer."
+    raise "[Worklets] Unsupported React Native version. Please use React Native 0.#{minimalReactNativeVersion} or newer."
   end
 end
 


### PR DESCRIPTION
## Summary

This PR fixes the error message that appears when trying to use Reanimated with an incompatible version of React Native.

```diff
-Please use 75 or newer.
+Please use React Native 0.75 or newer.
```

## Test plan
