### PR TITLE
fix(Worklets): Bundle Mode accidentally toggling in Expo54

### DIFF
--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1250,6 +1250,37 @@ var require_autoworkletization = __commonJS({
   }
 });
 
+// lib/bundleMode.js
+var require_bundleMode = __commonJS({
+  "lib/bundleMode.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.toggleBundleMode = toggleBundleMode;
+    var types_12 = require("@babel/types");
+    function toggleBundleMode(path, state) {
+      var _a;
+      if (!state.opts.bundleMode || !((_a = state.filename) === null || _a === void 0 ? void 0 : _a.includes("workletRuntimeEntry"))) {
+        return;
+      }
+      const expressionPath = path.get("expression");
+      if (!expressionPath.isAssignmentExpression()) {
+        return;
+      }
+      const left = expressionPath.get("left");
+      if (!left.isMemberExpression()) {
+        return;
+      }
+      const object = left.get("object");
+      const property = left.get("property");
+      if (!object.isIdentifier() || object.node.name !== "globalThis" || !property.isIdentifier() || property.node.name !== "_WORKLETS_BUNDLE_MODE") {
+        return;
+      }
+      const right = expressionPath.get("right");
+      right.replaceWith((0, types_12.booleanLiteral)(true));
+    }
+  }
+});
+
 // lib/class.js
 var require_class = __commonJS({
   "lib/class.js"(exports2) {
@@ -1703,6 +1734,7 @@ var require_webOptimization = __commonJS({
 // lib/plugin.js
 Object.defineProperty(exports, "__esModule", { value: true });
 var autoworkletization_1 = require_autoworkletization();
+var bundleMode_1 = require_bundleMode();
 var class_1 = require_class();
 var contextObject_1 = require_contextObject();
 var file_1 = require_file();
@@ -1763,6 +1795,13 @@ module.exports = function WorkletsBabelPlugin() {
         enter(path, state) {
           runWithTaggedExceptions(() => {
             (0, file_1.processIfWorkletFile)(path, state);
+          });
+        }
+      },
+      ExpressionStatement: {
+        enter(path, state) {
+          runWithTaggedExceptions(() => {
+            (0, bundleMode_1.toggleBundleMode)(path, state);
           });
         }
       },

--- a/packages/react-native-worklets/plugin/src/bundleMode.ts
+++ b/packages/react-native-worklets/plugin/src/bundleMode.ts
@@ -1,0 +1,54 @@
+import type { NodePath } from '@babel/core';
+import { booleanLiteral, type ExpressionStatement } from '@babel/types';
+
+import type { ReanimatedPluginPass } from './types';
+
+/**
+ * This function replaces the `false` value in
+ *
+ * `globalThis._WORKLETS_BUNDLE_MODE = false;`
+ *
+ * With `true` in the `workletRuntimeEntry` file when the `bundleMode` option is
+ * enabled in the Babel plugin.
+ *
+ * This way Bundle Mode is not accidentally set up in eager import environments,
+ */
+export function toggleBundleMode(
+  path: NodePath<ExpressionStatement>,
+  state: ReanimatedPluginPass
+) {
+  if (
+    !state.opts.bundleMode ||
+    !state.filename?.includes('workletRuntimeEntry')
+  ) {
+    return;
+  }
+
+  const expressionPath = path.get('expression');
+
+  if (!expressionPath.isAssignmentExpression()) {
+    return;
+  }
+
+  const left = expressionPath.get('left');
+
+  if (!left.isMemberExpression()) {
+    return;
+  }
+
+  const object = left.get('object');
+  const property = left.get('property');
+
+  if (
+    !object.isIdentifier() ||
+    object.node.name !== 'globalThis' ||
+    !property.isIdentifier() ||
+    property.node.name !== '_WORKLETS_BUNDLE_MODE'
+  ) {
+    return;
+  }
+
+  const right = expressionPath.get('right');
+
+  right.replaceWith(booleanLiteral(true));
+}

--- a/packages/react-native-worklets/plugin/src/plugin.ts
+++ b/packages/react-native-worklets/plugin/src/plugin.ts
@@ -2,6 +2,7 @@ import type { NodePath, PluginItem } from '@babel/core';
 import type {
   CallExpression,
   ClassDeclaration,
+  ExpressionStatement,
   JSXAttribute,
   ObjectExpression,
   Program,
@@ -11,6 +12,7 @@ import {
   processCalleesAutoworkletizableCallbacks,
   processIfAutoworkletizableCallback,
 } from './autoworkletization';
+import { toggleBundleMode } from './bundleMode';
 import { processIfWorkletClass } from './class';
 import { processIfWorkletContextObject } from './contextObject';
 import { processIfWorkletFile } from './file';
@@ -82,6 +84,16 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
         enter(path: NodePath<Program>, state: ReanimatedPluginPass) {
           runWithTaggedExceptions(() => {
             processIfWorkletFile(path, state);
+          });
+        },
+      },
+      ExpressionStatement: {
+        enter(
+          path: NodePath<ExpressionStatement>,
+          state: ReanimatedPluginPass
+        ) {
+          runWithTaggedExceptions(() => {
+            toggleBundleMode(path, state);
           });
         },
       },

--- a/packages/react-native-worklets/src/workletRuntimeEntry.ts
+++ b/packages/react-native-worklets/src/workletRuntimeEntry.ts
@@ -18,11 +18,13 @@ import { WorkletsError } from './WorkletsError';
  * `_WORKLETS_BUNDLE_MODE` flag.
  */
 export function bundleModeInit() {
-  if (SHOULD_BE_USE_WEB) {
+  // Worklets Babel Plugin replaces `false` with `true` here
+  // when Bundle Mode is enabled.
+  globalThis._WORKLETS_BUNDLE_MODE = false;
+
+  if (SHOULD_BE_USE_WEB || !globalThis._WORKLETS_BUNDLE_MODE) {
     return;
   }
-
-  globalThis._WORKLETS_BUNDLE_MODE = true;
 
   const runtimeKind = globalThis.__RUNTIME_KIND;
   if (runtimeKind && runtimeKind !== RuntimeKind.ReactNative) {


### PR DESCRIPTION
## Summary

Expo 54 performs eager imports contrary to Metro which is lazy. This results in `workletRuntimeEntry.ts` file to be executed and for the `globalThis._WORKLETS_BUNDLE_MODE` flag to be set wrongfully to `true`.

To handle both eager and lazy imports environments I decided to handle the setting of the flag's value in Worklets Babel Plugin. Worklets Babel Plugin makes it so the expression in `workletRuntimeEntry.ts`:

```ts
globalThis._WORKLETS_BUNDLE_MODE = false
```

becomes

```ts
globalThis._WORKLETS_BUNDLE_MODE = true
``` 

when Bundle Mode is enabled.

## Test plan

I tested these changes with an Expo 54 app and they worked.
