### PR TITLE
release(Reanimated): 3.18.1

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2416,7 +2416,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (3.18.0):
+  - RNReanimated (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2443,11 +2443,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.18.0)
-    - RNReanimated/worklets (= 3.18.0)
+    - RNReanimated/reanimated (= 3.18.1)
+    - RNReanimated/worklets (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (3.18.0):
+  - RNReanimated/reanimated (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2474,10 +2474,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.18.0)
+    - RNReanimated/reanimated/apple (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (3.18.0):
+  - RNReanimated/reanimated/apple (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2506,7 +2506,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated/worklets (3.18.0):
+  - RNReanimated/worklets (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2533,10 +2533,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.18.0)
+    - RNReanimated/worklets/apple (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/worklets/apple (3.18.0):
+  - RNReanimated/worklets/apple (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3024,7 +3024,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 7e0ce15656772a939ff0d269100bca3a182163c8
   RNFlashList: 3d87e2c97db48005075574cf525d0e889ba63179
   RNGestureHandler: fabb15d507aebf871bf391ec1cdded706c58688b
-  RNReanimated: 9091435878ec9ba1c9335617304146d67a9cc198
+  RNReanimated: f01726a4e0ee76959659cf3805d95d81da671d97
   RNScreens: def99c66327cd2e8c892b33069e98ec57d41a5bc
   RNSVG: 341f555dbcd83a34d1f058e88df387de7bbc3347
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -1478,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.18.0):
+  - RNReanimated (3.18.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1498,10 +1498,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.18.0)
-    - RNReanimated/worklets (= 3.18.0)
+    - RNReanimated/reanimated (= 3.18.1)
+    - RNReanimated/worklets (= 3.18.1)
     - Yoga
-  - RNReanimated/reanimated (3.18.0):
+  - RNReanimated/reanimated (3.18.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1521,9 +1521,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.18.0)
+    - RNReanimated/reanimated/apple (= 3.18.1)
     - Yoga
-  - RNReanimated/reanimated/apple (3.18.0):
+  - RNReanimated/reanimated/apple (3.18.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1544,7 +1544,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.18.0):
+  - RNReanimated/worklets (3.18.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1564,9 +1564,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.18.0)
+    - RNReanimated/worklets/apple (= 3.18.1)
     - Yoga
-  - RNReanimated/worklets/apple (3.18.0):
+  - RNReanimated/worklets/apple (3.18.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.11.18.00)
@@ -1875,7 +1875,7 @@ SPEC CHECKSUMS:
   ReactCommon: 7490617e54cc60ef0aecee2beaa1f44d4b413e61
   RNCAsyncStorage: c91d753ede6dc21862c4922cd13f98f7cfde578e
   RNGestureHandler: 3aebdd5727d76b567572472b9e52c29536ee0eef
-  RNReanimated: 331c31051ba12ee3d16e6c5bed03a0ae0ad9180e
+  RNReanimated: fd3eb44cb1891f57462279566eb7d6441698f6bd
   RNSVG: 67de7abef81f367387b708ba6d2acefe7d4f5895
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: b84121efc79fe86699a15c8ae59e5a6a8bca05c8

--- a/apps/paper-example/ios/Podfile.lock
+++ b/apps/paper-example/ios/Podfile.lock
@@ -2271,7 +2271,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (3.18.0):
+  - RNReanimated (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2298,11 +2298,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.18.0)
-    - RNReanimated/worklets (= 3.18.0)
+    - RNReanimated/reanimated (= 3.18.1)
+    - RNReanimated/worklets (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (3.18.0):
+  - RNReanimated/reanimated (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2329,10 +2329,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.18.0)
+    - RNReanimated/reanimated/apple (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (3.18.0):
+  - RNReanimated/reanimated/apple (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2361,7 +2361,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated/worklets (3.18.0):
+  - RNReanimated/worklets (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2388,10 +2388,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.18.0)
+    - RNReanimated/worklets/apple (= 3.18.1)
     - SocketRocket
     - Yoga
-  - RNReanimated/worklets/apple (3.18.0):
+  - RNReanimated/worklets/apple (3.18.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2791,7 +2791,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 780e715803c5d297245edcd2495aefebba69bdb3
   RNFlashList: ba3a3ddff4c0b616bae48f46c536635a904da47b
   RNGestureHandler: cad0a1b7e766a42852f8fb211f35a85b6199a26d
-  RNReanimated: aedc7b9560c8ffa41322dddd8dc9eb2612a5c87a
+  RNReanimated: a29289ee5a5425df516b417ea752506594abb232
   RNScreens: 54a1a57a3d575ba31dca9f651e55cb7a3ec32044
   RNSVG: 3446469442ca54ddf210d2a1b7c2b6eaecaca2c3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1653,7 +1653,7 @@ PODS:
     - React-logger (= 0.79.0-0rc2)
     - React-perflogger (= 0.79.0-0rc2)
     - React-utils (= 0.79.0-0rc2)
-  - RNReanimated (3.18.0):
+  - RNReanimated (3.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1676,10 +1676,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.18.0)
-    - RNReanimated/worklets (= 3.18.0)
+    - RNReanimated/reanimated (= 3.18.1)
+    - RNReanimated/worklets (= 3.18.1)
     - Yoga
-  - RNReanimated/reanimated (3.18.0):
+  - RNReanimated/reanimated (3.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1702,9 +1702,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.18.0)
+    - RNReanimated/reanimated/apple (= 3.18.1)
     - Yoga
-  - RNReanimated/reanimated/apple (3.18.0):
+  - RNReanimated/reanimated/apple (3.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1728,7 +1728,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.18.0):
+  - RNReanimated/worklets (3.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1751,9 +1751,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.18.0)
+    - RNReanimated/worklets/apple (= 3.18.1)
     - Yoga
-  - RNReanimated/worklets/apple (3.18.0):
+  - RNReanimated/worklets/apple (3.18.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2074,7 +2074,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ec07a48c499f7f1420c872ba3347ce7937000960
   ReactCodegen: a9e644a22d3ef480d4973dd117c9458da936d12b
   ReactCommon: 975c24e76b57544fa910b0caee34f4adbfe90abb
-  RNReanimated: 7176dec0de57c774c9c6b68d4fdc13f9e0b1f2e6
+  RNReanimated: cac5009bf716e3244f0c477937d3a3afb9deb7fe
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: d4280c1f5bc3aef681cf28421e3a988c2d77ba31
 

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "test": "jest",

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -4,4 +4,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '3.18.0';
+export const jsVersion = '3.18.1';


### PR DESCRIPTION
## Summary
Release with a fix for surfaces

Reanimated `3.18.1` release

## Current state

|| Fabric (iOS) | Fabric (Android) | Paper(iOS) | Paper(Android) | Web | TVOS (iOS) | TVOS (Android) | Next |
|-|-|-|-|-|-|-|-|-|
| Builds           | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Works            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

## TODOs

- [x] Test package on the clean expo app
- [x] Test package on the clean bare app


## Test plan
