### PR TITLE
fix: FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS feature flag crashes

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -33,13 +33,15 @@ void AnimatedPropsRegistry::update(jsi::Runtime &rt, const jsi::Value &operation
 
 void AnimatedPropsRegistry::remove(const Tag tag) {
   updatesRegistry_.erase(tag);
+  timestampMap_.erase(tag);
 }
 
 jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(jsi::Runtime &rt, const double timestamp) {
   std::vector<std::pair<Tag, std::reference_wrapper<const folly::dynamic>>> updates;
 
   for (const auto &[viewTag, pair] : updatesRegistry_) {
-    if (timestampMap_.at(viewTag) < timestamp) {
+    auto it = timestampMap_.find(viewTag);
+    if (it != timestampMap_.end() && it->second < timestamp) {
       updates.emplace_back(viewTag, std::cref(pair.second));
     }
   }


### PR DESCRIPTION
## Summary

This PR should fix crashes experienced when the `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` feature flag was enabled. I was not able to reproduce the issue in our example app but this place seems to be most likely to cause the crash so I hope this PR will resolve the issue. 