### PR TITLE
chore: disable certain examples per platform

### DIFF
--- a/apps/common-app/src/apps/reanimated/App.tsx
+++ b/apps/common-app/src/apps/reanimated/App.tsx
@@ -5,6 +5,7 @@ import type { StackNavigationProp } from '@react-navigation/stack';
 import React, { memo } from 'react';
 import {
   FlatList,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -77,7 +78,7 @@ function HomeScreen({ navigation }: HomeScreenProps) {
               setTimeout(() => setWasClicked([...wasClicked, name]), 500);
             }
           }}
-          missingOnFabric={EXAMPLES[name].missingOnFabric}
+          disabled={EXAMPLES[name].disabledPlatforms?.includes(Platform.OS)}
           wasClicked={wasClicked.includes(name)}
         />
       )}
@@ -91,29 +92,22 @@ function HomeScreen({ navigation }: HomeScreenProps) {
 interface ItemProps {
   icon?: string;
   title: string;
+  disabled?: boolean;
   onPress: () => void;
-  missingOnFabric?: boolean;
   wasClicked?: boolean;
 }
 
-function Item({
-  icon,
-  title,
-  onPress,
-  missingOnFabric,
-  wasClicked,
-}: ItemProps) {
-  const isDisabled = missingOnFabric;
+function Item({ icon, title, onPress, disabled, wasClicked }: ItemProps) {
   const Button = IS_MACOS ? Pressable : RectButton;
   return (
     <Button
       style={[
         styles.button,
-        isDisabled && styles.disabledButton,
+        disabled && styles.disabledButton,
         wasClicked && styles.visitedItem,
       ]}
       onPress={onPress}
-      enabled={!isDisabled}>
+      enabled={!disabled}>
       {icon && <Text style={styles.title}>{icon + '  '}</Text>}
       <Text style={styles.title}>{title}</Text>
     </Button>

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -138,14 +138,28 @@ import WorkletFactoryCrash from './WorkletFactoryCrashExample';
 import WorkletRuntimeExample from './WorkletRuntimeExample';
 import InstanceDiscoveryExample from './InstanceDiscoveryExample';
 
-interface Example {
+export const REAPlatform = {
+  IOS: 'ios',
+  ANDROID: 'android',
+  MACOS: 'macos',
+  WEB: 'web',
+};
+
+export interface Example {
   icon?: string;
   title: string;
   screen: React.FC;
-  missingOnFabric?: boolean;
+  disabledPlatforms?: (typeof REAPlatform)[keyof typeof REAPlatform][];
 }
 
 export const EXAMPLES: Record<string, Example> = {
+  // About
+  AboutExample: {
+    icon: 'ℹ️',
+    title: 'About',
+    screen: AboutExample,
+  },
+
   // Empty example for test purposes
   EmptyExample: {
     icon: '👻',
@@ -171,11 +185,13 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '⚙️',
     title: 'RuntimeTestsExample',
     screen: RuntimeTestsExample,
+    disabledPlatforms: [REAPlatform.WEB],
   },
   Synchronizable: {
     icon: '🔄',
     title: 'Synchronizable performance',
     screen: SynchronizablePerformanceExample,
+    disabledPlatforms: [REAPlatform.WEB],
   },
   ReactFreeze: {
     icon: '❄️',
@@ -191,6 +207,7 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🏃‍♂️',
     title: 'Worklet runtime',
     screen: WorkletRuntimeExample,
+    disabledPlatforms: [REAPlatform.WEB],
   },
   ModifyExample: {
     icon: '🪛',
@@ -211,6 +228,7 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🥶',
     title: 'Serializable freezing',
     screen: SerializableFreezingExample,
+    disabledPlatforms: [REAPlatform.WEB],
   },
   InvalidReadWriteExample: {
     icon: '🔒',
@@ -226,19 +244,12 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🔄',
     title: 'Copy serializable performance test',
     screen: CopySerializablePerformanceTest,
+    disabledPlatforms: [REAPlatform.WEB],
   },
   FlatListWithLayoutAnimations: {
     icon: '🎻',
     title: 'FlatList with layout animations',
     screen: FlatListWithLayoutAnimations,
-  },
-
-  // About
-
-  AboutExample: {
-    icon: 'ℹ️',
-    title: 'About',
-    screen: AboutExample,
   },
 
   // Showcase
@@ -307,6 +318,7 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '📺',
     title: 'Screen transition',
     screen: ScreenTransitionExample,
+    disabledPlatforms: [REAPlatform.WEB],
   },
 
   // Basic examples
@@ -509,6 +521,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🔌',
     title: 'Without Babel plugin',
     screen: WithoutBabelPluginExample,
+    disabledPlatforms: [
+      REAPlatform.ANDROID,
+      REAPlatform.IOS,
+      REAPlatform.MACOS,
+    ],
   },
   MatrixExample: {
     icon: '🧮',
@@ -544,7 +561,12 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🔎',
     title: 'getViewProp',
     screen: GetViewPropExample,
-    missingOnFabric: true,
+    disabledPlatforms: [
+      REAPlatform.WEB,
+      REAPlatform.ANDROID,
+      REAPlatform.IOS,
+      REAPlatform.MACOS,
+    ],
   },
   LogExample: {
     icon: '⌨',
@@ -595,6 +617,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'DynamicColorIOS',
     screen: DynamicColorIOSExample,
     icon: '🌗',
+    disabledPlatforms: [REAPlatform.ANDROID, REAPlatform.WEB],
   },
   PlatformColorExample: {
     title: 'PlatformColor',


### PR DESCRIPTION
## Summary

Some examples don't work on some platforms. This is confusing when testing so I made that they're not available on platform they don't work on.

## Test plan

Example app.
