### PR TITLE
fix: cpplint missing header include error

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
@@ -4,6 +4,7 @@
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNode.h>
 
+#include <memory>
 #include <unordered_map>
 #include <utility>
 


### PR DESCRIPTION
## Summary

I forgot to add the `#include <memory>` header in the modified file which caused cpplint errors shown in CI.