### PR TITLE
fix: Use correct `transformOrigin` processor for native CSS style processing

### DIFF
--- a/packages/react-native-reanimated/src/common/style/config.ts
+++ b/packages/react-native-reanimated/src/common/style/config.ts
@@ -1,7 +1,6 @@
 'use strict';
 import { IS_ANDROID } from '../constants';
 import type { PlainStyle } from '../types';
-import { processTransformOrigin } from '../web';
 import {
   processAspectRatio,
   processBoxShadowNative,
@@ -13,6 +12,7 @@ import {
   processInsetBlock,
   processInsetInline,
   processTransform,
+  processTransformOrigin,
 } from './processors';
 import type { StyleBuilderConfig } from './types';
 

--- a/packages/react-native-reanimated/src/common/style/processors/index.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/index.ts
@@ -11,3 +11,4 @@ export { processInset, processInsetBlock, processInsetInline } from './insets';
 export { processAspectRatio, processGap } from './others';
 export { processBoxShadowNative } from './shadows';
 export { processTransform } from './transform';
+export { processTransformOrigin } from './transformOrigin';


### PR DESCRIPTION
## Summary

This PR fixes the issue mistakenly introduced by me in the #8391 PR. The issue was caused by the fact that the `transformOrigin` processor was imported from the `web` style processors dir instead of the native ones.

## Examples

| Before | After |
|-|-|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-18 at 23 27 16" src="https://github.com/user-attachments/assets/f55af6cb-1822-4355-aac6-e8c1b62224ad" /> | <video src="https://github.com/user-attachments/assets/ce8569b0-2804-4ea1-9983-46aa2a67823f" /> |
