### PR TITLE
fix(Worklets): Adjust phone mockup padding on mobile devices

### DIFF
--- a/packages/docs-worklets/src/components/HomepageUseCasesSection/UseCase/styles.module.css
+++ b/packages/docs-worklets/src/components/HomepageUseCasesSection/UseCase/styles.module.css
@@ -66,13 +66,12 @@
     .phone {
       max-width: 270px;
       max-height: 572px;
+      padding: 0;
     }
 
     .content {
       .video {
         border-radius: 32px;
-        /* max-width: 208px;
-        height: 534px; */
       }
     }
   }


### PR DESCRIPTION
## Summary
Before: 
<img width="383" height="625" alt="image" src="https://github.com/user-attachments/assets/71ac5f85-37da-41c8-b213-10eb380f4289" />
After : 
<img width="415" height="849" alt="image" src="https://github.com/user-attachments/assets/1067d78f-2f1a-4413-9ae8-ef50155385c7" />

## Test plan
