### PR TITLE
chore: Move common parts of the CSSManager to the base class

### DIFF
--- a/packages/react-native-reanimated/src/css/managers/CSSManagerBase.ts
+++ b/packages/react-native-reanimated/src/css/managers/CSSManagerBase.ts
@@ -1,33 +1,80 @@
 'use strict';
+import type { AnyRecord, PlainStyle } from '../../common';
 import {
   isReactComponentName,
   logger,
   UNSUPPORTED_TRANSFORM_PROPS,
 } from '../../common';
-import type { CSSStyle } from '../types';
+import type {
+  ExistingCSSAnimationProperties,
+  CSSTransitionProperties,
+  CSSStyle,
+} from '../types';
+import type {
+  ICSSAnimationsManager,
+  ICSSTransitionsManager,
+} from '../types/interfaces';
+import { filterCSSAndStyleProperties } from '../utils';
 
 const UNSUPPORTED_TRANSFORM_PROPS_SET = new Set<string>(
   UNSUPPORTED_TRANSFORM_PROPS
 );
 
+type FilterResult = [
+  ExistingCSSAnimationProperties | null,
+  CSSTransitionProperties | null,
+  PlainStyle,
+];
+
 export default abstract class CSSManagerBase {
   private readonly warnedProps = new Set<string>();
+  protected readonly viewName: string;
+  protected readonly animationsManager: ICSSAnimationsManager;
+  protected readonly transitionsManager: ICSSTransitionsManager;
 
-  protected warnOnUnsupportedProps(style: CSSStyle, componentName: string) {
-    if (!isReactComponentName(componentName)) {
+  protected constructor(
+    viewName: string,
+    animationsManager: ICSSAnimationsManager,
+    transitionsManager: ICSSTransitionsManager
+  ) {
+    this.viewName = viewName;
+    this.animationsManager = animationsManager;
+    this.transitionsManager = transitionsManager;
+  }
+
+  protected filterAndValidateStyle<S extends AnyRecord>(
+    style: CSSStyle<S>
+  ): FilterResult {
+    const filtered = filterCSSAndStyleProperties(style);
+
+    if (__DEV__) {
+      const filteredStyle = filtered[2];
+      this.warnUnsupported(filteredStyle);
+    }
+
+    return filtered;
+  }
+
+  private warnUnsupported(style: AnyRecord) {
+    if (!isReactComponentName(this.viewName)) {
       return;
     }
 
-    Object.keys(style).forEach((prop) => {
+    for (const prop of Object.keys(style)) {
       if (
         UNSUPPORTED_TRANSFORM_PROPS_SET.has(prop) &&
         !this.warnedProps.has(prop)
       ) {
         this.warnedProps.add(prop);
         logger.warn(
-          `The style property "${prop}" is not supported for ${componentName} CSS animations. Use the "transform" property instead.`
+          `The style property "${prop}" is not supported for ${this.viewName} CSS animations. Use the "transform" property instead.`
         );
       }
-    });
+    }
+  }
+
+  unmountCleanup(): void {
+    this.animationsManager.unmountCleanup();
+    this.transitionsManager.unmountCleanup();
   }
 }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -4,52 +4,45 @@ import { ReanimatedError } from '../../../common';
 import type { StyleBuilder } from '../../../common/style';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
-import { CSSManagerBase } from '../../managers';
-import type { CSSStyle } from '../../types';
-import type { ICSSManager } from '../../types/interfaces';
-import { filterCSSAndStyleProperties } from '../../utils';
-import { setViewStyle } from '../proxy';
-import { getStyleBuilder, hasStyleBuilder } from '../registry';
 import CSSAnimationsManager from './CSSAnimationsManager';
 import CSSTransitionsManager from './CSSTransitionsManager';
+import CSSManagerBase from '../../managers/CSSManagerBase';
+import type { CSSStyle } from '../../types';
+import type { ICSSManager } from '../../types/interfaces';
+import { setViewStyle } from '../proxy';
+import { getStyleBuilder, hasStyleBuilder } from '../registry';
 
 export default class CSSManager extends CSSManagerBase implements ICSSManager {
-  private readonly cssAnimationsManager: CSSAnimationsManager;
-  private readonly cssTransitionsManager: CSSTransitionsManager;
   private readonly viewTag: number;
-  private readonly viewName: string;
   private readonly styleBuilder: StyleBuilder<AnyRecord> | null = null;
   private isFirstUpdate: boolean = true;
 
   constructor({ shadowNodeWrapper, viewTag, viewName = 'RCTView' }: ViewInfo) {
-    super();
-    const tag = (this.viewTag = viewTag as number);
     const wrapper = shadowNodeWrapper as ShadowNodeWrapper;
-
-    this.viewName = viewName;
-    this.styleBuilder = hasStyleBuilder(viewName)
-      ? getStyleBuilder(viewName)
-      : null;
-    this.cssAnimationsManager = new CSSAnimationsManager(
+    const tag = viewTag as number;
+    const animationsManager = new CSSAnimationsManager(
       wrapper,
       viewName,
       tag
     );
-    this.cssTransitionsManager = new CSSTransitionsManager(wrapper, tag);
+    const transitionsManager = new CSSTransitionsManager(wrapper, tag);
+
+    super(viewName, animationsManager, transitionsManager);
+    this.viewTag = tag;
+
+    this.styleBuilder = hasStyleBuilder(viewName)
+      ? getStyleBuilder(viewName)
+      : null;
   }
 
   update(style: CSSStyle): void {
     const [animationProperties, transitionProperties, filteredStyle] =
-      filterCSSAndStyleProperties(style);
+      this.filterAndValidateStyle(style);
 
     if (!this.styleBuilder && (animationProperties || transitionProperties)) {
       throw new ReanimatedError(
         `Tried to apply CSS animations to ${this.viewName} which is not supported`
       );
-    }
-
-    if (__DEV__) {
-      this.warnOnUnsupportedProps(filteredStyle, this.viewName);
     }
 
     const normalizedStyle = this.styleBuilder?.buildFrom(filteredStyle);
@@ -60,8 +53,8 @@ export default class CSSManager extends CSSManagerBase implements ICSSManager {
       setViewStyle(this.viewTag, normalizedStyle);
     }
 
-    this.cssTransitionsManager.update(transitionProperties);
-    this.cssAnimationsManager.update(animationProperties);
+    this.transitionsManager.update(transitionProperties);
+    this.animationsManager.update(animationProperties);
 
     // If the current update is not the fist one, we want to update CSS
     // animations and transitions first and update the style then to make
@@ -71,10 +64,5 @@ export default class CSSManager extends CSSManagerBase implements ICSSManager {
     }
 
     this.isFirstUpdate = false;
-  }
-
-  unmountCleanup(): void {
-    this.cssAnimationsManager.unmountCleanup();
-    this.cssTransitionsManager.unmountCleanup();
   }
 }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -4,13 +4,13 @@ import { ReanimatedError } from '../../../common';
 import type { StyleBuilder } from '../../../common/style';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
-import CSSAnimationsManager from './CSSAnimationsManager';
-import CSSTransitionsManager from './CSSTransitionsManager';
 import CSSManagerBase from '../../managers/CSSManagerBase';
 import type { CSSStyle } from '../../types';
 import type { ICSSManager } from '../../types/interfaces';
 import { setViewStyle } from '../proxy';
 import { getStyleBuilder, hasStyleBuilder } from '../registry';
+import CSSAnimationsManager from './CSSAnimationsManager';
+import CSSTransitionsManager from './CSSTransitionsManager';
 
 export default class CSSManager extends CSSManagerBase implements ICSSManager {
   private readonly viewTag: number;
@@ -20,16 +20,14 @@ export default class CSSManager extends CSSManagerBase implements ICSSManager {
   constructor({ shadowNodeWrapper, viewTag, viewName = 'RCTView' }: ViewInfo) {
     const wrapper = shadowNodeWrapper as ShadowNodeWrapper;
     const tag = viewTag as number;
-    const animationsManager = new CSSAnimationsManager(
-      wrapper,
+
+    super(
       viewName,
-      tag
+      new CSSAnimationsManager(wrapper, viewName, tag),
+      new CSSTransitionsManager(wrapper, tag)
     );
-    const transitionsManager = new CSSTransitionsManager(wrapper, tag);
 
-    super(viewName, animationsManager, transitionsManager);
     this.viewTag = tag;
-
     this.styleBuilder = hasStyleBuilder(viewName)
       ? getStyleBuilder(viewName)
       : null;
@@ -39,6 +37,8 @@ export default class CSSManager extends CSSManagerBase implements ICSSManager {
     const [animationProperties, transitionProperties, filteredStyle] =
       this.filterAndValidateStyle(style);
 
+    // TODO - move this to the base class later on once separate style builders
+    // for web css animations are implemented
     if (!this.styleBuilder && (animationProperties || transitionProperties)) {
       throw new ReanimatedError(
         `Tried to apply CSS animations to ${this.viewName} which is not supported`

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -2,18 +2,69 @@
 import { logger } from '../../../../common';
 import type { ShadowNodeWrapper } from '../../../../commonTypes';
 import type { CSSStyle } from '../../../types';
+import type { StyleBuilder } from '../../../../common/style';
+import CSSAnimationsManager from '../CSSAnimationsManager';
+import CSSTransitionsManager from '../CSSTransitionsManager';
 import CSSManager from '../CSSManager';
+import { setViewStyle } from '../../proxy';
+import { getStyleBuilder, hasStyleBuilder } from '../../registry';
 
 jest.mock('../CSSAnimationsManager');
 jest.mock('../CSSTransitionsManager');
 jest.mock('../../proxy.ts');
 
-const createManager = (viewName = 'RCTView') =>
-  new CSSManager({
+const MockAnimationsManager =
+  CSSAnimationsManager as jest.MockedClass<typeof CSSAnimationsManager>;
+const MockTransitionsManager =
+  CSSTransitionsManager as jest.MockedClass<typeof CSSTransitionsManager>;
+const setViewStyleMock = setViewStyle as jest.MockedFunction<typeof setViewStyle>;
+const hasStyleBuilderMock =
+  hasStyleBuilder as jest.MockedFunction<typeof hasStyleBuilder>;
+const getStyleBuilderMock =
+  getStyleBuilder as jest.MockedFunction<typeof getStyleBuilder>;
+
+const defaultBuildFrom: StyleBuilder['buildFrom'] = () => null;
+const defaultAdd: StyleBuilder['add'] = () => undefined;
+const defaultIsSeparatelyInterpolatedNestedProperty: StyleBuilder['isSeparatelyInterpolatedNestedProperty'] =
+  () => false;
+
+const createStyleBuilderMock = (
+  buildFrom?: jest.Mock
+): StyleBuilder => ({
+  buildFrom: (buildFrom as unknown as StyleBuilder['buildFrom']) ?? defaultBuildFrom,
+  add: defaultAdd,
+  isSeparatelyInterpolatedNestedProperty:
+    defaultIsSeparatelyInterpolatedNestedProperty,
+});
+
+type CreateManagerOptions = {
+  viewName?: string;
+  buildFrom?: jest.Mock;
+};
+
+function createManager(
+  options: string | CreateManagerOptions = {}
+): CSSManager {
+  const normalizedOptions: CreateManagerOptions =
+    typeof options === 'string' ? { viewName: options } : options;
+
+  const viewName = normalizedOptions.viewName ?? 'RCTView';
+  const builder = normalizedOptions.buildFrom
+    ? createStyleBuilderMock(normalizedOptions.buildFrom)
+    : undefined;
+
+  const hasBuilder = !!builder;
+  hasStyleBuilderMock.mockReturnValue(hasBuilder);
+  getStyleBuilderMock.mockReturnValue(
+    builder ?? createStyleBuilderMock()
+  );
+
+  return new CSSManager({
     shadowNodeWrapper: {} as ShadowNodeWrapper,
     viewTag: 1,
     viewName,
   });
+}
 
 describe('CSSManager', () => {
   const warnSpy = jest
@@ -27,6 +78,11 @@ describe('CSSManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    MockAnimationsManager.mockClear();
+    MockTransitionsManager.mockClear();
+    setViewStyleMock.mockClear();
+    hasStyleBuilderMock.mockReset();
+    getStyleBuilderMock.mockReset();
   });
 
   test('warns once per unsupported prop for React Native components', () => {
@@ -51,7 +107,7 @@ describe('CSSManager', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test('ignores supported props', () => {
+  test('does not warn for supported props', () => {
     const manager = createManager();
     const style = { transform: [{ translateX: 10 }] };
 
@@ -69,5 +125,85 @@ describe('CSSManager', () => {
     manager.update(styleB);
 
     expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('forwards transition properties to the transitions manager', () => {
+    const buildFrom = jest.fn().mockReturnValue({ opacity: 0.6 });
+    const manager = createManager({ buildFrom });
+    const style: CSSStyle = {
+      opacity: 0.4,
+      transitionDuration: ['150ms'],
+      transitionProperty: ['opacity'],
+    };
+
+    manager.update(style);
+
+    const transitionsInstance = MockTransitionsManager.mock.instances[0]!;
+    expect(transitionsInstance.update).toHaveBeenCalledWith({
+      transitionDuration: ['150ms'],
+      transitionProperty: ['opacity'],
+    });
+    expect(buildFrom).toHaveBeenCalledWith({ opacity: 0.4 });
+    expect(setViewStyleMock).toHaveBeenCalledWith(1, { opacity: 0.6 });
+  });
+
+  test('calls animation and transition managers with null when no configs provided', () => {
+    const manager = createManager();
+
+    manager.update({ opacity: 0.2 });
+
+    const animationsInstance = MockAnimationsManager.mock.instances[0]!;
+    const transitionsInstance = MockTransitionsManager.mock.instances[0]!;
+    expect(animationsInstance.update).toHaveBeenCalledWith(null);
+    expect(transitionsInstance.update).toHaveBeenCalledWith(null);
+    expect(setViewStyleMock).not.toHaveBeenCalled();
+  });
+
+  test('sets styles before transitions on first update and after on subsequent updates', () => {
+    const buildFrom = jest.fn().mockReturnValue({ opacity: 0.7 });
+    const manager = createManager({ buildFrom });
+    const animationsInstance = MockAnimationsManager.mock.instances[0]!;
+    const transitionsInstance = MockTransitionsManager.mock.instances[0]!;
+
+    manager.update({ opacity: 0.5 });
+
+    expect(setViewStyleMock).toHaveBeenCalledTimes(1);
+    expect(setViewStyleMock.mock.invocationCallOrder[0]).toBeLessThan(
+      (transitionsInstance.update as jest.Mock).mock.invocationCallOrder[0]
+    );
+
+    setViewStyleMock.mockClear();
+    (animationsInstance.update as jest.Mock).mockClear();
+    (transitionsInstance.update as jest.Mock).mockClear();
+
+    manager.update({ opacity: 0.9 });
+
+    expect(setViewStyleMock).toHaveBeenCalledTimes(1);
+    expect(setViewStyleMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      (animationsInstance.update as jest.Mock).mock.invocationCallOrder[0]
+    );
+  });
+
+  test('delegates unmountCleanup to both managers', () => {
+    const manager = createManager();
+    const animationsInstance = MockAnimationsManager.mock.instances[0]!;
+    const transitionsInstance = MockTransitionsManager.mock.instances[0]!;
+
+    manager.unmountCleanup();
+
+    expect(animationsInstance.unmountCleanup).toHaveBeenCalledTimes(1);
+    expect(transitionsInstance.unmountCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws when animations are provided without a style builder', () => {
+    const manager = createManager();
+    const style = {
+      animationDuration: ['1s'],
+      animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
+    } as CSSStyle;
+
+    expect(() => manager.update(style)).toThrow(
+      'Tried to apply CSS animations to RCTView which is not supported'
+    );
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -9,10 +9,11 @@ import CSSTransitionsManager from './CSSTransitionsManager';
 export default class CSSManager extends CSSManagerBase implements ICSSManager {
   constructor({ DOMElement, viewName = 'RCTView' }: ViewInfo) {
     const element = DOMElement as ReanimatedHTMLElement;
-    const animationsManager = new CSSAnimationsManager(element);
-    const transitionsManager = new CSSTransitionsManager(element);
-
-    super(viewName, animationsManager, transitionsManager);
+    super(
+      viewName,
+      new CSSAnimationsManager(element),
+      new CSSTransitionsManager(element)
+    );
   }
 
   update(style: CSSStyle): void {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -1,40 +1,25 @@
 'use strict';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
-import { CSSManagerBase } from '../../managers';
+import CSSManagerBase from '../../managers/CSSManagerBase';
 import type { CSSStyle, ICSSManager } from '../../types';
-import { filterCSSAndStyleProperties } from '../../utils';
 import CSSAnimationsManager from './CSSAnimationsManager';
 import CSSTransitionsManager from './CSSTransitionsManager';
 
 export default class CSSManager extends CSSManagerBase implements ICSSManager {
-  private readonly element: ReanimatedHTMLElement;
-  private readonly viewName: string;
-  private readonly animationsManager: CSSAnimationsManager;
-  private readonly transitionsManager: CSSTransitionsManager;
-
   constructor({ DOMElement, viewName = 'RCTView' }: ViewInfo) {
-    super();
-    this.element = DOMElement as ReanimatedHTMLElement;
-    this.viewName = viewName;
-    this.animationsManager = new CSSAnimationsManager(this.element);
-    this.transitionsManager = new CSSTransitionsManager(this.element);
+    const element = DOMElement as ReanimatedHTMLElement;
+    const animationsManager = new CSSAnimationsManager(element);
+    const transitionsManager = new CSSTransitionsManager(element);
+
+    super(viewName, animationsManager, transitionsManager);
   }
 
   update(style: CSSStyle): void {
-    const [animationProperties, transitionProperties, filteredStyle] =
-      filterCSSAndStyleProperties(style);
-
-    if (__DEV__) {
-      this.warnOnUnsupportedProps(filteredStyle, this.viewName);
-    }
+    const [animationProperties, transitionProperties] =
+      this.filterAndValidateStyle(style);
 
     this.animationsManager.update(animationProperties);
     this.transitionsManager.update(transitionProperties);
-  }
-
-  unmountCleanup(): void {
-    this.animationsManager.unmountCleanup();
-    this.transitionsManager.unmountCleanup();
   }
 }


### PR DESCRIPTION
## Summary

This PR moves common parts of `CSSManager` classes to the base `CSSManagerBase` class.