### PR TITLE
Improve husky error message

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,7 +13,7 @@ check_and_lint_docs() {
   if echo "$staged_files" | grep "^$docs_path/" --silent; then
     print "Changes spotted. Running $docs_name docs lint..."
     if [ ! -d "$docs_path/node_modules" ]; then
-      print "Error: node_modules not found in $docs_path. Please run 'yarn install' in the $docs_path directory."
+      print "Error: node_modules not found in $docs_path. Please run 'yarn' command in the $docs_path directory."
       exit 1
     fi
     try cd "$docs_path" && yarn lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,6 +12,10 @@ check_and_lint_docs() {
   print "Checking for changes in $docs_name docs..."
   if echo "$staged_files" | grep "^$docs_path/" --silent; then
     print "Changes spotted. Running $docs_name docs lint..."
+    if [ ! -d "$docs_path/node_modules" ]; then
+      print "Error: node_modules not found in $docs_path. Please run 'yarn install' in the $docs_path directory."
+      exit 1
+    fi
     try cd "$docs_path" && yarn lint
     print "Success."
   else


### PR DESCRIPTION
## Summary

This PR updates the Husky error message in cases where someone hasn't installed the node modules, which often happens. Husky tries to format the documentation, for example, during the merging process.

Before:
<img width="808" height="224" alt="image" src="https://github.com/user-attachments/assets/e5064cef-f4ba-4e71-9ac8-8c62e3cbead9" />

After:
<img width="1034" height="130" alt="image" src="https://github.com/user-attachments/assets/6b766e62-da09-4750-87ae-2121fe0ed2dd" />

## Test plan
