### PR TITLE
chore: Remove missing animationName CSS prop warning

### DIFF
--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -77,14 +77,6 @@ export function filterCSSAndStyleProperties<S extends AnyRecord>(
 }
 
 function validateCSSAnimationProps(props: Partial<CSSAnimationProperties>) {
-  // Check if any animation properties are present but animationName is missing
-  if (!('animationName' in props) && Object.keys(props).length > 0) {
-    logger.warn(
-      'CSS animation properties were provided without specifying animationName.\n' +
-        'If unintended, add animationName or remove unnecessary animation properties.'
-    );
-  }
-
   // Check if animationDuration is missing when animationName is present
   if (!('animationDuration' in props) && 'animationName' in props) {
     logger.warn(


### PR DESCRIPTION
## Summary

I decided to remove this one warning as it shows up for all components that use `react-native-css` library for styling and specify e.g. the `duration-100` class, which is converted to both: `animationDuration` and `transitionDuration` properties.

I decided to remove the warning on our side as it is not that much useful as remaining 2 warnings that still exist and seems to be simpler than trying to add complex logic on the `react-native-css` (or dependent) library side.