### PR TITLE
fix: Incorrect detach call in web `CSSAnimationsManager`

### DIFF
--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -226,10 +226,8 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     }
   }
 
-  private removeAnimationsFromStyleSheet(
-    attachedAnimations: ProcessedAnimation[]
-  ) {
-    attachedAnimations.forEach(
+  private removeAnimationsFromStyleSheet(animations: ProcessedAnimation[]) {
+    animations.forEach(
       ({ keyframesRule: { name, processedKeyframes }, removable }) => {
         if (removable && processedKeyframes) {
           removeCSSAnimation(name);


### PR DESCRIPTION
## Summary

Fixes crash caused by changes mistakenly introduced in #8472

Was getting this crash on the web:

<img width="530" height="99" alt="Screenshot 2025-11-10 at 03 06 15" src="https://github.com/user-attachments/assets/2e854df8-4ab3-4cfe-bceb-ef01b7416d0a" />

