### PR TITLE
fix: don't throw error on undefined color props

### DIFF
--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/colors.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/colors.test.ts
@@ -48,6 +48,14 @@ describe(processColorsInProps, () => {
       expect(props).toEqual({ [key]: value });
     });
   });
+
+  test('skips undefined color values', () => {
+    const props = { backgroundColor: undefined };
+
+    processColorsInProps(props);
+
+    expect(props).toEqual(props);
+  });
 });
 
 describe(processColor, () => {

--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -232,6 +232,7 @@ export function processColorsInProps(props: StyleProps) {
   for (const key in props) {
     if (!ColorProperties.includes(key)) continue;
     const value = props[key];
+    if (value == null) continue;
     props[key] = Array.isArray(value)
       ? value.map((c) => processColor(c))
       : processColor(value);


### PR DESCRIPTION
## Summary

Passing undefined to a color prop in v4 causes an error `[ReanimatedError: [Reanimated] Invalid color value: undefined]`, this skips processing props that are undefined or null.

## Test plan

Tested in an app with a style like `{ borderColor: undefined }`, which doesn't crash in v3, but does in v4. Tested that it no longer crashes after this change.
