### PR TITLE
fix: BottomSheet example crash

### DIFF
--- a/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch
+++ b/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch
@@ -1,0 +1,66 @@
+diff --git a/lib/commonjs/hooks/useBoundingClientRect.js b/lib/commonjs/hooks/useBoundingClientRect.js
+index b4a90b76ee55bf2cad9cf461017621b1ddab0fe1..ccd592713dbbdf47957d24a5bced0ea4742a82ad 100644
+--- a/lib/commonjs/hooks/useBoundingClientRect.js
++++ b/lib/commonjs/hooks/useBoundingClientRect.js
+@@ -46,7 +46,7 @@ function useBoundingClientRect(ref, handler) {
+     }
+ 
+     // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
+-    if (ref.current.unstable_getBoundingClientRect !== null) {
++    if (ref.current.unstable_getBoundingClientRect) {
+       // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
+       const layout = ref.current.unstable_getBoundingClientRect();
+       handler(layout);
+@@ -54,7 +54,7 @@ function useBoundingClientRect(ref, handler) {
+     }
+ 
+     // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
+-    if (ref.current.getBoundingClientRect !== null) {
++    if (ref.current.getBoundingClientRect) {
+       // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
+       const layout = ref.current.getBoundingClientRect();
+       handler(layout);
+diff --git a/lib/module/hooks/useBoundingClientRect.js b/lib/module/hooks/useBoundingClientRect.js
+index a723aede9d4cfbb46f5985c531e0dae8f517aba8..c11b18b569d67fc9993ac9ab492ee1d967c24867 100644
+--- a/lib/module/hooks/useBoundingClientRect.js
++++ b/lib/module/hooks/useBoundingClientRect.js
+@@ -42,7 +42,7 @@ export function useBoundingClientRect(ref, handler) {
+     }
+ 
+     // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
+-    if (ref.current.unstable_getBoundingClientRect !== null) {
++    if (ref.current.unstable_getBoundingClientRect) {
+       // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
+       const layout = ref.current.unstable_getBoundingClientRect();
+       handler(layout);
+@@ -50,7 +50,7 @@ export function useBoundingClientRect(ref, handler) {
+     }
+ 
+     // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
+-    if (ref.current.getBoundingClientRect !== null) {
++    if (ref.current.getBoundingClientRect) {
+       // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
+       const layout = ref.current.getBoundingClientRect();
+       handler(layout);
+diff --git a/src/hooks/useBoundingClientRect.ts b/src/hooks/useBoundingClientRect.ts
+index cc85c8ced2de8ec514360368ed20af733f8f9aec..c551df2694ef00023a2e4616f8969ffd5e21d695 100644
+--- a/src/hooks/useBoundingClientRect.ts
++++ b/src/hooks/useBoundingClientRect.ts
+@@ -56,7 +56,7 @@ export function useBoundingClientRect(
+     }
+ 
+     // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
+-    if (ref.current.unstable_getBoundingClientRect !== null) {
++    if (ref.current.unstable_getBoundingClientRect) {
+       // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
+       const layout = ref.current.unstable_getBoundingClientRect();
+       handler(layout);
+@@ -64,7 +64,7 @@ export function useBoundingClientRect(
+     }
+ 
+     // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
+-    if (ref.current.getBoundingClientRect !== null) {
++    if (ref.current.getBoundingClientRect) {
+       // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
+       const layout = ref.current.getBoundingClientRect();
+       handler(layout);

--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/fontawesome-svg-core": "6.5.2",
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@fortawesome/react-native-fontawesome": "0.3.2",
-    "@gorhom/bottom-sheet": "5.2.6",
+    "@gorhom/bottom-sheet": "patch:@gorhom/bottom-sheet@npm%3A5.2.6#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch",
     "@gorhom/portal": "1.0.14",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "1.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,6 +4307,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gorhom/bottom-sheet@patch:@gorhom/bottom-sheet@npm%3A5.2.6#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch":
+  version: 5.2.6
+  resolution: "@gorhom/bottom-sheet@patch:@gorhom/bottom-sheet@npm%3A5.2.6#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch::version=5.2.6&hash=5dd64e"
+  dependencies:
+    "@gorhom/portal": "npm:1.0.14"
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-native": "*"
+    react: "*"
+    react-native: "*"
+    react-native-gesture-handler: ">=2.16.1"
+    react-native-reanimated: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-native":
+      optional: true
+  checksum: 10/6b08b8c621a629759316198a73eb48cb0cb0bcb9a36f12adb0afe204f8bec9d414a5a7ba9daf1cfaaf06c3027bb391c630bc1444d8a5597d4356ded668e1642f
+  languageName: node
+  linkType: hard
+
 "@gorhom/portal@npm:1.0.14":
   version: 1.0.14
   resolution: "@gorhom/portal@npm:1.0.14"
@@ -12430,7 +12452,7 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": "npm:6.5.2"
     "@fortawesome/free-solid-svg-icons": "npm:6.5.2"
     "@fortawesome/react-native-fontawesome": "npm:0.3.2"
-    "@gorhom/bottom-sheet": "npm:5.2.6"
+    "@gorhom/bottom-sheet": "patch:@gorhom/bottom-sheet@npm%3A5.2.6#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.6-c24dba2629.patch"
     "@gorhom/portal": "npm:1.0.14"
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-clipboard/clipboard": "npm:1.16.3"


### PR DESCRIPTION
## Summary

It seems that the `unstable_getBoundingClientRect` no longer exists in RN `0.82` and the if check used in the Gorhom's bottom-sheet library is invalid as it checks whether the value is not `null`:

```ts
if (ref.current.unstable_getBoundingClientRect !== null) { ... }
```

Instead of checking if it is defined.

More details can be found in this issue:
https://github.com/gorhom/react-native-bottom-sheet/issues/2513