### PR TITLE
fix(Reanimated): parsing layout animations on web

### DIFF
--- a/packages/react-native-reanimated/src/layoutReanimation/web/Easing.web.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/Easing.web.ts
@@ -29,6 +29,10 @@ export function getEasingByName(easingName: WebEasingsNames) {
 export function maybeGetBezierEasing(
   easing: EasingFunctionFactory
 ): null | string {
+  if (typeof easing === 'string') {
+    return null;
+  }
+
   if (!('factory' in easing)) {
     return null;
   }


### PR DESCRIPTION
## Summary

The page https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/ is currently broken due to a bug that tries to use `in` operator in a string.

In web implementation easings are passed as strings

<img width="827" height="161" alt="Screenshot 2025-10-17 at 10 22 40" src="https://github.com/user-attachments/assets/bb0d3046-d996-4fbe-a26b-65f5bb27e6b6" />

I'll re-publish a nightly after this PR is merged and bump the version of Reanimated in the docs.

## Test plan

Docs don't crash anymore now.
