### PR TITLE
fix: CSS transform crashes caused by incorrectly thrown error

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.cpp
@@ -33,9 +33,9 @@ TransformMatrix2D::TransformMatrix2D(jsi::Runtime &rt, const jsi::Value &value)
     matrix_[6] = array.getValueAtIndex(rt, 12).asNumber();
     matrix_[7] = array.getValueAtIndex(rt, 13).asNumber();
     matrix_[8] = array.getValueAtIndex(rt, 15).asNumber();
+  } else {
+    throw std::invalid_argument("[Reanimated] TransformMatrix2D: Invalid matrix size: " + std::to_string(size));
   }
-
-  throw std::invalid_argument("[Reanimated] TransformMatrix2D: Invalid matrix size: " + std::to_string(size));
 }
 
 TransformMatrix2D::TransformMatrix2D(const folly::dynamic &array)
@@ -65,9 +65,9 @@ TransformMatrix2D::TransformMatrix2D(const folly::dynamic &array)
     matrix_[6] = array[12].asDouble();
     matrix_[7] = array[13].asDouble();
     matrix_[8] = array[15].asDouble();
+  } else {
+    throw std::invalid_argument("[Reanimated] TransformMatrix2D: Invalid matrix size: " + std::to_string(size));
   }
-
-  throw std::invalid_argument("[Reanimated] TransformMatrix2D: Invalid matrix size: " + std::to_string(size));
 }
 
 bool TransformMatrix2D::canConstruct(jsi::Runtime &rt, const jsi::Value &value) {


### PR DESCRIPTION
## Summary

My bad here. The 2D transform matrix constructor was throwing errors all the time instead only when the matrix cannot be created.

## Example recordings

You can see that the app freezez when I press on the button twice quickly - when the 2D matrix is created from the compatible 3D one which can be converted to 2D for optimization.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/c3936d47-f95b-4f37-a825-d0a979394047" /> | <video src="https://github.com/user-attachments/assets/7e28bf08-bd6d-4350-9fff-97e3dffd352a" /> |
