### PR TITLE
docs: Remove prop adapters from v4 docs, add migration guide

### DIFF
--- a/packages/docs-reanimated/docs/core/useAnimatedProps.mdx
+++ b/packages/docs-reanimated/docs/core/useAnimatedProps.mdx
@@ -33,8 +33,7 @@ function App() {
 ```typescript
 function useAnimatedProps<T extends {}>(
   updater: () => Partial<T>,
-  dependencies?: DependencyList | null,
-  adapters?: PropsAdapterFunction | PropsAdapterFunction[] | null
+  dependencies?: DependencyList | null
 ): Partial<T>;
 ```
 
@@ -51,25 +50,6 @@ A function returning an object with properties you want to animate.
 An optional array of dependencies.
 
 Only relevant when using Reanimated [without the Babel plugin on the Web](https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support#web-without-the-babel-plugin).
-
-#### `adapters` <Optional/>
-
-An optional function or an array of functions.
-
-Sometimes when working with third-party libraries properties might be named differently on the API surface from what they really represent on the native side. Adapters make it possible to handle these cases by defining a way to convert these props.
-
-Reanimated comes with two built-in adapters:
-
-- [`SVGAdapter`](https://github.com/software-mansion/react-native-reanimated/blob/Reanimated2/src/reanimated2/PropAdapters.ts#L19) for handling `transform` property in `react-native-svg`
-- [`TextInputAdapter`](https://github.com/software-mansion/react-native-reanimated/blob/Reanimated2/src/reanimated2/PropAdapters.ts#L57).
-
-You can create your own adapters using `createAnimatedPropAdapter` function.
-
-Here's an example of adapting `fill` and `stroke` properties from `react-native-svg` to be able to animate them with Reanimated.
-
-import AnimatedPropAdapterSrc from '!!raw-loader!@site/src/examples/AnimatedPropAdapter';
-
-<CollapsibleCode showLines={[13, 25]} src={AnimatedPropAdapterSrc} />
 
 ### Color-related properties
 
@@ -121,7 +101,6 @@ import AnimatingPropsSrc from '!!raw-loader!@site/src/examples/AnimatingProps';
 ## Remarks
 
 - You can share animated props between components to avoid code duplication.
-- We recommend to create adapters outside of the component's body to avoid unnecessary recalculations.
 
 ## Platform compatibility
 

--- a/packages/docs-reanimated/docs/guides/migration-from-3.x.md
+++ b/packages/docs-reanimated/docs/guides/migration-from-3.x.md
@@ -84,6 +84,45 @@ In Reanimated 4, we renamed `useScrollViewOffset` to `useScrollOffset`. For the 
 
 `useAnimatedGestureHandler` was marked as deprecated in Reanimated 3 and has been removed in Reanimated 4. You need to refactor all its usages to the new `Gesture` API introduced in Gesture Handler 2 according to the steps described in [React Native Gesture Handler documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/guides/upgrading-to-2).
 
+### Removed `adapters` parameter from `useAnimatedProps`
+
+In Reanimated 4, the `adapters` parameter has been removed from `useAnimatedProps`. All properties that previously required adapters now should work directly.
+
+```jsx
+// Before - using custom adapter for fill and stroke properties
+import {
+  createAnimatedPropAdapter,
+  processColor,
+} from 'react-native-reanimated';
+
+const adapter = createAnimatedPropAdapter(
+  (props) => {
+    if (Object.keys(props).includes('fill')) {
+      props.fill = { type: 0, payload: processColor(props.fill) };
+    }
+    if (Object.keys(props).includes('stroke')) {
+      props.stroke = { type: 0, payload: processColor(props.stroke) };
+    }
+  },
+  ['fill', 'stroke']
+);
+
+const animatedProps = useAnimatedProps(
+  () => ({
+    fill: 'yellow',
+    stroke: 'rgb(255,0,0)',
+  }),
+  [],
+  adapter
+);
+
+// After - properties work directly without adapter
+const animatedProps = useAnimatedProps(() => ({
+  fill: 'yellow',
+  stroke: 'rgb(255,0,0)',
+}));
+```
+
 ## Integration with other libraries
 
 All integrations with other third-party libraries such as [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/) or [React Native Skia](https://shopify.github.io/react-native-skia/) work the same as on 3.x. However, Reanimated 4 no longer provides support for [React Native V8](https://github.com/Kudo/react-native-v8/issues).

--- a/packages/docs-reanimated/docs/guides/migration-from-3.x.md
+++ b/packages/docs-reanimated/docs/guides/migration-from-3.x.md
@@ -84,7 +84,7 @@ In Reanimated 4, we renamed `useScrollViewOffset` to `useScrollOffset`. For the 
 
 `useAnimatedGestureHandler` was marked as deprecated in Reanimated 3 and has been removed in Reanimated 4. You need to refactor all its usages to the new `Gesture` API introduced in Gesture Handler 2 according to the steps described in [React Native Gesture Handler documentation](https://docs.swmansion.com/react-native-gesture-handler/docs/guides/upgrading-to-2).
 
-### Removed `adapters` parameter from `useAnimatedProps`
+### Removed `createAnimatedPropAdapter`
 
 In Reanimated 4, the `adapters` parameter has been removed from `useAnimatedProps`. All properties that previously required adapters now should work directly.
 

--- a/packages/docs-reanimated/docs/guides/migration-from-3.x.md
+++ b/packages/docs-reanimated/docs/guides/migration-from-3.x.md
@@ -88,8 +88,11 @@ In Reanimated 4, we renamed `useScrollViewOffset` to `useScrollOffset`. For the 
 
 In Reanimated 4, the `adapters` parameter has been removed from `useAnimatedProps`. All properties that previously required adapters now should work directly.
 
+#### Before
+
+Using custom adapter for fill and stroke properties:
+
 ```jsx
-// Before - using custom adapter for fill and stroke properties
 import {
   createAnimatedPropAdapter,
   processColor,
@@ -115,8 +118,13 @@ const animatedProps = useAnimatedProps(
   [],
   adapter
 );
+```
 
-// After - properties work directly without adapter
+#### After
+
+Properties work directly without adapter:
+
+```jsx
 const animatedProps = useAnimatedProps(() => ({
   fill: 'yellow',
   stroke: 'rgb(255,0,0)',


### PR DESCRIPTION
## Summary

This PR removes `adapters` prop from v4 docs and adds migration guide from `3.x`

## Example image

### Migration guide

<img width="1237" height="984" alt="Screenshot 2025-08-12 at 09 17 12" src="https://github.com/user-attachments/assets/a858f11a-1a47-4114-8059-e1beb7e214b9" />
