### PR TITLE
Add `getDynamicFeatureFlag` function

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/AboutExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/AboutExample.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { Platform, StyleSheet, Text, View } from 'react-native';
-import { getStaticFeatureFlag as getStaticFeatureFlagReanimated } from 'react-native-reanimated';
+import React, { useCallback, useReducer } from 'react';
+import { Button, Platform, StyleSheet, Text, View } from 'react-native';
+import {
+  getDynamicFeatureFlag,
+  getStaticFeatureFlag as getStaticFeatureFlagReanimated,
+  setDynamicFeatureFlag,
+} from 'react-native-reanimated';
 import { getStaticFeatureFlag as getStaticFeatureFlagWorklets } from 'react-native-worklets';
 
 function isWeb() {
@@ -46,6 +50,16 @@ function getReactNativeVersion() {
 }
 
 export default function AboutExample() {
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  const handleToggleExampleDynamicFlag = useCallback(() => {
+    setDynamicFeatureFlag(
+      'EXAMPLE_DYNAMIC_FLAG',
+      !getDynamicFeatureFlag('EXAMPLE_DYNAMIC_FLAG')
+    );
+    forceUpdate();
+  }, [forceUpdate]);
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
@@ -128,6 +142,16 @@ export default function AboutExample() {
               ? 'Enabled'
               : 'Disabled'}
           </Text>
+          <Text style={styles.text}>
+            <Text style={styles.bold}>EXAMPLE_DYNAMIC_FLAG:</Text>{' '}
+            {getDynamicFeatureFlag('EXAMPLE_DYNAMIC_FLAG')
+              ? 'Enabled'
+              : 'Disabled'}
+          </Text>
+          <Button
+            title={`Toggle EXAMPLE_DYNAMIC_FLAG`}
+            onPress={handleToggleExampleDynamicFlag}
+          />
         </>
       )}
     </View>

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -184,6 +184,8 @@ import { setDynamicFeatureFlag } from 'react-native-reanimated';
 setDynamicFeatureFlag('EXAMPLE_DYNAMIC_FLAG', true);
 ```
 
+To read a dynamic feature flag value in JavaScript, you can use `getDynamicFeatureFlag` function.
+
 ## Comparison of static and dynamic feature flags
 
 |                                          | Static feature flags | Dynamic feature flags |

--- a/docs/docs-worklets/docs/guides/feature-flags.md
+++ b/docs/docs-worklets/docs/guides/feature-flags.md
@@ -56,6 +56,8 @@ import { setDynamicFeatureFlag } from 'react-native-worklets';
 setDynamicFeatureFlag('EXAMPLE_DYNAMIC_FLAG', true);
 ```
 
+To read a dynamic feature flag value in JavaScript, you can use `getDynamicFeatureFlag` function.
+
 ## Comparison of static and dynamic feature flags
 
 |                                          | Static feature flags | Dynamic feature flags |

--- a/packages/react-native-reanimated/src/featureFlags/index.ts
+++ b/packages/react-native-reanimated/src/featureFlags/index.ts
@@ -7,16 +7,20 @@ type DynamicFlagsType = {
   EXAMPLE_DYNAMIC_FLAG: boolean;
   init(): void;
   setFlag(name: DynamicFlagName, value: boolean): void;
+  getFlag(name: DynamicFlagName): boolean;
 };
