### PR TITLE
chore: Bump macos runner version and xcode version on CI

### DIFF
--- a/.github/actions/reanimated-compatibility-check-build/action.yml
+++ b/.github/actions/reanimated-compatibility-check-build/action.yml
@@ -15,11 +15,11 @@ inputs:
     required: true
   app-name:
     description: Name of the test app
-    default: "app"
+    default: 'app'
     required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Setup Yarn
       shell: bash
@@ -50,7 +50,7 @@ runs:
       if: ${{ inputs.platform == 'iOS' }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+        ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Install Pods (iOS)
       if: ${{ inputs.platform == 'iOS' }}

--- a/.github/workflows/example-ios-build-check.yml
+++ b/.github/workflows/example-ios-build-check.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Install monorepo node dependencies

--- a/.github/workflows/example-macos-build-check.yml
+++ b/.github/workflows/example-macos-build-check.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       # TODO: Add caching for node_modules and artifacts that will work with monorepo setup.

--- a/.github/workflows/example-tvos-build-check.yml
+++ b/.github/workflows/example-tvos-build-check.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Install monorepo node dependencies

--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/expo-devclient-build-check-nightly.yml
   schedule:
-    - cron: "0 0 * * *" # after publishing new nightly version on NPM
+    - cron: '0 0 * * *' # after publishing new nightly version on NPM
   workflow_call:
   workflow_dispatch:
 
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.platform == 'iOS' && 'macos-26' || 'ubuntu-latest' }}
     strategy:
       matrix:
-        platform: ["iOS", "Android"]
+        platform: ['iOS', 'Android']
       fail-fast: false
     env:
       APP_NAME: ExpoApp
@@ -32,12 +32,12 @@ jobs:
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: 'zulu'
           java-version: 17
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'iOS' }}
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Create Expo app
         run: npx create-expo-app@latest ${{ env.APP_NAME }} --template blank-typescript

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - .github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
   schedule:
-    - cron: "37 19 * * *"
+    - cron: '37 19 * * *'
   workflow_call:
   workflow_dispatch:
 
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.platform == 'iOS' && 'macos-26' || 'ubuntu-latest'}}
     strategy:
       matrix:
-        platform: ["iOS", "Android"]
+        platform: ['iOS', 'Android']
       fail-fast: false
     env:
       REACT_NATIVE_TAG: nightly
@@ -33,8 +33,8 @@ jobs:
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
-          java-version: "18"
+          distribution: 'zulu'
+          java-version: '18'
       - name: Load "next" tag if available
         run: |
           if npm view react-native dist-tags | grep -q 'next:' ; then
@@ -59,7 +59,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'iOS' }}
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install Fabric Pods (iOS)
         if: ${{ matrix.platform == 'iOS' }}

--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
   schedule:
-    - cron: "37 19 * * *"
+    - cron: '37 19 * * *'
   workflow_call:
   workflow_dispatch:
 
@@ -30,8 +30,8 @@ jobs:
     needs: read-compatibility-json
     strategy:
       matrix:
-        platform: ["iOS", "Android"]
-        mode: ["Debug", "Release"]
+        platform: ['iOS', 'Android']
+        mode: ['Debug', 'Release']
         react-native-version: ${{ fromJson(needs.read-compatibility-json.outputs.react-native-versions) }}
       fail-fast: false
     env:
@@ -46,8 +46,8 @@ jobs:
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
-          java-version: "18"
+          distribution: 'zulu'
+          java-version: '18'
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -55,7 +55,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'iOS' }}
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Check if react-native version exists
         id: check-react-native-version

--- a/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
+++ b/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/use-frameworks-reanimated-build-check-nightly.yml
   schedule:
-    - cron: "37 19 * * *"
+    - cron: '37 19 * * *'
   workflow_call:
   workflow_dispatch:
 
@@ -53,7 +53,7 @@ jobs:
         run: yarn add "react-native-worklets@https://github.com/software-mansion/react-native-reanimated.git#workspace=react-native-worklets&commit=${{ github.sha }}"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3" # Not needed with a `.ruby-version` or `.tool-versions`
+          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install ${{matrix.type}} Pods
         working-directory: ${{env.APP_NAME}}/ios


### PR DESCRIPTION
## Summary

We were using `macos-15` runner with the manually selected XCode `16.4` version (which became default on the `macos-15` runner and we didn't have to select it manually anymore). I think it's time to migrate to the newer runner that uses iOS 26 by default.

See info about `macos-26` runner: https://github.com/actions/runner-images/issues/13008