### PR TITLE
fix: Web example app hot-reload not working on sources change

### DIFF
--- a/apps/web-example/tsconfig.json
+++ b/apps/web-example/tsconfig.json
@@ -4,7 +4,9 @@
     "strict": true,
     "baseUrl": "../..",
     "paths": {
-      "@/*": ["./apps/common-app/src/*"]
+      "@/*": ["./apps/common-app/src/*"],
+      // Required to enable hot reload when working on the react-native-reanimated source code
+      "react-native-reanimated": ["./packages/react-native-reanimated/src"]
     },
     "moduleSuffixes": [".web", ""]
   },


### PR DESCRIPTION
## Summary

This PR brings back the necessary path alias in the `tsconfig.json` used in the `web-example` app, which is needed for the hot-reload to work when TS sources are modified.