### PR TITLE
docs: Update compatibility tables in after releases

### DIFF
--- a/packages/docs-reanimated/docs/guides/compatibility.mdx
+++ b/packages/docs-reanimated/docs/guides/compatibility.mdx
@@ -16,9 +16,9 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 |                                      | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
 | <Version version="nightly"/>         | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
-| <Version version="4.0.0 – 4.0.1"/>   | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="4.0.0 – 4.0.2"/>   | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Spacer/>                            |       |        |        |        |        |        |        |        |        |        |        |        |
-| <Version version="3.19.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.19.0 – 3.19.1"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
 | <Version version="3.17.4 – 3.17.5"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
 | <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
@@ -42,7 +42,7 @@ Reanimated 4 works only with the React Native New Architecture. If your app stil
 |                                     | 0.3   | 0.4    | nightly |
 | ----------------------------------- | ----- | ------ | ------- |
 | <Version version="nightly"/>        | <No/> | <No/>  | <Yes/>  |
-| <Version version="4.0.0 – 4.0.1" /> | <No/> | <Yes/> | <No/>   |
+| <Version version="4.0.0 – 4.0.2" /> | <No/> | <Yes/> | <No/>   |
 | <Spacer/>                           |       |        |         |
 | <Version version="3.x.x"/>          | <No/> | <No/>  | <No/>   |
 

--- a/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
+++ b/packages/docs-reanimated/versioned_docs/version-3.x/guides/compatibility.mdx
@@ -11,9 +11,9 @@ sidebar_label: Compatibility
 
 |                                      | 0.63   | 0.64   | 0.65   | 0.66   | 0.67   | 0.68   | 0.69   | 0.70   | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.19.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.19.0 – 3.19.1"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.17.4 - 3.17.5"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.17.4 – 3.17.5"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
 | <Version version="3.17.1 – 3.17.3"/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
 | <Version version="3.17.0"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
 | <Version version="3.16.7"/>          | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
@@ -47,9 +47,9 @@ Reanimated supports the [bridgeless mode](https://github.com/reactwg/react-nativ
 
 |                                      | 0.63  | 0.64  | 0.65  | 0.66  | 0.67  | 0.68  | 0.69  | 0.70  | 0.71   | 0.72   | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
 | ------------------------------------ | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <Version version="3.19.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| <Version version="3.19.0 – 3.19.1"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 | <Version version="3.18.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  |
-| <Version version="3.17.4 - 3.17.5"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
+| <Version version="3.17.4 – 3.17.5"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  |
 | <Version version="3.17.1 – 3.17.3"/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  |
 | <Version version="3.17.0"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |
 | <Version version="3.16.7"/>          | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/> | <No/>  | <No/>  | <No/>  | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <No/>  | <No/>  | <No/>  | <No/>  |


### PR DESCRIPTION
## Summary

This PR adds the 2 new versions of reanimated to compatibility tables in docs: `3.19.1` and `4.0.2`