### PR TITLE
fix: LA Manager initialized too late on the UI runtime

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -2,6 +2,7 @@
 import { executeOnUIRuntimeSync } from 'react-native-worklets';
 
 import { withStyleAnimation } from '../animation';
+import { SHOULD_BE_USE_WEB } from '../common';
 import type {
   LayoutAnimation,
   LayoutAnimationStartFunction,
@@ -100,10 +101,12 @@ function createLayoutAnimationManager(): {
   };
 }
 
-executeOnUIRuntimeSync(() => {
-  'worklet';
-  global.LayoutAnimationsManager = createLayoutAnimationManager();
-})();
+if (!SHOULD_BE_USE_WEB) {
+  executeOnUIRuntimeSync(() => {
+    'worklet';
+    global.LayoutAnimationsManager = createLayoutAnimationManager();
+  })();
+}
 
 export type LayoutAnimationsManager = ReturnType<
   typeof createLayoutAnimationManager


### PR DESCRIPTION
## Summary

This PR fixes too late initialization of the UI LA manager, which caused crashes when the view with entering LA was rendered before initialization of this manager.

## Example recordings

### Before

<video src="https://github.com/user-attachments/assets/af6e5071-d2f6-42af-8634-2cbcc2b910ae" ></video>

### After

<video src="https://github.com/user-attachments/assets/ba24d946-f7e1-4d9e-b745-3371d00a6a61" ></video>

## Test example

Replace the entire app's code (`e.g. in the `fabric-example/App.tsx`) with the following code:

```tsx
import Animated, { FadeIn } from 'react-native-reanimated';

export default function App() {
  return (
    <Animated.View
      entering={FadeIn}
      style={{ width: 100, height: 100, backgroundColor: 'red' }}
    />
  );
}
```

It crashed before this change and works after applying changes from this PR.