### PR TITLE
docs: Add 4.0.0 to compatibility table

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -9,28 +9,31 @@ sidebar_label: Compatibility
 Reanimated 4 works only with the React Native New Architecture. If your app still uses the old architecture, you can use Reanimated in version 3 which is still actively maintained.
 :::
 
-### Supported React Native versions on the New Architecture (Fabric)
+### Supported React Native versions
 
 <div className="compatibility">
 
-|                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
-| ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.19.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="3.18.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.17.4 - 3.17.5"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
-| <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
-| <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.15.x"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
-| <Version version="3.0.x"/>           | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+|                                      | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
+| ------------------------------------ | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <Version version="nightly"/>         | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="4.0.0"/>           | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Spacer/>                            |       |        |        |        |        |        |        |        |        |        |        |        |
+| <Version version="3.19.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.18.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
+| <Version version="3.17.4 - 3.17.5"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
+| <Version version="3.17.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.16.7"/>          | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.16.0 – 3.16.6"/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.15.x"/>          | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.9.x – 3.14.x"/>  | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.6.x – 3.8.x"/>   | <No/> | <No/>  | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.1.x – 3.5.x"/>   | <No/> | <No/>  | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
+| <Version version="3.0.x"/>           | <No/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  |
 
 </div>
 
-### Supported react-native-worklets versions.
+### Supported react-native-worklets versions
 
 `react-native-worklets` is a dependency of Reanimated 4. However, Reanimated 3 will not work with `react-native-worklets` installed. Make sure to have a correct version of `react-native-worklets` installed when using Reanimated 4.
 
@@ -40,6 +43,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 | ---------------------------- | ----- | ------ | ------- |
 | <Version version="nightly"/> | <No/> | <No/>  | <Yes/>  |
 | <Version version="4.0.0" />  | <No/> | <Yes/> | <No/>   |
+| <Spacer/>                    |       |        |         |
 | <Version version="3.x.x"/>   | <No/> | <No/>  | <No/>   |
 
 </div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds `4.0.0` and `nightly` rows to the compatibility table as well as removes old React Native versions which are no longer supported.

<img src="https://github.com/user-attachments/assets/802550f9-0ef3-4213-923a-9c1cf7ffd920" alt="Screenshot 2025-07-28 at 12 36 28" />

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
