### PR TITLE
fix: precision errors in color interpolation keeping the animation to run forever

### DIFF
--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -309,9 +309,9 @@ function decorateAnimation<T extends AnimationObject | StyleLayoutAnimation>(
   ): boolean => {
     const res: Array<number> = [];
     let finished = true;
+    // We must restore nonscale current to ever end the animation.
+    animation.current = animation.nonscaledCurrent;
     tab.forEach((i) => {
-      // We must restore nonscale current to ever end the animation.
-      animation.current = animation.nonscaledCurrent;
       const result = animation[i].onFrame(animation[i], timestamp);
       // We really need to assign this value to result, instead of passing it directly - otherwise once "finished" is false, onFrame won't be called
       finished = finished && result;


### PR DESCRIPTION
## Summary

Animating colors works the way that a color in rgb format, say `#aabbcc00` is split into four channels `aa`, `bb`, `cc`, `00`. Then, all these channel are animated separately, i.e. starting 4 `withSpring` animations. For the purpose of the animation, these values are animated between 0-1 and when the frame is flushed, they are multiplied by 255 and rounded. However, after the flame is flushed, instead of restoring the original values to the animation, the multiplied value is divided back by 255, resulting in precision errors. These errors mean that an animation that would animate a channel from `0.54901961` to `0.55` in a frame, would be effectively reset, because `round(0.55*255)/255 = 0.54901961`. This makes the animation never end as it's stuck on re-calculating the frame forever.

## Test plan

```js
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  withSpring,
} from 'react-native-reanimated';
import { Button, StyleSheet, View } from 'react-native';
import { runOnUI } from 'react-native-worklets';

export default function EmptyExample() {
  const colorSv = useSharedValue('#ff0000ff');
  const animatedStyle = useAnimatedStyle(() => {
    return {
      backgroundColor: colorSv.value,
    };
  });
  return (
    <View style={styles.container}>
      <Animated.View
        style={[{ width: 100, height: 100 }, animatedStyle]}></Animated.View>
      <Button
        title="Press me"
        onPress={() => {
          runOnUI(() => {
            const now = performance.now();
            colorSv.value = withSpring('#00ff00ff', { duration: 1000 }, () =>
              console.log('Animation finished at', performance.now() - now)
            );
          })();
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```
