### PR TITLE
feat: adds `withTargetValues` modifier to default layout animations

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DefaultAnimationsOverrides.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DefaultAnimationsOverrides.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import Animated, { FadeIn, FadeOutDown } from 'react-native-reanimated';
+
+interface AnimatedBlockProps {
+  name: string;
+  animatedStyle: Record<string, unknown>;
+  defaultShow?: boolean;
+}
+
+const AnimatedBlock = ({
+  name,
+  animatedStyle,
+  defaultShow,
+}: AnimatedBlockProps) => {
+  const [show, setShow] = useState(defaultShow);
+  return (
+    <View style={styles.animatedBox}>
+      {show ? (
+        <TouchableWithoutFeedback onPress={() => setShow(!show)}>
+          {/* Workaround for TouchableWithoutFeedback overwriting the nativeID */}
+          <View>
+            <Animated.View style={styles.animatedBlock} {...animatedStyle}>
+              <Text style={styles.animatedText}>{name}</Text>
+            </Animated.View>
+          </View>
+        </TouchableWithoutFeedback>
+      ) : null}
+      {!show ? (
+        <Animated.View
+          entering={
+            'entering' in animatedStyle ? undefined : FadeIn.delay(350)
+          }>
+          <TouchableOpacity
+            style={styles.animatedBlockPlaceholder}
+            onPress={() => setShow(!show)}>
+            <Text style={styles.animatedTextPlaceholder}>{name}</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      ) : null}
+    </View>
+  );
+};
+
+export default function DefaultAnimationsOverrides() {
+  const [opacity, setOpacity] = useState('0');
+  const [translateY, setTranslateY] = useState('25');
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.groupText}>{`FadeOutDown.withTargetValues({`}</Text>
+
+      <View style={styles.textInputContainer}>
+        <Text>opacity: </Text>
+        <TextInput
+          placeholder="0"
+          keyboardType="numeric"
+          value={opacity}
+          onChangeText={setOpacity}
+          style={styles.textInput}
+        />
+      </View>
+
+      <View style={styles.textInputContainer}>
+        <Text>translateY: </Text>
+        <TextInput
+          placeholder="25"
+          keyboardType="numeric"
+          value={translateY.toString()}
+          onChangeText={setTranslateY}
+          style={styles.textInput}
+        />
+      </View>
+
+      <Text style={styles.groupText}>{`})`}</Text>
+
+      <AnimatedBlock
+        name="FadeOutDown"
+        animatedStyle={{
+          // todo: fix typescript error
+          // @ts-ignore
+          exiting: FadeOutDown.withTargetValues({
+            opacity,
+            translateY,
+          }),
+        }}
+        defaultShow={true}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'column',
+  },
+  groupText: {
+    fontSize: 20,
+    paddingTop: 5,
+    paddingLeft: 5,
+    paddingBottom: 5,
+  },
+  animatedBlock: {
+    height: 60,
+    width: 300,
+    borderWidth: 3,
+    borderColor: '#001a72',
+    backgroundColor: '#001a72',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  animatedTextPlaceholder: {
+    color: '#001a72',
+    fontSize: 20,
+  },
+  animatedBlockPlaceholder: {
+    height: 60,
+    width: 300,
+    borderWidth: 3,
+    borderColor: '#001a72',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderStyle: 'dashed',
+  },
+  animatedText: {
+    color: '#ffffff',
+    fontSize: 20,
+    userSelect: 'none',
+  },
+  animatedBox: {
+    padding: 5,
+    alignItems: 'center',
+  },
+  textInputContainer: {
+    marginLeft: 30,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textInput: { backgroundColor: '#ddd' },
+});

