### PR TITLE
(cherry-pick) fix: Make sure that tagToJSPropNamesMapping is initialized before being used

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/JSPropsUpdater.ts
@@ -17,12 +17,6 @@ class JSPropsUpdaterNative implements IJSPropsUpdater {
     AnimatedComponentType
   >();
 
-  constructor() {
-    runOnUI(() => {
-      global._tagToJSPropNamesMapping = {};
-    })();
-  }
-
   public registerComponent(
     animatedComponent: AnimatedComponentType,
     jsProps: string[]

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -24,5 +24,9 @@ export function initializeReanimatedModule(
 
 registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
 if (!SHOULD_BE_USE_WEB) {
-  executeOnUIRuntimeSync(registerLoggerConfig)(DEFAULT_LOGGER_CONFIG);
+  executeOnUIRuntimeSync(() => {
+    'worklet';
+    global._tagToJSPropNamesMapping = {};
+    registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
+  })();
 }


### PR DESCRIPTION
## Summary

Cherry-pick of the #7941