### PR TITLE
Undo conditional skip of reanimated commits

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -93,13 +93,7 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
     // it could lead to RN commits being delayed until the animation is finished
     // (very bad). We don't pause Reanimated commits for state updates coming
     // from React Native as this would break sticky header animations.
-#if REACT_NATIVE_MINOR_VERSION >= 80
-    if (commitOptions.source == ShadowTreeCommitSource::React) {
-      updatesRegistryManager_->pauseReanimatedCommits();
-    }
-#else
     updatesRegistryManager_->pauseReanimatedCommits();
-#endif
   }
 
   return rootNode;


### PR DESCRIPTION
## Summary

This PR reverts the conditional skip of reanimated commits (#7668). This breaks sticky headers, but fixes starvation issues, that would manifest on C++ state updates.

To fix the stick header one must use the `DISABLE_COMMIT_PAUSING_MECHANISM` feature flag in reanimated and the `preventShadowTreeCommitExhaustionWithLocking` in react-native.

## Test plan
