### PR TITLE
(cherry-pick) chore: Reduce CSS ValueInterpolator templating

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -11,6 +11,8 @@
 #include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
 #include <reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.h>
 #include <reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h>
+#include <reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h>
+#include <reanimated/CSS/interpolation/values/SimpleValueInterpolator.h>
 
 #include <memory>
 #include <string>
@@ -20,10 +22,10 @@ namespace reanimated::css {
 
 // Template class implementations
 template <typename... AllowedTypes>
-class ValueInterpolatorFactory : public PropertyInterpolatorFactory {
+class SimpleValueInterpolatorFactory : public PropertyInterpolatorFactory {
  public:
   template <typename TValue>
-  explicit ValueInterpolatorFactory(const TValue &defaultValue)
+  explicit SimpleValueInterpolatorFactory(const TValue &defaultValue)
       : PropertyInterpolatorFactory(), defaultValue_(defaultValue) {}
 
   bool isDiscreteProperty() const override {
@@ -40,7 +42,7 @@ class ValueInterpolatorFactory : public PropertyInterpolatorFactory {
       const PropertyPath &propertyPath,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
       const override {
-    return std::make_shared<ValueInterpolator<AllowedTypes...>>(
+    return std::make_shared<SimpleValueInterpolator<AllowedTypes...>>(
         propertyPath, defaultValue_, viewStylesRepository);
   }
 
@@ -90,7 +92,7 @@ template <typename... AllowedTypes>
 auto value(const auto &defaultValue) -> std::enable_if_t<
     (std::is_constructible_v<AllowedTypes, decltype(defaultValue)> || ...),
     std::shared_ptr<PropertyInterpolatorFactory>> {
-  return std::make_shared<ValueInterpolatorFactory<AllowedTypes...>>(
+  return std::make_shared<SimpleValueInterpolatorFactory<AllowedTypes...>>(
       CSSValueVariant<AllowedTypes...>(defaultValue));
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.h
@@ -1,46 +1,60 @@
 #pragma once
 
 #include <reanimated/CSS/common/values/CSSLength.h>
-#include <reanimated/CSS/interpolation/values/ValueInterpolator.h>
+#include <reanimated/CSS/interpolation/values/SimpleValueInterpolator.h>
 
 #include <memory>
-#include <string>
-#include <utility>
 
 namespace reanimated::css {
 
+/**
+ * Concrete implementation of ValueInterpolator for CSS values that require
+ * resolution before interpolation. This class handles interpolation of relative
+ * values (e.g., percentage length values) that need to be resolved to absolute
+ * values using the context describing the ShadowNode before the interpolation
+ * can occur.
+ */
 template <typename... AllowedTypes>
-class ResolvableValueInterpolator : public ValueInterpolator<AllowedTypes...> {
- public:
-  using ValueType = typename ValueInterpolator<AllowedTypes...>::ValueType;
+class ResolvableValueInterpolator final
+    : public SimpleValueInterpolator<AllowedTypes...> {
+  static_assert(
+      (... && std::is_base_of<CSSValue, AllowedTypes>::value),
+      "[Reanimated] ResolvableValueInterpolator: All interpolated types must inherit from CSSValue");
 
-  ResolvableValueInterpolator(
+ public:
+  using ValueType =
+      typename SimpleValueInterpolator<AllowedTypes...>::ValueType;
+
+  explicit ResolvableValueInterpolator(
       const PropertyPath &propertyPath,
       const ValueType &defaultStyleValue,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
       RelativeTo relativeTo,
       std::string relativeProperty)
-      : ValueInterpolator<AllowedTypes...>(
+      : SimpleValueInterpolator<AllowedTypes...>(
             propertyPath,
             defaultStyleValue,
             viewStylesRepository),
         relativeTo_(relativeTo),
         relativeProperty_(std::move(relativeProperty)) {}
-  virtual ~ResolvableValueInterpolator() = default;
 
  protected:
-  ValueType interpolateValue(
+  folly::dynamic interpolateValue(
       double progress,
-      const ValueType &fromValue,
-      const ValueType &toValue,
+      const std::shared_ptr<CSSValue> &fromValue,
+      const std::shared_ptr<CSSValue> &toValue,
       const ValueInterpolatorUpdateContext &context) const override {
-    return fromValue.interpolate(
-        progress,
-        toValue,
-        {.node = context.node,
-         .viewStylesRepository = this->viewStylesRepository_,
-         .relativeProperty = relativeProperty_,
-         .relativeTo = relativeTo_});
+    const auto &from = std::static_pointer_cast<ValueType>(fromValue);
+    const auto &to = std::static_pointer_cast<ValueType>(toValue);
+    return from
+        ->interpolate(
+            progress,
+            *to,
+            {.node = context.node,
+             .viewStylesRepository = this->viewStylesRepository_,
+             .relativeProperty = relativeProperty_,
+             .relativeTo = relativeTo_})
+        .toDynamic();
   }
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <reanimated/CSS/interpolation/values/ValueInterpolator.h>
+
+#include <memory>
+
+namespace reanimated::css {
+
+/**
+ * Concrete implementation of ValueInterpolator for simple CSS values that don't
+ * require resolution before interpolation. This class handles direct
+ * interpolation between values without any additional processing or resolution.
+ */
+template <typename... AllowedTypes>
+class SimpleValueInterpolator : public ValueInterpolator {
+  static_assert(
+      (... && std::is_base_of<CSSValue, AllowedTypes>::value),
+      "[Reanimated] SimpleValueInterpolator: All interpolated types must inherit from CSSValue");
+
+ public:
+  using ValueType = CSSValueVariant<AllowedTypes...>;
+
+  explicit SimpleValueInterpolator(
+      const PropertyPath &propertyPath,
+      const ValueType &defaultStyleValue,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
+      : ValueInterpolator(
+            propertyPath,
+            std::make_shared<ValueType>(defaultStyleValue),
+            viewStylesRepository) {}
+
+ protected:
+  std::shared_ptr<CSSValue> createValue(
+      jsi::Runtime &rt,
+      const jsi::Value &value) const override {
+    return std::make_shared<ValueType>(rt, value);
+  }
+  std::shared_ptr<CSSValue> createValue(
+      const folly::dynamic &value) const override {
+    return std::make_shared<ValueType>(value);
+  }
+
+  folly::dynamic interpolateValue(
+      double progress,
+      const std::shared_ptr<CSSValue> &fromValue,
+      const std::shared_ptr<CSSValue> &toValue,
+      const ValueInterpolatorUpdateContext &context) const override {
+    const auto &from = std::static_pointer_cast<ValueType>(fromValue);
+    const auto &to = std::static_pointer_cast<ValueType>(toValue);
+    return from->interpolate(progress, *to).toDynamic();
+  }
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
@@ -1,0 +1,151 @@
+#include <reanimated/CSS/interpolation/values/ValueInterpolator.h>
+
+namespace reanimated::css {
+
+ValueInterpolator::ValueInterpolator(
+    const PropertyPath &propertyPath,
+    const std::shared_ptr<CSSValue> &defaultValue,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
+    : PropertyInterpolator(propertyPath, viewStylesRepository),
+      defaultStyleValue_(defaultValue),
+      defaultStyleValueDynamic_(defaultValue->toDynamic()) {}
+
+folly::dynamic ValueInterpolator::getStyleValue(
+    const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  return viewStylesRepository_->getStyleProp(
+      shadowNode->getTag(), propertyPath_);
+}
+
+folly::dynamic ValueInterpolator::getResetStyle(
+    const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  auto styleValue = getStyleValue(shadowNode);
+
+  if (styleValue.isNull()) {
+    return defaultStyleValueDynamic_;
+  }
+
+  return styleValue;
+}
+
+folly::dynamic ValueInterpolator::getFirstKeyframeValue() const {
+  return convertOptionalToDynamic(keyframes_.front().value);
+}
+
+folly::dynamic ValueInterpolator::getLastKeyframeValue() const {
+  return convertOptionalToDynamic(keyframes_.back().value);
+}
+
+bool ValueInterpolator::equalsReversingAdjustedStartValue(
+    const folly::dynamic &propertyValue) const {
+  if (reversingAdjustedStartValue_.isNull()) {
+    return propertyValue.isNull();
+  }
+  return reversingAdjustedStartValue_ == propertyValue;
+}
+
+void ValueInterpolator::updateKeyframes(
+    jsi::Runtime &rt,
+    const jsi::Value &keyframes) {
+  const auto parsedKeyframes = parseJSIKeyframes(rt, keyframes);
+
+  keyframes_.clear();
+  keyframes_.reserve(parsedKeyframes.size());
+
+  for (const auto &[offset, value] : parsedKeyframes) {
+    if (value.isUndefined()) {
+      keyframes_.emplace_back(offset, std::nullopt);
+    } else {
+      keyframes_.emplace_back(
+          offset, std::make_optional(createValue(rt, value)));
+    }
+  }
+}
+
+void ValueInterpolator::updateKeyframesFromStyleChange(
+    const folly::dynamic &oldStyleValue,
+    const folly::dynamic &newStyleValue,
+    const folly::dynamic &lastUpdateValue) {
+  ValueKeyframe firstKeyframe, lastKeyframe;
+
+  if (!lastUpdateValue.isNull()) {
+    firstKeyframe = ValueKeyframe{0, createValue(lastUpdateValue)};
+  } else if (!oldStyleValue.isNull()) {
+    firstKeyframe = ValueKeyframe{0, createValue(oldStyleValue)};
+  } else {
+    firstKeyframe = ValueKeyframe{0, defaultStyleValue_};
+  }
+
+  if (newStyleValue.isNull()) {
+    lastKeyframe = ValueKeyframe{1, defaultStyleValue_};
+  } else {
+    lastKeyframe = ValueKeyframe{1, createValue(newStyleValue)};
+  }
+
+  keyframes_ = {std::move(firstKeyframe), std::move(lastKeyframe)};
+  reversingAdjustedStartValue_ = oldStyleValue;
+}
+
+folly::dynamic ValueInterpolator::interpolate(
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const {
+  const auto toIndex = getToKeyframeIndex(progressProvider);
+  const auto fromIndex = toIndex - 1;
+
+  const auto &fromKeyframe = keyframes_[fromIndex];
+  const auto &toKeyframe = keyframes_[toIndex];
+
+  // clang-format off
+  const auto &fromValue = fromKeyframe.value
+      ? fromKeyframe.value.value()
+      : getFallbackValue(shadowNode);
+  const auto &toValue = toKeyframe.value
+      ? toKeyframe.value.value()
+      : getFallbackValue(shadowNode);
+  // clang-format on
+
+  const auto keyframeProgress = progressProvider->getKeyframeProgress(
+      fromKeyframe.offset, toKeyframe.offset);
+
+  if (keyframeProgress == 1.0) {
+    return toValue->toDynamic();
+  }
+  if (keyframeProgress == 0.0) {
+    return fromValue->toDynamic();
+  }
+
+  return interpolateValue(
+      keyframeProgress, fromValue, toValue, {.node = shadowNode});
+}
+
+folly::dynamic ValueInterpolator::convertOptionalToDynamic(
+    const std::optional<std::shared_ptr<CSSValue>> &value) const {
+  return value ? value.value()->toDynamic() : folly::dynamic();
+}
+
+std::shared_ptr<CSSValue> ValueInterpolator::getFallbackValue(
+    const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  const auto styleValue = getStyleValue(shadowNode);
+  return styleValue.isNull() ? defaultStyleValue_ : createValue(styleValue);
+}
+
+size_t ValueInterpolator::getToKeyframeIndex(
+    const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const {
+  const auto progress = progressProvider->getGlobalProgress();
+
+  const auto it = std::upper_bound(
+      keyframes_.begin(),
+      keyframes_.end(),
+      progress,
+      [](double progress, const ValueKeyframe &keyframe) {
+        return progress < keyframe.offset;
+      });
+
+  // If we're at the end, return the last valid keyframe index
+  if (it == keyframes_.end()) {
+    return keyframes_.size() - 1;
+  }
+
+  return std::distance(keyframes_.begin(), it);
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -5,7 +5,8 @@
 #include <reanimated/CSS/utils/keyframes.h>
 
 #include <memory>
-#include <string>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {
@@ -17,190 +18,69 @@ struct ValueInterpolatorUpdateContext {
 template <typename TValue>
 struct is_css_value : std::is_base_of<CSSValue, TValue> {};
 
-template <typename... AllowedTypes>
 struct ValueKeyframe {
   double offset;
-  std::optional<CSSValueVariant<AllowedTypes...>> value;
+  std::optional<std::shared_ptr<CSSValue>> value;
 };
 
-template <typename... AllowedTypes>
+/**
+ * Base class for CSS value interpolators that provides common functionality
+ * for interpolating CSS values during animations. This class should be extended
+ * by concrete implementations for specific CSS value types to provide
+ * type-specific interpolation logic.
+ */
 class ValueInterpolator : public PropertyInterpolator {
-  static_assert(
-      (... && is_css_value<AllowedTypes>::value),
-      "[Reanimated] ValueInterpolator: All interpolated types must inherit from CSSValue");
-
  public:
-  using ValueType = CSSValueVariant<AllowedTypes...>;
-  using KeyframeType = ValueKeyframe<AllowedTypes...>;
-
   explicit ValueInterpolator(
       const PropertyPath &propertyPath,
-      const ValueType &defaultStyleValue,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository)
-      : PropertyInterpolator(propertyPath, viewStylesRepository),
-        defaultStyleValue_(defaultStyleValue) {}
+      const std::shared_ptr<CSSValue> &defaultValue,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
   virtual ~ValueInterpolator() = default;
 
   folly::dynamic getStyleValue(
-      const std::shared_ptr<const ShadowNode> &shadowNode) const override {
-    return viewStylesRepository_->getStyleProp(
-        shadowNode->getTag(), propertyPath_);
-  }
-
+      const std::shared_ptr<const ShadowNode> &shadowNode) const override;
   folly::dynamic getResetStyle(
-      const std::shared_ptr<const ShadowNode> &shadowNode) const override {
-    auto styleValue = getStyleValue(shadowNode);
-
-    if (styleValue.isNull()) {
-      return defaultStyleValue_.toDynamic();
-    }
-
-    return styleValue;
-  }
-
-  folly::dynamic getFirstKeyframeValue() const override {
-    return convertOptionalToDynamic(keyframes_.front().value);
-  }
-
-  folly::dynamic getLastKeyframeValue() const override {
-    return convertOptionalToDynamic(keyframes_.back().value);
-  }
-
+      const std::shared_ptr<const ShadowNode> &shadowNode) const override;
+  folly::dynamic getFirstKeyframeValue() const override;
+  folly::dynamic getLastKeyframeValue() const override;
   bool equalsReversingAdjustedStartValue(
-      const folly::dynamic &propertyValue) const override {
-    if (!reversingAdjustedStartValue_.has_value()) {
-      return propertyValue.isNull();
-    }
-    return reversingAdjustedStartValue_.value() == ValueType(propertyValue);
-  }
+      const folly::dynamic &propertyValue) const override;
 
-  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override {
-    const auto parsedKeyframes = parseJSIKeyframes(rt, keyframes);
-
-    keyframes_.clear();
-    keyframes_.reserve(parsedKeyframes.size());
-
-    for (const auto &[offset, value] : parsedKeyframes) {
-      if (value.isUndefined()) {
-        keyframes_.push_back(KeyframeType{offset, std::nullopt});
-      } else {
-        keyframes_.push_back(KeyframeType{offset, ValueType(rt, value)});
-      }
-    }
-  }
-
+  void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
   void updateKeyframesFromStyleChange(
       const folly::dynamic &oldStyleValue,
       const folly::dynamic &newStyleValue,
-      const folly::dynamic &lastUpdateValue) override {
-    KeyframeType firstKeyframe, lastKeyframe;
-
-    if (oldStyleValue.isNull()) {
-      reversingAdjustedStartValue_ = std::nullopt;
-    } else {
-      reversingAdjustedStartValue_ = ValueType(oldStyleValue);
-    }
-
-    if (!lastUpdateValue.isNull()) {
-      firstKeyframe = {0, ValueType(lastUpdateValue)};
-    } else if (!oldStyleValue.isNull()) {
-      firstKeyframe = {0, ValueType(oldStyleValue)};
-    } else {
-      firstKeyframe = {0, defaultStyleValue_};
-    }
-
-    if (newStyleValue.isNull()) {
-      lastKeyframe = {1, defaultStyleValue_};
-    } else {
-      lastKeyframe = {1, ValueType(newStyleValue)};
-    }
-
-    keyframes_ = {firstKeyframe, lastKeyframe};
-  }
+      const folly::dynamic &lastUpdateValue) override;
 
   folly::dynamic interpolate(
       const std::shared_ptr<const ShadowNode> &shadowNode,
       const std::shared_ptr<KeyframeProgressProvider> &progressProvider)
-      const override {
-    const auto toIndex = getToKeyframeIndex(progressProvider);
-    const auto fromIndex = toIndex - 1;
-
-    const auto &fromKeyframe = keyframes_[fromIndex];
-    const auto &toKeyframe = keyframes_[toIndex];
-
-    std::optional<ValueType> fromValue = fromKeyframe.value;
-    std::optional<ValueType> toValue = toKeyframe.value;
-
-    if (!fromValue.has_value()) {
-      fromValue = getFallbackValue(shadowNode);
-    }
-    if (!toValue.has_value()) {
-      toValue = getFallbackValue(shadowNode);
-    }
-
-    const auto keyframeProgress = progressProvider->getKeyframeProgress(
-        fromKeyframe.offset, toKeyframe.offset);
-
-    if (keyframeProgress == 1.0) {
-      return toValue.value().toDynamic();
-    }
-    if (keyframeProgress == 0.0) {
-      return fromValue.value().toDynamic();
-    }
-
-    return interpolateValue(
-               keyframeProgress,
-               fromValue.value(),
-               toValue.value(),
-               {.node = shadowNode})
-        .toDynamic();
-  }
+      const override;
 
  protected:
-  ValueType defaultStyleValue_;
+  std::vector<ValueKeyframe> keyframes_;
+  std::shared_ptr<CSSValue> defaultStyleValue_;
+  folly::dynamic defaultStyleValueDynamic_;
+  folly::dynamic reversingAdjustedStartValue_;
 
-  virtual ValueType interpolateValue(
+  virtual std::shared_ptr<CSSValue> createValue(
+      jsi::Runtime &rt,
+      const jsi::Value &value) const = 0;
+  virtual std::shared_ptr<CSSValue> createValue(
+      const folly::dynamic &value) const = 0;
+  virtual folly::dynamic interpolateValue(
       double progress,
-      const ValueType &fromValue,
-      const ValueType &toValue,
-      const ValueInterpolatorUpdateContext &context) const {
-    return fromValue.interpolate(progress, toValue);
-  }
+      const std::shared_ptr<CSSValue> &fromValue,
+      const std::shared_ptr<CSSValue> &toValue,
+      const ValueInterpolatorUpdateContext &context) const = 0;
 
  private:
-  std::vector<ValueKeyframe<AllowedTypes...>> keyframes_;
-  std::optional<ValueType> reversingAdjustedStartValue_;
-
-  ValueType getFallbackValue(
-      const std::shared_ptr<const ShadowNode> &shadowNode) const {
-    const auto styleValue = getStyleValue(shadowNode);
-    return styleValue.isNull() ? defaultStyleValue_ : ValueType(styleValue);
-  }
-
-  size_t getToKeyframeIndex(
-      const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const {
-    const auto progress = progressProvider->getGlobalProgress();
-
-    const auto it = std::upper_bound(
-        keyframes_.begin(),
-        keyframes_.end(),
-        progress,
-        [](double progress, const KeyframeType &keyframe) {
-          return progress < keyframe.offset;
-        });
-
-    // If we're at the end, return the last valid keyframe index
-    if (it == keyframes_.end()) {
-      return keyframes_.size() - 1;
-    }
-
-    return std::distance(keyframes_.begin(), it);
-  }
-
   folly::dynamic convertOptionalToDynamic(
-      const std::optional<ValueType> &value) const {
-    return value ? value.value().toDynamic() : folly::dynamic();
-  }
+      const std::optional<std::shared_ptr<CSSValue>> &value) const;
+  std::shared_ptr<CSSValue> getFallbackValue(
+      const std::shared_ptr<const ShadowNode> &shadowNode) const;
+  size_t getToKeyframeIndex(
+      const std::shared_ptr<KeyframeProgressProvider> &progressProvider) const;
 };
 
 } // namespace reanimated::css


### PR DESCRIPTION
## Summary

Cherry-pick of the #8198 PR with some adjustments for `4.1-stable` branch (I had to remove `fallbackInterpolationThreshold` changes).