### PR TITLE
Enable experimental release level and `DISABLE_COMMIT_PAUSING_MECHANISM` static feature flag in fabric-example

### DIFF
--- a/apps/fabric-example/android/app/src/main/java/com/fabricexample/MainApplication.kt
+++ b/apps/fabric-example/android/app/src/main/java/com/fabricexample/MainApplication.kt
@@ -7,9 +7,11 @@ import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.common.assets.ReactFontManager
+import com.facebook.react.common.ReleaseLevel
 
 class MainApplication : Application(), ReactApplication {
 
@@ -34,6 +36,7 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
+    DefaultNewArchitectureEntryPoint.releaseLevel = ReleaseLevel.EXPERIMENTAL
     loadReactNative(this)
 
     ReactFontManager.getInstance().addCustomFont(this, "Poppins", R.font.poppins)

--- a/apps/fabric-example/ios/FabricExample/AppDelegate.swift
+++ b/apps/fabric-example/ios/FabricExample/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     let delegate = ReactNativeDelegate()
-    let factory = RCTReactNativeFactory(delegate: delegate)
+    let factory = RCTReactNativeFactory(delegate: delegate, releaseLevel: RCTReleaseLevel.Experimental)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeDelegate = delegate

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -24,6 +24,7 @@
   },
   "reanimated": {
     "staticFeatureFlags": {
+      "DISABLE_COMMIT_PAUSING_MECHANISM": true,
       "RUNTIME_TEST_FLAG": true
     }
   },


### PR DESCRIPTION
## Summary

This PR enables React Native experimental release level which results in enabling `preventShadowTreeCommitExhaustion` React Native feature flag as well as `DISABLE_COMMIT_PAUSING_MECHANISM` Reanimated static feature flag in fabric-example app on Android and iOS.

## Test plan
