### PR TITLE
Fix inline props processing

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -38,31 +38,22 @@ function inlinePropsHasChanged(
   return false;
 }
 
-function getInlinePropsUpdateInternal(styleValue: unknown): unknown {
+function getInlinePropsUpdate(styleValue: StyleProps): unknown {
   'worklet';
   if (isSharedValue(styleValue)) {
     return styleValue.value;
   }
   if (Array.isArray(styleValue)) {
-    return styleValue.map(getInlinePropsUpdateInternal);
+    return styleValue.map(getInlinePropsUpdate);
   }
   if (styleValue && typeof styleValue === 'object') {
     const update: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(styleValue)) {
-      update[key] = getInlinePropsUpdateInternal(value);
+      update[key] = getInlinePropsUpdate(value);
     }
     return update;
   }
   return styleValue;
-}
-
-function getInlinePropsUpdate(styleValue: StyleProps): StyleProps {
-  'worklet';
-  const update: StyleProps = {};
-  for (const [key, value] of Object.entries(styleValue)) {
-    update[key] = getInlinePropsUpdateInternal(value);
-  }
-  return update;
 }
 
 function extractSharedValuesMapFromProps(
@@ -117,7 +108,7 @@ export function getInlineStyle(
   isFirstRender: boolean
 ) {
   if (isFirstRender) {
-    return getInlinePropsUpdate(style);
+    return getInlinePropsUpdate(style) as Record<string, unknown>;
   }
   const newStyle: StyleProps = {};
   for (const [key, styleValue] of Object.entries(style)) {


### PR DESCRIPTION
## Summary

This PR fixes incorrect inline props processing caused by a wrong assumption that all array elements used in style props must be objects (the `getInlinePropsUpdate` always treated its input as a key-value object, whilst the `getInlinePropsUpdate` was also called for every array element, also for string arrays like the `transformOrigin` value).

## Test plan

<details>
<summary>Code snippet</summary>

```tsx
import React, { useEffect } from 'react';
import { View } from 'react-native';
import Animated, {
  useSharedValue,
  withRepeat,
  withSequence,
  withTiming,
} from 'react-native-reanimated';

const App = () => {
  const width = useSharedValue(100);

  useEffect(() => {
    width.value = withRepeat(
      withSequence(withTiming(200), withTiming(100)),
      -1,
      true
    );
  }, [width]);

  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Animated.View
        style={{
          width,
          height: 100,
          backgroundColor: 'red',
          transform: [{ rotate: '45deg' }],
          transformOrigin: ['50%', '50%', 0],
        }}
      />
    </View>
  );
};

export default App;
```
</details>