### PR TITLE
Use legacy_makeMutableUI in animation manager

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -10,7 +10,7 @@ import type {
   SharedValue,
 } from '../commonTypes';
 import { LayoutAnimationType } from '../commonTypes';
-import { makeMutableUI } from '../mutables';
+import { legacy_makeMutableUI as makeMutableUI } from '../mutables';
 
 const TAG_OFFSET = 1e9;
 

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -151,6 +151,7 @@ function experimental_makeMutableUI<Value>(
   return mutable as Mutable<Value>;
 }
 
+// eslint-disable-next-line camelcase
 export function legacy_makeMutableUI<Value>(initial: Value): Mutable<Value> {
   'worklet';
   const listeners = new Map<number, Listener<Value>>();

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -100,7 +100,7 @@ function hideInternalValueProp<Value>(mutable: PartialMutable<Value>) {
 // eslint-disable-next-line camelcase
 function experimental_makeMutableUI<Value>(
   initial: Value,
-  dirtyFlag: Synchronizable<boolean>
+  dirtyFlag?: Synchronizable<boolean>
 ): Mutable<Value> {
   'worklet';
   const listeners = new Map<number, Listener<Value>>();
@@ -118,7 +118,7 @@ function experimental_makeMutableUI<Value>(
       return value;
     },
     set _value(newValue: Value) {
-      if (!isDirty) {
+      if (!isDirty && dirtyFlag) {
         dirtyFlag.setBlocking(true);
         isDirty = true;
       }

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -100,7 +100,7 @@ function hideInternalValueProp<Value>(mutable: PartialMutable<Value>) {
 // eslint-disable-next-line camelcase
 function experimental_makeMutableUI<Value>(
   initial: Value,
-  dirtyFlag?: Synchronizable<boolean>
+  dirtyFlag: Synchronizable<boolean>
 ): Mutable<Value> {
   'worklet';
   const listeners = new Map<number, Listener<Value>>();
@@ -118,7 +118,7 @@ function experimental_makeMutableUI<Value>(
       return value;
     },
     set _value(newValue: Value) {
-      if (!isDirty && dirtyFlag) {
+      if (!isDirty) {
         dirtyFlag.setBlocking(true);
         isDirty = true;
       }
@@ -151,7 +151,7 @@ function experimental_makeMutableUI<Value>(
   return mutable as Mutable<Value>;
 }
 
-function makeMutableUI_<Value>(initial: Value): Mutable<Value> {
+export function legacy_makeMutableUI<Value>(initial: Value): Mutable<Value> {
   'worklet';
   const listeners = new Map<number, Listener<Value>>();
   let value = initial;
@@ -199,11 +199,6 @@ function makeMutableUI_<Value>(initial: Value): Mutable<Value> {
 const USE_SYNCHRONIZABLE_FOR_MUTABLES = getStaticFeatureFlag(
   'USE_SYNCHRONIZABLE_FOR_MUTABLES'
 );
-
-export const makeMutableUI = USE_SYNCHRONIZABLE_FOR_MUTABLES
-  ? // eslint-disable-next-line camelcase
-    (experimental_makeMutableUI as typeof makeMutableUI_)
-  : makeMutableUI_;
 
 // eslint-disable-next-line camelcase
 function experimental_makeMutableNative<Value>(initial: Value): Mutable<Value> {
@@ -275,7 +270,7 @@ function makeMutableNative<Value>(initial: Value): Mutable<Value> {
   const handle = createSerializable({
     __init: () => {
       'worklet';
-      return makeMutableUI_(initial);
+      return legacy_makeMutableUI(initial);
     },
   });
 


### PR DESCRIPTION
## Summary

The layout animation manager calls `makeMutableUI`—[see here](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts#L69). It generally works great, but when we switch to the experimental mutable implementation, `experimental_makeMutableUI` expects a second argument, a synchronizable, that will act as a "dirty flag." However, the animation manager doesn't provide that value due to a misalignment in TypeScript:

```typescript
export const makeMutableUI = USE_SYNCHRONIZABLE_FOR_MUTABLES
  ? // eslint-disable-next-line camelcase
    (experimental_makeMutableUI as typeof makeMutableUI_) // <-- here
  : makeMutableUI_; // <-- accepts only one argument
```

This causes a situation where we try to call `setDirty` on an undefined flag—[see here](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/mutables.ts#L122).

<img width="579" height="28" alt="image" src="https://github.com/user-attachments/assets/82508f64-7745-43d5-9916-a02ad480a184" />

This PR forces animation manager to use legacy implementation of `makeMutableUI`. The animation manager is the only place where we call `makeMutableUI` directly, and it happens on the UI thread, so it's safe not to provide that flag.

## Test plan

Run any animation and see if it works or throws `[TypeError: Cannot read property 'setBlocking' of undefined]`