--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DefaultAnimationsOverrides.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DefaultAnimationsOverrides.tsx
@@ -1,25 +1,39 @@
-import React, { useState } from 'react';
+import React, { ComponentProps, useState } from 'react';
 import {
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import Animated, { FadeIn, FadeOutDown } from 'react-native-reanimated';
+import Animated, {
+  FadeIn,
+  FadeInRight,
+  FadeOutDown,
+  FlipInYRight,
+  RollOutRight,
+  ZoomInRotate,
+  ZoomOutLeft,
+} from 'react-native-reanimated';
+
+type EnteringAnimationProp = ComponentProps<typeof Animated.View>['entering'];
+type ExitingAnimationProp = ComponentProps<typeof Animated.View>['exiting'];
 
 interface AnimatedBlockProps {
   name: string;
-  animatedStyle: Record<string, unknown>;
+  entering?: EnteringAnimationProp;
+  exiting?: ExitingAnimationProp;
   defaultShow?: boolean;
+  compact?: boolean;
 }
 
 const AnimatedBlock = ({
-  name,
-  animatedStyle,
+  compact,
   defaultShow,
+  entering,
+  exiting,
+  name,
 }: AnimatedBlockProps) => {
   const [show, setShow] = useState(defaultShow);
   return (
@@ -28,19 +42,25 @@ const AnimatedBlock = ({
         <TouchableWithoutFeedback onPress={() => setShow(!show)}>
           {/* Workaround for TouchableWithoutFeedback overwriting the nativeID */}
           <View>
-            <Animated.View style={styles.animatedBlock} {...animatedStyle}>
+            <Animated.View
+              style={[
+                styles.animatedBlock,
+                compact ? styles.animatedBlockCompact : null,
+              ]}
+              entering={entering}
+              exiting={exiting}>
               <Text style={styles.animatedText}>{name}</Text>
             </Animated.View>
           </View>
         </TouchableWithoutFeedback>
       ) : null}
       {!show ? (
-        <Animated.View
-          entering={
-            'entering' in animatedStyle ? undefined : FadeIn.delay(350)
-          }>
+        <Animated.View entering={entering ? undefined : FadeIn.delay(350)}>
           <TouchableOpacity
-            style={styles.animatedBlockPlaceholder}
+            style={[
+              styles.animatedBlockPlaceholder,
+              compact ? styles.animatedBlockCompact : null,
+            ]}
             onPress={() => setShow(!show)}>
             <Text style={styles.animatedTextPlaceholder}>{name}</Text>
           </TouchableOpacity>
@@ -50,100 +70,196 @@ const AnimatedBlock = ({
   );
 };
 
-export default function DefaultAnimationsOverrides() {
-  const [opacity, setOpacity] = useState('0');
-  const [translateY, setTranslateY] = useState('25');
+interface ComparisonRowProps {
+  title: string;
+  description: string;
+  defaultEntering?: EnteringAnimationProp;
+  defaultExiting?: ExitingAnimationProp;
+  entering?: EnteringAnimationProp;
+  exiting?: ExitingAnimationProp;
+  isExitCase?: boolean;
+}
 
+const ComparisonRow = ({
+  defaultEntering,
+  defaultExiting,
+  description,
+  entering,
+  exiting,
+  isExitCase,
+  title,
+}: ComparisonRowProps) => {
+  const defaultShow = !!isExitCase;
+  return (
+    <View style={styles.comparisonSection}>
+      <Text style={styles.overrideText}>{title}</Text>
+      <Text style={styles.overrideDescription}>{description}</Text>
+      <View style={styles.comparisonRow}>
+        <View style={styles.comparisonColumn}>
+          <Text style={styles.comparisonLabel}>Default</Text>
+          <AnimatedBlock
+            defaultShow={defaultShow}
+            entering={defaultEntering}
+            exiting={defaultExiting}
+            name="Default"
+          />
+        </View>
+        <View style={styles.comparisonColumn}>
+          <Text style={styles.comparisonLabel}>Modified</Text>
+          <AnimatedBlock
+            defaultShow={defaultShow}
+            entering={entering}
+            exiting={exiting}
+            name="Modified"
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default function DefaultAnimationsOverrides() {
   return (
     <ScrollView style={styles.container}>
-      <Text style={styles.groupText}>{`FadeOutDown.withTargetValues({`}</Text>
+      <Text style={styles.groupText}>Entering overrides</Text>
+      <ComparisonRow
+        defaultEntering={FadeInRight}
+        description="withInitialValues({ opacity: 0, translateX: 360 })"
+        entering={FadeInRight.withInitialValues({
+          opacity: 0,
+          translateX: 360,
+        })}
+        title="FadeInRight"
+      />
+      <ComparisonRow
+        defaultEntering={ZoomInRotate}
+        description="withInitialValues({ rotate: 3rad, transform: [scale: 0.05, rotate: 2.4rad] })"
+        entering={ZoomInRotate.withInitialValues({
+          rotate: '3rad',
+          transform: [{ scale: 0.05 }, { rotate: '2.4rad' }],
+        })}
+        title="ZoomInRotate"
+      />
+      <ComparisonRow
+        defaultEntering={FlipInYRight}
+        description="withInitialValues({ transform: [perspective: 1200, rotateY: 45deg, translateX: 50] })"
+        entering={FlipInYRight.withInitialValues({
+          transform: [
+            { perspective: 1200 },
+            { rotateY: '45deg' },
+            { translateX: 50 },
+          ],
+        })}
+        title="FlipInYRight"
+      />
 
-      <View style={styles.textInputContainer}>
-        <Text>opacity: </Text>
-        <TextInput
-          placeholder="0"
-          keyboardType="numeric"
-          value={opacity}
-          onChangeText={setOpacity}
-          style={styles.textInput}
-        />
-      </View>
-
-      <View style={styles.textInputContainer}>
-        <Text>translateY: </Text>
-        <TextInput
-          placeholder="25"
-          keyboardType="numeric"
-          value={translateY.toString()}
-          onChangeText={setTranslateY}
-          style={styles.textInput}
-        />
-      </View>
-
-      <Text style={styles.groupText}>{`})`}</Text>
-
-      <AnimatedBlock
-        name="FadeOutDown"
-        animatedStyle={{
-          // todo: fix typescript error
-          // @ts-ignore
-          exiting: FadeOutDown.withTargetValues({
-            opacity,
-            translateY,
-          }),
-        }}
-        defaultShow={true}
+      <Text style={styles.groupText}>Exiting overrides</Text>
+      <ComparisonRow
+        defaultExiting={FadeOutDown}
+        description="withTargetValues({ opacity: 0, translateY: 320 })"
+        exiting={FadeOutDown.withTargetValues({
+          opacity: 0,
+          translateY: 320,
+        })}
+        title="FadeOutDown"
+        isExitCase
+      />
+      <ComparisonRow
+        defaultExiting={RollOutRight}
+        description="withTargetValues({ transform: [translateX: 900, rotate: 1080deg] })"
+        exiting={RollOutRight.withTargetValues({
+          transform: [{ translateX: 900 }, { rotate: '1080deg' }],
+        })}
+        title="RollOutRight"
+        isExitCase
+      />
+      <ComparisonRow
+        defaultExiting={ZoomOutLeft}
+        description="withTargetValues({ transform: [translateX: -50, scale: 0.08] })"
+        exiting={ZoomOutLeft.withTargetValues({
+          transform: [{ translateX: -50 }, { scale: 0.08 }],
+        })}
+        title="ZoomOutLeft"
+        isExitCase
       />
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'column',
-  },
-  groupText: {
-    fontSize: 20,
-    paddingTop: 5,
-    paddingLeft: 5,
-    paddingBottom: 5,
-  },
   animatedBlock: {
-    height: 60,
-    width: 300,
-    borderWidth: 3,
-    borderColor: '#001a72',
-    backgroundColor: '#001a72',
     alignItems: 'center',
+    backgroundColor: '#001a72',
+    borderColor: '#001a72',
+    borderWidth: 3,
+    height: 60,
     justifyContent: 'center',
+    width: 300,
   },
-  animatedTextPlaceholder: {
-    color: '#001a72',
-    fontSize: 20,
+  animatedBlockCompact: {
+    width: 160,
   },
   animatedBlockPlaceholder: {
-    height: 60,
-    width: 300,
-    borderWidth: 3,
-    borderColor: '#001a72',
     alignItems: 'center',
-    justifyContent: 'center',
+    borderColor: '#001a72',
     borderStyle: 'dashed',
+    borderWidth: 3,
+    height: 60,
+    justifyContent: 'center',
+    width: 300,
+  },
+  animatedBox: {
+    alignItems: 'center',
+    padding: 5,
   },
   animatedText: {
     color: '#ffffff',
     fontSize: 20,
     userSelect: 'none',
   },
-  animatedBox: {
-    padding: 5,
-    alignItems: 'center',
+  animatedTextPlaceholder: {
+    color: '#001a72',
+    fontSize: 20,
   },
-  textInputContainer: {
-    marginLeft: 30,
-    display: 'flex',
-    flexDirection: 'row',
+  comparisonColumn: {
     alignItems: 'center',
+    flex: 1,
   },
-  textInput: { backgroundColor: '#ddd' },
+  comparisonLabel: {
+    color: '#444',
+    fontSize: 13,
+    fontWeight: '600',
+    paddingBottom: 2,
+  },
+  comparisonRow: {
+    flexDirection: 'column',
+    gap: 2,
+    paddingHorizontal: 8,
+  },
+  comparisonSection: {
+    paddingBottom: 6,
+  },
+  container: {
+    flexDirection: 'column',
+  },
+  groupText: {
+    fontSize: 20,
+    paddingBottom: 5,
+    paddingLeft: 5,
+    paddingTop: 5,
+  },
+  overrideDescription: {
+    color: '#555',
+    fontSize: 12,
+    paddingBottom: 2,
+    paddingHorizontal: 10,
+  },
+  overrideText: {
+    color: '#333',
+    fontSize: 16,
+    fontWeight: '600',
+    paddingBottom: 2,
+    paddingLeft: 10,
+    paddingRight: 10,
+  },
 });

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -147,6 +147,10 @@ const DefaultAnimations: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/DefaultAnimations').default as React.FC
   );
+const DefaultAnimationsOverrides: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/DefaultAnimationsOverrides').default as React.FC
+  );
 const DeleteAncestorOfExiting: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/DeleteAncestorOfExiting').default
@@ -1194,6 +1198,10 @@ export const EXAMPLES: Record<string, Example> = {
   DurationZeroExample: {
     title: '[LA] Duration zero',
     screen: DurationZeroExample,
+  },
+  DefaultAnimationsOverrides: {
+    title: '[LA] Default layout animations overrides',
+    screen: DefaultAnimationsOverrides,
   },
 
   // Shared Element Transitions

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -13,16 +13,15 @@ import { BaseAnimationBuilder } from './BaseAnimationBuilder';
 
 /**
  * `this` type for every static method on {@link ComplexAnimationBuilder}.
- * Represents a subclass constructor that preserves the concrete
- * `TInitialValues` type argument while still exposing the static API inherited
- * from {@link BaseAnimationBuilder}.
+ * Represents a subclass constructor that preserves the concrete `TValues` type
+ * argument while still exposing the static API inherited from
+ * {@link BaseAnimationBuilder}.
  */
-type ComplexAnimationBuilderClass<TInitialValues> =
-  typeof BaseAnimationBuilder &
-    (new () => ComplexAnimationBuilder<TInitialValues>);
+type ComplexAnimationBuilderClass<TValues> = typeof BaseAnimationBuilder &
+  (new () => ComplexAnimationBuilder<TValues>);
 
 export class ComplexAnimationBuilder<
-  TInitialValues = StyleProps,
+  TValues = StyleProps,
 > extends BaseAnimationBuilder {
   easingV?: EasingFunction | EasingFunctionFactory;
   rotateV?: string;
@@ -33,7 +32,8 @@ export class ComplexAnimationBuilder<
   stiffnessV?: number;
   overshootClampingV?: number;
   energyThresholdV?: number;
-  initialValues?: Partial<TInitialValues>;
+  initialValues?: Partial<TValues>;
+  targetValues?: Partial<TValues>;
 
   static createInstance: <T extends typeof BaseAnimationBuilder>(
     this: T
@@ -47,10 +47,10 @@ export class ComplexAnimationBuilder<
    * @param easingFunction - An easing function which defines the animation
    *   curve.
    */
-  static easing<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static easing<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     easingFunction: EasingFunction | EasingFunctionFactory
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.easing(easingFunction);
   }
@@ -70,10 +70,10 @@ export class ComplexAnimationBuilder<
    *
    * @param degree - The rotation degree.
    */
-  static rotate<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static rotate<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     degree: string
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.rotate(degree);
   }
@@ -91,10 +91,10 @@ export class ComplexAnimationBuilder<
    * @param duration - An optional duration of the spring animation (in
    *   milliseconds).
    */
-  static springify<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static springify<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     duration?: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.springify(duration);
   }
@@ -112,10 +112,10 @@ export class ComplexAnimationBuilder<
    *
    * @param dampingRatio - How damped the spring is.
    */
-  static dampingRatio<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static dampingRatio<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     dampingRatio: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.dampingRatio(dampingRatio);
   }
@@ -133,10 +133,10 @@ export class ComplexAnimationBuilder<
    * @param value - Decides how quickly a spring stops moving. Higher damping
    *   means the spring will come to rest faster.
    */
-  static damping<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static damping<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     value: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.damping(value);
   }
@@ -154,10 +154,10 @@ export class ComplexAnimationBuilder<
    * @param mass - The weight of the spring. Reducing this value makes the
    *   animation faster.
    */
-  static mass<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static mass<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     mass: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.mass(mass);
   }
@@ -174,10 +174,10 @@ export class ComplexAnimationBuilder<
    *
    * @param stiffness - How bouncy the spring is.
    */
-  static stiffness<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static stiffness<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     stiffness: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.stiffness(stiffness);
   }
@@ -195,10 +195,10 @@ export class ComplexAnimationBuilder<
    * @param overshootClamping - Whether a spring can bounce over the final
    *   position.
    */
-  static overshootClamping<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static overshootClamping<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     overshootClamping: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.overshootClamping(overshootClamping);
   }
@@ -212,10 +212,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in the upcoming major version.
    */
-  static restDisplacementThreshold<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static restDisplacementThreshold<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     _restDisplacementThreshold: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     return this.createInstance();
   }
 
@@ -231,10 +231,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in a future version.
    */
-  static restSpeedThreshold<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static restSpeedThreshold<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     _restSpeedThreshold: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     return this.createInstance();
   }
 
@@ -254,10 +254,10 @@ export class ComplexAnimationBuilder<
    * @param energyThreshold - Relative energy threshold below which the spring
    *   will snap to `toValue` without further oscillations. Defaults to 6e-9.
    */
-  static energyThreshold<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
+  static energyThreshold<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
     energyThreshold: number
-  ): ComplexAnimationBuilder<TInitialValues> {
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.energyThreshold(energyThreshold);
   }
@@ -268,20 +268,38 @@ export class ComplexAnimationBuilder<
   }
 
   /**
-   * Lets you override the initial config of the animation
+   * Lets you override the initial properties of the animation
    *
    * @param values - An object containing the styles to override.
    */
-  static withInitialValues<TInitialValues>(
-    this: ComplexAnimationBuilderClass<TInitialValues>,
-    values: Partial<TInitialValues>
-  ): ComplexAnimationBuilder<TInitialValues> {
+  static withInitialValues<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
+    values: Partial<TValues>
+  ): ComplexAnimationBuilder<TValues> {
     const instance = this.createInstance();
     return instance.withInitialValues(values);
   }
 
