### PR TITLE
fix(android): fix bug w/ LA where animation never executed when scheduled from JS

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -395,18 +395,18 @@ void LayoutAnimationsProxy::addOngoingAnimations(
     SurfaceId surfaceId,
     ShadowViewMutationList &mutations) const {
   auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+  if (updateMap.empty()) {
+    return;
+  }
+
 #ifdef ANDROID
   std::vector<int> tagsToUpdate;
+  tagsToUpdate.reserve(updateMap.size());
   for (auto &[tag, updateValues] : updateMap) {
     tagsToUpdate.push_back(tag);
   }
 
-  auto maybeCorrectedTags = preserveMountedTags_(tagsToUpdate);
-  if (!maybeCorrectedTags.has_value()) {
-    return;
-  }
-
-  auto correctedTags = maybeCorrectedTags->get();
+  auto correctedTags = preserveMountedTags_(tagsToUpdate);
 
   // since the map is not updated, we can assume that the ordering of tags in
   // correctedTags matches the iterator

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -38,7 +38,7 @@ using SynchronouslyUpdateUIPropsFunction =
     std::function<void(const int, const folly::dynamic &)>;
 #endif // ANDROID
 using PreserveMountedTagsFunction =
-    std::function<std::optional<std::unique_ptr<int[]>>(std::vector<int> &)>;
+    std::function<std::unique_ptr<int[]>(std::vector<int> &)>;
 using GetAnimationTimestampFunction = std::function<double(void)>;
 
 using ProgressLayoutAnimationFunction =

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -174,21 +174,15 @@ void NativeProxy::maybeFlushUIUpdatesQueue() {
   method(javaPart_.get());
 }
 
-std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(
+std::unique_ptr<int[]> NativeProxy::preserveMountedTags(
     std::vector<int> &tags) {
-  if (tags.empty()) {
-    return {};
-  }
-
   static const auto method =
-      getJniMethod<jboolean(jni::alias_ref<jni::JArrayInt>)>(
+      getJniMethod<void(jni::alias_ref<jni::JArrayInt>)>(
           "preserveMountedTags");
   auto jArrayInt = jni::JArrayInt::newArray(tags.size());
   jArrayInt->setRegion(0, tags.size(), tags.data());
 
-  if (!method(javaPart_.get(), jArrayInt)) {
-    return {};
-  }
+  method(javaPart_.get(), jArrayInt);
 
   auto region = jArrayInt->getRegion(0, tags.size());
   return region;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -177,8 +177,7 @@ void NativeProxy::maybeFlushUIUpdatesQueue() {
 std::unique_ptr<int[]> NativeProxy::preserveMountedTags(
     std::vector<int> &tags) {
   static const auto method =
-      getJniMethod<void(jni::alias_ref<jni::JArrayInt>)>(
-          "preserveMountedTags");
+      getJniMethod<void(jni::alias_ref<jni::JArrayInt>)>("preserveMountedTags");
   auto jArrayInt = jni::JArrayInt::newArray(tags.size());
   jArrayInt->setRegion(0, tags.size(), tags.data());
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -53,8 +53,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>,
   // std::shared_ptr<facebook::react::Scheduler> reactScheduler_;
   // std::shared_ptr<EventListener> eventListener_;
   void installJSIBindings();
-  std::unique_ptr<int[]> preserveMountedTags(
-      std::vector<int> &tags);
+  std::unique_ptr<int[]> preserveMountedTags(std::vector<int> &tags);
   void synchronouslyUpdateUIProps(
       const std::vector<int> &intBuffer,
       const std::vector<double> &doubleBuffer);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -53,7 +53,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy>,
   // std::shared_ptr<facebook::react::Scheduler> reactScheduler_;
   // std::shared_ptr<EventListener> eventListener_;
   void installJSIBindings();
-  std::optional<std::unique_ptr<int[]>> preserveMountedTags(
+  std::unique_ptr<int[]> preserveMountedTags(
       std::vector<int> &tags);
   void synchronouslyUpdateUIProps(
       const std::vector<int> &intBuffer,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -289,9 +289,7 @@ public class NativeProxy {
     };
   }
 
-  /**
-   * Modifies tags in place, setting not mounted view tags to -1 at their index.
-   */
+  /** Modifies tags in place, setting not mounted view tags to -1 at their index. */
   @DoNotStrip
   public void preserveMountedTags(int[] tags) {
     for (int i = 0; i < tags.length; i++) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.java
@@ -289,19 +289,18 @@ public class NativeProxy {
     };
   }
 
+  /**
+   * Modifies tags in place, setting not mounted view tags to -1 at their index.
+   */
   @DoNotStrip
-  public boolean preserveMountedTags(int[] tags) {
-    if (!UiThreadUtil.isOnUiThread()) {
-      return false;
-    }
-
+  public void preserveMountedTags(int[] tags) {
     for (int i = 0; i < tags.length; i++) {
+      // Note: resolveView has assertOnUiThread, which only logs as softexception in debug
+      // It is actually completely thread safe and there is a RFC in RN to do something about it
       if (mFabricUIManager.resolveView(tags[i]) == null) {
         tags[i] = -1;
       }
     }
-
-    return true;
   }
 
   @DoNotStrip


### PR DESCRIPTION
## Summary

To my shame, i believe there is no issue for this yet and i also didn't create a reproduction (yet) 🥶 

### **The issue:**

There is a bug with `layout` animations where they don't seem to fire. Effects of this are:
- Views staying at opacity: 0
- Views not running their `layout` animation, and staying "stuck" on the screen

~~I have the hunch that it could for example fix this issue (will test tmrw):~~

- ~~https://github.com/software-mansion/react-native-reanimated/issues/8445~~

The issue started happening after upgrading from `3.17.4` to `3.19.3`, which includes this change:

- https://github.com/software-mansion/react-native-reanimated/pull/8083

---

### **The cause:**

The mentioned change was introduced to circumvent this bug:

- https://github.com/software-mansion/react-native-reanimated/issues/7493#issuecomment-2896990382

I believe the change introduced a regression where a layout animation might not run at all:

- `NativeProxy.preserveMountedTags` would return `false` when we are not on the UI thread, which is the case if `pullTransaction` is called from the JS thread
- In that case `NativeProxy::preserveMountedTags` will return an empty optional
- `LayoutAnimationsProxy::addOngoingAnimations` will return as the vector is empty:

https://github.com/software-mansion/react-native-reanimated/blob/794a669a5411608b5a707e7638c04a0d2fa981aa/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp#L404-L406

---

### **The fix:**

When you look into `FabricUIManager.resolveView(tag)` it has `UIThreadUtils.assertOnUIThread()`, which looks problematic.
However, if you check all the data structures that are being used, all of them are `ConcurrentHashMaps`, so I think `resolveView` is actually thread safe:

- https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L1038
- https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L81
- https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt#L43

Thus i removed the check if we are on the UI thread, and hence `addOngoingAnimation()` will execute, even if invoked from the JS thread.

> This will cause soft exceptions to be logged in debug

I will make a RFC in react-native to remove the UIThread check there since i think its not needed.
Alternatively I was thinking of two other ways:

- In `FabricUIManager` add a new thread safe `getViewExists` method (since in SurfaceMountingManager this method isn't marked as UI thread specific)
- Add a mechanism to `ShadowViews` to track in which revision they've been created. Then we can listen to the `shadowTreeDidMount` hook to capture the latest mounted revision and check if the tag/ shadowView we want to animate is equal or lower to that latest mounted revision. This way we would also avoid the JNI call. 

## Test plan

I tested all the LA tests from the fabric-example app.

> [!NOTE]
> I might completely have missed a good reason why we only ever want to run that code on the UI thread. But as i checked, before we also were okay with executing it from the JS thread, we just wanted to avoid running it on not yet mounted views.
