### PR TITLE
fix: Bundle mode patch corruption

### DIFF
--- a/scripts/patches/bundle-mode.patch
+++ b/scripts/patches/bundle-mode.patch
@@ -2,8 +2,8 @@ diff --git a/apps/fabric-example/android/gradle.properties b/apps/fabric-example
 index d183897bec..7fdf50386b 100644
 --- a/apps/fabric-example/android/gradle.properties
 +++ b/apps/fabric-example/android/gradle.properties
-@@ -49,7 +49,7 @@ isReanimatedExampleApp=true
- enableReanimatedProfiling=true
+@@ -50,7 +50,7 @@ enableReanimatedProfiling=true
+ enableWorkletsProfiling=true
  
  # Uncomment the next line to enable bundle mode.
 -# workletsBundleMode=true
@@ -15,7 +15,7 @@ diff --git a/apps/fabric-example/android/settings.gradle b/apps/fabric-example/a
 index afaf8c45a5..c3c5434878 100644
 --- a/apps/fabric-example/android/settings.gradle
 +++ b/apps/fabric-example/android/settings.gradle
-@@ -7,11 +7,11 @@ includeBuild('../../../node_modules/@react-native/gradle-plugin')
+@@ -8,11 +8,11 @@ includeBuild('../../../node_modules/@react-native/gradle-plugin')
  
  // Build from source (https://reactnative.dev/contributing/how-to-build-from-source)
  // NOTE: Please do not remove these lines even though they are commented out.
@@ -52,8 +52,7 @@ diff --git a/apps/fabric-example/ios/Podfile b/apps/fabric-example/ios/Podfile
 index 3f8fe4a6e2..e208389ca3 100644
 --- a/apps/fabric-example/ios/Podfile
 +++ b/apps/fabric-example/ios/Podfile
-@@ -10,7 +10,7 @@ require_relative '../../../packages/react-native-reanimated/scripts/clangd-add-x
- ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
+@@ -12,8 +12,8 @@ ENV['IS_WORKLETS_PROFILING'] = '1'
  
  # Uncomment the next line to enable bundle mode.
 -# ENV['WORKLETS_BUNDLE_MODE'] = '1'
@@ -61,12 +60,13 @@ index 3f8fe4a6e2..e208389ca3 100644
  
  platform :ios, min_ios_version_supported
  prepare_react_native_project!
+ 
+ linkage = ENV['USE_FRAMEWORKS']
 diff --git a/apps/fabric-example/metro.config.js b/apps/fabric-example/metro.config.js
 index 67158b31ff..3990fe93c2 100644
 --- a/apps/fabric-example/metro.config.js
 +++ b/apps/fabric-example/metro.config.js
-@@ -20,8 +20,8 @@ let config = {
- config = mergeConfig(getDefaultConfig(__dirname), config);
+@@ -32,8 +32,8 @@ config = mergeConfig(defaultConfig, config);
  
  // Uncomment the following to enable bundle mode.
 -// const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
@@ -75,17 +75,20 @@ index 67158b31ff..3990fe93c2 100644
 +config = mergeConfig(config, bundleModeMetroConfig);
  
  module.exports = wrapWithReanimatedMetroConfig(
-   mergeConfig(getDefaultConfig(__dirname), config)
+   mergeConfig(defaultConfig, config)
+ );
 diff --git a/package.json b/package.json
 index 141335c036..1261072923 100644
 --- a/package.json
 +++ b/package.json
-@@ -70,5 +70,10 @@
+@@ -70,8 +70,11 @@
      "react-native-builder-bob": "0.40.13",
      "shelljs": "0.10.0",
      "typescript": "5.8.3"
-+  },
-+  "resolutions": {
+   },
+   "resolutions": {
+-    "@react-native/gradle-plugin@npm:0.82.0": "patch:@react-native/gradle-plugin@npm%3A0.82.0#~/.yarn/patches/@react-native-gradle-plugin-npm-0.82.0-10aedc0588.patch"
++    "@react-native/gradle-plugin@npm:0.82.0": "patch:@react-native/gradle-plugin@npm%3A0.82.0#~/.yarn/patches/@react-native-gradle-plugin-npm-0.82.0-10aedc0588.patch",
 +    "metro": "patch:metro@npm%3A0.83.1#~/.yarn/patches/metro-npm-0.83.1-241fe42591.patch",
 +    "metro-runtime": "patch:metro-runtime@npm%3A0.83.1#~/.yarn/patches/metro-runtime-npm-0.83.1-c3d616063e.patch",
 +    "react-native": "patch:react-native@npm%3A0.82.0#~/.yarn/patches/react-native-npm-0.82.0-228ad0ffa7.patch"


### PR DESCRIPTION
## Summary

This PR fixes the incorrect bundle mode patch, which caused failures of the bundle mode CI runs while trying to toggle the Bundle Mode: https://github.com/software-mansion/react-native-reanimated/actions/runs/20076223959/job/57591158971

It also resulted in this ugly red status badge:

<img width="266" height="31" alt="Screenshot 2025-12-10 at 01 39 24" src="https://github.com/user-attachments/assets/f27a39fa-a9e4-45f6-b8ff-a31b919c7fc3" />