-  withInitialValues(values: Partial<TInitialValues>): this {
+  withInitialValues(values: Partial<TValues>): this {
     this.initialValues = values;
+    return this;
+  }
+
+  /**
+   * Lets you override the target properties of the animation
+   *
+   * @param values - An object containing the styles to override.
+   */
+  static withTargetValues<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
+    values: Partial<TValues>
+  ): ComplexAnimationBuilder<TValues> {
+    const instance = this.createInstance();
+    return instance.withTargetValues(values);
+  }
+
+  withTargetValues(values: Partial<TValues>): this {
+    this.targetValues = values;
     return this;
   }
 

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
@@ -1,7 +1,6 @@
 'use strict';
 import { withSequence, withTiming } from '../../animation';
 import type {
-  AnimatableValue,
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
   IEntryExitAnimationBuilder,
@@ -9,7 +8,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { Scale, TransformsConfig, TranslateX, TranslateY } from './types';
-import { pickTransformValues } from './utils';
+import { pickTransformValues, resolveTransformValue } from './utils';
 
 /**
  * Bounce entering animation. You can modify the behavior by chaining methods
@@ -60,7 +59,10 @@ export class BounceIn
                   withTiming(1.2, { duration: duration * 0.55 }),
                   withTiming(0.9, { duration: duration * 0.15 }),
                   withTiming(1.1, { duration: duration * 0.15 }),
-                  withTiming(1, { duration: duration * 0.15 })
+                  withTiming(
+                    resolveTransformValue({ scale: 1 }, 0, targetValues),
+                    { duration: duration * 0.15 }
+                  )
                 )
               ),
             },
@@ -124,7 +126,10 @@ export class BounceInDown
                   withTiming(-20, { duration: duration * 0.55 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
-                  withTiming(0, { duration: duration * 0.15 })
+                  withTiming(
+                    resolveTransformValue({ translateY: 0 }, 0, targetValues),
+                    { duration: duration * 0.15 }
+                  )
                 )
               ),
             },
@@ -191,7 +196,10 @@ export class BounceInUp
                   withTiming(20, { duration: duration * 0.55 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
-                  withTiming(0, { duration: duration * 0.15 })
+                  withTiming(
+                    resolveTransformValue({ translateY: 0 }, 0, targetValues),
+                    { duration: duration * 0.15 }
+                  )
                 )
               ),
             },
@@ -258,7 +266,10 @@ export class BounceInLeft
                   withTiming(20, { duration: duration * 0.55 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
-                  withTiming(0, { duration: duration * 0.15 })
+                  withTiming(
+                    resolveTransformValue({ translateX: 0 }, 0, targetValues),
+                    { duration: duration * 0.15 }
+                  )
                 )
               ),
             },
@@ -311,6 +322,7 @@ export class BounceInRight
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -324,7 +336,10 @@ export class BounceInRight
                   withTiming(-20, { duration: duration * 0.55 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
-                  withTiming(0, { duration: duration * 0.15 })
+                  withTiming(
+                    resolveTransformValue({ translateX: 0 }, 0, targetValues),
+                    { duration: duration * 0.15 }
+                  )
                 )
               ),
             },
@@ -391,7 +406,10 @@ export class BounceOut
                   withTiming(1.1, { duration: duration * 0.15 }),
                   withTiming(0.9, { duration: duration * 0.15 }),
                   withTiming(1.2, { duration: duration * 0.15 }),
-                  withTiming(0, { duration: duration * 0.55 })
+                  withTiming(
+                    resolveTransformValue({ scale: 0 }, 0, targetValues),
+                    { duration: duration * 0.55 }
+                  )
                 )
               ),
             },
@@ -455,9 +473,16 @@ export class BounceOutDown
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-20, { duration: duration * 0.15 }),
-                  withTiming(targetValues?.translateY ?? values.windowHeight, {
-                    duration: duration * 0.55,
-                  })
+                  withTiming(
+                    resolveTransformValue(
+                      { translateY: values.windowHeight },
+                      0,
+                      targetValues
+                    ),
+                    {
+                      duration: duration * 0.55,
+                    }
+                  )
                 )
               ),
             },
@@ -521,9 +546,14 @@ export class BounceOutUp
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(20, { duration: duration * 0.15 }),
-                  withTiming(targetValues?.translateY ?? -values.windowHeight, {
-                    duration: duration * 0.55,
-                  })
+                  withTiming(
+                    resolveTransformValue(
+                      { translateY: -values.windowHeight },
+                      0,
+                      targetValues
+                    ),
+                    { duration: duration * 0.55 }
+                  )
                 )
               ),
             },
@@ -587,9 +617,14 @@ export class BounceOutLeft
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(20, { duration: duration * 0.15 }),
-                  withTiming(targetValues?.translateX ?? -values.windowWidth, {
-                    duration: duration * 0.55,
-                  })
+                  withTiming(
+                    resolveTransformValue(
+                      { translateX: -values.windowWidth },
+                      0,
+                      targetValues
+                    ),
+                    { duration: duration * 0.55 }
+                  )
                 )
               ),
             },
@@ -653,9 +688,14 @@ export class BounceOutRight
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-20, { duration: duration * 0.15 }),
-                  withTiming(targetValues?.translateX ?? values.windowWidth, {
-                    duration: duration * 0.55,
-                  })
+                  withTiming(
+                    resolveTransformValue(
+                      { translateX: values.windowWidth },
+                      0,
+                      targetValues
+                    ),
+                    { duration: duration * 0.55 }
+                  )
                 )
               ),
             },

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { withSequence, withTiming } from '../../animation';
 import type {
+  AnimatableValue,
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
   IEntryExitAnimationBuilder,
@@ -45,6 +46,7 @@ export class BounceIn
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
@@ -108,6 +110,7 @@ export class BounceInDown
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -174,6 +177,7 @@ export class BounceInUp
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -240,6 +244,7 @@ export class BounceInLeft
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -372,6 +377,7 @@ export class BounceOut
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
@@ -435,6 +441,7 @@ export class BounceOutDown
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -448,7 +455,7 @@ export class BounceOutDown
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-20, { duration: duration * 0.15 }),
-                  withTiming(values.windowHeight, {
+                  withTiming(targetValues?.translateY ?? values.windowHeight, {
                     duration: duration * 0.55,
                   })
                 )
@@ -500,6 +507,7 @@ export class BounceOutUp
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -513,7 +521,7 @@ export class BounceOutUp
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(20, { duration: duration * 0.15 }),
-                  withTiming(-values.windowHeight, {
+                  withTiming(targetValues?.translateY ?? -values.windowHeight, {
                     duration: duration * 0.55,
                   })
                 )
@@ -565,6 +573,7 @@ export class BounceOutLeft
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -578,7 +587,7 @@ export class BounceOutLeft
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(20, { duration: duration * 0.15 }),
-                  withTiming(-values.windowWidth, {
+                  withTiming(targetValues?.translateX ?? -values.windowWidth, {
                     duration: duration * 0.55,
                   })
                 )
@@ -630,6 +639,7 @@ export class BounceOutRight
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -643,7 +653,7 @@ export class BounceOutRight
                   withTiming(-10, { duration: duration * 0.15 }),
                   withTiming(10, { duration: duration * 0.15 }),
                   withTiming(-20, { duration: duration * 0.15 }),
-                  withTiming(values.windowWidth, {
+                  withTiming(targetValues?.translateX ?? values.windowWidth, {
                     duration: duration * 0.55,
                   })
                 )

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
@@ -1,6 +1,8 @@
 'use strict';
 import type {
+  AnimationConfigFunction,
   EntryExitAnimationFunction,
+  ExitAnimationsValues,
   IEntryExitAnimationBuilder,
 } from '../../commonTypes';
 import type { BaseAnimationBuilder } from '../animationBuilder';
@@ -34,12 +36,17 @@ export class FadeIn
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -78,14 +85,24 @@ export class FadeInRight
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -126,14 +143,24 @@ export class FadeInLeft
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -174,14 +201,24 @@ export class FadeInUp
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -222,14 +259,24 @@ export class FadeInDown
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -268,12 +315,17 @@ export class FadeOut
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -312,14 +364,24 @@ export class FadeOutRight
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { translateX: delayFunction(delay, animation(25, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 25, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -360,14 +422,24 @@ export class FadeOutLeft
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { translateX: delayFunction(delay, animation(-25, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? -25, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -407,14 +479,24 @@ export class FadeOutUp
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { translateY: delayFunction(delay, animation(-25, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? -25, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -450,19 +532,29 @@ export class FadeOutDown
     return new FadeOutDown() as InstanceType<T>;
   }
 
-  build = (): EntryExitAnimationFunction => {
+  build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
     const [animation, config] = this.getAnimationAndConfig();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
     const delay = this.getDelay();
+
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { translateY: delayFunction(delay, animation(25, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 25, config)
+              ),
+            },
           ],
         },
         initialValues: {

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
@@ -8,7 +8,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { TransformsConfig, TranslateX, TranslateY } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Fade in animation. You can modify the behavior by chaining methods like
@@ -82,7 +82,8 @@ export class FadeInRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -96,14 +97,13 @@ export class FadeInRight
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -140,7 +140,8 @@ export class FadeInLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -154,14 +155,13 @@ export class FadeInLeft
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -198,7 +198,8 @@ export class FadeInUp
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -212,14 +213,13 @@ export class FadeInUp
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -256,7 +256,8 @@ export class FadeInDown
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -270,14 +271,13 @@ export class FadeInDown
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -361,7 +361,8 @@ export class FadeOutRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -375,14 +376,13 @@ export class FadeOutRight
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 25, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 25 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -419,7 +419,8 @@ export class FadeOutLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -433,14 +434,13 @@ export class FadeOutLeft
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? -25, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: -25 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -476,7 +476,8 @@ export class FadeOutUp
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -490,14 +491,13 @@ export class FadeOutUp
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? -25, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: -25 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -534,7 +534,8 @@ export class FadeOutDown
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
@@ -548,14 +549,13 @@ export class FadeOutDown
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 25, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 25 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
@@ -26,7 +26,7 @@ import type {
   TranslateX,
   TranslateY,
 } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Rotate from top on the X axis. You can modify the behavior by chaining
@@ -53,12 +53,13 @@ export class FlipInXUp
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const builderTargetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (layoutValues) => {
       'worklet';
       return {
         initialValues: {
@@ -66,17 +67,19 @@ export class FlipInXUp
             [
               { perspective: 500 },
               { rotateX: '90deg' },
-              { translateY: -targetValues.targetHeight },
+              { translateY: -layoutValues.targetHeight },
             ],
             initialValues
           ),
         },
         animations: {
-          transform: [
-            { perspective: 500 },
-            { rotateX: delayFunction(delay, animation('0deg', config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateX: '0deg' }, { translateY: 0 }],
+            builderTargetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -109,12 +112,13 @@ export class FlipInYLeft
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const builderTargetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (layoutValues) => {
       'worklet';
       return {
         initialValues: {
@@ -122,17 +126,19 @@ export class FlipInYLeft
             [
               { perspective: 500 },
               { rotateY: '-90deg' },
-              { translateX: -targetValues.targetWidth },
+              { translateX: -layoutValues.targetWidth },
             ],
             initialValues
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateY: '0deg' }, { translateX: 0 }],
+            builderTargetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -165,12 +171,13 @@ export class FlipInXDown
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const builderTargetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (layoutValues) => {
       'worklet';
       return {
         initialValues: {
@@ -178,17 +185,19 @@ export class FlipInXDown
             [
               { perspective: 500 },
               { rotateX: '-90deg' },
-              { translateY: targetValues.targetHeight },
+              { translateY: layoutValues.targetHeight },
             ],
             initialValues
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateX: delayFunction(delay, animation('0deg', config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateX: '0deg' }, { translateY: 0 }],
+            builderTargetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -221,12 +230,13 @@ export class FlipInYRight
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const builderTargetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (layoutValues) => {
       'worklet';
       return {
         initialValues: {
@@ -234,17 +244,19 @@ export class FlipInYRight
             [
               { perspective: 500 },
               { rotateY: '90deg' },
-              { translateX: targetValues.targetWidth },
+              { translateX: layoutValues.targetWidth },
             ],
             initialValues
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateY: '0deg' }, { translateX: 0 }],
+            builderTargetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -275,10 +287,11 @@ export class FlipInEasyX
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
@@ -290,10 +303,13 @@ export class FlipInEasyX
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateX: delayFunction(delay, animation('0deg', config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateX: '0deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -324,10 +340,11 @@ export class FlipInEasyY
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
@@ -339,10 +356,13 @@ export class FlipInEasyY
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('0deg', config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateY: '0deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -375,7 +395,7 @@ export class FlipOutXUp
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -391,19 +411,17 @@ export class FlipOutXUp
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateX: delayFunction(delay, animation('90deg', config)) },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? -values.currentHeight,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { perspective: 500 },
+              { rotateX: '90deg' },
+              { translateY: -values.currentHeight },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -436,7 +454,7 @@ export class FlipOutYLeft
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -452,29 +470,17 @@ export class FlipOutYLeft
           ),
         },
         animations: {
-          transform: [
-            {
-              perspective: delayFunction(
-                delay,
-                animation(targetValues?.perspective ?? 500, config)
-              ),
-            },
-            {
-              rotateY: delayFunction(
-                delay,
-                animation(targetValues?.rotateY ?? '-90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? -values.currentWidth,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { perspective: 500 },
+              { rotateY: '-90deg' },
+              { translateX: -values.currentWidth },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -507,7 +513,7 @@ export class FlipOutXDown
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -523,29 +529,17 @@ export class FlipOutXDown
           ),
         },
         animations: {
-          transform: [
-            {
-              perspective: delayFunction(
-                delay,
-                animation(targetValues?.perspective ?? 500, config)
-              ),
-            },
-            {
-              rotateX: delayFunction(
-                delay,
-                animation(targetValues?.rotateX ?? '-90deg', config)
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? values.currentHeight,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { perspective: 500 },
+              { rotateX: '-90deg' },
+              { translateY: values.currentHeight },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -578,15 +572,13 @@ export class FlipOutYRight
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const perspectiveOverride = this.targetValues?.perspective;
-    const rotateYOverride = this.targetValues?.rotateY;
-    const translateXOverride = this.targetValues?.translateX;
+    const builderTargetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (layoutValues) => {
       'worklet';
       return {
         initialValues: {
@@ -596,29 +588,17 @@ export class FlipOutYRight
           ),
         },
         animations: {
-          transform: [
-            {
-              perspective: delayFunction(
-                delay,
-                animation(perspectiveOverride ?? 500, config)
-              ),
-            },
-            {
-              rotateY: delayFunction(
-                delay,
-                animation(rotateYOverride ?? '90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  translateXOverride ?? targetValues.currentWidth,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { perspective: 500 },
+              { rotateY: '90deg' },
+              { translateX: layoutValues.currentWidth },
+            ],
+            builderTargetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -649,7 +629,7 @@ export class FlipOutEasyX
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -665,20 +645,13 @@ export class FlipOutEasyX
           ),
         },
         animations: {
-          transform: [
-            {
-              perspective: delayFunction(
-                delay,
-                animation(targetValues?.perspective ?? 500, config)
-              ),
-            },
-            {
-              rotateX: delayFunction(
-                delay,
-                animation(targetValues?.rotateX ?? '90deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateX: '90deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };
@@ -709,7 +682,7 @@ export class FlipOutEasyY
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -725,10 +698,13 @@ export class FlipOutEasyY
           ),
         },
         animations: {
-          transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('90deg', config)) },
-          ],
+          transform: animateTransformToValues(
+            [{ perspective: 500 }, { rotateY: '90deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         callback,
       };

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
@@ -1,5 +1,13 @@
 'use strict';
 import type {
+  PerspectiveTransform,
+  RotateXTransform,
+  RotateYTransform,
+  TranslateXTransform,
+  TranslateYTransform,
+} from 'react-native';
+
+import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
   EntryExitAnimationFunction,
@@ -371,8 +379,9 @@ export class FlipOutXUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -388,7 +397,10 @@ export class FlipOutXUp
             {
               translateY: delayFunction(
                 delay,
-                animation(-targetValues.currentHeight, config)
+                animation(
+                  targetValues?.translateY ?? -values.currentHeight,
+                  config
+                )
               ),
             },
           ],
@@ -428,8 +440,9 @@ export class FlipOutYLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -440,12 +453,25 @@ export class FlipOutYLeft
         },
         animations: {
           transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('-90deg', config)) },
+            {
+              perspective: delayFunction(
+                delay,
+                animation(targetValues?.perspective ?? 500, config)
+              ),
+            },
+            {
+              rotateY: delayFunction(
+                delay,
+                animation(targetValues?.rotateY ?? '-90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
-                animation(-targetValues.currentWidth, config)
+                animation(
+                  targetValues?.translateX ?? -values.currentWidth,
+                  config
+                )
               ),
             },
           ],
@@ -485,8 +511,9 @@ export class FlipOutXDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
-    return (targetValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -497,12 +524,25 @@ export class FlipOutXDown
         },
         animations: {
           transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateX: delayFunction(delay, animation('-90deg', config)) },
+            {
+              perspective: delayFunction(
+                delay,
+                animation(targetValues?.perspective ?? 500, config)
+              ),
+            },
+            {
+              rotateX: delayFunction(
+                delay,
+                animation(targetValues?.rotateX ?? '-90deg', config)
+              ),
+            },
             {
               translateY: delayFunction(
                 delay,
-                animation(targetValues.currentHeight, config)
+                animation(
+                  targetValues?.translateY ?? values.currentHeight,
+                  config
+                )
               ),
             },
           ],
@@ -542,6 +582,9 @@ export class FlipOutYRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const perspectiveOverride = this.targetValues?.perspective;
+    const rotateYOverride = this.targetValues?.rotateY;
+    const translateXOverride = this.targetValues?.translateX;
 
     return (targetValues) => {
       'worklet';
@@ -554,12 +597,25 @@ export class FlipOutYRight
         },
         animations: {
           transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateY: delayFunction(delay, animation('90deg', config)) },
+            {
+              perspective: delayFunction(
+                delay,
+                animation(perspectiveOverride ?? 500, config)
+              ),
+            },
+            {
+              rotateY: delayFunction(
+                delay,
+                animation(rotateYOverride ?? '90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
-                animation(targetValues.currentWidth, config)
+                animation(
+                  translateXOverride ?? targetValues.currentWidth,
+                  config
+                )
               ),
             },
           ],
@@ -597,6 +653,7 @@ export class FlipOutEasyX
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
@@ -609,8 +666,18 @@ export class FlipOutEasyX
         },
         animations: {
           transform: [
-            { perspective: delayFunction(delay, animation(500, config)) },
-            { rotateX: delayFunction(delay, animation('90deg', config)) },
+            {
+              perspective: delayFunction(
+                delay,
+                animation(targetValues?.perspective ?? 500, config)
+              ),
+            },
+            {
+              rotateX: delayFunction(
+                delay,
+                animation(targetValues?.rotateX ?? '90deg', config)
+              ),
+            },
           ],
         },
         callback,
@@ -646,6 +713,7 @@ export class FlipOutEasyY
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
@@ -1,13 +1,5 @@
 'use strict';
 import type {
-  PerspectiveTransform,
-  RotateXTransform,
-  RotateYTransform,
-  TranslateXTransform,
-  TranslateYTransform,
-} from 'react-native';
-
-import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
   EntryExitAnimationFunction,
@@ -57,9 +49,9 @@ export class FlipInXUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const builderTargetValues = this.targetValues;
+    const targetValues = this.targetValues;
 
-    return (layoutValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -67,7 +59,7 @@ export class FlipInXUp
             [
               { perspective: 500 },
               { rotateX: '90deg' },
-              { translateY: -layoutValues.targetHeight },
+              { translateY: -values.targetHeight },
             ],
             initialValues
           ),
@@ -75,7 +67,7 @@ export class FlipInXUp
         animations: {
           transform: animateTransformToValues(
             [{ perspective: 500 }, { rotateX: '0deg' }, { translateY: 0 }],
-            builderTargetValues,
+            targetValues,
             animationAndConfig,
             delayFunction,
             delay
@@ -116,9 +108,9 @@ export class FlipInYLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const builderTargetValues = this.targetValues;
+    const targetValues = this.targetValues;
 
-    return (layoutValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -126,7 +118,7 @@ export class FlipInYLeft
             [
               { perspective: 500 },
               { rotateY: '-90deg' },
-              { translateX: -layoutValues.targetWidth },
+              { translateX: -values.targetWidth },
             ],
             initialValues
           ),
@@ -134,7 +126,7 @@ export class FlipInYLeft
         animations: {
           transform: animateTransformToValues(
             [{ perspective: 500 }, { rotateY: '0deg' }, { translateX: 0 }],
-            builderTargetValues,
+            targetValues,
             animationAndConfig,
             delayFunction,
             delay
@@ -175,9 +167,9 @@ export class FlipInXDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const builderTargetValues = this.targetValues;
+    const targetValues = this.targetValues;
 
-    return (layoutValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -185,7 +177,7 @@ export class FlipInXDown
             [
               { perspective: 500 },
               { rotateX: '-90deg' },
-              { translateY: layoutValues.targetHeight },
+              { translateY: values.targetHeight },
             ],
             initialValues
           ),
@@ -193,7 +185,7 @@ export class FlipInXDown
         animations: {
           transform: animateTransformToValues(
             [{ perspective: 500 }, { rotateX: '0deg' }, { translateY: 0 }],
-            builderTargetValues,
+            targetValues,
             animationAndConfig,
             delayFunction,
             delay
@@ -234,9 +226,9 @@ export class FlipInYRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const builderTargetValues = this.targetValues;
+    const targetValues = this.targetValues;
 
-    return (layoutValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -244,7 +236,7 @@ export class FlipInYRight
             [
               { perspective: 500 },
               { rotateY: '90deg' },
-              { translateX: layoutValues.targetWidth },
+              { translateX: values.targetWidth },
             ],
             initialValues
           ),
@@ -252,7 +244,7 @@ export class FlipInYRight
         animations: {
           transform: animateTransformToValues(
             [{ perspective: 500 }, { rotateY: '0deg' }, { translateX: 0 }],
-            builderTargetValues,
+            targetValues,
             animationAndConfig,
             delayFunction,
             delay
@@ -576,9 +568,9 @@ export class FlipOutYRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
-    const builderTargetValues = this.targetValues;
+    const targetValues = this.targetValues;
 
-    return (layoutValues) => {
+    return (values) => {
       'worklet';
       return {
         initialValues: {
@@ -592,9 +584,9 @@ export class FlipOutYRight
             [
               { perspective: 500 },
               { rotateY: '90deg' },
-              { translateX: layoutValues.currentWidth },
+              { translateX: values.currentWidth },
             ],
-            builderTargetValues,
+            targetValues,
             animationAndConfig,
             delayFunction,
             delay

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -1,4 +1,10 @@
 'use strict';
+import type {
+  AnimatableNumericValue,
+  SkewXTransform,
+  TranslateXTransform,
+} from 'react-native';
+
 import { withSequence, withTiming } from '../../animation';
 import type {
   EntryExitAnimationFunction,
@@ -39,17 +45,24 @@ export class LightSpeedInRight
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, withTiming(1, { duration })),
+          opacity: delayFunction(
+            delay,
+            withTiming(targetValues?.opacity ?? 1, { duration })
+          ),
           transform: [
             {
               translateX: delayFunction(
                 delay,
-                animation(0, { ...config, duration: duration * 0.7 })
+                animation(targetValues?.translateX ?? 0, {
+                  ...config,
+                  duration: duration * 0.7,
+                })
               ),
             },
             {
@@ -58,7 +71,9 @@ export class LightSpeedInRight
                 withSequence(
                   withTiming('10deg', { duration: duration * 0.7 }),
                   withTiming('-5deg', { duration: duration * 0.15 }),
-                  withTiming('0deg', { duration: duration * 0.15 })
+                  withTiming(targetValues?.skewX ?? '0deg', {
+                    duration: duration * 0.15,
+                  })
                 )
               ),
             },
@@ -107,17 +122,24 @@ export class LightSpeedInLeft
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, withTiming(1, { duration })),
+          opacity: delayFunction(
+            delay,
+            withTiming(targetValues?.opacity ?? 1, { duration })
+          ),
           transform: [
             {
               translateX: delayFunction(
                 delay,
-                animation(0, { ...config, duration: duration * 0.7 })
+                animation(targetValues?.translateX ?? 0, {
+                  ...config,
+                  duration: duration * 0.7,
+                })
               ),
             },
             {
@@ -126,7 +148,9 @@ export class LightSpeedInLeft
                 withSequence(
                   withTiming('-10deg', { duration: duration * 0.7 }),
                   withTiming('5deg', { duration: duration * 0.15 }),
-                  withTiming('0deg', { duration: duration * 0.15 })
+                  withTiming(targetValues?.skewX ?? '0deg', {
+                    duration: duration * 0.15,
+                  })
                 )
               ),
             },
@@ -174,21 +198,31 @@ export class LightSpeedOutRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
             {
               translateX: delayFunction(
                 delay,
-                animation(values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? values.windowWidth,
+                  config
+                )
               ),
             },
             {
-              skewX: delayFunction(delay, animation('-45deg', config)),
+              skewX: delayFunction(
+                delay,
+                animation(targetValues?.skewX ?? '-45deg', config)
+              ),
             },
           ],
         },
@@ -234,21 +268,31 @@ export class LightSpeedOutLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
             {
               translateX: delayFunction(
                 delay,
-                animation(-values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? -values.windowWidth,
+                  config
+                )
               ),
             },
             {
-              skewX: delayFunction(delay, animation('45deg', config)),
+              skewX: delayFunction(
+                delay,
+                animation(targetValues?.skewX ?? '45deg', config)
+              ),
             },
           ],
         },

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -1,10 +1,4 @@
 'use strict';
-import type {
-  AnimatableNumericValue,
-  SkewXTransform,
-  TranslateXTransform,
-} from 'react-native';
-
 import { withSequence, withTiming } from '../../animation';
 import type {
   EntryExitAnimationFunction,
@@ -14,7 +8,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { SkewX, TransformsConfig, TranslateX } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 /**
  * Entry from right animation with change in skew and opacity. You can modify
  * the behavior by chaining methods like `.springify()` or `.duration(500)`.
@@ -194,7 +188,8 @@ export class LightSpeedOutRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -208,23 +203,13 @@ export class LightSpeedOutRight
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              skewX: delayFunction(
-                delay,
-                animation(targetValues?.skewX ?? '-45deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: values.windowWidth }, { skewX: '-45deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -264,7 +249,8 @@ export class LightSpeedOutLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -278,23 +264,13 @@ export class LightSpeedOutLeft
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? -values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              skewX: delayFunction(
-                delay,
-                animation(targetValues?.skewX ?? '45deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: -values.windowWidth }, { skewX: '45deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -8,7 +8,11 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { SkewX, TransformsConfig, TranslateX } from './types';
-import { animateTransformToValues, pickTransformValues } from './utils';
+import {
+  animateTransformToValues,
+  pickTransformValues,
+  resolveTransformSlot,
+} from './utils';
 /**
  * Entry from right animation with change in skew and opacity. You can modify
  * the behavior by chaining methods like `.springify()` or `.duration(500)`.
@@ -34,12 +38,24 @@ export class LightSpeedInRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
+
+    const { value: targetTranslateX } = resolveTransformSlot(
+      { translateX: 0 },
+      0,
+      targetValues
+    );
+    const { value: targetSkewX } = resolveTransformSlot(
+      { skewX: '0deg' },
+      1,
+      targetValues
+    );
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -53,7 +69,7 @@ export class LightSpeedInRight
             {
               translateX: delayFunction(
                 delay,
-                animation(targetValues?.translateX ?? 0, {
+                animation(targetTranslateX, {
                   ...config,
                   duration: duration * 0.7,
                 })
@@ -65,7 +81,7 @@ export class LightSpeedInRight
                 withSequence(
                   withTiming('10deg', { duration: duration * 0.7 }),
                   withTiming('-5deg', { duration: duration * 0.15 }),
-                  withTiming(targetValues?.skewX ?? '0deg', {
+                  withTiming(targetSkewX, {
                     duration: duration * 0.15,
                   })
                 )
@@ -111,12 +127,24 @@ export class LightSpeedInLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const duration = this.getDuration();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
     const targetValues = this.targetValues;
+
+    const { value: targetTranslateX } = resolveTransformSlot(
+      { translateX: 0 },
+      0,
+      targetValues
+    );
+    const { value: targetSkewX } = resolveTransformSlot(
+      { skewX: '0deg' },
+      1,
+      targetValues
+    );
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -130,7 +158,7 @@ export class LightSpeedInLeft
             {
               translateX: delayFunction(
                 delay,
-                animation(targetValues?.translateX ?? 0, {
+                animation(targetTranslateX, {
                   ...config,
                   duration: duration * 0.7,
                 })
@@ -142,7 +170,7 @@ export class LightSpeedInLeft
                 withSequence(
                   withTiming('-10deg', { duration: duration * 0.7 }),
                   withTiming('5deg', { duration: duration * 0.15 }),
-                  withTiming(targetValues?.skewX ?? '0deg', {
+                  withTiming(targetSkewX, {
                     duration: duration * 0.15,
                   })
                 )

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -1,18 +1,12 @@
 'use strict';
 import type {
-  AnimatableNumericValue,
-  RotateTransform,
-  ScaleTransform,
-} from 'react-native';
-
-import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
 } from '../../commonTypes';
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { Rotate, Scale, TransformsConfig } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Entry with change in rotation, scale, and opacity. You can modify the
@@ -39,7 +33,8 @@ export class PinwheelIn
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -53,20 +48,13 @@ export class PinwheelIn
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0rad', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 1 }, { rotate: '0rad' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -106,7 +94,8 @@ export class PinwheelOut
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -120,20 +109,13 @@ export class PinwheelOut
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '5rad', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 0 }, { rotate: '5rad' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -1,5 +1,11 @@
 'use strict';
 import type {
+  AnimatableNumericValue,
+  RotateTransform,
+  ScaleTransform,
+} from 'react-native';
+
+import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
 } from '../../commonTypes';
@@ -37,18 +43,28 @@ export class PinwheelIn
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
             {
-              scale: delayFunction(delay, animation(1, config)),
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
             },
             {
-              rotate: delayFunction(delay, animation('0rad', config)),
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0rad', config)
+              ),
             },
           ],
         },
@@ -94,18 +110,28 @@ export class PinwheelOut
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
             {
-              scale: delayFunction(delay, animation(0, config)),
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
             },
             {
-              rotate: delayFunction(delay, animation('5rad', config)),
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '5rad', config)
+              ),
             },
           ],
         },

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
@@ -1,6 +1,4 @@
 'use strict';
-import type { RotateTransform, TranslateXTransform } from 'react-native';
-
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
@@ -9,7 +7,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { Rotate, TransformsConfig, TranslateX } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Roll from left animation. You can modify the behavior by chaining methods
@@ -34,7 +32,7 @@ export class RollInLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -44,20 +42,13 @@ export class RollInLeft
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }, { rotate: '0deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -94,7 +85,7 @@ export class RollInRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -104,20 +95,13 @@ export class RollInRight
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }, { rotate: '0deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -154,7 +138,7 @@ export class RollOutLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -164,23 +148,13 @@ export class RollOutLeft
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? -values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '-180deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: -values.windowWidth }, { rotate: '-180deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -217,7 +191,7 @@ export class RollOutRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -227,23 +201,13 @@ export class RollOutRight
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '180deg', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: values.windowWidth }, { rotate: '180deg' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
@@ -1,4 +1,6 @@
 'use strict';
+import type { RotateTransform, TranslateXTransform } from 'react-native';
+
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
@@ -36,14 +38,25 @@ export class RollInLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { rotate: delayFunction(delay, animation('0deg', config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -85,14 +98,25 @@ export class RollInRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { rotate: delayFunction(delay, animation('0deg', config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -134,6 +158,7 @@ export class RollOutLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -143,10 +168,18 @@ export class RollOutLeft
             {
               translateX: delayFunction(
                 delay,
-                animation(-values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? -values.windowWidth,
+                  config
+                )
               ),
             },
-            { rotate: delayFunction(delay, animation('-180deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '-180deg', config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -188,6 +221,7 @@ export class RollOutRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -197,10 +231,18 @@ export class RollOutRight
             {
               translateX: delayFunction(
                 delay,
-                animation(values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? values.windowWidth,
+                  config
+                )
               ),
             },
-            { rotate: delayFunction(delay, animation('180deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '180deg', config)
+              ),
+            },
           ],
         },
         initialValues: {

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
@@ -1,6 +1,4 @@
 'use strict';
-import type { AnimatableNumericValue, RotateTransform } from 'react-native';
-
 import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
@@ -11,7 +9,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { Rotate, TransformsConfig, TranslateX, TranslateY } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Rotate to bottom from left edge. You can modify the behavior by chaining
@@ -38,7 +36,8 @@ export class RotateInDownLeft
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -52,26 +51,13 @@ export class RotateInDownLeft
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -117,7 +103,8 @@ export class RotateInDownRight
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -131,26 +118,13 @@ export class RotateInDownRight
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -198,7 +172,8 @@ export class RotateInUpLeft
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -212,26 +187,13 @@ export class RotateInUpLeft
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -275,7 +237,8 @@ export class RotateInUpRight
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -289,26 +252,13 @@ export class RotateInUpRight
             delay,
             animation(targetValues?.opacity ?? 1, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ rotate: '0deg' }, { translateX: 0 }, { translateY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 0,
@@ -354,7 +304,8 @@ export class RotateOutDownLeft
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -368,34 +319,21 @@ export class RotateOutDownLeft
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ??
-                    values.currentWidth / 2 - values.currentHeight / 2,
-                  config
-                )
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ??
-                    values.currentWidth / 2 - values.currentHeight / 2,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { rotate: '90deg' },
+              {
+                translateX: values.currentWidth / 2 - values.currentHeight / 2,
+              },
+              {
+                translateY: values.currentWidth / 2 - values.currentHeight / 2,
+              },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -435,7 +373,8 @@ export class RotateOutDownRight
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -449,34 +388,24 @@ export class RotateOutDownRight
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '-90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ??
-                    -(values.currentWidth / 2 - values.currentHeight / 2),
-                  config
-                )
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ??
-                    values.currentWidth / 2 - values.currentHeight / 2,
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { rotate: '-90deg' },
+              {
+                translateX: -(
+                  values.currentWidth / 2 -
+                  values.currentHeight / 2
+                ),
+              },
+              {
+                translateY: values.currentWidth / 2 - values.currentHeight / 2,
+              },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -516,7 +445,8 @@ export class RotateOutUpLeft
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -530,34 +460,24 @@ export class RotateOutUpLeft
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '-90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ??
-                    values.currentWidth / 2 - values.currentHeight / 2,
-                  config
-                )
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ??
-                    -(values.currentWidth / 2 - values.currentHeight / 2),
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { rotate: '-90deg' },
+              {
+                translateX: values.currentWidth / 2 - values.currentHeight / 2,
+              },
+              {
+                translateY: -(
+                  values.currentWidth / 2 -
+                  values.currentHeight / 2
+                ),
+              },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,
@@ -597,7 +517,8 @@ export class RotateOutUpRight
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
+    const [animation, config] = animationAndConfig;
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -611,34 +532,27 @@ export class RotateOutUpRight
             delay,
             animation(targetValues?.opacity ?? 0, config)
           ),
-          transform: [
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '90deg', config)
-              ),
-            },
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ??
-                    -(values.currentWidth / 2 - values.currentHeight / 2),
-                  config
-                )
-              ),
-            },
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ??
-                    -(values.currentWidth / 2 - values.currentHeight / 2),
-                  config
-                )
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [
+              { rotate: '90deg' },
+              {
+                translateX: -(
+                  values.currentWidth / 2 -
+                  values.currentHeight / 2
+                ),
+              },
+              {
+                translateY: -(
+                  values.currentWidth / 2 -
+                  values.currentHeight / 2
+                ),
+              },
+            ],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           opacity: initialValues?.opacity ?? 1,

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
@@ -1,4 +1,6 @@
 'use strict';
+import type { AnimatableNumericValue, RotateTransform } from 'react-native';
+
 import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
@@ -40,16 +42,35 @@ export class RotateInDownLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -100,16 +121,35 @@ export class RotateInDownRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -162,16 +202,35 @@ export class RotateInUpLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -220,16 +279,35 @@ export class RotateInUpRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(1, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 1, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('0deg', config)) },
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { translateY: delayFunction(delay, animation(0, config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0deg', config)
+              ),
+            },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -280,19 +358,29 @@ export class RotateOutDownLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('90deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
                 animation(
-                  values.currentWidth / 2 - values.currentHeight / 2,
+                  targetValues?.translateX ??
+                    values.currentWidth / 2 - values.currentHeight / 2,
                   config
                 )
               ),
@@ -301,7 +389,8 @@ export class RotateOutDownLeft
               translateY: delayFunction(
                 delay,
                 animation(
-                  values.currentWidth / 2 - values.currentHeight / 2,
+                  targetValues?.translateY ??
+                    values.currentWidth / 2 - values.currentHeight / 2,
                   config
                 )
               ),
@@ -350,19 +439,29 @@ export class RotateOutDownRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('-90deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '-90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
                 animation(
-                  -(values.currentWidth / 2 - values.currentHeight / 2),
+                  targetValues?.translateX ??
+                    -(values.currentWidth / 2 - values.currentHeight / 2),
                   config
                 )
               ),
@@ -371,7 +470,8 @@ export class RotateOutDownRight
               translateY: delayFunction(
                 delay,
                 animation(
-                  values.currentWidth / 2 - values.currentHeight / 2,
+                  targetValues?.translateY ??
+                    values.currentWidth / 2 - values.currentHeight / 2,
                   config
                 )
               ),
@@ -420,19 +520,29 @@ export class RotateOutUpLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('-90deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '-90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
                 animation(
-                  values.currentWidth / 2 - values.currentHeight / 2,
+                  targetValues?.translateX ??
+                    values.currentWidth / 2 - values.currentHeight / 2,
                   config
                 )
               ),
@@ -441,7 +551,8 @@ export class RotateOutUpLeft
               translateY: delayFunction(
                 delay,
                 animation(
-                  -(values.currentWidth / 2 - values.currentHeight / 2),
+                  targetValues?.translateY ??
+                    -(values.currentWidth / 2 - values.currentHeight / 2),
                   config
                 )
               ),
@@ -490,19 +601,29 @@ export class RotateOutUpRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
-          opacity: delayFunction(delay, animation(0, config)),
+          opacity: delayFunction(
+            delay,
+            animation(targetValues?.opacity ?? 0, config)
+          ),
           transform: [
-            { rotate: delayFunction(delay, animation('90deg', config)) },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '90deg', config)
+              ),
+            },
             {
               translateX: delayFunction(
                 delay,
                 animation(
-                  -(values.currentWidth / 2 - values.currentHeight / 2),
+                  targetValues?.translateX ??
+                    -(values.currentWidth / 2 - values.currentHeight / 2),
                   config
                 )
               ),
@@ -511,7 +632,8 @@ export class RotateOutUpRight
               translateY: delayFunction(
                 delay,
                 animation(
-                  -(values.currentWidth / 2 - values.currentHeight / 2),
+                  targetValues?.translateY ??
+                    -(values.currentWidth / 2 - values.currentHeight / 2),
                   config
                 )
               ),

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Slide.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Slide.ts
@@ -36,6 +36,7 @@ export class SlideInRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -43,7 +44,7 @@ export class SlideInRight
         animations: {
           originX: delayFunction(
             delay,
-            animation(values.targetOriginX, config)
+            animation(targetValues?.originX ?? values.targetOriginX, config)
           ),
         },
         initialValues: {
@@ -83,6 +84,7 @@ export class SlideInLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -90,7 +92,7 @@ export class SlideInLeft
         animations: {
           originX: delayFunction(
             delay,
-            animation(values.targetOriginX, config)
+            animation(targetValues?.originX ?? values.targetOriginX, config)
           ),
         },
         initialValues: {
@@ -130,6 +132,7 @@ export class SlideOutRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -138,10 +141,11 @@ export class SlideOutRight
           originX: delayFunction(
             delay,
             animation(
-              Math.max(
-                values.currentOriginX + values.windowWidth,
-                values.windowWidth
-              ),
+              targetValues?.originX ??
+                Math.max(
+                  values.currentOriginX + values.windowWidth,
+                  values.windowWidth
+                ),
               config
             )
           ),
@@ -183,6 +187,7 @@ export class SlideOutLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -191,10 +196,11 @@ export class SlideOutLeft
           originX: delayFunction(
             delay,
             animation(
-              Math.min(
-                values.currentOriginX - values.windowWidth,
-                -values.windowWidth
-              ),
+              targetValues?.originX ??
+                Math.min(
+                  values.currentOriginX - values.windowWidth,
+                  -values.windowWidth
+                ),
               config
             )
           ),
@@ -236,6 +242,7 @@ export class SlideInUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -243,7 +250,7 @@ export class SlideInUp
         animations: {
           originY: delayFunction(
             delay,
-            animation(values.targetOriginY, config)
+            animation(targetValues?.originY ?? values.targetOriginY, config)
           ),
         },
         initialValues: {
@@ -283,6 +290,7 @@ export class SlideInDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -290,7 +298,7 @@ export class SlideInDown
         animations: {
           originY: delayFunction(
             delay,
-            animation(values.targetOriginY, config)
+            animation(targetValues?.originY ?? values.targetOriginY, config)
           ),
         },
         initialValues: {
@@ -330,6 +338,7 @@ export class SlideOutUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -338,10 +347,11 @@ export class SlideOutUp
           originY: delayFunction(
             delay,
             animation(
-              Math.min(
-                values.currentOriginY - values.windowHeight,
-                -values.windowHeight
-              ),
+              targetValues?.originY ??
+                Math.min(
+                  values.currentOriginY - values.windowHeight,
+                  -values.windowHeight
+                ),
               config
             )
           ),
@@ -380,6 +390,7 @@ export class SlideOutDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -388,10 +399,11 @@ export class SlideOutDown
           originY: delayFunction(
             delay,
             animation(
-              Math.max(
-                values.currentOriginY + values.windowHeight,
-                values.windowHeight
-              ),
+              targetValues?.originY ??
+                Math.max(
+                  values.currentOriginY + values.windowHeight,
+                  values.windowHeight
+                ),
               config
             )
           ),

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
@@ -1,4 +1,6 @@
 'use strict';
+import type { ScaleXTransform, ScaleYTransform } from 'react-native';
+
 import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
@@ -121,12 +123,20 @@ export class StretchOutX
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scaleX: delayFunction(delay, animation(0, config)) }],
+          transform: [
+            {
+              scaleX: delayFunction(
+                delay,
+                animation(targetValues?.scaleX ?? 0, config)
+              ),
+            },
+          ],
         },
         initialValues: {
           transform: pickTransformValues([{ scaleX: 1 }], initialValues),
@@ -164,12 +174,20 @@ export class StretchOutY
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scaleY: delayFunction(delay, animation(0, config)) }],
+          transform: [
+            {
+              scaleY: delayFunction(
+                delay,
+                animation(targetValues?.scaleY ?? 0, config)
+              ),
+            },
+          ],
         },
         initialValues: {
           transform: pickTransformValues([{ scaleY: 1 }], initialValues),

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
@@ -1,6 +1,4 @@
 'use strict';
-import type { ScaleXTransform, ScaleYTransform } from 'react-native';
-
 import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
@@ -8,7 +6,7 @@ import type {
 import type { BaseAnimationBuilder } from '../animationBuilder';
 import { ComplexAnimationBuilder } from '../animationBuilder';
 import type { ScaleX, ScaleY, TransformsConfig } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Stretch animation on the X axis. You can modify the behavior by chaining
@@ -33,16 +31,23 @@ export class StretchInX
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scaleX: delayFunction(delay, animation(1, config)) }],
+          transform: animateTransformToValues(
+            [{ scaleX: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scaleX: 0 }], initialValues),
@@ -76,16 +81,23 @@ export class StretchInY
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scaleY: delayFunction(delay, animation(1, config)) }],
+          transform: animateTransformToValues(
+            [{ scaleY: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scaleY: 0 }], initialValues),
@@ -119,7 +131,7 @@ export class StretchOutX
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -129,14 +141,13 @@ export class StretchOutX
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scaleX: delayFunction(
-                delay,
-                animation(targetValues?.scaleX ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scaleX: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scaleX: 1 }], initialValues),
@@ -170,7 +181,7 @@ export class StretchOutY
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -180,14 +191,13 @@ export class StretchOutY
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scaleY: delayFunction(
-                delay,
-                animation(targetValues?.scaleY ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scaleY: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scaleY: 1 }], initialValues),

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
@@ -47,12 +47,20 @@ export class ZoomIn
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scale: delayFunction(delay, animation(1, config)) }],
+          transform: [
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
+          ],
         },
         initialValues: {
           transform: pickTransformValues([{ scale: 0 }], initialValues),
@@ -91,14 +99,25 @@ export class ZoomInRotate
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
           transform: [
-            { scale: delayFunction(delay, animation(1, config)) },
-            { rotate: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? '0rad', config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -140,14 +159,25 @@ export class ZoomInLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -189,14 +219,25 @@ export class ZoomInRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateX: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateX: delayFunction(
+                delay,
+                animation(targetValues?.translateX ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -238,14 +279,25 @@ export class ZoomInUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -287,14 +339,25 @@ export class ZoomInDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -336,14 +399,25 @@ export class ZoomInEasyUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -385,14 +459,25 @@ export class ZoomInEasyDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
       return {
         animations: {
           transform: [
-            { translateY: delayFunction(delay, animation(0, config)) },
-            { scale: delayFunction(delay, animation(1, config)) },
+            {
+              translateY: delayFunction(
+                delay,
+                animation(targetValues?.translateY ?? 0, config)
+              ),
+            },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 1, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -434,12 +519,20 @@ export class ZoomOut
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
-          transform: [{ scale: delayFunction(delay, animation(0, config)) }],
+          transform: [
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
+          ],
         },
         initialValues: {
           transform: pickTransformValues([{ scale: 1 }], initialValues),
@@ -478,14 +571,25 @@ export class ZoomOutRotate
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return () => {
       'worklet';
       return {
         animations: {
           transform: [
-            { scale: delayFunction(delay, animation(0, config)) },
-            { rotate: delayFunction(delay, animation(rotate, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
+            {
+              rotate: delayFunction(
+                delay,
+                animation(targetValues?.rotate ?? rotate, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -527,6 +631,7 @@ export class ZoomOutLeft
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -536,10 +641,18 @@ export class ZoomOutLeft
             {
               translateX: delayFunction(
                 delay,
-                animation(-values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? -values.windowWidth,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -581,6 +694,7 @@ export class ZoomOutRight
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -590,10 +704,18 @@ export class ZoomOutRight
             {
               translateX: delayFunction(
                 delay,
-                animation(values.windowWidth, config)
+                animation(
+                  targetValues?.translateX ?? values.windowWidth,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -635,6 +757,7 @@ export class ZoomOutUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -644,10 +767,18 @@ export class ZoomOutUp
             {
               translateY: delayFunction(
                 delay,
-                animation(-values.windowHeight, config)
+                animation(
+                  targetValues?.translateY ?? -values.windowHeight,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -689,6 +820,7 @@ export class ZoomOutDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values: EntryExitAnimationsValues) => {
       'worklet';
@@ -698,10 +830,18 @@ export class ZoomOutDown
             {
               translateY: delayFunction(
                 delay,
-                animation(values.windowHeight, config)
+                animation(
+                  targetValues?.translateY ?? values.windowHeight,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -743,6 +883,7 @@ export class ZoomOutEasyUp
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -752,10 +893,18 @@ export class ZoomOutEasyUp
             {
               translateY: delayFunction(
                 delay,
-                animation(-values.currentHeight, config)
+                animation(
+                  targetValues?.translateY ?? -values.currentHeight,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {
@@ -797,6 +946,7 @@ export class ZoomOutEasyDown
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
+    const targetValues = this.targetValues;
 
     return (values) => {
       'worklet';
@@ -806,10 +956,18 @@ export class ZoomOutEasyDown
             {
               translateY: delayFunction(
                 delay,
-                animation(values.currentHeight, config)
+                animation(
+                  targetValues?.translateY ?? values.currentHeight,
+                  config
+                )
               ),
             },
-            { scale: delayFunction(delay, animation(0, config)) },
+            {
+              scale: delayFunction(
+                delay,
+                animation(targetValues?.scale ?? 0, config)
+              ),
+            },
           ],
         },
         initialValues: {

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
@@ -18,7 +18,7 @@ import type {
   TranslateX,
   TranslateY,
 } from './types';
-import { pickTransformValues } from './utils';
+import { animateTransformToValues, pickTransformValues } from './utils';
 
 /**
  * Scale from center animation. You can modify the behavior by chaining methods
@@ -43,7 +43,7 @@ export class ZoomIn
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -53,14 +53,13 @@ export class ZoomIn
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scale: 0 }], initialValues),
@@ -94,7 +93,7 @@ export class ZoomInRotate
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
@@ -105,20 +104,13 @@ export class ZoomInRotate
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? '0rad', config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 1 }, { rotate: '0rad' }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -155,7 +147,7 @@ export class ZoomInLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -165,20 +157,13 @@ export class ZoomInLeft
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -215,7 +200,7 @@ export class ZoomInRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -225,20 +210,13 @@ export class ZoomInRight
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(targetValues?.translateX ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -275,7 +253,7 @@ export class ZoomInUp
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -285,20 +263,13 @@ export class ZoomInUp
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -335,7 +306,7 @@ export class ZoomInDown
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -345,20 +316,13 @@ export class ZoomInDown
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -395,7 +359,7 @@ export class ZoomInEasyUp
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -405,20 +369,13 @@ export class ZoomInEasyUp
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -455,7 +412,7 @@ export class ZoomInEasyDown
 
   build = (): AnimationConfigFunction<EntryAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -465,20 +422,13 @@ export class ZoomInEasyDown
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(targetValues?.translateY ?? 0, config)
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 1, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: 0 }, { scale: 1 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -515,7 +465,7 @@ export class ZoomOut
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -525,14 +475,13 @@ export class ZoomOut
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues([{ scale: 1 }], initialValues),
@@ -566,7 +515,7 @@ export class ZoomOutRotate
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const rotate = this.rotateV ? this.rotateV : '0.3';
     const callback = this.callbackV;
@@ -577,20 +526,13 @@ export class ZoomOutRotate
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-            {
-              rotate: delayFunction(
-                delay,
-                animation(targetValues?.rotate ?? rotate, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ scale: 0 }, { rotate }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -627,7 +569,7 @@ export class ZoomOutLeft
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -637,23 +579,13 @@ export class ZoomOutLeft
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? -values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: -values.windowWidth }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -690,7 +622,7 @@ export class ZoomOutRight
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -700,23 +632,13 @@ export class ZoomOutRight
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateX: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateX ?? values.windowWidth,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateX: values.windowWidth }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -753,7 +675,7 @@ export class ZoomOutUp
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -763,23 +685,13 @@ export class ZoomOutUp
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? -values.windowHeight,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: -values.windowHeight }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -816,7 +728,7 @@ export class ZoomOutDown
 
   build = (): EntryExitAnimationFunction => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -826,23 +738,13 @@ export class ZoomOutDown
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? values.windowHeight,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: values.windowHeight }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -879,7 +781,7 @@ export class ZoomOutEasyUp
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -889,23 +791,13 @@ export class ZoomOutEasyUp
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? -values.currentHeight,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: -values.currentHeight }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(
@@ -942,7 +834,7 @@ export class ZoomOutEasyDown
 
   build = (): AnimationConfigFunction<ExitAnimationsValues> => {
     const delayFunction = this.getDelayFunction();
-    const [animation, config] = this.getAnimationAndConfig();
+    const animationAndConfig = this.getAnimationAndConfig();
     const delay = this.getDelay();
     const callback = this.callbackV;
     const initialValues = this.initialValues;
@@ -952,23 +844,13 @@ export class ZoomOutEasyDown
       'worklet';
       return {
         animations: {
-          transform: [
-            {
-              translateY: delayFunction(
-                delay,
-                animation(
-                  targetValues?.translateY ?? values.currentHeight,
-                  config
-                )
-              ),
-            },
-            {
-              scale: delayFunction(
-                delay,
-                animation(targetValues?.scale ?? 0, config)
-              ),
-            },
-          ],
+          transform: animateTransformToValues(
+            [{ translateY: values.currentHeight }, { scale: 0 }],
+            targetValues,
+            animationAndConfig,
+            delayFunction,
+            delay
+          ),
         },
         initialValues: {
           transform: pickTransformValues(

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
@@ -1,25 +1,51 @@
 'use strict';
 
 import type { UnknownRecord } from '../../common';
+import type {
+  AnimationFunction,
+  LayoutAnimationAndConfig,
+} from '../../commonTypes';
 import type { TransformArray, TransformsConfig } from './types';
 
-/**
- * Resolves a whole transform tuple for layout animation initial values. For
- * each slot, tries the flat prop first, then the deprecated
- * `transform[index][key]`, then the provided default.
- */
+function resolveTransformSlot<const TTransforms extends TransformArray>(
+  entry: TTransforms[number],
+  index: number,
+  values: Partial<TransformsConfig<TTransforms>> | undefined
+): [string, unknown] {
+  'worklet';
+  const [key, defaultValue] = Object.entries(entry)[0];
+  const value =
+    values?.[key as keyof typeof values] ??
+    (values?.transform?.[index] as UnknownRecord | undefined)?.[key] ??
+    defaultValue;
+  return [key, value];
+}
+
 export function pickTransformValues<const TTransforms extends TransformArray>(
   defaults: TTransforms,
   values: Partial<TransformsConfig<TTransforms>> | undefined
 ): TTransforms {
   'worklet';
   return defaults.map((entry, index) => {
-    const [key, defaultValue] = Object.entries(entry)[0];
+    const [key, value] = resolveTransformSlot(entry, index, values);
+    return { [key]: value };
+  }) as unknown as TTransforms;
+}
+
+export function animateTransformToValues<
+  const TTransforms extends TransformArray,
+>(
+  defaults: TTransforms,
+  values: Partial<TransformsConfig<TTransforms>> | undefined,
+  [animation, config]: LayoutAnimationAndConfig,
+  delayFunction: AnimationFunction,
+  delay: number
+): TTransforms {
+  'worklet';
+  return defaults.map((entry, index) => {
+    const [key, value] = resolveTransformSlot(entry, index, values);
     return {
-      [key]:
-        values?.[key as keyof typeof values] ??
-        (values?.transform?.[index] as UnknownRecord | undefined)?.[key] ??
-        defaultValue,
+      [key]: delayFunction(delay, animation(value, config)),
     };
   }) as unknown as TTransforms;
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
@@ -24,6 +24,18 @@ export function resolveTransformSlot<
   return { key: key as keyof TEntry, value };
 }
 
+export function resolveTransformValue<
+  const TTransforms extends TransformArray,
+  TEntry extends TTransforms[number],
+>(
+  entry: TEntry,
+  index: number,
+  values: Partial<TransformsConfig<TTransforms>> | undefined
+): TEntry[keyof TEntry] {
+  'worklet';
+  return resolveTransformSlot(entry, index, values).value;
+}
+
 export function pickTransformValues<const TTransforms extends TransformArray>(
   defaults: TTransforms,
   values: Partial<TransformsConfig<TTransforms>> | undefined

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/utils.ts
@@ -7,18 +7,21 @@ import type {
 } from '../../commonTypes';
 import type { TransformArray, TransformsConfig } from './types';
 
-function resolveTransformSlot<const TTransforms extends TransformArray>(
-  entry: TTransforms[number],
+export function resolveTransformSlot<
+  const TTransforms extends TransformArray,
+  TEntry extends TTransforms[number],
+>(
+  entry: TEntry,
   index: number,
   values: Partial<TransformsConfig<TTransforms>> | undefined
-): [string, unknown] {
+): { key: keyof TEntry; value: TEntry[keyof TEntry] } {
   'worklet';
   const [key, defaultValue] = Object.entries(entry)[0];
   const value =
     values?.[key as keyof typeof values] ??
     (values?.transform?.[index] as UnknownRecord | undefined)?.[key] ??
     defaultValue;
-  return [key, value];
+  return { key: key as keyof TEntry, value };
 }
 
 export function pickTransformValues<const TTransforms extends TransformArray>(
@@ -27,7 +30,7 @@ export function pickTransformValues<const TTransforms extends TransformArray>(
 ): TTransforms {
   'worklet';
   return defaults.map((entry, index) => {
-    const [key, value] = resolveTransformSlot(entry, index, values);
+    const { key, value } = resolveTransformSlot(entry, index, values);
     return { [key]: value };
   }) as unknown as TTransforms;
 }
@@ -43,7 +46,7 @@ export function animateTransformToValues<
 ): TTransforms {
   'worklet';
   return defaults.map((entry, index) => {
-    const [key, value] = resolveTransformSlot(entry, index, values);
+    const { key, value } = resolveTransformSlot(entry, index, values);
     return {
       [key]: delayFunction(delay, animation(value, config)),
     };


### PR DESCRIPTION
## Summary

Adds "withTargetValues" modifier for all predefined default exit layout animations. "withInitialValues" allows to customize entering layout animations, but animation target vales were impossible to modify without creating a custom layout animation.

Example usage:

```
FadeOutDown.withTargetValues({
  opacity: 0.2,
  translateY: 100,
}),
```

Demo:

https://github.com/user-attachments/assets/1fa2c7ff-c7af-4225-ab21-b12ffe2982e7


## Test plan

Feature can be tested in added example: "[LA] Default layout animations overrides"
