### PR TITLE
Use `libhermesvm` instead of `libhermes` on RN 0.82+

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -242,6 +242,7 @@ android {
                 "**/libfolly_runtime.so",
                 "**/libglog.so",
                 "**/libhermes.so",
+                "**/libhermesvm.so",
                 "**/libhermes-executor-debug.so",
                 "**/libhermes_executor.so",
                 "**/libhermestooling.so",

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -105,7 +105,11 @@ else()
 endif()
 
 if(${JS_RUNTIME} STREQUAL "hermes")
-  target_link_libraries(worklets hermes-engine::libhermes)
+  if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 82)
+    target_link_libraries(worklets hermes-engine::libhermesvm)
+  else()
+    target_link_libraries(worklets hermes-engine::libhermes)
+  endif()
 
   if(${HERMES_ENABLE_DEBUGGER})
     string(APPEND CMAKE_CXX_FLAGS " -DHERMES_ENABLE_DEBUGGER=1")

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -248,6 +248,7 @@ android {
                 "**/libfolly_runtime.so",
                 "**/libglog.so",
                 "**/libhermes.so",
+                "**/libhermesvm.so",
                 "**/libhermes-executor-debug.so",
                 "**/libhermes_executor.so",
                 "**/libhermestooling.so",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

In https://github.com/facebook/react-native/pull/53094 `libhermes` prefab was renamed to `libhermesvm` and nightly builds are broken now so we need to adapt to this change on our side.

cc @cortinico

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
