### PR TITLE
refactor(Worklets): Rename `Shareable` to `Serializable` - part 1

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
@@ -26,7 +26,7 @@ jsi::Value AnimatedSensorModule::registerSensor(
     const jsi::Value &sensorDataHandler) {
   SensorType sensorType = static_cast<SensorType>(sensorTypeValue.asNumber());
 
-  auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
+  auto serializableHandler = extractSerializableOrThrow<SerializableWorklet>(
       rt,
       sensorDataHandler,
       "[Reanimated] Sensor event handler must be a worklet.");
@@ -36,7 +36,7 @@ jsi::Value AnimatedSensorModule::registerSensor(
       interval.asNumber(),
       iosReferenceFrame.asNumber(),
       [sensorType,
-       shareableHandler,
+       serializableHandler,
        weakUiWorkletRuntime = std::weak_ptr<WorkletRuntime>(uiWorkletRuntime)](
           double newValues[], int orientationDegrees) {
         auto uiWorkletRuntime = weakUiWorkletRuntime.lock();
@@ -65,7 +65,7 @@ jsi::Value AnimatedSensorModule::registerSensor(
         value.setProperty(
             uiRuntime, "interfaceOrientation", orientationDegrees);
 
-        uiWorkletRuntime->runGuarded(shareableHandler, value);
+        uiWorkletRuntime->runGuarded(serializableHandler, value);
       });
   if (sensorId != -1) {
     sensorsIds_.insert(sensorId);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -59,7 +59,7 @@ void LayoutAnimationsManager::startLayoutAnimation(
     const int tag,
     const LayoutAnimationType type,
     const jsi::Object &values) {
-  std::shared_ptr<Shareable> config;
+  std::shared_ptr<Serializable> config;
   {
     auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
     if (!getConfigsForType(type).contains(tag)) {
@@ -107,7 +107,7 @@ void LayoutAnimationsManager::transferConfigFromNativeID(
   enteringAnimationsForNativeID_.erase(nativeId);
 }
 
-std::unordered_map<int, std::shared_ptr<Shareable>> &
+std::unordered_map<int, std::shared_ptr<Serializable>> &
 LayoutAnimationsManager::getConfigsForType(const LayoutAnimationType type) {
   switch (type) {
     case ENTERING:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -23,7 +23,7 @@ using namespace worklets;
 struct LayoutAnimationConfig {
   int tag;
   LayoutAnimationType type;
-  std::shared_ptr<Shareable> config;
+  std::shared_ptr<Serializable> config;
 };
 
 class LayoutAnimationsManager {
@@ -45,16 +45,16 @@ class LayoutAnimationsManager {
   void transferConfigFromNativeID(const int nativeId, const int tag);
 
  private:
-  std::unordered_map<int, std::shared_ptr<Shareable>> &getConfigsForType(
+  std::unordered_map<int, std::shared_ptr<Serializable>> &getConfigsForType(
       const LayoutAnimationType type);
 
   std::shared_ptr<JSLogger> jsLogger_;
 
-  std::unordered_map<int, std::shared_ptr<Shareable>>
+  std::unordered_map<int, std::shared_ptr<Serializable>>
       enteringAnimationsForNativeID_;
-  std::unordered_map<int, std::shared_ptr<Shareable>> enteringAnimations_;
-  std::unordered_map<int, std::shared_ptr<Shareable>> exitingAnimations_;
-  std::unordered_map<int, std::shared_ptr<Shareable>> layoutAnimations_;
+  std::unordered_map<int, std::shared_ptr<Serializable>> enteringAnimations_;
+  std::unordered_map<int, std::shared_ptr<Serializable>> exitingAnimations_;
+  std::unordered_map<int, std::shared_ptr<Serializable>> layoutAnimations_;
   std::unordered_map<int, bool> shouldAnimateExitingForTag_;
   mutable std::recursive_mutex
       animationsMutex_; // Protects `enteringAnimations_`, `exitingAnimations_`,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -218,8 +218,10 @@ jsi::Value ReanimatedModuleProxy::registerEventHandler(
 
   uint64_t newRegistrationId = NEXT_EVENT_HANDLER_ID++;
   auto eventNameStr = eventName.asString(rt).utf8(rt);
-  auto handlerShareable = extractShareableOrThrow<ShareableWorklet>(
-      rt, worklet, "[Reanimated] Event handler must be a worklet.");
+  auto handlerSerializable = extractSerializableOrThrow<SerializableWorklet>(
+      rt,
+      worklet,
+      "[Reanimated] Event handler must be a serializable worklet.");
   int emitterReactTagInt = emitterReactTag.asNumber();
 
   workletsModuleProxy_->getUIScheduler()->scheduleOnUI(
@@ -232,7 +234,7 @@ jsi::Value ReanimatedModuleProxy::registerEventHandler(
             newRegistrationId,
             eventNameStr,
             emitterReactTagInt,
-            handlerShareable);
+            handlerSerializable);
         strongThis->eventHandlerRegistry_->registerEventHandler(
             std::move(handler));
       });
@@ -320,7 +322,7 @@ jsi::Value ReanimatedModuleProxy::configureLayoutAnimationBatch(
     if (config.isUndefined()) {
       batchItem.config = nullptr;
     } else {
-      batchItem.config = extractShareableOrThrow<ShareableObject>(
+      batchItem.config = extractSerializableOrThrow<SerializableObject>(
           rt,
           config,
           "[Reanimated] Layout animation config must be an object.");
@@ -919,7 +921,7 @@ jsi::Value ReanimatedModuleProxy::subscribeForKeyboardEvents(
     const jsi::Value &handlerWorklet,
     const jsi::Value &isStatusBarTranslucent,
     const jsi::Value &isNavigationBarTranslucent) {
-  auto shareableHandler = extractShareableOrThrow<ShareableWorklet>(
+  auto serializableHandler = extractSerializableOrThrow<SerializableWorklet>(
       rt,
       handlerWorklet,
       "[Reanimated] Keyboard event handler must be a worklet.");
@@ -930,7 +932,7 @@ jsi::Value ReanimatedModuleProxy::subscribeForKeyboardEvents(
           return;
         }
         strongThis->workletsModuleProxy_->getUIWorkletRuntime()->runGuarded(
-            shareableHandler, jsi::Value(keyboardState), jsi::Value(height));
+            serializableHandler, jsi::Value(keyboardState), jsi::Value(height));
       },
       isStatusBarTranslucent.getBool(),
       isNavigationBarTranslucent.getBool());

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -22,9 +22,9 @@ inline void scheduleOnUI(
     const std::weak_ptr<WorkletRuntime> &weakUIWorkletRuntime,
     jsi::Runtime &rt,
     const jsi::Value &worklet) {
-  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+  auto serializableWorklet = extractSerializableOrThrow<SerializableWorklet>(
       rt, worklet, "[Worklets] Only worklets can be scheduled to run on UI.");
-  uiScheduler->scheduleOnUI([shareableWorklet, weakUIWorkletRuntime]() {
+  uiScheduler->scheduleOnUI([serializableWorklet, weakUIWorkletRuntime]() {
     // This callback can outlive the WorkletsModuleProxy object during the
     // invalidation of React Native. This happens when WorkletsModuleProxy
     // destructor is called on the JS thread and the UI thread is
@@ -44,7 +44,7 @@ inline void scheduleOnUI(
     const auto scope = jsi::Scope(uiWorkletRuntime->getJSIRuntime());
 #endif // JS_RUNTIME_HERMES
 
-    uiWorkletRuntime->runGuarded(shareableWorklet);
+    uiWorkletRuntime->runGuarded(serializableWorklet);
   });
 }
 
@@ -64,7 +64,7 @@ inline jsi::Value createWorkletRuntime(
     const std::shared_ptr<MessageQueueThread> &jsQueue,
     std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
     const std::string &name,
-    std::shared_ptr<ShareableWorklet> &initializer) {
+    std::shared_ptr<SerializableWorklet> &initializer) {
   const auto workletRuntime = runtimeManager->createWorkletRuntime(
       jsiWorkletsModuleProxy, true /* supportsLocking */, name, initializer);
   return jsi::Object::createFromHostObject(originRuntime, workletRuntime);
@@ -185,7 +185,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableClone(rt, args[0], args[1], args[2]);
+          return makeSerializableClone(rt, args[0], args[1], args[2]);
         });
   }
 
@@ -198,7 +198,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableBigInt(rt, args[0].asBigInt(rt));
+          return makeSerializableBigInt(rt, args[0].asBigInt(rt));
         });
   }
 
@@ -211,7 +211,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableBoolean(rt, args[0].asBool());
+          return makeSerializableBoolean(rt, args[0].asBool());
         });
   }
 
@@ -224,7 +224,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableImport(
+          return makeSerializableImport(
               rt, args[0].asNumber(), args[1].asString(rt));
         });
   }
@@ -238,7 +238,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableNumber(rt, args[0].asNumber());
+          return makeSerializableNumber(rt, args[0].asNumber());
         });
   }
 
@@ -250,7 +250,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
         [](jsi::Runtime &rt,
            const jsi::Value &thisValue,
            const jsi::Value *args,
-           size_t count) { return makeShareableNull(rt); });
+           size_t count) { return makeSerializableNull(rt); });
   }
 
   if (name == "makeShareableString") {
@@ -262,7 +262,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableString(rt, args[0].asString(rt));
+          return makeSerializableString(rt, args[0].asString(rt));
         });
   }
 
