### PR TITLE
fix(Worklets): missing REACT_NATIVE_MINOR_VERSION on iOS

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -3190,7 +3190,7 @@ SPEC CHECKSUMS:
   RNReanimated: 97ebf4d3c76929b6b0f866cfbd41c49b3a0d2dbf
   RNScreens: 0bbf16c074ae6bb1058a7bf2d1ae017f4306797c
   RNSVG: 8c0bbfa480a24b24468f1c76bd852a4aac3178e6
-  RNWorklets: 991f94e4fa31fc20853e74d5d987426f8580cb0d
+  RNWorklets: f54a415f73a3fc653bfe65e599872fdc6bca0477
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: edeb9900b9e5bb5b27b9a6a2d5914e4fe4033c1b
 

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -2322,7 +2322,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 0397fea67f39d5a2d17fcf4a028e206f7ba098ba
   RNReanimated: 152207cf096f2badeef2c552a8f2886accd187e6
   RNSVG: 681f8ef5ca50e13cb3c6c88a907ea89b68fee74f
-  RNWorklets: da407fc9e80486f259c4a17f2e4e9a5a6e51b3db
+  RNWorklets: ee84c4d458ce35f4ed94462a2add070ff4e69edb
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 45ce05cb11db042ba2e5e51a2dfaf0ff63d269f9
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2732,7 +2732,7 @@ SPEC CHECKSUMS:
   ReactCodegen: f4d6e6fd5140eade461ffb5579795197956868c8
   ReactCommon: c178596d3ef05508bb6c0f88bfbbc281b5c4222b
   RNReanimated: cccf8b45cb675080e7c5f3a4f5d0498eff6c62a0
-  RNWorklets: bdeeff31c1e0ff8d69b16e88922de016bd5ca951
+  RNWorklets: 339aa12272b2ff6490d91526e8ced6599f7ef6a3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 0e792f39294e864568930600eeb71135364f777d
 

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -11,7 +11,7 @@ worklets_assert_new_architecture_enabled($new_arch_enabled)
 ios_min_version = '13.4'
 
 feature_flags = "-DWORKLETS_FEATURE_FLAGS=\"#{worklets_get_static_feature_flags()}\""
-version_flags = "-DWORKLETS_VERSION=#{package['version']}"
+version_flags = "-DWORKLETS_VERSION=#{package['version']} -DREACT_NATIVE_MINOR_VERSION=#{$worklets_config[:react_native_minor_version]}"
 
 Pod::Spec.new do |s|
   s.name         = "RNWorklets"


### PR DESCRIPTION
## Summary

Until recently Worklets didn't have any ifs for the RN version and the macro was removed erroneously for iOS only. This PR brings the macro back.

## Test plan

CI
