### PR TITLE
Remove debug symbols from release build

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -31,7 +31,7 @@ if(${IS_REANIMATED_EXAMPLE_APP})
 endif()
 
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-  string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG")
+  string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG -g0")
 endif()
 
 set(BUILD_DIR "${CMAKE_SOURCE_DIR}/build")

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -223,6 +223,15 @@ android {
                 doNotStrip "**/**/*.so"
             }
         }
+        release {
+            externalNativeBuild {
+                cmake {
+                    def currentArgs = arguments ?: []
+                    currentArgs += "-DCMAKE_BUILD_TYPE=Release"
+                    arguments = currentArgs
+                }
+            }
+        }
     }
     lintOptions {
         abortOnError false

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -29,7 +29,7 @@ if(${WORKLETS_BUNDLE_MODE})
 endif()
 
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-  string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG")
+  string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG -g0")
 endif()
 
 if(${JS_RUNTIME} STREQUAL "hermes")

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -231,6 +231,15 @@ android {
                 doNotStrip "**/**/*.so"
             }
         }
+        release {
+            externalNativeBuild {
+                cmake {
+                    def currentArgs = arguments ?: []
+                    currentArgs += "-DCMAKE_BUILD_TYPE=Release"
+                    arguments = currentArgs
+                }
+            }
+        }
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
## Summary

I noticed, release build uses -g (don't strip debug symbols) during compilation and later strips all the debug symbols. While trying to get rid of this implicitly set flag I stumbled upon "-DCMAKE_BUILD_TYPE=Release" flag which could be set for a release build to make it a bit more optimized for release. The flag itself tells other cmake files that they can omit things that are done only for debug e.g. they can set -O3 instead of -O2 or that they don't have to include -g (it also automatically adds '-NDEBUG', which we do explicitly). 

Even though those flags don't change the size of the output `.apk`, they reduce the size of intermediate binaries that are created during the build. On my PC that's a 2GB difference per build so I figured it might be a meaningful change. 

## Testing

I don't really know how to test if those flags don't break anything so for now I made it a draft PR.

 
