### PR TITLE
 chore: bump min and target sdks in libs 

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -147,7 +147,7 @@ apply plugin: "maven-publish"
 apply plugin: "de.undercouch.download"
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
 
     namespace "com.swmansion.reanimated"
 
@@ -171,8 +171,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion safeExtGet("minSdkVersion", 23)
-        targetSdkVersion safeExtGet("targetSdkVersion", 34)
+        minSdkVersion safeExtGet("minSdkVersion", 24)
+        targetSdkVersion safeExtGet("targetSdkVersion", 36)
         versionCode 1
         versionName REANIMATED_VERSION
 

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -149,7 +149,7 @@ apply from: "./fix-prefab.gradle"
 
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
 
     namespace "com.swmansion.worklets"
 
@@ -173,8 +173,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion safeExtGet("minSdkVersion", 23)
-        targetSdkVersion safeExtGet("targetSdkVersion", 34)
+        minSdkVersion safeExtGet("minSdkVersion", 24)
+        targetSdkVersion safeExtGet("targetSdkVersion", 36)
         versionCode 1
         versionName WORKLETS_VERSION
 
@@ -253,17 +253,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    sourceSets {
-        main {
-            java {
-                if (BUNDLE_MODE) {
-                    srcDirs += "src/experimentalBundling"
-                } else {
-                    srcDirs += "src/legacyBundling"
-                }
-            }
-        }
     }
     tasks.withType(ExternalNativeBuildJsonTask).tap {
         configureEach { compileTask ->


### PR DESCRIPTION
## Summary

[RN 0.79 has SDK 24](https://github.com/facebook/react-native/blame/v0.79.7/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml) as min supported and [RN 0.83 has SDK 36](https://github.com/facebook/react-native/blame/v0.83.0/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml) as the target.

## Test plan

🚀 
