### PR TITLE
fix: CSS animations not being removed from the stylesheet on web

### DIFF
--- a/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.web.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.web.ts
@@ -91,7 +91,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   }
 
   unmountCleanup(): void {
-    // noop
+    setTimeout(this.detach.bind(this));
   }
 
   private detach() {

--- a/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.web.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSAnimationsManager.web.ts
@@ -91,6 +91,8 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   }
 
   unmountCleanup(): void {
+    // We use setTimeout to ensure that the animation is removed after the
+    // component is unmounted (it puts the detach call at the end of the event loop)
     setTimeout(this.detach.bind(this));
   }
 


### PR DESCRIPTION
## Summary

@m-bert noticed that animations aren't cleaned up from the Reanimated's CSS stylesheet when components are unmounted. As a result, we ended up having multiple instances of animations that were no longer used.

## Example recording

### Before

<video src="https://github.com/user-attachments/assets/9e7d9987-80eb-44b0-8519-ee5a2978f2b0"></video>

### After

<video src="https://github.com/user-attachments/assets/cb52aaca-7dab-4dfb-bd0a-98fe7e90a09a"></video> 

### Test example

<details>
<summary>Code snippet</summary>

```tsx
import { useState } from 'react';
import { Button } from 'react-native';
import Animated from 'react-native-reanimated';

export default function App() {
  const [show, setShow] = useState(false);

  return (
    <>
      <Button title="Show" onPress={() => setShow(!show)} />
      {show && (
        <Animated.View
          style={{
            backgroundColor: 'green',
            flex: 1,
            animationName: {
              from: { backgroundColor: 'red' },
              to: { backgroundColor: 'blue' },
            },
            animationDuration: '1s',
            animationTimingFunction: 'ease-in-out',
            animationDelay: '0s',
            animationIterationCount: 'infinite',
            animationDirection: 'alternate',
            animationFillMode: 'forwards',
            animationPlayState: 'running',
          }}
        />
      )}
    </>
  );
}
```
</details>