### PR TITLE
Add missing quotes in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -175,7 +175,7 @@ body:
       label: Acknowledgements
       description: I searched for similar issues in the repository.
       options:
-        - Yes
-        - No
+        - 'Yes'
+        - 'No'
     validations:
       required: true


### PR DESCRIPTION
## Summary

Turns out, the quotes were there for a reason.

<img width="925" height="148" alt="Screenshot 2025-07-25 at 12 31 39" src="https://github.com/user-attachments/assets/e1732906-cd09-4fe9-b572-c4ae2c48c4dd" />

## Test plan
