### PR TITLE
fix: Crash when 'none' string is passed for the SVG `fill` property

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/native/processors/colors.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/colors.ts
@@ -10,6 +10,9 @@ export const processColorSVG: ValueProcessor<
   if (value === 'currentColor') {
     return 'currentColor';
   }
+  if (value === 'none') {
+    return null;
+  }
 
   return processColor(value);
 };


### PR DESCRIPTION
## Summary

Quick fix for cashes that started to happen after `processColor` refactor.

## Test plan

| Before | After |
|-|-|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 23 45 16" src="https://github.com/user-attachments/assets/c59341ea-ec20-457e-8a2c-99f5e96abad9" /> | <video src="https://github.com/user-attachments/assets/a6b7ba63-e4a1-4fd4-9ac2-b170d1899319" /> |
