### PR TITLE
Fix linking error after Gradle clean project on Android

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -65,8 +65,7 @@ target_include_directories(
           "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor"
           "${REACT_NATIVE_DIR}/ReactCommon/react/renderer/graphics/platform/cxx"
           "${REACT_NATIVE_WORKLETS_DIR}/Common/cpp"
-          "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp"
-)
+          "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp")
 
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 
@@ -77,15 +76,15 @@ else()
 endif()
 
 find_library(
-  LIBWORKLETS
-  worklets
-  PATHS "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}"
-  NO_DEFAULT_PATH
-  NO_CMAKE_FIND_ROOT_PATH)
+  LIBWORKLETS worklets
+  PATHS
+    "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}"
+  NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android ${LIBWORKLETS})
+target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android
+                      ${LIBWORKLETS})
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(reanimated ReactAndroid::reactnative)

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -77,11 +77,17 @@ endif()
 
 add_library(worklets SHARED IMPORTED)
 
-set_target_properties(worklets PROPERTIES IMPORTED_LOCATION "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so")
+set_target_properties(
+  worklets
+  PROPERTIES
+    IMPORTED_LOCATION
+    "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"
+)
 
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android worklets)
+target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android
+                      worklets)
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(reanimated ReactAndroid::reactnative)

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -68,6 +68,8 @@ target_include_directories(
           "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp"
 )
 
+set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
+
 if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
   set(BUILD_TYPE "debug")
 else()

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -75,16 +75,13 @@ else()
   set(BUILD_TYPE "release")
 endif()
 
-find_library(
-  LIBWORKLETS worklets
-  PATHS
-    "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}"
-  NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+add_library(worklets SHARED IMPORTED)
+
+set_target_properties(worklets PROPERTIES IMPORTED_LOCATION "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so")
 
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android
-                      ${LIBWORKLETS})
+target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android worklets)
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(reanimated ReactAndroid::reactnative)

--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -49,7 +49,6 @@ file(GLOB_RECURSE REANIMATED_ANDROID_CPP_SOURCES CONFIGURE_DEPENDS
 
 find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
-find_package(react-native-worklets REQUIRED CONFIG)
 
 add_library(reanimated SHARED ${REANIMATED_COMMON_CPP_SOURCES}
                               ${REANIMATED_ANDROID_CPP_SOURCES})
@@ -65,13 +64,26 @@ target_include_directories(
           "${REACT_NATIVE_DIR}/ReactCommon/runtimeexecutor"
           "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor"
           "${REACT_NATIVE_DIR}/ReactCommon/react/renderer/graphics/platform/cxx"
+          "${REACT_NATIVE_WORKLETS_DIR}/Common/cpp"
+          "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp"
 )
+
+if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+  set(BUILD_TYPE "debug")
+else()
+  set(BUILD_TYPE "release")
+endif()
+
+find_library(
+  LIBWORKLETS
+  worklets
+  PATHS "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH)
 
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android)
-
-target_link_libraries(reanimated react-native-worklets::worklets)
+target_link_libraries(reanimated log ReactAndroid::jsi fbjni::fbjni android ${LIBWORKLETS})
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(reanimated ReactAndroid::reactnative)

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -349,9 +349,11 @@ dependencies {
 
 preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)
 
-evaluationDependsOn(":react-native-worklets")
+if (project != rootProject) {
+    evaluationDependsOn(":react-native-worklets")
 
-afterEvaluate {
-    tasks.getByName("externalNativeBuildDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildDebug"))
-    tasks.getByName("externalNativeBuildRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildRelease"))
+    afterEvaluate {
+        tasks.getByName("externalNativeBuildDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildDebug"))
+        tasks.getByName("externalNativeBuildRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildRelease"))
+    }
 }

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -348,3 +348,10 @@ dependencies {
 }
 
 preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)
