### PR TITLE
fix: Web example drawer navigator behavior

### DIFF
--- a/apps/common-app/src/App.tsx
+++ b/apps/common-app/src/App.tsx
@@ -109,7 +109,7 @@ function Navigator() {
           borderRadius: radius.lg,
         },
         drawerLabelStyle: text.heading4,
-        drawerPosition: 'right',
+        drawerPosition: IS_WEB ? 'left' : 'right',
         drawerStyle: {
           backgroundColor: colors.background1,
         },


### PR DESCRIPTION
## Summary

It looks like the web implementation of the drawer navigator is invalid when the `drawerPosition: 'right'` is set. It must be using the `left: <window-width>` to position the drawer on the right side of the window, which doesn't respect changes of the window size. The correct approach would be to use `right: 0` instead but, since this is an external library and I don't want to waste time on fixing that, I decide to just switch the position to the `left` on the web.

## Example recordings

### Before

https://github.com/user-attachments/assets/3f217d30-330b-4f43-9c12-81e5b2d468ca

### After

https://github.com/user-attachments/assets/c4438f31-798a-47fb-98b3-81d25799e64f
