### PR TITLE
feat(Worklets): obtain WorkletRuntime from runtime address

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -22,6 +22,17 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::getRuntime(
   return nullptr;
 }
 
+// #ifdef WORKLETS_BUNDLE_MODE
+std::shared_ptr<WorkletRuntime> RuntimeManager::getRuntime(
+    jsi::Runtime *runtime) {
+  std::shared_lock lock(weakRuntimesMutex_);
+  if (runtimeAddressToRuntimeId_.contains(runtime)) {
+    return getRuntime(runtimeAddressToRuntimeId_.at(runtime));
+  }
+  return nullptr;
+}
+// #endif // WORKLETS_BUNDLE_MODE
+
 std::vector<std::shared_ptr<WorkletRuntime>> RuntimeManager::getAllRuntimes() {
   std::shared_lock lock(weakRuntimesMutex_);
 
@@ -58,9 +69,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
     workletRuntime->runGuarded(initializer);
   }
 
-  std::unique_lock lock(weakRuntimesMutex_);
-  weakRuntimes_[runtimeId] = workletRuntime;
-  nameToRuntimeId_[name] = runtimeId;
+  registerRuntime(runtimeId, name, workletRuntime);
 
   return workletRuntime;
 }
@@ -70,13 +79,24 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::createUninitializedUIRuntime(
     std::shared_ptr<AsyncQueue> uiAsyncQueue) {
   const auto uiRuntime = std::make_shared<WorkletRuntime>(
       uiRuntimeId, jsQueue, uiRuntimeName, uiAsyncQueue);
-  std::unique_lock lock(weakRuntimesMutex_);
-  weakRuntimes_[uiRuntimeId] = uiRuntime;
+
+  registerRuntime(uiRuntimeId, uiRuntimeName, uiRuntime);
+
   return uiRuntime;
 }
 
 uint64_t RuntimeManager::getNextRuntimeId() {
   return nextRuntimeId_.fetch_add(1, std::memory_order_relaxed);
 }
+
+void RuntimeManager::registerRuntime(
+    const uint64_t runtimeId,
+    const std::string &name,
+    const std::shared_ptr<WorkletRuntime> &workletRuntime) {
+  std::unique_lock lock(weakRuntimesMutex_);
+  weakRuntimes_[runtimeId] = workletRuntime;
+  nameToRuntimeId_[name] = runtimeId;
+  runtimeAddressToRuntimeId_[&workletRuntime->getJSIRuntime()] = runtimeId;
+};
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::getRuntime(
   return nullptr;
 }
 
-// #ifdef WORKLETS_BUNDLE_MODE
+#ifdef WORKLETS_BUNDLE_MODE
 std::shared_ptr<WorkletRuntime> RuntimeManager::getRuntime(
     jsi::Runtime *runtime) {
   std::shared_lock lock(weakRuntimesMutex_);
@@ -31,7 +31,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::getRuntime(
   }
   return nullptr;
 }
