### PR TITLE
Add a missing include in Quaternion.cpp

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/Quaternion.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/Quaternion.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/common/transforms/Quaternion.h>
+#include <cmath>
 
 namespace reanimated::css {
 


### PR DESCRIPTION
## Summary

I've run into a build error when trying to create release builds of the example app: `Use of undeclared identifier 'std'` in `Quaternion.cpp` file.

<img width="1722" height="490" alt="image" src="https://github.com/user-attachments/assets/3b448272-e259-4b0a-a79d-6ff5c494130e" />

A glance at the source code made me realize that we're calling functions like `std::sqrt`, `std::sin` etc. without importing `cmath` anywhere before.

This error does not appear in debug builds. It seems to me that this is because in debug builds we are [importing `iostream` in the "if debug" condition](https://github.com/software-mansion/react-native-reanimated/blob/a9c36e69d37348eb80399ac9b63d81514326e858/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/Quaternion.h#L4) and I assume that through that we indirectly import cmath as well.

This PR adds an explicit `cmath` import to handle this issue.

## Test plan
