### PR TITLE
fix(Reanimated): withSpring overshoot clamping coordinates

### DIFF
--- a/packages/react-native-reanimated/src/animation/spring/springUtils.ts
+++ b/packages/react-native-reanimated/src/animation/spring/springUtils.ts
@@ -354,10 +354,9 @@ export function isAnimationTerminatingCalculation(
   const { toValue, velocity, startValue, current, initialEnergy } = animation;
 
   if (config.overshootClamping) {
-    if (
-      (current > toValue && startValue < toValue) ||
-      (current < toValue && startValue > toValue)
-    ) {
+    const leftBound = startValue >= 0 ? toValue : toValue + startValue;
+    const rightBound = leftBound + Math.abs(startValue);
+    if (current < leftBound || current > rightBound) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #7947

When fixing various thing in withSpring in #7803 I moved over to a coherent coordinate system for the animation. This means that when animating a value from 700 to 600, the animation internally animated from 100 to 0. For 600 to 700 it's -100 to 0. I accidentally didn't reflect that change for `overshootClamping` checks.

## Test plan

```tsx
import React, { useEffect, useState } from 'react';
import { Button, StyleSheet, Text, View } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withSpring,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const [toggle, setToggle] = useState(false);
  const height = useSharedValue(600);

  const animatedStyle = useAnimatedStyle(() => {
    return {
      height: withSpring(height.value, {
        overshootClamping: true,
      }),
    };
  });

  return (
    <View style={styles.container}>
      <Animated.View
        style={[{ width: 100, backgroundColor: 'blue' }, animatedStyle]}
      />
      <Button
        title="Change Height"
        onPress={() => {
          const target = toggle ? 600 : 500;
          height.value = target;
          setToggle(!toggle);
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```


| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/75ac8595-90dd-44f1-ab04-5c5126941e1e"/> | <video src="https://github.com/user-attachments/assets/45c6f4e8-0291-42be-a268-8ee43ee72fb7"/> | 
