### PR TITLE
fix: Small CSS issues introduced in recent PRs

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
@@ -164,10 +164,10 @@ std::ostream &operator<<(std::ostream &os, const CSSColor &colorValue) {
   return os;
 }
 
+#endif // NDEBUG
+
 bool CSSColor::isValidColorString(const std::string &colorString) {
   return colorString == "transparent" || colorString == "currentColor";
 }
-
-#endif // NDEBUG
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/config/interpolators/registry.cpp
@@ -33,12 +33,6 @@ const InterpolatorFactoriesRecord &getComponentInterpolators(
 void registerComponentInterpolators(
     const std::string &componentName,
     const InterpolatorFactoriesRecord &interpolators) {
-  if (registry.contains(componentName)) {
-    throw std::invalid_argument(
-        "[Reanimated] CSS interpolators for component '" + componentName +
-        "' are already registered. Cannot register duplicate interpolators.");
-  }
-
   registry[componentName] = interpolators;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes 2 issues:

1. Release build [failing](https://github.com/software-mansion/react-native-reanimated/actions/runs/16658346570/job/47149005018#step:12:3141) because of the missing implementation of the `isValidColorString` method - I mistakenly put it within the `#ifdef DEBUG` block
2. Error thrown during the app development on hot reloads when the new code was added in the app - caused by the check if interpolators for the specific component have already been registered. I just removed this check as it is unlikely that someone registers different interpolators for the view with the same name and I don't know if there is a better solution to fix the hot reloads issue.