### PR TITLE
docs: Add missing comma in `interpolateColorPlayground`

### DIFF
--- a/docs/docs-reanimated/src/components/InteractivePlayground/useInterpolateColorPlayground/index.tsx
+++ b/docs/docs-reanimated/src/components/InteractivePlayground/useInterpolateColorPlayground/index.tsx
@@ -72,7 +72,7 @@ export default function useInterpolateColorPlayground() {
     interpolateColor(
         sv.value,
         [0, 1],
-        ['${colorLeftBoundary.toUpperCase()}', '${colorRightBoundary.toUpperCase()}']
+        ['${colorLeftBoundary.toUpperCase()}', '${colorRightBoundary.toUpperCase()}'],
         '${colorSpace}'${optionsCode ? `,
         {
           ${optionsCode}


### PR DESCRIPTION
## Summary

The ready to copy snippet was missing a comma all these years

## Test plan
