### PR TITLE
chore: Remove duplicate ValueProcessor type

### DIFF
--- a/packages/react-native-reanimated/src/common/types.ts
+++ b/packages/react-native-reanimated/src/common/types.ts
@@ -1,7 +1,9 @@
 'use strict';
 export type Maybe<T> = T | null | undefined;
 
-export type ValueProcessor<V, R = V> = (value: V) => Maybe<R>;
+export type ValueProcessor<V, R = V> = (
+  value: V
+) => Maybe<R> | Record<string, R>;
 
 export type TransformOrigin = string | Array<string | number>;
 

--- a/packages/react-native-reanimated/src/css/native/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/css/native/style/processors/colors.ts
@@ -1,12 +1,11 @@
 'use strict';
 import type { ColorValue } from 'react-native';
 
-import type { Maybe } from '../../../../common';
+import type { Maybe, ValueProcessor } from '../../../../common';
 import {
   processColor as processColorInternal,
   ReanimatedError,
 } from '../../../../common';
-import type { ValueProcessor } from '../types';
 
 export const ERROR_MESSAGES = {
   invalidColor: (color: Maybe<ColorValue | number>) =>

--- a/packages/react-native-reanimated/src/css/native/style/processors/font.ts
+++ b/packages/react-native-reanimated/src/css/native/style/processors/font.ts
@@ -1,7 +1,7 @@
 'use strict';
+import type { ValueProcessor } from '../../../../common';
 import { ReanimatedError } from '../../../../common';
 import { FONT_WEIGHT_MAPPINGS } from '../../../constants';
-import type { ValueProcessor } from '../types';
 
 const ERROR_MESSAGES = {
   invalidFontWeight: (weight: string | number) =>

--- a/packages/react-native-reanimated/src/css/native/style/processors/insets.ts
+++ b/packages/react-native-reanimated/src/css/native/style/processors/insets.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { DimensionValue } from 'react-native';
 
-import type { ValueProcessor } from '../types';
+import type { ValueProcessor } from '../../../../common';
 
 type InsetProcessor = ValueProcessor<
   DimensionValue,

--- a/packages/react-native-reanimated/src/css/native/style/processors/others.ts
+++ b/packages/react-native-reanimated/src/css/native/style/processors/others.ts
@@ -1,6 +1,6 @@
 'use strict';
+import type { ValueProcessor } from '../../../../common';
 import { ReanimatedError } from '../../../../common';
-import type { ValueProcessor } from '../types';
 
 export const ERROR_MESSAGES = {
   unsupportedAspectRatio: (ratio: string | number) =>

--- a/packages/react-native-reanimated/src/css/native/style/processors/transform.ts
+++ b/packages/react-native-reanimated/src/css/native/style/processors/transform.ts
@@ -1,8 +1,8 @@
 'use strict';
+import type { ValueProcessor } from '../../../../common';
 import { ReanimatedError } from '../../../../common';
 import type { TransformsArray } from '../../../types';
 import { isAngle, isNumber, isNumberArray, isPercentage } from '../../../utils';
-import type { ValueProcessor } from '../types';
 
 export const ERROR_MESSAGES = {
   invalidTransform: (transform: string) =>

--- a/packages/react-native-reanimated/src/css/native/style/types.ts
+++ b/packages/react-native-reanimated/src/css/native/style/types.ts
@@ -1,10 +1,6 @@
 'use strict';
-import type { Maybe } from '../../../common';
+import type { ValueProcessor } from '../../../common';
 import type { AnyRecord, ConfigPropertyAlias } from '../../types';
-
-export type ValueProcessor<V, R = V> = (
-  value: V
-) => Maybe<R> | Record<string, R>;
 
 export type StyleBuildMiddleware<P extends AnyRecord> = (props: P) => P;
 

--- a/packages/react-native-reanimated/src/css/svg/native/processors/colors.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/colors.ts
@@ -1,7 +1,8 @@
 'use strict';
 import type { ColorValue } from 'react-native';
 
-import { processColor, type ValueProcessor } from '../../../native';
+import type { ValueProcessor } from '../../../../common';
+import { processColor } from '../../../native';
 
 export const processColorSVG: ValueProcessor<
   ColorValue | number,

--- a/packages/react-native-reanimated/src/css/svg/native/processors/opacity.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/opacity.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { NumberProp } from 'react-native-svg';
 
-import type { ValueProcessor } from '../../../native';
+import type { ValueProcessor } from '../../../../common';
 
 export const processOpacity: ValueProcessor<NumberProp, number> = (opacity) => {
   const value =

--- a/packages/react-native-reanimated/src/css/svg/native/processors/others.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/others.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { ValueProcessor } from '../../../native';
+import type { ValueProcessor } from '../../../../common';
 
 export const convertStringToNumber =
   <S extends string>(


### PR DESCRIPTION
## Summary

This PR removed the duplicate definition of the `ValueProcessor` type.