### PR TITLE
chore: fix pre-commit clang-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "8.46.0",
     "babel-eslint": "10.1.0",
     "babel-plugin-module-resolver": "5.0.2",
+    "clang-format-node": "1.3.5",
     "eslint": "9.37.0",
     "eslint-config-prettier": "10.1.5",
     "eslint-import-resolver-babel-module": "5.3.2",

--- a/packages/react-native-reanimated/.lintstagedrc.js
+++ b/packages/react-native-reanimated/.lintstagedrc.js
@@ -1,6 +1,6 @@
 const commonConfig = require('../../.lintstagedrc-common.js');
 
-/** @type {import('lint-staged').Config} */
+/** @type {import('lint-staged').Configuration} */
 module.exports = {
   ...commonConfig,
   '*.{cpp,h}': ['clang-format -i'],

--- a/packages/react-native-worklets/.lintstagedrc.js
+++ b/packages/react-native-worklets/.lintstagedrc.js
@@ -1,6 +1,6 @@
 const commonConfig = require('../../.lintstagedrc-common.js');
 
-/** @type {import('lint-staged').Config} */
+/** @type {import('lint-staged').Configuration} */
 module.exports = {
   ...commonConfig,
   '*.{cpp,h}': ['clang-format -i'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -26180,6 +26180,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:8.46.0"
     babel-eslint: "npm:10.1.0"
     babel-plugin-module-resolver: "npm:5.0.2"
+    clang-format-node: "npm:1.3.5"
     eslint: "npm:9.37.0"
     eslint-config-prettier: "npm:10.1.5"
     eslint-import-resolver-babel-module: "npm:5.3.2"


### PR DESCRIPTION
## Summary

`lint-staged` executes linting scripts in the directory it was invoked in (root of the monorepo). Because of that pre-commit fails when trying to format .cpp files since clang-format binary wasn't available in the root.

## Test plan

🚀 
