### PR TITLE
fix: Move android-only prop definition to ifdef block

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -54,8 +54,8 @@ struct LayoutAnimationsProxy
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   jsi::Runtime &uiRuntime_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
-  PreserveMountedTagsFunction preserveMountedTags_;
 #ifdef ANDROID
+  PreserveMountedTagsFunction preserveMountedTags_;
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<CallInvoker> jsInvoker_;
 #endif


### PR DESCRIPTION
## Summary

Fixes impossibility to build the iOS app becuase of the incorrectly placed prop.