### PR TITLE
fix: CSS transition immediate finished state in web example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx
@@ -1,20 +1,10 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function EmptyExample() {
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      shadowColor: 'black',
-      shadowOffset: { width: 0, height: 10 },
-      shadowOpacity: 0.25,
-      shadowRadius: 3.84,
-    };
-  });
-
   return (
     <View style={styles.container}>
-      <Animated.View style={[styles.box, animatedStyle]} />
+      <Text>Hello world!</Text>
     </View>
   );
 }
@@ -24,10 +14,5 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  box: {
-    width: 100,
-    height: 100,
-    backgroundColor: 'red',
   },
 });


### PR DESCRIPTION
## Summary

I just added a timeout to ensure that the transition is triggered with some delay. I also removed unused transition props from the style that doesn't require them.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/513a89c5-087f-4587-a95e-832be4419075" /> | <video src="https://github.com/user-attachments/assets/13590eab-5c57-4c04-9b64-573c392dc94a" /> |
