### PR TITLE
fix: CSS transition color crashes

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.cpp
@@ -8,7 +8,7 @@ CSSColor::CSSColor()
 CSSColor::CSSColor(ColorType colorType)
     : channels{0, 0, 0, 0}, colorType(colorType) {}
 
-CSSColor::CSSColor(double numberValue)
+CSSColor::CSSColor(int64_t numberValue)
     : channels{0, 0, 0, 0}, colorType(ColorType::Rgba) {
   uint32_t color;
   // On Android, colors are represented as signed 32-bit integers. In JS, we use
@@ -73,7 +73,7 @@ CSSColor::CSSColor(jsi::Runtime &rt, const jsi::Value &jsiValue)
 CSSColor::CSSColor(const folly::dynamic &value)
     : channels{0, 0, 0, 0}, colorType(ColorType::Transparent) {
   if (value.isNumber()) {
-    *this = CSSColor(value.getDouble());
+    *this = CSSColor(value.asInt());
   } else if (value.isString()) {
     *this = CSSColor(value.getString());
   } else if (value.empty()) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
@@ -26,7 +26,7 @@ struct CSSColor : public CSSSimpleValue<CSSColor> {
 
   CSSColor();
   explicit CSSColor(ColorType colorType);
-  explicit CSSColor(double numberValue);
+  explicit CSSColor(int64_t numberValue);
   explicit CSSColor(const std::string &colorString);
 
   explicit CSSColor(uint8_t r, uint8_t g, uint8_t b);


### PR DESCRIPTION
## Summary

This issue was introduced in the #7784 PR and was caused by the `getDouble()` call on the `folly::dynamic` value. I assumed that all values that come from JS are double (since this is how JS represents all numbers) but, in fact, the value was stored as the 64-bit integer in the `folly::dynamic` and the `.getDouble()` call caused crashes.

To fix the issue, I decided to use the safer method `.asInt`, which will convert the number to the integer type (if it is not already an int) instead of throwing error. I also changed the `double` constructor to the `int64_t` constructor as the integer type is more correct than the `double` type.

## Example recording

### Before

https://github.com/user-attachments/assets/6b5dc444-7049-4687-a36d-55dd7c9f33ac

### After

https://github.com/user-attachments/assets/d9c22957-ba62-41ab-897f-8e31ebac90c0


## Test plan

Open the `Transitions -> Test Examples -> Playground` example and press on the **Change state** button a few times in a row.
