### PR TITLE
chore: No need to rebuild types after TS sources changes

### DIFF
--- a/apps/common-app/tsconfig.json
+++ b/apps/common-app/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "react-native-reanimated": ["../../packages/react-native-reanimated/src"]
     }
   },
   "include": ["src", "index.ts"]


### PR DESCRIPTION
## Summary

Before this PR we had to regenerate TS definitions on every TS change in the library source code to reflect changes in the example app. This simple PR makes it ensures that types are pulled from library sources instead of generated type definitions, thus every change is reflected right away.

## Example recordings

### Before

https://github.com/user-attachments/assets/ab5937d5-c4cb-4113-83aa-a81b96069dff

### After

https://github.com/user-attachments/assets/b8c4d73c-529d-4691-be91-54edd3b1b07f
