### PR TITLE
fix: Stop passing unfiltered props to the rendered component

### DIFF
--- a/packages/react-native-reanimated/__tests__/__snapshots__/animatedProps.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/animatedProps.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`animatedProps Custom animated component 1`] = `
     </RNSVGGroup>
   </RNSVGSvgView>
   <TextInput
-    animatedProps={"{}"}
     collapsable={false}
     defaultValue="Box width: 20"
     jestAnimatedProps={
@@ -178,7 +177,6 @@ exports[`animatedProps SVG component cannot be tested 1`] = `
     </RNSVGGroup>
   </RNSVGSvgView>
   <TextInput
-    animatedProps={"{}"}
     collapsable={false}
     defaultValue="Box width: 20"
     jestAnimatedProps={

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -208,8 +208,7 @@ export default class AnimatedComponent<
 
     return (
       <ChildComponent
-        {...this.props}
-        {...props}
+        {...(props ?? this.props)}
         {...platformProps}
         style={filterNonCSSStyleProps(props?.style ?? this.props.style)}
         // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.


### PR DESCRIPTION
## Summary

While testing the web example app, I noticed the following error:

<img width="742" height="70" alt="Screenshot 2025-08-28 at 16 15 51" src="https://github.com/user-attachments/assets/44739f46-bd6b-46c0-9af9-e75ddf3a8945" />

It was caused by the fact that we passed unfiltered component props together with filtered props. To fix the issue, I just check whether the `render` method on the base animated component class is called with the props object or not. If it does, then I don't pass `this.props` (unfiltered props).