### PR TITLE
chore: Add e2e test step to release markdown

### DIFF
--- a/packages/react-native-reanimated/RELEASE.md
+++ b/packages/react-native-reanimated/RELEASE.md
@@ -68,7 +68,7 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
 
 10. Testing:
 
-    - **Required**: Run `yarn test:e2e` in the repository root and ensure all tests pass before proceeding with the release.
+    - Run `yarn test:e2e` in the repository root and ensure all tests pass before proceeding with the release.
     - Run the examples from Reanimated app, especially those affected by release changes.
     - Test each example app on each platform (if possible, run in both **release** and **debug** mode using **Android** and **iOS**).
     - On rare cases it might be necessary to also test unusual configurations, i.e. **release** app with a **development** bundle. Please consult the team for more instructions here.


### PR DESCRIPTION
## Summary

Just a minor improvement to the release markdown. Since I started adding `e2e` tests, it is worth adding this step not to forget to run `e2e` tests before the release. We don't have any CI running them yet - maybe it will be worth to add them sometime in the future.