### PR TITLE
fix: Make sure that tagToJSPropNamesMapping is initialized before being used

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -5,7 +5,6 @@ export default function EmptyExample() {
   return (
     <View style={styles.container}>
       <Text>Hello world!</Text>
-      <Text>Hello world!</Text>
     </View>
   );
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -17,12 +17,6 @@ class JSPropsUpdaterNative implements IJSPropsUpdater {
     AnimatedComponentType
   >();
 
-  constructor() {
-    runOnUI(() => {
-      global._tagToJSPropNamesMapping = {};
-    })();
-  }
-
   public registerComponent(
     animatedComponent: AnimatedComponentType,
     jsProps: string[]

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -24,5 +24,9 @@ export function initializeReanimatedModule(
 
 registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
 if (!SHOULD_BE_USE_WEB) {
-  executeOnUIRuntimeSync(registerLoggerConfig)(DEFAULT_LOGGER_CONFIG);
+  executeOnUIRuntimeSync(() => {
+    'worklet';
+    global._tagToJSPropNamesMapping = {};
+    registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
+  })();
 }


### PR DESCRIPTION
## Summary

This PR should fix the issue when the `global._tagToJSPropNamesMapping` was accessed before being created.