### PR TITLE
fix: Screen transition example crash

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ScreenTransitionExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScreenTransitionExample.tsx
@@ -1,11 +1,13 @@
 import type { ParamListBase } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackScreenProps,
+} from '@react-navigation/native-stack';
 import React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import type { AnimatedScreenTransition } from 'react-native-reanimated';
 import { ScreenTransition } from 'react-native-reanimated';
 import { GestureDetectorProvider } from 'react-native-screens/gesture-handler';
-import type { NativeStackScreenProps } from 'react-native-screens/native-stack';
-import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 
 function MainScreen({ navigation }: NativeStackScreenProps<ParamListBase>) {
   return (


### PR DESCRIPTION
## Summary

This PR changes invalid imports from `react-native-screens/native-stack` to `@react-navigation/native-stack`. The old import caused crash when the **Screen transition** example was opened.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/5d6c71cc-598c-4a73-a2c0-054bf016172b" /> | <video src="https://github.com/user-attachments/assets/baed2d47-b82e-4517-aed7-607ff85916aa" /> |









