### PR TITLE
(cherry-pick) fix: Don't pass uninitialized ref to dispatchCommand, add warnings

### DIFF
--- a/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/dispatchCommand.ts
@@ -38,8 +38,21 @@ function dispatchCommandNative(
     return;
   }
 
-  const shadowNodeWrapper = animatedRef() as ShadowNodeWrapper;
-  global._dispatchCommand!(shadowNodeWrapper, commandName, args);
+  const shadowNodeWrapper = animatedRef();
+
+  // This prevents crashes if ref has not been set yet
+  if (!shadowNodeWrapper) {
+    logger.warn(
+      `Tried to dispatch command "${commandName}" with an uninitialized ref. Make sure to pass the animated ref to the component before using it.`
+    );
+    return;
+  }
+
+  global._dispatchCommand!(
+    shadowNodeWrapper as ShadowNodeWrapper,
+    commandName,
+    args
+  );
 }
 
 function dispatchCommandJest() {

--- a/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
+++ b/packages/react-native-reanimated/src/platformFunctions/scrollTo.web.ts
@@ -1,6 +1,7 @@
 'use strict';
 import type { ScrollView } from 'react-native';
 
+import { logger } from '../common';
 import type { WrapperRef } from '../commonTypes';
 import type { AnimatedRef } from '../hook/commonTypes';
 
@@ -13,9 +14,14 @@ export function scrollTo<TRef extends WrapperRef>(
   const element = animatedRef();
 
   // This prevents crashes if ref has not been set yet
-  if (element) {
-    // By ScrollView we mean any scrollable component
-    const scrollView = element as unknown as ScrollView;
-    scrollView?.scrollTo({ x, y, animated });
+  if (!element) {
+    logger.warn(
+      'Called scrollTo() with an uninitialized ref. Make sure to pass the animated ref to the scrollable component before calling scrollTo().'
+    );
+    return;
   }
+
+  // By ScrollView we mean any scrollable component
+  const scrollView = element as unknown as ScrollView;
+  scrollView?.scrollTo({ x, y, animated });
 }


### PR DESCRIPTION
Cherry-pick of the #8327