### PR TITLE
chore: Remove `ReanimatedError` and `WorkletsError` from global types

### DIFF
--- a/packages/react-native-reanimated/src/common/constants.ts
+++ b/packages/react-native-reanimated/src/common/constants.ts
@@ -10,7 +10,6 @@ function isWindowAvailable() {
 }
 
 export const IS_ANDROID: boolean = Platform.OS === 'android';
-/** @knipIgnore */
 export const IS_IOS: boolean = Platform.OS === 'ios';
 export const IS_WEB: boolean = Platform.OS === 'web';
 export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;

--- a/packages/react-native-reanimated/src/common/errors.ts
+++ b/packages/react-native-reanimated/src/common/errors.ts
@@ -18,15 +18,15 @@ function ReanimatedErrorConstructor(message: string): ReanimatedError {
 export function registerReanimatedError() {
   'worklet';
   if (globalThis.__RUNTIME_KIND !== RuntimeKind.ReactNative) {
-    globalThis.ReanimatedError =
-      ReanimatedErrorConstructor as IReanimatedErrorConstructor;
+    (globalThis as Record<string, unknown>).ReanimatedError =
+      ReanimatedErrorConstructor;
   }
 }
 
 export const ReanimatedError =
   ReanimatedErrorConstructor as IReanimatedErrorConstructor;
 
-export interface IReanimatedErrorConstructor extends Error {
+interface IReanimatedErrorConstructor extends Error {
   new (message?: string): ReanimatedError;
   (message?: string): ReanimatedError;
   readonly prototype: ReanimatedError;

--- a/packages/react-native-reanimated/src/privateGlobals.d.ts
+++ b/packages/react-native-reanimated/src/privateGlobals.d.ts
@@ -3,10 +3,7 @@
 // This file works by accident - currently Builder Bob doesn't move `.d.ts` files to output types.
 // If it ever breaks, we should address it so we'd not pollute the user's global namespace.
 
-import type {
-  IReanimatedErrorConstructor,
-  LoggerConfigInternal,
-} from './common';
+import type { LoggerConfigInternal } from './common';
 import type {
   MapperRegistry,
   MeasuredDimensions,
@@ -82,5 +79,4 @@ declare global {
    *   future.
    */
   var __frameTimestamp: number | undefined;
-  var ReanimatedError: IReanimatedErrorConstructor;
 }

--- a/packages/react-native-worklets/src/WorkletsError.ts
+++ b/packages/react-native-worklets/src/WorkletsError.ts
@@ -19,8 +19,8 @@ function WorkletsErrorConstructor(message?: string): WorkletsError {
 export function registerWorkletsError() {
   'worklet';
   if (globalThis.__RUNTIME_KIND !== RuntimeKind.ReactNative) {
-    globalThis.WorkletsError =
-      WorkletsErrorConstructor as IWorkletsErrorConstructor;
+    (globalThis as Record<string, unknown>).WorkletsError =
+      WorkletsErrorConstructor;
   }
 }
 
@@ -29,7 +29,7 @@ export const WorkletsError =
 
 export type WorkletsError = Error & { name: 'Worklets' }; // signed type
 
-export interface IWorkletsErrorConstructor extends Error {
+interface IWorkletsErrorConstructor extends Error {
   new (message?: string): WorkletsError;
   (message?: string): WorkletsError;
   readonly prototype: WorkletsError;

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -6,7 +6,6 @@ import type { callGuardDEV } from './callGuard';
 import type { reportFatalRemoteError } from './errors';
 import type { Queue } from './runLoop/workletRuntime/taskQueue';
 import type { SynchronizableUnpacker } from './synchronizableUnpacker';
-import type { IWorkletsErrorConstructor } from './WorkletsError';
 import type { WorkletsModuleProxy } from './WorkletsModule';
 import type { ValueUnpacker } from './workletTypes';
 
@@ -70,7 +69,6 @@ declare global {
     worklet: SerializableRef<() => void>
   ) => void;
   var _microtaskQueueFinalizers: (() => void)[];
-  var WorkletsError: IWorkletsErrorConstructor;
   var _scheduleTimeoutCallback: (delay: number, handlerId: number) => void;
   var __runTimeoutCallback: (handlerId: number) => void;
   var __flushMicrotasks: () => void;


### PR DESCRIPTION
## Summary

This PR removes `ReanimatedError` and `WorkletsError` types from `privateGlobals.d.ts` type declarations. I decided to remove them as it was very confusing that TS wasn't complaining when these error constructors were called without importing them but the missing import resulted in the runtime crashes.

## Examples

### Before

Allowed to use `ReanimatedError` without the necessary import.

| Without import | With import |
|-|-|
| <img width="467" height="260" alt="Screenshot 2025-10-21 at 20 31 14" src="https://github.com/user-attachments/assets/040ec83a-a161-4bdb-be5f-50448b290946" /> | <img width="455" height="267" alt="Screenshot 2025-10-21 at 20 31 56" src="https://github.com/user-attachments/assets/d9e2cb8b-d740-46e9-bac0-311b08d4525f" /> |

#### Without import in tests

<img width="453" height="477" alt="Screenshot 2025-10-21 at 20 31 32" src="https://github.com/user-attachments/assets/62e813d4-eff4-4331-95a9-7bfb8274bf1f" />

### After

Properly shows that the `ReanimatedError` is not imported if there is no import.

| Without import | With import |
|-|-|
| <img width="454" height="262" alt="Screenshot 2025-10-21 at 20 28 48" src="https://github.com/user-attachments/assets/6b48acb8-3a10-4f1f-8af5-80865106472e" /> | <img width="454" height="267" alt="Screenshot 2025-10-21 at 20 29 00" src="https://github.com/user-attachments/assets/fb3f2721-d670-46c4-8975-27e47e2e60a7" /> |
