### PR TITLE
refactor(Worklets): move version prop outside of initData

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/BabelVersionCheckExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/BabelVersionCheckExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
-import { runOnUI } from 'react-native-reanimated';
+import { runOnUI } from 'react-native-worklets';
 
 function shortOffender() {
   'worklet';
@@ -24,13 +24,13 @@ function longOffender() {
 export default function BabelVersionCheckExample() {
   const forceErrorWithShortWorklet = () => {
     // @ts-ignore this is fine
-    shortOffender.__initData.version = 'x.y.z';
+    shortOffender.__pluginVersion = 'x.y.z';
     runOnUI(shortOffender)();
   };
 
   const forceErrorWithLongWorklet = () => {
     // @ts-ignore this is fine
-    longOffender.__initData.version = 'x.y.z';
+    longOffender.__pluginVersion = 'x.y.z';
     runOnUI(longOffender)();
   };
 

--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin.test.ts.snap
@@ -18,8 +18,7 @@ exports[`babel plugin for DirectiveLiterals doesn't transform string literals 1`
 "var _worklet_7224155149057_init_data = {
   code: "function foo_null1(x){const bar='worklet';const baz=\\"worklet\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_7224155149057_init_data = _ref._worklet_7224155149057_init_data;
@@ -30,6 +29,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 7224155149057;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_7224155149057_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -42,8 +42,7 @@ exports[`babel plugin for DirectiveLiterals removes "worklet"; directive from wo
 "var _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
@@ -53,6 +52,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 2156194750585;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_2156194750585_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -65,8 +65,7 @@ exports[`babel plugin for DirectiveLiterals removes 'worklet'; directive from wo
 "var _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
@@ -76,6 +75,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 2156194750585;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_2156194750585_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -148,8 +148,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on kn
 "var _worklet_7317097572766_init_data = {
   code: "function null1(){console.log('FadeIn with build after');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 FadeIn.withCallback(function null1Factory(_ref) {
   var _worklet_7317097572766_init_data = _ref._worklet_7317097572766_init_data;
@@ -159,6 +158,7 @@ FadeIn.withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 7317097572766;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_7317097572766_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -171,8 +171,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on kn
 "var _worklet_7317097572766_init_data = {
   code: "function null1(){console.log('FadeIn with build after');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 new FadeIn().withCallback(function null1Factory(_ref) {
   var _worklet_7317097572766_init_data = _ref._worklet_7317097572766_init_data;
@@ -182,6 +181,7 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 7317097572766;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_7317097572766_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -194,8 +194,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on kn
 "var _worklet_12678290670659_init_data = {
   code: "function null1(){console.log('FadeIn with build before');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 FadeIn.build().withCallback(function null1Factory(_ref) {
   var _worklet_12678290670659_init_data = _ref._worklet_12678290670659_init_data;
@@ -205,6 +204,7 @@ FadeIn.build().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 12678290670659;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_12678290670659_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -217,8 +217,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on kn
 "var _worklet_12678290670659_init_data = {
   code: "function null1(){console.log('FadeIn with build before');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 new FadeIn().build().withCallback(function null1Factory(_ref) {
   var _worklet_12678290670659_init_data = _ref._worklet_12678290670659_init_data;
@@ -228,6 +227,7 @@ new FadeIn().build().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 12678290670659;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_12678290670659_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -240,8 +240,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on lo
 "var _worklet_11557425704826_init_data = {
   code: "function null1(){console.log('FadeIn with build');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 FadeIn.build().duration().withCallback(function null1Factory(_ref) {
   var _worklet_11557425704826_init_data = _ref._worklet_11557425704826_init_data;
@@ -251,6 +250,7 @@ FadeIn.build().duration().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 11557425704826;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_11557425704826_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -263,8 +263,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on lo
 "var _worklet_11557425704826_init_data = {
   code: "function null1(){console.log('FadeIn with build');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 new FadeIn().build().duration().withCallback(function null1Factory(_ref) {
   var _worklet_11557425704826_init_data = _ref._worklet_11557425704826_init_data;
@@ -274,6 +273,7 @@ new FadeIn().build().duration().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 11557425704826;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_11557425704826_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -286,8 +286,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on un
 "var _worklet_6642833765517_init_data = {
   code: "function null1(){console.log('FadeIn with AmogusIn after');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 FadeIn.withCallback(function null1Factory(_ref) {
   var _worklet_6642833765517_init_data = _ref._worklet_6642833765517_init_data;
@@ -297,6 +296,7 @@ FadeIn.withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 6642833765517;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_6642833765517_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -309,8 +309,7 @@ exports[`babel plugin for Layout Animations workletizes callback functions on un
 "var _worklet_6642833765517_init_data = {
   code: "function null1(){console.log('FadeIn with AmogusIn after');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 new FadeIn().withCallback(function null1Factory(_ref) {
   var _worklet_6642833765517_init_data = _ref._worklet_6642833765517_init_data;
@@ -320,6 +319,7 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 6642833765517;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_6642833765517_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -332,8 +332,7 @@ exports[`babel plugin for Layout Animations workletizes unchained callback funct
 "var _worklet_5714930700718_init_data = {
   code: "function null1(){console.log('FadeIn');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 FadeIn.withCallback(function null1Factory(_ref) {
   var _worklet_5714930700718_init_data = _ref._worklet_5714930700718_init_data;
@@ -343,6 +342,7 @@ FadeIn.withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 5714930700718;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_5714930700718_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -355,8 +355,7 @@ exports[`babel plugin for Layout Animations workletizes unchained callback funct
 "var _worklet_5714930700718_init_data = {
   code: "function null1(){console.log('FadeIn');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 new FadeIn().withCallback(function null1Factory(_ref) {
   var _worklet_5714930700718_init_data = _ref._worklet_5714930700718_init_data;
@@ -366,6 +365,7 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 5714930700718;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_5714930700718_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -380,8 +380,7 @@ var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/
 var _worklet_14005565322850_init_data = {
   code: "async function foo_null1(){await Promise.resolve();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_14005565322850_init_data = _ref._worklet_14005565322850_init_data;
@@ -396,6 +395,7 @@ var foo = function foo_null1Factory(_ref) {
   }();
   foo.__closure = {};
   foo.__workletHash = 14005565322850;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_14005565322850_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -410,8 +410,7 @@ var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/
 var _worklet_14005565322850_init_data = {
   code: "async function foo_null1(){await Promise.resolve();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_14005565322850_init_data = _ref._worklet_14005565322850_init_data;
@@ -426,6 +425,7 @@ var foo = function foo_null1Factory(_ref) {
   }();
   foo.__closure = {};
   foo.__workletHash = 14005565322850;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_14005565322850_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -441,8 +441,7 @@ var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/cl
 var _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = (0, _createClass2.default)(function Foo() {
   (0, _classCallCheck2.default)(this, Foo);
@@ -454,6 +453,7 @@ var Foo = (0, _createClass2.default)(function Foo() {
     };
     null1.__closure = {};
     null1.__workletHash = 2294411833184;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_2294411833184_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -470,8 +470,7 @@ var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/cl
 var _worklet_8889327806636_init_data = {
   code: "function Foo_null1(x){const Foo_null1=this._recur;const{_classCallCheck}=this.__closure;_classCallCheck(this,Foo_null1);this.x=x;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = (0, _createClass2.default)(function Foo_null1Factory(_ref) {
   var _worklet_8889327806636_init_data = _ref._worklet_8889327806636_init_data,
@@ -485,6 +484,7 @@ var Foo = (0, _createClass2.default)(function Foo_null1Factory(_ref) {
     _classCallCheck: _classCallCheck
   };
   _Foo.__workletHash = 8889327806636;
+  _Foo.__pluginVersion = "x.y.z";
   _Foo.__initData = _worklet_8889327806636_init_data;
   _Foo.__stackDetails = _e;
   return _Foo;
@@ -502,8 +502,7 @@ var x = 5;
 var _worklet_13515258128853_init_data = {
   code: "function get_null1(){const{x}=this.__closure;return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = function () {
   function Foo() {
@@ -522,6 +521,7 @@ var Foo = function () {
         x: x
       };
       get.__workletHash = 13515258128853;
+      get.__pluginVersion = "x.y.z";
       get.__initData = _worklet_13515258128853_init_data;
       get.__stackDetails = _e;
       return get;
@@ -540,8 +540,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/creat
 var _worklet_10686480819086_init_data = {
   code: "function bar_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = function () {
   function Foo() {
@@ -557,6 +556,7 @@ var Foo = function () {
       };
       bar.__closure = {};
       bar.__workletHash = 10686480819086;
+      bar.__pluginVersion = "x.y.z";
       bar.__initData = _worklet_10686480819086_init_data;
       bar.__stackDetails = _e;
       return bar;
@@ -574,8 +574,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/creat
 var _worklet_14784735859354_init_data = {
   code: "function set_null1(x){this.x=x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = function () {
   function Foo() {
@@ -591,6 +590,7 @@ var Foo = function () {
       };
       set.__closure = {};
       set.__workletHash = 14784735859354;
+      set.__pluginVersion = "x.y.z";
       set.__initData = _worklet_14784735859354_init_data;
       set.__stackDetails = _e;
       return set;
@@ -611,8 +611,7 @@ var Foo = (0, _createClass2.default)(function Foo() {
 var _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 Foo.bar = function null1Factory(_ref) {
   var _worklet_2294411833184_init_data = _ref._worklet_2294411833184_init_data;
@@ -622,6 +621,7 @@ Foo.bar = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2294411833184;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2294411833184_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -637,8 +637,7 @@ var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/creat
 var _worklet_10686480819086_init_data = {
   code: "function bar_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Foo = function () {
   function Foo() {
@@ -654,6 +653,7 @@ var Foo = function () {
       };
       bar.__closure = {};
       bar.__workletHash = 10686480819086;
+      bar.__pluginVersion = "x.y.z";
       bar.__initData = _worklet_10686480819086_init_data;
       bar.__stackDetails = _e;
       return bar;
@@ -673,8 +673,7 @@ exports[`babel plugin for closure capturing captures locally bound variables nam
 var _worklet_1380037982666_init_data = {
   code: "function f_null1(){const{console}=this.__closure;console.log(console);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_1380037982666_init_data = _ref._worklet_1380037982666_init_data,
@@ -687,6 +686,7 @@ var f = function f_null1Factory(_ref) {
     console: console
   };
   f.__workletHash = 1380037982666;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_1380037982666_init_data;
   f.__stackDetails = _e;
   return f;
@@ -704,8 +704,7 @@ var objX = {
 var _worklet_10550735168277_init_data = {
   code: "function f_null1(){const{x,objX}=this.__closure;return{res:x+objX.x};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_10550735168277_init_data = _ref._worklet_10550735168277_init_data,
@@ -722,6 +721,7 @@ var f = function f_null1Factory(_ref) {
     objX: objX
   };
   f.__workletHash = 10550735168277;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_10550735168277_init_data;
   f.__stackDetails = _e;
   return f;
@@ -736,8 +736,7 @@ exports[`babel plugin for closure capturing doesn't capture arguments 1`] = `
 "var _worklet_11756143316246_init_data = {
   code: "function f_null1(a,b,c){console.log(arguments);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_11756143316246_init_data = _ref._worklet_11756143316246_init_data;
@@ -747,6 +746,7 @@ var f = function f_null1Factory(_ref) {
   };
   f.__closure = {};
   f.__workletHash = 11756143316246;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_11756143316246_init_data;
   f.__stackDetails = _e;
   return f;
@@ -759,8 +759,7 @@ exports[`babel plugin for closure capturing doesn't capture custom globals 1`] =
 "var _worklet_11658370598384_init_data = {
   code: "function f_null1(){console.log(foo);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_11658370598384_init_data = _ref._worklet_11658370598384_init_data;
@@ -770,6 +769,7 @@ var f = function f_null1Factory(_ref) {
   };
   f.__closure = {};
   f.__workletHash = 11658370598384;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_11658370598384_init_data;
   f.__stackDetails = _e;
   return f;
@@ -782,8 +782,7 @@ exports[`babel plugin for closure capturing doesn't capture default globals 1`] 
 "var _worklet_9451494835104_init_data = {
   code: "function f_null1(){console.log('test');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_9451494835104_init_data = _ref._worklet_9451494835104_init_data;
@@ -793,6 +792,7 @@ var f = function f_null1Factory(_ref) {
   };
   f.__closure = {};
   f.__workletHash = 9451494835104;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_9451494835104_init_data;
   f.__stackDetails = _e;
   return f;
@@ -806,8 +806,7 @@ exports[`babel plugin for closure capturing doesn't capture locally bound variab
 var _worklet_6398258314122_init_data = {
   code: "function f_null1(){const{foo}=this.__closure;console.log(foo);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_6398258314122_init_data = _ref._worklet_6398258314122_init_data,
@@ -820,6 +819,7 @@ var f = function f_null1Factory(_ref) {
     foo: foo
   };
   f.__workletHash = 6398258314122;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_6398258314122_init_data;
   f.__stackDetails = _e;
   return f;
@@ -836,8 +836,7 @@ exports[`babel plugin for closure capturing doesn't capture objects' properties 
 var _worklet_239990909653_init_data = {
   code: "function f_null1(){const{foo}=this.__closure;console.log(foo.bar);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function f_null1Factory(_ref) {
   var _worklet_239990909653_init_data = _ref._worklet_239990909653_init_data,
@@ -850,6 +849,7 @@ var f = function f_null1Factory(_ref) {
     foo: foo
   };
   f.__workletHash = 239990909653;
+  f.__pluginVersion = "x.y.z";
   f.__initData = _worklet_239990909653_init_data;
   f.__stackDetails = _e;
   return f;
@@ -863,8 +863,7 @@ exports[`babel plugin for context objects creates factories 1`] = `
 "var _worklet_9226058452652_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar() {
@@ -882,6 +881,7 @@ var foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 9226058452652;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -895,8 +895,7 @@ exports[`babel plugin for context objects preserves bindings 1`] = `
 "var _worklet_4592588545601_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar() {
@@ -920,6 +919,7 @@ var foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 4592588545601;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -933,8 +933,7 @@ exports[`babel plugin for context objects removes marker 1`] = `
 "var _worklet_9226058452652_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar() {
@@ -952,6 +951,7 @@ var foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 9226058452652;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -965,8 +965,7 @@ exports[`babel plugin for context objects workletizes regardless of marker value
 "var _worklet_9226058452652_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar() {
@@ -984,6 +983,7 @@ var foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 9226058452652;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -997,8 +997,7 @@ exports[`babel plugin for debugging does inject location for worklets in dev bui
 "var _worklet_8623346549410_init_data = {
   code: "function null1(){const x=1;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = useAnimatedStyle(function null1Factory(_ref) {
   var _worklet_8623346549410_init_data = _ref._worklet_8623346549410_init_data;
@@ -1008,6 +1007,7 @@ var foo = useAnimatedStyle(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 8623346549410;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_8623346549410_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1056,8 +1056,7 @@ exports[`babel plugin for explicit worklets workletizes ArrowFunctionExpression 
 "var _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null1Factory(_ref) {
   var _worklet_2294411833184_init_data = _ref._worklet_2294411833184_init_data;
@@ -1067,6 +1066,7 @@ var foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2294411833184;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2294411833184_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1079,8 +1079,7 @@ exports[`babel plugin for explicit worklets workletizes FunctionDeclaration 1`] 
 "var _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
@@ -1090,6 +1089,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 2156194750585;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_2156194750585_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1102,8 +1102,7 @@ exports[`babel plugin for explicit worklets workletizes ObjectMethod 1`] = `
 "var _worklet_10686480819086_init_data = {
   code: "function bar_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar_null1Factory(_ref) {
@@ -1114,6 +1113,7 @@ var foo = {
     };
     bar.__closure = {};
     bar.__workletHash = 10686480819086;
+    bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_10686480819086_init_data;
     bar.__stackDetails = _e;
     return bar;
@@ -1127,8 +1127,7 @@ exports[`babel plugin for explicit worklets workletizes named FunctionExpression
 "var _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
@@ -1138,6 +1137,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 2156194750585;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_2156194750585_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1150,8 +1150,7 @@ exports[`babel plugin for explicit worklets workletizes unnamed FunctionExpressi
 "var _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null1Factory(_ref) {
   var _worklet_2294411833184_init_data = _ref._worklet_2294411833184_init_data;
@@ -1161,6 +1160,7 @@ var foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2294411833184;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2294411833184_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1181,8 +1181,7 @@ exports[`babel plugin for file workletization moves CommonJS export to the botto
 "var _worklet_15780239751281_init_data = {
   code: "function foo_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_15780239751281_init_data = _ref._worklet_15780239751281_init_data;
@@ -1190,6 +1189,7 @@ var foo = function foo_null1Factory(_ref) {
   var foo = function foo() {};
   foo.__closure = {};
   foo.__workletHash = 15780239751281;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_15780239751281_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1204,8 +1204,7 @@ exports[`babel plugin for file workletization moves multiple CommonJS exports to
 "var _worklet_15780239751281_init_data = {
   code: "function foo_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_15780239751281_init_data = _ref._worklet_15780239751281_init_data;
@@ -1213,6 +1212,7 @@ var foo = function foo_null1Factory(_ref) {
   var foo = function foo() {};
   foo.__closure = {};
   foo.__workletHash = 15780239751281;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_15780239751281_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1222,8 +1222,7 @@ var foo = function foo_null1Factory(_ref) {
 var _worklet_552304524261_init_data = {
   code: "function bar_null2(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var bar = function bar_null2Factory(_ref2) {
   var _worklet_552304524261_init_data = _ref2._worklet_552304524261_init_data;
@@ -1231,6 +1230,7 @@ var bar = function bar_null2Factory(_ref2) {
   var bar = function bar() {};
   bar.__closure = {};
   bar.__workletHash = 552304524261;
+  bar.__pluginVersion = "x.y.z";
   bar.__initData = _worklet_552304524261_init_data;
   bar.__stackDetails = _e;
   return bar;
@@ -1240,8 +1240,7 @@ var bar = function bar_null2Factory(_ref2) {
 var _worklet_9955902016844_init_data = {
   code: "function baz_null3(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var baz = function baz_null3Factory(_ref3) {
   var _worklet_9955902016844_init_data = _ref3._worklet_9955902016844_init_data;
@@ -1249,6 +1248,7 @@ var baz = function baz_null3Factory(_ref3) {
   var baz = function baz() {};
   baz.__closure = {};
   baz.__workletHash = 9955902016844;
+  baz.__pluginVersion = "x.y.z";
   baz.__initData = _worklet_9955902016844_init_data;
   baz.__stackDetails = _e;
   return baz;
@@ -1258,8 +1258,7 @@ var baz = function baz_null3Factory(_ref3) {
 var _worklet_3271684035845_init_data = {
   code: "function foobar_null4(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foobar = function foobar_null4Factory(_ref4) {
   var _worklet_3271684035845_init_data = _ref4._worklet_3271684035845_init_data;
@@ -1267,6 +1266,7 @@ var foobar = function foobar_null4Factory(_ref4) {
   var foobar = function foobar() {};
   foobar.__closure = {};
   foobar.__workletHash = 3271684035845;
+  foobar.__pluginVersion = "x.y.z";
   foobar.__initData = _worklet_3271684035845_init_data;
   foobar.__stackDetails = _e;
   return foobar;
@@ -1283,8 +1283,7 @@ exports[`babel plugin for file workletization workletizes ArrowFunctionExpressio
 "var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -1294,6 +1293,7 @@ var foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1310,8 +1310,7 @@ exports.default = void 0;
 var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _default = exports.default = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -1321,6 +1320,7 @@ var _default = exports.default = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1337,8 +1337,7 @@ exports.foo = void 0;
 var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = exports.foo = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -1348,6 +1347,7 @@ var foo = exports.foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1362,38 +1362,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -1404,6 +1398,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -1425,6 +1420,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -1443,6 +1439,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -1464,6 +1461,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -1484,6 +1482,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -1516,6 +1515,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -1539,38 +1539,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = exports.default = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -1581,6 +1575,7 @@ var Clazz = exports.default = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -1602,6 +1597,7 @@ var Clazz = exports.default = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -1620,6 +1616,7 @@ var Clazz = exports.default = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -1641,6 +1638,7 @@ var Clazz = exports.default = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -1661,6 +1659,7 @@ var Clazz = exports.default = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -1693,6 +1692,7 @@ var Clazz = exports.default = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -1716,38 +1716,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = exports.Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -1758,6 +1752,7 @@ var Clazz = exports.Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -1779,6 +1774,7 @@ var Clazz = exports.Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -1797,6 +1793,7 @@ var Clazz = exports.Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -1818,6 +1815,7 @@ var Clazz = exports.Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -1838,6 +1836,7 @@ var Clazz = exports.Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -1870,6 +1869,7 @@ var Clazz = exports.Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -1887,8 +1887,7 @@ exports[`babel plugin for file workletization workletizes FunctionDeclaration 1`
 "var _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
@@ -1898,6 +1897,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 5253890412305;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1914,8 +1914,7 @@ exports.default = void 0;
 var _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _default = exports.default = function foo_null1Factory(_ref) {
   var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
@@ -1925,6 +1924,7 @@ var _default = exports.default = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 5253890412305;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1941,8 +1941,7 @@ exports.foo = void 0;
 var _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = exports.foo = function foo_null1Factory(_ref) {
   var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
@@ -1952,6 +1951,7 @@ var foo = exports.foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 5253890412305;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -1964,8 +1964,7 @@ exports[`babel plugin for file workletization workletizes FunctionExpression 1`]
 "var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -1975,6 +1974,7 @@ var foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -1991,8 +1991,7 @@ exports.default = void 0;
 var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _default = exports.default = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -2002,6 +2001,7 @@ var _default = exports.default = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2018,8 +2018,7 @@ exports.foo = void 0;
 var _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = exports.foo = function null1Factory(_ref) {
   var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
@@ -2029,6 +2028,7 @@ var foo = exports.foo = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2420910284744;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2041,8 +2041,7 @@ exports[`babel plugin for file workletization workletizes ObjectMethod 1`] = `
 "var _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar_null1Factory(_ref) {
@@ -2053,6 +2052,7 @@ var foo = {
     };
     bar.__closure = {};
     bar.__workletHash = 17582834634406;
+    bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_17582834634406_init_data;
     bar.__stackDetails = _e;
     return bar;
@@ -2070,8 +2070,7 @@ exports.default = void 0;
 var _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _default = exports.default = {
   bar: function bar_null1Factory(_ref) {
@@ -2082,6 +2081,7 @@ var _default = exports.default = {
     };
     bar.__closure = {};
     bar.__workletHash = 17582834634406;
+    bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_17582834634406_init_data;
     bar.__stackDetails = _e;
     return bar;
@@ -2099,8 +2099,7 @@ exports.foo = void 0;
 var _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = exports.foo = {
   bar: function bar_null1Factory(_ref) {
@@ -2111,6 +2110,7 @@ var foo = exports.foo = {
     };
     bar.__closure = {};
     bar.__workletHash = 17582834634406;
+    bar.__pluginVersion = "x.y.z";
     bar.__initData = _worklet_17582834634406_init_data;
     bar.__stackDetails = _e;
     return bar;
@@ -2124,8 +2124,7 @@ exports[`babel plugin for file workletization workletizes assigned FunctionDecla
 "var _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
@@ -2135,6 +2134,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 5253890412305;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2147,8 +2147,7 @@ exports[`babel plugin for file workletization workletizes implicit WorkletContex
 "var _worklet_4592588545601_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = {
   bar: function bar() {
@@ -2172,6 +2171,7 @@ var foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 4592588545601;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -2189,8 +2189,7 @@ exports.default = void 0;
 var _worklet_4592588545601_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _default = exports.default = {
   bar: function bar() {
@@ -2214,6 +2213,7 @@ var _default = exports.default = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 4592588545601;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -2231,8 +2231,7 @@ exports.foo = void 0;
 var _worklet_4592588545601_init_data = {
   code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = exports.foo = {
   bar: function bar() {
@@ -2256,6 +2255,7 @@ var foo = exports.foo = {
     };
     __workletContextObjectFactory.__closure = {};
     __workletContextObjectFactory.__workletHash = 4592588545601;
+    __workletContextObjectFactory.__pluginVersion = "x.y.z";
     __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
     __workletContextObjectFactory.__stackDetails = _e;
     return __workletContextObjectFactory;
@@ -2269,8 +2269,7 @@ exports[`babel plugin for file workletization workletizes multiple functions 1`]
 "var _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
@@ -2280,6 +2279,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 5253890412305;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2289,8 +2289,7 @@ var foo = function foo_null1Factory(_ref) {
 var _worklet_17530869641357_init_data = {
   code: "function null2(){return'foobar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var bar = function null2Factory(_ref2) {
   var _worklet_17530869641357_init_data = _ref2._worklet_17530869641357_init_data;
@@ -2300,6 +2299,7 @@ var bar = function null2Factory(_ref2) {
   };
   null2.__closure = {};
   null2.__workletHash = 17530869641357;
+  null2.__pluginVersion = "x.y.z";
   null2.__initData = _worklet_17530869641357_init_data;
   null2.__stackDetails = _e;
   return null2;
@@ -2312,8 +2312,7 @@ exports[`babel plugin for function hooks workletizes hook wrapped ArrowFunctionE
 "var _worklet_1392490775014_init_data = {
   code: "function null1(){return{width:50};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   var _worklet_1392490775014_init_data = _ref._worklet_1392490775014_init_data;
@@ -2325,6 +2324,7 @@ var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 1392490775014;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1392490775014_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2337,8 +2337,7 @@ exports[`babel plugin for function hooks workletizes hook wrapped named Function
 "var _worklet_9984171279103_init_data = {
   code: "function foo_null1(){return{width:50};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var animatedStyle = useAnimatedStyle(function foo_null1Factory(_ref) {
   var _worklet_9984171279103_init_data = _ref._worklet_9984171279103_init_data;
@@ -2350,6 +2349,7 @@ var animatedStyle = useAnimatedStyle(function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 9984171279103;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_9984171279103_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2362,8 +2362,7 @@ exports[`babel plugin for function hooks workletizes hook wrapped unnamed Functi
 "var _worklet_1392490775014_init_data = {
   code: "function null1(){return{width:50};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   var _worklet_1392490775014_init_data = _ref._worklet_1392490775014_init_data;
@@ -2375,6 +2374,7 @@ var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 1392490775014;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1392490775014_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2387,8 +2387,7 @@ exports[`babel plugin for function hooks workletizes hook wrapped worklet refere
 "var _worklet_3038192071896_init_data = {
   code: "function style_null1(){return{color:'red',backgroundColor:'blue'};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var style = function style_null1Factory({
   _worklet_3038192071896_init_data
@@ -2402,6 +2401,7 @@ var style = function style_null1Factory({
   };
   style.__closure = {};
   style.__workletHash = 3038192071896;
+  style.__pluginVersion = "x.y.z";
   style.__initData = _worklet_3038192071896_init_data;
   style.__stackDetails = _e;
   return style;
@@ -2415,8 +2415,7 @@ exports[`babel plugin for generators makes a generator worklet factory 1`] = `
 "var _worklet_4135278281851_init_data = {
   code: "function*foo_null1(){yield'hello';yield'world';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_4135278281851_init_data = _ref._worklet_4135278281851_init_data;
@@ -2427,6 +2426,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 4135278281851;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_4135278281851_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2439,8 +2439,7 @@ exports[`babel plugin for generators makes a generator worklet string 1`] = `
 "var _worklet_4135278281851_init_data = {
   code: "function*foo_null1(){yield'hello';yield'world';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_4135278281851_init_data = _ref._worklet_4135278281851_init_data;
@@ -2451,6 +2450,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 4135278281851;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_4135278281851_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2526,8 +2526,7 @@ exports[`babel plugin for object hooks transforms ArrowFunctionExpression as arg
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler(function null1Factory(_ref) {
   var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
@@ -2537,6 +2536,7 @@ useAnimatedScrollHandler(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 6572201563503;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_6572201563503_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2549,20 +2549,17 @@ exports[`babel plugin for object hooks transforms each object property in useAni
 "var _worklet_17107900483944_init_data = {
   code: "function null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_15612771346699_init_data = {
   code: "function null2(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_3001796818986_init_data = {
   code: "function null3(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onStart: function null1Factory(_ref) {
@@ -2571,6 +2568,7 @@ useAnimatedGestureHandler({
     var null1 = function null1() {};
     null1.__closure = {};
     null1.__workletHash = 17107900483944;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_17107900483944_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2583,6 +2581,7 @@ useAnimatedGestureHandler({
     var null2 = function null2() {};
     null2.__closure = {};
     null2.__workletHash = 15612771346699;
+    null2.__pluginVersion = "x.y.z";
     null2.__initData = _worklet_15612771346699_init_data;
     null2.__stackDetails = _e;
     return null2;
@@ -2595,6 +2594,7 @@ useAnimatedGestureHandler({
     var null3 = function null3() {};
     null3.__closure = {};
     null3.__workletHash = 3001796818986;
+    null3.__pluginVersion = "x.y.z";
     null3.__initData = _worklet_3001796818986_init_data;
     null3.__stackDetails = _e;
     return null3;
@@ -2608,32 +2608,27 @@ exports[`babel plugin for object hooks transforms each object property in useAni
 "var _worklet_17107900483944_init_data = {
   code: "function null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_15612771346699_init_data = {
   code: "function null2(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_3001796818986_init_data = {
   code: "function null3(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_14370141256397_init_data = {
   code: "function null4(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_16301592545772_init_data = {
   code: "function null5(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
   onScroll: function null1Factory(_ref) {
@@ -2642,6 +2637,7 @@ useAnimatedScrollHandler({
     var null1 = function null1() {};
     null1.__closure = {};
     null1.__workletHash = 17107900483944;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_17107900483944_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2654,6 +2650,7 @@ useAnimatedScrollHandler({
     var null2 = function null2() {};
     null2.__closure = {};
     null2.__workletHash = 15612771346699;
+    null2.__pluginVersion = "x.y.z";
     null2.__initData = _worklet_15612771346699_init_data;
     null2.__stackDetails = _e;
     return null2;
@@ -2666,6 +2663,7 @@ useAnimatedScrollHandler({
     var null3 = function null3() {};
     null3.__closure = {};
     null3.__workletHash = 3001796818986;
+    null3.__pluginVersion = "x.y.z";
     null3.__initData = _worklet_3001796818986_init_data;
     null3.__stackDetails = _e;
     return null3;
@@ -2678,6 +2676,7 @@ useAnimatedScrollHandler({
     var null4 = function null4() {};
     null4.__closure = {};
     null4.__workletHash = 14370141256397;
+    null4.__pluginVersion = "x.y.z";
     null4.__initData = _worklet_14370141256397_init_data;
     null4.__stackDetails = _e;
     return null4;
@@ -2690,6 +2689,7 @@ useAnimatedScrollHandler({
     var null5 = function null5() {};
     null5.__closure = {};
     null5.__workletHash = 16301592545772;
+    null5.__pluginVersion = "x.y.z";
     null5.__initData = _worklet_16301592545772_init_data;
     null5.__stackDetails = _e;
     return null5;
@@ -2703,8 +2703,7 @@ exports[`babel plugin for object hooks transforms named FunctionExpression as ar
 "var _worklet_13903338421046_init_data = {
   code: "function foo_null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler(function foo_null1Factory(_ref) {
   var _worklet_13903338421046_init_data = _ref._worklet_13903338421046_init_data;
@@ -2714,6 +2713,7 @@ useAnimatedScrollHandler(function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 13903338421046;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_13903338421046_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -2726,8 +2726,7 @@ exports[`babel plugin for object hooks transforms unnamed FunctionExpression as 
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler(function null1Factory(_ref) {
   var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
@@ -2737,6 +2736,7 @@ useAnimatedScrollHandler(function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 6572201563503;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_6572201563503_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -2749,8 +2749,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedGestureHandler wra
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onStart: function null1Factory(_ref) {
@@ -2761,6 +2760,7 @@ useAnimatedGestureHandler({
     };
     null1.__closure = {};
     null1.__workletHash = 6572201563503;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_6572201563503_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2774,8 +2774,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedGestureHandler wra
 "var _worklet_6368412250705_init_data = {
   code: "function onStart_null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onStart: function onStart_null1Factory(_ref) {
@@ -2786,6 +2785,7 @@ useAnimatedGestureHandler({
     };
     onStart.__closure = {};
     onStart.__workletHash = 6368412250705;
+    onStart.__pluginVersion = "x.y.z";
     onStart.__initData = _worklet_6368412250705_init_data;
     onStart.__stackDetails = _e;
     return onStart;
@@ -2799,8 +2799,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedGestureHandler wra
 "var _worklet_6368412250705_init_data = {
   code: "function onStart_null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onStart: function onStart_null1Factory(_ref) {
@@ -2811,6 +2810,7 @@ useAnimatedGestureHandler({
     };
     onStart.__closure = {};
     onStart.__workletHash = 6368412250705;
+    onStart.__pluginVersion = "x.y.z";
     onStart.__initData = _worklet_6368412250705_init_data;
     onStart.__stackDetails = _e;
     return onStart;
@@ -2824,8 +2824,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedGestureHandler wra
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onStart: function null1Factory(_ref) {
@@ -2836,6 +2835,7 @@ useAnimatedGestureHandler({
     };
     null1.__closure = {};
     null1.__workletHash = 6572201563503;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_6572201563503_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2849,8 +2849,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrap
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
   onScroll: function null1Factory(_ref) {
@@ -2861,6 +2860,7 @@ useAnimatedScrollHandler({
     };
     null1.__closure = {};
     null1.__workletHash = 6572201563503;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_6572201563503_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2874,8 +2874,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrap
 "var _worklet_11162089192476_init_data = {
   code: "function onScroll_null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedGestureHandler({
   onScroll: function onScroll_null1Factory(_ref) {
@@ -2886,6 +2885,7 @@ useAnimatedGestureHandler({
     };
     onScroll.__closure = {};
     onScroll.__workletHash = 11162089192476;
+    onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_11162089192476_init_data;
     onScroll.__stackDetails = _e;
     return onScroll;
@@ -2899,8 +2899,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrap
 "var _worklet_11162089192476_init_data = {
   code: "function onScroll_null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
   onScroll: function onScroll_null1Factory(_ref) {
@@ -2911,6 +2910,7 @@ useAnimatedScrollHandler({
     };
     onScroll.__closure = {};
     onScroll.__workletHash = 11162089192476;
+    onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_11162089192476_init_data;
     onScroll.__stackDetails = _e;
     return onScroll;
@@ -2924,8 +2924,7 @@ exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrap
 "var _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
   onScroll: function null1Factory(_ref) {
@@ -2936,6 +2935,7 @@ useAnimatedScrollHandler({
     };
     null1.__closure = {};
     null1.__workletHash = 6572201563503;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_6572201563503_init_data;
     null1.__stackDetails = _e;
     return null1;
@@ -2977,8 +2977,7 @@ exports[`babel plugin for react-native-gesture-handler transforms spread operato
 "var _worklet_10797201137439_init_data = {
   code: "function foo_null1(){const bar=[4,5];const baz=[1,...[2,3],...bar];}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_10797201137439_init_data = _ref._worklet_10797201137439_init_data;
@@ -2989,6 +2988,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 10797201137439;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_10797201137439_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3001,8 +3001,7 @@ exports[`babel plugin for react-native-gesture-handler transforms spread operato
 "var _worklet_7564534166424_init_data = {
   code: "function foo_null1(...args){console.log(args);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_7564534166424_init_data = _ref._worklet_7564534166424_init_data;
@@ -3015,6 +3014,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 7564534166424;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_7564534166424_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3029,8 +3029,7 @@ var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers
 var _worklet_14662302952728_init_data = {
   code: "function foo_null1(arg){console.log(...arg);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_14662302952728_init_data = _ref._worklet_14662302952728_init_data;
@@ -3041,6 +3040,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 14662302952728;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_14662302952728_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3053,8 +3053,7 @@ exports[`babel plugin for react-native-gesture-handler transforms spread operato
 "var _worklet_4831123253572_init_data = {
   code: "function foo_null1(){const bar={d:4,e:5};const baz={a:1,...{b:2,c:3},...bar};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_4831123253572_init_data = _ref._worklet_4831123253572_init_data;
@@ -3073,6 +3072,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 4831123253572;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_4831123253572_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3085,20 +3085,17 @@ exports[`babel plugin for react-native-gesture-handler workletizes possibly chai
 "var _worklet_2359797567586_init_data = {
   code: "function null1(_event,_success){console.log('onEnd');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_16446448315454_init_data = {
   code: "function null2(_event){console.log('onStart');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_13974752356811_init_data = {
   code: "function null3(){console.log('onBegin');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   var _worklet_13974752356811_init_data = _ref._worklet_13974752356811_init_data;
@@ -3108,6 +3105,7 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   };
   null3.__closure = {};
   null3.__workletHash = 13974752356811;
+  null3.__pluginVersion = "x.y.z";
   null3.__initData = _worklet_13974752356811_init_data;
   null3.__stackDetails = _e;
   return null3;
@@ -3121,6 +3119,7 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   };
   null2.__closure = {};
   null2.__workletHash = 16446448315454;
+  null2.__pluginVersion = "x.y.z";
   null2.__initData = _worklet_16446448315454_init_data;
   null2.__stackDetails = _e;
   return null2;
@@ -3134,6 +3133,7 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 2359797567586;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_2359797567586_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -3146,8 +3146,7 @@ exports[`babel plugin for react-native-gesture-handler workletizes referenced ca
 "var _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var onStart = function onStart_null1Factory({
   _worklet_8764176270806_init_data
@@ -3156,6 +3155,7 @@ var onStart = function onStart_null1Factory({
   const onStart = function () {};
   onStart.__closure = {};
   onStart.__workletHash = 8764176270806;
+  onStart.__pluginVersion = "x.y.z";
   onStart.__initData = _worklet_8764176270806_init_data;
   onStart.__stackDetails = _e;
   return onStart;
@@ -3172,8 +3172,7 @@ exports[`babel plugin for referenced worklets prefers AssignmentExpression over 
 var _worklet_7165463824996_init_data = {
   code: "function styleFactory_null1(){return'AssignmentExpression';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function styleFactory_null1Factory({
   _worklet_7165463824996_init_data
@@ -3184,6 +3183,7 @@ styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 7165463824996;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_7165463824996_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3199,8 +3199,7 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_2619465543015_init_data = {
   code: "function styleFactory_null1(){return'FunctionDeclaration';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var styleFactory = function styleFactory_null1Factory(_ref) {
   var _worklet_2619465543015_init_data = _ref._worklet_2619465543015_init_data;
@@ -3210,6 +3209,7 @@ var styleFactory = function styleFactory_null1Factory(_ref) {
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 2619465543015;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_2619465543015_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3227,8 +3227,7 @@ exports[`babel plugin for referenced worklets workletizes ArrowFunctionExpressio
 var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
@@ -3239,6 +3238,7 @@ styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3252,8 +3252,7 @@ exports[`babel plugin for referenced worklets workletizes ArrowFunctionExpressio
 "var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
@@ -3264,6 +3263,7 @@ var styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3281,8 +3281,7 @@ styleFactory = function styleFactory() {
 var _worklet_7165463824996_init_data = {
   code: "function styleFactory_null1(){return'AssignmentExpression';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function styleFactory_null1Factory({
   _worklet_7165463824996_init_data
@@ -3293,6 +3292,7 @@ styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 7165463824996;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_7165463824996_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3306,8 +3306,7 @@ exports[`babel plugin for referenced worklets workletizes FunctionDeclaration 1`
 "var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var styleFactory = function styleFactory_null1Factory(_ref) {
   var _worklet_17388574355683_init_data = _ref._worklet_17388574355683_init_data;
@@ -3317,6 +3316,7 @@ var styleFactory = function styleFactory_null1Factory(_ref) {
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3331,8 +3331,7 @@ exports[`babel plugin for referenced worklets workletizes FunctionExpression on 
 var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
@@ -3343,6 +3342,7 @@ styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3356,8 +3356,7 @@ exports[`babel plugin for referenced worklets workletizes FunctionExpression on 
 "var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
@@ -3368,6 +3367,7 @@ var styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3385,8 +3385,7 @@ styleFactory = function styleFactory() {
 var _worklet_7165463824996_init_data = {
   code: "function styleFactory_null1(){return'AssignmentExpression';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function styleFactory_null1Factory({
   _worklet_7165463824996_init_data
@@ -3397,6 +3396,7 @@ styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 7165463824996;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_7165463824996_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3411,8 +3411,7 @@ exports[`babel plugin for referenced worklets workletizes ObjectExpression on it
 var _worklet_10431207809979_init_data = {
   code: "function onScroll_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 handler = {
   onScroll: function onScroll_null1Factory({
@@ -3422,6 +3421,7 @@ handler = {
     const onScroll = function () {};
     onScroll.__closure = {};
     onScroll.__workletHash = 10431207809979;
+    onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_10431207809979_init_data;
     onScroll.__stackDetails = _e;
     return onScroll;
@@ -3436,8 +3436,7 @@ exports[`babel plugin for referenced worklets workletizes ObjectExpression on it
 "var _worklet_10431207809979_init_data = {
   code: "function onScroll_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var handler = {
   onScroll: function onScroll_null1Factory({
@@ -3447,6 +3446,7 @@ var handler = {
     const onScroll = function () {};
     onScroll.__closure = {};
     onScroll.__workletHash = 10431207809979;
+    onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_10431207809979_init_data;
     onScroll.__stackDetails = _e;
     return onScroll;
@@ -3467,8 +3467,7 @@ handler = {
 var _worklet_3006312818667_init_data = {
   code: "function onScroll_null1(){return'AssignmentExpression';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 handler = {
   onScroll: function onScroll_null1Factory({
@@ -3480,6 +3479,7 @@ handler = {
     };
     onScroll.__closure = {};
     onScroll.__workletHash = 3006312818667;
+    onScroll.__pluginVersion = "x.y.z";
     onScroll.__initData = _worklet_3006312818667_init_data;
     onScroll.__stackDetails = _e;
     return onScroll;
@@ -3498,8 +3498,7 @@ animatedStyle = useAnimatedStyle(styleFactory);
 var _worklet_506044013293_init_data = {
   code: "function null1(){return'AssignmentAfterUse';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 styleFactory = function null1Factory(_ref) {
   var _worklet_506044013293_init_data = _ref._worklet_506044013293_init_data;
@@ -3509,6 +3508,7 @@ styleFactory = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 506044013293;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_506044013293_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -3521,8 +3521,7 @@ exports[`babel plugin for referenced worklets workletizes in immediate scope 1`]
 "var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
@@ -3533,6 +3532,7 @@ var styleFactory = function styleFactory_null1Factory({
   };
   styleFactory.__closure = {};
   styleFactory.__workletHash = 17388574355683;
+  styleFactory.__pluginVersion = "x.y.z";
   styleFactory.__initData = _worklet_17388574355683_init_data;
   styleFactory.__stackDetails = _e;
   return styleFactory;
@@ -3546,8 +3546,7 @@ exports[`babel plugin for referenced worklets workletizes in nested scope 1`] = 
 "var _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function outerScope() {
   var styleFactory = function styleFactory_null1Factory({
@@ -3559,6 +3558,7 @@ function outerScope() {
     };
     styleFactory.__closure = {};
     styleFactory.__workletHash = 17388574355683;
+    styleFactory.__pluginVersion = "x.y.z";
     styleFactory.__initData = _worklet_17388574355683_init_data;
     styleFactory.__stackDetails = _e;
     return styleFactory;
@@ -3575,8 +3575,7 @@ exports[`babel plugin for referenced worklets workletizes multiple referencing 1
 "var _worklet_12252375123771_init_data = {
   code: "function secondReference_null1(){return{};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var secondReference = function secondReference_null1Factory({
   _worklet_12252375123771_init_data
@@ -3587,6 +3586,7 @@ var secondReference = function secondReference_null1Factory({
   };
   secondReference.__closure = {};
   secondReference.__workletHash = 12252375123771;
+  secondReference.__pluginVersion = "x.y.z";
   secondReference.__initData = _worklet_12252375123771_init_data;
   secondReference.__stackDetails = _e;
   return secondReference;
@@ -3601,8 +3601,7 @@ exports[`babel plugin for referenced worklets workletizes recursion 1`] = `
 "var _worklet_14493084721304_init_data = {
   code: "function recursiveWorklet_null1(){const recursiveWorklet_null1=this._recur;const{runOnUI}=this.__closure;if(!globalThis._WORKLET){runOnUI(recursiveWorklet_null1)();}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var recursiveWorklet = function recursiveWorklet_null1Factory(_ref) {
   var _worklet_14493084721304_init_data = _ref._worklet_14493084721304_init_data,
@@ -3617,6 +3616,7 @@ var recursiveWorklet = function recursiveWorklet_null1Factory(_ref) {
     runOnUI: runOnUI
   };
   _recursiveWorklet.__workletHash = 14493084721304;
+  _recursiveWorklet.__pluginVersion = "x.y.z";
   _recursiveWorklet.__initData = _worklet_14493084721304_init_data;
   _recursiveWorklet.__stackDetails = _e;
   return _recursiveWorklet;
@@ -3638,8 +3638,7 @@ exports[`babel plugin for sequence expressions supports SequenceExpression, many
 "var _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, 3, fun)({
@@ -3649,6 +3648,7 @@ function App() {
       var onStart = function onStart() {};
       onStart.__closure = {};
       onStart.__workletHash = 8764176270806;
+      onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_8764176270806_init_data;
       onStart.__stackDetails = _e;
       return onStart;
@@ -3663,8 +3663,7 @@ exports[`babel plugin for sequence expressions supports SequenceExpression, with
 "var _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, useAnimatedGestureHandler)({
@@ -3674,6 +3673,7 @@ function App() {
       var onStart = function onStart() {};
       onStart.__closure = {};
       onStart.__workletHash = 8764176270806;
+      onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_8764176270806_init_data;
       onStart.__stackDetails = _e;
       return onStart;
@@ -3688,8 +3688,7 @@ exports[`babel plugin for sequence expressions supports SequenceExpression, with
 "var _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, fun)({
@@ -3699,6 +3698,7 @@ function App() {
       var onStart = function onStart() {};
       onStart.__closure = {};
       onStart.__workletHash = 8764176270806;
+      onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_8764176270806_init_data;
       onStart.__stackDetails = _e;
       return onStart;
@@ -3713,8 +3713,7 @@ exports[`babel plugin for sequence expressions supports SequenceExpression, with
 "var _worklet_10926786553639_init_data = {
   code: "function onStart_null1(){const{obj}=this.__closure;const a=obj.a;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function App() {
   var obj = {
@@ -3733,6 +3732,7 @@ function App() {
         obj: obj
       };
       onStart.__workletHash = 10926786553639;
+      onStart.__pluginVersion = "x.y.z";
       onStart.__initData = _worklet_10926786553639_init_data;
       onStart.__stackDetails = _e;
       return onStart;
@@ -3748,8 +3748,7 @@ exports[`babel plugin for web configuration doesn't substitute isWeb and shouldB
 "var _worklet_8645270621312_init_data = {
   code: "function foo_null1(){const{isWeb,shouldBeUseWeb}=this.__closure;const x=isWeb();const y=shouldBeUseWeb();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_8645270621312_init_data = _ref._worklet_8645270621312_init_data,
@@ -3765,6 +3764,7 @@ var foo = function foo_null1Factory(_ref) {
     shouldBeUseWeb: shouldBeUseWeb
   };
   foo.__workletHash = 8645270621312;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_8645270621312_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3789,8 +3789,7 @@ exports[`babel plugin for web configuration includes initData when omitNativeOnl
 "var _worklet_8266917884050_init_data = {
   code: "function foo_null1(){var bar='bar';}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_8266917884050_init_data = _ref._worklet_8266917884050_init_data;
@@ -3800,6 +3799,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 8266917884050;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_8266917884050_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -3819,6 +3819,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 7087145691632;
+  foo.__pluginVersion = "x.y.z";
   foo.__stackDetails = _e;
   return foo;
 }({});"
@@ -3835,38 +3836,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -3877,6 +3872,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -3898,6 +3894,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -3916,6 +3913,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -3937,6 +3935,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -3957,6 +3956,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -3989,6 +3989,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4008,38 +4009,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -4050,6 +4045,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -4071,6 +4067,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -4089,6 +4086,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -4110,6 +4108,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -4130,6 +4129,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -4162,6 +4162,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4179,8 +4180,7 @@ exports[`babel plugin for worklet classes injects class factory into worklets 1`
 "var _worklet_3370991485663_init_data = {
   code: "function foo_null1(){const{Clazz__classFactory}=this.__closure;const Clazz=Clazz__classFactory();const clazz=new Clazz();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_3370991485663_init_data = _ref._worklet_3370991485663_init_data,
@@ -4193,6 +4193,7 @@ var foo = function foo_null1Factory(_ref) {
     Clazz__classFactory: Clazz.Clazz__classFactory
   };
   foo.__workletHash = 3370991485663;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_3370991485663_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -4208,44 +4209,37 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_2394858016888_init_data = {
   code: "function _defineProperty_null6(e,r,t){const{_toPropertyKey}=this.__closure;return(r=_toPropertyKey(r))in e?Object.defineProperty(e,r,{value:t,enumerable:!0,configurable:!0,writable:!0}):e[r]=t,e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_11384144076188_init_data = {
   code: "function Clazz__classFactory_null7(){const Clazz__classFactory_null7=this._recur;const{_classCallCheck,_defineProperty,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);_defineProperty(this,\\"member\\",1);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return this.member;}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null7;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -4256,6 +4250,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -4277,6 +4272,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -4295,6 +4291,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -4316,6 +4313,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -4336,6 +4334,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -4359,6 +4358,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperty.__workletHash = 2394858016888;
+    _defineProperty.__pluginVersion = "x.y.z";
     _defineProperty.__initData = _worklet_2394858016888_init_data;
     _defineProperty.__stackDetails = _e;
     return _defineProperty;
@@ -4394,6 +4394,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 11384144076188;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_11384144076188_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4412,8 +4413,7 @@ exports[`babel plugin for worklet classes modifies closures 1`] = `
 "var _worklet_3370991485663_init_data = {
   code: "function foo_null1(){const{Clazz__classFactory}=this.__closure;const Clazz=Clazz__classFactory();const clazz=new Clazz();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_3370991485663_init_data = _ref._worklet_3370991485663_init_data,
@@ -4426,6 +4426,7 @@ var foo = function foo_null1Factory(_ref) {
     Clazz__classFactory: Clazz.Clazz__classFactory
   };
   foo.__workletHash = 3370991485663;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_3370991485663_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -4441,38 +4442,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -4483,6 +4478,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -4504,6 +4500,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -4522,6 +4519,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -4543,6 +4541,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -4563,6 +4562,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -4595,6 +4595,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4614,38 +4615,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -4656,6 +4651,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -4677,6 +4673,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -4695,6 +4692,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -4716,6 +4714,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -4736,6 +4735,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -4768,6 +4768,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4787,38 +4788,32 @@ var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/rea
 var _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var Clazz = function () {
   var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
@@ -4829,6 +4824,7 @@ var Clazz = function () {
     };
     _classCallCheck.__closure = {};
     _classCallCheck.__workletHash = 14560075646677;
+    _classCallCheck.__pluginVersion = "x.y.z";
     _classCallCheck.__initData = _worklet_14560075646677_init_data;
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
@@ -4850,6 +4846,7 @@ var Clazz = function () {
     };
     _toPrimitive.__closure = {};
     _toPrimitive.__workletHash = 12814759901173;
+    _toPrimitive.__pluginVersion = "x.y.z";
     _toPrimitive.__initData = _worklet_12814759901173_init_data;
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
@@ -4868,6 +4865,7 @@ var Clazz = function () {
       _toPrimitive: _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
+    _toPropertyKey.__pluginVersion = "x.y.z";
     _toPropertyKey.__initData = _worklet_10645339112046_init_data;
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
@@ -4889,6 +4887,7 @@ var Clazz = function () {
       _toPropertyKey: _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
+    _defineProperties.__pluginVersion = "x.y.z";
     _defineProperties.__initData = _worklet_8234197014582_init_data;
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
@@ -4909,6 +4908,7 @@ var Clazz = function () {
       _defineProperties: _defineProperties
     };
     _createClass.__workletHash = 405664377367;
+    _createClass.__pluginVersion = "x.y.z";
     _createClass.__initData = _worklet_405664377367_init_data;
     _createClass.__stackDetails = _e;
     return _createClass;
@@ -4941,6 +4941,7 @@ var Clazz = function () {
       _createClass: _createClass
     };
     _Clazz__classFactory.__workletHash = 7066863147557;
+    _Clazz__classFactory.__pluginVersion = "x.y.z";
     _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
     _Clazz__classFactory.__stackDetails = _e;
     return _Clazz__classFactory;
@@ -4957,8 +4958,7 @@ var Clazz = function () {
 exports[`babel plugin for worklet names appends file name to function name 1`] = `
 "var _worklet_3008648901742_init_data = {
   code: "function foo_sourceJs1(){return 1;}",
-  location: "/source.js",
-  version: "x.y.z"
+  location: "/source.js"
 };
 var foo = function foo_sourceJs1Factory(_ref) {
   var _worklet_3008648901742_init_data = _ref._worklet_3008648901742_init_data;
@@ -4968,6 +4968,7 @@ var foo = function foo_sourceJs1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 3008648901742;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_3008648901742_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -4979,8 +4980,7 @@ var foo = function foo_sourceJs1Factory(_ref) {
 exports[`babel plugin for worklet names appends library name to function name 1`] = `
 "var _worklet_1237424241422_init_data = {
   code: "function foo_library_sourceJs1(){return 1;}",
-  location: "/node_modules/library/source.js",
-  version: "x.y.z"
+  location: "/node_modules/library/source.js"
 };
 var foo = function foo_library_sourceJs1Factory(_ref) {
   var _worklet_1237424241422_init_data = _ref._worklet_1237424241422_init_data;
@@ -4990,6 +4990,7 @@ var foo = function foo_library_sourceJs1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 1237424241422;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_1237424241422_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -5001,8 +5002,7 @@ var foo = function foo_library_sourceJs1Factory(_ref) {
 exports[`babel plugin for worklet names handles names with illegal characters 1`] = `
 "var _worklet_16115589986830_init_data = {
   code: "function foo_SourceJs1(){return 1;}",
-  location: "/-source.js",
-  version: "x.y.z"
+  location: "/-source.js"
 };
 var foo = function foo_SourceJs1Factory(_ref) {
   var _worklet_16115589986830_init_data = _ref._worklet_16115589986830_init_data;
@@ -5012,6 +5012,7 @@ var foo = function foo_SourceJs1Factory(_ref) {
   };
   foo.__closure = {};
   foo.__workletHash = 16115589986830;
+  foo.__pluginVersion = "x.y.z";
   foo.__initData = _worklet_16115589986830_init_data;
   foo.__stackDetails = _e;
   return foo;
@@ -5024,8 +5025,7 @@ exports[`babel plugin for worklet names preserves recursion 1`] = `
 "var _worklet_13087563218653_init_data = {
   code: "function foo_null1(){const foo_null1=this._recur;foo_null1(1);}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_13087563218653_init_data = _ref._worklet_13087563218653_init_data;
@@ -5035,6 +5035,7 @@ var foo = function foo_null1Factory(_ref) {
   };
   _foo.__closure = {};
   _foo.__workletHash = 13087563218653;
+  _foo.__pluginVersion = "x.y.z";
   _foo.__initData = _worklet_13087563218653_init_data;
   _foo.__stackDetails = _e;
   return _foo;
@@ -5047,8 +5048,7 @@ exports[`babel plugin for worklet names unnamed ArrowFunctionExpression 1`] = `
 "var _worklet_1420107288296_init_data = {
   code: "function null1(){return 1;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 (function null1Factory(_ref) {
   var _worklet_1420107288296_init_data = _ref._worklet_1420107288296_init_data;
@@ -5058,6 +5058,7 @@ exports[`babel plugin for worklet names unnamed ArrowFunctionExpression 1`] = `
   };
   null1.__closure = {};
   null1.__workletHash = 1420107288296;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1420107288296_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -5070,8 +5071,7 @@ exports[`babel plugin for worklet names unnamed FunctionExpression 1`] = `
 "var _worklet_1420107288296_init_data = {
   code: "function null1(){return 1;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 [function null1Factory(_ref) {
   var _worklet_1420107288296_init_data = _ref._worklet_1420107288296_init_data;
@@ -5081,6 +5081,7 @@ exports[`babel plugin for worklet names unnamed FunctionExpression 1`] = `
   };
   null1.__closure = {};
   null1.__workletHash = 1420107288296;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_1420107288296_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -5093,17 +5094,15 @@ exports[`babel plugin for worklet nesting transpiles nested worklets 1`] = `
 "var _worklet_8064116599518_init_data = {
   code: "function null1(){console.log('bar');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_290818181475_init_data = {
-  code: "function null2(){const{_worklet_8064116599518_init_data}=this.__closure;const bar=function null1Factory({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('bar');};null1.__closure={};null1.__workletHash=8064116599518;null1.__initData=_worklet_8064116599518_init_data;null1.__stackDetails=_e;return null1;}({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data});bar();}",
+var _worklet_2538811677737_init_data = {
+  code: "function null2(){const{_worklet_8064116599518_init_data}=this.__closure;const bar=function null1Factory({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('bar');};null1.__closure={};null1.__workletHash=8064116599518;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_8064116599518_init_data;null1.__stackDetails=_e;return null1;}({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data});bar();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null2Factory(_ref) {
-  var _worklet_290818181475_init_data = _ref._worklet_290818181475_init_data,
+  var _worklet_2538811677737_init_data = _ref._worklet_2538811677737_init_data,
     _worklet_8064116599518_init_data = _ref._worklet_8064116599518_init_data;
   var _e = [new global.Error(), -2, -27];
   var null2 = function null2() {
@@ -5115,6 +5114,7 @@ var foo = function null2Factory(_ref) {
       };
       null1.__closure = {};
       null1.__workletHash = 8064116599518;
+      null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_8064116599518_init_data;
       null1.__stackDetails = _e;
       return null1;
@@ -5126,12 +5126,13 @@ var foo = function null2Factory(_ref) {
   null2.__closure = {
     _worklet_8064116599518_init_data: _worklet_8064116599518_init_data
   };
-  null2.__workletHash = 290818181475;
-  null2.__initData = _worklet_290818181475_init_data;
+  null2.__workletHash = 2538811677737;
+  null2.__pluginVersion = "x.y.z";
+  null2.__initData = _worklet_2538811677737_init_data;
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_290818181475_init_data: _worklet_290818181475_init_data,
+  _worklet_2538811677737_init_data: _worklet_2538811677737_init_data,
   _worklet_8064116599518_init_data: _worklet_8064116599518_init_data
 });"
 `;
@@ -5140,17 +5141,15 @@ exports[`babel plugin for worklet nesting transpiles nested worklets embedded in
 "var _worklet_5655279400236_init_data = {
   code: "function null1(){console.log('Hello from JS thread');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_3520436828983_init_data = {
-  code: "function null2(){const{runOnJS,_worklet_5655279400236_init_data}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from JS thread');};null1.__closure={};null1.__workletHash=5655279400236;null1.__initData=_worklet_5655279400236_init_data;null1.__stackDetails=_e;return null1;}({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}))();}",
+var _worklet_13421160986429_init_data = {
+  code: "function null2(){const{runOnJS,_worklet_5655279400236_init_data}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from JS thread');};null1.__closure={};null1.__workletHash=5655279400236;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_5655279400236_init_data;null1.__stackDetails=_e;return null1;}({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}))();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 runOnUI(function null2Factory(_ref) {
-  var _worklet_3520436828983_init_data = _ref._worklet_3520436828983_init_data,
+  var _worklet_13421160986429_init_data = _ref._worklet_13421160986429_init_data,
     runOnJS = _ref.runOnJS,
     _worklet_5655279400236_init_data = _ref._worklet_5655279400236_init_data;
   var _e = [new global.Error(), -3, -27];
@@ -5164,6 +5163,7 @@ runOnUI(function null2Factory(_ref) {
       };
       null1.__closure = {};
       null1.__workletHash = 5655279400236;
+      null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_5655279400236_init_data;
       null1.__stackDetails = _e;
       return null1;
@@ -5175,12 +5175,13 @@ runOnUI(function null2Factory(_ref) {
     runOnJS: runOnJS,
     _worklet_5655279400236_init_data: _worklet_5655279400236_init_data
   };
-  null2.__workletHash = 3520436828983;
-  null2.__initData = _worklet_3520436828983_init_data;
+  null2.__workletHash = 13421160986429;
+  null2.__pluginVersion = "x.y.z";
+  null2.__initData = _worklet_13421160986429_init_data;
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_3520436828983_init_data: _worklet_3520436828983_init_data,
+  _worklet_13421160986429_init_data: _worklet_13421160986429_init_data,
   runOnJS: runOnJS,
   _worklet_5655279400236_init_data: _worklet_5655279400236_init_data
 }))();"
@@ -5190,23 +5191,20 @@ exports[`babel plugin for worklet nesting transpiles nested worklets embedded in
 "var _worklet_7185083753711_init_data = {
   code: "function null1(){const{runOnUI}=this.__closure;console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_5239381324954_init_data = {
-  code: "function null2(){const{runOnJS,_worklet_7185083753711_init_data,runOnUI}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}){const _e=[new global.Error(),-2,-27];const null1=function(){console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();};null1.__closure={runOnUI:runOnUI};null1.__workletHash=7185083753711;null1.__initData=_worklet_7185083753711_init_data;null1.__stackDetails=_e;return null1;}({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}))();}",
+var _worklet_9142654516624_init_data = {
+  code: "function null2(){const{runOnJS,_worklet_7185083753711_init_data,runOnUI}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}){const _e=[new global.Error(),-2,-27];const null1=function(){console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();};null1.__closure={runOnUI:runOnUI};null1.__workletHash=7185083753711;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_7185083753711_init_data;null1.__stackDetails=_e;return null1;}({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}))();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_2520605269387_init_data = {
   code: "function null3(){console.log('Hello from UI thread again');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 runOnUI(function null2Factory(_ref) {
-  var _worklet_5239381324954_init_data = _ref._worklet_5239381324954_init_data,
+  var _worklet_9142654516624_init_data = _ref._worklet_9142654516624_init_data,
     runOnJS = _ref.runOnJS,
     _worklet_7185083753711_init_data = _ref._worklet_7185083753711_init_data,
     runOnUI = _ref.runOnUI;
@@ -5227,6 +5225,7 @@ runOnUI(function null2Factory(_ref) {
           };
           null3.__closure = {};
           null3.__workletHash = 2520605269387;
+          null3.__pluginVersion = "x.y.z";
           null3.__initData = _worklet_2520605269387_init_data;
           null3.__stackDetails = _e;
           return null3;
@@ -5238,6 +5237,7 @@ runOnUI(function null2Factory(_ref) {
         runOnUI: runOnUI
       };
       null1.__workletHash = 7185083753711;
+      null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_7185083753711_init_data;
       null1.__stackDetails = _e;
       return null1;
@@ -5251,12 +5251,13 @@ runOnUI(function null2Factory(_ref) {
     _worklet_7185083753711_init_data: _worklet_7185083753711_init_data,
     runOnUI: runOnUI
   };
-  null2.__workletHash = 5239381324954;
-  null2.__initData = _worklet_5239381324954_init_data;
+  null2.__workletHash = 9142654516624;
+  null2.__pluginVersion = "x.y.z";
+  null2.__initData = _worklet_9142654516624_init_data;
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_5239381324954_init_data: _worklet_5239381324954_init_data,
+  _worklet_9142654516624_init_data: _worklet_9142654516624_init_data,
   runOnJS: runOnJS,
   _worklet_7185083753711_init_data: _worklet_7185083753711_init_data,
   runOnUI: runOnUI
@@ -5267,29 +5268,26 @@ exports[`babel plugin for worklet nesting transpiles nested worklets with depth 
 "var _worklet_3230974749144_init_data = {
   code: "function null1(){console.log('foobar');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_5639712570574_init_data = {
-  code: "function null2(){const{_worklet_3230974749144_init_data}=this.__closure;const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});}",
+var _worklet_16149303679428_init_data = {
+  code: "function null2(){const{_worklet_3230974749144_init_data}=this.__closure;const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_14678677712570_init_data = {
-  code: "function null3(){const{_worklet_5639712570574_init_data,_worklet_3230974749144_init_data}=this.__closure;const bar=function null2Factory({_worklet_5639712570574_init_data:_worklet_5639712570574_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),-2,-27];const null2=function(){const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});};null2.__closure={_worklet_3230974749144_init_data:_worklet_3230974749144_init_data};null2.__workletHash=5639712570574;null2.__initData=_worklet_5639712570574_init_data;null2.__stackDetails=_e;return null2;}({_worklet_5639712570574_init_data:_worklet_5639712570574_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});bar();}",
+var _worklet_975664358989_init_data = {
+  code: "function null3(){const{_worklet_16149303679428_init_data,_worklet_3230974749144_init_data}=this.__closure;const bar=function null2Factory({_worklet_16149303679428_init_data:_worklet_16149303679428_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),-2,-27];const null2=function(){const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});};null2.__closure={_worklet_3230974749144_init_data:_worklet_3230974749144_init_data};null2.__workletHash=16149303679428;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_16149303679428_init_data;null2.__stackDetails=_e;return null2;}({_worklet_16149303679428_init_data:_worklet_16149303679428_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});bar();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function null3Factory(_ref) {
-  var _worklet_14678677712570_init_data = _ref._worklet_14678677712570_init_data,
-    _worklet_5639712570574_init_data = _ref._worklet_5639712570574_init_data,
+  var _worklet_975664358989_init_data = _ref._worklet_975664358989_init_data,
+    _worklet_16149303679428_init_data = _ref._worklet_16149303679428_init_data,
     _worklet_3230974749144_init_data = _ref._worklet_3230974749144_init_data;
   var _e = [new global.Error(), -3, -27];
   var null3 = function null3() {
     var bar = function null2Factory(_ref2) {
-      var _worklet_5639712570574_init_data = _ref2._worklet_5639712570574_init_data,
+      var _worklet_16149303679428_init_data = _ref2._worklet_16149303679428_init_data,
         _worklet_3230974749144_init_data = _ref2._worklet_3230974749144_init_data;
       var _e = [new global.Error(), -2, -27];
       var null2 = function null2() {
@@ -5301,6 +5299,7 @@ var foo = function null3Factory(_ref) {
           };
           null1.__closure = {};
           null1.__workletHash = 3230974749144;
+          null1.__pluginVersion = "x.y.z";
           null1.__initData = _worklet_3230974749144_init_data;
           null1.__stackDetails = _e;
           return null1;
@@ -5311,27 +5310,29 @@ var foo = function null3Factory(_ref) {
       null2.__closure = {
         _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
       };
-      null2.__workletHash = 5639712570574;
-      null2.__initData = _worklet_5639712570574_init_data;
+      null2.__workletHash = 16149303679428;
+      null2.__pluginVersion = "x.y.z";
+      null2.__initData = _worklet_16149303679428_init_data;
       null2.__stackDetails = _e;
       return null2;
     }({
-      _worklet_5639712570574_init_data: _worklet_5639712570574_init_data,
+      _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
       _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
     });
     bar();
   };
   null3.__closure = {
-    _worklet_5639712570574_init_data: _worklet_5639712570574_init_data,
+    _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
     _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
   };
-  null3.__workletHash = 14678677712570;
-  null3.__initData = _worklet_14678677712570_init_data;
+  null3.__workletHash = 975664358989;
+  null3.__pluginVersion = "x.y.z";
+  null3.__initData = _worklet_975664358989_init_data;
   null3.__stackDetails = _e;
   return null3;
 }({
-  _worklet_14678677712570_init_data: _worklet_14678677712570_init_data,
-  _worklet_5639712570574_init_data: _worklet_5639712570574_init_data,
+  _worklet_975664358989_init_data: _worklet_975664358989_init_data,
+  _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
   _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
 });"
 `;
@@ -5340,23 +5341,20 @@ exports[`babel plugin for worklet nesting transpiles worklets with functions def
 "var _worklet_12864992966034_init_data = {
   code: "function null1(){console.log('Good morning from JS thread!');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var _worklet_4437925222314_init_data = {
   code: "function null2(){console.log('Good afternoon from JS thread');}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
-var _worklet_9988976046939_init_data = {
-  code: "function null3(){const{_worklet_12864992966034_init_data,_worklet_4437925222314_init_data,runOnJS}=this.__closure;const a=function null1Factory({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Good morning from JS thread!');};null1.__closure={};null1.__workletHash=12864992966034;null1.__initData=_worklet_12864992966034_init_data;null1.__stackDetails=_e;return null1;}({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data});const b=function null2Factory({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data}){const _e=[new global.Error(),1,-27];const null2=function(){console.log('Good afternoon from JS thread');};null2.__closure={};null2.__workletHash=4437925222314;null2.__initData=_worklet_4437925222314_init_data;null2.__stackDetails=_e;return null2;}({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data});const func=Math.random()<0.5?a:b;runOnJS(func)();}",
+var _worklet_614202054968_init_data = {
+  code: "function null3(){const{_worklet_12864992966034_init_data,_worklet_4437925222314_init_data,runOnJS}=this.__closure;const a=function null1Factory({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Good morning from JS thread!');};null1.__closure={};null1.__workletHash=12864992966034;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_12864992966034_init_data;null1.__stackDetails=_e;return null1;}({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data});const b=function null2Factory({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data}){const _e=[new global.Error(),1,-27];const null2=function(){console.log('Good afternoon from JS thread');};null2.__closure={};null2.__workletHash=4437925222314;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_4437925222314_init_data;null2.__stackDetails=_e;return null2;}({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data});const func=Math.random()<0.5?a:b;runOnJS(func)();}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 runOnUI(function null3Factory(_ref) {
-  var _worklet_9988976046939_init_data = _ref._worklet_9988976046939_init_data,
+  var _worklet_614202054968_init_data = _ref._worklet_614202054968_init_data,
     _worklet_12864992966034_init_data = _ref._worklet_12864992966034_init_data,
     _worklet_4437925222314_init_data = _ref._worklet_4437925222314_init_data,
     runOnJS = _ref.runOnJS;
@@ -5370,6 +5368,7 @@ runOnUI(function null3Factory(_ref) {
       };
       null1.__closure = {};
       null1.__workletHash = 12864992966034;
+      null1.__pluginVersion = "x.y.z";
       null1.__initData = _worklet_12864992966034_init_data;
       null1.__stackDetails = _e;
       return null1;
@@ -5384,6 +5383,7 @@ runOnUI(function null3Factory(_ref) {
       };
       null2.__closure = {};
       null2.__workletHash = 4437925222314;
+      null2.__pluginVersion = "x.y.z";
       null2.__initData = _worklet_4437925222314_init_data;
       null2.__stackDetails = _e;
       return null2;
@@ -5398,12 +5398,13 @@ runOnUI(function null3Factory(_ref) {
     _worklet_4437925222314_init_data: _worklet_4437925222314_init_data,
     runOnJS: runOnJS
   };
-  null3.__workletHash = 9988976046939;
-  null3.__initData = _worklet_9988976046939_init_data;
+  null3.__workletHash = 614202054968;
+  null3.__pluginVersion = "x.y.z";
+  null3.__initData = _worklet_614202054968_init_data;
   null3.__stackDetails = _e;
   return null3;
 }({
-  _worklet_9988976046939_init_data: _worklet_9988976046939_init_data,
+  _worklet_614202054968_init_data: _worklet_614202054968_init_data,
   _worklet_12864992966034_init_data: _worklet_12864992966034_init_data,
   _worklet_4437925222314_init_data: _worklet_4437925222314_init_data,
   runOnJS: runOnJS
@@ -5414,8 +5415,7 @@ exports[`babel plugin generally removes comments from worklets 1`] = `
 "var _worklet_5099191671055_init_data = {
   code: "function null1(){return true;}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var f = function null1Factory(_ref) {
   var _worklet_5099191671055_init_data = _ref._worklet_5099191671055_init_data;
@@ -5425,6 +5425,7 @@ var f = function null1Factory(_ref) {
   };
   null1.__closure = {};
   null1.__workletHash = 5099191671055;
+  null1.__pluginVersion = "x.y.z";
   null1.__initData = _worklet_5099191671055_init_data;
   null1.__stackDetails = _e;
   return null1;
@@ -5438,8 +5439,7 @@ exports[`babel plugin generally supports recursive calls 1`] = `
 var _worklet_12624627966719_init_data = {
   code: "function foo_null1(t){const foo_null1=this._recur;const{a}=this.__closure;if(t>0){return a+foo_null1(t-1);}}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 var foo = function foo_null1Factory(_ref) {
   var _worklet_12624627966719_init_data = _ref._worklet_12624627966719_init_data,
@@ -5454,6 +5454,7 @@ var foo = function foo_null1Factory(_ref) {
     a: a
   };
   _foo.__workletHash = 12624627966719;
+  _foo.__pluginVersion = "x.y.z";
   _foo.__initData = _worklet_12624627966719_init_data;
   _foo.__stackDetails = _e;
   return _foo;
@@ -5471,8 +5472,7 @@ function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; 
 var _worklet_6576407799916_init_data = {
   code: "function null1(){const{offset}=this.__closure;return{transform:[{translateX:offset.value*255}]};}",
   location: "/dev/null",
-  sourceMap: "\\"mock source map\\"",
-  version: "x.y.z"
+  sourceMap: "\\"mock source map\\""
 };
 function Box() {
   var offset = (0, _reactNativeReanimated.useSharedValue)(0);
@@ -5491,6 +5491,7 @@ function Box() {
       offset: offset
     };
     null1.__workletHash = 6576407799916;
+    null1.__pluginVersion = "x.y.z";
     null1.__initData = _worklet_6576407799916_init_data;
     null1.__stackDetails = _e;
     return null1;

--- a/packages/react-native-worklets/__tests__/plugin.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin.test.ts
@@ -83,7 +83,7 @@ describe('babel plugin', () => {
       </script>`;
 
       const { code } = runPlugin(input);
-      expect(code).toContain(`version: "${packageVersion}"`);
+      expect(code).toContain(`__pluginVersion = "${packageVersion}"`);
     });
 
     it('injects source maps', () => {

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -836,10 +836,6 @@ var require_workletFactory = __commonJS({
       if (sourceMapString) {
         initDataObjectExpression.properties.push((0, types_12.objectProperty)((0, types_12.identifier)("sourceMap"), (0, types_12.stringLiteral)(sourceMapString)));
       }
-      const shouldInjectVersion = !(0, utils_1.isRelease)();
-      if (shouldInjectVersion) {
-        initDataObjectExpression.properties.push((0, types_12.objectProperty)((0, types_12.identifier)("version"), (0, types_12.stringLiteral)(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION)));
-      }
       const shouldIncludeInitData = !state.opts.omitNativeOnlyData;
       if (shouldIncludeInitData && !state.opts.bundleMode) {
         pathForStringDefinitions.insertBefore((0, types_12.variableDeclaration)("const", [
@@ -855,6 +851,10 @@ var require_workletFactory = __commonJS({
         (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__closure"), false), (0, types_12.objectExpression)(closureVariables.map((variable) => !state.opts.bundleMode && variable.name.endsWith(types_2.workletClassFactorySuffix) ? (0, types_12.objectProperty)((0, types_12.identifier)(variable.name), (0, types_12.memberExpression)((0, types_12.identifier)(variable.name.slice(0, variable.name.length - types_2.workletClassFactorySuffix.length)), (0, types_12.identifier)(variable.name))) : (0, types_12.objectProperty)((0, types_12.cloneNode)(variable, true), (0, types_12.cloneNode)(variable, true), false, true))))),
         (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__workletHash"), false), (0, types_12.numericLiteral)(workletHash)))
       ];
+      const shouldInjectVersion = !(0, utils_1.isRelease)();
+      if (shouldInjectVersion) {
+        statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__pluginVersion")), (0, types_12.stringLiteral)(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION))));
+      }
       if (shouldIncludeInitData && !state.opts.bundleMode) {
         statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__initData"), false), (0, types_12.cloneNode)(initDataId, true))));
       }

--- a/packages/react-native-worklets/plugin/src/workletFactory.ts
+++ b/packages/react-native-worklets/plugin/src/workletFactory.ts
@@ -180,16 +180,6 @@ export function makeWorkletFactory(
     );
   }
 
-  const shouldInjectVersion = !isRelease();
-  if (shouldInjectVersion) {
-    initDataObjectExpression.properties.push(
-      objectProperty(
-        identifier('version'),
-        stringLiteral(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION)
-      )
-    );
-  }
-
   const shouldIncludeInitData = !state.opts.omitNativeOnlyData;
 
   if (shouldIncludeInitData && !state.opts.bundleMode) {
@@ -257,6 +247,22 @@ export function makeWorkletFactory(
       )
     ),
   ];
+
+  const shouldInjectVersion = !isRelease();
+  if (shouldInjectVersion) {
+    statements.push(
+      expressionStatement(
+        assignmentExpression(
+          '=',
+          memberExpression(
+            identifier(reactName),
+            identifier('__pluginVersion')
+          ),
+          stringLiteral(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION)
+        )
+      )
+    );
+  }
 
   if (shouldIncludeInitData && !state.opts.bundleMode) {
     statements.push(

--- a/packages/react-native-worklets/src/shareables.ts
+++ b/packages/react-native-worklets/src/shareables.ts
@@ -370,12 +370,8 @@ function cloneWorklet<T extends WorkletFunction>(
   depth: number
 ): ShareableRef<T> {
   if (__DEV__) {
-    const babelVersion = (value as WorkletFunction).__initData.version;
-    if (
-      !globalThis._WORKLETS_BUNDLE_MODE &&
-      babelVersion !== undefined &&
-      babelVersion !== jsVersion
-    ) {
+    const babelVersion = (value as WorkletFunction).__pluginVersion;
+    if (babelVersion !== undefined && babelVersion !== jsVersion) {
       throw new WorkletsError(
         `Mismatch between JavaScript code version and Worklets Babel plugin version (${jsVersion} vs. ${babelVersion}).
     See \`https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting#mismatch-between-javascript-code-version-and-worklets-babel-plugin-version\` for more details.

--- a/packages/react-native-worklets/src/valueUnpacker.ts
+++ b/packages/react-native-worklets/src/valueUnpacker.ts
@@ -25,9 +25,9 @@ function __valueUnpacker(
         // that debugger understands and loads the source code of the file where
         // the worklet is defined.
         workletFun = global.evalWithSourceMap(
-          '(' + initData.code + '\n)',
-          initData.location!,
-          initData.sourceMap!
+          '(' + initData!.code + '\n)',
+          initData!.location!,
+          initData!.sourceMap!
         );
       } else if (global.evalWithSourceUrl) {
         // if the runtime doesn't support loading source maps, in dev mode we
@@ -35,13 +35,13 @@ function __valueUnpacker(
         // the actual file location we use worklet hash, as it the allows us to
         // properly symbolicate traces (see errors.ts for details)
         workletFun = global.evalWithSourceUrl(
-          '(' + initData.code + '\n)',
+          '(' + initData!.code + '\n)',
           `worklet_${workletHash}`
         );
       } else {
         // in release we use the regular eval to save on JSI calls
         // eslint-disable-next-line no-eval
-        workletFun = eval('(' + initData.code + '\n)');
+        workletFun = eval('(' + initData!.code + '\n)');
       }
       workletsCache.set(workletHash, workletFun!);
     }

--- a/packages/react-native-worklets/src/workletTypes.ts
+++ b/packages/react-native-worklets/src/workletTypes.ts
@@ -37,18 +37,19 @@ interface WorkletInitData {
   location?: string;
   /** Only in dev builds. */
   sourceMap?: string;
-  /** Only in dev builds. */
-  version?: string;
 }
 
 interface WorkletProps {
   __closure: WorkletClosure;
   __workletHash: number;
-  __initData: WorkletInitData;
+  /** Only in Legacy Bundling. */
+  __initData?: WorkletInitData;
   /** Only for Handles. */
   __init?: () => unknown;
   /** `__stackDetails` is removed after parsing. */
   __stackDetails?: WorkletStackDetails;
+  /** Only in dev builds. */
+  __pluginVersion?: string;
 }
 
 export type WorkletFunction<


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Moving `version` property from `initData` to the property of the worklet:

```js
const _worklet_7806112130965_init_data = {
  code: "function foo_fileJs1(){}",
  location: "/Users/bigpoppe/swmansion/reanimated/primary/packages/react-native-worklets/plugin/file.js",
  sourceMap: "{\"version\":3,\"names\":[\"foo_fileJs1\"],\"sources\":[\"/Users/bigpoppe/swmansion/reanimated/primary/packages/react-native-worklets/plugin/file.js\"],\"mappings\":\"AAAA,SAAAA,WAEAA,CAAA\",\"ignoreList\":[]}"
};
const foo = function foo_fileJs1Factory({
  _worklet_7806112130965_init_data
}) {
  const _e = [new global.Error(), 1, -27];
  const foo = function () {};
  foo.__closure = {};
  foo.__workletHash = 7806112130965;
  foo.__pluginVersion = "0.4.0";
  foo.__initData = _worklet_7806112130965_init_data;
  foo.__stackDetails = _e;
  return foo;
}({
  _worklet_7806112130965_init_data
});
```

This is due to fact that Bundle Mode doesn't add `initData` property but we'd still benefit from version checking there.

## Test plan

Jest tests and the runtime example.
