### PR TITLE
fix: Use correct color processor in CSS

### DIFF
--- a/packages/react-native-reanimated/src/css/native/style/config.ts
+++ b/packages/react-native-reanimated/src/css/native/style/config.ts
@@ -2,12 +2,12 @@
 import {
   IS_ANDROID,
   processBoxShadowNative,
-  processColor,
   processTransformOrigin,
 } from '../../../common';
 import type { PlainStyle } from '../../types';
 import {
   processAspectRatio,
+  processColor,
   processFontWeight,
   processGap,
   processInset,


### PR DESCRIPTION
## Summary

The invalid `processColor` function was used in the CSS style builder config resulting in improper transparent color handling. This PR replaced the invalid one with the correct implementation.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/e2432ebd-1d9e-480b-82cf-8fc006b56952" /> | <video src="https://github.com/user-attachments/assets/48114dba-7d5f-4387-bff5-cf30fefbdab7" /> |
