### PR TITLE
chore: Change condition on Release Compatibility Check CI 

### DIFF
--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -4,8 +4,6 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, edited, labeled, unlabeled]
-    branches:
-      - '**release**'
   schedule:
     - cron: '37 19 * * *'
   workflow_call:


### PR DESCRIPTION
## Summary

Before it would only start if there was a label `Check Compatibility` assigned, but know it is sensitive to `release` or `Release` in titile, and optionally also to the label.

you can check it by removing`release` from the title and watch as CI dissapearc:

if you want, we can also add check if the branch name contains release.


btw. Github does not support any `lowerCase` func so that why double conditional -> https://github.com/orgs/community/discussions/25768

## Test plan
