### PR TITLE
fix: Animated style and switch not working in Freeze Example on web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/FreezeExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/FreezeExample.tsx
@@ -4,7 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { useContext, useEffect, useState } from 'react';
 import { Freeze } from 'react-freeze';
-import { Button, Text, View } from 'react-native';
+import { Button, Pressable, Text, View } from 'react-native';
 import Animated, {
   css,
   Easing,
@@ -43,9 +43,11 @@ const AnimatedSwitch = () => {
   });
 
   return (
-    <View style={styles.switchContainer} onTouchEnd={handleToggle}>
-      <Animated.View style={[styles.toggle, animatedStyles]} />
-    </View>
+    <Pressable onPress={handleToggle}>
+      <View style={styles.switchContainer}>
+        <Animated.View style={[styles.toggle, animatedStyles]} />
+      </View>
+    </Pressable>
   );
 };
 
@@ -78,14 +80,16 @@ const AnimatedStyleAnimation = () => {
     sv.value = 100;
   }, [sv]);
 
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      left: withDelay(
-        1000,
-        withTiming(sv.value, { duration: 10000, easing: Easing.linear })
-      ),
-    };
-  });
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX: withDelay(
+          1000,
+          withTiming(sv.value, { duration: 10000, easing: Easing.linear })
+        ),
+      },
+    ],
+  }));
 
   return (
     <Animated.View style={[styles.box, animatedStyle]}>


### PR DESCRIPTION
## Summary

As the title states. It seems that the `onTouchEnd` prop on the `View` component doesn't work with `react-native-web`. We can't also animate the `left` property on views with `static` or `relative` position on web (it only works for views with `absolute` position or is applied when the view is rendered), thus I replaced it with the `transform` property that works for all view position types.

## Test plan

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/6f91f4ce-ba86-4283-9a63-d6d53e7324d6" /> | <video src="https://github.com/user-attachments/assets/0fcc9981-0535-433d-b503-2e4440d82a81" /> |

>[!note]
> You can see that the CSS animation restarts every time the screen is entered. This happens because of renders being triggered when the screen is mounted and new renders trigger the new animation to start. I will experiment to make this behavior more consistent with how it works on mobile to ensure that the animation is not restarted when the screen is reentered.
