### PR TITLE
fix: `Infinity` parsing in web CSS `animationIterationCount`

### DIFF
--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -21,6 +21,7 @@ import {
   removeCSSAnimation,
 } from '../domUtils';
 import { CSSKeyframesRuleImpl } from '../keyframes';
+import { normalizeIterationCount } from '../normalization';
 import { maybeAddSuffixes, parseTimingFunction } from '../utils';
 
 const isCSSKeyframesRuleImpl = (
@@ -197,7 +198,9 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
 
     if (animationSettings.animationIterationCount) {
       this.element.style.animationIterationCount =
-        animationSettings.animationIterationCount.join(',');
+        animationSettings.animationIterationCount
+          .map(normalizeIterationCount)
+          .join(',');
     }
 
     if (animationSettings.animationDirection) {

--- a/packages/react-native-reanimated/src/css/web/normalization/__tests__/settings.test.ts
+++ b/packages/react-native-reanimated/src/css/web/normalization/__tests__/settings.test.ts
@@ -1,0 +1,19 @@
+'use strict';
+import { normalizeIterationCount } from '../settings';
+
+describe(normalizeIterationCount, () => {
+  test('converts Infinity to "infinite"', () => {
+    expect(normalizeIterationCount(Infinity)).toBe('infinite');
+  });
+
+  test('converts "infinite" string to "infinite"', () => {
+    expect(normalizeIterationCount('infinite')).toBe('infinite');
+  });
+
+  test('converts regular numbers to strings', () => {
+    expect(normalizeIterationCount(0)).toBe('0');
+    expect(normalizeIterationCount(1)).toBe('1');
+    expect(normalizeIterationCount(42)).toBe('42');
+    expect(normalizeIterationCount(3.5)).toBe('3.5');
+  });
+});

--- a/packages/react-native-reanimated/src/css/web/normalization/index.ts
+++ b/packages/react-native-reanimated/src/css/web/normalization/index.ts
@@ -1,2 +1,3 @@
 'use strict';
+export * from './settings';
 export * from './transition';

--- a/packages/react-native-reanimated/src/css/web/normalization/settings.ts
+++ b/packages/react-native-reanimated/src/css/web/normalization/settings.ts
@@ -1,0 +1,11 @@
+'use strict';
+import type { CSSAnimationIterationCount } from '../../types';
+
+export function normalizeIterationCount(
+  iterationCount: CSSAnimationIterationCount
+): string {
+  if (iterationCount === Infinity || iterationCount === 'infinite') {
+    return 'infinite';
+  }
+  return String(iterationCount);
+}


### PR DESCRIPTION
## Summary

Fixes issue when `Infinity` number was passed instead of the `'infinite'` string. On the web, `Infinity` is not supported as a number and must be converted to the `'infinite'` string.

## Example

In the **Before** example the `animation-iteration-count` wasn't applied.

| Before | After |
|-|-|
| <img width="782" height="542" alt="Screenshot 2025-12-22 at 11 32 08" src="https://github.com/user-attachments/assets/1e498185-72ad-40ac-ac12-ca8414e20f09" /> | <video src="https://github.com/user-attachments/assets/a51aaa0a-02cf-422c-856c-00249e89455c" /> |

## Test Plan

Open the `EmptyExample` and pass the following code:

<details>
<summary>Code snippet</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import Animated, { CSSAnimationKeyframes } from 'react-native-reanimated';

const pulse: CSSAnimationKeyframes = {
  from: {
    transform: [{ scale: 1 }],
    opacity: 1,
  },
  to: {
    transform: [{ scale: 1.2 }],
    opacity: 0.7,
  },
};

export default function EmptyExample() {
  return (
    <View style={styles.container}>
      <Animated.View
        style={[
          styles.animatedBox,
          {
            animationName: pulse,
            animationDuration: '1s',
            animationIterationCount: Infinity,
            animationTimingFunction: 'ease-in-out',
            animationDirection: 'alternate',
          },
        ]}>
        <Text>Hello world!</Text>
      </Animated.View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  animatedBox: {
    padding: 20,
  },
});
```

</details>