### PR TITLE
docs: Adjust path for Compatibility

### DIFF
--- a/docs/docs-reanimated/src/components/Compatibility/index.tsx
+++ b/docs/docs-reanimated/src/components/Compatibility/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import compatibilityData from '../../../../../packages/react-native-worklets/compatibility.json';
+import compatibilityData from '../../../../../packages/react-native-reanimated/compatibility.json';
 import styles from './styles.module.css';
 
 export function Yes() {


### PR DESCRIPTION
There was some change in path when moving documentation from `packages` to `docs` - probably caused by path changing automatically across docs. ## Summary
Before:

<img width="1309" height="744" alt="image" src="https://github.com/user-attachments/assets/9ca3360d-ce2e-4e80-941e-4b0024d290c7" />

After:
<img width="1284" height="813" alt="image" src="https://github.com/user-attachments/assets/4ba05530-1c0f-4d07-9f62-d043330b93c1" />
## Test plan
