### PR TITLE
Fix incorrect filename in `RuntimeTestsExample.tsx`

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -45,8 +45,8 @@ export default function RuntimeTestsExample() {
           testSuiteName: 'serializable',
           importTest: () => {
             require('./tests/serializable/createSerializable.test');
-            require('./tests/serializable/createSerializableOnUI.test');
             require('./tests/serializable/isSerializableRef.test');
+            require('./tests/serializable/makeShareableCloneOnUI.test');
           },
         },
         {


### PR DESCRIPTION
## Summary

While working on #8208 I've noticed that `web-example` fails to start. Seems like after renaming some test files, wrong filename was left in `RuntimeTestsExample.tsx`

## Test plan

Try to open `web-example` before and after these changes.
