### PR TITLE
fix: Incompatible WrapperRef type in RN 0.81

### DIFF
--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -2,6 +2,7 @@
 import type { ComponentRef } from 'react';
 import type {
   ImageStyle,
+  NativeMethods,
   ScrollResponderMixin,
   ScrollViewComponent,
   TextStyle,
@@ -448,7 +449,11 @@ export type AnimatedTransform = MaybeSharedValueRecursive<
 >;
 
 type NativeScrollRef = Maybe<
-  (ComponentRef<typeof View> | ComponentRef<typeof ScrollViewComponent>) & {
+  (
+    | ComponentRef<typeof View>
+    | ComponentRef<typeof ScrollViewComponent>
+    | NativeMethods
+  ) & {
     __internalInstanceHandle?: AnyRecord;
   }
 >;


### PR DESCRIPTION
## Summary

This PR adds just one missing possible type of the `getNativeScrollRef` return value to the `NativeScrollRef` type union.

The `NativeMethods` type was exported from RN version before as well and it wasn't just added in RN 0.81, so it is safe to import it and use in the union type.

## Test plan

I tested on the branch with RN 0.81 and typecheck passed with no issues