### PR TITLE
Swap acknowledgements dropdown options in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -175,7 +175,7 @@ body:
       label: Acknowledgements
       description: I searched for similar issues in the repository.
       options:
-        - 'Yes'
         - 'No'
+        - 'Yes'
     validations:
       required: true


### PR DESCRIPTION
## Summary

Turns out, if the dropdown is required, the first option is selected by default.

## Test plan
