### PR TITLE
[Web LA] Adjust animation cleanup to slower devices

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -173,15 +173,19 @@ export function setElementAnimation(
     configureAnimation();
   }
 
+  const maybeRemoveElement = () => {
+    if (element.reanimatedDummy && parent?.contains(element)) {
+      element.removedAfterAnimation = true;
+      parent.removeChild(element);
+    }
+  };
+
   element.onanimationend = () => {
     if (shouldSavePosition) {
       saveSnapshot(element);
     }
 
-    if (parent?.contains(element)) {
-      element.removedAfterAnimation = true;
-      parent.removeChild(element);
-    }
+    maybeRemoveElement();
 
     animationConfig.callback?.(true);
     element.removeEventListener('animationcancel', animationCancelHandler);
@@ -190,10 +194,7 @@ export function setElementAnimation(
   const animationCancelHandler = () => {
     animationConfig.callback?.(false);
 
-    if (parent?.contains(element)) {
-      element.removedAfterAnimation = true;
-      parent.removeChild(element);
-    }
+    maybeRemoveElement();
 
     element.removeEventListener('animationcancel', animationCancelHandler);
   };
@@ -212,6 +213,8 @@ export function setElementAnimation(
       if (shouldSavePosition) {
         setElementPosition(element, snapshots.get(element)!);
       }
+
+      maybeRemoveElement();
     });
   }
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
@@ -118,7 +118,7 @@ function removeWebAnimation(
   }
 }
 
-const timeoutScale = 1.25; // We use this value to enlarge timeout duration. It can prove useful if animation lags.
+const timeoutScale = 5; // We use this value to enlarge timeout duration. It can prove useful if animation lags.
 const frameDurationMs = 16; // Just an approximation.
 const minimumFrames = 10;
 

--- a/packages/react-native-reanimated/src/layoutReanimation/web/transition/Curved.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/transition/Curved.web.ts
@@ -93,6 +93,7 @@ function prepareDummy(
   };
 
   const dummy = element.cloneNode(true) as ReanimatedHTMLElement;
+  dummy.reanimatedDummy = true;
   resetStyle(dummy);
 
   return { dummy, dummyAnimationConfig };


### PR DESCRIPTION
## Summary

Turns out that on slower devices when animation lags, it can be removed from DOM before it finishes. This results in callbacks not being called and `dummy` being left instead of removed. 

This PR:

1. Adjusts timeout value for slower devices,
2. Removes dummy elements when their animation is removed from DOM

## Test plan

<details>
<summary>Tested on the following code, with 20x throttling enabled in chrome dev tools:</summary>

```jsx
import { useState } from 'react';
import { Button, View } from 'react-native';
import Animated, { Keyframe, Easing } from 'react-native-reanimated';

function Square() {
  const [visible, setVisible] = useState(false);

  const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0).factory();
  const animation = new Keyframe({
    from: { transform: [{ translateX: '0%' }] },
    to: {
      transform: [{ translateX: '100%' }],
      easing,
    },
  });

  return (
    <View
      style={{
        padding: 20,
        flex: 1,
        flexDirection: 'row',
        alignItems: 'center',
      }}>
      <Button
        title="Toggle"
        onPress={() => setVisible((visible) => !visible)}
      />
      {visible && (
        <Animated.View
          style={{
            backgroundColor: 'red',
            width: 200,
            height: 200,
            flexDirection: 'row',
            flexWrap: 'wrap',
          }}
          exiting={animation
            .duration(300)
            .withCallback(() => console.log('callback!'))}>
          {Array(10000)
            .fill(0)
            .map((_, i) => (
              <View
                key={i}
                style={{ backgroundColor: 'yellow', width: 2, height: 2 }}
              />
            ))}
        </Animated.View>
      )}
    </View>
  );
}

export default function App() {
  return (
    <View style={{ flex: 1 }}>
      <Square />
    </View>
  );
}
```

</details>
