### PR TITLE
Enable executeSync not only in Bundle Mode

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -173,7 +173,6 @@ jsi::Value WorkletRuntime::executeSync(
   return serializableResult->toJSValue(rt);
 }
 
-#ifdef WORKLETS_BUNDLE_MODE
 jsi::Value WorkletRuntime::executeSync(
     std::function<jsi::Value(jsi::Runtime &)> &&job) const {
   auto lock = std::unique_lock<std::recursive_mutex>(*runtimeMutex_);
@@ -187,7 +186,6 @@ jsi::Value WorkletRuntime::executeSync(
   jsi::Runtime &uiRuntime = getJSIRuntime();
   return job(uiRuntime);
 }
-#endif // WORKLETS_BUNDLE_MODE
 
 jsi::Value WorkletRuntime::get(
     jsi::Runtime &rt,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -56,12 +56,10 @@ class WorkletRuntime : public jsi::HostObject,
 
   jsi::Value executeSync(jsi::Runtime &rt, const jsi::Value &worklet) const;
 
-#ifdef WORKLETS_BUNDLE_MODE
   jsi::Value executeSync(std::function<jsi::Value(jsi::Runtime &)> &&job) const;
 
   jsi::Value executeSync(
       const std::function<jsi::Value(jsi::Runtime &)> &job) const;
-#endif // WORKLETS_BUNDLE_MODE
 
   std::string toString() const {
     return "[WorkletRuntime \"" + name_ + "\"]";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Enabling `executeSync` could be beneficial for libraries that depend on worklets, such as `react-native-audio-api`.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
