### PR TITLE
fix: prevent possible error in deferencing native tags

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -104,7 +104,7 @@ export class NativeEventsManager implements INativeEventsManager {
       return this.#managedComponent.getComponentViewTag();
     }
     if (componentAnimatedRef?.__nativeTag) {
-      return componentAnimatedRef?.__nativeTag ?? -1;
+      return componentAnimatedRef.__nativeTag ?? -1;
     }
     /*
       When a component is updated, a child could potentially change and have a different 


### PR DESCRIPTION
## Summary

Found an error thrown when this code tries to run on a null ref. This fix prevents the error.

## Test plan

This is needed to make Nativewind 4 work with the Expo SDK 54 preview. See demo at 

https://github.com/react-native-tvos/NativewindMultiplatform/tree/sdk-54-beta