### PR TITLE
Remove unnecessary `makeShareable` call for color names and properties

### DIFF
--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -354,10 +354,6 @@ export const ColorProperties = [
   'stroke',
 ];
 
-setTimeout(() => {
-  console.log('Adding beautifulColor to ColorProperties');
-  ColorProperties.push('beautifulColor');
-}, 5000);
 
 export function normalizeColor(color: unknown): number | null {
   'worklet';

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -6,7 +6,6 @@
  */
 
 /* eslint no-bitwise: 0 */
-import { makeShareable } from 'react-native-worklets';
 
 interface RGB {
   r: number;
@@ -354,6 +353,11 @@ export const ColorProperties = [
   'stopColor',
   'stroke',
 ];
+
+setTimeout(() => {
+  console.log('Adding beautifulColor to ColorProperties');
+  ColorProperties.push('beautifulColor');
+}, 5000);
 
 export function normalizeColor(color: unknown): number | null {
   'worklet';

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -169,7 +169,7 @@ export function clampRGBA(RGBA: ParsedColorArray): void {
   }
 }
 
-const names: Record<string, number> = makeShareable({
+const names: Record<string, number> = {
   transparent: 0x00000000,
 
   /* spell-checker: disable */
@@ -324,10 +324,10 @@ const names: Record<string, number> = makeShareable({
   yellow: 0xffff00ff,
   yellowgreen: 0x9acd32ff,
   /* spell-checker: enable */
-});
+};
 
 // copied from react-native/Libraries/Components/View/ReactNativeStyleAttributes
-export const ColorProperties = makeShareable([
+export const ColorProperties = [
   'backgroundColor',
   'borderBottomColor',
   'borderColor',
@@ -353,7 +353,7 @@ export const ColorProperties = makeShareable([
   'lightingColor',
   'stopColor',
   'stroke',
-]);
+];
 
 export function normalizeColor(color: unknown): number | null {
   'worklet';

--- a/packages/react-native-reanimated/src/Colors.ts
+++ b/packages/react-native-reanimated/src/Colors.ts
@@ -354,7 +354,6 @@ export const ColorProperties = [
   'stroke',
 ];
 
-
 export function normalizeColor(color: unknown): number | null {
   'worklet';
 


### PR DESCRIPTION
## Summary

I don't think we need `makeShareable` here.

## Test plan

1. `ColorExample` works as expected
2. Cannot modify `ColorProperties` and `names` as expected because they are frozen once passed to worklet via closure

```tsx
setTimeout(() => {
  console.log('Adding beautifulColor to ColorProperties');
  ColorProperties.push('beautifulColor');
}, 5000);
```

<img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-31 at 13 20 43" src="https://github.com/user-attachments/assets/6e46dc36-1945-4348-94b1-3c1f762d6efa" />
