### PR TITLE
chore(Worklets): fix PlatformChecker init

### DIFF
--- a/packages/react-native-worklets/src/PlatformChecker/index.ts
+++ b/packages/react-native-worklets/src/PlatformChecker/index.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { RuntimeKind } from '../runtimeKind';
+import { getRuntimeKind, RuntimeKind } from '../runtimeKind';
 import {
   IS_JEST as RN_IS_JEST,
   IS_WEB as RN_IS_WEB,
@@ -13,7 +13,7 @@ let IS_WEB = false;
 let IS_WINDOWS = false;
 let SHOULD_BE_USE_WEB = false;
 
-if (globalThis.__RUNTIME_KIND === RuntimeKind.ReactNative) {
+if (getRuntimeKind() === RuntimeKind.ReactNative) {
   IS_JEST = RN_IS_JEST;
   IS_WEB = RN_IS_WEB;
   IS_WINDOWS = RN_IS_WINDOWS;

--- a/packages/react-native-worklets/src/threads.ts
+++ b/packages/react-native-worklets/src/threads.ts
@@ -153,7 +153,7 @@ export function runOnUI<Args extends unknown[], ReturnValue>(
   };
 }
 
-if (__DEV__) {
+if (__DEV__ && !SHOULD_BE_USE_WEB) {
   function runOnUIWorklet(): void {
     'worklet';
     throw new WorkletsError(
@@ -392,7 +392,7 @@ export function runOnUIAsync<Args extends unknown[], ReturnValue>(
   };
 }
 
-if (__DEV__) {
+if (__DEV__ && !SHOULD_BE_USE_WEB) {
   function runOnUIAsyncWorklet(): void {
     'worklet';
     throw new WorkletsError(


### PR DESCRIPTION
## Summary

Fixes #8285.

When initializing "PlatformChecker" in lazy import environments `globalThis.__RUNTIME_KIND` will be executed before it's defined in `runtimeKind` file. By changing it to function invocation we enforce that it's properly initialized.

Also setting serialized values manually for `runOnUI` and `runOnUIAsync` has to be done only when not in web implementation.

## Test plan

See fixed issue.
