### PR TITLE
Ignore deep imports warning in common-app

### DIFF
--- a/apps/common-app/src/App.tsx
+++ b/apps/common-app/src/App.tsx
@@ -17,7 +17,9 @@ import { IS_MACOS, IS_WEB, noop } from '@/utils';
 import { CSSApp, ReanimatedApp } from './apps';
 import { LeakCheck, NukeContext } from './components';
 
-LogBox.ignoreLogs(["Deep imports from the 'react-native' package are deprecated"]);
+LogBox.ignoreLogs([
+  "Deep imports from the 'react-native' package are deprecated",
+]);
 
 export default function App() {
   const [nuked, setNuked] = useState(false);


### PR DESCRIPTION
## Summary

This PR hides the deep imports deprecation warning visible at the bottom of the screen in common-app.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img width="502" height="951" alt="Screenshot 2025-11-05 at 18 03 03" src="https://github.com/user-attachments/assets/ae61cc90-e4ad-44cf-984b-eae9a13a1444" /></td>
<td><img width="502" height="951" alt="Screenshot 2025-11-05 at 18 02 34" src="https://github.com/user-attachments/assets/bb636f31-416e-4514-be8e-8a789df338df" /></td>
</tr>
</table>

## Test plan
