### PR TITLE
chore: satisfy clang-tidy CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks:
   - -cppcoreguidelines-pro-bounds-constant-array-index
   - -cppcoreguidelines-init-variables
   - -cppcoreguidelines-pro-bounds-array-to-pointer-decay
+  - -cppcoreguidelines-avoid-non-const-global-variables
   # - google-*
   # - hicpp-*
   # - llvm-*
@@ -36,6 +37,4 @@ Checks:
   # - performance-*
   # - portability-*
   # - readability-*
-WarningsAsErrors: '*'
-CheckOptions:
-  cppcoreguidelines-avoid-non-const-global-variables.AllowInternalLinkage: true
+WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,3 +37,5 @@ Checks:
   # - portability-*
   # - readability-*
 WarningsAsErrors: "*"
+CheckOptions:
+  cppcoreguidelines-avoid-non-const-global-variables.AllowInternalLinkage: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,4 +37,4 @@ Checks:
   # - performance-*
   # - portability-*
   # - readability-*
-WarningsAsErrors: "*"
+WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,6 @@ Checks:
   # - performance-*
   # - portability-*
   # - readability-*
-WarningsAsErrors: "*"
+WarningsAsErrors: '*'
 CheckOptions:
   cppcoreguidelines-avoid-non-const-global-variables.AllowInternalLinkage: true

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
@@ -4,7 +4,7 @@ namespace reanimated::css {
 
 namespace {
 
-ComponentInterpolatorsMap registry = {
+static ComponentInterpolatorsMap registry = {
     {"View", VIEW_INTERPOLATORS},
     {"Paragraph", TEXT_INTERPOLATORS},
     {"Image", IMAGE_INTERPOLATORS},

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
@@ -4,7 +4,7 @@ namespace reanimated::css {
 
 namespace {
 
-static ComponentInterpolatorsMap registry = {
+ComponentInterpolatorsMap registry = {
     {"View", VIEW_INTERPOLATORS},
     {"Paragraph", TEXT_INTERPOLATORS},
     {"Image", IMAGE_INTERPOLATORS},


### PR DESCRIPTION
## Summary

Fixes https://github.com/software-mansion/react-native-reanimated/actions/runs/16658361282/job/47149055694#step:7:914

I also moved `.clang-tidy` file to the monorepo root for it to also be used in worklets.

## Test plan

CI should pass now.
