### PR TITLE
fix: Make node marking as removable safer

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
@@ -47,11 +47,13 @@ class UpdatesRegistryManager {
 #endif
 
  private:
+  using RemovableShadowNodes =
+      std::unordered_map<Tag, std::shared_ptr<const ShadowNode>>;
+
   mutable std::mutex mutex_;
   std::atomic<bool> isPaused_;
   std::atomic<bool> shouldCommitAfterPause_;
-  std::unordered_map<Tag, std::shared_ptr<const ShadowNode>>
-      removableShadowNodes_;
+  RemovableShadowNodes removableShadowNodes_;
   std::vector<std::shared_ptr<UpdatesRegistry>> registries_;
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -415,6 +415,7 @@ void ReanimatedModuleProxy::setViewStyle(
 void ReanimatedModuleProxy::markNodeAsRemovable(
     jsi::Runtime &rt,
     const jsi::Value &shadowNodeWrapper) {
+  auto lock = updatesRegistryManager_->lock();
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
   updatesRegistryManager_->markNodeAsRemovable(shadowNode);
 }
@@ -422,6 +423,7 @@ void ReanimatedModuleProxy::markNodeAsRemovable(
 void ReanimatedModuleProxy::unmarkNodeAsRemovable(
     jsi::Runtime &rt,
     const jsi::Value &viewTag) {
+  auto lock = updatesRegistryManager_->lock();
   updatesRegistryManager_->unmarkNodeAsRemovable(viewTag.asNumber());
 }
 


### PR DESCRIPTION
## Summary

This PR aims to fix the following issue #8001.

I was unable to reproduce this issue but I suspect that these lock calls were missing before, which resulted in crashes when the `removableShadowNodes_` map was modified while the `handleNodeRemovals` method in the mount hook was called
