### PR TITLE
Rewrite BokehExample into transforms in the example app

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/BokehExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/BokehExample.tsx
@@ -23,6 +23,8 @@ interface CircleProps {
 }
 
 function Circle({
+  size,
+  opacity,
   duration,
   startX,
   startY,
@@ -30,8 +32,6 @@ function Circle({
   endY,
   startHue,
   endHue,
-  size,
-  opacity,
 }: CircleProps) {
   const left = useSharedValue(startX);
   const top = useSharedValue(startY);
@@ -110,6 +110,8 @@ function makeBokehCircleParams(): CircleProps {
   const endHue = randBetween(0, 360);
 
   return {
+    size,
+    opacity,
     duration,
     startX,
     startY,
@@ -117,8 +119,6 @@ function makeBokehCircleParams(): CircleProps {
     endY,
     startHue,
     endHue,
-    size,
-    opacity,
   };
 }
 


### PR DESCRIPTION
## Summary

This PR optimizes the Bokeh example in the example app, by rewriting:
- the animation logic to use `withRepeat` instead of JS intervals
- introducing props-based `Circle` component for potential reusability in some other examples
- animating the `transform` property instead of `left` and `top` directly

## Test plan