@@ -274,7 +274,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
         [](jsi::Runtime &rt,
            const jsi::Value &thisValue,
            const jsi::Value *args,
-           size_t count) { return makeShareableUndefined(rt); });
+           size_t count) { return makeSerializableUndefined(rt); });
   }
 
   if (name == "makeShareableInitializer") {
@@ -286,7 +286,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableInitializer(rt, args[0].asObject(rt));
+          return makeSerializableInitializer(rt, args[0].asObject(rt));
         });
   }
 
@@ -299,7 +299,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableArray(
+          return makeSerializableArray(
               rt, args[0].asObject(rt).asArray(rt), args[1]);
         });
   }
@@ -313,7 +313,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableMap(
+          return makeSerializableMap(
               rt,
               args[0].asObject(rt).asArray(rt),
               args[1].asObject(rt).asArray(rt));
@@ -329,7 +329,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableSet(rt, args[0].asObject(rt).asArray(rt));
+          return makeSerializableSet(rt, args[0].asObject(rt).asArray(rt));
         });
   }
 
@@ -342,7 +342,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableHostObject(
+          return makeSerializableHostObject(
               rt, args[0].asObject(rt).asHostObject(rt));
         });
   }
@@ -356,7 +356,8 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableFunction(rt, args[0].asObject(rt).asFunction(rt));
+          return makeSerializableFunction(
+              rt, args[0].asObject(rt).asFunction(rt));
         });
   }
 
@@ -369,7 +370,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableTurboModuleLike(
+          return makeSerializableTurboModuleLike(
               rt, args[0].asObject(rt), args[1].asObject(rt).asHostObject(rt));
         });
   }
@@ -383,7 +384,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableObject(
+          return makeSerializableObject(
               rt, args[0].getObject(rt), args[1].getBool(), args[2]);
         });
   }
@@ -397,7 +398,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
            const jsi::Value &thisValue,
            const jsi::Value *args,
            size_t count) {
-          return makeShareableWorklet(
+          return makeSerializableWorklet(
               rt, args[0].getObject(rt), args[1].getBool());
         });
   }
