### PR TITLE
Fix synchronous props updates on iOS below RN 0.81

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -167,7 +167,8 @@ using namespace facebook::react;
 
   RCTSurfacePresenter *surfacePresenter = self.surfacePresenter;
   RCTComponentViewRegistry *componentViewRegistry = surfacePresenter.mountingManager.componentViewRegistry;
-  REAUIView<RCTComponentViewProtocol> *componentView = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(viewTag)];
+  REAUIView<RCTComponentViewProtocol> *componentView =
+      [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(viewTag)];
   NSSet<NSString *> *propKeysManagedByAnimated = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
 #if REACT_NATIVE_MINOR_VERSION >= 81
   [surfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:viewTag props:props];


### PR DESCRIPTION
## Summary

Currently, animating props synchronously is broken on React Native 0.80 or older because `schedulerDidSynchronouslyUpdateViewOnUIThread:props:` method that we're using was added https://github.com/facebook/react-native/pull/51470 in which was released in React Native 0.81.

In https://github.com/software-mansion/react-native-reanimated/pull/8248, @patrycjakalinska added ifdefs to disable this flow on `react-native-macos` but it is not a problem with macOS itself but rather with the version of React Native (currently, `macos-example` runs on 0.79).

This PR fixes animating props synchronously on iOS on React Native 0.80 and older.

## Test plan
