### PR TITLE
release(Reanimated): 4.1.6

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2450,7 +2450,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.1.5):
+  - RNReanimated (4.1.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2477,11 +2477,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.1.5)
+    - RNReanimated/reanimated (= 4.1.6)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (4.1.5):
+  - RNReanimated/reanimated (4.1.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2508,11 +2508,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.1.5)
+    - RNReanimated/reanimated/apple (= 4.1.6)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (4.1.5):
+  - RNReanimated/reanimated/apple (4.1.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -3081,7 +3081,7 @@ SPEC CHECKSUMS:
   RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
   RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: b73fe6ee696b547852a2f711de57cc53cc2b1955
+  RNReanimated: b64d1c96185cb815d56fc17034f61d25e094f5fa
   RNScreens: 6ced6ae8a526512a6eef6e28c2286e1fc2d378c3
   RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
   RNWorklets: 888b4b640573d215b00d4a3f1c67a22bd7f67374

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1653,7 +1653,7 @@ PODS:
     - React-logger (= 0.79.1-0)
     - React-perflogger (= 0.79.1-0)
     - React-utils (= 0.79.1-0)
-  - RNReanimated (4.1.5):
+  - RNReanimated (4.1.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1676,10 +1676,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.1.5)
+    - RNReanimated/reanimated (= 4.1.6)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated (4.1.5):
+  - RNReanimated/reanimated (4.1.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1702,10 +1702,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.1.5)
+    - RNReanimated/reanimated/apple (= 4.1.6)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated/apple (4.1.5):
+  - RNReanimated/reanimated/apple (4.1.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2104,7 +2104,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 29fb2827ec6c6c8ee9ee9108e838b4e0e4e1b730
   ReactCodegen: 3a01f76123e04b8b945d43e5ffccae6f90f4a26e
   ReactCommon: 59e7bd3cf331ba77a96a75e6b603abf05883b102
-  RNReanimated: cf11a147108659743c64fa128c927655c365ab1b
+  RNReanimated: be22f8580a465c5e427bba29a92f4ce05357aeb6
   RNWorklets: e6d5390f64b412d2443a8a21430dfe79b8899af1
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 770a077e3a222f162c2e0c8a95e7e997b7682a8e

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "More powerful alternative to Animated library for React Native.",
   "keywords": [
     "react-native",

--- a/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
+++ b/packages/react-native-reanimated/src/platform-specific/jsVersion.ts
@@ -4,4 +4,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '4.1.5';
+export const jsVersion = '4.1.6';


### PR DESCRIPTION
## Summary

Locally installing Worklets 0.7.0 from npm and disabling referencing that package.

Some example App TS fixes were necessary to pass CI.

Artifact build CI: https://github.com/software-mansion/react-native-reanimated/actions/runs/19935640788

## Test plan

🚀

Babel plugin and MacOS example CIs can be ignored