### PR TITLE
feat: Add `WorkletRuntime::executeAsync`

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -61,6 +61,8 @@ class WorkletRuntime : public jsi::HostObject,
   jsi::Value executeSync(
       const std::function<jsi::Value(jsi::Runtime &)> &job) const;
 
+  void executeAsync(std::function<void(jsi::Runtime &)> &&job) const;
+
   std::string toString() const {
     return "[WorkletRuntime \"" + name_ + "\"]";
   }


### PR DESCRIPTION
## Summary

Adds a new method to the `WorkletRuntime` called `executeAsync`. This method schedules a new job (`std::function`) on the thread connected with the runtime. Currently, the only available function allows us to schedule a worklet, which doesn't fit my use case.

## Test plan

- `expo/expo` ✅ 
