### PR TITLE
fix: Invalid workflow name

### DIFF
--- a/.github/workflows/reanimated-release-checks.yml
+++ b/.github/workflows/reanimated-release-checks.yml
@@ -83,7 +83,7 @@ jobs:
   static_framework_reanimated_build_check_nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'
     name: Static framework Reanimated build check [Nightly]
-    uses: ./.github/workflows/static-framework-reanimated-build-check-nightly.yml
+    uses: ./.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
 
   windows_hosted_app_reanimated_build_check_nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'


### PR DESCRIPTION
## Summary

I noticed that one of the workflows wan't triggered because of the invalid path:

<img width="1214" height="540" alt="image" src="https://github.com/user-attachments/assets/ef5b2c98-6ba8-4224-97cb-baf10fa2df6a" />

I asked @tjzel about that and he told me that the name of the workflow changed. I updated it to the correct name in this PR.