### PR TITLE
fix: turn off build IDs for reproducibility

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -11,6 +11,13 @@ set(CMAKE_CXX_STANDARD 20)
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
+// Turn off build IDs for reproducibility (ensuring the same code will produce the same bundle when built)
+// See https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids 
+// for more information
+add_link_options(
+    -Wl,--build-id=none
+)
+
 string(
   APPEND
   CMAKE_CXX_FLAGS

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -11,6 +11,13 @@ set(CMAKE_CXX_STANDARD 20)
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 add_compile_options(${folly_FLAGS})
 
+// Turn off build IDs for reproducibility (ensuring the same code will produce the same bundle when built) 
+// See https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids 
+// for more information
+add_link_options(
+  -Wl,--build-id=none
+)
+
 string(
   APPEND
   CMAKE_CXX_FLAGS


### PR DESCRIPTION
## Summary

see https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids for context.

see also software-mansion/react-native-gesture-handler#3602

## Test plan

I've used these changes for a while with my own app.
