### PR TITLE
fix: Add backgroundColor to layout animations supported props

### DIFF
--- a/packages/react-native-reanimated/src/animation/util.ts
+++ b/packages/react-native-reanimated/src/animation/util.ts
@@ -64,6 +64,7 @@ const LAYOUT_ANIMATION_SUPPORTED_PROPS = {
   globalOriginY: true,
   opacity: true,
   transform: true,
+  backgroundColor: true,
 };
 
 type LayoutAnimationProp = keyof typeof LAYOUT_ANIMATION_SUPPORTED_PROPS;


### PR DESCRIPTION
## Summary

I noticed that the `backgroundColor` can be animated with layout animations and we even have an example in our example app that does this thing. This PR just adds this prop to the list of supported props to prevent the annoying warning from showing up.

## Example recording

https://github.com/user-attachments/assets/4e3f7c57-119b-420e-98b0-61d360e04e73

