### PR TITLE
(cherry-pick) Fix "Cannot read property '__nativeTag' of null"  (#8093)

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -103,7 +103,7 @@ export class NativeEventsManager implements INativeEventsManager {
       // On the first render of a component, we may already receive a resolved view tag.
       return this.#managedComponent.getComponentViewTag();
     }
-    if (componentAnimatedRef.__nativeTag) {
+    if (componentAnimatedRef?.__nativeTag) {
       return componentAnimatedRef.__nativeTag ?? -1;
     }
     /*


### PR DESCRIPTION
Cherry-pick of the #8093