### PR TITLE
fix(Worklets): incorrect initialization of BundleMode in Jest

### DIFF
--- a/packages/react-native-worklets/src/workletRuntimeEntry.ts
+++ b/packages/react-native-worklets/src/workletRuntimeEntry.ts
@@ -18,11 +18,14 @@ import { WorkletsError } from './WorkletsError';
  * `_WORKLETS_BUNDLE_MODE` flag.
  */
 export function bundleModeInit() {
+  if (SHOULD_BE_USE_WEB) {
+    return;
+  }
+
   globalThis._WORKLETS_BUNDLE_MODE = true;
-  if (
-    !SHOULD_BE_USE_WEB &&
-    globalThis.__RUNTIME_KIND !== RuntimeKind.ReactNative
-  ) {
+
+  const runtimeKind = globalThis.__RUNTIME_KIND;
+  if (runtimeKind && runtimeKind !== RuntimeKind.ReactNative) {
     /**
      * We shouldn't call `init()` on RN Runtime here, as it would initialize our
      * module before React Native has configured the RN Runtime.


### PR DESCRIPTION
## Summary

Fixes #7891 

Jest environments load `workletRuntimeEntry.ts` file eagerly, even if its unused. This flips the `_WORKLETS_BUNDLE_MODE` flag to `true` and causes issues with `require.resolveWeak` function being undefined in the environment.

With this PR the flag is no longer set in Jest environments.

## Test plan

Tested it against https://github.com/Expensify/App/pull/69469 where this problem manifests.
