### PR TITLE
Update getting-started.mdx with the right installation command for re…

### DIFF
--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -28,18 +28,18 @@ It takes two steps to add Reanimated 4 to an Expo project:
 
 ### Step 1: Install the package
 
-Install `react-native-reanimated@latest` and `react-native-worklets` packages from npm:
+Install `react-native-reanimated` and `react-native-worklets` packages from npm:
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     ```bash
-    npm install react-native-reanimated@latest
+    npm install react-native-reanimated
     ```
 
   </TabItem>
   <TabItem value="yarn" label="YARN">
     ```bash
-    yarn add react-native-reanimated@latest
+    yarn add react-native-reanimated
     ```
 
   </TabItem>

--- a/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/packages/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -28,18 +28,18 @@ It takes two steps to add Reanimated 4 to an Expo project:
 
 ### Step 1: Install the package
 
-Install `react-native-reanimated@next` and `react-native-worklets` packages from npm:
+Install `react-native-reanimated@latest` and `react-native-worklets` packages from npm:
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     ```bash
-    npm install react-native-reanimated@next
+    npm install react-native-reanimated@latest
     ```
 
   </TabItem>
   <TabItem value="yarn" label="YARN">
     ```bash
-    yarn add react-native-reanimated@next
+    yarn add react-native-reanimated@latest
     ```
 
   </TabItem>


### PR DESCRIPTION
…-animated 4

The next tag doesn't exist anymore when user tries to install re-animated 4 with npm install react-native-reanimated@next or bun add react-native-reanimated@next. This PR updates the documentation to use the right tag

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
