### PR TITLE
docs: Add info about testing `react-native-svg` with Reanimated

### DIFF
--- a/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
+++ b/docs/docs-reanimated/docs/guides/testing-with-jest.mdx
@@ -113,8 +113,7 @@ More examples from `react-native-reanimated` repository:
 
 ## Testing `react-native-svg`
 
-Because of how `react-native-svg` manages its props, it cannot be tested with Reanimated out of the box.
-To enable testing, you can use the mock provided by Reanimated:
+Because of how `react-native-svg` manages its props, you need to use the mock provided by Reanimated to enable testing:
 
 ```js
 jest.mock('react-native-svg', () => require('react-native-reanimated/mock'));


### PR DESCRIPTION
## Summary

As the title declares, we added info for users how the can mock the react-native-svg library - because it's common problem with Reanimated and Jest.

<img width="905" height="450" alt="image" src="https://github.com/user-attachments/assets/a26cc9fe-9034-4128-8eb6-1b77c47eadab" />



## Test plan
