### PR TITLE
Deprecate old spring layout animations modifiers

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SwipeableListExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SwipeableListExample.tsx
@@ -84,8 +84,6 @@ const springConfig = (velocity: number) => {
     damping: 500,
     mass: 3,
     overshootClamping: true,
-    restDisplacementThreshold: 0.01,
-    restSpeedThreshold: 0.01,
     velocity,
   };
 };

--- a/packages/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -135,8 +135,7 @@ FadeInUp.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -144,8 +143,7 @@ FadeInUp.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -390,8 +388,7 @@ FlipInXUp.springify()
   .mass(3)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -399,8 +396,7 @@ FlipInXUp.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -519,8 +515,7 @@ LightSpeedInLeft.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -528,8 +523,7 @@ LightSpeedInLeft.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -640,8 +634,7 @@ PinwheelIn.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -649,8 +642,7 @@ PinwheelIn.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -767,8 +759,7 @@ RollInLeft.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -776,8 +767,7 @@ RollInLeft.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -906,8 +896,7 @@ RotateInUpLeft.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -915,8 +904,7 @@ RotateInUpLeft.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -1045,8 +1033,7 @@ SlideInUp.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -1054,8 +1041,7 @@ SlideInUp.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -1171,8 +1157,7 @@ StretchInX.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -1180,8 +1165,7 @@ StretchInX.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -1332,8 +1316,7 @@ ZoomInRotate.springify()
   .mass(5)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(0.1);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -1341,8 +1324,7 @@ ZoomInRotate.springify()
 - `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
 - `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second from which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 

--- a/packages/docs-reanimated/docs/layout-animations/layout-transitions.mdx
+++ b/packages/docs-reanimated/docs/layout-animations/layout-transitions.mdx
@@ -63,8 +63,7 @@ LinearTransition.springify()
   .rotate(20)
   .stiffness(10)
   .overshootClamping(false)
-  .restDisplacementThreshold(0.1)
-  .restSpeedThreshold(5);
+  .energyThreshold(6e-8);
 ```
 
 - `.springify()` enables the spring-based animation configuration.
@@ -74,8 +73,7 @@ LinearTransition.springify()
 - `.rotate(degree: string)` lets you rotate the element.
 - `.stiffness(value: number)` decides how bouncy the spring is - the higher the number, the less bouncy it is. Defaults to `100`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
-- `.restDisplacementThreshold(value: number)` is the displacement below which the spring will snap to the designated position without further oscillations. Defaults to `0.001`.
-- `.restSpeedThreshold(value: number)` is the speed in pixels per second below which the spring will snap to the designated position without further oscillations. Defaults to `2`.
+- `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
 #### Common <Optional/>
 
@@ -93,10 +91,6 @@ LinearTransition.delay(500)
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion [accessibility](/docs/guides/accessibility) setting.
 - `.withInitialValues(values: StyleProps)` allows to override the initial config of the animation.
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
-
-### Remarks
-
-- The animation will end if **both** the animation speed is below `restSpeedThreshold` and the distance to its end is less than `restDisplacementThreshold`. Keep in mind that if you haven't set one of the thresholds, its value will be set to the default.
 
 ### Example
 

--- a/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/Controls/SpringControls.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/Controls/SpringControls.tsx
@@ -59,28 +59,15 @@ const SpringControls = ({
         }}
       />
       <Range
-        label="Displacement threshold"
-        min={0.01}
-        max={150}
-        step={0.01}
-        value={type.restDisplacementThreshold}
+        label="Energy threshold"
+        min={1e-12}
+        max={1e-1}
+        step={1e-12}
+        value={type.energyThreshold}
         onChange={(option) => {
           setType((prevState) => ({
             ...prevState,
-            restDisplacementThreshold: option,
-          }));
-        }}
-      />
-      <Range
-        label="Speed threshold"
-        min={0.01}
-        max={150}
-        step={0.01}
-        value={type.restSpeedThreshold}
-        onChange={(option) => {
-          setType((prevState) => ({
-            ...prevState,
-            restSpeedThreshold: option,
+            energyThreshold: option,
           }));
         }}
       />

--- a/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/Example.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/Example.tsx
@@ -176,7 +176,7 @@ export const EXITING_ANIMATIONS = {
 };
 
 // when springify() on web is enabled, add following props:
-// isSpringBased, mass, damping, stiffness, overshootClamping, restDisplacementThreshold, restSpeedThreshold
+// isSpringBased, mass, damping, stiffness, overshootClamping, energyThreshold
 
 export default function Example({ entering, exiting }: ExampleProps) {
   const [visible, setVisible] = React.useState(true);

--- a/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/index.tsx
+++ b/packages/docs-reanimated/src/components/InteractivePlayground/useEnteringExitingAnimationPlayground/index.tsx
@@ -38,8 +38,7 @@ export interface EnteringExitingConfigProps
 //   mass: 1,
 //   stiffness: 100,
 //   overshootClamping: false,
-//   restDisplacementThreshold: 0.01,
-//   restSpeedThreshold: 2,
+//   energyThreshold: 6e-9,
 // };
 
 const defaultEasingConfig = {
@@ -208,9 +207,7 @@ export default function useEnteringExitingPlayground() {
        // .mass(${entering.mass})
        // .damping(${entering.damping})
        // .stiffness(${entering.stiffness})
-       // .overshootClamping(${entering.overshootClamping})
-       // .restDisplacementThreshold(${entering.restDisplacementThreshold})
-       // .restSpeedThreshold(${entering.restSpeedThreshold}`
+       // .overshootClamping(${entering.overshootClamping})`
        `.duration(${entering.duration})
      .easing(${formatEasing(entering).code})`
      }
@@ -228,9 +225,7 @@ export default function useEnteringExitingPlayground() {
        // .mass(${exiting.mass})
        // .damping(${exiting.damping})
        // .stiffness(${exiting.stiffness})
-       // .overshootClamping(${exiting.overshootClamping})
-       // .restDisplacementThreshold(${exiting.restDisplacementThreshold})
-       // .restSpeedThreshold(${exiting.restSpeedThreshold}`
+       // .overshootClamping(${exiting.overshootClamping})`
        `.duration(${exiting.duration})
      .easing(${formatEasing(exiting).code})`
      }

--- a/packages/docs-reanimated/src/examples/SpringCarousel.tsx
+++ b/packages/docs-reanimated/src/examples/SpringCarousel.tsx
@@ -34,10 +34,7 @@ export default function App() {
     ) {
       const newOffset = offset.value + (SIZE + 2 * MARGIN) * -position;
       // highlight-start
-      offset.value = withSpring(newOffset, {
-        restDisplacementThreshold: 5,
-        restSpeedThreshold: 5,
-      });
+      offset.value = withSpring(newOffset);
       // highlight-end
     }
   };

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -122,8 +122,7 @@ export interface BaseLayoutAnimationConfig {
   mass?: number;
   stiffness?: number;
   overshootClamping?: number;
-  restDisplacementThreshold?: number;
-  restSpeedThreshold?: number;
+  energyThreshold?: number;
 }
 
 export interface BaseBuilderAnimationConfig extends BaseLayoutAnimationConfig {

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -20,8 +20,7 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
   massV?: number;
   stiffnessV?: number;
   overshootClampingV?: number;
-  restDisplacementThresholdV?: number;
-  restSpeedThresholdV?: number;
+  energyThresholdV?: number;
   initialValues?: StyleProps;
 
   static createInstance: <T extends typeof BaseAnimationBuilder>(
@@ -195,45 +194,61 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
   }
 
   /**
-   * Lets you adjust the rest displacement threshold of the spring animation.
-   * Can be chained alongside other [layout animation
-   * modifiers](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#layout-animation-modifier).
-   *
-   * @param restDisplacementThreshold - The displacement below which the spring
-   *   will snap to the designated position without further oscillations.
+   * @deprecated Use {@link energyThreshold} instead. This method currently does
+   *   nothing and will be removed in the upcoming major version.
    */
   static restDisplacementThreshold<T extends typeof ComplexAnimationBuilder>(
     this: T,
-    restDisplacementThreshold: number
+    _restDisplacementThreshold: number
   ) {
-    const instance = this.createInstance();
-    return instance.restDisplacementThreshold(restDisplacementThreshold);
+    return this.createInstance();
   }
 
-  restDisplacementThreshold(restDisplacementThreshold: number) {
-    this.restDisplacementThresholdV = restDisplacementThreshold;
+  /**
+   * @deprecated Use {@link energyThreshold} instead. This method currently does
+   *   nothing and will be removed in the upcoming major version.
+   */
+  restDisplacementThreshold(_restDisplacementThreshold: number) {
     return this;
   }
 
   /**
-   * Lets you adjust the rest speed threshold of the spring animation. Can be
-   * chained alongside other [layout animation
-   * modifiers](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#layout-animation-modifier).
-   *
-   * @param restSpeedThreshold - The speed in pixels per second from which the
-   *   spring will snap to the designated position without further
-   *   oscillations.
+   * @deprecated Use {@link energyThreshold} instead. This method currently does
+   *   nothing and will be removed in the upcoming major version.
    */
   static restSpeedThreshold<T extends typeof ComplexAnimationBuilder>(
     this: T,
-    restSpeedThreshold: number
+    _restSpeedThreshold: number
   ) {
-    const instance = this.createInstance();
-    return instance.restSpeedThreshold(restSpeedThreshold);
+    return this.createInstance();
   }
 
-  restSpeedThreshold(restSpeedThreshold: number): this {
-    this.restSpeedThresholdV = restSpeedThreshold;
+  /**
+   * @deprecated Use {@link energyThreshold} instead. This method currently does
+   *   nothing and will be removed in the upcoming major version.
+   */
+  restSpeedThreshold(_restSpeedThreshold: number): this {
+    return this;
+  }
+
+  /**
+   * Lets you adjust the energy speed threshold level to stop the spring
+   * animation. Can be chained alongside other [layout animation
+   * modifiers](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#layout-animation-modifier).
+   *
+   * @param energyThreshold - Relative energy threshold below which the spring
+   *   will snap to `toValue` without further oscillations. Defaults to 6e-9.
+   */
+  static energyThreshold<T extends typeof ComplexAnimationBuilder>(
+    this: T,
+    energyThreshold: number
+  ) {
+    const instance = this.createInstance();
+    return instance.energyThreshold(energyThreshold);
+  }
+
+  energyThreshold(energyThreshold: number): this {
+    this.energyThresholdV = energyThreshold;
     return this;
   }
 
@@ -265,8 +280,7 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
     const mass = this.massV;
     const stiffness = this.stiffnessV;
     const overshootClamping = this.overshootClampingV;
-    const restDisplacementThreshold = this.restDisplacementThresholdV;
-    const restSpeedThreshold = this.restSpeedThresholdV;
+    const energyThreshold = this.energyThresholdV;
 
     const animation = type;
 
@@ -292,11 +306,7 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
         { variableName: 'mass', value: mass },
         { variableName: 'stiffness', value: stiffness },
         { variableName: 'overshootClamping', value: overshootClamping },
-        {
-          variableName: 'restDisplacementThreshold',
-          value: restDisplacementThreshold,
-        },
-        { variableName: 'restSpeedThreshold', value: restSpeedThreshold },
+        { variableName: 'energyThreshold', value: energyThreshold },
         { variableName: 'duration', value: duration },
         { variableName: 'rotate', value: rotate },
       ] as const

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -199,6 +199,7 @@ var require_layoutAnimationAutoworkletization = __commonJS({
       "mass",
       "stiffness",
       "overshootClamping",
+      "energyThreshold",
       "restDisplacementThreshold",
       "restSpeedThreshold",
       "withInitialValues",

--- a/packages/react-native-worklets/plugin/src/layoutAnimationAutoworkletization.ts
+++ b/packages/react-native-worklets/plugin/src/layoutAnimationAutoworkletization.ts
@@ -124,6 +124,7 @@ const ComplexAnimationsChainableMethods = new Set([
   'mass',
   'stiffness',
   'overshootClamping',
+  'energyThreshold',
   'restDisplacementThreshold',
   'restSpeedThreshold',
   'withInitialValues',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->
With https://github.com/software-mansion/react-native-reanimated/pull/7803, we've changed the API of the spring animation. This PR adjusts the spring modifiers for layout animations accordingly.

<img width="1182" height="89" alt="image" src="https://github.com/user-attachments/assets/cca809f9-9a2c-4820-9fde-1151f00e205d" />

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
