### PR TITLE
fix: Improve animated ref value type

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
@@ -27,7 +27,7 @@ export default function GetViewPropExample() {
   const handlePress = async () => {
     // @ts-ignore this is fine
     const viewTag = animatedRef() as number;
-    const result = await getViewProp(viewTag, 'opacity');
+    const result = await getViewProp(viewTag, 'opacity', animatedRef.current);
     console.log(result);
   };
 

--- a/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
@@ -27,7 +27,7 @@ export default function GetViewPropExample() {
   const handlePress = async () => {
     // @ts-ignore this is fine
     const viewTag = animatedRef() as number;
-    const result = await getViewProp(viewTag, 'opacity', animatedRef.current);
+    const result = await getViewProp(viewTag, 'opacity');
     console.log(result);
   };
 

--- a/packages/react-native-reanimated/__typetests__/common/useAnimatedRefTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/useAnimatedRefTest.tsx
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { FlashListRef } from '@shopify/flash-list';
+import { FlashList } from '@shopify/flash-list';
 import type { Ref } from 'react';
 import React, { useRef } from 'react';
 import type { ImageProps, ViewProps } from 'react-native';
@@ -494,6 +496,49 @@ function UseAnimatedRefTest() {
         <CreatedAnimatedCustomClassComponent ref={plainRefCreatedComponent} />
         <CreatedAnimatedCustomClassComponent
           ref={animatedRefCreatedComponent}
+        />
+      </>
+    );
+  }
+
+  function UseAnimatedRefTestFlashListNoType() {
+    const CreatedAnimatedFlashList =
+      Animated.createAnimatedComponent(FlashList);
+    const plainRef = useRef<FlashListRef<unknown>>(null);
+    const animatedRef = useAnimatedRef<FlashListRef<unknown>>();
+
+    return (
+      <>
+        <FlashList ref={plainRef} data={[]} renderItem={null} />
+        <FlashList ref={animatedRef} data={[]} renderItem={null} />
+
+        <CreatedAnimatedFlashList ref={plainRef} data={[]} renderItem={null} />
+        <CreatedAnimatedFlashList
+          ref={animatedRef}
+          data={[]}
+          renderItem={null}
+        />
+      </>
+    );
+  }
+
+  function UseAnimatedRefTestFlashListWithType() {
+    const CreatedAnimatedFlashList = Animated.createAnimatedComponent(
+      FlashList<number>
+    );
+    const plainRef = useRef<FlashListRef<number>>(null);
+    const animatedRef = useAnimatedRef<FlashListRef<number>>();
+
+    return (
+      <>
+        <FlashList ref={plainRef} data={[]} renderItem={null} />
+        <FlashList ref={animatedRef} data={[]} renderItem={null} />
+
+        <CreatedAnimatedFlashList ref={plainRef} data={[]} renderItem={null} />
+        <CreatedAnimatedFlashList
+          ref={animatedRef}
+          data={[]}
+          renderItem={null}
         />
       </>
     );

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -104,6 +104,7 @@
     "@react-native/eslint-config": "0.80.0",
     "@react-native/metro-config": "0.80.0",
     "@react-native/typescript-config": "0.80.0",
+    "@shopify/flash-list": "2.0.2",
     "@testing-library/jest-native": "^4.0.4",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "^13.0.1",

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -19,6 +19,7 @@ import type {
   StyleProps,
   Value3D,
   ValueRotation,
+  WrapperRef,
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
@@ -135,12 +136,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   getViewProp<T>(
     viewTag: number,
     propName: string,
-    component: React.Component | undefined, // required on Fabric
+    component: WrapperRef, // required on Fabric
     callback?: (result: T) => void
   ) {
-    const shadowNodeWrapper = getShadowNodeWrapperFromRef(
-      component as React.Component
-    );
+    const shadowNodeWrapper = getShadowNodeWrapperFromRef(component);
     return this.#reanimatedModuleProxy.getViewProp(
       shadowNodeWrapper,
       propName,

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 'use strict';
-import type React from 'react';
 import type {
   IWorkletsModule,
   SerializableRef,

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -18,6 +18,7 @@ import type {
   StyleProps,
   Value3D,
   ValueRotation,
+  WrapperRef,
 } from '../../commonTypes';
 import { SensorType } from '../../commonTypes';
 import type {
@@ -254,7 +255,7 @@ class JSReanimated implements IReanimatedModule {
   getViewProp<T>(
     _viewTag: number,
     _propName: string,
-    _component?: React.Component,
+    _component?: WrapperRef | null,
     _callback?: (result: T) => void
   ): Promise<T> {
     throw new ReanimatedError('getViewProp is not available in JSReanimated.');

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -5,6 +5,7 @@ import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 import type {
   LayoutAnimationBatchItem,
   ShadowNodeWrapper,
+  WrapperRef,
   StyleProps,
   Value3D,
   ValueRotation,
@@ -94,7 +95,7 @@ export interface IReanimatedModule
   getViewProp<TValue>(
     viewTag: number,
     propName: string,
-    component: React.Component | undefined,
+    component: WrapperRef | null,
     callback?: (result: TValue) => void
   ): Promise<TValue>;
 }

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -5,10 +5,10 @@ import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 import type {
   LayoutAnimationBatchItem,
   ShadowNodeWrapper,
-  WrapperRef,
   StyleProps,
   Value3D,
   ValueRotation,
+  WrapperRef,
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -1,14 +1,19 @@
 'use strict';
-
+import type { ComponentRef } from 'react';
 import type {
   ImageStyle,
+  ScrollResponderMixin,
+  ScrollViewComponent,
   TextStyle,
   TransformsStyle,
+  View,
   ViewStyle,
 } from 'react-native';
 import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 
+import type { Maybe } from './common/types';
 import type { CSSAnimationProperties, CSSTransitionProperties } from './css';
+import type { AnyRecord } from './css/types';
 import type { EasingFunctionFactory } from './Easing';
 
 type LayoutAnimationOptions =
@@ -441,3 +446,23 @@ export type AnimatedStyle<Style = DefaultStyle> =
 export type AnimatedTransform = MaybeSharedValueRecursive<
   TransformsStyle['transform']
 >;
+
+type NativeScrollRef = Maybe<
+  (ComponentRef<typeof View> | ComponentRef<typeof ScrollViewComponent>) & {
+    __internalInstanceHandle?: AnyRecord;
+  }
+>;
+
+type InstanceMethods = {
+  getScrollResponder?: () => Maybe<
+    (ScrollResponderMixin | React.JSX.Element) & {
+      getNativeScrollRef?: () => NativeScrollRef;
+    }
+  >;
+  getNativeScrollRef?: () => NativeScrollRef;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getScrollableNode?: () => any;
+  __internalInstanceHandle?: AnyRecord;
+};
+
+export type WrapperRef = (React.Component & InstanceMethods) | InstanceMethods;

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -15,6 +15,7 @@ import type {
   SharedValue,
   Value3D,
   ValueRotation,
+  WrapperRef,
 } from './commonTypes';
 import { ReanimatedModule } from './ReanimatedModule';
 import { SensorContainer } from './SensorContainer';
@@ -48,7 +49,7 @@ export const isConfigured = isReanimated3;
 export function getViewProp<T>(
   viewTag: number,
   propName: string,
-  component?: React.Component // required on Fabric
+  component?: WrapperRef | null // required on Fabric
 ): Promise<T> {
   if (!component) {
     throw new ReanimatedError(

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -126,6 +126,7 @@ export interface IAnimatedComponentInternalBase {
   _componentRef: AnimatedComponentRef | HTMLElement | null;
   _hasAnimatedRef: boolean;
   _viewInfo?: ViewInfo;
+
   /**
    * Used for Layout Animations and Animated Styles. It is not related to event
    * handling.

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -121,8 +121,20 @@ export interface AnimatedComponentRef extends Component {
   elementRef?: React.RefObject<HTMLElement>;
 }
 
-export interface IAnimatedComponentInternal {
+export interface IAnimatedComponentInternalBase {
   ChildComponent: AnyComponent;
+  _componentRef: AnimatedComponentRef | HTMLElement | null;
+  _hasAnimatedRef: boolean;
+  _viewInfo?: ViewInfo;
+  /**
+   * Used for Layout Animations and Animated Styles. It is not related to event
+   * handling.
+   */
+  getComponentViewTag: () => number;
+}
+
+export interface IAnimatedComponentInternal
+  extends IAnimatedComponentInternalBase {
   _animatedStyles: StyleProps[];
   _prevAnimatedStyles: StyleProps[];
   _animatedProps: Partial<AnimatedComponentProps<AnimatedProps>>[];
@@ -131,19 +143,11 @@ export interface IAnimatedComponentInternal {
   jestInlineStyle: NestedArray<StyleProps> | undefined;
   jestAnimatedStyle: { value: StyleProps };
   jestAnimatedProps: { value: AnimatedProps };
-  _componentRef: AnimatedComponentRef | HTMLElement | null;
-  _hasAnimatedRef: boolean;
   _InlinePropManager: IInlinePropManager;
   _PropsFilter: IPropsFilter;
   /** Doesn't exist on web. */
   _NativeEventsManager?: INativeEventsManager;
-  _viewInfo?: ViewInfo;
   context: React.ContextType<typeof SkipEnteringContext>;
-  /**
-   * Used for Layout Animations and Animated Styles. It is not related to event
-   * handling.
-   */
-  getComponentViewTag: () => number;
   setNativeProps: (props: StyleProps) => void;
 }
 

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -5,9 +5,10 @@ import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 
 import { IS_JEST, ReanimatedError, SHOULD_BE_USE_WEB } from '../../common';
-import type { ShadowNodeWrapper } from '../../commonTypes';
+import type { ShadowNodeWrapper, WrapperRef } from '../../commonTypes';
 import type {
   AnimatedComponentRef,
+  IAnimatedComponentInternalBase,
   ViewInfo,
 } from '../../createAnimatedComponent/commonTypes';
 import { getViewInfo } from '../../createAnimatedComponent/getViewInfo';
@@ -27,8 +28,11 @@ export type AnimatedComponentProps = Record<string, unknown> & {
 // private/protected ones when possible (when changes from this repo are merged
 // to the main one)
 export default class AnimatedComponent<
-  P extends AnyRecord = AnimatedComponentProps,
-> extends Component<P> {
+    P extends AnyRecord = AnimatedComponentProps,
+  >
+  extends Component<P>
+  implements IAnimatedComponentInternalBase
+{
   ChildComponent: AnyComponent;
 
   _CSSManager?: CSSManager;
@@ -86,7 +90,10 @@ export default class AnimatedComponent<
       const viewInfo = getViewInfo(hostInstance);
       viewTag = viewInfo.viewTag ?? -1;
       viewName = viewInfo.viewName;
-      shadowNodeWrapper = getShadowNodeWrapperFromRef(this, hostInstance);
+      shadowNodeWrapper = getShadowNodeWrapperFromRef(
+        this as WrapperRef,
+        hostInstance
+      );
     }
     this._viewInfo = { viewTag, shadowNodeWrapper, viewName };
     if (DOMElement) {

--- a/packages/react-native-reanimated/src/fabricUtils.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.ts
@@ -1,53 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 'use strict';
-/* eslint-disable */
-
-import type { ShadowNodeWrapper } from './commonTypes';
-import {
-  findHostInstance,
-  HostInstance,
-} from './platform-specific/findHostInstance';
+import type { ShadowNodeWrapper, WrapperRef } from './commonTypes';
+import type { HostInstance } from './platform-specific/findHostInstance';
+import { findHostInstance } from './platform-specific/findHostInstance';
 
 let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
   stateNode: { node: unknown };
 };
 
 export function getShadowNodeWrapperFromRef(
-  ref: React.Component,
+  ref: WrapperRef,
   hostInstance?: HostInstance
 ): ShadowNodeWrapper {
   if (getInternalInstanceHandleFromPublicInstance === undefined) {
     try {
       getInternalInstanceHandleFromPublicInstance =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
         require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance')
           .getInternalInstanceHandleFromPublicInstance ??
         ((_ref: any) => _ref._internalInstanceHandle);
-    } catch (e) {
+    } catch {
       getInternalInstanceHandleFromPublicInstance = (_ref: any) =>
         _ref._internalInstanceHandle;
     }
   }
 
-  // TODO: Clean this up since 0.74 is the minimum supported version now.
-  // taken from https://github.com/facebook/react-native/commit/803bb16531697233686efd475f004c1643e03617#diff-d8172256c6d63b5d32db10e54d7b10f37a26b337d5280d89f5bfd7bcea778292R196
-  // @ts-ignore some weird stuff on RN 0.74 - see examples with scrollView
-  const scrollViewRef = ref?.getScrollResponder?.()?.getNativeScrollRef?.();
-  // @ts-ignore some weird stuff on RN 0.74  - see examples with scrollView
-  const otherScrollViewRef = ref?.getNativeScrollRef?.();
-  // @ts-ignore some weird stuff on RN 0.74 - see setNativeProps example
-  const textInputRef = ref?.__internalInstanceHandle?.stateNode?.node;
+  const resolvedRef =
+    ref.getScrollResponder?.()?.getNativeScrollRef?.() ??
+    ref.getNativeScrollRef?.() ??
+    ref;
 
-  let resolvedRef;
-  if (scrollViewRef) {
-    resolvedRef = scrollViewRef.__internalInstanceHandle.stateNode.node;
-  } else if (otherScrollViewRef) {
-    resolvedRef = otherScrollViewRef.__internalInstanceHandle.stateNode.node;
-  } else if (textInputRef) {
-    resolvedRef = textInputRef;
-  } else {
-    const instance = hostInstance ?? findHostInstance(ref);
-    resolvedRef =
-      getInternalInstanceHandleFromPublicInstance(instance).stateNode.node;
-  }
+  const resolvedInstance =
+    ref?.__internalInstanceHandle ??
+    getInternalInstanceHandleFromPublicInstance(
+      hostInstance ?? findHostInstance(resolvedRef)
+    );
 
-  return resolvedRef;
+  return resolvedInstance?.stateNode?.node;
 }

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { Component, MutableRefObject } from 'react';
+import type { MutableRefObject } from 'react';
 import type {
   ImageStyle,
   NativeScrollEvent,
@@ -13,6 +13,7 @@ import type {
   AnimatedPropsAdapterFunction,
   AnimatedStyle,
   ShadowNodeWrapper,
+  WrapperRef,
 } from '../commonTypes';
 import type { AnimatedProps } from '../createAnimatedComponent/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
@@ -29,17 +30,17 @@ export type MaybeObserverCleanup = (() => void) | undefined;
 
 export type AnimatedRefObserver = (tag: number | null) => MaybeObserverCleanup;
 
-export type AnimatedRef<T extends Component> = {
-  (component?: T):
+export type AnimatedRef<Ref extends WrapperRef> = {
+  (ref?: Ref | null):
     | ShadowNodeWrapper // Native
     | HTMLElement; // web
-  current: T | null;
+  current: Ref | null;
   observe: (observer: AnimatedRefObserver) => void;
   getTag?: () => number | null;
 };
 
 // Might make that type generic if it's ever needed.
-export type AnimatedRefOnJS = AnimatedRef<Component>;
+export type AnimatedRefOnJS = AnimatedRef<WrapperRef>;
 
 /**
  * `AnimatedRef` is mapped to this type on the UI thread via a serializable

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -30,11 +30,11 @@ export type MaybeObserverCleanup = (() => void) | undefined;
 
 export type AnimatedRefObserver = (tag: number | null) => MaybeObserverCleanup;
 
-export type AnimatedRef<Ref extends WrapperRef> = {
-  (ref?: Ref | null):
+export type AnimatedRef<TRef extends WrapperRef> = {
+  (ref?: TRef | null):
     | ShadowNodeWrapper // Native
     | HTMLElement; // web
-  current: Ref | null;
+  current: TRef | null;
   observe: (observer: AnimatedRefObserver) => void;
   getTag?: () => number | null;
 };

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -21,17 +21,17 @@ function getComponentOrScrollable(ref: WrapperRef) {
   return ref.getNativeScrollRef?.() ?? ref.getScrollableNode?.() ?? ref;
 }
 
-function useAnimatedRefBase<Ref extends WrapperRef>(
-  getWrapper: (ref: Ref) => ShadowNodeWrapper
-): AnimatedRef<Ref> {
+function useAnimatedRefBase<TRef extends WrapperRef>(
+  getWrapper: (ref: TRef) => ShadowNodeWrapper
+): AnimatedRef<TRef> {
   const observers = useRef<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
     new Map()
   ).current;
   const wrapperRef = useRef<ShadowNodeWrapper | null>(null);
-  const resultRef = useRef<AnimatedRef<Ref> | null>(null);
+  const resultRef = useRef<AnimatedRef<TRef> | null>(null);
 
   if (!resultRef.current) {
-    const fun = <AnimatedRef<Ref>>((ref) => {
+    const fun = <AnimatedRef<TRef>>((ref) => {
       if (ref) {
         wrapperRef.current = getWrapper(ref);
 
@@ -74,13 +74,13 @@ function useAnimatedRefBase<Ref extends WrapperRef>(
 }
 
 function useAnimatedRefNative<
-  Ref extends WrapperRef = React.Component,
->(): AnimatedRef<Ref> {
+  TRef extends WrapperRef = React.Component,
+>(): AnimatedRef<TRef> {
   const [sharedWrapper] = useState(() =>
     makeMutable<ShadowNodeWrapper | null>(null)
   );
 
-  const resultRef = useAnimatedRefBase<Ref>((ref) => {
+  const resultRef = useAnimatedRefBase<TRef>((ref) => {
     const currentWrapper = getShadowNodeWrapperFromRef(
       getComponentOrScrollable(ref)
     );
@@ -104,9 +104,9 @@ function useAnimatedRefNative<
 }
 
 function useAnimatedRefWeb<
-  Ref extends WrapperRef = React.Component,
->(): AnimatedRef<Ref> {
-  return useAnimatedRefBase<Ref>((ref) => getComponentOrScrollable(ref));
+  TRef extends WrapperRef = React.Component,
+>(): AnimatedRef<TRef> {
+  return useAnimatedRefBase<TRef>((ref) => getComponentOrScrollable(ref));
 }
 
 /**

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -1,14 +1,12 @@
 'use strict';
-import type { Component } from 'react';
 import { useRef, useState } from 'react';
-import type { FlatList } from 'react-native';
 import {
   createSerializable,
   serializableMappingCache,
 } from 'react-native-worklets';
 
 import { SHOULD_BE_USE_WEB } from '../common/constants';
-import type { ShadowNodeWrapper } from '../commonTypes';
+import type { ShadowNodeWrapper, WrapperRef } from '../commonTypes';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import { makeMutable } from '../mutables';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
@@ -19,42 +17,27 @@ import type {
   MaybeObserverCleanup,
 } from './commonTypes';
 
-interface MaybeScrollableComponent extends Component {
-  getNativeScrollRef?: FlatList['getNativeScrollRef'];
-  getScrollableNode?: FlatList['getScrollableNode'];
+function getComponentOrScrollable(ref: WrapperRef) {
+  return ref.getNativeScrollRef?.() ?? ref.getScrollableNode?.() ?? ref;
 }
 
-function getComponentOrScrollable(component: MaybeScrollableComponent) {
-  if (component.getNativeScrollRef) {
-    return component.getNativeScrollRef();
-  }
-  if (component.getScrollableNode) {
-    return component.getScrollableNode();
-  }
-  return component;
-}
-
-function useAnimatedRefBase<TComponent extends Component>(
-  getWrapper: (component: TComponent) => ShadowNodeWrapper
-): AnimatedRef<TComponent> {
+function useAnimatedRefBase<Ref extends WrapperRef>(
+  getWrapper: (ref: Ref) => ShadowNodeWrapper
+): AnimatedRef<Ref> {
   const observers = useRef<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
     new Map()
   ).current;
   const wrapperRef = useRef<ShadowNodeWrapper | null>(null);
+  const resultRef = useRef<AnimatedRef<Ref> | null>(null);
 
-  const ref = useRef<AnimatedRef<TComponent> | null>(null);
-
-  if (!ref.current) {
-    const fun: AnimatedRef<TComponent> = <AnimatedRef<TComponent>>((
-      component
-    ) => {
-      if (component) {
-        wrapperRef.current = getWrapper(component);
+  if (!resultRef.current) {
+    const fun = <AnimatedRef<Ref>>((ref) => {
+      if (ref) {
+        wrapperRef.current = getWrapper(ref);
 
         // We have to unwrap the tag from the shadow node wrapper.
-        fun.getTag = () =>
-          findNodeHandle(getComponentOrScrollable(component) as Component)!;
-        fun.current = component;
+        fun.getTag = () => findNodeHandle(getComponentOrScrollable(ref));
+        fun.current = ref;
 
         if (observers.size) {
           const currentTag = fun?.getTag?.() ?? null;
@@ -84,22 +67,22 @@ function useAnimatedRefBase<TComponent extends Component>(
     };
 
     fun.current = null;
-    ref.current = fun;
+    resultRef.current = fun;
   }
 
-  return ref.current;
+  return resultRef.current;
 }
 
 function useAnimatedRefNative<
-  TComponent extends Component,
->(): AnimatedRef<TComponent> {
+  Ref extends WrapperRef = React.Component,
+>(): AnimatedRef<Ref> {
   const [sharedWrapper] = useState(() =>
     makeMutable<ShadowNodeWrapper | null>(null)
   );
 
-  const ref = useAnimatedRefBase<TComponent>((component) => {
+  const resultRef = useAnimatedRefBase<Ref>((ref) => {
     const currentWrapper = getShadowNodeWrapperFromRef(
-      getComponentOrScrollable(component) as Component
+      getComponentOrScrollable(ref)
     );
 
     sharedWrapper.value = currentWrapper;
@@ -107,32 +90,30 @@ function useAnimatedRefNative<
     return currentWrapper;
   });
 
-  if (!serializableMappingCache.get(ref)) {
+  if (!serializableMappingCache.get(resultRef)) {
     const animatedRefSerializableHandle = createSerializable({
       __init: (): AnimatedRefOnUI => {
         'worklet';
         return () => sharedWrapper.value;
       },
     });
-    serializableMappingCache.set(ref, animatedRefSerializableHandle);
+    serializableMappingCache.set(resultRef, animatedRefSerializableHandle);
   }
 
-  return ref;
+  return resultRef;
 }
 
 function useAnimatedRefWeb<
-  TComponent extends Component,
->(): AnimatedRef<TComponent> {
-  return useAnimatedRefBase<TComponent>((component) =>
-    getComponentOrScrollable(component)
-  );
+  Ref extends WrapperRef = React.Component,
+>(): AnimatedRef<Ref> {
+  return useAnimatedRefBase<Ref>((ref) => getComponentOrScrollable(ref));
 }
 
 /**
  * Lets you get a reference of a view that you can use inside a worklet.
  *
- * @returns An object with a `.current` property which contains an instance of a
- *   component.
+ * @returns An object with a `.current` property which contains an instance of
+ *   the reference object.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedRef
  */
 export const useAnimatedRef = SHOULD_BE_USE_WEB

--- a/packages/react-native-reanimated/src/hook/useScrollOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollOffset.ts
@@ -46,7 +46,7 @@ function useScrollOffsetWeb<Ref extends WrapperRef>(
 
   const eventHandler = useCallback(() => {
     'worklet';
-    if (animatedRef?.current) {
+    if (animatedRef) {
       const element = getWebScrollableElement(animatedRef.current);
       // scrollLeft is the X axis scrolled offset, works properly also with RTL layout
       offset.value =
@@ -118,6 +118,8 @@ function useScrollOffsetNative<Ref extends WrapperRef>(
   return offset;
 }
 
-function getWebScrollableElement(scrollComponent: WrapperRef): HTMLElement {
-  return scrollComponent.getScrollableNode?.() ?? scrollComponent;
+function getWebScrollableElement(
+  scrollComponent: WrapperRef | null
+): HTMLElement {
+  return scrollComponent?.getScrollableNode?.() ?? scrollComponent;
 }

--- a/packages/react-native-reanimated/src/hook/useScrollOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollOffset.ts
@@ -37,8 +37,8 @@ export const useScrollOffset = IS_WEB
   ? useScrollOffsetWeb
   : useScrollOffsetNative;
 
-function useScrollOffsetWeb<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref> | null,
+function useScrollOffsetWeb<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);
@@ -60,7 +60,7 @@ function useScrollOffsetWeb<Ref extends WrapperRef>(
     }
 
     return animatedRef.observe((tag) => {
-      if (!animatedRef.current || !tag) {
+      if (!tag) {
         logger.warn(NOT_INITIALIZED_WARNING);
         return;
       }
@@ -77,8 +77,8 @@ function useScrollOffsetWeb<Ref extends WrapperRef>(
   return offset;
 }
 
-function useScrollOffsetNative<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref> | null,
+function useScrollOffsetNative<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -2,7 +2,8 @@
 'use strict';
 
 import { ReanimatedError } from '../common';
-import type { IAnimatedComponentInternal } from '../createAnimatedComponent/commonTypes';
+import type { WrapperRef } from '../commonTypes';
+import type { IAnimatedComponentInternalBase } from '../createAnimatedComponent/commonTypes';
 
 export type HostInstance = {
   __internalInstanceHandle?: Record<string, unknown>;
@@ -45,11 +46,11 @@ function resolveFindHostInstance_DEPRECATED() {
 
 let findHostInstance_DEPRECATED: (ref: unknown) => HostInstance;
 export function findHostInstance(
-  component: IAnimatedComponentInternal | React.Component
+  ref: IAnimatedComponentInternalBase | WrapperRef
 ): HostInstance {
   // Fast path for native refs
   const hostInstance = findHostInstanceFastPath(
-    (component as IAnimatedComponentInternal)._componentRef as HostInstance
+    (ref as IAnimatedComponentInternalBase)._componentRef as HostInstance
   );
   if (hostInstance !== undefined) {
     return hostInstance;
@@ -63,8 +64,8 @@ export function findHostInstance(
     a valid React ref.
   */
   return findHostInstance_DEPRECATED(
-    (component as IAnimatedComponentInternal)._hasAnimatedRef
-      ? (component as IAnimatedComponentInternal)._componentRef
-      : component
+    (ref as IAnimatedComponentInternalBase)._hasAnimatedRef
+      ? (ref as IAnimatedComponentInternalBase)._componentRef
+      : ref
   );
 }

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -1,16 +1,14 @@
 'use strict';
-import type { Component } from 'react';
-
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
-import type { ShadowNodeWrapper } from '../commonTypes';
+import type { ShadowNodeWrapper, WrapperRef } from '../commonTypes';
 import type {
   AnimatedRef,
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type DispatchCommand = <T extends Component>(
-  animatedRef: AnimatedRef<T>,
+type DispatchCommand = <Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   commandName: string,
   args?: unknown[]
 ) => void;

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -7,8 +7,8 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type DispatchCommand = <Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+type DispatchCommand = <TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   commandName: string,
   args?: unknown[]
 ) => void;

--- a/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
@@ -21,8 +21,8 @@ export interface ComponentCoords {
  *   {@link ComponentCoords}.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/getRelativeCoords
  */
-export function getRelativeCoords<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+export function getRelativeCoords<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   absoluteX: number,
   absoluteY: number
 ): ComponentCoords | null {

--- a/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
@@ -1,6 +1,5 @@
 'use strict';
-import type { Component } from 'react';
-
+import type { WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import { measure } from './measure';
 
@@ -22,8 +21,8 @@ export interface ComponentCoords {
  *   {@link ComponentCoords}.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/getRelativeCoords
  */
-export function getRelativeCoords(
-  animatedRef: AnimatedRef<Component>,
+export function getRelativeCoords<Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   absoluteX: number,
   absoluteY: number
 ): ComponentCoords | null {

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -1,16 +1,18 @@
 'use strict';
-import type { Component } from 'react';
-
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
-import type { MeasuredDimensions, ShadowNodeWrapper } from '../commonTypes';
+import type {
+  MeasuredDimensions,
+  ShadowNodeWrapper,
+  WrapperRef,
+} from '../commonTypes';
 import type {
   AnimatedRef,
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type Measure = <T extends Component>(
-  animatedRef: AnimatedRef<T>
+type Measure = <Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>
 ) => MeasuredDimensions | null;
 
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -11,8 +11,8 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type Measure = <Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>
+type Measure = <TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>
 ) => MeasuredDimensions | null;
 
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
@@ -1,12 +1,10 @@
 'use strict';
-import type { Component } from 'react';
-
 import { logger } from '../common';
-import type { MeasuredDimensions } from '../commonTypes';
+import type { MeasuredDimensions, WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function measure<T extends Component>(
-  animatedRef: AnimatedRef<T>
+export function measure<Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>
 ): MeasuredDimensions | null {
   const element = animatedRef() as HTMLElement | null;
 

--- a/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
@@ -3,8 +3,8 @@ import { logger } from '../common';
 import type { MeasuredDimensions, WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function measure<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>
+export function measure<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>
 ): MeasuredDimensions | null {
   const element = animatedRef() as HTMLElement | null;
 

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -4,8 +4,8 @@ import type { WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import { dispatchCommand } from './dispatchCommand';
 
-type ScrollTo = <Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+type ScrollTo = <TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   x: number,
   y: number,
   animated: boolean
@@ -24,8 +24,8 @@ type ScrollTo = <Ref extends WrapperRef>(
  */
 export let scrollTo: ScrollTo;
 
-function scrollToNative<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+function scrollToNative<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   x: number,
   y: number,
   animated: boolean

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -1,16 +1,11 @@
 'use strict';
-import type { Component } from 'react';
-
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
-import type {
-  AnimatedRef,
-  AnimatedRefOnJS,
-  AnimatedRefOnUI,
-} from '../hook/commonTypes';
+import type { WrapperRef } from '../commonTypes';
+import type { AnimatedRef } from '../hook/commonTypes';
 import { dispatchCommand } from './dispatchCommand';
 
-type ScrollTo = <T extends Component>(
-  animatedRef: AnimatedRef<T>,
+type ScrollTo = <Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   x: number,
   y: number,
   animated: boolean
@@ -29,19 +24,14 @@ type ScrollTo = <T extends Component>(
  */
 export let scrollTo: ScrollTo;
 
-function scrollToNative(
-  animatedRef: AnimatedRefOnJS | AnimatedRefOnUI,
+function scrollToNative<Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   x: number,
   y: number,
   animated: boolean
 ) {
   'worklet';
-  dispatchCommand(
-    // This assertion is needed to comply to `dispatchCommand` interface
-    animatedRef as unknown as AnimatedRef<Component>,
-    'scrollTo',
-    [x, y, animated]
-  );
+  dispatchCommand(animatedRef, 'scrollTo', [x, y, animated]);
 }
 
 function scrollToJest() {

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
@@ -4,8 +4,8 @@ import type { ScrollView } from 'react-native';
 import type { WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function scrollTo<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+export function scrollTo<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   x: number,
   y: number,
   animated: boolean

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
@@ -1,11 +1,11 @@
 'use strict';
-import type { Component } from 'react';
 import type { ScrollView } from 'react-native';
 
+import type { WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function scrollTo<T extends Component>(
-  animatedRef: AnimatedRef<T>,
+export function scrollTo<Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   x: number,
   y: number,
   animated: boolean
@@ -15,7 +15,7 @@ export function scrollTo<T extends Component>(
   // This prevents crashes if ref has not been set yet
   if (element) {
     // By ScrollView we mean any scrollable component
-    const scrollView = element as HTMLElement as unknown as ScrollView;
+    const scrollView = element as unknown as ScrollView;
     scrollView?.scrollTo({ x, y, animated });
   }
 }

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -12,8 +12,8 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type SetNativeProps = <Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+type SetNativeProps = <TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   updates: StyleProps
 ) => void;
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -1,21 +1,19 @@
 'use strict';
-import type { Component } from 'react';
-
 import {
   IS_JEST,
   logger,
   processColorsInProps,
   SHOULD_BE_USE_WEB,
 } from '../common';
-import type { ShadowNodeWrapper, StyleProps } from '../commonTypes';
+import type { ShadowNodeWrapper, StyleProps, WrapperRef } from '../commonTypes';
 import type {
   AnimatedRef,
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type SetNativeProps = <T extends Component>(
-  animatedRef: AnimatedRef<T>,
+type SetNativeProps = <Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   updates: StyleProps
 ) => void;
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
@@ -1,13 +1,11 @@
 'use strict';
-import type { Component } from 'react';
-
-import type { StyleProps } from '../commonTypes';
+import type { StyleProps, WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { _updatePropsJS } from '../ReanimatedModule/js-reanimated';
 
-export function setNativeProps<T extends Component>(
-  animatedRef: AnimatedRef<T>,
+export function setNativeProps<Ref extends WrapperRef>(
+  animatedRef: AnimatedRef<Ref>,
   updates: StyleProps
 ) {
   const component = animatedRef() as ReanimatedHTMLElement;

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
@@ -4,8 +4,8 @@ import type { AnimatedRef } from '../hook/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { _updatePropsJS } from '../ReanimatedModule/js-reanimated';
 
-export function setNativeProps<Ref extends WrapperRef>(
-  animatedRef: AnimatedRef<Ref>,
+export function setNativeProps<TRef extends WrapperRef>(
+  animatedRef: AnimatedRef<TRef>,
   updates: StyleProps
 ) {
   const component = animatedRef() as ReanimatedHTMLElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,6 +6447,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shopify/flash-list@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@shopify/flash-list@npm:2.0.2"
+  dependencies:
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    "@babel/runtime": "*"
+    react: "*"
+    react-native: "*"
+  checksum: 10/9e4dad24e886b6ff318a66a27500e1293fa28d7c466453893c45a73ca195e9fac5d6cd41142cb5ad7480f8a89475ecd5ba0dfbac61a20b7704eb85b690990540
+  languageName: node
+  linkType: hard
+
 "@shopify/flash-list@patch:@shopify/flash-list@npm%3A1.8.0#~/.yarn/patches/@shopify-flash-list-npm-1.8.0-54e02d8f74.patch":
   version: 1.8.0
   resolution: "@shopify/flash-list@patch:@shopify/flash-list@npm%3A1.8.0#~/.yarn/patches/@shopify-flash-list-npm-1.8.0-54e02d8f74.patch::version=1.8.0&hash=ccc3df"
@@ -19862,6 +19875,7 @@ __metadata:
     "@react-native/eslint-config": "npm:0.80.0"
     "@react-native/metro-config": "npm:0.80.0"
     "@react-native/typescript-config": "npm:0.80.0"
+    "@shopify/flash-list": "npm:2.0.2"
     "@testing-library/jest-native": "npm:^4.0.4"
     "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/react-native": "npm:^13.0.1"


### PR DESCRIPTION
## Summary

This PR improves types used for the animated ref value. The previous implementation required the value to be an instance of the `React.Component`, which worked in most cases. This broke in `FlashList` v2 because the `ref` prop doesn't extend the `React.Component` type and instead it included just types of a few methods that can be used to obtain the view instance.

