### PR TITLE
fix: Use correct color processor in CSS animations and transitions

### DIFF
--- a/packages/react-native-reanimated/src/css/native/style/config.ts
+++ b/packages/react-native-reanimated/src/css/native/style/config.ts
@@ -2,12 +2,12 @@
 import {
   IS_ANDROID,
   processBoxShadowNative,
-  processColor,
   processTransformOrigin,
 } from '../../../common';
 import type { PlainStyle } from '../../types';
 import {
   processAspectRatio,
+  processColor,
   processFontWeight,
   processGap,
   processInset,


### PR DESCRIPTION
## Summary

The incorrect color processor was used before, which broke the interpolation to/from the `transparent` color. Instead of returning the `'transparent'` string for `transparent` colors, the `undefined` value was returned, which was treated as a missing value in CSS transitions, thus the color was interpolated to the default fallback value, which is `black`.