### PR TITLE
[Web LA] Fix resetting scroll positions in exiting animations

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/componentUtils.ts
@@ -314,9 +314,9 @@ export function handleExitingAnimation(
 
   // Moving elements in DOM resets their scroll positions
   // so we memorize them here and restore after
-  const scrollPositions: { top: number; left: number }[] = [];
+  const scrollPositions = new Map<Element, { top: number; left: number }>();
   const saveScrollPosition = (node: Element) => {
-    scrollPositions.push({
+    scrollPositions.set(node, {
       top: node.scrollTop,
       left: node.scrollLeft,
     });
@@ -337,11 +337,12 @@ export function handleExitingAnimation(
 
   parent?.appendChild(dummy);
 
-  let index = 0;
   const restoreScrollPosition = (node: Element) => {
-    const scrollPosition = scrollPositions[index++];
-    node.scrollTop = scrollPosition.top;
-    node.scrollLeft = scrollPosition.left;
+    const scrollPosition = scrollPositions.get(node === dummy ? element : node);
+    if (scrollPosition) {
+      node.scrollTop = scrollPosition.top;
+      node.scrollLeft = scrollPosition.left;
+    }
     for (const child of Array.from(node.children)) {
       restoreScrollPosition(child);
     }


### PR DESCRIPTION
## Summary

In exiting animations, the element is cloned and its children are moved to the dummy element. Moving the children causes them (and their descendants) to lose scroll positions. So when we have e.g. a FlatList inside a view with an exiting animation, it jumps to the start when animating out. This PR fixes it by recording the positions before moving the children and restoring them after that.

current behavior (before these changes):

https://github.com/user-attachments/assets/69341546-1018-44d4-8bc2-b287b2ac61a2


## Test plan

<details>
<summary>Code</summary>

```tsx
import { useEffect, useRef, useState } from "react";
import { Button, FlatList, View } from "react-native";
import Animated, { Keyframe, Easing } from "react-native-reanimated";

function Square() {
  const [visible, setVisible] = useState(false);

  const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0).factory();
  const animation = new Keyframe({
    from: { transform: [{ translateX: "0%" }] },
    to: {
      transform: [{ translateX: "100%" }],
      easing,
    },
  });

  const ref = useRef<Animated.FlatList<any>>(null);

  useEffect(() => {
    if (visible) {
      ref.current?.scrollToOffset({ animated: true, offset: 225 });
    }
  }, [visible]);

  return (
    <View
      style={{
        padding: 20,
        flex: 1,
        flexDirection: "row",
        alignItems: "center",
      }}
    >
      <Button
        title="Toggle"
        onPress={() => setVisible((visible) => !visible)}
      />
      {visible && (
        <Animated.View
          style={{
            width: 200,
            height: 200,
          }}
          exiting={animation
            .duration(5000)
            .withCallback(() => console.log("callback!"))}
        >
          <View
            style={{
              width: 200,
              height: 200,
            }}
          >
            <FlatList
              initialNumToRender={100}
              ref={ref}
              data={Array(100)
                .fill(0)
                .map((x, i) => i)}
              renderItem={(x) => <View>{x.item}</View>}
            />
          </View>
        </Animated.View>
      )}
    </View>
  );
}

export default function App() {
  return (
    <View style={{ flex: 1 }}>
      <Square />
    </View>
  );
}

```
</details>
