### PR TITLE
fix: CSS animation early finish for fractional `animationIterationCount`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -49,10 +49,6 @@ AnimationProgressState AnimationProgressProvider::getState(const double timestam
   if (timestamp < getStartTimestamp(timestamp) || !rawProgress_.has_value()) {
     return AnimationProgressState::Pending;
   }
-  const auto rawProgress = rawProgress_.value();
-  if (rawProgress >= 1) {
-    return AnimationProgressState::Finished;
-  }
   return AnimationProgressState::Running;
 }
 
@@ -149,12 +145,6 @@ double AnimationProgressProvider::updateIterationProgress(const double currentIt
   const auto deltaIterations = static_cast<unsigned>(progress);
 
   if (deltaIterations > 0) {
-    // Return 1 if the current iteration is the last one
-    if (iterationCount_ != -1 && currentIteration_ + deltaIterations > iterationCount_) {
-      currentIteration_ = iterationCount_;
-      return 1;
-    }
-
     currentIteration_ += deltaIterations;
     previousIterationsDuration_ = (currentIteration_ - 1) * duration_;
   }


### PR DESCRIPTION
## Summary

I didn't notice this issue before. The CSS animation was finishing too early if the fractional number of animation iterations was used (e.g. `1.75`).

## Example recordings

Before it finished incorrectly on full iterations, so the `1.75` example finished after just after the first iteration passed.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/5f847088-78a9-4e9e-9038-ebccff23dcb5" /> | <video src="https://github.com/user-attachments/assets/554e86e9-300e-4d9b-a5cb-9aeac2c33f68" /> |

## Test Plan

Open the **Iteration Count** example in CSS Animations examples