### PR TITLE
fix: Invalid default CSS transforms value

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.cpp
@@ -8,7 +8,7 @@
 namespace reanimated::css {
 
 const folly::dynamic TransformsStyleInterpolator::defaultStyleValueDynamic_ =
-    MatrixOperation(TransformMatrix3D()).toDynamic();
+    folly::dynamic::array(MatrixOperation(TransformMatrix3D()).toDynamic());
 
 TransformsStyleInterpolator::TransformsStyleInterpolator(
     const PropertyPath &propertyPath,


### PR DESCRIPTION
## Summary

Fixes this warning shown when the default transforms value was used.

<img width="547" height="38" alt="Screenshot 2025-11-10 at 03 22 38" src="https://github.com/user-attachments/assets/23eaa289-2efc-4470-8ef6-0b08a7fa37d0" />
