### PR TITLE
chore: deprecate `useAnimatedKeyboard`

### DIFF
--- a/packages/react-native-reanimated/src/hook/useAnimatedKeyboard.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedKeyboard.ts
@@ -15,6 +15,8 @@ import {
 /**
  * Lets you synchronously get the position and state of the keyboard.
  *
+ * @deprecated Please use `react-native-keyboard-controller` instead. See
+ *   https://docs.swmansion.com/react-native-reanimated/docs/device/useAnimatedKeyboard#migration-guide
  * @param options - An additional keyboard configuration options.
  * @returns An object with the current keyboard `height` and `state` as [shared
  *   values](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#shared-value).


### PR DESCRIPTION
## Summary

Initial changes for https://github.com/software-mansion/react-native-reanimated/pull/8622

## Test plan

Confirm that hook is highlighted as a deprectaed:

<img width="680" height="403" alt="image" src="https://github.com/user-attachments/assets/03aa935f-ddc3-41bc-8612-1422bee3048e" />
