### PR TITLE
fix: Animated styles not registered after unfreeze

### DIFF
--- a/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
+++ b/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
@@ -7,13 +7,17 @@ export interface ViewDescriptorsSet {
   shareableViewDescriptors: SharedValue<Descriptor[]>;
   add: (item: Descriptor, updaterContainer?: StyleUpdaterContainer) => void;
   remove: (viewTag: number) => void;
+  has: (viewTag: number) => boolean;
 }
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const shareableViewDescriptors = makeMutable<Descriptor[]>([]);
+  const viewTags = new Set<number>();
+
   const data: ViewDescriptorsSet = {
     shareableViewDescriptors,
     add: (item: Descriptor, updaterContainer?: StyleUpdaterContainer) => {
+      viewTags.add(item.tag as number);
       const updater = updaterContainer?.current;
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
@@ -31,6 +35,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
     },
 
     remove: (viewTag: number) => {
+      viewTags.delete(viewTag);
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(
@@ -42,6 +47,9 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
         return descriptors;
       }, false);
     },
+
+    has: (viewTag: number) => viewTags.has(viewTag),
   };
+
   return data;
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -212,6 +212,9 @@ export default class AnimatedComponent
     const { viewTag, shadowNodeWrapper } = this._getViewInfo();
     const newStyles = new Set<StyleProps>(currentStyles);
 
+    const isStyleAttached = (style: StyleProps) =>
+      style.viewDescriptors.has(viewTag);
+
     // remove old styles
     if (prevStyles) {
       // in most of the cases, views have only a single animated style and it remains unchanged
@@ -220,14 +223,14 @@ export default class AnimatedComponent
         prevStyles.length === 1 &&
         currentStyles[0] === prevStyles[0];
 
-      if (hasOneSameStyle) {
+      if (hasOneSameStyle && isStyleAttached(prevStyles[0])) {
         return;
       }
 
       // otherwise, remove each style that is not present in new styles
       for (const prevStyle of prevStyles) {
         const isPresent = currentStyles.some((style) => {
-          if (style === prevStyle) {
+          if (style === prevStyle && isStyleAttached(style)) {
             newStyles.delete(style);
             return true;
           }
@@ -238,6 +241,7 @@ export default class AnimatedComponent
         }
       }
     }
+
     newStyles.forEach((style) => {
       style.viewDescriptors.add(
         {


### PR DESCRIPTION
## Summary

This PR fixes animated styles registering on freeze/unfreeze. The issue was caused by the cleanup made in the `componentWillUnmount`, which removes the current view tag from the animated style's view descriptors. This view tag was never added later on because only the style object references were compared and, because the style prop didn't change between freeze/unfreeze, we assumed that there is no need to register the animated styles again. This assumption was correct as long as the `componentWillUnmount` was executed before the component was actually unmounted (but, it turns out that this method is also called when the component is frozen, not unmounted).

## Example recordings

The pink rectangle with the animated style attached didn't animate after navigating back to the previously frozen screen.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/eaaa21ae-266a-4649-8fb3-b492e80fc186" /> | <video src="https://github.com/user-attachments/assets/744eb171-d231-49aa-92f2-e89174dd2b15" /> |
