### PR TITLE
chore: Simplify and optimize `interpolate` implementation

### DIFF
--- a/packages/react-native-reanimated/src/interpolation.ts
+++ b/packages/react-native-reanimated/src/interpolation.ts
@@ -201,7 +201,7 @@ export function interpolate(
       rightEdgeOutput: outputRange[length - 1],
     };
   } else {
-    let left = 0;
+    let left = 1;
     let right = length - 1;
 
     while (left < right) {
@@ -213,7 +213,7 @@ export function interpolate(
       }
     }
 
-    const segmentIndex = Math.max(1, left);
+    const segmentIndex = left;
     narrowedInput = {
       leftEdgeInput: inputRange[segmentIndex - 1],
       rightEdgeInput: inputRange[segmentIndex],


### PR DESCRIPTION
## Summary

The previous implementation unnecessarily used the `O(n)` loop to find the current interpolation value instead of using a simple binary search. It also Used unnecessary check if length of the input range is greater than 2 as this case doesn't have to be handled separately.