@@ -442,8 +443,9 @@ jsi::Value JSIWorkletsModuleProxy::get(
             const jsi::Value *args,
             size_t count) {
           auto name = args[0].asString(rt).utf8(rt);
-          auto shareableInitializer = extractShareableOrThrow<ShareableWorklet>(
-              rt, args[1], "[Worklets] Initializer must be a worklet.");
+          auto serializableInitializer =
+              extractSerializableOrThrow<SerializableWorklet>(
+                  rt, args[1], "[Worklets] Initializer must be a worklet.");
 
           return createWorkletRuntime(
               rt,
@@ -451,7 +453,7 @@ jsi::Value JSIWorkletsModuleProxy::get(
               clone->getJSQueue(),
               clone,
               name,
-              shareableInitializer);
+              serializableInitializer);
         });
   }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -39,230 +39,238 @@ jsi::Function getCallGuard(jsi::Runtime &rt) {
 
 #endif // NDEBUG
 
-jsi::Value makeShareableClone(
+jsi::Value makeSerializableClone(
     jsi::Runtime &rt,
     const jsi::Value &value,
     const jsi::Value &shouldRetainRemote,
     const jsi::Value &nativeStateSource) {
-  std::shared_ptr<Shareable> shareable;
+  std::shared_ptr<Serializable> serializable;
   if (value.isObject()) {
     auto object = value.asObject(rt);
     if (!object.getProperty(rt, "__workletHash").isUndefined()) {
       // We pass `false` because this function is invoked only
-      // by `makeShareableCloneOnUIRecursive` which doesn't
-      // make Retaining Shareables.
-      return makeShareableWorklet(rt, object, false);
+      // by `makeSerializableCloneOnUIRecursive` which doesn't
+      // make Retaining Serializables.
+      return makeSerializableWorklet(rt, object, false);
     } else if (!object.getProperty(rt, "__init").isUndefined()) {
-      return makeShareableInitializer(rt, object);
+      return makeSerializableInitializer(rt, object);
     } else if (object.isFunction(rt)) {
-      return makeShareableFunction(rt, object.asFunction(rt));
+      return makeSerializableFunction(rt, object.asFunction(rt));
     } else if (object.isArray(rt)) {
       if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
-        shareable = std::make_shared<RetainingShareable<ShareableArray>>(
-            rt, object.asArray(rt));
+        serializable =
+            std::make_shared<RetainingSerializable<SerializableArray>>(
+                rt, object.asArray(rt));
       } else {
-        shareable = std::make_shared<ShareableArray>(rt, object.asArray(rt));
+        serializable =
+            std::make_shared<SerializableArray>(rt, object.asArray(rt));
       }
     } else if (object.isArrayBuffer(rt)) {
-      shareable =
-          std::make_shared<ShareableArrayBuffer>(rt, object.getArrayBuffer(rt));
+      serializable = std::make_shared<SerializableArrayBuffer>(
+          rt, object.getArrayBuffer(rt));
     } else if (object.isHostObject(rt)) {
-      if (object.isHostObject<ShareableJSRef>(rt)) {
+      if (object.isHostObject<SerializableJSRef>(rt)) {
         return object;
       }
-      shareable =
-          std::make_shared<ShareableHostObject>(rt, object.getHostObject(rt));
+      serializable = std::make_shared<SerializableHostObject>(
+          rt, object.getHostObject(rt));
     } else {
       if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
-        shareable = std::make_shared<RetainingShareable<ShareableObject>>(
-            rt, object, nativeStateSource);
+        serializable =
+            std::make_shared<RetainingSerializable<SerializableObject>>(
+                rt, object, nativeStateSource);
       } else {
-        shareable =
-            std::make_shared<ShareableObject>(rt, object, nativeStateSource);
+        serializable =
+            std::make_shared<SerializableObject>(rt, object, nativeStateSource);
       }
     }
   } else if (value.isString()) {
-    shareable = std::make_shared<ShareableString>(value.asString(rt).utf8(rt));
+    serializable =
+        std::make_shared<SerializableString>(value.asString(rt).utf8(rt));
   } else if (value.isUndefined()) {
-    shareable = std::make_shared<ShareableScalar>();
+    serializable = std::make_shared<SerializableScalar>();
   } else if (value.isNull()) {
-    shareable = std::make_shared<ShareableScalar>(nullptr);
+    serializable = std::make_shared<SerializableScalar>(nullptr);
   } else if (value.isBool()) {
-    shareable = std::make_shared<ShareableScalar>(value.getBool());
+    serializable = std::make_shared<SerializableScalar>(value.getBool());
   } else if (value.isNumber()) {
-    shareable = std::make_shared<ShareableScalar>(value.getNumber());
+    serializable = std::make_shared<SerializableScalar>(value.getNumber());
   } else if (value.isBigInt()) {
-    shareable = std::make_shared<ShareableBigInt>(rt, value.getBigInt(rt));
+    serializable =
+        std::make_shared<SerializableBigInt>(rt, value.getBigInt(rt));
   } else if (value.isSymbol()) {
     // TODO: this is only a placeholder implementation, here we replace symbols
     // with strings in order to make certain objects to be captured. There isn't
     // yet any usecase for using symbols on the UI runtime so it is fine to keep
     // it like this for now.
-    shareable =
-        std::make_shared<ShareableString>(value.getSymbol(rt).toString(rt));
+    serializable =
+        std::make_shared<SerializableString>(value.getSymbol(rt).toString(rt));
   } else {
     throw std::runtime_error(
         "[Worklets] Attempted to convert an unsupported value type.");
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableString(jsi::Runtime &rt, const jsi::String &string) {
-  const auto shareable = std::make_shared<ShareableString>(string.utf8(rt));
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableString(jsi::Runtime &rt, const jsi::String &string) {
+  const auto serializable =
+      std::make_shared<SerializableString>(string.utf8(rt));
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableNumber(jsi::Runtime &rt, double number) {
-  const auto shareable = std::make_shared<ShareableScalar>(number);
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableNumber(jsi::Runtime &rt, double number) {
+  const auto serializable = std::make_shared<SerializableScalar>(number);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableBoolean(jsi::Runtime &rt, bool boolean) {
-  const auto shareable = std::make_shared<ShareableScalar>(boolean);
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableBoolean(jsi::Runtime &rt, bool boolean) {
+  const auto serializable = std::make_shared<SerializableScalar>(boolean);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint) {
-  const auto shareable = std::make_shared<ShareableBigInt>(rt, bigint);
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint) {
+  const auto serializable = std::make_shared<SerializableBigInt>(rt, bigint);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableUndefined(jsi::Runtime &rt) {
-  const auto shareable = std::make_shared<ShareableScalar>();
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableUndefined(jsi::Runtime &rt) {
+  const auto serializable = std::make_shared<SerializableScalar>();
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableNull(jsi::Runtime &rt) {
-  const auto shareable = std::make_shared<ShareableScalar>(nullptr);
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableNull(jsi::Runtime &rt) {
+  const auto serializable = std::make_shared<SerializableScalar>(nullptr);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableWorklet(
+jsi::Value makeSerializableWorklet(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const bool &shouldRetainRemote) {
-  std::shared_ptr<Shareable> shareable;
+  std::shared_ptr<Serializable> serializable;
   if (shouldRetainRemote) {
-    shareable =
-        std::make_shared<RetainingShareable<ShareableWorklet>>(rt, object);
+    serializable = std::make_shared<RetainingSerializable<SerializableWorklet>>(
+        rt, object);
   } else {
-    shareable = std::make_shared<ShareableWorklet>(rt, object);
+    serializable = std::make_shared<SerializableWorklet>(rt, object);
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableInitializer(
+jsi::Value makeSerializableInitializer(
     jsi::Runtime &rt,
     const jsi::Object &initializerObject) {
-  const auto shareable =
-      std::make_shared<ShareableInitializer>(rt, initializerObject);
-  return ShareableJSRef::newHostObject(rt, shareable);
+  const auto serializable =
+      std::make_shared<SerializableInitializer>(rt, initializerObject);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableFunction(jsi::Runtime &rt, jsi::Function function) {
-  std::shared_ptr<Shareable> shareable;
+jsi::Value makeSerializableFunction(jsi::Runtime &rt, jsi::Function function) {
+  std::shared_ptr<Serializable> serializable;
   if (function.isHostFunction(rt)) {
-    shareable =
-        std::make_shared<ShareableHostFunction>(rt, std::move(function));
+    serializable =
+        std::make_shared<SerializableHostFunction>(rt, std::move(function));
   } else {
-    shareable =
-        std::make_shared<ShareableRemoteFunction>(rt, std::move(function));
+    serializable =
+        std::make_shared<SerializableRemoteFunction>(rt, std::move(function));
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableArray(
+jsi::Value makeSerializableArray(
     jsi::Runtime &rt,
     const jsi::Array &array,
     const jsi::Value &shouldRetainRemote) {
-  std::shared_ptr<Shareable> shareable;
+  std::shared_ptr<Serializable> serializable;
   if (shouldRetainRemote.isBool() && shouldRetainRemote.getBool()) {
-    shareable = std::make_shared<RetainingShareable<ShareableArray>>(rt, array);
+    serializable =
+        std::make_shared<RetainingSerializable<SerializableArray>>(rt, array);
   } else {
-    shareable = std::make_shared<ShareableArray>(rt, array);
+    serializable = std::make_shared<SerializableArray>(rt, array);
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableMap(
+jsi::Value makeSerializableMap(
     jsi::Runtime &rt,
     const jsi::Array &keys,
     const jsi::Array &values) {
-  auto shareable = std::make_shared<ShareableMap>(rt, keys, values);
-  return ShareableJSRef::newHostObject(rt, shareable);
+  auto serializable = std::make_shared<SerializableMap>(rt, keys, values);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableSet(jsi::Runtime &rt, const jsi::Array &values) {
-  auto shareable = std::make_shared<ShareableSet>(rt, values);
-  return ShareableJSRef::newHostObject(rt, shareable);
+jsi::Value makeSerializableSet(jsi::Runtime &rt, const jsi::Array &values) {
+  auto serializable = std::make_shared<SerializableSet>(rt, values);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableHostObject(
+jsi::Value makeSerializableHostObject(
     jsi::Runtime &rt,
     const std::shared_ptr<jsi::HostObject> &value) {
-  const auto shareable = std::make_shared<ShareableHostObject>(rt, value);
-  return ShareableJSRef::newHostObject(rt, shareable);
+  const auto serializable = std::make_shared<SerializableHostObject>(rt, value);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableTurboModuleLike(
+jsi::Value makeSerializableTurboModuleLike(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const std::shared_ptr<jsi::HostObject> &proto) {
-  const auto shareable =
-      std::make_shared<ShareableTurboModuleLike>(rt, object, proto);
-  return ShareableJSRef::newHostObject(rt, shareable);
+  const auto serializable =
+      std::make_shared<SerializableTurboModuleLike>(rt, object, proto);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableImport(
+jsi::Value makeSerializableImport(
     jsi::Runtime &rt,
     const double source,
     const jsi::String &imported) {
-  auto shareable = std::make_shared<ShareableImport>(rt, source, imported);
-  return ShareableJSRef::newHostObject(rt, shareable);
+  auto serializable =
+      std::make_shared<SerializableImport>(rt, source, imported);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-jsi::Value makeShareableObject(
+jsi::Value makeSerializableObject(
     jsi::Runtime &rt,
     jsi::Object object,
     bool shouldRetainRemote,
     const jsi::Value &nativeStateSource) {
-  std::shared_ptr<Shareable> shareable;
+  std::shared_ptr<Serializable> serializable;
   if (shouldRetainRemote) {
-    shareable = std::make_shared<RetainingShareable<ShareableObject>>(
+    serializable = std::make_shared<RetainingSerializable<SerializableObject>>(
         rt, object, nativeStateSource);
   } else {
-    shareable =
-        std::make_shared<ShareableObject>(rt, object, nativeStateSource);
+    serializable =
+        std::make_shared<SerializableObject>(rt, object, nativeStateSource);
   }
-  return ShareableJSRef::newHostObject(rt, shareable);
+  return SerializableJSRef::newHostObject(rt, serializable);
 }
 
-std::shared_ptr<Shareable> extractShareableOrThrow(
+std::shared_ptr<Serializable> extractSerializableOrThrow(
     jsi::Runtime &rt,
-    const jsi::Value &maybeShareableValue,
+    const jsi::Value &maybeSerializableValue,
     const std::string &errorMessage) {
-  if (maybeShareableValue.isObject()) {
-    auto object = maybeShareableValue.asObject(rt);
-    if (object.isHostObject<ShareableJSRef>(rt)) {
-      return object.getHostObject<ShareableJSRef>(rt)->value();
+  if (maybeSerializableValue.isObject()) {
+    auto object = maybeSerializableValue.asObject(rt);
+    if (object.isHostObject<SerializableJSRef>(rt)) {
+      return object.getHostObject<SerializableJSRef>(rt)->value();
     }
     throw std::runtime_error(
-        "[Worklets] Attempted to extract from a HostObject that wasn't converted to a Shareable.");
-  } else if (maybeShareableValue.isUndefined()) {
-    return Shareable::undefined();
+        "[Worklets] Attempted to extract from a HostObject that wasn't converted to a Serializable.");
+  } else if (maybeSerializableValue.isUndefined()) {
+    return Serializable::undefined();
   }
   throw std::runtime_error(errorMessage);
 }
 
-Shareable::~Shareable() {}
+Serializable::~Serializable() {}
 
-std::shared_ptr<Shareable> Shareable::undefined() {
-  static auto undefined = std::make_shared<ShareableScalar>();
+std::shared_ptr<Serializable> Serializable::undefined() {
+  static auto undefined = std::make_shared<SerializableScalar>();
   return undefined;
 }
 
 template <typename BaseClass>
-jsi::Value RetainingShareable<BaseClass>::toJSValue(jsi::Runtime &rt) {
+jsi::Value RetainingSerializable<BaseClass>::toJSValue(jsi::Runtime &rt) {
   if (&rt == primaryRuntime_) {
     // TODO: it is suboptimal to generate new object every time getJS is
     // called on host runtime – the objects we are generating already exists
@@ -284,18 +292,19 @@ jsi::Value RetainingShareable<BaseClass>::toJSValue(jsi::Runtime &rt) {
   return BaseClass::toJSValue(rt);
 }
 
-ShareableJSRef::~ShareableJSRef() {}
+SerializableJSRef::~SerializableJSRef() {}
 
-ShareableArray::ShareableArray(jsi::Runtime &rt, const jsi::Array &array)
-    : Shareable(ArrayType) {
+SerializableArray::SerializableArray(jsi::Runtime &rt, const jsi::Array &array)
+    : Serializable(ArrayType) {
   auto size = array.size(rt);
   data_.reserve(size);
   for (size_t i = 0; i < size; i++) {
-    data_.push_back(extractShareableOrThrow(rt, array.getValueAtIndex(rt, i)));
+    data_.push_back(
+        extractSerializableOrThrow(rt, array.getValueAtIndex(rt, i)));
   }
 }
 
-jsi::Value ShareableArray::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableArray::toJSValue(jsi::Runtime &rt) {
   auto size = data_.size();
   auto ary = jsi::Array(rt, size);
   for (size_t i = 0; i < size; i++) {
@@ -304,7 +313,7 @@ jsi::Value ShareableArray::toJSValue(jsi::Runtime &rt) {
   return ary;
 }
 
-jsi::Value ShareableArrayBuffer::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableArrayBuffer::toJSValue(jsi::Runtime &rt) {
   auto size = static_cast<int>(data_.size());
   auto arrayBuffer = rt.global()
                          .getPropertyAsFunction(rt, "ArrayBuffer")
@@ -315,14 +324,16 @@ jsi::Value ShareableArrayBuffer::toJSValue(jsi::Runtime &rt) {
   return arrayBuffer;
 }
 
-ShareableObject::ShareableObject(jsi::Runtime &rt, const jsi::Object &object)
-    : Shareable(ObjectType) {
+SerializableObject::SerializableObject(
+    jsi::Runtime &rt,
+    const jsi::Object &object)
+    : Serializable(ObjectType) {
   auto propertyNames = object.getPropertyNames(rt);
   auto size = propertyNames.size(rt);
   data_.reserve(size);
   for (size_t i = 0; i < size; i++) {
     auto key = propertyNames.getValueAtIndex(rt, i).asString(rt);
-    auto value = extractShareableOrThrow(rt, object.getProperty(rt, key));
+    auto value = extractSerializableOrThrow(rt, object.getProperty(rt, key));
     data_.emplace_back(key.utf8(rt), value);
   }
   if (object.hasNativeState(rt)) {
@@ -330,18 +341,18 @@ ShareableObject::ShareableObject(jsi::Runtime &rt, const jsi::Object &object)
   }
 }
 
-ShareableObject::ShareableObject(
+SerializableObject::SerializableObject(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const jsi::Value &nativeStateSource)
-    : ShareableObject(rt, object) {
+    : SerializableObject(rt, object) {
   if (nativeStateSource.isObject() &&
       nativeStateSource.asObject(rt).hasNativeState(rt)) {
     nativeState_ = nativeStateSource.asObject(rt).getNativeState(rt);
   }
 }
 
-jsi::Value ShareableObject::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableObject::toJSValue(jsi::Runtime &rt) {
   auto obj = jsi::Object(rt);
   for (size_t i = 0, size = data_.size(); i < size; i++) {
     obj.setProperty(
@@ -355,24 +366,24 @@ jsi::Value ShareableObject::toJSValue(jsi::Runtime &rt) {
   return obj;
 }
 
-ShareableMap::ShareableMap(
+SerializableMap::SerializableMap(
     jsi::Runtime &rt,
     const jsi::Array &keys,
     const jsi::Array &values)
-    : Shareable(MapType) {
+    : Serializable(MapType) {
   auto size = keys.size(rt);
   react_native_assert(
       size == values.size(rt) &&
       "Keys and values arrays must have the same size.");
   data_.reserve(size);
   for (size_t i = 0; i < size; i++) {
-    auto key = extractShareableOrThrow(rt, keys.getValueAtIndex(rt, i));
-    auto value = extractShareableOrThrow(rt, values.getValueAtIndex(rt, i));
+    auto key = extractSerializableOrThrow(rt, keys.getValueAtIndex(rt, i));
+    auto value = extractSerializableOrThrow(rt, values.getValueAtIndex(rt, i));
     data_.emplace_back(key, value);
   }
 }
 
-jsi::Value ShareableMap::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableMap::toJSValue(jsi::Runtime &rt) {
   const auto keyValues = jsi::Array(rt, data_.size());
   for (size_t i = 0, size = data_.size(); i < size; i++) {
     const auto pair = jsi::Array(rt, 2);
@@ -388,16 +399,17 @@ jsi::Value ShareableMap::toJSValue(jsi::Runtime &rt) {
   return map;
 }
 
-ShareableSet::ShareableSet(jsi::Runtime &rt, const jsi::Array &values)
-    : Shareable(SetType) {
+SerializableSet::SerializableSet(jsi::Runtime &rt, const jsi::Array &values)
+    : Serializable(SetType) {
   auto size = values.size(rt);
   data_.reserve(size);
   for (size_t i = 0; i < size; i++) {
-    data_.push_back(extractShareableOrThrow(rt, values.getValueAtIndex(rt, i)));
+    data_.push_back(
+        extractSerializableOrThrow(rt, values.getValueAtIndex(rt, i)));
   }
 }
 
-jsi::Value ShareableSet::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableSet::toJSValue(jsi::Runtime &rt) {
   const auto values = jsi::Array(rt, data_.size());
   for (size_t i = 0, size = data_.size(); i < size; i++) {
     values.setValueAtIndex(rt, i, data_[i]->toJSValue(rt));
@@ -410,28 +422,28 @@ jsi::Value ShareableSet::toJSValue(jsi::Runtime &rt) {
   return set;
 }
 
-jsi::Value ShareableHostObject::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableHostObject::toJSValue(jsi::Runtime &rt) {
   return jsi::Object::createFromHostObject(rt, hostObject_);
 }
 
-jsi::Value ShareableHostFunction::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableHostFunction::toJSValue(jsi::Runtime &rt) {
   return jsi::Function::createFromHostFunction(
       rt, jsi::PropNameID::forUtf8(rt, name_), paramCount_, hostFunction_);
 }
 
-jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableWorklet::toJSValue(jsi::Runtime &rt) {
   react_native_assert(
       std::any_of(
           data_.cbegin(),
           data_.cend(),
           [](const auto &item) { return item.first == "__workletHash"; }) &&
-      "ShareableWorklet doesn't have `__workletHash` property");
-  jsi::Value obj = ShareableObject::toJSValue(rt);
+      "SerializableWorklet doesn't have `__workletHash` property");
+  jsi::Value obj = SerializableObject::toJSValue(rt);
   return getValueUnpacker(rt).call(
       rt, obj, jsi::String::createFromAscii(rt, "Worklet"));
 }
 
-jsi::Value ShareableImport::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableImport::toJSValue(jsi::Runtime &rt) {
   /**
    * The only way to obtain a module in runtime is to use the Metro's require
    * method implementation, which is injected into the global object as `__r`.
@@ -449,23 +461,23 @@ jsi::Value ShareableImport::toJSValue(jsi::Runtime &rt) {
       .getProperty(rt, imported);
 }
 
-jsi::Value ShareableRemoteFunction::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableRemoteFunction::toJSValue(jsi::Runtime &rt) {
   if (&rt == runtime_) {
     return jsi::Value(rt, *function_);
   } else {
 #ifndef NDEBUG
     return getValueUnpacker(rt).call(
         rt,
-        ShareableJSRef::newHostObject(rt, shared_from_this()),
+        SerializableJSRef::newHostObject(rt, shared_from_this()),
         jsi::String::createFromAscii(rt, "RemoteFunction"),
         jsi::String::createFromUtf8(rt, name_));
 #else
-    return ShareableJSRef::newHostObject(rt, shared_from_this());
+    return SerializableJSRef::newHostObject(rt, shared_from_this());
 #endif
   }
 }
 
-jsi::Value ShareableInitializer::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableInitializer::toJSValue(jsi::Runtime &rt) {
   if (remoteValue_ == nullptr) {
     auto initObj = initializer_->toJSValue(rt);
     auto value = std::make_unique<jsi::Value>(getValueUnpacker(rt).call(
@@ -492,25 +504,25 @@ jsi::Value ShareableInitializer::toJSValue(jsi::Runtime &rt) {
       rt, initObj, jsi::String::createFromAscii(rt, "Handle"));
 }
 
-jsi::Value ShareableString::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableString::toJSValue(jsi::Runtime &rt) {
   return jsi::String::createFromUtf8(rt, data_);
 }
 
-jsi::Value ShareableBigInt::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableBigInt::toJSValue(jsi::Runtime &rt) {
   return rt.global()
       .getPropertyAsFunction(rt, "BigInt")
       .call(rt, jsi::String::createFromUtf8(rt, string_));
 }
 
-jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {
+jsi::Value SerializableScalar::toJSValue(jsi::Runtime &) {
   switch (valueType_) {
-    case Shareable::UndefinedType:
+    case Serializable::UndefinedType:
       return jsi::Value();
-    case Shareable::NullType:
+    case Serializable::NullType:
       return jsi::Value(nullptr);
-    case Shareable::BooleanType:
+    case Serializable::BooleanType:
       return jsi::Value(data_.boolean);
-    case Shareable::NumberType:
+    case Serializable::NumberType:
       return jsi::Value(data_.number);
     default:
       throw std::runtime_error(
@@ -518,7 +530,7 @@ jsi::Value ShareableScalar::toJSValue(jsi::Runtime &) {
   }
 }
 
-jsi::Value ShareableTurboModuleLike::toJSValue(jsi::Runtime &rt) {
+jsi::Value SerializableTurboModuleLike::toJSValue(jsi::Runtime &rt) {
   auto obj = properties_->toJSValue(rt).asObject(rt);
   const auto prototype = proto_->toJSValue(rt);
   rt.global()

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Shareables.h
@@ -62,11 +62,11 @@ inline void cleanupIfRuntimeExists(
   }
 }
 
-class Shareable {
+class Serializable {
  public:
   virtual jsi::Value toJSValue(jsi::Runtime &rt) = 0;
 
-  virtual ~Shareable();
+  virtual ~Serializable();
 
   enum ValueType {
     UndefinedType,
@@ -90,20 +90,20 @@ class Shareable {
     ImportType,
   };
 
-  explicit Shareable(ValueType valueType) : valueType_(valueType) {}
+  explicit Serializable(ValueType valueType) : valueType_(valueType) {}
 
   inline ValueType valueType() const {
     return valueType_;
   }
 
-  static std::shared_ptr<Shareable> undefined();
+  static std::shared_ptr<Serializable> undefined();
 
  protected:
   ValueType valueType_;
 };
 
 template <typename BaseClass>
-class RetainingShareable : virtual public BaseClass {
+class RetainingSerializable : virtual public BaseClass {
  private:
   jsi::Runtime *primaryRuntime_;
   jsi::Runtime *secondaryRuntime_;
@@ -111,134 +111,134 @@ class RetainingShareable : virtual public BaseClass {
 
  public:
   template <typename... Args>
-  explicit RetainingShareable(jsi::Runtime &rt, Args &&...args)
+  explicit RetainingSerializable(jsi::Runtime &rt, Args &&...args)
       : BaseClass(rt, std::forward<Args>(args)...), primaryRuntime_(&rt) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt);
 
-  ~RetainingShareable() {
+  ~RetainingSerializable() {
     cleanupIfRuntimeExists(secondaryRuntime_, secondaryValue_);
   }
 };
 
-class ShareableJSRef : public jsi::HostObject {
+class SerializableJSRef : public jsi::HostObject {
  private:
-  const std::shared_ptr<Shareable> value_;
+  const std::shared_ptr<Serializable> value_;
 
  public:
-  explicit ShareableJSRef(const std::shared_ptr<Shareable> &value)
+  explicit SerializableJSRef(const std::shared_ptr<Serializable> &value)
       : value_(value) {}
 
-  virtual ~ShareableJSRef();
+  virtual ~SerializableJSRef();
 
-  std::shared_ptr<Shareable> value() const {
+  std::shared_ptr<Serializable> value() const {
     return value_;
   }
 
   static jsi::Object newHostObject(
       jsi::Runtime &rt,
-      const std::shared_ptr<Shareable> &value) {
+      const std::shared_ptr<Serializable> &value) {
     return jsi::Object::createFromHostObject(
-        rt, std::make_shared<ShareableJSRef>(value));
+        rt, std::make_shared<SerializableJSRef>(value));
   }
 };
 
-jsi::Value makeShareableClone(
+jsi::Value makeSerializableClone(
     jsi::Runtime &rt,
     const jsi::Value &value,
     const jsi::Value &shouldRetainRemote,
     const jsi::Value &nativeStateSource);
 
-jsi::Value makeShareableString(jsi::Runtime &rt, const jsi::String &string);
+jsi::Value makeSerializableString(jsi::Runtime &rt, const jsi::String &string);
 
-jsi::Value makeShareableNumber(jsi::Runtime &rt, double number);
+jsi::Value makeSerializableNumber(jsi::Runtime &rt, double number);
 
-jsi::Value makeShareableBoolean(jsi::Runtime &rt, bool boolean);
+jsi::Value makeSerializableBoolean(jsi::Runtime &rt, bool boolean);
 
-jsi::Value makeShareableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint);
+jsi::Value makeSerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint);
 
-jsi::Value makeShareableUndefined(jsi::Runtime &rt);
+jsi::Value makeSerializableUndefined(jsi::Runtime &rt);
 
-jsi::Value makeShareableNull(jsi::Runtime &rt);
+jsi::Value makeSerializableNull(jsi::Runtime &rt);
 
-jsi::Value makeShareableTurboModuleLike(
+jsi::Value makeSerializableTurboModuleLike(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const std::shared_ptr<jsi::HostObject> &proto);
 
-jsi::Value makeShareableObject(
+jsi::Value makeSerializableObject(
     jsi::Runtime &rt,
     jsi::Object object,
     bool shouldRetainRemote,
     const jsi::Value &nativeStateSource);
 
-jsi::Value makeShareableImport(
+jsi::Value makeSerializableImport(
     jsi::Runtime &rt,
     const double source,
     const jsi::String &imported);
 
-jsi::Value makeShareableHostObject(
+jsi::Value makeSerializableHostObject(
     jsi::Runtime &rt,
     const std::shared_ptr<jsi::HostObject> &value);
 
-jsi::Value makeShareableArray(
+jsi::Value makeSerializableArray(
     jsi::Runtime &rt,
     const jsi::Array &array,
     const jsi::Value &shouldRetainRemote);
 
-jsi::Value makeShareableMap(
+jsi::Value makeSerializableMap(
     jsi::Runtime &rt,
     const jsi::Array &keys,
     const jsi::Array &values);
 
-jsi::Value makeShareableSet(jsi::Runtime &rt, const jsi::Array &values);
+jsi::Value makeSerializableSet(jsi::Runtime &rt, const jsi::Array &values);
 
-jsi::Value makeShareableInitializer(
+jsi::Value makeSerializableInitializer(
     jsi::Runtime &rt,
     const jsi::Object &initializerObject);
 
-jsi::Value makeShareableFunction(jsi::Runtime &rt, jsi::Function function);
+jsi::Value makeSerializableFunction(jsi::Runtime &rt, jsi::Function function);
 
-jsi::Value makeShareableWorklet(
+jsi::Value makeSerializableWorklet(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const bool &shouldRetainRemote);
 
-std::shared_ptr<Shareable> extractShareableOrThrow(
+std::shared_ptr<Serializable> extractSerializableOrThrow(
     jsi::Runtime &rt,
-    const jsi::Value &maybeShareableValue,
+    const jsi::Value &maybeSerializableValue,
     const std::string &errorMessage =
-        "[Worklets] Expecting the object to be of type ShareableJSRef.");
+        "[Worklets] Expecting the object to be of type SerializableJSRef.");
 
 template <typename T>
-std::shared_ptr<T> extractShareableOrThrow(
+std::shared_ptr<T> extractSerializableOrThrow(
     jsi::Runtime &rt,
-    const jsi::Value &shareableRef,
+    const jsi::Value &serializableRef,
     const std::string &errorMessage =
-        "[Worklets] Provided shareable object is of an incompatible type.") {
+        "[Worklets] Provided serializable object is of an incompatible type.") {
   auto res = std::dynamic_pointer_cast<T>(
-      extractShareableOrThrow(rt, shareableRef, errorMessage));
+      extractSerializableOrThrow(rt, serializableRef, errorMessage));
   if (!res) {
     throw std::runtime_error(errorMessage);
   }
   return res;
 }
 
-class ShareableArray : public Shareable {
+class SerializableArray : public Serializable {
  public:
-  ShareableArray(jsi::Runtime &rt, const jsi::Array &array);
+  SerializableArray(jsi::Runtime &rt, const jsi::Array &array);
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
  protected:
-  std::vector<std::shared_ptr<Shareable>> data_;
+  std::vector<std::shared_ptr<Serializable>> data_;
 };
 
-class ShareableObject : public Shareable {
+class SerializableObject : public Serializable {
  public:
-  ShareableObject(jsi::Runtime &rt, const jsi::Object &object);
+  SerializableObject(jsi::Runtime &rt, const jsi::Object &object);
 
-  ShareableObject(
+  SerializableObject(
       jsi::Runtime &rt,
       const jsi::Object &object,
       const jsi::Value &nativeStateSource);
@@ -246,13 +246,13 @@ class ShareableObject : public Shareable {
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
  protected:
-  std::vector<std::pair<std::string, std::shared_ptr<Shareable>>> data_;
+  std::vector<std::pair<std::string, std::shared_ptr<Serializable>>> data_;
   std::shared_ptr<jsi::NativeState> nativeState_;
 };
 
-class ShareableMap : public Shareable {
+class SerializableMap : public Serializable {
  public:
-  ShareableMap(
+  SerializableMap(
       jsi::Runtime &rt,
       const jsi::Array &keys,
       const jsi::Array &values);
@@ -260,26 +260,27 @@ class ShareableMap : public Shareable {
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
  protected:
-  std::vector<std::pair<std::shared_ptr<Shareable>, std::shared_ptr<Shareable>>>
+  std::vector<
+      std::pair<std::shared_ptr<Serializable>, std::shared_ptr<Serializable>>>
       data_;
 };
 
-class ShareableSet : public Shareable {
+class SerializableSet : public Serializable {
  public:
-  ShareableSet(jsi::Runtime &rt, const jsi::Array &values);
+  SerializableSet(jsi::Runtime &rt, const jsi::Array &values);
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
  protected:
-  std::vector<std::shared_ptr<Shareable>> data_;
+  std::vector<std::shared_ptr<Serializable>> data_;
 };
 
-class ShareableHostObject : public Shareable {
+class SerializableHostObject : public Serializable {
  public:
-  ShareableHostObject(
+  SerializableHostObject(
       jsi::Runtime &,
       const std::shared_ptr<jsi::HostObject> &hostObject)
-      : Shareable(HostObjectType), hostObject_(hostObject) {}
+      : Serializable(HostObjectType), hostObject_(hostObject) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
@@ -287,10 +288,10 @@ class ShareableHostObject : public Shareable {
   const std::shared_ptr<jsi::HostObject> hostObject_;
 };
 
-class ShareableHostFunction : public Shareable {
+class SerializableHostFunction : public Serializable {
  public:
-  ShareableHostFunction(jsi::Runtime &rt, jsi::Function function)
-      : Shareable(HostFunctionType),
+  SerializableHostFunction(jsi::Runtime &rt, jsi::Function function)
+      : Serializable(HostFunctionType),
         hostFunction_(function.getHostFunction(rt)),
         name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
         paramCount_(function.getProperty(rt, "length").asNumber()) {}
@@ -303,10 +304,10 @@ class ShareableHostFunction : public Shareable {
   const unsigned int paramCount_;
 };
 
-class ShareableArrayBuffer : public Shareable {
+class SerializableArrayBuffer : public Serializable {
  public:
-  ShareableArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer)
-      : Shareable(ArrayBufferType),
+  SerializableArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer)
+      : Serializable(ArrayBufferType),
         data_(
             arrayBuffer.data(rt),
             arrayBuffer.data(rt) + arrayBuffer.size(rt)) {}
@@ -317,23 +318,25 @@ class ShareableArrayBuffer : public Shareable {
   const std::vector<uint8_t> data_;
 };
 
-class ShareableWorklet : public ShareableObject {
+class SerializableWorklet : public SerializableObject {
  public:
-  ShareableWorklet(jsi::Runtime &rt, const jsi::Object &worklet)
-      : ShareableObject(rt, worklet) {
+  SerializableWorklet(jsi::Runtime &rt, const jsi::Object &worklet)
+      : SerializableObject(rt, worklet) {
     valueType_ = WorkletType;
   }
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class ShareableImport : public Shareable {
+class SerializableImport : public Serializable {
  public:
-  ShareableImport(
+  SerializableImport(
       jsi::Runtime &rt,
       const double source,
       const jsi::String &imported)
-      : Shareable(ImportType), source_(source), imported_(imported.utf8(rt)) {}
+      : Serializable(ImportType),
+        source_(source),
+        imported_(imported.utf8(rt)) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
@@ -342,9 +345,9 @@ class ShareableImport : public Shareable {
   const std::string imported_;
 };
 
-class ShareableRemoteFunction
-    : public Shareable,
-      public std::enable_shared_from_this<ShareableRemoteFunction> {
+class SerializableRemoteFunction
+    : public Serializable,
+      public std::enable_shared_from_this<SerializableRemoteFunction> {
  private:
   jsi::Runtime *runtime_;
 #ifndef NDEBUG
@@ -353,8 +356,8 @@ class ShareableRemoteFunction
   std::unique_ptr<jsi::Value> function_;
 
  public:
-  ShareableRemoteFunction(jsi::Runtime &rt, jsi::Function &&function)
-      : Shareable(RemoteFunctionType),
+  SerializableRemoteFunction(jsi::Runtime &rt, jsi::Function &&function)
+      : Serializable(RemoteFunctionType),
         runtime_(&rt),
 #ifndef NDEBUG
         name_(function.getProperty(rt, "name").asString(rt).utf8(rt)),
@@ -362,41 +365,43 @@ class ShareableRemoteFunction
         function_(std::make_unique<jsi::Value>(rt, std::move(function))) {
   }
 
-  ~ShareableRemoteFunction() {
+  ~SerializableRemoteFunction() {
     cleanupIfRuntimeExists(runtime_, function_);
   }
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class ShareableInitializer : public Shareable {
+class SerializableInitializer : public Serializable {
  private:
   // We don't release the initializer since the handle can get
   // initialized in parallel on multiple threads. However this is not a problem,
   // since the final value is taken from a cache on the runtime which guarantees
   // sequential access.
-  std::unique_ptr<ShareableObject> initializer_;
+  std::unique_ptr<SerializableObject> initializer_;
   std::unique_ptr<jsi::Value> remoteValue_;
   mutable std::mutex initializationMutex_;
   jsi::Runtime *remoteRuntime_;
 
  public:
-  ShareableInitializer(jsi::Runtime &rt, const jsi::Object &initializerObject)
-      : Shareable(HandleType),
-        initializer_(std::make_unique<ShareableObject>(rt, initializerObject)) {
-  }
+  SerializableInitializer(
+      jsi::Runtime &rt,
+      const jsi::Object &initializerObject)
+      : Serializable(HandleType),
+        initializer_(
+            std::make_unique<SerializableObject>(rt, initializerObject)) {}
 
-  ~ShareableInitializer() {
+  ~SerializableInitializer() {
     cleanupIfRuntimeExists(remoteRuntime_, remoteValue_);
   }
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class ShareableString : public Shareable {
+class SerializableString : public Serializable {
  public:
-  explicit ShareableString(const std::string &string)
-      : Shareable(StringType), data_(string) {}
+  explicit SerializableString(const std::string &string)
+      : Serializable(StringType), data_(string) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
@@ -404,10 +409,10 @@ class ShareableString : public Shareable {
   const std::string data_;
 };
 
-class ShareableBigInt : public Shareable {
+class SerializableBigInt : public Serializable {
  public:
-  explicit ShareableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint)
-      : Shareable(BigIntType), string_(bigint.toString(rt).utf8(rt)) {}
+  explicit SerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint)
+      : Serializable(BigIntType), string_(bigint.toString(rt).utf8(rt)) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
@@ -415,16 +420,16 @@ class ShareableBigInt : public Shareable {
   const std::string string_;
 };
 
-class ShareableScalar : public Shareable {
+class SerializableScalar : public Serializable {
  public:
-  explicit ShareableScalar(double number) : Shareable(NumberType) {
+  explicit SerializableScalar(double number) : Serializable(NumberType) {
     data_.number = number;
   }
-  explicit ShareableScalar(bool boolean) : Shareable(BooleanType) {
+  explicit SerializableScalar(bool boolean) : Serializable(BooleanType) {
     data_.boolean = boolean;
   }
-  ShareableScalar() : Shareable(UndefinedType) {}
-  explicit ShareableScalar(std::nullptr_t) : Shareable(NullType) {}
+  SerializableScalar() : Serializable(UndefinedType) {}
+  explicit SerializableScalar(std::nullptr_t) : Serializable(NullType) {}
 
   jsi::Value toJSValue(jsi::Runtime &);
 
@@ -438,21 +443,21 @@ class ShareableScalar : public Shareable {
   Data data_;
 };
 
-class ShareableTurboModuleLike : public Shareable {
+class SerializableTurboModuleLike : public Serializable {
  public:
-  ShareableTurboModuleLike(
+  SerializableTurboModuleLike(
       jsi::Runtime &rt,
       const jsi::Object &object,
       const std::shared_ptr<jsi::HostObject> &proto)
-      : Shareable(TurboModuleLikeType),
-        proto_(std::make_unique<ShareableHostObject>(rt, proto)),
-        properties_(std::make_unique<ShareableObject>(rt, object)) {}
+      : Serializable(TurboModuleLikeType),
+        proto_(std::make_unique<SerializableHostObject>(rt, proto)),
+        properties_(std::make_unique<SerializableObject>(rt, object)) {}
 
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 
  private:
-  const std::unique_ptr<ShareableHostObject> proto_;
-  const std::unique_ptr<ShareableObject> properties_;
+  const std::unique_ptr<SerializableHostObject> proto_;
+  const std::unique_ptr<SerializableObject> properties_;
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletEventHandler.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/WorkletEventHandler.h
@@ -16,14 +16,14 @@ class WorkletEventHandler {
   const uint64_t handlerId_;
   const uint64_t emitterReactTag_;
   const std::string eventName_;
-  const std::shared_ptr<ShareableWorklet> handlerFunction_;
+  const std::shared_ptr<SerializableWorklet> handlerFunction_;
 
  public:
   WorkletEventHandler(
       const uint64_t handlerId,
       const std::string &eventName,
       const uint64_t emitterReactTag,
-      const std::shared_ptr<ShareableWorklet> &handlerFunction)
+      const std::shared_ptr<SerializableWorklet> &handlerFunction)
       : handlerId_(handlerId),
         emitterReactTag_(emitterReactTag),
         eventName_(eventName),

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
     std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
     const bool supportsLocking,
     const std::string &name,
-    std::shared_ptr<ShareableWorklet> initializer) {
+    std::shared_ptr<SerializableWorklet> initializer) {
   const auto runtimeId = getNextRuntimeId();
   const auto jsQueue = jsiWorkletsModuleProxy->getJSQueue();
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -38,7 +38,7 @@ class RuntimeManager {
       std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
       const bool supportsLocking,
       const std::string &name,
-      std::shared_ptr<ShareableWorklet> initializer = nullptr);
+      std::shared_ptr<SerializableWorklet> initializer = nullptr);
 
   std::shared_ptr<WorkletRuntime> createUninitializedUIRuntime(
       const std::shared_ptr<MessageQueueThread> &jsQueue);

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -142,16 +142,16 @@ jsi::Value WorkletRuntime::executeSync(
       supportsLocking_ &&
       ("[Worklets] Runtime \"" + name_ + "\" doesn't support locking.")
           .c_str());
-  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+  auto serializableWorklet = extractSerializableOrThrow<SerializableWorklet>(
       rt,
       worklet,
       "[Worklets] Only worklets can be executed synchronously on UI runtime.");
   auto lock = std::unique_lock<std::recursive_mutex>(*runtimeMutex_);
   jsi::Runtime &uiRuntime = getJSIRuntime();
-  auto result = runGuarded(shareableWorklet);
-  auto shareableResult = extractShareableOrThrow(uiRuntime, result);
+  auto result = runGuarded(serializableWorklet);
+  auto serializableResult = extractSerializableOrThrow(uiRuntime, result);
   lock.unlock();
-  return shareableResult->toJSValue(rt);
+  return serializableResult->toJSValue(rt);
 }
 
 jsi::Value WorkletRuntime::get(
@@ -197,13 +197,13 @@ std::shared_ptr<WorkletRuntime> extractWorkletRuntime(
 void scheduleOnRuntime(
     jsi::Runtime &rt,
     const jsi::Value &workletRuntimeValue,
-    const jsi::Value &shareableWorkletValue) {
+    const jsi::Value &serializableWorkletValue) {
   auto workletRuntime = extractWorkletRuntime(rt, workletRuntimeValue);
-  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+  auto serializableWorklet = extractSerializableOrThrow<SerializableWorklet>(
       rt,
-      shareableWorkletValue,
-      "[Worklets] Function passed to `_scheduleOnRuntime` is not a shareable worklet.");
-  workletRuntime->runAsyncGuarded(shareableWorklet);
+      serializableWorkletValue,
+      "[Worklets] Function passed to `_scheduleOnRuntime` is not a serializable worklet.");
+  workletRuntime->runAsyncGuarded(serializableWorklet);
 }
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -40,15 +40,15 @@ class WorkletRuntime : public jsi::HostObject,
 
   template <typename... Args>
   inline jsi::Value runGuarded(
-      const std::shared_ptr<ShareableWorklet> &shareableWorklet,
+      const std::shared_ptr<SerializableWorklet> &serializableWorklet,
       Args &&...args) const {
     jsi::Runtime &rt = *runtime_;
     return runOnRuntimeGuarded(
-        rt, shareableWorklet->toJSValue(rt), std::forward<Args>(args)...);
+        rt, serializableWorklet->toJSValue(rt), std::forward<Args>(args)...);
   }
 
   void runAsyncGuarded(
-      const std::shared_ptr<ShareableWorklet> &shareableWorklet) {
+      const std::shared_ptr<SerializableWorklet> &serializableWorklet) {
     if (queue_ == nullptr) {
       queue_ = std::make_shared<AsyncQueue>(name_);
     }
@@ -58,7 +58,7 @@ class WorkletRuntime : public jsi::HostObject,
         return;
       }
 
-      strongThis->runGuarded(shareableWorklet);
+      strongThis->runGuarded(serializableWorklet);
     });
   }
 


### PR DESCRIPTION
## Summary

This PR is the first part of a series of PRs that refactor the naming convention. This PR renames `Shareable` to `Serializable` for now only on the cpp side.

## Test plan
`Shareables` Runtime tests
