### PR TITLE
docs: Add missing 4.0.1 to compat table

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -16,7 +16,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 |                                      | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
 | <Version version="nightly"/>         | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="4.0.0 - 4.0.1"/>   | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="4.0.0 – 4.0.1"/>   | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Spacer/>                            |       |        |        |        |        |        |        |        |        |        |        |        |
 | <Version version="3.19.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |

--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -16,7 +16,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 |                                      | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
 | <Version version="nightly"/>         | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="4.0.0"/>           | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="4.0.0 - 4.0.1"/>   | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Spacer/>                            |       |        |        |        |        |        |        |        |        |        |        |        |
 | <Version version="3.19.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
@@ -39,11 +39,11 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 
 <div className="compatibility">
 
-|                              | 0.3   | 0.4    | nightly |
-| ---------------------------- | ----- | ------ | ------- |
-| <Version version="nightly"/> | <No/> | <No/>  | <Yes/>  |
-| <Version version="4.0.0" />  | <No/> | <Yes/> | <No/>   |
-| <Spacer/>                    |       |        |         |
-| <Version version="3.x.x"/>   | <No/> | <No/>  | <No/>   |
+|                                     | 0.3   | 0.4    | nightly |
+| ----------------------------------- | ----- | ------ | ------- |
+| <Version version="nightly"/>        | <No/> | <No/>  | <Yes/>  |
+| <Version version="4.0.0 - 4.0.1" /> | <No/> | <Yes/> | <No/>   |
+| <Spacer/>                           |       |        |         |
+| <Version version="3.x.x"/>          | <No/> | <No/>  | <No/>   |
 
 </div>

--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -20,7 +20,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 | <Spacer/>                            |       |        |        |        |        |        |        |        |        |        |        |        |
 | <Version version="3.19.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.17.4 - 3.17.5"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.17.4 – 3.17.5"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
 | <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
 | <Version version="3.17.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
 | <Version version="3.16.7"/>          | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |

--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -42,7 +42,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 |                                     | 0.3   | 0.4    | nightly |
 | ----------------------------------- | ----- | ------ | ------- |
 | <Version version="nightly"/>        | <No/> | <No/>  | <Yes/>  |
-| <Version version="4.0.0 - 4.0.1" /> | <No/> | <Yes/> | <No/>   |
+| <Version version="4.0.0 – 4.0.1" /> | <No/> | <Yes/> | <No/>   |
 | <Spacer/>                           |       |        |         |
 | <Version version="3.x.x"/>          | <No/> | <No/>  | <No/>   |
 


### PR DESCRIPTION
## Summary

<img width="957" height="810" alt="Screenshot 2025-07-29 at 16 08 34" src="https://github.com/user-attachments/assets/d60a5c6f-f482-4b0b-ba04-24933453fb57" />

<img width="886" height="242" alt="Screenshot 2025-07-29 at 16 08 40" src="https://github.com/user-attachments/assets/97754b3c-a56e-4944-b71b-911d86e8d8ee" />

