### PR TITLE
fix: Keyframe LA easing not working properly on web

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
@@ -17,9 +17,12 @@ export interface ReanimatedWebTransformProperties {
   skewX?: string;
 }
 
+type EasingName = keyof typeof WebEasings;
+
 export interface AnimationStyle {
   opacity?: number;
   transform?: ReanimatedWebTransformProperties[];
+  easing?: EasingName | { name: EasingName };
 }
 
 export interface AnimationData {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
@@ -1,5 +1,10 @@
 'use strict';
 
+import type {
+  EasingFunction,
+  EasingFunctionFactory,
+} from 'react-native-reanimated';
+
 import type { WebEasingsNames } from './Easing.web';
 import { WebEasings } from './Easing.web';
 
@@ -17,12 +22,10 @@ export interface ReanimatedWebTransformProperties {
   skewX?: string;
 }
 
-type EasingName = keyof typeof WebEasings;
-
 export interface AnimationStyle {
   opacity?: number;
   transform?: ReanimatedWebTransformProperties[];
-  easing?: EasingName | { name: EasingName };
+  easing?: EasingFunction | EasingFunctionFactory;
 }
 
 export interface AnimationData {

--- a/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/animationParser.ts
@@ -1,10 +1,7 @@
 'use strict';
 
-import type {
-  EasingFunction,
-  EasingFunctionFactory,
-} from 'react-native-reanimated';
-
+import type { EasingFunction } from '../../commonTypes';
+import type { EasingFunctionFactory } from '../../Easing';
 import type { WebEasingsNames } from './Easing.web';
 import { WebEasings } from './Easing.web';
 

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -78,6 +78,7 @@ export function createCustomKeyFrameAnimation(
     if (style.easing) {
       keyframeDefinitions[i - 1].easing = style.easing;
     }
+    delete style.easing;
   }
 
   const parsedKeyframe = convertAnimationObjectToKeyframes(animationData);

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -77,8 +77,8 @@ export function createCustomKeyFrameAnimation(
     const style = keyframeDefinitions[offsets[i]];
     if (style.easing) {
       keyframeDefinitions[i - 1].easing = style.easing;
+      delete style.easing;
     }
-    delete style.easing;
   }
 
   const parsedKeyframe = convertAnimationObjectToKeyframes(animationData);

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -68,6 +68,18 @@ export function createCustomKeyFrameAnimation(
 
   animationData.name = generateNextCustomKeyframeName();
 
+  // Move keyframe easings one keyframe up (our LA Keyframe definition is different
+  // from the CSS keyframes and expects easing to be present in the keyframe to which
+  // we animate instead of the keyframe we animate from)
+  const offsets = Object.keys(keyframeDefinitions).map(Number);
+
+  for (let i = 1; i < offsets.length; i++) {
+    const style = keyframeDefinitions[offsets[i]];
+    if (style.easing) {
+      keyframeDefinitions[i - 1].easing = style.easing;
+    }
+  }
+
   const parsedKeyframe = convertAnimationObjectToKeyframes(animationData);
 
   insertWebAnimation(animationData.name, parsedKeyframe);


### PR DESCRIPTION
## Summary

Fixes: #7950

This PR fixes the problem with easings configured via the custom `Keyframe` layout animation on web. The problem results from the adopted convention in which we expect the keyframe easing to be defined in the second keyframe of the keyframes pair between which the easing should be applied.

This is different from how CSS animations work and slightly confusing but, since changing this behavior will introduce a breaking change, I decide to just adjust the web implementation to shift keyframe easings one keyframe before, which in result makes it possible to create a valid CSS animation from out LA `Keyframe` object.

## Test example

Before this PR the custom easing was not applied and the animation progressed with a default easing.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/15629df8-f9d1-4b34-b119-eb325b30ee97" />  | <video src="https://github.com/user-attachments/assets/a7145b3b-cefa-4dbb-8eb5-a0454bb0346b" /> |

<details>
<summary>Source code</summary>

```tsx
import React from 'react';
import { Easing, StyleSheet, Text } from 'react-native';
import Animated, { Keyframe } from 'react-native-reanimated';

export default function EmptyExample() {
  const keyframe = new Keyframe({
    0: {
      transform: [{ translateY: `100%` }],
    },
    100: {
      transform: [{ translateY: `0%` }],
      easing: Easing.exp,
    },
  });

  return (
    <Animated.View entering={keyframe.duration(1000)} style={styles.box}>
      <Text>Some text</Text>
    </Animated.View>
  );
}

const styles = StyleSheet.create({
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'red',
  },
});
```

</details>