### PR TITLE
chore: fix hermesc path in FabricExample

### DIFF
--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "./node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
+    // hermesCommand = "./node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
## Summary

Recently the paths changed and without this release builds won't work.

## Test plan

Build Android release app 🚀 