-type DynamicFlagName = keyof Omit<Omit<DynamicFlagsType, 'setFlag'>, 'init'>;
+type DynamicFlagName = keyof Omit<
+  Omit<DynamicFlagsType, 'setFlag' | 'getFlag'>,
+  'init'
+>;
 
 /** @knipIgnore */
 export const DynamicFlags: DynamicFlagsType = {
-  EXAMPLE_DYNAMIC_FLAG: false,
+  EXAMPLE_DYNAMIC_FLAG: true,
 
   init() {
     Object.keys(DynamicFlags).forEach((key) => {
-      if (key !== 'init' && key !== 'setFlag') {
+      if (key !== 'init' && key !== 'setFlag' && key !== 'getFlag') {
         ReanimatedModule.setDynamicFeatureFlag(
           key,
           DynamicFlags[key as DynamicFlagName]
@@ -34,6 +38,16 @@ export const DynamicFlags: DynamicFlagsType = {
       );
     }
   },
+  getFlag(name) {
+    if (name in DynamicFlags) {
+      return DynamicFlags[name];
+    } else {
+      logger.warn(
+        `The feature flag: '${name}' no longer exists, you can safely remove invocation of \`getDynamicFeatureFlag('${name}')\` from your code.`
+      );
+      return false;
+    }
+  },
 };
 DynamicFlags.init();
 
@@ -43,6 +57,11 @@ export function setDynamicFeatureFlag(
   value: boolean
 ): void {
   DynamicFlags.setFlag(name, value);
+}
+
+// Public API function to read a feature flag
+export function getDynamicFeatureFlag(name: DynamicFlagName): boolean {
+  return DynamicFlags.getFlag(name);
 }
 
 /**

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -106,7 +106,11 @@ export {
 export * from './css';
 export type { EasingFunctionFactory } from './Easing';
 export { Easing } from './Easing';
-export { getStaticFeatureFlag, setDynamicFeatureFlag } from './featureFlags';
+export {
+  getDynamicFeatureFlag,
+  getStaticFeatureFlag,
+  setDynamicFeatureFlag,
+} from './featureFlags';
 export type { FrameInfo } from './frameCallback';
 export type { AnimatedProps, EntryOrExitLayoutType } from './helperTypes';
 export type {

--- a/packages/react-native-worklets/src/featureFlags/featureFlags.native.ts
+++ b/packages/react-native-worklets/src/featureFlags/featureFlags.native.ts
@@ -12,7 +12,7 @@ export const DynamicFlags: DynamicFlagsType = {
 
   init() {
     Object.keys(DynamicFlags).forEach((key) => {
-      if (key !== 'init' && key !== 'setFlag') {
+      if (key !== 'init' && key !== 'setFlag' && key !== 'getFlag') {
         WorkletsModule.setDynamicFeatureFlag(
           key,
           DynamicFlags[key as DynamicFlagName]
@@ -30,14 +30,30 @@ export const DynamicFlags: DynamicFlagsType = {
       );
     }
   },
+  getFlag(name) {
+    if (name in DynamicFlags) {
+      return DynamicFlags[name];
+    } else {
+      logger.warn(
+        `The feature flag: '${name}' no longer exists, you can safely remove invocation of \`getDynamicFeatureFlag('${name}')\` from your code.`
+      );
+      return false;
+    }
+  },
 };
 DynamicFlags.init();
+
 // Public API function to update a feature flag
 export function setDynamicFeatureFlag(
   name: DynamicFlagName,
   value: boolean
 ): void {
   DynamicFlags.setFlag(name, value);
+}
+
+// Public API function to read a feature flag
+export function getDynamicFeatureFlag(name: DynamicFlagName): boolean {
+  return DynamicFlags.getFlag(name);
 }
 
 const staticFeatureFlags: Partial<StaticFeatureFlagsSchema> = {};

--- a/packages/react-native-worklets/src/featureFlags/featureFlags.ts
+++ b/packages/react-native-worklets/src/featureFlags/featureFlags.ts
@@ -14,3 +14,7 @@ export function setDynamicFeatureFlag(
 ): void {
   // no-op
 }
+
+export function getDynamicFeatureFlag(_name: DynamicFlagName): boolean {
+  return false;
+}

--- a/packages/react-native-worklets/src/featureFlags/types.ts
+++ b/packages/react-native-worklets/src/featureFlags/types.ts
@@ -6,10 +6,11 @@ export type DynamicFlagsType = {
   EXAMPLE_DYNAMIC_FLAG: boolean;
   init(): void;
   setFlag(name: DynamicFlagName, value: boolean): void;
+  getFlag(name: DynamicFlagName): boolean;
 };
 
 export type DynamicFlagName = keyof Omit<
-  Omit<DynamicFlagsType, 'setFlag'>,
+  Omit<DynamicFlagsType, 'setFlag' | 'getFlag'>,
   'init'
 >;
 

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -22,6 +22,7 @@ export {
   type ShareableRef,
 } from './deprecated';
 export {
+  getDynamicFeatureFlag,
   getStaticFeatureFlag,
   setDynamicFeatureFlag,
 } from './featureFlags/featureFlags';


### PR DESCRIPTION
## Summary

This PR adds `getDynamicFeatureFlag` function in `react-native-reanimated` and `react-native-worklets` which lets you read feature flag value analogously to how you can already set its value with `setDynamicFeatureFlag`.

## Test plan

* Toggle `EXAMPLE_DYNAMIC_FLAG` in AboutExample
