### PR TITLE
Add filter example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/FilterExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/FilterExample.tsx
@@ -105,7 +105,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>blur</Text>
+      <Text>blur (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -114,7 +114,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>contrast</Text>
+      <Text>contrast (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -123,7 +123,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>dropShadow</Text>
+      <Text>dropShadow (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -132,7 +132,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>grayscale</Text>
+      <Text>grayscale (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -141,7 +141,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>hueRotate</Text>
+      <Text>hueRotate (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -150,7 +150,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>invert</Text>
+      <Text>invert (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -159,7 +159,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>sepia</Text>
+      <Text>sepia (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types
@@ -168,7 +168,7 @@ export default function FilterExample() {
         height={80}
       />
 
-      <Text>saturate</Text>
+      <Text>saturate (only Android)</Text>
       <Animated.Image
         source={balloonsImage}
         // @ts-expect-error TODO: fix types

--- a/apps/common-app/src/apps/reanimated/examples/FilterExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/FilterExample.tsx
@@ -1,0 +1,191 @@
+import { balloonsImage } from '@/apps/css/assets';
+import React, { useEffect } from 'react';
+import { ScrollView, StyleSheet, Text } from 'react-native';
+import Animated, {
+  interpolateColor,
+  processColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+export default function FilterExample() {
+  const sv = useSharedValue(0);
+
+  useEffect(() => {
+    sv.value = 0;
+    sv.value = withRepeat(withTiming(1, { duration: 500 }), -1, true);
+  }, [sv]);
+
+  // https://reactnative.dev/docs/view-style-props#filter
+
+  const brightness = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ brightness: sv.value }] };
+  });
+
+  const opacity = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ opacity: sv.value }] };
+  });
+
+  const blur = useAnimatedStyle(() => {
+    return { filter: [{ blur: sv.value * 10 }] };
+  });
+
+  const contrast = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ contrast: sv.value * 3 }] };
+  });
+
+  // @ts-expect-error TODO: call processColor automatically
+  const dropShadow = useAnimatedStyle(() => {
+    return {
+      filter: [
+        {
+          dropShadow: {
+            offsetX: sv.value * 10,
+            offsetY: sv.value * 10,
+            standardDeviation: sv.value * 10,
+            color: processColor(
+              interpolateColor(sv.value, [0, 1], ['red', 'blue'])
+            ),
+          },
+        },
+      ],
+    };
+  });
+
+  const grayscale = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ grayscale: sv.value }] };
+  });
+
+  const hueRotate = useAnimatedStyle(() => {
+    // TODO: support deg and rad string
+    return { filter: [{ hueRotate: sv.value * 360 }] };
+  });
+
+  const invert = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ invert: sv.value }] };
+  });
+
+  const sepia = useAnimatedStyle(() => {
+    // TODO: support percentage string
+    return { filter: [{ sepia: sv.value }] };
+  });
+
+  const saturate = useAnimatedStyle(() => {
+    return { filter: [{ saturate: sv.value * 2 }] };
+  });
+
+  // TODO: support filter string
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}>
+      <Text>brightness</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={brightness}
+        width={80}
+        height={80}
+      />
+
+      <Text>opacity</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={opacity}
+        width={80}
+        height={80}
+      />
+
+      <Text>blur</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={blur}
+        width={80}
+        height={80}
+      />
+
+      <Text>contrast</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={contrast}
+        width={80}
+        height={80}
+      />
+
+      <Text>dropShadow</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={dropShadow}
+        width={80}
+        height={80}
+      />
+
+      <Text>grayscale</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={grayscale}
+        width={80}
+        height={80}
+      />
+
+      <Text>hueRotate</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={hueRotate}
+        width={80}
+        height={80}
+      />
+
+      <Text>invert</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={invert}
+        width={80}
+        height={80}
+      />
+
+      <Text>sepia</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={sepia}
+        width={80}
+        height={80}
+      />
+
+      <Text>saturate</Text>
+      <Animated.Image
+        source={balloonsImage}
+        // @ts-expect-error TODO: fix types
+        style={saturate}
+        width={80}
+        height={80}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    alignItems: 'center',
+    paddingVertical: 50,
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -33,6 +33,7 @@ import DragAndSnapExample from './DragAndSnapExample';
 import EmojiWaterfallExample from './EmojiWaterfallExample';
 import EmptyExample from './EmptyExample';
 import ExtrapolationExample from './ExtrapolationExample';
+import FilterExample from './FilterExample';
 import FrameCallbackExample from './FrameCallbackExample';
 import FreezeExample from './FreezeExample';
 import Game2048Example from './Game2048Example';
@@ -300,6 +301,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🌈',
     title: 'Animate colors',
     screen: ColorExample,
+  },
+  FilterExample: {
+    icon: '🖼️',
+    title: 'Animate filter',
+    screen: FilterExample,
   },
   ScreenStackHeaderConfigBackgroundColorExample: {
     icon: '🎨',


### PR DESCRIPTION
## Summary

This PR adds example for animating `filter` view style prop (https://reactnative.dev/docs/view-style-props#filter) via `useAnimatedStyle`.

Note that on iOS only `brightness` and `opacity` filters are supported.

| Android | iOS |
|:-:|:-:|
| <img width="300" src="https://github.com/user-attachments/assets/978dcae0-24a4-4843-bfcf-d78be4b7ae88" /> | <img width="300" src="https://github.com/user-attachments/assets/0b57295d-faf3-4054-9b96-31bed8db9a87" /> |

## Test plan
