### PR TITLE
fix: CSS template compilation

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperation.cpp
@@ -1,10 +1,8 @@
-#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
-
 #include <reanimated/CSS/common/filters/FilterOp.h>
 #include <reanimated/CSS/common/values/CSSAngle.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
 #include <reanimated/CSS/common/values/complex/CSSDropShadow.h>
-
+#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
 #include <reanimated/CSS/interpolation/filters/operations/blur.h>
 #include <reanimated/CSS/interpolation/filters/operations/brightness.h>
 #include <reanimated/CSS/interpolation/filters/operations/contrast.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperation.h
@@ -1,18 +1,15 @@
 #pragma once
 
 #include <reanimated/CSS/common/filters/FilterOp.h>
-#include <reanimated/CSS/common/values/CSSValue.h>
-
-#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
-
-#include <reanimated/CSS/common/filters/FilterOp.h>
 #include <reanimated/CSS/common/values/CSSAngle.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/CSSValue.h>
 #include <reanimated/CSS/common/values/complex/CSSDropShadow.h>
 
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperationInterpolator.cpp
@@ -1,5 +1,4 @@
 #include <reanimated/CSS/interpolation/filters/FilterOperationInterpolator.h>
-
 #include <reanimated/CSS/interpolation/filters/operations/blur.h>
 #include <reanimated/CSS/interpolation/filters/operations/brightness.h>
 #include <reanimated/CSS/interpolation/filters/operations/contrast.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperationInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/filters/FilterOperationInterpolator.h
@@ -1,16 +1,11 @@
 #pragma once
 
 #include <reanimated/CSS/common/filters/FilterOp.h>
-#include <reanimated/CSS/interpolation/configs.h>
-#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
-
-#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
-
-#include <reanimated/CSS/common/filters/FilterOp.h>
 #include <reanimated/CSS/common/values/CSSAngle.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
 #include <reanimated/CSS/common/values/complex/CSSDropShadow.h>
-
+#include <reanimated/CSS/interpolation/configs.h>
+#include <reanimated/CSS/interpolation/filters/FilterOperation.h>
 #include <reanimated/CSS/interpolation/filters/operations/blur.h>
 #include <reanimated/CSS/interpolation/filters/operations/brightness.h>
 #include <reanimated/CSS/interpolation/filters/operations/contrast.h>


### PR DESCRIPTION
## Summary

#8483 added template definition in .cpp files which break for `Release` builds. This PR moves these definitions to header files to fix the compilation.

## Test plan

Compatibility CI works again

Previously: https://github.com/software-mansion/react-native-reanimated/actions/runs/19309658301
