### PR TITLE
chore: amend monorepo build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "private": true,
   "scripts": {
-    "build": "husky && yarn workspaces foreach --all --parallel --topological-dev run build",
+    "build": "husky && yarn build-packages",
+    "build-packages": "yarn workspace react-native-reanimated build",
+    "build-all": "husky && yarn workspaces foreach --all --parallel --topological-dev run build",
     "format": "yarn format:root && yarn format:workspaces",
     "format:root": "prettier --cache --write --list-different --ignore-path .gitignore --ignore-path .prettierignore --ignore-path .prettiereslintignore .",
     "format:workspaces": "yarn workspaces foreach --all --exclude \"react-native-reanimated-monorepo\" --parallel --topological-dev run format",

--- a/packages/docs-reanimated/docs/guides/contributing.mdx
+++ b/packages/docs-reanimated/docs/guides/contributing.mdx
@@ -239,7 +239,7 @@ If you want to implement a new feature or fix a bug, but still are unsure after 
 
 To start with, let's install all dependencies:
 
-1. `yarn && yarn build`
+1. `yarn && yarn build-all`
 2. `cd apps/fabric-example`
 3. `yarn start` &ndash; make sure to start metro bundler before building the app in Android Studio.
 
@@ -253,7 +253,7 @@ The native source code of Reanimated can be found in `react-native-reanimated` m
 
 To begin with, let's install all the necessary dependencies:
 
-1. `yarn && yarn build`
+1. `yarn && yarn build-all`
 2. `(cd apps/fabric-example/ios && bundle install && bundle exec pod install)` &ndash; install Pods for iOS
 3. `cd apps/fabric-example && yarn start` &ndash; make sure to start metro bundler before building the app in Xcode.
 

--- a/packages/react-native-reanimated/RELEASE.md
+++ b/packages/react-native-reanimated/RELEASE.md
@@ -41,7 +41,7 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
    - `tvos-example/ios/Podfile.lock`
    - `macos-example/macos/Podfile.lock`
 
-   If releasing v4, just run `yarn build` in the root directory.
+   If releasing v4, run `yarn build-all` in the root directory.
 
 8. When releasing v3, make sure to update the branch used for nightly releases of Reanimated 3 in [the workflow](../../.github/workflows/npm-reanimated-publish-nightly.yml).
 


### PR DESCRIPTION
## Summary

Currently `yarn build` in root install Pods in all apps, effectively discouraging us from using it. The problem is that it also sets up pre-commit Husky, which is handful. This PR makes `yarn build` lighter.

## Test plan

🚀 
