### PR TITLE
chore: Clean up getViewProp implementation

### DIFF
--- a/.lintstagedrc-common.js
+++ b/.lintstagedrc-common.js
@@ -1,7 +1,7 @@
 /** @type {import('lint-staged').Config} */
 module.exports = {
   '*.(js|jsx|ts|tsx)': [
-    'yarn eslint --flag unstable_config_lookup_from_file',
+    'yarn eslint --flag unstable_config_lookup_from_file --fix',
     'yarn prettier --write',
   ],
 };

--- a/.lintstagedrc-common.js
+++ b/.lintstagedrc-common.js
@@ -1,7 +1,7 @@
 /** @type {import('lint-staged').Config} */
 module.exports = {
   '*.(js|jsx|ts|tsx)': [
-    'yarn eslint --flag unstable_config_lookup_from_file --fix',
+    'yarn eslint --flag unstable_config_lookup_from_file',
     'yarn prettier --write',
   ],
 };

--- a/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/GetViewPropExample.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import Animated, {
-  getViewProp,
   useAnimatedRef,
   useAnimatedStyle,
   useSharedValue,
@@ -25,9 +24,7 @@ export default function GetViewPropExample() {
   });
 
   const handlePress = async () => {
-    // @ts-ignore this is fine
-    const viewTag = animatedRef() as number;
-    const result = await getViewProp(viewTag, 'opacity');
+    const result = await animatedRef.getViewProp<number>('opacity');
     console.log(result);
   };
 

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -518,7 +518,6 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🔎',
     title: 'getViewProp',
     screen: GetViewPropExample,
