### PR TITLE
Try to fix OIDC publishing

### DIFF
--- a/.github/workflows/npm-reanimated-package-build.yml
+++ b/.github/workflows/npm-reanimated-package-build.yml
@@ -46,6 +46,11 @@ jobs:
           node-version: 22
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
+
+      # Ensure npm 11.5.1 or later is installed for OIDC
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
 


### PR DESCRIPTION
## Summary

The nightly publish actions are now failing with 404 after #8653. While there is a number of possibilities why this is happening (see https://github.com/orgs/community/discussions/176761) we have sucesfully set up OIDC in other projects. Based on that I am copying the command that installs fixed npm version much like we did in screens where this setup works: https://github.com/software-mansion/react-native-screens/pull/3220

## Test plan
Will just run publish action after this lands