### PR TITLE
Fixes-build-for-16kb-pages,  closes #6368

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -203,7 +203,9 @@ android {
                         "-DREANIMATED_PROFILING=${REANIMATED_PROFILING}",
                         "-DREANIMATED_VERSION=${REANIMATED_VERSION}",
                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
-                        "-DREANIMATED_FEATURE_FLAGS=${REANIMATED_FEATURE_FLAGS}"
+                        "-DREANIMATED_FEATURE_FLAGS=${REANIMATED_FEATURE_FLAGS}",
+                        "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384",
+                        "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
                 abiFilters (*reactNativeArchitectures())
                 targets("reanimated")
             }


### PR DESCRIPTION
## Summary
This pull request adds parameters for building native code with the ability to support 16 KB pages on Android.

## Test plan
Check 16 KB page support for arm64-v8a
