### PR TITLE
chore(Worklets): add scope recrawling during closure creation in Babel plugin

### DIFF
--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -439,6 +439,7 @@ var require_closure = __commonJS({
       const closureVariables = new Array();
       const libraryBindingsToImport = /* @__PURE__ */ new Set();
       const relativeBindingsToImport = /* @__PURE__ */ new Set();
+      let recrawled = false;
       funPath.traverse({
         "TSType|TSTypeAliasDeclaration|TSInterfaceDeclaration"(typePath) {
           typePath.skip();
@@ -451,7 +452,12 @@ var require_closure = __commonJS({
           if (capturedNames.has(name)) {
             return;
           }
-          const binding = idPath.scope.getBinding(name);
+          let binding = idPath.scope.getBinding(name);
+          if (!binding && !recrawled) {
+            recrawled = true;
+            idPath.scope.crawl();
+            binding = idPath.scope.getBinding(name);
+          }
           if (!binding) {
             if (globals_12.globals.has(name)) {
               return;


### PR DESCRIPTION
## Summary

During closure creation of worklets we might get into a situation where another plugin has added an identifier but didn't update the scope. Since the algorithm assumes that the scope is the source of truth, we forcefully recrawl the scope once when we fail to find a binding, to fix other plugins' mistakes.

## Test plan

Reported by @kitten, he confirmed that it fixes the problem.
