### PR TITLE
fix(Reanimated): flaky RN$Bridgeless assertion

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -83,7 +83,7 @@ class NativeReanimatedModule implements IReanimatedModule {
 See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#native-part-of-reanimated-doesnt-seem-to-be-initialized for more details.`
       );
     }
-    if (!globalThis.RN$Bridgeless && !SHOULD_BE_USE_WEB) {
+    if (__DEV__ && !globalThis.RN$Bridgeless && !SHOULD_BE_USE_WEB) {
       throw new ReanimatedError(
         'Reanimated 4 supports only the React Native New Architecture and web.'
       );


### PR DESCRIPTION
## Summary

It seems that there's a race condition with setting the `RN$Bridgeless` global env on Fabric. To avoid unnecessary crashes I moved the check if Fabric is enabled to dev bundles only.

Fixes #8235

## Test plan

🚀 