### PR TITLE
Fix BaseAnimationMock

### DIFF
--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -235,6 +235,10 @@ class BaseAnimationMock {
     return this;
   }
 
+  energyThreshold() {
+    return this;
+  }
+
   withCallback() {
     return this;
   }


### PR DESCRIPTION
## Summary
BaseAnimationMock is missing a mock for energyThreshold(). Let's fix that.

## Test plan
N/A, I suppose