### PR TITLE
chore: silence Reanimated Plugin warning

### DIFF
--- a/packages/react-native-reanimated/plugin/index.js
+++ b/packages/react-native-reanimated/plugin/index.js
@@ -1,6 +1,4 @@
 // @ts-ignore plugin type isn't exposed
 const plugin = require('react-native-worklets/plugin');
-console.warn(
-  '[Reanimated] Seems like you are using a Babel plugin `react-native-reanimated/plugin`. It was moved to `react-native-worklets` package. Please use `react-native-worklets/plugin` instead.'
-);
+
 module.exports = plugin;


### PR DESCRIPTION
## Summary

Fixes #8231

Some React Native setups (like Babel presets) support both Reanimated 4 and Reanimated 3. In these scenarios they can't reliably import the correct plugin without triggering the deprecation warning.

This PR silences this warning to make life easier for the aforementioned setups. The warning itself already did its job raising awareness about the fact that Worklets are a separate library now.

## Test plan

🚀 
