### PR TITLE
docs: how to enable feature flags in react-native

### DIFF
--- a/packages/docs-reanimated/docs/guides/feature-flags.md
+++ b/packages/docs-reanimated/docs/guides/feature-flags.md
@@ -33,7 +33,7 @@ Feature flags available in `react-native-worklets` are listed [on this page](htt
 
 When enabled, this feature flag is supposed to eliminate jittering of animated components like sticky header while scrolling. This feature flag is safe to enable only if `preventShadowTreeCommitExhaustion` feature flag from `react-native` (available since React Native 0.81) is also enabled – see instructions below. In all other cases it can lead to unresponsiveness of the app due to the starvation of React commits. For more details, see [PR #7852](https://github.com/software-mansion/react-native-reanimated/pull/7852).
 
-In React Native, `preventShadowTreeCommitExhaustion` feature flag can be enabled by setting experimental release level. For Android, you need to add the following lines in `MainApplication.kt` of your app:
+In React Native 0.81, `preventShadowTreeCommitExhaustion` feature flag can be enabled by setting experimental release level. For Android, you need to add the following lines in `MainApplication.kt` of your app:
 
 ```kt
 package com.helloworld


### PR DESCRIPTION
## Summary

This PR adds instructions how to enable React Native feature flags by setting experimental release level on Android and iOS.

## Test plan
