### PR TITLE
Don't cleanup layout animations on the JS thread

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DurationZeroVirtual.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/DurationZeroVirtual.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import Animated, {
+  withTiming,
+  type LayoutAnimationFunction,
+} from 'react-native-reanimated';
+
+type Box = { id: number; color: string; y: number };
+
+const INITIAL_DATA: Box[] = [...new Array<number>(6)].map((_, index) => ({
+  id: index,
+  color: `hsl(${(index * 137.5) % 360}, 70%, 60%)`,
+  y: 20 + index * 100,
+}));
+
+const customLayout: LayoutAnimationFunction = (values) => {
+  'worklet';
+  return {
+    initialValues: { originY: values.currentOriginY },
+    animations: { originY: withTiming(values.targetOriginY, { duration: 0 }) },
+  };
+};
+
+export default function DurationZeroVirtualization() {
+  const [data, setData] = React.useState<Box[]>(INITIAL_DATA);
+
+  const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offsetY = event.nativeEvent.contentOffset.y;
+    setData((data) =>
+      data.map((box) => ({
+        ...box,
+        y:
+          offsetY > box.y
+            ? box.y + data.length * 100
+            : box.y - data.length * 100 > offsetY
+              ? box.y - data.length * 100
+              : box.y,
+      }))
+    );
+  };
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.contentContainer}
+      onScroll={onScroll}
+      scrollEventThrottle={16}>
+      {data.map((box) => (
+        <Animated.View
+          layout={customLayout}
+          key={box.id}
+          style={[styles.content, { backgroundColor: box.color, top: box.y }]}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    alignItems: 'center',
+    paddingVertical: 50,
+    gap: 8,
+    height: 10000,
+  },
+  content: {
+    position: 'absolute',
+    left: '15%',
+    width: '70%',
+    height: 80,
+    borderRadius: 10,
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -161,6 +161,7 @@ import InstanceDiscoveryExample from './InstanceDiscoveryExample';
 import ShadowNodesCloningExample from './ShadowNodesCloningExample';
 import EmptyExample from './EmptyExample';
 import AnimatedPropsExample from './AnimatedPropsExample';
+import DurationZeroVirtualization from './LayoutAnimations/DurationZeroVirtual';
 
 export const REAPlatform = {
   IOS: 'ios',
@@ -173,33 +174,18 @@ export interface Example {
   icon?: string;
   title: string;
   screen: React.FC;
-  shouldWork?: {
-    ios: boolean;
-    android: boolean;
-  };
+  shouldWork?: { ios: boolean; android: boolean };
   missingOnFabric?: boolean;
   disabledPlatforms?: (typeof REAPlatform)[keyof typeof REAPlatform][];
 }
 
 export const EXAMPLES: Record<string, Example> = {
   // About
-  AboutExample: {
-    icon: 'ℹ️',
-    title: 'About',
-    screen: AboutExample,
-  },
+  AboutExample: { icon: 'ℹ️', title: 'About', screen: AboutExample },
 
   // Empty example for test purposes
-  EmptyExample: {
-    icon: '👻',
-    title: 'Empty',
-    screen: EmptyExample,
-  },
-  FpsExample: {
-    icon: '🎞️',
-    title: 'FPS',
-    screen: FpsExample,
-  },
+  EmptyExample: { icon: '👻', title: 'Empty', screen: EmptyExample },
+  FpsExample: { icon: '🎞️', title: 'FPS', screen: FpsExample },
   SyncBackToReactExample: {
     icon: '🔄',
     title: 'Sync back to React',
@@ -232,11 +218,7 @@ export const EXAMPLES: Record<string, Example> = {
     screen: SynchronizablePerformanceExample,
     disabledPlatforms: [REAPlatform.WEB],
   },
-  ReactFreeze: {
-    icon: '❄️',
-    title: 'React freeze',
-    screen: FreezeExample,
-  },
+  ReactFreeze: { icon: '❄️', title: 'React freeze', screen: FreezeExample },
   RunOnUIAsyncExample: {
     icon: '👷‍♂️',
     title: 'runOnUIAsync',
@@ -248,21 +230,13 @@ export const EXAMPLES: Record<string, Example> = {
     screen: WorkletRuntimeExample,
     disabledPlatforms: [REAPlatform.WEB],
   },
-  ModifyExample: {
-    icon: '🪛',
-    title: 'Modify',
-    screen: ModifyExample,
-  },
+  ModifyExample: { icon: '🪛', title: 'Modify', screen: ModifyExample },
   CircularSliderExample: {
     icon: '🔘',
     title: 'Circular slider',
     screen: CircularSliderExample,
   },
-  MemoExample: {
-    icon: '🧠',
-    title: 'Memo',
-    screen: MemoExample,
-  },
+  MemoExample: { icon: '🧠', title: 'Memo', screen: MemoExample },
   AnimatedPropsExample: {
     icon: '🎨',
     title: 'Animated props',
@@ -298,26 +272,14 @@ export const EXAMPLES: Record<string, Example> = {
 
   // Showcase
 
-  BokehExample: {
-    icon: '✨',
-    title: 'Bokeh',
-    screen: BokehExample,
-  },
-  BubblesExample: {
-    icon: '🫧',
-    title: 'Bubbles',
-    screen: BubblesExample,
-  },
+  BokehExample: { icon: '✨', title: 'Bokeh', screen: BokehExample },
+  BubblesExample: { icon: '🫧', title: 'Bubbles', screen: BubblesExample },
   OpacityTransformExample: {
     icon: '🌀',
     title: 'opacity & transform',
     screen: OpacityTransformExample,
   },
-  IPodExample: {
-    icon: '🎧',
-    title: 'iPod',
-    screen: IPodExample,
-  },
+  IPodExample: { icon: '🎧', title: 'iPod', screen: IPodExample },
   EmojiWaterfallExample: {
     icon: '💸',
     title: 'Emoji waterfall',
@@ -328,11 +290,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Camera roll',
     screen: LightBoxExample,
   },
-  LiquidSwipe: {
-    icon: '♠️',
-    title: 'Liquid swipe',
-    screen: LiquidSwipe,
-  },
+  LiquidSwipe: { icon: '♠️', title: 'Liquid swipe', screen: LiquidSwipe },
   SwipeableListExample: {
     icon: '📞',
     title: 'Swipeable list',
@@ -343,11 +301,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Article progress',
     screen: ArticleProgressExample,
   },
-  LettersExample: {
-    icon: '📖',
-    title: 'Letters',
-    screen: LettersExample,
-  },
+  LettersExample: { icon: '📖', title: 'Letters', screen: LettersExample },
   SetNativePropsExample: {
     icon: '🪄',
     title: 'setNativeProps',
@@ -371,31 +325,15 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Animate inner component',
     screen: AnimatableRefExample,
   },
-  AmountExample: {
-    icon: '📈',
-    title: 'Amount',
-    screen: AmountExample,
-  },
-  CounterExample: {
-    icon: '🎰',
-    title: 'Counter',
-    screen: CounterExample,
-  },
+  AmountExample: { icon: '📈', title: 'Amount', screen: AmountExample },
+  CounterExample: { icon: '🎰', title: 'Counter', screen: CounterExample },
   AnimatedTextWidthExample: {
     icon: '✂️',
     title: 'Animate text width',
     screen: AnimatedTextWidthExample,
   },
-  ColorExample: {
-    icon: '🌈',
-    title: 'Animate colors',
-    screen: ColorExample,
-  },
-  FilterExample: {
-    icon: '🖼️',
-    title: 'Animate filter',
-    screen: FilterExample,
-  },
+  ColorExample: { icon: '🌈', title: 'Animate colors', screen: ColorExample },
+  FilterExample: { icon: '🖼️', title: 'Animate filter', screen: FilterExample },
   SynchronousPropsExample: {
     icon: '⚡',
     title: 'Animate synchronous props',
@@ -416,16 +354,8 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Draggable circle',
     screen: GestureHandlerExample,
   },
-  SvgExample: {
-    icon: '🟢',
-    title: 'Animated SVG circle',
-    screen: SvgExample,
-  },
-  PlanetsExample: {
-    icon: '🪐',
-    title: 'Planets',
-    screen: PlanetsExample,
-  },
+  SvgExample: { icon: '🟢', title: 'Animated SVG circle', screen: SvgExample },
+  PlanetsExample: { icon: '🪐', title: 'Planets', screen: PlanetsExample },
   BouncingBoxExample: {
     icon: '📦',
     title: 'Bouncing box',
@@ -471,11 +401,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'useAnimatedScrollHandler',
     screen: ScrollViewExample,
   },
-  ScrollToExample: {
-    icon: '🦘',
-    title: 'scrollTo',
-    screen: ScrollToExample,
-  },
+  ScrollToExample: { icon: '🦘', title: 'scrollTo', screen: ScrollToExample },
   ScrollViewOffsetExample: {
     icon: '𝌍',
     title: 'useScrollOffset',
@@ -496,11 +422,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Dispatch command',
     screen: DispatchCommandExample,
   },
-  MeasureExample: {
-    icon: '📐',
-    title: 'measure',
-    screen: MeasureExample,
-  },
+  MeasureExample: { icon: '📐', title: 'measure', screen: MeasureExample },
   WorkletExample: {
     icon: '🧵',
     title: 'scheduleOnRN / scheduleOnUI',
@@ -516,11 +438,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Transform',
     screen: TransformExample,
   },
-  WidthExample: {
-    icon: '🌲',
-    title: 'Layout props',
-    screen: WidthExample,
-  },
+  WidthExample: { icon: '🌲', title: 'Layout props', screen: WidthExample },
   NonLayoutPropAndRenderExample: {
     icon: '🎭',
     title: 'Non-layout prop and render example',
@@ -531,21 +449,13 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Ref & useImperativeHandle',
     screen: RefExample,
   },
-  ChessExample: {
-    icon: '♟️',
-    title: 'Chess',
-    screen: ChessExample,
-  },
+  ChessExample: { icon: '♟️', title: 'Chess', screen: ChessExample },
   ChessboardExample: {
     icon: '♟️',
     title: 'Chessboard',
     screen: ChessboardExample,
   },
-  Game2048Example: {
-    icon: '🕹️',
-    title: '2048',
-    screen: Game2048Example,
-  },
+  Game2048Example: { icon: '🕹️', title: '2048', screen: Game2048Example },
   OverlappingBoxesExample: {
     icon: '🔝',
     title: 'z-index & elevation',
@@ -556,11 +466,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Conditional',
     screen: NewestShadowNodesRegistryRemoveExample,
   },
-  RainbowExample: {
-    icon: '🌈',
-    title: 'Rainbow',
-    screen: RainbowExample,
-  },
+  RainbowExample: { icon: '🌈', title: 'Rainbow', screen: RainbowExample },
   WithoutBabelPluginExample: {
     icon: '🔌',
     title: 'Without Babel plugin',
@@ -612,21 +518,13 @@ export const EXAMPLES: Record<string, Example> = {
       REAPlatform.MACOS,
     ],
   },
-  LogExample: {
-    icon: '⌨',
-    title: 'Log test',
-    screen: LogExample,
-  },
+  LogExample: { icon: '⌨', title: 'Log test', screen: LogExample },
   WorkletFactoryCrash: {
     icon: '🏭',
     title: 'Worklet factory crash',
     screen: WorkletFactoryCrash,
   },
-  HabitsExample: {
-    icon: '🧑‍💻',
-    title: 'Habits',
-    screen: HabitsExample,
-  },
+  HabitsExample: { icon: '🧑‍💻', title: 'Habits', screen: HabitsExample },
   PerformanceMonitorExample: {
     icon: '⏱️',
     title: 'Performance monitor',
@@ -647,11 +545,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Composed handler internal merging',
     screen: ComposedHandlerInternalMergingExample,
   },
-  BBExample: {
-    icon: '💀',
-    title: 'BB',
-    screen: BBExample,
-  },
+  BBExample: { icon: '💀', title: 'BB', screen: BBExample },
   StrictDOMExample: {
     icon: '👮‍♂️',
     title: 'React Strict DOM',
@@ -661,28 +555,19 @@ export const EXAMPLES: Record<string, Example> = {
     icon: '🙆‍♂️',
     title: 'Profiles',
     screen: ProfilesExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   ProgressTransitionExample: {
     icon: '☕',
     title: 'Progress transition',
     screen: ProgressTransitionExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   GalleryExample: {
     icon: '🇮🇹',
     title: 'Gallery',
     screen: GalleryExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   DynamicColorIOSExample: {
     title: 'DynamicColorIOS',
@@ -706,26 +591,11 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Animated style update',
     screen: AnimatedStyleUpdateExample,
   },
-  SharedStyleExample: {
-    title: 'Shared style',
-    screen: SharedStyleExample,
-  },
-  AnimatedTabBarExample: {
-    title: 'Tab bar',
-    screen: AnimatedTabBarExample,
-  },
-  ChatHeadsExample: {
-    title: 'Chat heads',
-    screen: ChatHeadsExample,
-  },
-  CubesExample: {
-    title: 'Cubes',
-    screen: CubesExample,
-  },
-  DragAndSnapExample: {
-    title: 'Drag and snap',
-    screen: DragAndSnapExample,
-  },
+  SharedStyleExample: { title: 'Shared style', screen: SharedStyleExample },
+  AnimatedTabBarExample: { title: 'Tab bar', screen: AnimatedTabBarExample },
+  ChatHeadsExample: { title: 'Chat heads', screen: ChatHeadsExample },
+  CubesExample: { title: 'Cubes', screen: CubesExample },
+  DragAndSnapExample: { title: 'Drag and snap', screen: DragAndSnapExample },
   ColorInterpolationExample: {
     title: 'Color interpolation',
     screen: ColorInterpolationExample,
@@ -742,14 +612,8 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Old animated sensor example',
     screen: OldAnimatedSensorExample,
   },
-  OldMeasureExample: {
-    title: 'Accordion',
-    screen: OldMeasureExample,
-  },
-  PinExample: {
-    title: 'PIN example',
-    screen: PinExample,
-  },
+  OldMeasureExample: { title: 'Accordion', screen: OldMeasureExample },
+  PinExample: { title: 'PIN example', screen: PinExample },
   ScrollableViewExample: {
     title: 'Scrollable view example',
     screen: ScrollableViewExample,
@@ -758,10 +622,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: 'Scroll event example',
     screen: ScrollEventExample,
   },
-  WobbleExample: {
-    title: 'Wobble example',
-    screen: WobbleExample,
-  },
+  WobbleExample: { title: 'Wobble example', screen: WobbleExample },
   TransformOriginExample: {
     title: 'Transform origin example',
     screen: TransformOriginExample,
@@ -820,10 +681,7 @@ export const EXAMPLES: Record<string, Example> = {
     title: '[LA] Custom layout animation',
     screen: CustomLayoutAnimationScreen,
   },
-  ModalNewAPI: {
-    title: '[LA] ModalNewAPI',
-    screen: ModalNewAPI,
-  },
+  ModalNewAPI: { title: '[LA] ModalNewAPI', screen: ModalNewAPI },
   SpringLayoutAnimation: {
     title: '[LA] Spring Layout Animation',
     screen: SpringLayoutAnimation,
@@ -844,22 +702,13 @@ export const EXAMPLES: Record<string, Example> = {
     title: '[LA] List item layout animation',
     screen: ListItemLayoutAnimation,
   },
-  SwipeableList: {
-    title: '[LA] Swipeable list',
-    screen: SwipeableList,
-  },
-  Modal: {
-    title: '[LA] Modal',
-    screen: Modal,
-  },
+  SwipeableList: { title: '[LA] Swipeable list', screen: SwipeableList },
+  Modal: { title: '[LA] Modal', screen: Modal },
   NativeModals: {
     title: '[LA] Native modals (RN and Screens)',
     screen: NativeModals,
   },
-  Carousel: {
-    title: '[LA] Carousel',
-    screen: Carousel,
-  },
+  Carousel: { title: '[LA] Carousel', screen: Carousel },
   ReducedMotionLayoutExample: {
     title: '[LA] Reduced Motion',
     screen: ReducedMotionLayoutExample,
@@ -872,37 +721,26 @@ export const EXAMPLES: Record<string, Example> = {
     title: '[LA] FlatList skip entering & exiting',
     screen: FlatListSkipEnteringExiting,
   },
-  ChangeTheme: {
-    title: '[LA] Change theme',
-    screen: ChangeThemeExample,
-  },
-  BottomTabs: {
-    title: '[LA] Bottom Tabs',
-    screen: BottomTabsExample,
-  },
+  ChangeTheme: { title: '[LA] Change theme', screen: ChangeThemeExample },
+  BottomTabs: { title: '[LA] Bottom Tabs', screen: BottomTabsExample },
   ViewFlattening: {
     title: '[LA] View Flattening',
     screen: ViewFlatteningExample,
   },
-  ViewRecycling: {
-    title: '[LA] View Recycling',
-    screen: ViewRecyclingExample,
-  },
-  ReparentingExample: {
-    title: '[LA] Reparenting',
-    screen: ReparentingExample,
-  },
+  ViewRecycling: { title: '[LA] View Recycling', screen: ViewRecyclingExample },
+  ReparentingExample: { title: '[LA] Reparenting', screen: ReparentingExample },
   ModalExitingExample: {
     title: '[LA] Modal exiting example',
     screen: ModalExitingExample,
   },
-  MoveWithExiting: {
-    title: '[LA] Move with exiting',
-    screen: MoveWithExiting,
-  },
+  MoveWithExiting: { title: '[LA] Move with exiting', screen: MoveWithExiting },
   DurationZeroExample: {
     title: '[LA] Duration zero',
     screen: DurationZeroExample,
+  },
+  DurationZeroVirtual: {
+    title: '[LA] Duration Zero layout with Virtualization',
+    screen: DurationZeroVirtualization,
   },
 
   // Shared Element Transitions
@@ -910,50 +748,32 @@ export const EXAMPLES: Record<string, Example> = {
   CardExample: {
     title: '[SET] Card',
     screen: CardExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   CustomTransitionExample: {
     title: '[SET] Custom transition',
     screen: CustomTransitionExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   LayoutAnimationExample: {
     title: '[SET] Layout Animation',
     screen: LayoutAnimationExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   ManyScreensExample: {
     title: '[SET] Many screens',
     screen: ManyScreensExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   ManyTagsExample: {
     title: '[SET] Many tags',
     screen: ManyTagsExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   NestedStacksExample: {
     title: '[SET] Nested stacks',
     screen: NestedStacksExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   ModalsExample: {
     title: '[SET] Modals',
@@ -966,26 +786,17 @@ export const EXAMPLES: Record<string, Example> = {
   FlatListExample: {
     title: '[SET] FlatList',
     screen: FlatListExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   ImageStackExample: {
     title: '[SET] Image Stack',
     screen: ImageStackExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   RestoreStateExample: {
     title: '[SET] Restore State',
     screen: RestoreStateExample,
-    shouldWork: {
-      ios: true,
-      android: true,
-    },
+    shouldWork: { ios: true, android: true },
   },
   DuplicateTagsExample: {
     title: '[SET] Duplicate Tags',

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -120,7 +120,8 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   void cleanupAnimations(
       ShadowViewMutationList &filteredMutations,
       const PropsParserContext &propsParserContext,
-      SurfaceId surfaceId) const;
+      SurfaceId surfaceId,
+      bool shouldCleanupLayoutAnimations) const;
   void cleanupSharedTransitions(
       ShadowViewMutationList &filteredMutations,
       const PropsParserContext &propsParserContext,
@@ -182,7 +183,7 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
 
   void handleRemovals(ShadowViewMutationList &filteredMutations, std::vector<std::shared_ptr<LightNode>> &roots) const;
 
-  void addOngoingAnimations(SurfaceId surfaceId, ShadowViewMutationList &mutations) const;
+  bool addOngoingAnimations(SurfaceId surfaceId, ShadowViewMutationList &mutations) const;
   void updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation) const;
   ShadowView cloneViewWithoutOpacity(const ShadowView &shadowView, const PropsParserContext &propsParserContext) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -164,7 +164,7 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       ShadowViewMutationList &mutations,
       const PropsParserContext &propsParserContext,
       SurfaceId surfaceId) const;
-  void addOngoingAnimations(SurfaceId surfaceId, ShadowViewMutationList &mutations) const;
+  bool addOngoingAnimations(SurfaceId surfaceId, ShadowViewMutationList &mutations) const;
   void updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation) const;
   std::shared_ptr<ShadowView> cloneViewWithoutOpacity(
       facebook::react::ShadowViewMutation &mutation,

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -152,10 +152,6 @@ void NativeProxy::maybeFlushUIUpdatesQueue() {
 }
 
 std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vector<int> &tags) {
-  if (tags.empty()) {
-    return {};
-  }
-
   static const auto method = getJniMethod<jboolean(jni::alias_ref<jni::JArrayInt>)>("preserveMountedTags");
   auto jArrayInt = jni::JArrayInt::newArray(tags.size());
   jArrayInt->setRegion(0, tags.size(), tags.data());


### PR DESCRIPTION
## Summary

This PR skips layout animation cleanup when the `preserveMountedTags_` function return false due to being called on the jsThread. Up to this point we simply skipped `addOngoing` id the transaction was called on the js thread, but this could lead to cleanup happening before we apply the animation (for duration 0 animations, this would mean the view never moves). So now if it was called no the js thread we skip cleanup and let it happen when the main thread is invoked with `pullTransaction`. This issue can happen only on android and should be gone when the pull model/branching is implemented.

### BEFORE

https://github.com/user-attachments/assets/1b6936fb-0fea-441f-9bdd-fcae5a251273

### AFTER

https://github.com/user-attachments/assets/3b28d52d-aea5-4d8a-b3da-117841ede0c9

## Test plan

`[LA] Duration Zero layout with Virtualization` example
