### PR TITLE
chore: Fix Reanimated Static Check Nightly CI

### DIFF
--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'iOS' }}
         with:


### PR DESCRIPTION
## Summary

metro `0.83.3` needs node `20`, and this workflow was using `18` - this should fix the issue.

## Test plan
