### PR TITLE
Bump setup-node action and node versions for worklets publishing

### DIFF
--- a/.github/workflows/npm-reanimated-package-build.yml
+++ b/.github/workflows/npm-reanimated-package-build.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'yarn'

--- a/.github/workflows/npm-worklets-package-build.yml
+++ b/.github/workflows/npm-worklets-package-build.yml
@@ -40,10 +40,16 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
+          cache: 'yarn'
           registry-url: https://registry.npmjs.org/
+
+      # Ensure npm 11.5.1 or later is installed for OIDC
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
 


### PR DESCRIPTION
## Summary

This PR updates setup-node action version to make it compatible with OIDC publishing. We also use node 22 that is minimum requirement for OIDC in worklets workflow.

## Test plan
Will run publish after this lands