+
+evaluationDependsOn(":react-native-worklets")
+
+afterEvaluate {
+    tasks.getByName("configureCMakeDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("configureCMakeDebug"))
+    tasks.getByName("configureCMakeRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("configureCMakeRelease"))
+}

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -42,6 +42,28 @@ def resolveReactNativeDirectory() {
     )
 }
 
+def resolveReactNativeWorkletsDirectory() {
+    def reactNativeWorkletsLocation = safeAppExtGet("REACT_NATIVE_WORKLETS_NODE_MODULES_DIR", null)
+    if (reactNativeWorkletsLocation != null) {
+        return file(reactNativeWorkletsLocation)
+    }
+
+    // Fallback to node resolver for custom directory structures like monorepos.
+    def reactNativeWorkletsPackage = file(
+        providers.exec {
+            workingDir(rootDir)
+            commandLine("node", "--print", "require.resolve('react-native-worklets/package.json')")
+        }.standardOutput.asText.get().trim()
+    )
+    if (reactNativeWorkletsPackage.exists()) {
+        return reactNativeWorkletsPackage.parentFile
+    }
+
+    throw new GradleException(
+        "[Reanimated] Unable to resolve react-native-worklets location in node_modules. You should set project extension property (in `app/build.gradle`) named `REACT_NATIVE_WORKLETS_NODE_MODULES_DIR` with the path to react-native-worklets in node_modules."
+    )
+}
+
 def getReactNativeMinorVersion() {
     def reactNativeRootDir = resolveReactNativeDirectory()
     def reactProperties = new Properties()
@@ -102,6 +124,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 def reactNativeRootDir = resolveReactNativeDirectory()
+def reactNativeWorkletsRootDir = resolveReactNativeWorkletsDirectory()
 def REACT_NATIVE_MINOR_VERSION = getReactNativeMinorVersion()
 def REANIMATED_VERSION = getReanimatedVersion()
 def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
@@ -181,6 +204,7 @@ android {
                         "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                         "-DANDROID_TOOLCHAIN=clang",
                         "-DREACT_NATIVE_DIR=${toPlatformFileString(reactNativeRootDir.path)}",
+                        "-DREACT_NATIVE_WORKLETS_DIR=${toPlatformFileString(reactNativeWorkletsRootDir.path)}",
                         "-DIS_REANIMATED_EXAMPLE_APP=${IS_REANIMATED_EXAMPLE_APP}",
                         "-DREANIMATED_PROFILING=${REANIMATED_PROFILING}",
                         "-DREANIMATED_VERSION=${REANIMATED_VERSION}",

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -352,6 +352,6 @@ preBuild.dependsOn(prepareReanimatedHeadersForPrefabs)
 evaluationDependsOn(":react-native-worklets")
 
 afterEvaluate {
-    tasks.getByName("configureCMakeDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("configureCMakeDebug"))
-    tasks.getByName("configureCMakeRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("configureCMakeRelease"))
+    tasks.getByName("externalNativeBuildDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildDebug"))
+    tasks.getByName("externalNativeBuildRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildRelease"))
 }

--- a/scripts/lint-cmake.sh
+++ b/scripts/lint-cmake.sh
@@ -5,4 +5,4 @@ if ! which cmake-lint >/dev/null; then
   exit 1
 fi
 
-cmake-lint "$@"
+cmake-lint "$@" --line-width 120


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes the following linking error `on Android due to undefined symbols when trying to build fabric-example via Android Studio after running Clean project after the app was built successfully.

<img alt="" src="https://github.com/user-attachments/assets/a96dfc25-b039-4e0b-8a2f-0a88ef4703c2" />

```
ld.lld: error: undefined symbol: worklets::stringifyJSIValue(facebook::jsi::Runtime&, facebook::jsi::Value const&)
```

Previously, we would include `react-native-worklets::worklets` prefab but still build `libworklets.so` from source. Because of the way how Android Gradle Plugin works (ask @lukmccall for more details), `libworklets` would sometimes be treated like a header-only library with no shared object files, causing the aforementioned linking error.

The proposed solution is to abandon prefabs in favor of linking `libworklets.so` manually (using `add_library`) as well as passing additional header search paths (using `target_include_directories`).

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
