### PR TITLE
docs: remove reading from shared value on JS thread in "your first animation" example

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/your-first-animation.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/your-first-animation.mdx
@@ -88,7 +88,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = width.value + 50;
+    width.value = Math.random() * 100 + 50;
   };
 
   return (
@@ -106,8 +106,6 @@ export default function App() {
 }
 ```
 
-Please hold on a second before you shorten `width.value = width.value + 50` to `width.value += 50`. We're preparing this code for the final step which will finally bring our animation to life!
-
 :::caution
 
 It's a common mistake to modify a shared value directly like this: ~~`sv = sv + 100;`~~. Always remember to access the shared value by using the `.value` property instead. Here, the correct usage would be `sv.value = sv.value + 100;`.
@@ -116,7 +114,7 @@ It's a common mistake to modify a shared value directly like this: ~~`sv = sv + 
 
 ## Using an animation function
 
-Finally, import `withSpring` function and wrap around `width.value + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `width.value + 50`).
+Finally, import `withSpring` function and wrap around `Math.random() * 100 + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `Math.random() * 100 + 50`).
 
 ```jsx {2,8}
 import { Button, View } from 'react-native';
@@ -126,7 +124,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = withSpring(width.value + 50);
+    width.value = withSpring(Math.random() * 100 + 50);
   };
 
   return (

--- a/docs/docs-reanimated/versioned_docs/version-3.x/fundamentals/your-first-animation.mdx
+++ b/docs/docs-reanimated/versioned_docs/version-3.x/fundamentals/your-first-animation.mdx
@@ -88,7 +88,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = width.value + 50;
+    width.value = Math.random() * 100 + 50;
   };
 
   return (
@@ -106,8 +106,6 @@ export default function App() {
 }
 ```
 
-Please hold on a second before you shorten `width.value = width.value + 50` to `width.value += 50`. We're preparing this code for the final step which will finally bring our animation to life!
-
 :::caution
 
 It's a common mistake to modify a shared value directly like this: ~~`sv = sv + 100;`~~. Always remember to access the shared value by using the `.value` property instead. Here, the correct usage would be `sv.value = sv.value + 100;`.
@@ -116,7 +114,7 @@ It's a common mistake to modify a shared value directly like this: ~~`sv = sv + 
 
 ## Using an animation function
 
-Finally, import `withSpring` function and wrap around `width.value + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `width.value + 50`).
+Finally, import `withSpring` function and wrap around `Math.random() * 100 + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `Math.random() * 100 + 50`).
 
 ```jsx {2,8}
 import { Button, View } from 'react-native';
@@ -126,7 +124,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = withSpring(width.value + 50);
+    width.value = withSpring(Math.random() * 100 + 50);
   };
 
   return (


### PR DESCRIPTION
## Summary

While going through the docs, I've noticed that the example of an animation we give in the docs in the "Your First Animation" page contains a piece of code that reads from the shared value on the JS thread. That is something we discourage doing in some other places in the docs (like the **Performance** page)

While discussing it with @tomekzaw the conclusion we made was that perhaps replacing this with some variant of `Math.random` is the best way out of this. "Your First Animation" is still supposed to be presenting a simple case of an animation so bringing into it more APIs (to avoid reading from shared value on JS thread) could be confusing for new users, while `Math.random` is still keeping it simple.

For the initial width 100 in the example I've added a random width of range 50-150 for the consecutive values.

## Test plan
