### PR TITLE
chore: Remove double templating in css variant

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -89,8 +89,27 @@ class CSSValueVariant final : public CSSValue {
                    ...)) {
       storage_ = std::forward<ValueType>(value);
     } else {
-      // Otherwise, try each type in turn
-      if (!tryConstruct(std::forward<ValueType>(value))) {
+      // Otherwise, try to construct the CSSValue from each type in turn
+      auto tryOne = [&]<typename TCSSValue>() -> bool {
+        if constexpr (std::is_constructible_v<TCSSValue, ValueType>) {
+          if constexpr (ValueConstructibleCSSValue<TCSSValue, ValueType>) {
+            // For construction from a non-jsi::Value, we perform a runtime
+            // canConstruct check only if the type has a canConstruct method.
+            // (this is needed e.g. when different CSS value types can be
+            // constructed from the same value type, like CSSLength and
+            // CSSKeyword)
+            if (!TCSSValue::canConstruct(std::forward<ValueType>(value))) {
+              return false;
+            }
+          }
+          storage_ = TCSSValue(std::forward<ValueType>(value));
+          return true;
+        }
+        return false;
+      };
+
+      // Try constructing with each allowed type until one succeeds
+      if (!(tryOne.template operator()<AllowedTypes>() || ...)) {
         throw std::runtime_error(
             "[Reanimated] No compatible type found for construction");
       }
@@ -102,7 +121,19 @@ class CSSValueVariant final : public CSSValue {
    * (chooses the first one that matches)
    */
   CSSValueVariant(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-    if (!tryConstruct(rt, jsiValue)) {
+    auto tryOne = [&]<typename TCSSValue>() -> bool {
+      // We have to check in a runtime if the type can be constructed from the
+      // provided jsi::Value. The first match will be used to construct the
+      // CSS value.
+      if (!TCSSValue::canConstruct(rt, jsiValue)) {
+        return false;
+      }
+      storage_ = TCSSValue(rt, jsiValue);
+      return true;
+    };
+
+    // Try constructing with each allowed type until one succeeds
+    if (!(tryOne.template operator()<AllowedTypes>() || ...)) {
       throw std::runtime_error(
           "[Reanimated] No compatible type found for construction from: " +
           stringifyJSIValue(rt, jsiValue));
@@ -114,7 +145,19 @@ class CSSValueVariant final : public CSSValue {
    * (chooses the first one that matches)
    */
   explicit CSSValueVariant(const folly::dynamic &value) {
-    if (!tryConstruct(value)) {
+    auto tryOne = [&]<typename TCSSValue>() -> bool {
+      // We have to check in a runtime if the type can be constructed from the
+      // provided folly::dynamic. The first match will be used to construct the
+      // CSS value.
+      if (!TCSSValue::canConstruct(value)) {
+        return false;
+      }
+      storage_ = TCSSValue(value);
+      return true;
+    };
+
+    // Try constructing with each allowed type until one succeeds
+    if (!(tryOne.template operator()<AllowedTypes>() || ...)) {
       throw std::runtime_error(
           "[Reanimated] No compatible type found for construction from: " +
           folly::toJson(value));
@@ -219,71 +262,6 @@ class CSSValueVariant final : public CSSValue {
       const CSSValueVariant &to,
       const double fallbackInterpolateThreshold) const {
     return (progress < fallbackInterpolateThreshold) ? *this : to;
-  }
-
-  /**
-   * Tries to construct type from a given value
-   */
-  bool tryConstruct(auto &&value) {
-    using ValueType = decltype(value);
-
-    auto tryOne = [&]<typename TCSSValue>() -> bool {
-      if constexpr (std::is_constructible_v<TCSSValue, ValueType>) {
-        if constexpr (ValueConstructibleCSSValue<TCSSValue, ValueType>) {
-          // For construction from a non-jsi::Value, we perform a runtime
-          // canConstruct check only if the type has a canConstruct method.
-          // (this is needed e.g. when different CSS value types can be
-          // constructed from the same value type, like CSSLength and
-          // CSSKeyword)
-          if (!TCSSValue::canConstruct(std::forward<ValueType>(value))) {
-            return false;
-          }
-        }
-        storage_ = TCSSValue(std::forward<ValueType>(value));
-        return true;
-      }
-      return false;
-    };
-
-    // Try constructing with each allowed type until one succeeds
-    return (tryOne.template operator()<AllowedTypes>() || ...);
-  }
-
-  /**
-   * Tries to construct type from a given jsi::Value
-   */
-  bool tryConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-    auto tryOne = [&]<typename TCSSValue>() -> bool {
-      // We have to check in a runtime if the type can be constructed from the
-      // provided jsi::Value. The first match will be used to construct the
-      // CSS value.
-      if (!TCSSValue::canConstruct(rt, jsiValue)) {
-        return false;
-      }
-      storage_ = TCSSValue(rt, jsiValue);
-      return true;
-    };
-
-    // Try constructing with each allowed type until one succeeds
-    return (tryOne.template operator()<AllowedTypes>() || ...);
-  }
-
-  /**
-   * Tries to construct type from a given folly::dynamic
-   */
-  bool tryConstruct(const folly::dynamic &value) {
-    auto tryOne = [&]<typename TCSSValue>() -> bool {
-      // We have to check in a runtime if the type can be constructed from the
-      // provided folly::dynamic. The first match will be used to construct the
-      // CSS value.
-      if (!TCSSValue::canConstruct(value)) {
-        return false;
-      }
-      storage_ = TCSSValue(value);
-      return true;
-    };
-    // Try constructing with each allowed type until one succeeds
-    return (tryOne.template operator()<AllowedTypes>() || ...);
   }
 };
 


### PR DESCRIPTION
## Summary

This PR removes the unnecessary `TValue` template type and replaces it by `auto`. Thanks to this we will have less explicit templates after moving the implementation to the cpp file. I also removed `tryConstruct` and moved their implementations directly to constructors in order to have less template implementations after moving to cpp.