### PR TITLE
fix: Content overflowing screen in the example app

### DIFF
--- a/apps/common-app/src/apps/css/navigation/Navigator.tsx
+++ b/apps/common-app/src/apps/css/navigation/Navigator.tsx
@@ -229,6 +229,7 @@ function Navigator() {
 const styles = StyleSheet.create({
   content: {
     ...flex.fill,
+    overflow: 'hidden',
     backgroundColor: colors.background3,
   },
   listBullet: {


### PR DESCRIPTION
## Summary

This PR fixes a small bug

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/b294b4e4-708b-4649-a2fa-3b25f55ce277" /> | <video src="https://github.com/user-attachments/assets/c7cfb984-4952-4982-9771-644b6bf54b8a" /> | 
