### PR TITLE
cherry-pick(Reanimated): Use `hermesvm` instead of `libhermes` on RN 0.82+

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -242,6 +242,7 @@ android {
                 "**/libfolly_runtime.so",
                 "**/libglog.so",
                 "**/libhermes.so",
+                "**/libhermesvm.so",
                 "**/libhermes-executor-debug.so",
                 "**/libhermes_executor.so",
                 "**/libhermestooling.so",

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -105,7 +105,11 @@ else()
 endif()
 
 if(${JS_RUNTIME} STREQUAL "hermes")
-  target_link_libraries(worklets hermes-engine::libhermes)
+  if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 82)
+    target_link_libraries(worklets hermes-engine::hermesvm)
+  else()
+    target_link_libraries(worklets hermes-engine::libhermes)
+  endif()
 
   if(${HERMES_ENABLE_DEBUGGER})
     string(APPEND CMAKE_CXX_FLAGS " -DHERMES_ENABLE_DEBUGGER=1")

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -248,6 +248,7 @@ android {
                 "**/libfolly_runtime.so",
                 "**/libglog.so",
                 "**/libhermes.so",
+                "**/libhermesvm.so",
                 "**/libhermes-executor-debug.so",
                 "**/libhermes_executor.so",
                 "**/libhermestooling.so",


### PR DESCRIPTION
## Summary

Fix failing CI builds because of missing `hermes-engine::libhermes`