### PR TITLE
fix: Move `PlatformColor` processing to the `processColor`

### DIFF
--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/colors.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/colors.test.ts
@@ -204,11 +204,14 @@ describe(processColor, () => {
     test.each(['ios', 'android'] as const)(
       'returns PlatformColor values unchanged on %s',
       (platform) => {
-        withMockedPlatform(platform, ({ processColor: processColor_, PlatformColor }) => {
-          const platformColor = PlatformColor('systemBlue');
+        withMockedPlatform(
+          platform,
+          ({ processColor: processColor_, PlatformColor }) => {
+            const platformColor = PlatformColor('systemBlue');
 
-          expect(processColor_(platformColor)).toBe(platformColor);
-        });
+            expect(processColor_(platformColor)).toBe(platformColor);
+          }
+        );
       }
     );
   });

--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -12,17 +12,19 @@ import { ReanimatedError } from '../../errors';
 import { isRecord } from '../../utils';
 
 /**
- * copied from:
+ * Copied from:
  * https://github.com/facebook/react-native/blob/v0.81.0/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.d.ts
  */
 export function PlatformColor(...names: string[]): OpaqueColorValue {
-  // eslint-disable-next-line camelcase
-  return (IS_IOS ? { semantic: names } : { resource_paths: names }) as unknown as OpaqueColorValue;
+  return (IS_IOS
+    ? { semantic: names }
+    : // eslint-disable-next-line camelcase
+      { resource_paths: names }) as unknown as OpaqueColorValue;
 }
 
-type PlatformColorObject = 
- { semantic: Array<string>; resource_paths?: never } | 
- { semantic?: never; resource_paths?: Array<string>; };
+type PlatformColorObject =
+  | { semantic: Array<string>; resource_paths?: never }
+  | { semantic?: never; resource_paths?: Array<string> };
 
 function isPlatformColorObject(value: unknown): value is PlatformColorObject {
   return (
@@ -130,7 +132,10 @@ function processDynamicColorObjectIOS(
   };
 }
 
-type ProcessedColor = number | PlatformColorObject | ProcessedDynamicColorObjectIOS;
+type ProcessedColor =
+  | number
+  | PlatformColorObject
+  | ProcessedDynamicColorObjectIOS;
 
 /**
  * Processes a color value and returns a normalized color representation.
@@ -156,7 +161,7 @@ export function processColor(value: unknown): ProcessedColor {
       throw new ReanimatedError(ERROR_MESSAGES.dynamicNotAvailableOnPlatform());
     }
     result = processDynamicColorObjectIOS(value);
-  } 
+  }
 
   if (result === null) {
     throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
@@ -169,6 +174,8 @@ export function processColorsInProps(props: StyleProps) {
   for (const key in props) {
     if (!ColorProperties.includes(key)) continue;
     const value = props[key];
-    props[key] = Array.isArray(value) ? value.map((c) => processColor(c)) : processColor(value)
+    props[key] = Array.isArray(value)
+      ? value.map((c) => processColor(c))
+      : processColor(value);
   }
 }


### PR DESCRIPTION
## Summary

This PR moves the `PlatformColor` processing logic to the `processColor` function, similar to the [previous](https://github.com/software-mansion/react-native-reanimated/pull/8617) PR with the `DynamicColorIOS`.

## Examples

| Before | After |
|-|-|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 23 31 34" src="https://github.com/user-attachments/assets/895b43f6-452e-42da-ad76-cd8757283811" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 23 32 01" src="https://github.com/user-attachments/assets/1a9330a3-ab61-42f8-adbf-25dabca3934a" /> | 

## Test Plan

Tested on the `PlatformColor` example in the `Reanimated` example app.

And on these simple examples:

<details>
<summary>With RN `PlatformColor`</summary>

```tsx
import { PlatformColor, StyleSheet } from 'react-native';
import Animated from 'react-native-reanimated';

export default function App() {
  return <Animated.View style={styles.container} />;
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: PlatformColor('systemBlue'),
  },
});
```
</details>

<details>
<summary>With Reanimated `PlatformColor`</summary>

```tsx
import { StyleSheet } from 'react-native';
import Animated, { PlatformColor } from 'react-native-reanimated';

export default function App() {
  return <Animated.View style={styles.container} />;
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: PlatformColor('systemBlue'),
  },
});
```
</details>
