### PR TITLE
cherry-pick(Worklets): Fix static feature flags resolution on iOS #8130

### DIFF
--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -10,7 +10,7 @@ worklets_assert_new_architecture_enabled($new_arch_enabled)
 
 ios_min_version = '13.4'
 
-feature_flags = "-DWORKLETS_FEATURE_FLAGS=\"#{get_static_feature_flags()}\""
+feature_flags = "-DWORKLETS_FEATURE_FLAGS=\"#{worklets_get_static_feature_flags()}\""
 version_flags = "-DWORKLETS_VERSION=#{package['version']}"
 
 Pod::Spec.new do |s|

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -66,7 +66,7 @@ def worklets_assert_new_architecture_enabled(new_arch_enabled)
   end
 end
 
-def get_static_feature_flags()
+def worklets_get_static_feature_flags()
   feature_flags = {}
 
   static_feature_flags_path = File.path('./src/featureFlags/staticFlags.json')


### PR DESCRIPTION
## Summary

This PR fixes static feature flags resolution on iOS in `react-native-reanimated` due to a name clash of `get_static_feature_flags` functions defined both in `reanimated_utils.rb` and `worklets_utils.rb` which would result in the latter being called for both libraries. Adding `worklets_` prefix for consistency with other functions resolves the issue.

## Test plan
