### PR TITLE
fix: check if `node_modules` is present before run `docs-lint` step

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -65,9 +65,14 @@ fi
 
 # Linting docs
 REANIMATED_DOCS_PATH="packages/docs-reanimated"
-check_and_lint_docs "$STAGED_FILES" "$REANIMATED_DOCS_PATH" "Reanimated"
+if [ -d "$REANIMATED_DOCS_PATH/node_modules" ]; then
+  check_and_lint_docs "$STAGED_FILES" "$REANIMATED_DOCS_PATH" "Reanimated"
+fi
+
 WORKLETS_DOCS_PATH="packages/docs-worklets"
-check_and_lint_docs "$STAGED_FILES" "$WORKLETS_DOCS_PATH" "Worklets"
+if [ -d "$WORKLETS_DOCS_PATH/node_modules" ]; then
+  check_and_lint_docs "$STAGED_FILES" "$WORKLETS_DOCS_PATH" "Worklets"
+fi
 
 # This automatically builds Reanimated Babel plugin JavaScript files if their
 # TypeScript counterparts were changed. It also adds the output file to the commit


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
Check if `node_modules` is present before run `docs-lint` step

## Test plan
Add a new line to any CSS file in `docs-worklets` or `docs-reanimated` and try to commit this change, precommit hook should throw an error if `node_modules` is present, without `node_modules` should skip lint step.

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
