### PR TITLE
feat: Expose `WorkletRuntime` using a global object

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -26,6 +26,18 @@ namespace worklets {
  * Forward declaration to avoid circular dependencies.
  */
 class JSIWorkletsModuleProxy;
+class WorkletRuntime;
+
+class WorkletRuntimeHolderNativeState : public jsi::NativeState {
+ public:
+  explicit WorkletRuntimeHolderNativeState(
+      const std::weak_ptr<WorkletRuntime> &workletRuntime);
+
+  std::weak_ptr<WorkletRuntime> getWorkletRuntime() const;
+
+ private:
+  std::weak_ptr<WorkletRuntime> weakWorkletRuntime_;
+};
 
 class WorkletRuntime : public jsi::HostObject,
                        public std::enable_shared_from_this<WorkletRuntime> {

--- a/packages/react-native-worklets/src/publicGlobals.ts
+++ b/packages/react-native-worklets/src/publicGlobals.ts
@@ -36,4 +36,10 @@ declare global {
    * - Value _3_: Worker Worklet Runtime
    */
   var __RUNTIME_KIND: RuntimeKind | 1 | 2 | 3;
+
+  /**
+   * Holds a reference to the WorkletRuntimeHolderNativeState instance used to
+   * obtain a weak reference to the WorkletRuntime.
+   */
+  var _WORKLET_RUNTIME_HOLDER: object | undefined;
 }


### PR DESCRIPTION
## Summary

Expose `WorkletRuntime` via `WorkletRuntimeHolderNativeState`, which is added as a property on the global object. This allows other libraries to access the UI `WorkletRuntime`.

## Test plan

- `expo/expo` ✅ 