### PR TITLE
chore: Add `animatedProps` e2e test for web

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/AnimatedPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/AnimatedPropsExample.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { Circle, Svg } from 'react-native-svg';
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+// Shared constants
+const ANIMATION_DURATION = 500;
+const CIRCLE_SIZE = 100;
+const CIRCLE_RADIUS = 40;
+const INITIAL_X = CIRCLE_SIZE / 2; // 50 - top-left area
+const INITIAL_Y = CIRCLE_SIZE / 2; // 50 - top-left area
+const FINAL_X = 180; // 180 - bottom-right area (50 from right edge, matching 50 from left initially)
+const FINAL_Y = 180; // 180 - bottom-right area (50 from bottom edge, matching 50 from top initially)
+const SVG_SIZE = FINAL_X + CIRCLE_SIZE / 2; // 230
+const PROPS_ATTACH_OFFSET = 50; // Offset applied when animated props are first attached
+
+function TestSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.testSection}>
+      <Text>{title}</Text>
+      {description.map((line, index) => (
+        <Text key={index}>{line}</Text>
+      ))}
+      {children}
+    </View>
+  );
+}
+
+function AnimatedCircleWrapper({
+  animatedProps,
+  testID,
+}: {
+  animatedProps?: React.ComponentProps<typeof AnimatedCircle>['animatedProps'];
+  testID?: string;
+}) {
+  return (
+    <View style={styles.svgContainer} testID={testID}>
+      <Svg height={SVG_SIZE} width={SVG_SIZE}>
+        <AnimatedCircle
+          cx={INITIAL_X}
+          cy={INITIAL_Y}
+          r={CIRCLE_RADIUS}
+          fill="blue"
+          animatedProps={animatedProps}
+        />
+      </Svg>
+    </View>
+  );
+}
+
+function Test1SingleInitial() {
+  const sv = useSharedValue(0);
+  const [isAnimated, setIsAnimated] = useState(false);
+  const animatedProps = useAnimatedProps(() => ({
+    cx: INITIAL_X + sv.value * (FINAL_X - INITIAL_X),
+    cy: INITIAL_Y + sv.value * (FINAL_Y - INITIAL_Y),
+  }));
+
+  return (
+    <View style={styles.testContainer} testID="test-1-container">
+      <AnimatedCircleWrapper
+        animatedProps={animatedProps}
+        testID="test-1-circle"
+      />
+      <Button
+        title="Animate"
+        disabled={isAnimated}
+        testID="test-1-animate-button"
+        onPress={() => {
+          sv.value = withTiming(1, { duration: ANIMATION_DURATION });
+          setIsAnimated(true);
+        }}
+      />
+    </View>
+  );
+}
+
+function Test2SingleDelayed() {
+  const sv = useSharedValue(0);
+  const [hasAnimatedProps, setHasAnimatedProps] = useState(false);
+  const [isAnimated, setIsAnimated] = useState(false);
+  const animatedProps = useAnimatedProps(() => ({
+    cx:
+      INITIAL_X +
+      PROPS_ATTACH_OFFSET +
+      sv.value * (FINAL_X - INITIAL_X - PROPS_ATTACH_OFFSET),
+    cy:
+      INITIAL_Y +
+      PROPS_ATTACH_OFFSET +
+      sv.value * (FINAL_Y - INITIAL_Y - PROPS_ATTACH_OFFSET),
+  }));
+
+  return (
+    <View style={styles.testContainer} testID="test-2-container">
+      <AnimatedCircleWrapper
+        animatedProps={hasAnimatedProps ? animatedProps : undefined}
+        testID="test-2-circle"
+      />
+      <Button
+        title="Attach Animated Props"
+        disabled={hasAnimatedProps}
+        testID="test-2-attach-button"
+        onPress={() => setHasAnimatedProps(true)}
+      />
+      {hasAnimatedProps && (
+        <Button
+          title="Animate"
+          disabled={isAnimated}
+          testID="test-2-animate-button"
+          onPress={() => {
+            sv.value = withTiming(1, { duration: ANIMATION_DURATION });
+            setIsAnimated(true);
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+function Test3MultipleInitial() {
+  const sv = useSharedValue(0);
+  const [isAnimated, setIsAnimated] = useState(false);
+  const animatedPropsCx = useAnimatedProps(() => ({
+    cx: INITIAL_X + sv.value * (FINAL_X - INITIAL_X),
+  }));
+  const animatedPropsCy = useAnimatedProps(() => ({
+    cy: INITIAL_Y + sv.value * (FINAL_Y - INITIAL_Y),
+  }));
+
+  return (
+    <View style={styles.testContainer} testID="test-3-container">
+      <AnimatedCircleWrapper
+        animatedProps={[animatedPropsCx, animatedPropsCy]}
+        testID="test-3-circle"
+      />
+      <Button
+        title="Animate"
+        disabled={isAnimated}
+        testID="test-3-animate-button"
+        onPress={() => {
+          sv.value = withTiming(1, { duration: ANIMATION_DURATION });
+          setIsAnimated(true);
+        }}
+      />
+    </View>
+  );
+}
+
+function Test4MultipleMixedTiming() {
+  const svCx = useSharedValue(0);
+  const svCy = useSharedValue(0);
+  const [showCyProps, setShowCyProps] = useState(false);
+  const [isCxAnimated, setIsCxAnimated] = useState(false);
+  const [isCyAnimated, setIsCyAnimated] = useState(false);
+
+  const animatedPropsCx = useAnimatedProps(() => ({
+    cx: INITIAL_X + svCx.value * (FINAL_X - INITIAL_X),
+  }));
+  const animatedPropsCy = useAnimatedProps(() => ({
+    cy:
+      INITIAL_Y +
+      PROPS_ATTACH_OFFSET +
+      svCy.value * (FINAL_Y - INITIAL_Y - PROPS_ATTACH_OFFSET),
+  }));
+
+  return (
+    <View style={styles.testContainer} testID="test-4-container">
+      <AnimatedCircleWrapper
+        animatedProps={
+          showCyProps ? [animatedPropsCx, animatedPropsCy] : animatedPropsCx
+        }
+        testID="test-4-circle"
+      />
+      <Button
+        title="Animate Horizontal"
+        disabled={isCxAnimated}
+        testID="test-4-animate-horizontal-button"
+        onPress={() => {
+          svCx.value = withTiming(1, { duration: ANIMATION_DURATION });
+          setIsCxAnimated(true);
+        }}
+      />
+      <Button
+        title="Attach Vertical Props"
+        disabled={showCyProps}
+        testID="test-4-attach-vertical-button"
+        onPress={() => setShowCyProps(true)}
+      />
+      {showCyProps && (
+        <Button
+          title="Animate Vertical"
+          disabled={isCyAnimated}
+          testID="test-4-animate-vertical-button"
+          onPress={() => {
+            svCy.value = withTiming(1, { duration: ANIMATION_DURATION });
+            setIsCyAnimated(true);
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+export default function EmptyExample() {
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <TestSection
+        title="Test 1: Single Animated Props (Initial)"
+        description={[
+          'Initial: Circle in top-left area of gray container',
+          "Click 'Animate': Circle moves to bottom-right area",
+        ]}>
+        <Test1SingleInitial />
+      </TestSection>
+
+      <TestSection
+        title="Test 2: Single Animated Props (Delayed)"
+        description={[
+          'Initial: Circle in top-left area without animated props',
+          "Click 'Attach Animated Props': Circle moves slightly right and down (props attached)",
+          "Click 'Animate': Circle moves to bottom-right area",
+        ]}>
+        <Test2SingleDelayed />
+      </TestSection>
+
+      <TestSection
+        title="Test 3: Multiple Animated Props (Initial)"
+        description={[
+          'Initial: Circle in top-left area of gray container',
+          "Click 'Animate': Circle moves to bottom-right area",
+        ]}>
+        <Test3MultipleInitial />
+      </TestSection>
+
+      <TestSection
+        title="Test 4: Multiple Animated Props (Separate Objects)"
+        description={[
+          'Initial: Circle in top-left area of gray container',
+          "Click 'Animate Horizontal': Circle moves to right side",
+          "Click 'Attach Vertical Props': Circle moves slightly down (props attached)",
+          "Click 'Animate Vertical': Circle moves to bottom-right area",
+        ]}>
+        <Test4MultipleMixedTiming />
+      </TestSection>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+  },
+  testSection: {
+    marginBottom: 40,
+    paddingBottom: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ccc',
+    alignItems: 'center',
+  },
+  testContainer: {
+    alignItems: 'center',
+    gap: 15,
+  },
+  svgContainer: {
+    backgroundColor: '#cccccc',
+    padding: 10,
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -160,6 +160,7 @@ import WorkletRuntimeExample from './WorkletRuntimeExample';
 import InstanceDiscoveryExample from './InstanceDiscoveryExample';
 import ShadowNodesCloningExample from './ShadowNodesCloningExample';
 import EmptyExample from './EmptyExample';
+import AnimatedPropsExample from './AnimatedPropsExample';
 
 export const REAPlatform = {
   IOS: 'ios',
@@ -261,6 +262,11 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🧠',
     title: 'Memo',
     screen: MemoExample,
+  },
+  AnimatedPropsExample: {
+    icon: '🎨',
+    title: 'Animated props',
+    screen: AnimatedPropsExample,
   },
   SerializableFreezingExample: {
     icon: '🥶',

--- a/apps/web-example/e2e/animated-props.spec.ts
+++ b/apps/web-example/e2e/animated-props.spec.ts
@@ -1,0 +1,180 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Wait time for animations to complete
+const ANIMATION_DURATION = 500;
+const ANIMATION_WAIT_TIME = ANIMATION_DURATION + 100;
+
+// Constants from AnimatedPropsExample.tsx
+// INITIAL_X = CIRCLE_SIZE / 2 = 50 (50 from left/top edge)
+// FINAL_X = 180 (50 from right/bottom edge, matching initial distance)
+// SVG_SIZE = FINAL_X + CIRCLE_SIZE / 2 = 230
+// PROPS_ATTACH_OFFSET = 50 (offset applied when animated props are first attached)
+const INITIAL_X = 50;
+const INITIAL_Y = 50;
+const FINAL_X = 180;
+const FINAL_Y = 180;
+const PROPS_ATTACH_OFFSET = 50;
+
+const clickAndWait = async (page: Page, testID: string) => {
+  await page.getByTestId(testID).click();
+  await page.waitForTimeout(ANIMATION_WAIT_TIME);
+};
+
+const expectCirclePosition = async (
+  page: Page,
+  testID: string,
+  position: { x?: number; y?: number }
+) => {
+  const circle = page.getByTestId(testID).locator('circle');
+  const [cx, cy] = await Promise.all([
+    circle.getAttribute('cx'),
+    circle.getAttribute('cy'),
+  ]);
+
+  if (position.x !== undefined) {
+    expect(parseFloat(cx!)).toBeCloseTo(position.x, 1);
+  }
+  if (position.y !== undefined) {
+    expect(parseFloat(cy!)).toBeCloseTo(position.y, 1);
+  }
+};
+
+test.describe('AnimatedPropsExample', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/Reanimated/AnimatedPropsExample');
+    await page.waitForSelector('text=Test 1: Single Animated Props (Initial)');
+  });
+
+  test('Single Animated Props (Initial) - circle animates from initial to final position', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-1-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-1-animate-button');
+    await expectCirclePosition(page, 'test-1-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Single Animated Props (Delayed) - circle moves when props are attached and animates to final position', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-2-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-2-attach-button');
+    await expectCirclePosition(page, 'test-2-circle', {
+      x: INITIAL_X + PROPS_ATTACH_OFFSET,
+      y: INITIAL_Y + PROPS_ATTACH_OFFSET,
+    });
+    await clickAndWait(page, 'test-2-animate-button');
+    await expectCirclePosition(page, 'test-2-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Multiple Animated Props (Initial) - circle animates from initial to final position', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-3-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-3-animate-button');
+    await expectCirclePosition(page, 'test-3-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Multiple Animated Props (Separate Objects) - animate horizontal first, then attach vertical, then animate vertical', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-4-animate-horizontal-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-4-attach-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: INITIAL_Y + PROPS_ATTACH_OFFSET,
+    });
+    await clickAndWait(page, 'test-4-animate-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Multiple Animated Props (Separate Objects) - attach vertical first, then animate horizontal, then animate vertical', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-4-attach-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y + PROPS_ATTACH_OFFSET,
+    });
+    await clickAndWait(page, 'test-4-animate-horizontal-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: INITIAL_Y + PROPS_ATTACH_OFFSET,
+    });
+    await clickAndWait(page, 'test-4-animate-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Multiple Animated Props (Separate Objects) - attach vertical, animate vertical, then animate horizontal', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-4-attach-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y + PROPS_ATTACH_OFFSET,
+    });
+    await clickAndWait(page, 'test-4-animate-vertical-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: FINAL_Y,
+    });
+    await clickAndWait(page, 'test-4-animate-horizontal-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: FINAL_Y,
+    });
+  });
+
+  test('Multiple Animated Props (Separate Objects) - animate horizontal only', async ({
+    page,
+  }) => {
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: INITIAL_X,
+      y: INITIAL_Y,
+    });
+    await clickAndWait(page, 'test-4-animate-horizontal-button');
+    await expectCirclePosition(page, 'test-4-circle', {
+      x: FINAL_X,
+      y: INITIAL_Y,
+    });
+  });
+});

--- a/packages/react-native-reanimated/__typetests__/common/AnimatedPropsTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/AnimatedPropsTest.tsx
@@ -214,4 +214,14 @@ function AnimatedPropsTest() {
       />
     );
   }
+
+  function UseAnimatedPropsTestMultipleRejectInvalidType() {
+    const animatedProps = useAnimatedProps(() => ({
+      pointerEvents: 'none' as const,
+    }));
+    return (
+      // @ts-expect-error Invalid types are not supported - only useAnimatedProps results are allowed in the array
+      <Animated.View animatedProps={[animatedProps, 'invalid']} />
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds playwright e2e test for multiple `animatedProps` support.

## Example recording

This recording shows how this example (that is tested with web e2e tests) looks like

https://github.com/user-attachments/assets/2159380d-b5ad-4f4b-a234-009095da5c85
