### PR TITLE
fix: Accordion example crashing on web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/OldMeasureExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/OldMeasureExample.tsx
@@ -188,6 +188,7 @@ function SectionHeader({
   let onActiveImpl;
   if (Platform.OS === 'web') {
     onActiveImpl = async () => {
+      'worklet';
       try {
         applyMeasure(await asyncMeasure(animatedRef));
       } catch (e) {

--- a/packages/react-native-reanimated/src/hook/useHandler.ts
+++ b/packages/react-native-reanimated/src/hook/useHandler.ts
@@ -86,7 +86,7 @@ export function useHandler<
   for (const handlerName in handlers) {
     if (!isWorkletFunction(handlers[handlerName])) {
       throw new ReanimatedError(
-        'Passed a function is not a worklet. Please provide a worklet function.'
+        'Passed a function that is not a worklet. Please provide a worklet function.'
       );
     }
   }


### PR DESCRIPTION
## Summary

`useHandler` requires worklet functions to be passed after changes applied in the #7604 PR. The example on the web was missing the `'worklet'` directive, thus it crashed when the screen was open.