### PR TITLE
docs(Reanimated): Fix link on mobile sidebar

### DIFF
--- a/docs/docs-reanimated/versioned_docs/version-3.x/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/versioned_docs/version-3.x/fundamentals/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
## Summary

Getting started should be introductional page with `slug: /` as other introductional pages on previous versions

fixes #8661


## Test plan
