### PR TITLE
chore: Bump react-native-pager-view to v7

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -33,7 +33,7 @@
     "fuse.js": "patch:fuse.js@npm%3A7.1.0#~/.yarn/patches/fuse.js-npm-7.1.0-5dcae892a6.patch",
     "react": "19.1.1",
     "react-native-gesture-handler": "2.28.0",
-    "react-native-pager-view": "6.9.1",
+    "react-native-pager-view": "7.0.0",
     "react-native-reanimated": "workspace:*",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.14.1",

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1781,7 +1781,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-pager-view (6.9.1):
+  - react-native-pager-view (7.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3129,7 +3129,7 @@ SPEC CHECKSUMS:
   React-logger: 2fb8a9f32bbc80f6a37dc02c95579d5d3bf6fb58
   React-Mapbuffer: 54166856b49f9e140c3db0c5ddba90dc256a402c
   React-microtasksnativemodule: 36b1d448cbf4c8ef706d5e6c4267238943a369d1
-  react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
+  react-native-pager-view: 0b0b445d3cb9f8e9972842edf6ddf892b46bdc55
   react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
   React-NativeModulesApple: 71d6462e4b71c937be98abcd077f8823711b1586
   React-oscompat: 807cec62bbd3251a44defc198424c20ee9d1558c

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,7 +10578,7 @@ __metadata:
     react-native: "patch:react-native@npm%3A0.82.0-rc.0#~/.yarn/patches/react-native-npm-0.82.0-rc.0-4775a171a4.patch"
     react-native-gesture-handler: "npm:2.28.0"
     react-native-monorepo-tools: "npm:^1.2.1"
-    react-native-pager-view: "npm:6.9.1"
+    react-native-pager-view: "npm:7.0.0"
     react-native-reanimated: "workspace:*"
     react-native-safe-area-context: "npm:5.6.0"
     react-native-screens: "npm:4.14.1"
@@ -20819,13 +20819,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-pager-view@npm:6.9.1":
-  version: 6.9.1
-  resolution: "react-native-pager-view@npm:6.9.1"
+"react-native-pager-view@npm:7.0.0":
+  version: 7.0.0
+  resolution: "react-native-pager-view@npm:7.0.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/20fc4f22a68eeb4b8ce64ca0d62ec594040816d08690bb2749354d7dc0a4250f1ff9ea88c3b9fbbb7da498f1a6ece07abe79d3cdaba2f2147508283cc5ecf040
+  checksum: 10/652c12ebc9b473d81df99111d2dec0139585742b903dff916a6726156295af27d4bf464b9dcc22c133375dfc253a0653dba9c3cb705c892ba0beb7de8479792e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

I was facing [this](https://github.com/callstack/react-native-pager-view/issues/979) issue multiple times which was very annoying while working on native changes in reanimated. Usually, the only thing that worked was a full cleanup of the project and reinstallation of all dependencies and pods.

I hope that the issue is fixed in v7. At least, I think we can give it a try and see if it works after the upgrade.

I tested if the pager example in our example app works so I think it is safe to bump the version to v7.