### PR TITLE
fix(Worklets): strip RN Runtime assertions only for other runtimes

### DIFF
--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
@@ -33,7 +33,7 @@ class NativeWorklets implements IWorkletsModule {
 See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting#native-part-of-worklets-doesnt-seem-to-be-initialized for more details.`
       );
     }
-    if (__DEV__) {
+    if (__DEV__ && globalThis.__RUNTIME_KIND === RuntimeKind.ReactNative) {
       checkCppVersion();
     }
     this.#workletsModuleProxy = global.__workletsModuleProxy;

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -4,6 +4,7 @@ import { registerWorkletStackDetails } from '../debug/errors';
 import { jsVersion } from '../debug/jsVersion';
 import { logger } from '../debug/logger';
 import { WorkletsError } from '../debug/WorkletsError';
+import { RuntimeKind } from '../runtimeKind';
 import type { WorkletFunction, WorkletImport } from '../types';
 import { isWorkletFunction } from '../workletFunction';
 import { WorkletsModule } from '../WorkletsModule/NativeWorklets';
@@ -650,7 +651,7 @@ function isRemoteFunction<TValue>(value: {
  * should use shared values instead.
  */
 function freezeObjectInDev<TValue extends object>(value: TValue) {
-  if (!__DEV__) {
+  if (!__DEV__ || globalThis.__RUNTIME_KIND !== RuntimeKind.ReactNative) {
     return;
   }
   Object.entries(value).forEach(([key, element]) => {


### PR DESCRIPTION
## Summary

After the changes done in #8471 it turned out that in Bundle Mode there were redundant checks for cpp version on Worklet Runtimes and also freezing Serializables on Worklet Runtimes. Check for the cpp version started to crash the runtime (previously it was silently failing) while the freezing could in some circumstances break the logic of Mutables.

## Test plan

Run the app in Bundle Mode and see it's no longer crashing.
