### PR TITLE
fix: Android validation CI failure

### DIFF
--- a/packages/react-native-reanimated/android/settings.gradle
+++ b/packages/react-native-reanimated/android/settings.gradle
@@ -1,1 +1,0 @@
-include 'lib'


### PR DESCRIPTION
## Summary

Not sure why this file was here. We don't have such a `settings.gradle` file in the `react-native-worklets` package so it seems to be useless. Android still compiles and works without it.