### PR TITLE
(cherry-pick) Fix `Cannot read property '__nativeTag' of null`.

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -108,15 +108,15 @@ export class NativeEventsManager implements INativeEventsManager {
       // On the first render of a component, we may already receive a resolved view tag.
       return this.#managedComponent.getComponentViewTag();
     }
-    if (componentAnimatedRef.__nativeTag || componentAnimatedRef._nativeTag) {
+    if (componentAnimatedRef?.__nativeTag || componentAnimatedRef?._nativeTag) {
       /*
         Fast path for native refs,
         _nativeTag is used by Paper components,
         __nativeTag is used by Fabric components.
       */
       return (
-        componentAnimatedRef.__nativeTag ??
-        componentAnimatedRef._nativeTag ??
+        componentAnimatedRef?.__nativeTag ??
+        componentAnimatedRef?._nativeTag ??
         -1
       );
     }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -115,8 +115,8 @@ export class NativeEventsManager implements INativeEventsManager {
         __nativeTag is used by Fabric components.
       */
       return (
-        componentAnimatedRef?.__nativeTag ??
-        componentAnimatedRef?._nativeTag ??
+        componentAnimatedRef.__nativeTag ??
+        componentAnimatedRef._nativeTag ??
         -1
       );
     }

--- a/packages/react-native-reanimated/src/helperTypes.ts
+++ b/packages/react-native-reanimated/src/helperTypes.ts
@@ -7,7 +7,7 @@ until time comes to refactor the code and get necessary types right.
 This will not be easy though! 
 */
 
-import type { RegisteredStyle, StyleProp } from 'react-native';
+import type { StyleProp } from 'react-native';
 
 import type {
   AnimatedStyle,
@@ -19,6 +19,10 @@ import type {
 import type { BaseAnimationBuilder } from './layoutReanimation/animationBuilder/BaseAnimationBuilder';
 import type { ReanimatedKeyframe } from './layoutReanimation/animationBuilder/Keyframe';
 import type { SharedTransition } from './layoutReanimation/sharedTransitions';
+
+// RegisteredStyle was removed from React Native, provide a fallback type
+// This is only used in a deprecated type definition
+type RegisteredStyle<T> = number & {__registeredStyleBrand: T};
 
 export type EntryOrExitLayoutType =
   | BaseAnimationBuilder

--- a/packages/react-native-reanimated/src/helperTypes.ts
+++ b/packages/react-native-reanimated/src/helperTypes.ts
@@ -22,7 +22,7 @@ import type { SharedTransition } from './layoutReanimation/sharedTransitions';
 
 // RegisteredStyle was removed from React Native, provide a fallback type
 // This is only used in a deprecated type definition
-type RegisteredStyle<T> = number & {__registeredStyleBrand: T};
+type RegisteredStyle<T> = number & { __registeredStyleBrand: T };
 
 export type EntryOrExitLayoutType =
   | BaseAnimationBuilder


### PR DESCRIPTION
## Summary
Cherry-pick of the https://github.com/software-mansion/react-native-reanimated/pull/8093

## Test plan
