### PR TITLE
Remove ifdefs for pre-0.78

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -406,10 +406,7 @@ void LayoutAnimationsProxy::addOngoingAnimations(
     updateLayoutMetrics(newView->layoutMetrics, updateValues.frame);
 
     mutations.push_back(ShadowViewMutation::UpdateMutation(
-        *layoutAnimation.currentView,
-        *newView,
-        layoutAnimation.parentTag
-        ));
+        *layoutAnimation.currentView, *newView, layoutAnimation.parentTag));
     layoutAnimation.currentView = newView;
   }
   updateMap.clear();
@@ -661,11 +658,7 @@ void LayoutAnimationsProxy::startEnteringAnimation(
       auto lock = std::unique_lock<std::recursive_mutex>(mutex);
       strongThis->layoutAnimations_.insert_or_assign(
           tag,
-          LayoutAnimation{
-              finalView,
-              current,
-              mutation.parentTag,
-              opacity});
+          LayoutAnimation{finalView, current, mutation.parentTag, opacity});
       window = strongThis->surfaceManager.getWindow(
           mutation.newChildShadowView.surfaceId);
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -22,12 +22,8 @@ class ReanimatedModuleProxy;
 using namespace facebook;
 
 struct LayoutAnimation {
-#if REACT_NATIVE_MINOR_VERSION >= 78
   std::shared_ptr<ShadowView> finalView, currentView;
   Tag parentTag;
-#else
-  std::shared_ptr<ShadowView> finalView, currentView, parentView;
-#endif // REACT_NATIVE_MINOR_VERSION >= 78
   std::optional<double> opacity;
   int count = 1;
   LayoutAnimation &operator=(const LayoutAnimation &other) = default;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsUtils.cpp
@@ -30,12 +30,7 @@ Rect SurfaceManager::getWindow(SurfaceId surfaceId) {
 }
 
 void Node::applyMutationToIndices(ShadowViewMutation mutation) {
-#if REACT_NATIVE_MINOR_VERSION >= 78
   const auto parentTag = mutation.parentTag;
-#else
-  const auto parentTag = mutation.parentShadowView.tag;
-#endif // REACT_NATIVE_MINOR_VERSION >= 78
-
   if (tag != parentTag) {
     return;
   }


### PR DESCRIPTION
## Summary

This PR removes code inside `#if REACT_NATIVE_MINOR_VERSION < 78` and outside of `#if REACT_NATIVE_MINOR_VERSION >= 78`.

## Test plan
