### PR TITLE
fix(Reanimated): false positive animated style in non-animated component error in InlinePropManager

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/InlinePropManager.ts
@@ -71,6 +71,9 @@ function extractSharedValuesMapFromProps(
         if (!style) {
           return;
         }
+        if (__DEV__ && '_requiresAnimatedComponent' in style) {
+          return;
+        }
         for (const [styleKey, styleValue] of Object.entries(style)) {
           if (isSharedValue(styleValue)) {
             inlineProps[styleKey] = styleValue;


### PR DESCRIPTION
## Summary

#8662 added a QoL error when passing an animated style to non-animated component but this triggers a false positive in `InlinePropsManager` because it goes over `Object.entries` of every style object in the component. I just simply omit animated styles before the throwing property is accessed.

## Test plan

I went over several examples in the Example App on native and web and all was gucci 👌 