-// #endif // WORKLETS_BUNDLE_MODE
+#endif // WORKLETS_BUNDLE_MODE
 
 std::vector<std::shared_ptr<WorkletRuntime>> RuntimeManager::getAllRuntimes() {
   std::shared_lock lock(weakRuntimesMutex_);
@@ -96,7 +96,9 @@ void RuntimeManager::registerRuntime(
   std::unique_lock lock(weakRuntimesMutex_);
   weakRuntimes_[runtimeId] = workletRuntime;
   nameToRuntimeId_[name] = runtimeId;
+#ifdef WORKLETS_BUNDLE_MODE
   runtimeAddressToRuntimeId_[&workletRuntime->getJSIRuntime()] = runtimeId;
+#endif // WORKLETS_BUNDLE_MODE
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -24,9 +24,9 @@ class RuntimeManager {
  public:
   std::shared_ptr<WorkletRuntime> getRuntime(uint64_t runtimeId);
   std::shared_ptr<WorkletRuntime> getRuntime(const std::string &name);
-  // #ifdef WORKLETS_BUNDLE_MODE
+#ifdef WORKLETS_BUNDLE_MODE
   std::shared_ptr<WorkletRuntime> getRuntime(jsi::Runtime *runtime);
-  // #endif // WORKLETS_BUNDLE_MODE
+#endif // WORKLETS_BUNDLE_MODE
 
   std::vector<std::shared_ptr<WorkletRuntime>> getAllRuntimes();
 
@@ -54,9 +54,9 @@ class RuntimeManager {
   std::map<uint64_t, std::weak_ptr<WorkletRuntime>> weakRuntimes_;
   std::shared_mutex weakRuntimesMutex_;
   std::map<std::string, uint64_t> nameToRuntimeId_;
-  // #ifdef WORKLETS_BUNDLE_MODE
+#ifdef WORKLETS_BUNDLE_MODE
   std::map<jsi::Runtime *, uint64_t> runtimeAddressToRuntimeId_;
-  // #endif // WORKLETS_BUNDLE_MODE
+#endif // WORKLETS_BUNDLE_MODE
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -6,6 +6,7 @@
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <shared_mutex>
@@ -23,6 +24,9 @@ class RuntimeManager {
  public:
   std::shared_ptr<WorkletRuntime> getRuntime(uint64_t runtimeId);
   std::shared_ptr<WorkletRuntime> getRuntime(const std::string &name);
+  // #ifdef WORKLETS_BUNDLE_MODE
+  std::shared_ptr<WorkletRuntime> getRuntime(jsi::Runtime *runtime);
+  // #endif // WORKLETS_BUNDLE_MODE
 
   std::vector<std::shared_ptr<WorkletRuntime>> getAllRuntimes();
 
@@ -41,10 +45,18 @@ class RuntimeManager {
  private:
   uint64_t getNextRuntimeId();
 
+  void registerRuntime(
+      const uint64_t runtimeId,
+      const std::string &name,
+      const std::shared_ptr<WorkletRuntime> &workletRuntime);
+
   std::atomic_uint64_t nextRuntimeId_{uiRuntimeId + 1};
   std::map<uint64_t, std::weak_ptr<WorkletRuntime>> weakRuntimes_;
   std::shared_mutex weakRuntimesMutex_;
   std::map<std::string, uint64_t> nameToRuntimeId_;
+  // #ifdef WORKLETS_BUNDLE_MODE
+  std::map<jsi::Runtime *, uint64_t> runtimeAddressToRuntimeId_;
+  // #endif // WORKLETS_BUNDLE_MODE
 };
 
 } // namespace worklets


### PR DESCRIPTION
## Summary

This change is hidden behind `BundleMode` feature flag. It allows us to get the shared pointer to `WorkletRuntime` from it's js address - a prototype feature used in `fetch` implementation on Worklet Runtimes.

## Test plan

Apply the following diff and try out the example

```diff
diff --git a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
index 7f3a1ac26c..3b487f08cd 100644
--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Button } from 'react-native';
+import { runOnRuntime, runOnUI } from 'react-native-worklets';
 
 export default function EmptyExample() {
   return (
     <View style={styles.container}>
       <Text>Hello world!</Text>
+      <Button
+        title="Run on UI"
+        onPress={() => {
+          runOnUI(() => {
+            'worklet';
+            const currentRuntimeRef =
+              globalThis.__workletsModuleProxy.getCurrentWorkletRuntimeRef();
+            runOnRuntime(currentRuntimeRef, () => {
+              'worklet';
+              console.log('Running on UI thread');
+            })();
+          })();
+        }}
+      />
     </View>
   );
 }
diff --git a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
index e716fb0448..28d36e2131 100644
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -204,6 +204,10 @@ std::vector<jsi::PropNameID> JSIWorkletsModuleProxy::getPropertyNames(
       jsi::PropNameID::forAscii(rt, "reportFatalErrorOnJS"));
   propertyNames.emplace_back(
       jsi::PropNameID::forAscii(rt, "setDynamicFeatureFlag"));
+  // #ifdef WORKLETS_BUNDLE_MODE
+  propertyNames.emplace_back(
+      jsi::PropNameID::forAscii(rt, "getCurrentWorkletRuntimeRef"));
+  // #endif // WORKLETS_BUNDLE_MODE
 
 #ifdef WORKLETS_BUNDLE_MODE
   propertyNames.emplace_back(
@@ -541,6 +545,27 @@ jsi::Value JSIWorkletsModuleProxy::get(
         });
   }
 
+  // #ifdef WORKLETS_BUNDLE_MODE
+  if (name == "getCurrentWorkletRuntimeRef") {
+    return jsi::Function::createFromHostFunction(
+        rt,
+        propName,
+        0,
+        [runtimeManager = runtimeManager_](
+            jsi::Runtime &rt,
+            const jsi::Value &thisValue,
+            const jsi::Value *args,
+            size_t count) {
+          auto workletRuntime = runtimeManager->getRuntime(&rt);
+          if (!workletRuntime) {
+            return jsi::Value::undefined();
+          }
+          return static_cast<jsi::Value>(
+              jsi::Object::createFromHostObject(rt, workletRuntime));
+        });
+  }
+  // #endif // WORKLETS_BUNDLE_MODE
+
 #ifdef WORKLETS_BUNDLE_MODE
   if (name == "propagateModuleUpdate") {
     return jsi::Function::createFromHostFunction(

```
