### PR TITLE
fix: Add missing check for the new architecture in 3.19

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -36,6 +36,7 @@
 
 namespace reanimated {
 
+#ifdef RCT_NEW_ARCH_ENABLED
 #if REACT_NATIVE_MINOR_VERSION >= 81
 static inline std::shared_ptr<const ShadowNode> shadowNodeFromValue(
     jsi::Runtime &rt,
@@ -43,7 +44,8 @@ static inline std::shared_ptr<const ShadowNode> shadowNodeFromValue(
   return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
       rt, shadowNodeWrapper);
 }
-#endif
+#endif // REACT_NATIVE_MINOR_VERSION >= 81
+#endif // RCT_NEW_ARCH_ENABLED
 
 ReanimatedModuleProxy::ReanimatedModuleProxy(
     const std::shared_ptr<WorkletsModuleProxy> &workletsModuleProxy,


### PR DESCRIPTION
## Summary

This PR fixes the #7974 issue