### PR TITLE
Remove native view export

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -287,15 +287,6 @@ type ToHaveAnimatedStyleConfig = {
 };
 
 export const setUpTests = (userFramerateConfig = {}) => {
-  // Mock ReanimatedView
-  jest.mock(
-    'react-native-reanimated/lib/module/specs/ReanimatedNativeComponent',
-    () => ({})
-  );
-  jest.mock(
-    'react-native-reanimated/src/specs/ReanimatedNativeComponent',
-    () => ({})
-  );
   let expect: jest.Expect = (global as typeof global & { expect: jest.Expect })
     .expect;
   if (expect === undefined) {

--- a/packages/react-native-reanimated/src/specs/ReanimatedNativeComponent.ts
+++ b/packages/react-native-reanimated/src/specs/ReanimatedNativeComponent.ts
@@ -1,9 +1,0 @@
-'use strict';
-import type { ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-
-interface NativeProps extends ViewProps {}
-
-export default codegenNativeComponent<NativeProps>('ReanimatedView', {
-  interfaceOnly: true,
-});

--- a/packages/react-native-reanimated/src/specs/ReanimatedViewProvider.native.ts
+++ b/packages/react-native-reanimated/src/specs/ReanimatedViewProvider.native.ts
@@ -1,4 +1,0 @@
-'use strict';
-import ReanimatedView from './ReanimatedNativeComponent';
-
-export default ReanimatedView;

--- a/packages/react-native-reanimated/src/specs/ReanimatedViewProvider.ts
+++ b/packages/react-native-reanimated/src/specs/ReanimatedViewProvider.ts
@@ -1,6 +1,0 @@
-'use strict';
-
-import type { HostComponent } from 'react-native';
-
-// This is workaround for next.js
-export default {} as HostComponent<any>;

--- a/packages/react-native-reanimated/src/specs/index.ts
+++ b/packages/react-native-reanimated/src/specs/index.ts
@@ -1,10 +1,5 @@
 'use strict';
 
 import ReanimatedTurboModule from './NativeReanimatedModule';
-import ReanimatedView from './ReanimatedViewProvider';
 
-export {
-  ReanimatedTurboModule,
-  /** @knipIgnore */
-  ReanimatedView,
-};
+export { ReanimatedTurboModule };


### PR DESCRIPTION
## Summary

Since we currently don't use the native view, we can simply remove the export to fix the Jest issue. We can then move these changes to the branch with native view integration by @MatiPl01

Fixes https://github.com/software-mansion/react-native-reanimated/issues/7718
