### PR TITLE
fix: Add check for nullable in DynamicColorIOS

### DIFF
--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -113,7 +113,9 @@ export function processColorsInProps(props: StyleProps) {
       const dynamicFields = value.dynamic;
       for (const field in dynamicFields) {
         processed.dynamic[field] =
-          dynamicFields[field] != null ? processColor(dynamicFields[field]) : undefined;
+          dynamicFields[field] != null
+            ? processColor(dynamicFields[field])
+            : undefined;
       }
       props[key] = processed;
     } else {


### PR DESCRIPTION
## Summary

Before the optional fields `highContrastLight` and `highContrastDark` were undefined and when the function called `processColor` on them - they obv threw the error. I've fixed it by adding a guard before.

## Test plan
