### PR TITLE
feat(Worklets): `scheduleOnRuntime`

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -56,6 +56,7 @@ export default function RuntimeTestsExample() {
             require('./tests/runtimes/createWorkletRuntime.test');
             require('./tests/runtimes/scheduleOnRN.test');
             require('./tests/runtimes/runOnUISync.test');
+            require('./tests/runtimes/scheduleOnRuntime.test');
           },
         },
         {

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntime.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntime.test.tsx
@@ -1,0 +1,78 @@
+import { createSynchronizable, createWorkletRuntime, runOnJS, scheduleOnRuntime } from 'react-native-worklets';
+import { describe, expect, test, waitForNotify, notify } from '../../ReJest/RuntimeTestsApi';
+import { ComparisonMode } from '../../ReJest/types';
+
+const NOTIFICATION_NAME = 'NOTIFICATION_NAME';
+
+describe('scheduleOnRN', () => {
+  // For now there is no way to schedule a function on the Worker Runtime from the UI Runtime
+  //   test('should schedule a function on the RN runtime from UI', async () => {
+  //     // Arrange
+  //     const synchronizable = createSynchronizable(0);
+  //     const workletRuntime = createWorkletRuntime({ name: 'test' });
+  //     const onJSCallback = () => {
+  //       notify(NOTIFICATION_NAME);
+  //     };
+
+  //     // Act
+  //     runOnUI(() => {
+  //       'worklet';
+  //       scheduleOnRuntime(workletRuntime, () => {
+  //         'worklet';
+  //         synchronizable.setBlocking(100);
+  //         runOnJS(onJSCallback)();
+  //       });
+  //     })();
+
+  //     // Assert
+  //     await waitForNotify(NOTIFICATION_NAME);
+  //   });
+
+  test('should schedule a function on the Worker Runtime from RN Runtime', async () => {
+    // Arrange
+    const synchronizable = createSynchronizable(0);
+    const workletRuntime = createWorkletRuntime({ name: 'test' });
+
+    const onJSCallback = () => {
+      notify(NOTIFICATION_NAME);
+    };
+
+    // Act
+    scheduleOnRuntime(workletRuntime, () => {
+      'worklet';
+      synchronizable.setBlocking(100);
+      runOnJS(onJSCallback)();
+    });
+
+    // Assert
+    await waitForNotify(NOTIFICATION_NAME);
+    expect(synchronizable.getBlocking()).toBe(100, ComparisonMode.NUMBER);
+  });
+
+  // For now there is no way to schedule a function on the Worker Runtime from the other Worker Runtime
+  //   test('should schedule a function on the RN runtime from workletRuntime', async () => {
+  //     // Arrange
+  //     const synchronizable = createSynchronizable(0);
+  //     const workletRuntime = createWorkletRuntime({ name: 'test' });
+  //     const workletRuntime2 = createWorkletRuntime({ name: 'test2' });
+
+  //     const onJSCallback = () => {
+  //       notify(NOTIFICATION_NAME);
+  //     };
+
+  //     // Act
+  //     scheduleOnRuntime(workletRuntime, () => {
+  //       'worklet';
+
+  //       scheduleOnRuntime(workletRuntime2, () => {
+  //         'worklet';
+  //         synchronizable.setBlocking(200);
+  //         runOnJS(onJSCallback)();
+  //       });
+  //     });
+
+  //     // Assert
+  //     await waitForNotify(NOTIFICATION_NAME);
+  //     expect(synchronizable.getBlocking()).toBe(200, ComparisonMode.NUMBER);
+  //   });
+});

--- a/packages/docs-worklets/docs/threading/runOnRuntime.mdx
+++ b/packages/docs-worklets/docs/threading/runOnRuntime.mdx
@@ -2,6 +2,14 @@
 sidebar_position: 5
 ---
 
+<DeprecatedBanner
+  text={
+    <>
+      This API is deprecated and will be removed in the next major release. Use <a href="/docs/threading/scheduleOnRuntime">scheduleOnRuntime</a> instead.
+    </>
+  }
+/>
+
 # runOnRuntime
 
 `runOnRuntime` lets you asynchronously run [workletized](/docs/fundamentals/glossary#to-workletize) functions on a separate worklet runtime on a separate thread.

--- a/packages/docs-worklets/docs/threading/scheduleOnRuntime.mdx
+++ b/packages/docs-worklets/docs/threading/scheduleOnRuntime.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 12
+---
+
+# scheduleOnRuntime
+
+`scheduleOnRuntime` lets you schedule a function to be executed on a separate worklet runtime.
+
+## Reference
+
+```javascript
+import { scheduleOnRuntime, createWorkletRuntime } from 'react-native-worklets';
+
+const workletRuntime = createWorkletRuntime({ name: 'background' });
+
+scheduleOnRuntime(workletRuntime, (greeting: string) => {
+  console.log(`${greeting} from the background Worklet Runtime`);
+}, 'Hello');
+```
+
+<details>
+<summary>Type definitions</summary>
+
+```typescript
+function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
+  workletRuntime: WorkletRuntime,
+  worklet: (...args: Args) => ReturnValue,
+  ...args: Args
+): void
+```
+
+</details>
+
+## Arguments
+
+### workletRuntime
+
+The worklet runtime to schedule the worklet on.
+
+### worklet
+
+A reference to a function you want to execute on the [Worklet Runtime](/docs/fundamentals/glossary#worklet-runtime).
+
+### args
+
+Arguments to the function you want to execute on the [Worklet Runtime](/docs/fundamentals/glossary#worklet-runtime).
+
+## Remarks
+
+- The worklet is scheduled on the Worker Runtime's [Async
+  Queue](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/Tools/AsyncQueueImpl.cpp)
+- The worklet cannot be scheduled on the Worker Runtime from [UI
+  Runtime](/docs/fundamentals/glossary#ui-runtime) or another [Worker
+  Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime)
+
+```javascript
+import { createWorkletRuntime, scheduleOnRuntime } from 'react-native-worklets';
+
+const workletRuntime = createWorkletRuntime({ name: 'background' });
+
+runOnUI(() => {
+  scheduleOnRuntime(workletRuntime, (greeting: string) => { 
+    console.log(`${greeting} from the background Worklet Runtime`); 
+  }, 'Hello'); // This will throw an error 🚨
+});
+```
+
+```javascript
+import { createWorkletRuntime, scheduleOnRuntime } from 'react-native-worklets';
+
+const workletRuntime = createWorkletRuntime({ name: 'background' });
+const anotherWorkletRuntime = createWorkletRuntime({ name: 'anotherBackground' });
+
+scheduleOnRuntime(anotherWorkletRuntime, () => {
+  scheduleOnRuntime(workletRuntime, (greeting: string) => {
+    console.log(`${greeting} from the background Worklet Runtime`);
+  }, 'Hello'); // This will throw an error 🚨
+});
+```

--- a/packages/react-native-worklets/__typetests__/scheduleOnRuntime.tsx
+++ b/packages/react-native-worklets/__typetests__/scheduleOnRuntime.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { createWorkletRuntime, scheduleOnRuntime } from '..';
+
+function scheduleOnRNTypeTests() {
+  const workletRuntime = createWorkletRuntime({ name: 'test' });
+  // Correct usage - correct usage
+  scheduleOnRuntime(
+    workletRuntime,
+    (num: number) => {
+      'worklet';
+      console.log(num);
+    },
+    0
+  );
+
+  // Correct usage - correct usage
+  scheduleOnRuntime(
+    workletRuntime,
+    (obj: Record<string, unknown>) => console.log(obj),
+    {
+      a: [],
+    }
+  );
+
+  scheduleOnRuntime(
+    workletRuntime,
+    (num: number) => {
+      console.log(num);
+    },
+    // @ts-expect-error - wrong args type
+    'tets'
+  );
+
+  scheduleOnRuntime(
+    workletRuntime,
+    (obj: Record<string, unknown>) => console.log(obj),
+    // @ts-expect-error - wrong args type
+    []
+  );
+
+  // @ts-expect-error - expected no args, but arg is provided
+  scheduleOnRuntime(workletRuntime, () => {}, 0);
+
+  // @ts-expect-error - expected args, but arg is not provided
+  scheduleOnRuntime(workletRuntime, (num: number) => {
+    console.log(num);
+  });
+}

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -18,7 +18,11 @@ export {
 export { getStaticFeatureFlag, setDynamicFeatureFlag } from './featureFlags';
 export { isSynchronizable } from './isSynchronizable';
 export { getRuntimeKind, RuntimeKind } from './runtimeKind';
-export { createWorkletRuntime, runOnRuntime } from './runtimes';
+export {
+  createWorkletRuntime,
+  runOnRuntime,
+  scheduleOnRuntime,
+} from './runtimes';
 export { createSerializable, isSerializableRef } from './serializable';
 export { serializableMappingCache } from './serializableMappingCache';
 export type { Synchronizable } from './synchronizable';

--- a/packages/react-native-worklets/src/runtimes.ts
+++ b/packages/react-native-worklets/src/runtimes.ts
@@ -87,37 +87,6 @@ export function createWorkletRuntime(
   );
 }
 
-/**
- * Lets you asynchronously run
- * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
- * functions on the [Worker
- * Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
- *
- * Check
- * {@link https://docs.swmansion.com/react-native-worklets/docs/fundamentals/runtimeKinds}
- * for more information about the different runtime kinds.
- *
- * - The worklet is automatically
- *   [workletized](/docs/fundamentals/glossary#to-workletize) and ready to be
- *   run on the [Worker
- *   Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
- * - The worklet is scheduled on the Worker Runtime's [Async
- *   Queue](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/Tools/AsyncQueueImpl.cpp)
- *
- * @param workletRuntime - The runtime to schedule the worklet on.
- * @param worklet - The worklet to schedule.
- * @param args - The arguments to pass to the worklet.
- * @returns The return value of the worklet.
- */
-export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
-  workletRuntime: WorkletRuntime,
-  worklet: (...args: Args) => ReturnValue,
-  ...args: Args
-): void {
-  'worklet';
-  runOnRuntime(workletRuntime, worklet)(...args);
-}
-
 /** @deprecated Use `scheduleOnRuntime` instead. */
 // @ts-expect-error Check `runOnUI` overload.
 export function runOnRuntime<Args extends unknown[], ReturnValue>(
@@ -153,6 +122,36 @@ export function runOnRuntime<Args extends unknown[], ReturnValue>(
         worklet(...args);
       })
     );
+}
+
+/**
+ * Lets you asynchronously run
+ * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
+ * functions on the [Worker
+ * Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
+ *
+ * Check
+ * {@link https://docs.swmansion.com/react-native-worklets/docs/fundamentals/runtimeKinds}
+ * for more information about the different runtime kinds.
+ *
+ * - The worklet is scheduled on the Worker Runtime's [Async
+ *   Queue](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/Tools/AsyncQueueImpl.cpp)
+ * - The function cannot be scheduled on the Worker Runtime from [UI
+ *   Runtime](/docs/fundamentals/glossary#ui-runtime) or another [Worker
+ *   Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime)
+ *
+ * @param workletRuntime - The runtime to schedule the worklet on.
+ * @param worklet - The worklet to schedule.
+ * @param args - The arguments to pass to the worklet.
+ * @returns The return value of the worklet.
+ */
+export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
+  workletRuntime: WorkletRuntime,
+  worklet: (...args: Args) => ReturnValue,
+  ...args: Args
+): void {
+  'worklet';
+  runOnRuntime(workletRuntime, worklet)(...args);
 }
 
 /** Configuration object for creating a worklet runtime. */

