### PR TITLE
fix: Make obtaining logger config safer

### DIFF
--- a/packages/react-native-reanimated/src/ConfigHelper.ts
+++ b/packages/react-native-reanimated/src/ConfigHelper.ts
@@ -3,7 +3,11 @@
 import { runOnUISync } from 'react-native-worklets';
 
 import type { LoggerConfig } from './common';
-import { SHOULD_BE_USE_WEB, updateLoggerConfig } from './common';
+import {
+  getLoggerConfig,
+  SHOULD_BE_USE_WEB,
+  updateLoggerConfig,
+} from './common';
 
 /** @deprecated This function is a no-op in Reanimated 4. */
 export function addWhitelistedNativeProps(
@@ -27,10 +31,12 @@ export function addWhitelistedUIProps(_props: Record<string, boolean>): void {
  * @param config - The new logger configuration to apply.
  */
 export function configureReanimatedLogger(config: LoggerConfig) {
+  // Get the current config from the React runtime (to have a single source of truth)
+  const currentConfig = getLoggerConfig();
   // Update the configuration object in the React runtime
-  updateLoggerConfig(config);
+  updateLoggerConfig(currentConfig, config);
   // Register the updated configuration in the UI runtime
   if (!SHOULD_BE_USE_WEB) {
-    runOnUISync(updateLoggerConfig, config);
+    runOnUISync(updateLoggerConfig, currentConfig, config);
   }
 }

--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -1,13 +1,7 @@
 'use strict';
 import { runOnUISync } from 'react-native-worklets';
 
-import {
-  DEFAULT_LOGGER_CONFIG,
-  IS_WEB,
-  ReanimatedError,
-  registerLoggerConfig,
-  SHOULD_BE_USE_WEB,
-} from './common';
+import { IS_WEB, ReanimatedError, SHOULD_BE_USE_WEB } from './common';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
 import type { IReanimatedModule } from './ReanimatedModule';
@@ -25,11 +19,9 @@ export function initializeReanimatedModule(
   }
 }
 
-registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
 if (!SHOULD_BE_USE_WEB) {
   runOnUISync(() => {
     'worklet';
     global._tagToJSPropNamesMapping = {};
-    registerLoggerConfig(DEFAULT_LOGGER_CONFIG);
   });
 }

--- a/packages/react-native-reanimated/src/privateGlobals.d.ts
+++ b/packages/react-native-reanimated/src/privateGlobals.d.ts
@@ -53,7 +53,7 @@ declare global {
     | undefined;
   var _frameCallbackRegistry: FrameCallbackRegistryUI;
   var console: Console;
-  var __reanimatedLoggerConfig: LoggerConfigInternal;
+  var __reanimatedLoggerConfig: LoggerConfigInternal | undefined;
   var __mapperRegistry: MapperRegistry;
   var __sensorContainer: SensorContainer;
   var LayoutAnimationsManager: LayoutAnimationsManager;


### PR DESCRIPTION
## Summary

This PR adds a helper `getLoggerConfig` function that returns the current logger config stored under `global.__reanimatedLoggerConfig` if it exists or stores the default config in the `global.__reanimatedLoggerConfig` variable before returning it. This approach is much safer than the previous one which assumed that the `registerLoggerConfig` is executed on the UI runtime before the logger is used.

I decided to rewrite this logic as the issue I tried to fix in the #8227 PR seems to still persist (see [this](https://github.com/expo/expo/issues/39582#issuecomment-3481631086) comment).