### PR TITLE
Reduce `libreanimate.so` size

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -18,7 +18,7 @@ string(
     -DREANIMATED_VERSION=${REANIMATED_VERSION}\
     -DREANIMATED_FEATURE_FLAGS=\"${REANIMATED_FEATURE_FLAGS}\"")
 string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fstack-protector-all")
-# flags to optimizing the binary size
+# flags to optimize the binary size
 string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden -ffunction-sections -fdata-sections")
 
 if(${REANIMATED_PROFILING})


### PR DESCRIPTION
## Summary

Due to the fact that the CSS implementation extensively uses C++ templates, it has an impact on binary size. Currently, the stripped binary is 9.1 MB. This PR adds some compilation flags to optimize binary size. As a result, these flags reduce the binary size to 6.6 MB, and with changes from [this PR](https://github.com/software-mansion/react-native-reanimated/pull/8226), we will achieve **5.8 MB**.

Explanation of flags:
- `-fvisibility=hidden`: This flag hides symbols, meaning it doesn't produce public symbol definitions, preventing other libraries from calling the methods in the binary. Since we aren't aware of any library that directly integrates with the Reanimated binary, we consider this safe - other libraries integrate with the `worklets` binary. It's still possible to export some methods as public, but it's necessary to mark them with the `__attribute__((visibility("default")))` directive.
- `-ffunction-sections -fdata-sections`: These flags instruct the compiler to place each function/global variable declaration in its own unique section within the object file. By placing each function in its own section, the linker can more easily identify and eliminate unused functions when the `--gc-sections` option is used during linking.

## Test plan
