### PR TITLE
Add libworklets.so to excludes

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -231,7 +231,8 @@ android {
                     "**/libhermesvm.so",
                     "**/libhermestooling.so",
                     "**/libreactnative.so",
-                    "**/libjscexecutor.so",]
+                    "**/libjscexecutor.so",
+                    "**/libworklets.so",]
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
## Summary

This commit removes libworklets.so from the generated AAR file by adding it to the excludes list in the build.gradle file. This is necessary to avoid conflicts when used with worklets' AAR.
The libworklets.so is added to reanimated's AAR via the linking it in CMakeLists.txt and defining worklets as a dependency in the build.gradle file. It should not affect other parts of the project.

## Test plan

0. Use current main (without this commit)
1. Setup fabric example app from apps/
2. go to `./apps/fabric-example/android`
3. Run `./gradlew :react-native-reanimated:bundleReleaseAar` 
   - builded aar in `./packages/react-native-reanimated/android/build/outputs/aar/react-native-reanimated-release.aar`
   - unpack AAR (change ext to .zip)
   - AAR should have `jni/<arch>/libworklets.so`
4. Add this commit
5. Run again `./gradlew :react-native-reanimated:bundleReleaseAar`
    - builded aar in `./packages/react-native-reanimated/android/build/outputs/aar/react-native-reanimated-release.aar`
    - unpack AAR (change ext to .zip)
    - AAR should NOT have `jni/<arch>/libworklets.so`
