### PR TITLE
feat(Worklets): `scheduleOnUI`

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -56,6 +56,7 @@ export default function RuntimeTestsExample() {
             require('./tests/runtimes/createWorkletRuntime.test');
             require('./tests/runtimes/scheduleOnRN.test');
             require('./tests/runtimes/runOnUISync.test');
+            require('./tests/runtimes/scheduleOnUI.test');
           },
         },
         {

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
@@ -1,0 +1,46 @@
+import { scheduleOnUI } from 'react-native-worklets';
+import {
+  describe,
+  expect,
+  getRegisteredValue,
+  registerValue,
+  render,
+  test,
+  waitForNotify,
+  notify,
+} from '../../ReJest/RuntimeTestsApi';
+import { SharedValue, useSharedValue } from 'react-native-reanimated';
+import { ComparisonMode } from '../../ReJest/types';
+import { View } from 'react-native';
+import { useEffect } from 'react';
+
+const SHARED_VALUE_REF = 'SHARED_VALUE_REF';
+const NOTIFICATION_NAME = 'NOTIFICATION_NAME';
+
+const TestComponent = () => {
+  const sharedValue = useSharedValue(0);
+  registerValue(SHARED_VALUE_REF, sharedValue as SharedValue<unknown>);
+
+  useEffect(() => {
+    const callback = (num: number) => {
+      'worklet';
+      sharedValue.value = num;
+      notify(NOTIFICATION_NAME);
+    };
+    scheduleOnUI(callback, 100);
+  }, [sharedValue]);
+
+  return <View />;
+};
+
+describe('scheduleOnUI', () => {
+  test('use scheduleOnUI to run a function on the UI runtime', async () => {
+    // Arrange & Act
+    await render(<TestComponent />);
+
+    // Assert
+    await waitForNotify(NOTIFICATION_NAME);
+    const sharedValueOnJS = await getRegisteredValue(SHARED_VALUE_REF);
+    expect(sharedValueOnJS.onJS).toBe(100, ComparisonMode.NUMBER);
+  });
+});

--- a/packages/docs-worklets/docs/threading/runOnUI.mdx
+++ b/packages/docs-worklets/docs/threading/runOnUI.mdx
@@ -2,6 +2,14 @@
 sidebar_position: 2
 ---
 
+<DeprecatedBanner
+  text={
+    <>
+      This API is deprecated and will be removed in the next major release. Use <a href="/docs/threading/scheduleOnUI">scheduleOnUI</a> instead.
+    </>
+  }
+/>
+
 # runOnUI
 
 `runOnUI` lets you asynchronously run [workletized](/docs/fundamentals/glossary#to-workletize) functions on the [UI thread](/docs/fundamentals/glossary#ui-thread).

--- a/packages/docs-worklets/docs/threading/scheduleOnUI.mdx
+++ b/packages/docs-worklets/docs/threading/scheduleOnUI.mdx
@@ -1,0 +1,53 @@
+---
+sidebar_position: 11
+---
+
+# scheduleOnUI
+
+`scheduleOnUI` lets you schedule a function to be executed on the [UI Runtime](/docs/fundamentals/glossary#ui-runtime) from [RN Runtime](/docs/fundamentals/glossary#react-native-runtime-rn-runtime).
+
+## Reference
+
+```javascript
+import { scheduleOnUI } from 'react-native-worklets';
+
+const myFunction = (): void => {
+  'worklet';
+  console.log('Hello from the UI Runtime!');
+};
+
+scheduleOnUI(myFunction); // Hello from the UI Runtime!
+```
+
+
+<details>
+<summary>Type definitions</summary>
+
+```typescript
+function scheduleOnUI<Args extends unknown[], ReturnValue>(
+  fun: (...args: Args) => ReturnValue,
+  ...args: Args
+): void
+```
+
+</details>
+
+### Arguments
+
+#### fun
+
+A reference to a function you want to schedule on the [UI Runtime](/docs/fundamentals/glossary#ui-runtime).
+
+#### args
+
+Arguments to pass to the function.
+
+## Remarks
+
+- This method does not schedule the work immediately but instead waits for other worklets to be scheduled within the same JS loop. It uses `queueMicrotask` to schedule all the worklets at once making sure they will run within the same frame boundaries on the [UI Runtime](/docs/fundamentals/glossary#ui-runtime).
+
+- The callback passed as the argument is automatically [workletized](/docs/fundamentals/glossary#to-workletize) and ready to be run on the [UI Runtime](/docs/fundamentals/glossary#ui-runtime).
+
+- Make sure not to execute `scheduleOnUI` on the [UI Runtime](/docs/fundamentals/glossary#ui-runtime) or [Worker Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime) as this will result in an error.
+
+- In browsers there's no separate UI Runtime available. Because of that, on the Web, `scheduleOnUI` behaves similarly to `requestAnimationFrame`. It creates a function that, when called, will be scheduled to run with given arguments on next animation frame.

--- a/packages/react-native-worklets/__typetests__/scheduleOnUI.tsx
+++ b/packages/react-native-worklets/__typetests__/scheduleOnUI.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { scheduleOnUI } from '..';
+
+function scheduleOnUITypeTests() {
+  // Correct usage - correct usage
+  scheduleOnUI((num: number) => {
+    console.log(num);
+  }, 0);
+
+  // Correct usage - correct usage
+  scheduleOnUI((obj: Record<string, unknown>) => console.log(obj), { a: [] });
+
+  scheduleOnUI((num: number) => {
+    console.log(num);
+    // @ts-expect-error - wrong args type
+  }, 'tets');
+
+  // @ts-expect-error - wrong args type
+  scheduleOnUI((obj: Record<string, unknown>) => console.log(obj), []);
+
+  // @ts-expect-error - expected no args, but arg is provided
+  scheduleOnUI(() => {}, 0);
+
+  // @ts-expect-error - expected args, but arg is not provided
+  scheduleOnUI((num: number) => {
+    console.log(num);
+  });
+}

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -31,6 +31,7 @@ export {
   runOnUIAsync,
   runOnUISync,
   scheduleOnRN,
+  scheduleOnUI,
 } from './threads';
 export { isWorkletFunction } from './workletFunction';
 export type { IWorkletsModule, WorkletsModuleProxy } from './WorkletsModule';

--- a/packages/react-native-worklets/src/threads.ts
+++ b/packages/react-native-worklets/src/threads.ts
@@ -60,18 +60,18 @@ export const callMicrotasks = SHOULD_BE_USE_WEB
 
 /**
  * Lets you schedule a function to be executed on the [UI
- * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime)
+ * from the [RN
+ * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#react-native-runtime-rn-runtime).
  *
- * This method does not schedule the work immediately but instead waits for
- * other worklets to be scheduled within the same JS loop. It uses
- * queueMicrotask to schedule all the worklets at once making sure they will run
- * within the same frame boundaries on the [UI
- * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
- *
- * Passed function and args are automatically
- * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
- * and serialized.
- *
+ * - This method does not schedule the work immediately but instead waits for
+ *   other worklets to be scheduled within the same JS loop. It uses
+ *   `queueMicrotask` to schedule all the worklets at once making sure they will
+ *   run within the same frame boundaries on the [UI
+ *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ * - Passed function and args are automatically
+ *   [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
+ *   and serialized.
  * - This function cannot be called from the [UI
  *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
  * - This function cannot be called from a [Worker

--- a/packages/react-native-worklets/src/threads.ts
+++ b/packages/react-native-worklets/src/threads.ts
@@ -59,6 +59,37 @@ export const callMicrotasks = SHOULD_BE_USE_WEB
   : callMicrotasksOnUIThread;
 
 /**
+ * Lets you schedule a function to be executed on the [UI
+ * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ *
+ * This method does not schedule the work immediately but instead waits for
+ * other worklets to be scheduled within the same JS loop. It uses
+ * queueMicrotask to schedule all the worklets at once making sure they will run
+ * within the same frame boundaries on the [UI
+ * Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ *
+ * Passed function and args are automatically
+ * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
+ * and serialized.
+ *
+ * - This function cannot be called from the [UI
+ *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ * - This function cannot be called from a [Worker
+ *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
+ *
+ * @param fun - A reference to a function you want to schedule on the [UI
+ *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#ui-runtime).
+ * @param args - Arguments to pass to the function.
+ * @see https://docs.swmansion.com/react-native-worklets/docs/threading/scheduleOnUI
+ */
+export function scheduleOnUI<Args extends unknown[], ReturnValue>(
+  worklet: (...args: Args) => ReturnValue,
+  ...args: Args
+): void {
+  runOnUI(worklet)(...args);
+}
+
+/**
  * Lets you asynchronously run
  * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
  * functions on the [UI
@@ -75,7 +106,7 @@ export const callMicrotasks = SHOULD_BE_USE_WEB
  *   thread](https://docs.swmansion.com/react-native-worklets/docs/threading/runOnUI/).
  * @returns A function that accepts arguments for the function passed as the
  *   first argument.
- * @see https://docs.swmansion.com/react-native-worklets/docs/threading/runOnUI/
+ * @see https://docs.swmansion.com/react-native-worklets/docs/threading/runOnUI
  */
 // @ts-expect-error This overload is correct since it's what user sees in his code
 // before it's transformed by Reanimated Babel plugin.
@@ -323,7 +354,7 @@ export function scheduleOnRN<Args extends unknown[], ReturnValue>(
  *   Runtime](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#javascript-runtime).
  * @returns A promise that resolves to the return value of the function passed
  *   as the first argument.
- * @see https://docs.swmansion.com/react-native-worklets/docs/threading/runOnUIAsync/
+ * @see https://docs.swmansion.com/react-native-worklets/docs/threading/runOnUIAsync
  */
 export function runOnUIAsync<Args extends unknown[], ReturnValue>(
   worklet: (...args: Args) => ReturnValue


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
This PR : 

- adds `scheduleOnUI` API function
- marks `runOnUI` as deprecated
- adds `scheduleOnUI` type tests and runtime test
- adds docs for `scheduleOnUI` function

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan
`docs`: 
<img width="1067" height="815" alt="image" src="https://github.com/user-attachments/assets/7aecc355-40fd-4e02-a2df-e7068839e7c1" />
<img width="817" height="495" alt="image" src="https://github.com/user-attachments/assets/01e448ce-5cb9-4ae6-9699-11898b9bed4c" />

`runtime tests`:
<img width="1277" height="592" alt="image" src="https://github.com/user-attachments/assets/b18540bc-b121-40fa-9fb2-8b03d4e7405b" />


<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
