### PR TITLE
fix: Initialize logger before all other things

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/index.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/index.ts
@@ -1,4 +1,7 @@
 'use strict';
 
 export { ReanimatedModule } from './reanimatedModuleInstance';
-export type { ReanimatedModuleProxy } from './reanimatedModuleProxy';
+export type {
+  IReanimatedModule,
+  ReanimatedModuleProxy,
+} from './reanimatedModuleProxy';

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -1,10 +1,15 @@
 'use strict';
 
-// TODO: Specify the initialization pipeline since now there's no
-// universal source of truth for it.
-import './initializers';
 import './publicGlobals';
 
+import { initializeReanimatedModule } from './initializers';
+import { ReanimatedModule } from './ReanimatedModule';
+
+// TODO: Specify the initialization pipeline since now there's no
+// universal source of truth for it.
+initializeReanimatedModule(ReanimatedModule);
+
+// eslint-disable-next-line import/first
 import * as Animated from './Animated';
 
 export default Animated;

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -10,15 +10,19 @@ import {
 } from './common';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
-import { ReanimatedModule } from './ReanimatedModule';
+import type { IReanimatedModule } from './ReanimatedModule';
 
-if (!IS_WEB && !ReanimatedModule) {
-  throw new ReanimatedError(
-    'Tried to initialize Reanimated without a valid ReanimatedModule'
-  );
-}
-if (getStaticFeatureFlag('EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS')) {
-  initSvgCssSupport();
+export function initializeReanimatedModule(
+  ReanimatedModule: IReanimatedModule
+) {
+  if (!IS_WEB && !ReanimatedModule) {
+    throw new ReanimatedError(
+      'Tried to initialize Reanimated without a valid ReanimatedModule'
+    );
+  }
+  if (getStaticFeatureFlag('EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS')) {
+    initSvgCssSupport();
+  }
 }
 
 registerLoggerConfig(DEFAULT_LOGGER_CONFIG);


### PR DESCRIPTION
## Summary

The current initialization pipeline is quite tricky and it turned out that the logger could have been used before the logger config was written into the `global` object.

I suspect that this may be caused by the imports chain starting from the `Animated.ts` file that imports many other files, which in the end have imports from the `packages/react-native-reanimated/src/animation/util.ts` file. This file contains the following global if statement:

```ts
if (__DEV__ && ReducedMotionManager.jsValue) {
  logger.warn(
    `Reduced motion setting is enabled on this device. This warning is visible only in the development mode. Some animations will be disabled by default. You can override the behavior for individual animations, see https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#reduced-motion-setting-is-enabled-on-this-device.`
  );
}
```

Because of that, this log could be executed before the `initializeReanimatedModule` function in the `src/index.ts` file was called, which resulted in the crash reported in this issue: #8199
