### PR TITLE
chore(3.18): Set yarn berry in CI - compatibility check 

### DIFF
--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -30,7 +30,6 @@ jobs:
           ]
       fail-fast: false
     env:
-      YARN_ENABLE_HARDENED_MODE: 0
       APP_NAME: app
       RCT_NEW_ARCH_ENABLED: ${{ matrix.react-native.architecture == 'Fabric' && '1' || '0' }}
     concurrency:
@@ -69,6 +68,8 @@ jobs:
           yarn set version berry
           yarn config set nodeLinker node-modules
       - name: Install Reanimated
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0 
         working-directory: ${{ env.APP_NAME }}
         run: yarn add "react-native-reanimated@https://github.com/software-mansion/react-native-reanimated.git#workspace=react-native-reanimated&commit=${{ github.sha }}"
       - name: Install Pods


### PR DESCRIPTION
## Summary

What happend was we had set `YARN_ENABLE_HARDENED_MODE: 0` in the global env of workflow. And it would be okay if not this fragment:

```yaml
      - name: Setup Yarn Modern in app
        # For convenience, sometimes there are vague issues with RN CLI and Yarn Legacy on the runner.
        working-directory: ${{ env.APP_NAME }}
        run: |
          touch yarn.lock
          yarn set version berry
          yarn config set nodeLinker node-modules

```

that at the same time wanted to read the `env` and set Yarn Berry instead of currently running Yarn v1. 

But why is that bad? Because this `env` only works with Yarn v2+. Initially the workflow has Yarn v1. In this step above we try to set the Yarn Berry, so the next step (**Installing Reanimated**) could run with **both Yarn Berry and use the env!!**

That's why I moved the env to more closed scope that is the `Install Reanimated step` 


## Test plan
