### PR TITLE
fix: Add missing react import causing web crashes

### DIFF
--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import type { ComponentProps, Ref } from 'react';
-import { Component } from 'react';
+import React, { Component } from 'react';
 import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 


### PR DESCRIPTION
## Summary

This missing import was causing crashed on the web:

```
AnimatedComponent.js:181 Uncaught ReferenceError: React is not defined
    at AnimatedComponent.render (AnimatedComponent.js:181:5)
    at AnimatedComponent.render (AnimatedComponent.js:269:18)
    at react-stack-bottom-frame (react-dom-client.development.js:22442:29)
    at updateClassComponent (react-dom-client.development.js:8579:23)
    at beginWork (react-dom-client.development.js:9698:13)
    at runWithFiberInDEV (react-dom-client.development.js:544:16)
    at performUnitOfWork (react-dom-client.development.js:15045:22)
    at workLoopSync (react-dom-client.development.js:14871:41)
    at renderRootSync (react-dom-client.development.js:14851:11)
    at performWorkOnRoot (react-dom-client.development.js:14385:44)
```

I got this issue report and the link to the [patch](https://github.com/Expensify/App/pull/69469/commits/93ff430e70f9a16ef2967340355d1e14d64caf80) that fixes the issue at Expensify from @blazejkustra ❤️.