### PR TITLE
Add `globalThis` to `_log` in the example app

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LogExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LogExample.tsx
@@ -9,7 +9,7 @@ export default function LogExample() {
       // @ts-ignore _toString function is registered for UI runtime
       const actual = global._toString(value);
       // @ts-ignore _log function is registered for UI runtime
-      global._log(actual);
+      globalThis._log(actual);
       if (actual !== expected) {
         throw new Error(`Test failed, expected "${expected}", got "${actual}"`);
       }
@@ -18,7 +18,7 @@ export default function LogExample() {
     runOnUI(() => {
       'worklet';
       // @ts-ignore _log function is registered for UI runtime
-      _log('==============================================');
+      globalThis._log('==============================================');
 
       test(42, '42');
       test(3.14, '3.14');


### PR DESCRIPTION
## Summary
Missing `globalThis` was causing this example to fail.

## Test plan