-    missingOnFabric: true,
   },
   LogExample: {
     icon: '⌨',

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -133,11 +133,11 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   }
 
   getViewProp<T>(
-    ref: ComponentWithInstanceMethods, // required on Fabric
+    component: ComponentWithInstanceMethods,
     propName: string,
     callback?: (result: T) => void
   ) {
-    const shadowNodeWrapper = getShadowNodeWrapperFromRef(ref);
+    const shadowNodeWrapper = getShadowNodeWrapperFromRef(component);
     return this.#reanimatedModuleProxy.getViewProp(
       shadowNodeWrapper,
       propName,

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -13,12 +13,12 @@ import {
   SHOULD_BE_USE_WEB,
 } from '../common';
 import type {
+  ComponentWithInstanceMethods,
   LayoutAnimationBatchItem,
   ShadowNodeWrapper,
   StyleProps,
   Value3D,
   ValueRotation,
-  WrapperRef,
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
@@ -133,12 +133,11 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   }
 
   getViewProp<T>(
-    viewTag: number,
+    ref: ComponentWithInstanceMethods, // required on Fabric
     propName: string,
-    component: WrapperRef, // required on Fabric
     callback?: (result: T) => void
   ) {
-    const shadowNodeWrapper = getShadowNodeWrapperFromRef(component);
+    const shadowNodeWrapper = getShadowNodeWrapperFromRef(ref);
     return this.#reanimatedModuleProxy.getViewProp(
       shadowNodeWrapper,
       propName,

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -14,11 +14,11 @@ import {
   ReanimatedError,
 } from '../../common';
 import type {
+  ComponentWithInstanceMethods,
   ShadowNodeWrapper,
   StyleProps,
   Value3D,
   ValueRotation,
-  WrapperRef,
 } from '../../commonTypes';
 import { SensorType } from '../../commonTypes';
 import type {
@@ -253,9 +253,8 @@ class JSReanimated implements IReanimatedModule {
   }
 
   getViewProp<T>(
-    _viewTag: number,
+    _ref: ComponentWithInstanceMethods,
     _propName: string,
-    _component?: WrapperRef | null,
     _callback?: (result: T) => void
   ): Promise<T> {
     throw new ReanimatedError('getViewProp is not available in JSReanimated.');

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -253,7 +253,7 @@ class JSReanimated implements IReanimatedModule {
   }
 
   getViewProp<T>(
-    _ref: ComponentWithInstanceMethods,
+    _component: ComponentWithInstanceMethods,
     _propName: string,
     _callback?: (result: T) => void
   ): Promise<T> {

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -93,7 +93,7 @@ export interface ReanimatedModuleProxy {
 export interface IReanimatedModule
   extends Omit<ReanimatedModuleProxy, 'getViewProp'> {
   getViewProp<TValue>(
-    ref: ComponentWithInstanceMethods | null,
+    component: ComponentWithInstanceMethods | null,
     propName: string,
     callback?: (result: TValue) => void
   ): Promise<TValue>;

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -3,12 +3,12 @@
 import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 
 import type {
+  ComponentWithInstanceMethods,
   LayoutAnimationBatchItem,
   ShadowNodeWrapper,
   StyleProps,
   Value3D,
   ValueRotation,
-  WrapperRef,
 } from '../commonTypes';
 import type {
   CSSAnimationUpdates,
@@ -93,9 +93,8 @@ export interface ReanimatedModuleProxy {
 export interface IReanimatedModule
   extends Omit<ReanimatedModuleProxy, 'getViewProp'> {
   getViewProp<TValue>(
-    viewTag: number,
+    ref: ComponentWithInstanceMethods | null,
     propName: string,
-    component: WrapperRef | null,
     callback?: (result: TValue) => void
   ): Promise<TValue>;
 }

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -465,4 +465,6 @@ type InstanceMethods = {
   __internalInstanceHandle?: AnyRecord;
 };
 
-export type WrapperRef = (React.Component & InstanceMethods) | InstanceMethods;
+export type ComponentWithInstanceMethods =
+  | (React.Component & InstanceMethods)
+  | InstanceMethods;

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -47,10 +47,10 @@ export const isReanimated3 = () => {
 export const isConfigured = isReanimated3;
 
 export function getViewPropImpl<T = unknown>(
-  ref: ComponentWithInstanceMethods | null,
+  component: ComponentWithInstanceMethods | null,
   propName: string
 ): Promise<T> {
-  if (!ref) {
+  if (!component) {
     throw new ReanimatedError(
       'Function `getViewProp` requires a component to be passed as an argument.'
     );
@@ -58,7 +58,7 @@ export function getViewPropImpl<T = unknown>(
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return new Promise((resolve, reject) => {
-    return ReanimatedModule.getViewProp(ref, propName, (result: T) => {
+    return ReanimatedModule.getViewProp(component, propName, (result: T) => {
       if (typeof result === 'string' && result.slice(0, 6) === 'error:') {
         // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
         reject(result);
@@ -72,9 +72,9 @@ export function getViewPropImpl<T = unknown>(
 export function getViewProp<T = unknown>(
   _viewTag: number,
   propName: string,
-  ref: ComponentWithInstanceMethods | null
+  component: ComponentWithInstanceMethods | null
 ): Promise<T> {
-  return getViewPropImpl(ref, propName);
+  return getViewPropImpl(component, propName);
 }
 
 function getSensorContainer(): SensorContainer {

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -9,13 +9,13 @@ import { createSerializable } from 'react-native-worklets';
 import { logger, ReanimatedError } from './common';
 import type {
   AnimatedKeyboardOptions,
+  ComponentWithInstanceMethods,
   LayoutAnimationBatchItem,
   SensorConfig,
   SensorType,
   SharedValue,
   Value3D,
   ValueRotation,
-  WrapperRef,
 } from './commonTypes';
 import { ReanimatedModule } from './ReanimatedModule';
 import { SensorContainer } from './SensorContainer';
@@ -46,33 +46,35 @@ export const isReanimated3 = () => {
  */
 export const isConfigured = isReanimated3;
 
-export function getViewProp<T>(
-  viewTag: number,
-  propName: string,
-  component?: WrapperRef | null // required on Fabric
+export function getViewPropImpl<T = unknown>(
+  ref: ComponentWithInstanceMethods | null,
+  propName: string
 ): Promise<T> {
-  if (!component) {
+  if (!ref) {
     throw new ReanimatedError(
-      'Function `getViewProp` requires a component to be passed as an argument on Fabric.'
+      'Function `getViewProp` requires a component to be passed as an argument.'
     );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return new Promise((resolve, reject) => {
-    return ReanimatedModule.getViewProp(
-      viewTag,
-      propName,
-      component,
-      (result: T) => {
-        if (typeof result === 'string' && result.slice(0, 6) === 'error:') {
-          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-          reject(result);
-        } else {
-          resolve(result);
-        }
+    return ReanimatedModule.getViewProp(ref, propName, (result: T) => {
+      if (typeof result === 'string' && result.slice(0, 6) === 'error:') {
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+        reject(result);
+      } else {
+        resolve(result);
       }
-    );
+    });
   });
+}
+
+export function getViewProp<T = unknown>(
+  _viewTag: number,
+  propName: string,
+  ref: ComponentWithInstanceMethods | null
+): Promise<T> {
+  return getViewPropImpl(ref, propName);
 }
 
 function getSensorContainer(): SensorContainer {

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -5,7 +5,10 @@ import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 
 import { IS_JEST, ReanimatedError, SHOULD_BE_USE_WEB } from '../../common';
-import type { ShadowNodeWrapper, WrapperRef } from '../../commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  ShadowNodeWrapper,
+} from '../../commonTypes';
 import type {
   AnimatedComponentRef,
   IAnimatedComponentInternalBase,
@@ -91,7 +94,7 @@ export default class AnimatedComponent<
       viewTag = viewInfo.viewTag ?? -1;
       viewName = viewInfo.viewName;
       shadowNodeWrapper = getShadowNodeWrapperFromRef(
-        this as WrapperRef,
+        this as ComponentWithInstanceMethods,
         hostInstance
       );
     }

--- a/packages/react-native-reanimated/src/fabricUtils.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.ts
@@ -12,7 +12,7 @@ let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
 };
 
 export function getShadowNodeWrapperFromRef(
-  ref: ComponentWithInstanceMethods,
+  component: ComponentWithInstanceMethods,
   hostInstance?: HostInstance
 ): ShadowNodeWrapper {
   if (getInternalInstanceHandleFromPublicInstance === undefined) {
@@ -28,15 +28,15 @@ export function getShadowNodeWrapperFromRef(
     }
   }
 
-  const resolvedRef =
-    ref.getScrollResponder?.()?.getNativeScrollRef?.() ??
-    ref.getNativeScrollRef?.() ??
-    ref;
+  const resolvedComponent =
+    component.getScrollResponder?.()?.getNativeScrollRef?.() ??
+    component.getNativeScrollRef?.() ??
+    component;
 
   const resolvedInstance =
-    ref?.__internalInstanceHandle ??
+    component?.__internalInstanceHandle ??
     getInternalInstanceHandleFromPublicInstance(
-      hostInstance ?? findHostInstance(resolvedRef)
+      hostInstance ?? findHostInstance(resolvedComponent)
     );
 
   return resolvedInstance?.stateNode?.node;

--- a/packages/react-native-reanimated/src/fabricUtils.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 'use strict';
-import type { ShadowNodeWrapper, WrapperRef } from './commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  ShadowNodeWrapper,
+} from './commonTypes';
 import type { HostInstance } from './platform-specific/findHostInstance';
 import { findHostInstance } from './platform-specific/findHostInstance';
 
@@ -9,7 +12,7 @@ let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
 };
 
 export function getShadowNodeWrapperFromRef(
-  ref: WrapperRef,
+  ref: ComponentWithInstanceMethods,
   hostInstance?: HostInstance
 ): ShadowNodeWrapper {
   if (getInternalInstanceHandleFromPublicInstance === undefined) {

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -12,8 +12,8 @@ import type { WorkletFunction } from 'react-native-worklets';
 import type {
   AnimatedPropsAdapterFunction,
   AnimatedStyle,
+  ComponentWithInstanceMethods,
   ShadowNodeWrapper,
-  WrapperRef,
 } from '../commonTypes';
 import type { AnimatedProps } from '../createAnimatedComponent/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
@@ -30,17 +30,18 @@ export type MaybeObserverCleanup = (() => void) | undefined;
 
 export type AnimatedRefObserver = (tag: number | null) => MaybeObserverCleanup;
 
-export type AnimatedRef<TRef extends WrapperRef> = {
-  (ref?: TRef | null):
+export type AnimatedRef<TComponent extends ComponentWithInstanceMethods> = {
+  (ref?: TComponent | null):
     | ShadowNodeWrapper // Native
     | HTMLElement; // web
-  current: TRef | null;
+  current: TComponent | null;
   observe: (observer: AnimatedRefObserver) => void;
+  getViewProp: <T = unknown>(propName: string) => Promise<T>;
   getTag?: () => number | null;
 };
 
 // Might make that type generic if it's ever needed.
-export type AnimatedRefOnJS = AnimatedRef<WrapperRef>;
+export type AnimatedRefOnJS = AnimatedRef<ComponentWithInstanceMethods>;
 
 /**
  * `AnimatedRef` is mapped to this type on the UI thread via a serializable

--- a/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedRef.ts
@@ -6,7 +6,11 @@ import {
 } from 'react-native-worklets';
 
 import { SHOULD_BE_USE_WEB } from '../common/constants';
-import type { ShadowNodeWrapper, WrapperRef } from '../commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  ShadowNodeWrapper,
+} from '../commonTypes';
+import { getViewPropImpl } from '../core';
 import { getShadowNodeWrapperFromRef } from '../fabricUtils';
 import { makeMutable } from '../mutables';
 import { findNodeHandle } from '../platformFunctions/findNodeHandle';
@@ -17,23 +21,23 @@ import type {
   MaybeObserverCleanup,
 } from './commonTypes';
 
-function getComponentOrScrollable(ref: WrapperRef) {
+function getComponentOrScrollable(ref: ComponentWithInstanceMethods) {
   return ref.getNativeScrollRef?.() ?? ref.getScrollableNode?.() ?? ref;
 }
 
-function useAnimatedRefBase<TRef extends WrapperRef>(
-  getWrapper: (ref: TRef) => ShadowNodeWrapper
-): AnimatedRef<TRef> {
+function useAnimatedRefBase<TComponent extends ComponentWithInstanceMethods>(
+  getWrapper: (ref: TComponent) => ShadowNodeWrapper
+): AnimatedRef<TComponent> {
   const observers = useRef<Map<AnimatedRefObserver, MaybeObserverCleanup>>(
     new Map()
   ).current;
-  const wrapperRef = useRef<ShadowNodeWrapper | null>(null);
-  const resultRef = useRef<AnimatedRef<TRef> | null>(null);
+  const shadowNodeWrapperRef = useRef<ShadowNodeWrapper | null>(null);
+  const resultRef = useRef<AnimatedRef<TComponent> | null>(null);
 
   if (!resultRef.current) {
-    const fun = <AnimatedRef<TRef>>((ref) => {
+    const fun = <AnimatedRef<TComponent>>((ref) => {
       if (ref) {
-        wrapperRef.current = getWrapper(ref);
+        shadowNodeWrapperRef.current = getWrapper(ref);
 
         // We have to unwrap the tag from the shadow node wrapper.
         fun.getTag = () => findNodeHandle(getComponentOrScrollable(ref));
@@ -52,7 +56,7 @@ function useAnimatedRefBase<TRef extends WrapperRef>(
         }
       }
 
-      return wrapperRef.current;
+      return shadowNodeWrapperRef.current;
     });
 
     fun.observe = (observer: AnimatedRefObserver) => {
@@ -66,6 +70,9 @@ function useAnimatedRefBase<TRef extends WrapperRef>(
       };
     };
 
+    fun.getViewProp = (propName: string) =>
+      getViewPropImpl(fun.current, propName);
+
     fun.current = null;
     resultRef.current = fun;
   }
@@ -74,13 +81,13 @@ function useAnimatedRefBase<TRef extends WrapperRef>(
 }
 
 function useAnimatedRefNative<
-  TRef extends WrapperRef = React.Component,
->(): AnimatedRef<TRef> {
+  TComponent extends ComponentWithInstanceMethods = React.Component,
+>(): AnimatedRef<TComponent> {
   const [sharedWrapper] = useState(() =>
     makeMutable<ShadowNodeWrapper | null>(null)
   );
 
-  const resultRef = useAnimatedRefBase<TRef>((ref) => {
+  const resultRef = useAnimatedRefBase<TComponent>((ref) => {
     const currentWrapper = getShadowNodeWrapperFromRef(
       getComponentOrScrollable(ref)
     );
@@ -104,9 +111,9 @@ function useAnimatedRefNative<
 }
 
 function useAnimatedRefWeb<
-  TRef extends WrapperRef = React.Component,
->(): AnimatedRef<TRef> {
-  return useAnimatedRefBase<TRef>((ref) => getComponentOrScrollable(ref));
+  TComponent extends ComponentWithInstanceMethods = React.Component,
+>(): AnimatedRef<TComponent> {
+  return useAnimatedRefBase<TComponent>((ref) => getComponentOrScrollable(ref));
 }
 
 /**

--- a/packages/react-native-reanimated/src/hook/useScrollOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollOffset.ts
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import { IS_WEB, logger } from '../common';
-import type { SharedValue, WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods, SharedValue } from '../commonTypes';
 import type {
   AnimatedRef,
   ReanimatedScrollEvent,
@@ -37,8 +37,8 @@ export const useScrollOffset = IS_WEB
   ? useScrollOffsetWeb
   : useScrollOffsetNative;
 
-function useScrollOffsetWeb<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef> | null,
+function useScrollOffsetWeb<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);
@@ -77,8 +77,8 @@ function useScrollOffsetWeb<TRef extends WrapperRef>(
   return offset;
 }
 
-function useScrollOffsetNative<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef> | null,
+function useScrollOffsetNative<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent> | null,
   providedOffset?: SharedValue<number>
 ): SharedValue<number> {
   const internalOffset = useSharedValue(0);
@@ -118,6 +118,8 @@ function useScrollOffsetNative<TRef extends WrapperRef>(
   return offset;
 }
 
-function getWebScrollableElement(scrollComponent: WrapperRef): HTMLElement {
+function getWebScrollableElement(
+  scrollComponent: ComponentWithInstanceMethods
+): HTMLElement {
   return scrollComponent?.getScrollableNode?.() ?? scrollComponent;
 }

--- a/packages/react-native-reanimated/src/hook/useScrollOffset.ts
+++ b/packages/react-native-reanimated/src/hook/useScrollOffset.ts
@@ -119,7 +119,7 @@ function useScrollOffsetNative<TComponent extends ComponentWithInstanceMethods>(
 }
 
 function getWebScrollableElement(
-  scrollComponent: ComponentWithInstanceMethods
+  component: ComponentWithInstanceMethods
 ): HTMLElement {
-  return scrollComponent?.getScrollableNode?.() ?? scrollComponent;
+  return component?.getScrollableNode?.() ?? component;
 }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 import { ReanimatedError } from '../common';
-import type { WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods } from '../commonTypes';
 import type { IAnimatedComponentInternalBase } from '../createAnimatedComponent/commonTypes';
 
 export type HostInstance = {
@@ -46,7 +46,7 @@ function resolveFindHostInstance_DEPRECATED() {
 
 let findHostInstance_DEPRECATED: (ref: unknown) => HostInstance;
 export function findHostInstance(
-  ref: IAnimatedComponentInternalBase | WrapperRef
+  ref: IAnimatedComponentInternalBase | ComponentWithInstanceMethods
 ): HostInstance {
   // Fast path for native refs
   const hostInstance = findHostInstanceFastPath(

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -46,11 +46,11 @@ function resolveFindHostInstance_DEPRECATED() {
 
 let findHostInstance_DEPRECATED: (ref: unknown) => HostInstance;
 export function findHostInstance(
-  ref: IAnimatedComponentInternalBase | ComponentWithInstanceMethods
+  component: IAnimatedComponentInternalBase | ComponentWithInstanceMethods
 ): HostInstance {
   // Fast path for native refs
   const hostInstance = findHostInstanceFastPath(
-    (ref as IAnimatedComponentInternalBase)._componentRef as HostInstance
+    (component as IAnimatedComponentInternalBase)._componentRef as HostInstance
   );
   if (hostInstance !== undefined) {
     return hostInstance;
@@ -64,8 +64,8 @@ export function findHostInstance(
     a valid React ref.
   */
   return findHostInstance_DEPRECATED(
-    (ref as IAnimatedComponentInternalBase)._hasAnimatedRef
-      ? (ref as IAnimatedComponentInternalBase)._componentRef
-      : ref
+    (component as IAnimatedComponentInternalBase)._hasAnimatedRef
+      ? (component as IAnimatedComponentInternalBase)._componentRef
+      : component
   );
 }

--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -2,15 +2,18 @@
 import { RuntimeKind } from 'react-native-worklets';
 
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
-import type { ShadowNodeWrapper, WrapperRef } from '../commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  ShadowNodeWrapper,
+} from '../commonTypes';
 import type {
   AnimatedRef,
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type DispatchCommand = <TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+type DispatchCommand = <TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   commandName: string,
   args?: unknown[]
 ) => void;

--- a/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/getRelativeCoords.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import { measure } from './measure';
 
@@ -21,8 +21,10 @@ export interface ComponentCoords {
  *   {@link ComponentCoords}.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/utilities/getRelativeCoords
  */
-export function getRelativeCoords<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+export function getRelativeCoords<
+  TComponent extends ComponentWithInstanceMethods,
+>(
+  animatedRef: AnimatedRef<TComponent>,
   absoluteX: number,
   absoluteY: number
 ): ComponentCoords | null {

--- a/packages/react-native-reanimated/src/platformFunctions/measure.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.ts
@@ -3,9 +3,9 @@ import { RuntimeKind } from 'react-native-worklets';
 
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
 import type {
+  ComponentWithInstanceMethods,
   MeasuredDimensions,
   ShadowNodeWrapper,
-  WrapperRef,
 } from '../commonTypes';
 import type {
   AnimatedRef,
@@ -13,8 +13,8 @@ import type {
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type Measure = <TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>
+type Measure = <TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>
 ) => MeasuredDimensions | null;
 
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/measure.web.ts
@@ -1,10 +1,13 @@
 'use strict';
 import { logger } from '../common';
-import type { MeasuredDimensions, WrapperRef } from '../commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  MeasuredDimensions,
+} from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function measure<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>
+export function measure<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>
 ): MeasuredDimensions | null {
   const element = animatedRef() as HTMLElement | null;
 

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.ts
@@ -1,11 +1,11 @@
 'use strict';
 import { IS_JEST, logger, SHOULD_BE_USE_WEB } from '../common';
-import type { WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import { dispatchCommand } from './dispatchCommand';
 
-type ScrollTo = <TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+type ScrollTo = <TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   x: number,
   y: number,
   animated: boolean
@@ -24,8 +24,8 @@ type ScrollTo = <TRef extends WrapperRef>(
  */
 export let scrollTo: ScrollTo;
 
-function scrollToNative<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+function scrollToNative<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   x: number,
   y: number,
   animated: boolean

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
@@ -1,11 +1,11 @@
 'use strict';
 import type { ScrollView } from 'react-native';
 
-import type { WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
-export function scrollTo<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+export function scrollTo<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   x: number,
   y: number,
   animated: boolean

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.ts
@@ -7,15 +7,19 @@ import {
   processColorsInProps,
   SHOULD_BE_USE_WEB,
 } from '../common';
-import type { ShadowNodeWrapper, StyleProps, WrapperRef } from '../commonTypes';
+import type {
+  ComponentWithInstanceMethods,
+  ShadowNodeWrapper,
+  StyleProps,
+} from '../commonTypes';
 import type {
   AnimatedRef,
   AnimatedRefOnJS,
   AnimatedRefOnUI,
 } from '../hook/commonTypes';
 
-type SetNativeProps = <TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+type SetNativeProps = <TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   updates: StyleProps
 ) => void;
 /**

--- a/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/setNativeProps.web.ts
@@ -1,11 +1,11 @@
 'use strict';
-import type { StyleProps, WrapperRef } from '../commonTypes';
+import type { ComponentWithInstanceMethods, StyleProps } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { _updatePropsJS } from '../ReanimatedModule/js-reanimated';
 
-export function setNativeProps<TRef extends WrapperRef>(
-  animatedRef: AnimatedRef<TRef>,
+export function setNativeProps<TComponent extends ComponentWithInstanceMethods>(
+  animatedRef: AnimatedRef<TComponent>,
   updates: StyleProps
 ) {
   const component = animatedRef() as ReanimatedHTMLElement;


### PR DESCRIPTION
## Summary

This PR removes unused `viewTag` prop from the `getViewProp` function which is a leftover from the old Paper-compatible implementation.
 
## Test plan

I tested it on the `getViewProp` example (which for some reason was disabled before on Fabric, likely because of the invalid `getViewProp` implementation).

https://github.com/user-attachments/assets/61eafbb7-e887-47b4-9517-bf6f68dc32ab
