### PR TITLE
(cherry-pick) fix: CSS transition crashes on complex prop animation

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/testExamples/Playground.tsx
@@ -18,12 +18,31 @@ const transitionStyles: Array<ViewStyle> = [
       { skewX: '45deg' },
       { rotateX: '45deg' },
     ],
+    boxShadow:
+      'inset 0 0 20px 10px rgba(34, 197, 94, 0.3), 0 8px 16px #ff6b35, 0 16px 32px rgba(59, 130, 246, 0.4)',
   },
   {
     backgroundColor: 'blue',
     borderRadius: 100,
     opacity: 0.5,
     transform: [{ translateY: 200 }, { rotate: '45deg' }, { scale: 2 }],
+    boxShadow: [
+      {
+        color: 'rgba(34, 197, 94, 0.8)',
+        offsetX: 0,
+        offsetY: 8,
+        blurRadius: 12,
+        spreadDistance: 0,
+      },
+      {
+        color: '#dc2626',
+        inset: true,
+        offsetX: 4,
+        offsetY: 4,
+        blurRadius: 8,
+        spreadDistance: 2,
+      },
+    ],
   },
   {
     backgroundColor: 'green',

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -45,14 +45,19 @@ void ArrayPropertiesInterpolator::updateKeyframesFromStyleChange(
     const folly::dynamic &oldStyleValue,
     const folly::dynamic &newStyleValue,
     const folly::dynamic &lastUpdateValue) {
-  const folly::dynamic empty = folly::dynamic::array();
-  const auto oldStyleArray = !oldStyleValue.empty() ? oldStyleValue : empty;
-  const auto newStyleArray = !newStyleValue.empty() ? newStyleValue : empty;
-  const auto lastUpdateArray =
-      !lastUpdateValue.empty() ? lastUpdateValue : empty;
+  const auto emptyArray = folly::dynamic::array();
+  const auto null = folly::dynamic();
+
+  const auto &oldStyleArray =
+      oldStyleValue.empty() ? emptyArray : oldStyleValue;
+  const auto &newStyleArray =
+      newStyleValue.empty() ? emptyArray : newStyleValue;
+  const auto &lastUpdateArray =
+      lastUpdateValue.empty() ? emptyArray : lastUpdateValue;
 
   const size_t oldSize = oldStyleArray.size();
   const size_t newSize = newStyleArray.size();
+  const size_t lastSize = lastUpdateArray.size();
   const size_t valuesCount = std::max(oldSize, newSize);
 
   resizeInterpolators(valuesCount);
@@ -61,9 +66,9 @@ void ArrayPropertiesInterpolator::updateKeyframesFromStyleChange(
     // These index checks ensure that interpolation works between 2 arrays
     // with different lengths
     interpolators_[i]->updateKeyframesFromStyleChange(
-        i < oldSize ? oldStyleArray[i] : empty,
-        i < newSize ? newStyleArray[i] : empty,
-        i < valuesCount ? lastUpdateArray[i] : empty);
+        i < oldSize ? oldStyleArray[i] : null,
+        i < newSize ? newStyleArray[i] : null,
+        i < lastSize ? lastUpdateArray[i] : null);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -37,14 +37,16 @@ void RecordPropertiesInterpolator::updateKeyframesFromStyleChange(
     const folly::dynamic &newStyleValue,
     const folly::dynamic &lastUpdateValue) {
   // TODO - maybe add a possibility to remove interpolators that are no longer
-  // used  (for now, for simplicity, we only add new ones)
-  const folly::dynamic empty = folly::dynamic::object();
-  const folly::dynamic &oldStyleObject =
-      !oldStyleValue.empty() ? oldStyleValue : empty;
-  const folly::dynamic &newStyleObject =
-      !newStyleValue.empty() ? newStyleValue : empty;
-  const folly::dynamic &lastUpdateObject =
-      !lastUpdateValue.empty() ? lastUpdateValue : empty;
+  // used (for now, for simplicity, we only add new ones)
+  const folly::dynamic emptyObject = folly::dynamic::object();
+  const auto null = folly::dynamic();
+
+  const auto &oldStyleObject =
+      oldStyleValue.empty() ? emptyObject : oldStyleValue;
+  const auto &newStyleObject =
+      newStyleValue.empty() ? emptyObject : newStyleValue;
+  const auto &lastUpdateObject =
+      lastUpdateValue.empty() ? emptyObject : lastUpdateValue;
 
   std::unordered_set<std::string> propertyNamesSet;
   for (const auto &key : oldStyleObject.keys()) {
@@ -57,9 +59,9 @@ void RecordPropertiesInterpolator::updateKeyframesFromStyleChange(
   for (const auto &propertyName : propertyNamesSet) {
     maybeCreateInterpolator(propertyName);
     interpolators_[propertyName]->updateKeyframesFromStyleChange(
-        oldStyleObject.getDefault(propertyName, empty),
-        newStyleObject.getDefault(propertyName, empty),
-        lastUpdateObject.getDefault(propertyName, empty));
+        oldStyleObject.getDefault(propertyName, null),
+        newStyleObject.getDefault(propertyName, null),
+        lastUpdateObject.getDefault(propertyName, null));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -87,9 +87,10 @@ void TransitionStyleInterpolator::updateInterpolatedProperties(
     const auto &newValue = newPropsObj.getDefault(propertyName, empty);
     // Pass lastValue only if the interpolator is updated (no new interpolator
     // was created), otherwise pass an empty value
-    const auto &lastValue = !shouldCreateInterpolator
-        ? lastUpdateValue.getDefault(propertyName, empty)
-        : empty;
+    const auto &lastValue =
+        (shouldCreateInterpolator || lastUpdateValue.empty())
+        ? empty
+        : lastUpdateValue.getDefault(propertyName, empty);
 
     it->second->updateKeyframesFromStyleChange(oldValue, newValue, lastValue);
   }


### PR DESCRIPTION
Cherry-pick of the #8106