### PR TITLE
fix(worklets-docs): `og-images` generation

### DIFF
--- a/docs/docs-worklets/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-worklets/docs/fundamentals/getting-started.mdx
@@ -7,8 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Getting started
-{/* TODO: Uncomment this when we implement missing parts of the docs (examples, etc.) */}
-{/* The goal of the _Fundamentals_ section is to help you gain a strong foundation on the core concepts of _Worklets_ and give you the confidence to explore more advanced use cases on your own. This section is packed with interactive examples, code snippets and explanations. Are you ready? Let's dive in! */}
 
 ## What is React Native Worklets?
 

--- a/docs/docs-worklets/scripts/og-image-stream.jsx
+++ b/docs/docs-worklets/scripts/og-image-stream.jsx
@@ -3,7 +3,11 @@ import { ImageResponse } from '@vercel/og';
 import fs from 'fs';
 import path from 'path';
 
-export default async function OGImageStream(header, base64Image) {
+/**
+ * @param {string} _header
+ * @param {string} base64Image
+ */
+export default async function OGImageStream(_header, base64Image) {
   return new ImageResponse(
     (
       <div
@@ -16,8 +20,7 @@ export default async function OGImageStream(header, base64Image) {
           height: '100%',
           padding: '50px 200px',
           textAlign: 'center',
-          justifyContent: 'center',
-          alignItems: 'center',
+          position: 'relative',
         }}>
         <img
           style={{
@@ -33,33 +36,22 @@ export default async function OGImageStream(header, base64Image) {
         />
         <div
           style={{
+            position: 'absolute',
+            bottom: 40,
             display: 'flex',
-            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
             width: 1200,
-            gap: -20,
-            padding: '0 201px 0 67px',
           }}>
-          <p
-            style={{
-              fontSize: 72,
-              fontWeight: 'bold',
-              color: '#001A72',
-              textAlign: 'left',
-              fontFamily: 'Aeonik Bold',
-              textWrap: 'wrap',
-            }}>
-            {header}
-          </p>
           <pre
             style={{
-              fontSize: 40,
+              fontSize: 32,
+              color: 'white',
               fontWeight: 'normal',
-              color: '#001A72',
-              textAlign: 'left',
               fontFamily: 'Aeonik Regular',
               textWrap: 'wrap',
             }}>
-            {'Check out the React Native\nWorklets documentation.'}
+            Check out the React Native Worklets documentation.
           </pre>
         </div>
       </div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Before: 
<img width="1221" height="645" alt="image" src="https://github.com/user-attachments/assets/a9e0f647-5a27-434e-8b18-1d951e2537cd" />

After: 
<img width="1166" height="609" alt="image" src="https://github.com/user-attachments/assets/751df18e-929a-4c08-9653-c316b13ecc06" />


<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
