### PR TITLE
docs: Require worklets in denyList when using RNRepo

### DIFF
--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -186,7 +186,7 @@ Static flags are intended to be resolved during code compilation and cannot be c
 Static feature flags are not supported in environments where Reanimated is prebuilt with the default configuration of flags, like for instance in [Expo Go](https://expo.dev/go) and [RNRepo](https://rnrepo.org/).
 
 - It's not possible to modify static feature flags in Expo Go. Please consider using [Expo Prebuild](https://docs.expo.dev/workflow/continuous-native-generation/) instead.
-- If your project uses RNRepo, you need to force building Reanimated from source by adding `react-native-reanimated` and `react-native-worklets` to the deny list as described in [RNRepo's documentation](https://github.com/software-mansion/rnrepo/blob/main/TROUBLESHOOTING.md#deny-list-configuration).
+- If your project uses RNRepo, you need to force building Reanimated and Worklets from source by adding `react-native-reanimated` and `react-native-worklets` to the deny list as described in [RNRepo's documentation](https://github.com/software-mansion/rnrepo/blob/main/TROUBLESHOOTING.md#deny-list-configuration).
 
 :::
 


### PR DESCRIPTION
## Summary

Updated the documentation to clarify that `react-native-worklets` must be added to the denyList alongside `react-native-reanimated` when using static-feature-flag with RNRepo.

Only adding `react-native-reanimated` will cause this error: 

```
ninja: error: '.../libworklets.so', needed by '.../libreanimated.so', missing and no known rule to make it
```

## Test plan
