### PR TITLE
Revert worklets visibility changes (from #8408)

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/Registries/EventHandlerRegistry.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Registries/EventHandlerRegistry.h
@@ -17,7 +17,7 @@ namespace worklets {
 
 class WorkletEventHandler;
 
-class __attribute__((visibility("default"))) EventHandlerRegistry {
+class EventHandlerRegistry {
   std::map<std::pair<int, std::string>, std::unordered_map<uint64_t, std::shared_ptr<WorkletEventHandler>>>
       eventMappingsWithTag;
   std::map<std::string, std::unordered_map<uint64_t, std::shared_ptr<WorkletEventHandler>>> eventMappingsWithoutTag;

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -16,7 +16,7 @@ namespace worklets {
 jsi::Function getValueUnpacker(jsi::Runtime &rt);
 
 #ifndef NDEBUG
-__attribute__((visibility("default"))) jsi::Function getCallGuard(jsi::Runtime &rt);
+jsi::Function getCallGuard(jsi::Runtime &rt);
 #endif // NDEBUG
 
 // If possible, please use `WorkletRuntime::runGuarded` instead.
@@ -57,7 +57,7 @@ inline void cleanupIfRuntimeExists(jsi::Runtime *rt, std::unique_ptr<jsi::Value>
   }
 }
 
-class __attribute__((visibility("default"))) Serializable {
+class Serializable {
  public:
   virtual jsi::Value toJSValue(jsi::Runtime &rt) = 0;
 
@@ -117,7 +117,7 @@ class RetainingSerializable : virtual public BaseClass {
   }
 };
 
-class __attribute__((visibility("default"))) SerializableJSRef : public jsi::NativeState {
+class SerializableJSRef : public jsi::NativeState {
  private:
   const std::shared_ptr<Serializable> value_;
 
@@ -138,66 +138,58 @@ class __attribute__((visibility("default"))) SerializableJSRef : public jsi::Nat
   }
 };
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableClone(
+jsi::Value makeSerializableClone(
     jsi::Runtime &rt,
     const jsi::Value &value,
     const jsi::Value &shouldRetainRemote,
     const jsi::Value &nativeStateSource);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableString(jsi::Runtime &rt, const jsi::String &string);
+jsi::Value makeSerializableString(jsi::Runtime &rt, const jsi::String &string);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableNumber(jsi::Runtime &rt, double number);
+jsi::Value makeSerializableNumber(jsi::Runtime &rt, double number);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableBoolean(jsi::Runtime &rt, bool boolean);
+jsi::Value makeSerializableBoolean(jsi::Runtime &rt, bool boolean);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint);
+jsi::Value makeSerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableUndefined(jsi::Runtime &rt);
+jsi::Value makeSerializableUndefined(jsi::Runtime &rt);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableNull(jsi::Runtime &rt);
+jsi::Value makeSerializableNull(jsi::Runtime &rt);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableTurboModuleLike(
+jsi::Value makeSerializableTurboModuleLike(
     jsi::Runtime &rt,
     const jsi::Object &object,
     const std::shared_ptr<jsi::HostObject> &proto);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableObject(
+jsi::Value makeSerializableObject(
     jsi::Runtime &rt,
     jsi::Object object,
     bool shouldRetainRemote,
     const jsi::Value &nativeStateSource);
 
-jsi::Value __attribute__((visibility("default")))
-makeSerializableImport(jsi::Runtime &rt, const double source, const jsi::String &imported);
+jsi::Value makeSerializableImport(jsi::Runtime &rt, const double source, const jsi::String &imported);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableHostObject(
-    jsi::Runtime &rt,
-    const std::shared_ptr<jsi::HostObject> &value);
+jsi::Value makeSerializableHostObject(jsi::Runtime &rt, const std::shared_ptr<jsi::HostObject> &value);
 
-jsi::Value __attribute__((visibility("default")))
-makeSerializableArray(jsi::Runtime &rt, const jsi::Array &array, const jsi::Value &shouldRetainRemote);
+jsi::Value makeSerializableArray(jsi::Runtime &rt, const jsi::Array &array, const jsi::Value &shouldRetainRemote);
 
-jsi::Value __attribute__((visibility("default")))
-makeSerializableMap(jsi::Runtime &rt, const jsi::Array &keys, const jsi::Array &values);
+jsi::Value makeSerializableMap(jsi::Runtime &rt, const jsi::Array &keys, const jsi::Array &values);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableSet(jsi::Runtime &rt, const jsi::Array &values);
+jsi::Value makeSerializableSet(jsi::Runtime &rt, const jsi::Array &values);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableInitializer(
-    jsi::Runtime &rt,
-    const jsi::Object &initializerObject);
+jsi::Value makeSerializableInitializer(jsi::Runtime &rt, const jsi::Object &initializerObject);
 
-jsi::Value __attribute__((visibility("default"))) makeSerializableFunction(jsi::Runtime &rt, jsi::Function function);
+jsi::Value makeSerializableFunction(jsi::Runtime &rt, jsi::Function function);
 
-jsi::Value __attribute__((visibility("default")))
-makeSerializableWorklet(jsi::Runtime &rt, const jsi::Object &object, const bool &shouldRetainRemote);
+jsi::Value makeSerializableWorklet(jsi::Runtime &rt, const jsi::Object &object, const bool &shouldRetainRemote);
 
-__attribute__((visibility("default"))) std::shared_ptr<Serializable> extractSerializableOrThrow(
+std::shared_ptr<Serializable> extractSerializableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeSerializableValue,
     const std::string &errorMessage = "[Worklets] Expecting the object to be of type SerializableJSRef.");
 
 template <typename T>
-__attribute__((visibility("default"))) std::shared_ptr<T> extractSerializableOrThrow(
+std::shared_ptr<T> extractSerializableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &serializableRef,
     const std::string &errorMessage = "[Worklets] Provided serializable object is of an incompatible type.") {
@@ -208,7 +200,7 @@ __attribute__((visibility("default"))) std::shared_ptr<T> extractSerializableOrT
   return res;
 }
 
-class __attribute__((visibility("default"))) SerializableArray : public Serializable {
+class SerializableArray : public Serializable {
  public:
   SerializableArray(jsi::Runtime &rt, const jsi::Array &array);
 
@@ -218,7 +210,7 @@ class __attribute__((visibility("default"))) SerializableArray : public Serializ
   std::vector<std::shared_ptr<Serializable>> data_;
 };
 
-class __attribute__((visibility("default"))) SerializableObject : public Serializable {
+class SerializableObject : public Serializable {
  public:
   SerializableObject(jsi::Runtime &rt, const jsi::Object &object);
 
@@ -231,7 +223,7 @@ class __attribute__((visibility("default"))) SerializableObject : public Seriali
   std::shared_ptr<jsi::NativeState> nativeState_;
 };
 
-class __attribute__((visibility("default"))) SerializableMap : public Serializable {
+class SerializableMap : public Serializable {
  public:
   SerializableMap(jsi::Runtime &rt, const jsi::Array &keys, const jsi::Array &values);
 
@@ -241,7 +233,7 @@ class __attribute__((visibility("default"))) SerializableMap : public Serializab
   std::vector<std::pair<std::shared_ptr<Serializable>, std::shared_ptr<Serializable>>> data_;
 };
 
-class __attribute__((visibility("default"))) SerializableSet : public Serializable {
+class SerializableSet : public Serializable {
  public:
   SerializableSet(jsi::Runtime &rt, const jsi::Array &values);
 
@@ -251,7 +243,7 @@ class __attribute__((visibility("default"))) SerializableSet : public Serializab
   std::vector<std::shared_ptr<Serializable>> data_;
 };
 
-class __attribute__((visibility("default"))) SerializableHostObject : public Serializable {
+class SerializableHostObject : public Serializable {
  public:
   SerializableHostObject(jsi::Runtime &, const std::shared_ptr<jsi::HostObject> &hostObject)
       : Serializable(ValueType::HostObjectType), hostObject_(hostObject) {}
@@ -262,7 +254,7 @@ class __attribute__((visibility("default"))) SerializableHostObject : public Ser
   const std::shared_ptr<jsi::HostObject> hostObject_;
 };
 
-class __attribute__((visibility("default"))) SerializableHostFunction : public Serializable {
+class SerializableHostFunction : public Serializable {
  public:
   SerializableHostFunction(jsi::Runtime &rt, jsi::Function function)
       : Serializable(ValueType::HostFunctionType),
@@ -278,7 +270,7 @@ class __attribute__((visibility("default"))) SerializableHostFunction : public S
   const unsigned int paramCount_;
 };
 
-class __attribute__((visibility("default"))) SerializableArrayBuffer : public Serializable {
+class SerializableArrayBuffer : public Serializable {
  public:
   SerializableArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer)
       : Serializable(ValueType::ArrayBufferType),
@@ -290,7 +282,7 @@ class __attribute__((visibility("default"))) SerializableArrayBuffer : public Se
   const std::vector<uint8_t> data_;
 };
 
-class __attribute__((visibility("default"))) SerializableWorklet : public SerializableObject {
+class SerializableWorklet : public SerializableObject {
  public:
   SerializableWorklet(jsi::Runtime &rt, const jsi::Object &worklet) : SerializableObject(rt, worklet) {
     valueType_ = ValueType::WorkletType;
@@ -299,7 +291,7 @@ class __attribute__((visibility("default"))) SerializableWorklet : public Serial
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class __attribute__((visibility("default"))) SerializableImport : public Serializable {
+class SerializableImport : public Serializable {
  public:
   SerializableImport(jsi::Runtime &rt, const double source, const jsi::String &imported)
       : Serializable(ValueType::ImportType), source_(source), imported_(imported.utf8(rt)) {}
@@ -311,9 +303,8 @@ class __attribute__((visibility("default"))) SerializableImport : public Seriali
   const std::string imported_;
 };
 
-class __attribute__((visibility("default"))) SerializableRemoteFunction
-    : public Serializable,
-      public std::enable_shared_from_this<SerializableRemoteFunction> {
+class SerializableRemoteFunction : public Serializable,
+                                   public std::enable_shared_from_this<SerializableRemoteFunction> {
  private:
   jsi::Runtime *runtime_;
 #ifndef NDEBUG
@@ -338,7 +329,7 @@ class __attribute__((visibility("default"))) SerializableRemoteFunction
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class __attribute__((visibility("default"))) SerializableInitializer : public Serializable {
+class SerializableInitializer : public Serializable {
  private:
   // We don't release the initializer since the handle can get
   // initialized in parallel on multiple threads. However this is not a problem,
@@ -361,7 +352,7 @@ class __attribute__((visibility("default"))) SerializableInitializer : public Se
   jsi::Value toJSValue(jsi::Runtime &rt) override;
 };
 
-class __attribute__((visibility("default"))) SerializableString : public Serializable {
+class SerializableString : public Serializable {
  public:
   explicit SerializableString(const std::string &string) : Serializable(ValueType::StringType), data_(string) {}
 
@@ -371,7 +362,7 @@ class __attribute__((visibility("default"))) SerializableString : public Seriali
   const std::string data_;
 };
 
-class __attribute__((visibility("default"))) SerializableBigInt : public Serializable {
+class SerializableBigInt : public Serializable {
  public:
   explicit SerializableBigInt(jsi::Runtime &rt, const jsi::BigInt &bigint)
       : Serializable(ValueType::BigIntType), string_(bigint.toString(rt).utf8(rt)) {}
@@ -382,7 +373,7 @@ class __attribute__((visibility("default"))) SerializableBigInt : public Seriali
   const std::string string_;
 };
 
-class __attribute__((visibility("default"))) SerializableScalar : public Serializable {
+class SerializableScalar : public Serializable {
  public:
   explicit SerializableScalar(double number) : Serializable(ValueType::NumberType) {
     data_.number = number;
@@ -405,7 +396,7 @@ class __attribute__((visibility("default"))) SerializableScalar : public Seriali
   Data data_;
 };
 
-class __attribute__((visibility("default"))) SerializableTurboModuleLike : public Serializable {
+class SerializableTurboModuleLike : public Serializable {
  public:
   SerializableTurboModuleLike(
       jsi::Runtime &rt,

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/JSISerializer.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/JSISerializer.h
@@ -8,7 +8,7 @@ using namespace facebook;
 
 namespace worklets {
 
-class __attribute__((visibility("default"))) JSISerializer {
+class JSISerializer {
  public:
   explicit JSISerializer(jsi::Runtime &rt);
   std::string stringifyJSIValueRecursively(const jsi::Value &value, bool isTopLevel = false);
@@ -37,6 +37,6 @@ class __attribute__((visibility("default"))) JSISerializer {
   jsi::Object visitedNodes_;
 };
 
-__attribute__((visibility("default"))) std::string stringifyJSIValue(jsi::Runtime &rt, const jsi::Value &value);
+std::string stringifyJSIValue(jsi::Runtime &rt, const jsi::Value &value);
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/JSScheduler.h
@@ -10,7 +10,7 @@ using namespace react;
 
 namespace worklets {
 
-class __attribute__((visibility("default"))) JSScheduler {
+class JSScheduler {
   using Job = std::function<void(jsi::Runtime &rt)>;
 
  public:

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/VersionUtils.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/VersionUtils.h
@@ -13,7 +13,7 @@ namespace worklets {
 
 bool matchVersion(const std::string &version1, const std::string &version2);
 
-__attribute__((visibility("default"))) void checkJSVersion(
+void checkJSVersion(
     jsi::Runtime &runtime,
     jsi::Value &jsVersionValue,
     const std::shared_ptr<worklets::JSLogger> &jsLogger,

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -20,8 +20,6 @@ string(
     -DHERMES_V1_ENABLED=${HERMES_V1_ENABLED}")
 
 string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fstack-protector-all")
-# flags to optimize the binary size
-string(APPEND CMAKE_CXX_FLAGS " -fvisibility=hidden")
 
 if(${IS_REANIMATED_EXAMPLE_APP})
   string(APPEND CMAKE_CXX_FLAGS " -DIS_REANIMATED_EXAMPLE_APP -Wpedantic")


### PR DESCRIPTION
## Summary

In #8408 I proposed hiding all Worklets' symbols unused by Reanimated. I didn't realise there are other libraries that use worklets, which require access to more symbols. This PR reverts the visibility change.