--- a/packages/react-native-worklets/src/runtimes.ts
+++ b/packages/react-native-worklets/src/runtimes.ts
@@ -87,6 +87,38 @@ export function createWorkletRuntime(
   );
 }
 
+/**
+ * Lets you asynchronously run
+ * [workletized](https://docs.swmansion.com/react-native-worklets/docs/fundamentals/glossary#to-workletize)
+ * functions on the [Worker
+ * Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
+ *
+ * Check
+ * {@link https://docs.swmansion.com/react-native-worklets/docs/fundamentals/runtimeKinds}
+ * for more information about the different runtime kinds.
+ *
+ * - The worklet is automatically
+ *   [workletized](/docs/fundamentals/glossary#to-workletize) and ready to be
+ *   run on the [Worker
+ *   Runtime](/docs/fundamentals/glossary#worker-worklet-runtime---worker-runtime).
+ * - The worklet is scheduled on the Worker Runtime's [Async
+ *   Queue](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/Tools/AsyncQueueImpl.cpp)
+ *
+ * @param workletRuntime - The runtime to schedule the worklet on.
+ * @param worklet - The worklet to schedule.
+ * @param args - The arguments to pass to the worklet.
+ * @returns The return value of the worklet.
+ */
+export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
+  workletRuntime: WorkletRuntime,
+  worklet: (...args: Args) => ReturnValue,
+  ...args: Args
+): void {
+  'worklet';
+  runOnRuntime(workletRuntime, worklet)(...args);
+}
+
+/** @deprecated Use `scheduleOnRuntime` instead. */
 // @ts-expect-error Check `runOnUI` overload.
 export function runOnRuntime<Args extends unknown[], ReturnValue>(
   workletRuntime: WorkletRuntime,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
This PR :

- adds `scheduleOnRuntime` API function
- marks `runOnRuntime` as deprecated
- adds `scheduleOnRuntime` type tests and runtime test
- adds docs for `scheduleOnRuntime` function

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

`docs`: 
<img width="1260" height="754" alt="image" src="https://github.com/user-attachments/assets/4f3d010a-6860-40a9-ac00-2d20ee4e4eb5" />
<img width="1206" height="1008" alt="image" src="https://github.com/user-attachments/assets/732bdfec-eeac-4b8b-806e-ab4715e88114" />
<img width="1086" height="690" alt="image" src="https://github.com/user-attachments/assets/d4e7ee41-ed53-4327-986b-4ad88dd8e379" />

`runtime tests`:
<img width="1459" height="766" alt="image" src="https://github.com/user-attachments/assets/18805ce0-cef8-46f9-91d2-fc6c76f59417" />


<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
