### PR TITLE
chore: consider new arch always enabled in react-native 0.82+

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -106,7 +106,7 @@ def getReanimatedStaticFeatureFlags() {
     return featureFlags.collect { key, value -> "[${key}:${value}]" }.join("")
 }
 
-if (isNewArchitectureEnabled()) {
+if (isNewArchitectureEnabled() && project != rootProject) {
     apply plugin: "com.facebook.react"
 }
 

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -88,7 +88,7 @@ def getStaticFeatureFlags() {
     return featureFlags.collect { key, value -> "[${key}:${value}]" }.join("")
 }
 
-if (isNewArchitectureEnabled()) {
+if (isNewArchitectureEnabled() && project != rootProject) {
     apply plugin: "com.facebook.react"
 }
 


### PR DESCRIPTION
## Summary

Starting from react-native 0.82, users can no longer disable the new architecture in their projects, and because of that, the `newArchEnabled` property in `gradle.properties` is no longer required. The problem is that we still check specifically for `rootProject.hasProperty("newArchEnabled")` in `android/build.gradle`.

## Test plan

In a react-native project running 0.82+, remove the `newArchEnabled` property from `gradle.properties` and build

