### PR TITLE
docs: Fix 3.19 compatibility table

### DIFF
--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
@@ -47,7 +47,7 @@ Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-nativ
 
 |                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.19.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.19.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.17.4 - 3.17.5"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
 | <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |


### PR DESCRIPTION
## Summary

The compatibility table for Fabric showed support for `0.75`, `0.76` and `0.77`, which is incorrect.

## Example image

https://github.com/user-attachments/assets/7658553a-21f2-45e8-a53c-aca66493c35b
