### PR TITLE
docs: fix cli instructions, dropping useless "bash" preview

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -35,13 +35,11 @@ Install `react-native-reanimated` and `react-native-worklets` packages from npm:
     ```bash
     npm install react-native-reanimated
     ```
-
   </TabItem>
   <TabItem value="yarn" label="YARN">
     ```bash
     yarn add react-native-reanimated
     ```
-
   </TabItem>
 </Tabs>
 
@@ -53,10 +51,14 @@ You can read more about Worklets in the [Worklets documentation](https://docs.sw
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     {/* TODO - add information about the necessity to specify a proper version of the library compatible with reanimated */}
-    ```bash npm install react-native-worklets ```
+    ```bash 
+    npm install react-native-worklets
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn add react-native-worklets ```
+    ```bash
+    yarn add react-native-worklets
+    ```
   </TabItem>
 </Tabs>
 
@@ -66,10 +68,14 @@ Run prebuild to update the native code in the `ios` and `android` directories.
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npx expo prebuild ```
+    ```bash
+    npx expo prebuild
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn expo prebuild ```
+    ```bash
+    yarn expo prebuild
+    ```
   </TabItem>
 </Tabs>
 
@@ -112,10 +118,14 @@ To learn more about the plugin head onto to [Worklets Babel plugin docs page](ht
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm start -- --reset-cache ```
+    ```bash
+    npm start -- --reset-cache
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn start --reset-cache ```
+    ```bash
+    yarn start --reset-cache
+    ```
   </TabItem>
 </Tabs>
 
@@ -139,10 +149,14 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm install @babel/plugin-proposal-export-namespace-from ```
+    ```bash
+    npm install @babel/plugin-proposal-export-namespace-from
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn add @babel/plugin-proposal-export-namespace-from ```
+    ```bash
+    yarn add @babel/plugin-proposal-export-namespace-from
+    ```
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
the markdown + `TabItem` is somewhow broken

## Summary

actually

<img width="2016" height="268" alt="CleanShot 2025-12-03 at 15 17 08@2x" src="https://github.com/user-attachments/assets/88bffac5-24a9-41ac-92f4-1e32bf21cd2b" />

wanted

<img width="2022" height="306" alt="CleanShot 2025-12-03 at 15 16 32@2x" src="https://github.com/user-attachments/assets/fe9b51a9-9184-4cce-aed2-ed1ca0f5ab30" />


## Test plan

double check https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/