### PR TITLE
fix: IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS causing animated styles to be dropped

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1074,29 +1074,28 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
           "transform",
       };
 
-      UpdatesBatch synchronousUpdatesBatch, shadowTreeUpdatesBatch;
+      UpdatesBatch synchronousUpdatesBatch;
 
       for (const auto &[shadowNode, props] : updatesBatch) {
-        bool hasOnlySynchronousProps = true;
-        for (const auto &key : props.keys()) {
+        folly::dynamic synchronousPropsForNode = folly::dynamic::object();
+
+        for (const auto &[key, value] : props.items()) {
           const auto keyStr = key.asString();
-          if (!synchronousProps.contains(keyStr)) {
-            hasOnlySynchronousProps = false;
-            break;
+          if (synchronousProps.contains(keyStr)) {
+            synchronousPropsForNode[key] = value;
           }
         }
-        if (hasOnlySynchronousProps) {
-          synchronousUpdatesBatch.emplace_back(shadowNode, props);
-        } else {
-          shadowTreeUpdatesBatch.emplace_back(shadowNode, props);
+
+        if (!synchronousPropsForNode.empty()) {
+          synchronousUpdatesBatch.emplace_back(shadowNode, synchronousPropsForNode);
         }
       }
 
-      for (const auto &[shadowNode, props] : synchronousUpdatesBatch) {
-        synchronouslyUpdateUIPropsFunction_(shadowNode->getTag(), props);
+      if (!synchronousUpdatesBatch.empty()) {
+        for (const auto &[shadowNode, props] : synchronousUpdatesBatch) {
+          synchronouslyUpdateUIPropsFunction_(shadowNode->getTag(), props);
+        }
       }
-
-      updatesBatch = std::move(shadowTreeUpdatesBatch);
     }
 #endif // __APPLE__
 


### PR DESCRIPTION
## Summary

fixes: https://github.com/software-mansion/react-native-reanimated/issues/8810

Synchronous props were bypassing the `AnimatedPropsRegistry`, causing stale values to be reapplied during commits. Fixed by keeping all props in the update batch while also sending synchronous props via the fast path.

Animated styles now correctly persist when animated props change on iOS with `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` feature flag enabled.

## Test plan

Tested with the https://github.com/mozzius/sync-ui-drawer-repro - the drawer overlay no longer flickers at 5% progress.
