### PR TITLE
Fix worklets version checking in runtime

### DIFF
--- a/packages/react-native-reanimated/scripts/validate-worklets-build.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-build.js
@@ -2,9 +2,14 @@
 
 // We don't use this script in runtime since `process` might not be available.
 
+const path = require('path');
+const packageJsonPath = path.resolve(__dirname, '../package.json');
+const packageJson = require(packageJsonPath);
+const reanimatedVersion = packageJson.version;
+
 const validateVersion = require('./validate-worklets-version');
 
-const result = validateVersion();
+const result = validateVersion(reanimatedVersion);
 if (!result.ok) {
   // eslint-disable-next-line reanimated/use-logger
   console.error('[Reanimated] ' + result.message);

--- a/packages/react-native-reanimated/scripts/validate-worklets-version.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-version.js
@@ -2,18 +2,12 @@
 
 const semverSatisfies = require('semver/functions/satisfies');
 const semverPrerelease = require('semver/functions/prerelease');
-const path = require('path');
 const expectedVersion = require('./worklets-version.json');
 const compatibilityFile = require('../compatibility.json');
 
-const packageJsonPath = path.resolve(__dirname, '../package.json');
-const packageJson = require(packageJsonPath);
-const reanimatedVersion = packageJson.version;
-
 /** @returns {{ ok: boolean; message?: string }} */
-function validateVersion() {
+function validateVersion(reanimatedVersion) {
   let workletsVersion;
-
   try {
     const { version } = require('react-native-worklets/package.json');
     workletsVersion = version;

--- a/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/workletsVersion.ts
@@ -4,9 +4,10 @@
 import validateWorkletsVersion from 'react-native-reanimated/scripts/validate-worklets-version';
 
 import { ReanimatedError } from '../common/errors';
+import { jsVersion as reanimatedVersion } from './jsVersion';
 
 export function assertWorkletsVersion() {
-  const result = validateWorkletsVersion();
+  const result = validateWorkletsVersion(reanimatedVersion);
 
   if (!result.ok) {
     throw new ReanimatedError(result.message);


### PR DESCRIPTION
## Summary
Fix worklets version checking in runtime:
<img width="446" height="942" alt="image" src="https://github.com/user-attachments/assets/1731e63a-51cb-4c9e-9ed2-b46899a6e3b9" />

We can dynamically resolve imports with `require(packageJsonPath)`. I changed the implementation to accept the Reanimated version as a parameter.

## Test plan
