### PR TITLE
chore: Rename box shadow processing function

### DIFF
--- a/packages/react-native-reanimated/__tests__/props.test.tsx
+++ b/packages/react-native-reanimated/__tests__/props.test.tsx
@@ -9,7 +9,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from '../src';
-import { processBoxShadowNative, processColor } from '../src/common';
+import { processBoxShadow, processColor } from '../src/common';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -186,7 +186,7 @@ describe('Test of boxShadow prop', () => {
 
     const unprocessedStyle = getAnimatedStyle(pressable);
 
-    const parsedStyle = processBoxShadowNative(
+    const parsedStyle = processBoxShadow(
       (unprocessedStyle as ViewStyle).boxShadow!
     );
 
@@ -212,9 +212,7 @@ describe('Test of boxShadow prop', () => {
   test('two boxShadows string parsing', () => {
     const multipleBoxShadowStyle = getMultipleBoxShadowStyle();
 
-    const parsedStyle = processBoxShadowNative(
-      multipleBoxShadowStyle.boxShadow
-    );
+    const parsedStyle = processBoxShadow(multipleBoxShadowStyle.boxShadow);
 
     expect(parsedStyle).toEqual([
       {

--- a/packages/react-native-reanimated/src/common/style/config.ts
+++ b/packages/react-native-reanimated/src/common/style/config.ts
@@ -4,7 +4,7 @@ import { IS_ANDROID } from '../constants';
 import type { PlainStyle } from '../types';
 import {
   processAspectRatio,
-  processBoxShadowNative,
+  processBoxShadow,
   processColor,
   processFilter,
   processFontWeight,
@@ -139,7 +139,7 @@ export const BASE_PROPERTIES_CONFIG: StyleBuilderConfig<PlainStyle> = {
   elevation: IS_ANDROID,
   textShadowOffset: true,
   textShadowRadius: true,
-  boxShadow: { process: processBoxShadowNative },
+  boxShadow: { process: processBoxShadow },
 
   // BORDERS
   // Radius

--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/shadows.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/shadows.test.ts
@@ -4,13 +4,13 @@ import type { BoxShadowValue } from 'react-native';
 import { ValueProcessorTarget } from '../../../types';
 import { processColor } from '../colors';
 import type { ProcessedBoxShadowValue } from '../shadows';
-import { processBoxShadowNative } from '../shadows';
+import { processBoxShadow } from '../shadows';
 
-describe(processBoxShadowNative, () => {
+describe(processBoxShadow, () => {
   describe('returns a correct number of shadows', () => {
     describe('when input is a string', () => {
       test('returns undefined when input is "none"', () => {
-        expect(processBoxShadowNative('none')).toBeUndefined();
+        expect(processBoxShadow('none')).toBeUndefined();
       });
 
       test.each([
@@ -19,7 +19,7 @@ describe(processBoxShadowNative, () => {
         ['0 0 10px 0 red', 1],
         ['0 0 10px 0 red, 0 0 20px 0 blue', 2],
       ])('returns a correct number of shadows', (input, expected) => {
-        expect(processBoxShadowNative(input)).toHaveLength(expected);
+        expect(processBoxShadow(input)).toHaveLength(expected);
       });
     });
 
@@ -37,7 +37,7 @@ describe(processBoxShadowNative, () => {
       ] satisfies [BoxShadowValue[], number][])(
         'returns a correct number of shadows',
         (input, expected) => {
-          expect(processBoxShadowNative(input)).toHaveLength(expected);
+          expect(processBoxShadow(input)).toHaveLength(expected);
         }
       );
     });
@@ -46,7 +46,7 @@ describe(processBoxShadowNative, () => {
   describe('returns correct shadow values', () => {
     describe('when input is a string', () => {
       test('provides proper default values', () => {
-        expect(processBoxShadowNative('0 0')).toEqual([
+        expect(processBoxShadow('0 0')).toEqual([
           {
             offsetX: 0,
             offsetY: 0,
@@ -86,7 +86,7 @@ describe(processBoxShadowNative, () => {
       ] satisfies [string | BoxShadowValue[], ProcessedBoxShadowValue[]][])(
         'for input %s returns %s',
         (input, expected) => {
-          expect(processBoxShadowNative(input)).toEqual(expected);
+          expect(processBoxShadow(input)).toEqual(expected);
         }
       );
     });
@@ -138,7 +138,7 @@ describe(processBoxShadowNative, () => {
       ] satisfies [BoxShadowValue[], ProcessedBoxShadowValue[]][])(
         'returns a correct number of shadows',
         (input, expected) => {
-          expect(processBoxShadowNative(input)).toEqual(expected);
+          expect(processBoxShadow(input)).toEqual(expected);
         }
       );
     });
@@ -146,7 +146,7 @@ describe(processBoxShadowNative, () => {
 
   describe('context-aware transparent color handling', () => {
     test('returns numeric color by default', () => {
-      const result = processBoxShadowNative([
+      const result = processBoxShadow([
         { offsetX: 0, offsetY: 0, color: 'transparent' },
       ]);
 
@@ -162,7 +162,7 @@ describe(processBoxShadowNative, () => {
     });
 
     test('returns false for transparent color with CSS target', () => {
-      const result = processBoxShadowNative(
+      const result = processBoxShadow(
         [{ offsetX: 0, offsetY: 0, color: 'transparent' }],
         {
           target: ValueProcessorTarget.CSS,

--- a/packages/react-native-reanimated/src/common/style/processors/index.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/index.ts
@@ -10,6 +10,6 @@ export { processFilter } from './filter';
 export { processFontWeight } from './font';
 export { processInset, processInsetBlock, processInsetInline } from './insets';
 export { processAspectRatio, processGap } from './others';
-export { processBoxShadowNative } from './shadows';
+export { processBoxShadow } from './shadows';
 export { processTransform } from './transform';
 export { processTransformOrigin } from './transformOrigin';

--- a/packages/react-native-reanimated/src/common/style/processors/shadows.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/shadows.ts
@@ -33,7 +33,7 @@ const parseBlurRadius = (value: string) => {
   return parseFloat(value);
 };
 
-export const processBoxShadowNative: ValueProcessor<
+export const processBoxShadow: ValueProcessor<
   ReadonlyArray<BoxShadowValue> | string,
   ProcessedBoxShadowValue[]
 > = (value, context) => {

--- a/packages/react-native-reanimated/src/updateProps/updateProps.ts
+++ b/packages/react-native-reanimated/src/updateProps/updateProps.ts
@@ -6,7 +6,7 @@ import { scheduleOnRN, scheduleOnUI } from 'react-native-worklets';
 
 import {
   IS_JEST,
-  processBoxShadowNative,
+  processBoxShadow,
   processColorsInProps,
   processFilter,
   processTransform,
@@ -64,7 +64,7 @@ if (SHOULD_BE_USE_WEB) {
       updates.transform = processTransform(updates.transform);
     }
     if ('boxShadow' in updates) {
-      updates.boxShadow = processBoxShadowNative(updates.boxShadow);
+      updates.boxShadow = processBoxShadow(updates.boxShadow);
     }
     if ('filter' in updates) {
       updates.filter = processFilter(updates.filter);


### PR DESCRIPTION
## Summary

Renamed to be consistent with other native prop processors. Only web-specific ones use the `Web` suffix, these for native props processing should not use any suffixes.