### PR TITLE
fix(Worklets): missing sideEffects property

### DIFF
--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -118,6 +118,15 @@
     "!**/__mocks__",
     "!**/.*"
   ],
+  "sideEffects": [
+    "./src/index.ts",
+    "./lib/module/index.js",
+    "./**/runtimeKind.{js,ts}",
+    "./**/serializable.native.{js,ts}",
+    "./**/workletRuntimeEntry.native.{js,ts}",
+    "./**/initializers.native.{js,ts}",
+    "./**/featureFlags.native.{js,ts}"
+  ],
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",


### PR DESCRIPTION
## Summary

Fixes #8752

Tree shaking plugins can strip Worklets initialization code which happens at top level. I'm adding a `sideEffects` property in `package.json`, just like in Reanimated, to circumvent this problem.

## Test plan

With these changes repro in #8752 doesn't crash anymore.
