### PR TITLE
chore(Worklets): fix broken anchor in docs

### DIFF
--- a/docs/docs-worklets/docs/threading/runOnRuntimeSync.mdx
+++ b/docs/docs-worklets/docs/threading/runOnRuntimeSync.mdx
@@ -51,7 +51,7 @@ Arguments to the function you want to execute on the [Worker Runtime](/docs/fund
 
 ## Remarks
 
-- `runOnRuntimeSync` can only be called on the [RN Runtime](/docs/fundamentals/glossary#react-native-runtime) unless the [Bundle Mode](/docs/experimental/bundleMode) is enabled.
+- `runOnRuntimeSync` can only be called on the [RN Runtime](/docs/fundamentals/runtimeKinds#rn-runtime) unless the [Bundle Mode](/docs/experimental/bundleMode) is enabled.
 
 ```javascript
 import { createWorkletRuntime, runOnRuntimeSync } from 'react-native-worklets';


### PR DESCRIPTION
## Summary

I don't know why didn't CI catch it before 🤔 

## Test plan
