### PR TITLE
chore: prevent input hijacking in RuntimeTests runner

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/RuntimeTestsRunner.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/RuntimeTestsRunner.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
 import { configure, runTests } from './RuntimeTestsApi';
@@ -79,9 +79,9 @@ export default function RuntimeTestsRunner({ tests }: RuntimeTestRunnerProps) {
       {started ? null : (
         <>
           <TestSelector tests={tests} testSelectionCallbacks={testSelectionCallbacks} />
-          <Pressable onPressOut={handleStartClick} style={button}>
+          <TouchableOpacity onPress={handleStartClick} style={button}>
             <Text style={whiteText}>Run tests</Text>
-          </Pressable>
+          </TouchableOpacity>
         </>
       )}
       {/* Don't render anything if component is undefined to prevent blinking */}
@@ -166,28 +166,20 @@ interface SelectTestProps {
 }
 
 function SelectTest({ testSuiteName, selectClick, selectedTests, disabled }: SelectTestProps) {
-  const [isPressed, setIsPressed] = useState<boolean>(false);
-
-  function handleSelectClickIn() {
-    setIsPressed(true);
-  }
-
   function handleSelectClickOut() {
     selectClick();
-    setIsPressed(false);
   }
 
   return (
-    <Pressable
+    <TouchableOpacity
       disabled={disabled}
-      style={[styles.buttonWrapper, isPressed ? styles.pressedButton : {}, disabled ? styles.disabledButton : {}]}
-      onPressIn={() => handleSelectClickIn()}
-      onPressOut={() => handleSelectClickOut()}>
+      style={[styles.buttonWrapper, disabled ? styles.disabledButton : {}]}
+      onPress={() => handleSelectClickOut()}>
       <View style={[styles.checkbox, selectedTests.get(testSuiteName) ? styles.checkedCheckbox : {}]} />
       <View style={selectButton}>
         <Text style={navyText}>{testSuiteName}</Text>
       </View>
-    </Pressable>
+    </TouchableOpacity>
   );
 }
 
@@ -197,24 +189,10 @@ interface SelectAllButtonProps {
 }
 
 function SelectAllButtonProps({ handleSelectAllClick, select }: SelectAllButtonProps) {
-  const [isPressed, setIsPressed] = useState<boolean>(false);
-
-  function handleSelectAllClickIn() {
-    setIsPressed(true);
-  }
-
-  function handleSelectAllClickOut() {
-    handleSelectAllClick(select);
-    setIsPressed(false);
-  }
-
   return (
-    <Pressable
-      onPressIn={handleSelectAllClickIn}
-      onPressOut={() => handleSelectAllClickOut()}
-      style={[selectAllButton, isPressed ? styles.pressedButton : {}]}>
+    <TouchableOpacity onPress={() => handleSelectAllClick(select)} style={selectAllButton}>
       <Text style={navyText}>{select ? 'Select all' : 'Deselect all'}</Text>
-    </Pressable>
+    </TouchableOpacity>
   );
 }
 
@@ -282,12 +260,6 @@ const styles = StyleSheet.create({
   },
   checkedCheckbox: {
     backgroundColor: 'navy',
-  },
-  pressedButton: {
-    zIndex: 2,
-    backgroundColor: '#FFFA',
-    borderRadius: 10,
-    borderColor: '#FFFF',
   },
   disabledButton: {
     opacity: 0.5,


### PR DESCRIPTION
## Summary

Migrating to `TouchableOpacity` to prevent selecting and deselecting tests while scrolling the list.

## Test plan

🚀 
