### PR TITLE
refactor(AnimatedSensorModule): remove assert in destructor

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.cpp
@@ -10,10 +10,6 @@ AnimatedSensorModule::AnimatedSensorModule(const PlatformDepMethodsHolder &platf
     : platformRegisterSensorFunction_(platformDepMethodsHolder.registerSensor),
       platformUnregisterSensorFunction_(platformDepMethodsHolder.unregisterSensor) {}
 
-AnimatedSensorModule::~AnimatedSensorModule() {
-  react_native_assert(sensorsIds_.empty() && "Tried to deallocate AnimatedSensorModule with registered sensors");
-}
-
 jsi::Value AnimatedSensorModule::registerSensor(
     jsi::Runtime &rt,
     const std::shared_ptr<WorkletRuntime> &uiWorkletRuntime,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/AnimatedSensor/AnimatedSensorModule.h
@@ -30,7 +30,6 @@ class AnimatedSensorModule {
 
  public:
   explicit AnimatedSensorModule(const PlatformDepMethodsHolder &platformDepMethodsHolder);
-  ~AnimatedSensorModule();
 
   jsi::Value registerSensor(
       jsi::Runtime &rt,


### PR DESCRIPTION
## Summary

This PR removes `sensorsIds_.empty()` assert in `~AnimatedSensorModule()` along with the (now empty) destructor itself which was supposedly causing a crash when the app is suspended and moved to the background on iOS.

> If you move the app to the background, iOS suspends it, and after some time, if you reopen it, the constructor will be called again as the app resumes. However, the `sensorsIds_` variable is not empty at this point, so the assert will cause the app to crash. There are methods that will clear the `sensorsIds_` upon unmounting, so this assert is essentially causing unnecessary issues.

## Test plan
