### PR TITLE
Add support for percentage values for border radius in fast path on Android

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -131,8 +131,6 @@ export default function SynchronousPropsExample() {
         source={require('./assets/logo.png')}
       />
 
-      {/* TODO: support % for border(...)Radius */}
-      {/* TODO: test px and % */}
       {[
         'borderRadius',
         'borderTopLeftRadius',
@@ -149,13 +147,22 @@ export default function SynchronousPropsExample() {
         'borderEndEndRadius',
       ].map((prop) => (
         <React.Fragment key={prop}>
-          <Text>{prop}</Text>
+          <Text>{prop} [px]</Text>
           <Animated.View
             style={{
               width: 50,
               height: 50,
               borderWidth: 1,
               [prop]: fiftySv,
+            }}
+          />
+          <Text>{prop} [%]</Text>
+          <Animated.View
+            style={{
+              width: 50,
+              height: 50,
+              borderWidth: 1,
+              [prop]: percentSv,
             }}
           />
         </React.Fragment>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -948,19 +948,6 @@ void ReanimatedModuleProxy::performOperations() {
               case CMD_Z_INDEX:
               case CMD_SHADOW_OPACITY:
               case CMD_SHADOW_RADIUS:
-              case CMD_BORDER_RADIUS:
-              case CMD_BORDER_TOP_LEFT_RADIUS:
-              case CMD_BORDER_TOP_RIGHT_RADIUS:
-              case CMD_BORDER_TOP_START_RADIUS:
-              case CMD_BORDER_TOP_END_RADIUS:
-              case CMD_BORDER_BOTTOM_LEFT_RADIUS:
-              case CMD_BORDER_BOTTOM_RIGHT_RADIUS:
-              case CMD_BORDER_BOTTOM_START_RADIUS:
-              case CMD_BORDER_BOTTOM_END_RADIUS:
-              case CMD_BORDER_START_START_RADIUS:
-              case CMD_BORDER_START_END_RADIUS:
-              case CMD_BORDER_END_START_RADIUS:
-              case CMD_BORDER_END_END_RADIUS:
                 intBuffer.push_back(command);
                 doubleBuffer.push_back(value.asDouble());
                 break;
@@ -977,6 +964,37 @@ void ReanimatedModuleProxy::performOperations() {
               case CMD_BORDER_END_COLOR:
                 intBuffer.push_back(command);
                 intBuffer.push_back(value.asInt());
+                break;
+
+              case CMD_BORDER_RADIUS:
+              case CMD_BORDER_TOP_LEFT_RADIUS:
+              case CMD_BORDER_TOP_RIGHT_RADIUS:
+              case CMD_BORDER_TOP_START_RADIUS:
+              case CMD_BORDER_TOP_END_RADIUS:
+              case CMD_BORDER_BOTTOM_LEFT_RADIUS:
+              case CMD_BORDER_BOTTOM_RIGHT_RADIUS:
+              case CMD_BORDER_BOTTOM_START_RADIUS:
+              case CMD_BORDER_BOTTOM_END_RADIUS:
+              case CMD_BORDER_START_START_RADIUS:
+              case CMD_BORDER_START_END_RADIUS:
+              case CMD_BORDER_END_START_RADIUS:
+              case CMD_BORDER_END_END_RADIUS:
+                intBuffer.push_back(command);
+                if (value.isDouble()) {
+                  intBuffer.push_back(CMD_UNIT_PX);
+                  doubleBuffer.push_back(value.asDouble());
+                } else if (value.isString()) {
+                  const auto &valueStr = value.getString();
+                  if (!valueStr.ends_with("%")) {
+                    throw std::runtime_error(
+                        "Border radius string must be a percentage");
+                  }
+                  intBuffer.push_back(CMD_UNIT_PERCENT);
+                  doubleBuffer.push_back(std::stof(valueStr.substr(0, -1)));
+                } else {
+                  throw std::runtime_error(
+                      "Border radius value must be either a number or a string");
+                }
                 break;
 
               case CMD_START_OF_TRANSFORM:

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -308,19 +308,6 @@ public class NativeProxy {
         case CMD_Z_INDEX:
         case CMD_SHADOW_OPACITY:
         case CMD_SHADOW_RADIUS:
-        case CMD_BORDER_RADIUS:
-        case CMD_BORDER_TOP_LEFT_RADIUS:
-        case CMD_BORDER_TOP_RIGHT_RADIUS:
-        case CMD_BORDER_TOP_START_RADIUS:
-        case CMD_BORDER_TOP_END_RADIUS:
-        case CMD_BORDER_BOTTOM_LEFT_RADIUS:
-        case CMD_BORDER_BOTTOM_RIGHT_RADIUS:
-        case CMD_BORDER_BOTTOM_START_RADIUS:
-        case CMD_BORDER_BOTTOM_END_RADIUS:
-        case CMD_BORDER_START_START_RADIUS:
-        case CMD_BORDER_START_END_RADIUS:
-        case CMD_BORDER_END_START_RADIUS:
-        case CMD_BORDER_END_END_RADIUS:
           {
             String name = commandToString(command);
             props.putDouble(name, doubleIterator.nextDouble());
@@ -340,6 +327,30 @@ public class NativeProxy {
           {
             String name = commandToString(command);
             props.putInt(name, intIterator.nextInt());
+            break;
+          }
+
+        case CMD_BORDER_RADIUS:
+        case CMD_BORDER_TOP_LEFT_RADIUS:
+        case CMD_BORDER_TOP_RIGHT_RADIUS:
+        case CMD_BORDER_TOP_START_RADIUS:
+        case CMD_BORDER_TOP_END_RADIUS:
+        case CMD_BORDER_BOTTOM_LEFT_RADIUS:
+        case CMD_BORDER_BOTTOM_RIGHT_RADIUS:
+        case CMD_BORDER_BOTTOM_START_RADIUS:
+        case CMD_BORDER_BOTTOM_END_RADIUS:
+        case CMD_BORDER_START_START_RADIUS:
+        case CMD_BORDER_START_END_RADIUS:
+        case CMD_BORDER_END_START_RADIUS:
+        case CMD_BORDER_END_END_RADIUS:
+          {
+            String name = commandToString(command);
+            double value = doubleIterator.nextDouble();
+            switch (intIterator.nextInt()) {
+              case CMD_UNIT_PX -> props.putDouble(name, value);
+              case CMD_UNIT_PERCENT -> props.putString(name, value + "%");
+              default -> throw new RuntimeException("Unknown unit command");
+            }
             break;
           }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds support for animating border radius properties (i.e. `border((Top|Bottom)(Left|Right|Start|End)|(Start|End){2})?Radius`) using percentage values (i.e. `${number)%`) in fast path using `synchronouslyUpdateViewOnUIThread` on Android when `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS` Reanimated static feature flag is enabled.

## Test plan

Open `SynchronousPropsExample` and scroll down to `borderRadius` etc.