### PR TITLE
chore: Move CSS SVG opacity interpolator to common interpolators

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -296,6 +296,7 @@ const InterpolatorFactoriesRecord SVG_COMMON_INTERPOLATORS = mergeInterpolators(
     SVG_COLOR_INTERPOLATORS,
     SVG_FILL_INTERPOLATORS,
     SVG_STROKE_INTERPOLATORS,
+    InterpolatorFactoriesRecord{{"opacity", value<CSSDouble>(1)}},
 });
 
 const InterpolatorFactoriesRecord SVG_CIRCLE_INTERPOLATORS = mergeInterpolators(
@@ -304,7 +305,6 @@ const InterpolatorFactoriesRecord SVG_CIRCLE_INTERPOLATORS = mergeInterpolators(
          {"cx", value<SVGLength, CSSKeyword>(0)},
          {"cy", value<SVGLength, CSSKeyword>(0)},
          {"r", value<SVGLength, CSSKeyword>(0)},
-         {"opacity", value<CSSDouble>(1)},
      }});
 
 const InterpolatorFactoriesRecord SVG_ELLIPSE_INTERPOLATORS = mergeInterpolators(
@@ -314,7 +314,6 @@ const InterpolatorFactoriesRecord SVG_ELLIPSE_INTERPOLATORS = mergeInterpolators
          {"cy", value<SVGLength, CSSKeyword>(0)},
          {"rx", value<SVGLength, CSSKeyword>(0)},
          {"ry", value<SVGLength, CSSKeyword>(0)},
-         {"opacity", value<CSSDouble>(1)},
      }});
 
 const InterpolatorFactoriesRecord SVG_LINE_INTERPOLATORS = mergeInterpolators(
@@ -324,7 +323,6 @@ const InterpolatorFactoriesRecord SVG_LINE_INTERPOLATORS = mergeInterpolators(
          {"y1", value<SVGLength, CSSKeyword>(0)},
          {"x2", value<SVGLength, CSSKeyword>(0)},
          {"y2", value<SVGLength, CSSKeyword>(0)},
-         {"opacity", value<CSSDouble>(1)},
      }});
 
 const InterpolatorFactoriesRecord SVG_RECT_INTERPOLATORS = mergeInterpolators(
@@ -336,7 +334,6 @@ const InterpolatorFactoriesRecord SVG_RECT_INTERPOLATORS = mergeInterpolators(
          {"height", value<SVGLength, CSSKeyword>(0)},
          {"rx", value<SVGLength, CSSKeyword>(0)},
          {"ry", value<SVGLength, CSSKeyword>(0)},
-         {"opacity", value<CSSDouble>(1)},
      }});
 
 const InterpolatorFactoriesRecord SVG_PATH_INTERPOLATORS = mergeInterpolators(

--- a/packages/react-native-reanimated/src/css/svg/native/configs/circle.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/circle.ts
@@ -4,7 +4,6 @@
 // @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
 import type { CircleProps } from 'react-native-svg';
 
-import { processOpacity } from '../processors';
 import type { SvgStyleBuilderConfig } from './common';
 import { commonSvgProps } from './common';
 
@@ -14,5 +13,4 @@ export const SVG_CIRCLE_PROPERTIES_CONFIG: SvgStyleBuilderConfig<CircleProps> =
     cx: true,
     cy: true,
     r: true,
-    opacity: { process: processOpacity },
   };

--- a/packages/react-native-reanimated/src/css/svg/native/configs/common.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/common.ts
@@ -141,4 +141,5 @@ export const commonSvgProps = {
   ...commonMarkerProps,
   ...commonMaskProps,
   ...commonFilterProps,
+  opacity: { process: processOpacity },
 } as const;

--- a/packages/react-native-reanimated/src/css/svg/native/configs/ellipse.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/ellipse.ts
@@ -14,5 +14,4 @@ export const SVG_ELLIPSE_PROPERTIES_CONFIG: SvgStyleBuilderConfig<EllipseProps> 
     cy: true,
     rx: true,
     ry: true,
-    opacity: true,
   };

--- a/packages/react-native-reanimated/src/css/svg/native/configs/line.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/line.ts
@@ -13,5 +13,4 @@ export const SVG_LINE_PROPERTIES_CONFIG: SvgStyleBuilderConfig<LineProps> = {
   y1: true,
   x2: true,
   y2: true,
-  opacity: true,
 };

--- a/packages/react-native-reanimated/src/css/svg/native/configs/rect.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/rect.ts
@@ -15,5 +15,4 @@ export const SVG_RECT_PROPERTIES_CONFIG: SvgStyleBuilderConfig<RectProps> = {
   ry: true,
   width: true,
   height: true,
-  opacity: true,
 };


### PR DESCRIPTION
## Summary

I noticed that this interpolator was unnecessarily duplicated across different SVG configuration objects and it could be simply moved to a single place.