### PR TITLE
fix: Throw error when CSS is used on unsupported components

### DIFF
--- a/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
@@ -1,0 +1,77 @@
+'use strict';
+import {
+  ERROR_MESSAGES,
+  getStyleBuilder,
+  hasStyleBuilder,
+  registerComponentStyleBuilder,
+} from '../registry';
+import { BASE_PROPERTIES_CONFIG } from '../style';
+
+describe('registry', () => {
+  describe('hasStyleBuilder', () => {
+    it('returns true for registered component names', () => {
+      const componentName = 'CustomComponent';
+      const config = { width: true, height: true };
+
+      registerComponentStyleBuilder(componentName, config);
+
+      expect(hasStyleBuilder(componentName)).toBe(true);
+    });
+
+    it('returns true for RCT prefixed component names', () => {
+      expect(hasStyleBuilder('RCTView')).toBe(true);
+      expect(hasStyleBuilder('RCTText')).toBe(true);
+    });
+
+    it('returns false for unregistered component names', () => {
+      expect(hasStyleBuilder('UnregisteredComponent')).toBe(false);
+    });
+  });
+
+  describe('getStyleBuilder', () => {
+    it('returns registered style builder for custom component', () => {
+      const componentName = 'CustomComponent';
+      const config = { width: true, height: true };
+
+      registerComponentStyleBuilder(componentName, config);
+      const styleBuilder = getStyleBuilder(componentName);
+
+      expect(styleBuilder).toBeDefined();
+      expect(typeof styleBuilder.buildFrom).toBe('function');
+    });
+
+    it('returns base style builder for RCT prefixed components', () => {
+      const styleBuilder = getStyleBuilder('RCTView');
+
+      expect(styleBuilder).toBeDefined();
+      expect(typeof styleBuilder.buildFrom).toBe('function');
+    });
+
+    it('throws error for unregistered component names', () => {
+      expect(() => {
+        getStyleBuilder('UnregisteredComponent');
+      }).toThrow(ERROR_MESSAGES.styleBuilderNotFound('UnregisteredComponent'));
+    });
+  });
+
+  describe('registerComponentStyleBuilder', () => {
+    it('registers a style builder', () => {
+      const componentName = 'TestComponent';
+      const config = { width: true, height: true };
+
+      registerComponentStyleBuilder(componentName, config);
+
+      expect(hasStyleBuilder(componentName)).toBe(true);
+      expect(getStyleBuilder(componentName)).toBeDefined();
+    });
+
+    it('works with base properties config', () => {
+      const componentName = 'BaseConfigComponent';
+
+      registerComponentStyleBuilder(componentName, BASE_PROPERTIES_CONFIG);
+
+      expect(hasStyleBuilder(componentName)).toBe(true);
+      expect(getStyleBuilder(componentName)).toBeDefined();
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/keyframes/__tests__/CSSKeyframesRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/keyframes/__tests__/CSSKeyframesRegistry.test.ts
@@ -3,7 +3,7 @@ import { registerCSSKeyframes, unregisterCSSKeyframes } from '../../proxy';
 import cssKeyframesRegistry from '../CSSKeyframesRegistry';
 import CSSKeyframesRuleImpl from '../CSSKeyframesRuleImpl';
 
-const VIEW_NAME = 'ViewName';
+const VIEW_NAME = 'RCTView'; // Must be a valid view name
 
 jest.mock('../../proxy.ts', () => ({
   registerCSSKeyframes: jest.fn(),

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -1,11 +1,12 @@
 'use strict';
+import { ReanimatedError } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
 import type { AnyRecord, CSSStyle } from '../../types';
 import type { ICSSManager } from '../../types/interfaces';
 import { filterCSSAndStyleProperties } from '../../utils';
 import { setViewStyle } from '../proxy';
-import { getStyleBuilder } from '../registry';
+import { getStyleBuilder, hasStyleBuilder } from '../registry';
 import type { StyleBuilder } from '../style';
 import CSSAnimationsManager from './CSSAnimationsManager';
 import CSSTransitionsManager from './CSSTransitionsManager';
@@ -14,17 +15,21 @@ export default class CSSManager implements ICSSManager {
   private readonly cssAnimationsManager: CSSAnimationsManager;
   private readonly cssTransitionsManager: CSSTransitionsManager;
   private readonly viewTag: number;
-  private readonly styleBuilder: StyleBuilder<AnyRecord>;
+  private readonly viewName: string;
+  private readonly styleBuilder: StyleBuilder<AnyRecord> | null = null;
   private isFirstUpdate: boolean = true;
 
-  constructor({ shadowNodeWrapper, viewTag, viewName }: ViewInfo) {
+  constructor({ shadowNodeWrapper, viewTag, viewName = 'RCTView' }: ViewInfo) {
     const tag = (this.viewTag = viewTag as number);
     const wrapper = shadowNodeWrapper as ShadowNodeWrapper;
-    this.styleBuilder = getStyleBuilder(viewName);
 
+    this.viewName = viewName;
+    this.styleBuilder = hasStyleBuilder(viewName)
+      ? getStyleBuilder(viewName)
+      : null;
     this.cssAnimationsManager = new CSSAnimationsManager(
       wrapper,
-      viewName ?? 'View',
+      viewName,
       tag
     );
     this.cssTransitionsManager = new CSSTransitionsManager(wrapper, tag);
@@ -33,7 +38,14 @@ export default class CSSManager implements ICSSManager {
   update(style: CSSStyle): void {
     const [animationProperties, transitionProperties, filteredStyle] =
       filterCSSAndStyleProperties(style);
-    const normalizedStyle = this.styleBuilder.buildFrom(filteredStyle);
+
+    if (!this.styleBuilder && (animationProperties || transitionProperties)) {
+      throw new ReanimatedError(
+        `Tried to apply CSS animations or transitions to ${this.viewName} which is not supported`
+      );
+    }
+
+    const normalizedStyle = this.styleBuilder?.buildFrom(filteredStyle);
 
     // If the update is called during the first css style update, we won't
     // trigger CSS transitions and set styles before attaching CSS transitions

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -41,7 +41,7 @@ export default class CSSManager implements ICSSManager {
 
     if (!this.styleBuilder && (animationProperties || transitionProperties)) {
       throw new ReanimatedError(
-        `Tried to apply CSS animations or transitions to ${this.viewName} which is not supported`
+        `Tried to apply CSS animations to ${this.viewName} which is not supported`
       );
     }
 

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
@@ -13,7 +13,8 @@ import {
 } from '../../proxy';
 import CSSAnimationsManager from '../CSSAnimationsManager';
 
-const VIEW_NAME = 'ViewName';
+const VIEW_NAME = 'RCTView'; // Must be a valid view name
+
 const animationName = (id: number) => `${ANIMATION_NAME_PREFIX}${id}`;
 
 jest.mock('../../proxy.ts', () => ({

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/__tests__/animationName.test.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/__tests__/animationName.test.ts
@@ -5,7 +5,7 @@ import { getStyleBuilder } from '../../../registry';
 import { ERROR_MESSAGES, normalizeAnimationKeyframes } from '../keyframes';
 
 describe(normalizeAnimationKeyframes, () => {
-  const styleBuilder = getStyleBuilder('base');
+  const styleBuilder = getStyleBuilder('RCTView'); // Must be a valid view name
 
   describe('offset normalization', () => {
     describe('when offset is valid', () => {

--- a/packages/react-native-reanimated/src/css/native/registry.ts
+++ b/packages/react-native-reanimated/src/css/native/registry.ts
@@ -1,20 +1,32 @@
 'use strict';
+import { ReanimatedError } from '../../common';
 import type { StyleBuilder, StyleBuilderConfig } from './style';
 import { BASE_PROPERTIES_CONFIG, createStyleBuilder } from './style';
 
-const STYLE_BUILDERS: Record<string, StyleBuilder> = {
-  // react-native / fallback
-  base: createStyleBuilder(BASE_PROPERTIES_CONFIG, {
-    separatelyInterpolatedArrayProperties: ['transformOrigin', 'boxShadow'],
-  }),
-};
+const baseStyleBuilder = createStyleBuilder(BASE_PROPERTIES_CONFIG, {
+  separatelyInterpolatedArrayProperties: ['transformOrigin', 'boxShadow'],
+});
 
-export function getStyleBuilder(componentName = 'base'): StyleBuilder {
-  return (
-    STYLE_BUILDERS[componentName] ??
-    // We use this as a fallback and for all react-native components as there
-    // is no point in separating this config for different component types.
-    STYLE_BUILDERS.base
+const STYLE_BUILDERS: Record<string, StyleBuilder> = {};
+
+export function hasStyleBuilder(componentName: string): boolean {
+  return !!STYLE_BUILDERS[componentName] || componentName.startsWith('RCT');
+}
+
+export function getStyleBuilder(componentName: string): StyleBuilder {
+  const styleBuilder = STYLE_BUILDERS[componentName];
+
+  if (styleBuilder) {
+    return styleBuilder;
+  }
+
+  // This captures all React Native components
+  if (componentName.startsWith('RCT')) {
+    return baseStyleBuilder;
+  }
+
+  throw new ReanimatedError(
+    `CSS style builder for component ${componentName} was not found`
   );
 }
 

--- a/packages/react-native-reanimated/src/css/native/registry.ts
+++ b/packages/react-native-reanimated/src/css/native/registry.ts
@@ -3,6 +3,11 @@ import { ReanimatedError } from '../../common';
 import type { StyleBuilder, StyleBuilderConfig } from './style';
 import { BASE_PROPERTIES_CONFIG, createStyleBuilder } from './style';
 
+export const ERROR_MESSAGES = {
+  styleBuilderNotFound: (componentName: string) =>
+    `CSS style builder for component ${componentName} was not found`,
+};
+
 const baseStyleBuilder = createStyleBuilder(BASE_PROPERTIES_CONFIG, {
   separatelyInterpolatedArrayProperties: ['transformOrigin', 'boxShadow'],
 });
@@ -25,9 +30,7 @@ export function getStyleBuilder(componentName: string): StyleBuilder {
     return baseStyleBuilder;
   }
 
-  throw new ReanimatedError(
-    `CSS style builder for component ${componentName} was not found`
-  );
+  throw new ReanimatedError(ERROR_MESSAGES.styleBuilderNotFound(componentName));
 }
 
 export function registerComponentStyleBuilder(


### PR DESCRIPTION
## Summary

This PR fixes unpredictable behavior when CSS animation/transition was passed to the SVG component. The behavior was unpredictable because, when the support for SVGs was disabled, on the JS side we used the base style builder as a fallback (the one that is used for React Native components). As a result, some properties, such as the `color` property, were passed to the native side where we tried to create an interpolator for them, but, since there were no native interpolators registered in CPP, we got a weird error message that the respective interpolator was not found.

To make the error message more user-friendly, I decided to change this behavior and no longer use the base style builder as a fallback for all unsupported components. Instead, I check if the component is supported and throw an error only if the user passed some CSS properties to the unsupported component.

## Example recordings

When `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS` is set to `false`.

We can see that before we were able to render SVG components when support for them was disabled but there was no animation (which is a bit confusing to me as no error or warning was shown, so I think that throwing an error is better). We were able to navigate between screens until the component that has the same prop as one of the base style builder properties was rendered.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/e1e469ad-db6f-4c52-9d2d-ba748badddee" /> | <video src="https://github.com/user-attachments/assets/6efbbea5-2970-422d-b7b1-9ef0e549b727" /> |
