### PR TITLE
fix: add `compatibility.json` to `package.json` files section

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -56,6 +56,7 @@
     "scripts/validate-worklets-version.js",
     "scripts/worklets-version.json",
     "scripts/validate-react-native-version.js",
+    "compatibility.json",
     "mock.js",
     "plugin/index.js",
     "metro-config",


### PR DESCRIPTION
## Summary

This PR adds `compatibility.json` to `package.json` files section to fix the nightly build. 

https://github.com/software-mansion/react-native-reanimated/actions/runs/17137179425/job/48615928321

## Test plan
