### PR TITLE
[ios][worklets] add explicit dependency on React-hermes

### DIFF
--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -42,6 +42,9 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/c925872e72d2422be46670777bfa2111e13c9e4c/packages/react-native/scripts/cocoapods/new_architecture.rb#L71.
   install_modules_dependencies(s)
 
+  # To be able to call Hermes APIs when USE_FRAMEWORKS=dynamic we need an explicit dependency on React-Hermes
+  add_dependency(s, "React-hermes")
+
   # React Native doesn't expose these flags, but not having them
   # can lead to runtime errors due to ABI mismatches.
   # There's also

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -42,8 +42,11 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/c925872e72d2422be46670777bfa2111e13c9e4c/packages/react-native/scripts/cocoapods/new_architecture.rb#L71.
   install_modules_dependencies(s)
 
-  # To be able to call Hermes APIs when USE_FRAMEWORKS=dynamic we need an explicit dependency on React-Hermes
-  add_dependency(s, "React-hermes")
+  s.dependency 'React-jsi'
+  using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
+  if using_hermes && !$config[:is_tvos_target]
+    s.dependency 'React-hermes'
+  end
 
   # React Native doesn't expose these flags, but not having them
   # can lead to runtime errors due to ABI mismatches.


### PR DESCRIPTION
## Summary

To support USE_FRAMEWORKS=dynamic RNWorklets are missing an explicit dependency on React-hermes.

This commit adds the dependency since it is not set when calling `install_modules_dependencies`.

## Test plan

This can be tested by enabling USE_FRAMEWORKS="dynamic" in the Pod-file in a test project.