### PR TITLE
chore: Disable Stack animation on macos

### DIFF
--- a/apps/common-app/src/apps/reanimated/App.tsx
+++ b/apps/common-app/src/apps/reanimated/App.tsx
@@ -131,8 +131,16 @@ const screenOptions = {
   headerRight: IS_MACOS ? undefined : () => <DrawerButton />,
 };
 
+type AnimationType = 'none' | 'default' | 'fade';
+
 function Navigator() {
   const shouldReduceMotion = useReducedMotion();
+  let animation: AnimationType = 'default';
+  if (IS_MACOS) {
+    animation = 'none';
+  } else if (shouldReduceMotion) {
+    animation = 'fade';
+  }
 
   return (
     <Stack.Navigator screenOptions={screenOptions}>
@@ -150,11 +158,7 @@ function Navigator() {
           name={name}
           component={EXAMPLES[name].screen}
           options={{
-            animation: IS_MACOS
-              ? 'none'
-              : shouldReduceMotion
-                ? 'fade'
-                : 'default',
+            animation: animation,
             headerTitle: EXAMPLES[name].title,
             title: EXAMPLES[name].title,
           }}


### PR DESCRIPTION
## Summary

`Stack.Navigator` config option `animation` does not work on macos by default. This is quite a quick fix, cause I'm not sure why the animation does not work on `Stack` - I suppose it is not integrated for MacOS. For now, to test Reanimated I'd suggest we merge this, and in the future eventually adjust 


Edit: 28.10.2025 - the Macos is not supported by RN-Navigation, so we might be sure until it is (but it may never be) we can keep `animation` turned off.

## Test plan
