### PR TITLE
refactor(Worklets): dont use @react-native/babel-preset for unit tests

### DIFF
--- a/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch
+++ b/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch
@@ -1,0 +1,10 @@
+diff --git a/types/cypress-expect.d.ts b/types/cypress-expect.d.ts
+index bea4c7f566d362f988b534ac4ef2791f4052ed6f..bd0cbe5c6c7cae7a1b47aad53e6df50bae231fa7 100644
+--- a/types/cypress-expect.d.ts
++++ b/types/cypress-expect.d.ts
+@@ -1,3 +1,3 @@
+ // Cypress adds chai expect and assert to global
+-declare var expect: Chai.ExpectStatic
+-declare var assert: Chai.AssertStatic
++// declare var expect: Chai.ExpectStatic
++// declare var assert: Chai.AssertStatic

--- a/apps/next-example/package.json
+++ b/apps/next-example/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "7.28.4",
     "@expo/next-adapter": "6.0.0",
     "@next/bundle-analyzer": "15.5.4",
-    "cypress": "15.4.0",
+    "cypress": "patch:cypress@npm%3A15.4.0#~/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch",
     "eslint": "9.37.0",
     "next-compose-plugins": "2.2.1",
     "prettier": "3.6.2",

--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin.test.ts.snap
@@ -15,17 +15,18 @@ exports[`babel plugin for DirectiveLiterals doesn't transform functions without 
 `;
 
 exports[`babel plugin for DirectiveLiterals doesn't transform string literals 1`] = `
-"var _worklet_7224155149057_init_data = {
+"const _worklet_7224155149057_init_data = {
   code: "function foo_null1(x){const bar='worklet';const baz=\\"worklet\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_7224155149057_init_data = _ref._worklet_7224155149057_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(x) {
-    var bar = 'worklet';
-    var baz = "worklet";
+const foo = function foo_null1Factory({
+  _worklet_7224155149057_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (x) {
+    const bar = 'worklet'; // prettier-ignore
+    const baz = "worklet"; // prettier-ignore
   };
   foo.__closure = {};
   foo.__workletHash = 7224155149057;
@@ -34,20 +35,22 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_7224155149057_init_data: _worklet_7224155149057_init_data
+  _worklet_7224155149057_init_data
 });"
 `;
 
 exports[`babel plugin for DirectiveLiterals removes "worklet"; directive from worklets 1`] = `
-"var _worklet_2156194750585_init_data = {
+"const _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(x) {
+const foo = function foo_null1Factory({
+  _worklet_2156194750585_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (x) {
+    // prettier-ignore
     return x + 2;
   };
   foo.__closure = {};
@@ -57,20 +60,22 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_2156194750585_init_data: _worklet_2156194750585_init_data
+  _worklet_2156194750585_init_data
 });"
 `;
 
 exports[`babel plugin for DirectiveLiterals removes 'worklet'; directive from worklets 1`] = `
-"var _worklet_2156194750585_init_data = {
+"const _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(x) {
+const foo = function foo_null1Factory({
+  _worklet_2156194750585_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (x) {
+    // prettier-ignore
     return x + 2;
   };
   foo.__closure = {};
@@ -80,80 +85,81 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_2156194750585_init_data: _worklet_2156194750585_init_data
+  _worklet_2156194750585_init_data
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown chained methods before 1`] = `
-"FadeIn.AmogusIn().withCallback(function () {
+"FadeIn.AmogusIn().withCallback(() => {
   console.log('FadeIn with AmogusIn before');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown chained methods before with new keyword 1`] = `
-"new FadeIn().AmogusIn().withCallback(function () {
+"new FadeIn().AmogusIn().withCallback(() => {
   console.log('FadeIn with AmogusIn before');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects 1`] = `
-"AmogusIn.withCallback(function () {
+"AmogusIn.withCallback(() => {
   console.log('AmogusIn');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects chained with known objects 1`] = `
-"AmogusIn.FadeIn().withCallback(function () {
+"AmogusIn.FadeIn().withCallback(() => {
   console.log('AmogusIn with FadeIn after');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects chained with known objects with new keyword 1`] = `
-"new AmogusIn().FadeIn().withCallback(function () {
+"new AmogusIn().FadeIn().withCallback(() => {
   console.log('AmogusIn with FadeIn after');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects on known chained methods before 1`] = `
-"AmogusIn.build().withCallback(function () {
+"AmogusIn.build().withCallback(() => {
   console.log('AmogusIn with build before');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects on known chained methods before with new keyword 1`] = `
-"new AmogusIn().build().withCallback(function () {
+"new AmogusIn().build().withCallback(() => {
   console.log('AmogusIn with build before');
 });"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects with known object chained after 1`] = `
-"AmogusIn.withCallback(function () {
+"AmogusIn.withCallback(() => {
   console.log('AmogusIn with FadeIn before');
 }).FadeIn();"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects with known object chained after with new keyword 1`] = `
-"new AmogusIn().withCallback(function () {
+"new AmogusIn().withCallback(() => {
   console.log('AmogusIn with FadeIn before');
 }).FadeIn();"
 `;
 
 exports[`babel plugin for Layout Animations doesn't workletize callback functions on unknown objects with new keyword 1`] = `
-"new AmogusIn().withCallback(function () {
+"new AmogusIn().withCallback(() => {
   console.log('AmogusIn');
 });"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on known chained methods after 1`] = `
-"var _worklet_7317097572766_init_data = {
+"const _worklet_7317097572766_init_data = {
   code: "function null1(){console.log('FadeIn with build after');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-FadeIn.withCallback(function null1Factory(_ref) {
-  var _worklet_7317097572766_init_data = _ref._worklet_7317097572766_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+FadeIn.withCallback(function null1Factory({
+  _worklet_7317097572766_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build after');
   };
   null1.__closure = {};
@@ -163,20 +169,21 @@ FadeIn.withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_7317097572766_init_data: _worklet_7317097572766_init_data
+  _worklet_7317097572766_init_data
 })).build();"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on known chained methods after with new keyword 1`] = `
-"var _worklet_7317097572766_init_data = {
+"const _worklet_7317097572766_init_data = {
   code: "function null1(){console.log('FadeIn with build after');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-new FadeIn().withCallback(function null1Factory(_ref) {
-  var _worklet_7317097572766_init_data = _ref._worklet_7317097572766_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+new FadeIn().withCallback(function null1Factory({
+  _worklet_7317097572766_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build after');
   };
   null1.__closure = {};
@@ -186,20 +193,21 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_7317097572766_init_data: _worklet_7317097572766_init_data
+  _worklet_7317097572766_init_data
 })).build();"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on known chained methods before 1`] = `
-"var _worklet_12678290670659_init_data = {
+"const _worklet_12678290670659_init_data = {
   code: "function null1(){console.log('FadeIn with build before');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-FadeIn.build().withCallback(function null1Factory(_ref) {
-  var _worklet_12678290670659_init_data = _ref._worklet_12678290670659_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+FadeIn.build().withCallback(function null1Factory({
+  _worklet_12678290670659_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build before');
   };
   null1.__closure = {};
@@ -209,20 +217,21 @@ FadeIn.build().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_12678290670659_init_data: _worklet_12678290670659_init_data
+  _worklet_12678290670659_init_data
 }));"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on known chained methods before with new keyword 1`] = `
-"var _worklet_12678290670659_init_data = {
+"const _worklet_12678290670659_init_data = {
   code: "function null1(){console.log('FadeIn with build before');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-new FadeIn().build().withCallback(function null1Factory(_ref) {
-  var _worklet_12678290670659_init_data = _ref._worklet_12678290670659_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+new FadeIn().build().withCallback(function null1Factory({
+  _worklet_12678290670659_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build before');
   };
   null1.__closure = {};
@@ -232,20 +241,21 @@ new FadeIn().build().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_12678290670659_init_data: _worklet_12678290670659_init_data
+  _worklet_12678290670659_init_data
 }));"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on longer chains of known objects 1`] = `
-"var _worklet_11557425704826_init_data = {
+"const _worklet_11557425704826_init_data = {
   code: "function null1(){console.log('FadeIn with build');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-FadeIn.build().duration().withCallback(function null1Factory(_ref) {
-  var _worklet_11557425704826_init_data = _ref._worklet_11557425704826_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+FadeIn.build().duration().withCallback(function null1Factory({
+  _worklet_11557425704826_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build');
   };
   null1.__closure = {};
@@ -255,20 +265,21 @@ FadeIn.build().duration().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_11557425704826_init_data: _worklet_11557425704826_init_data
+  _worklet_11557425704826_init_data
 }));"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on longer chains of known objects with new keyword 1`] = `
-"var _worklet_11557425704826_init_data = {
+"const _worklet_11557425704826_init_data = {
   code: "function null1(){console.log('FadeIn with build');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-new FadeIn().build().duration().withCallback(function null1Factory(_ref) {
-  var _worklet_11557425704826_init_data = _ref._worklet_11557425704826_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+new FadeIn().build().duration().withCallback(function null1Factory({
+  _worklet_11557425704826_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with build');
   };
   null1.__closure = {};
@@ -278,20 +289,21 @@ new FadeIn().build().duration().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_11557425704826_init_data: _worklet_11557425704826_init_data
+  _worklet_11557425704826_init_data
 }));"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on unknown objects chained after 1`] = `
-"var _worklet_6642833765517_init_data = {
+"const _worklet_6642833765517_init_data = {
   code: "function null1(){console.log('FadeIn with AmogusIn after');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-FadeIn.withCallback(function null1Factory(_ref) {
-  var _worklet_6642833765517_init_data = _ref._worklet_6642833765517_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+FadeIn.withCallback(function null1Factory({
+  _worklet_6642833765517_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with AmogusIn after');
   };
   null1.__closure = {};
@@ -301,20 +313,21 @@ FadeIn.withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_6642833765517_init_data: _worklet_6642833765517_init_data
+  _worklet_6642833765517_init_data
 })).AmogusIn();"
 `;
 
 exports[`babel plugin for Layout Animations workletizes callback functions on unknown objects chained after with new keyword 1`] = `
-"var _worklet_6642833765517_init_data = {
+"const _worklet_6642833765517_init_data = {
   code: "function null1(){console.log('FadeIn with AmogusIn after');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-new FadeIn().withCallback(function null1Factory(_ref) {
-  var _worklet_6642833765517_init_data = _ref._worklet_6642833765517_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+new FadeIn().withCallback(function null1Factory({
+  _worklet_6642833765517_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn with AmogusIn after');
   };
   null1.__closure = {};
@@ -324,20 +337,21 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_6642833765517_init_data: _worklet_6642833765517_init_data
+  _worklet_6642833765517_init_data
 })).AmogusIn();"
 `;
 
 exports[`babel plugin for Layout Animations workletizes unchained callback functions automatically 1`] = `
-"var _worklet_5714930700718_init_data = {
+"const _worklet_5714930700718_init_data = {
   code: "function null1(){console.log('FadeIn');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-FadeIn.withCallback(function null1Factory(_ref) {
-  var _worklet_5714930700718_init_data = _ref._worklet_5714930700718_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+FadeIn.withCallback(function null1Factory({
+  _worklet_5714930700718_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn');
   };
   null1.__closure = {};
@@ -347,20 +361,21 @@ FadeIn.withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_5714930700718_init_data: _worklet_5714930700718_init_data
+  _worklet_5714930700718_init_data
 }));"
 `;
 
 exports[`babel plugin for Layout Animations workletizes unchained callback functions automatically with new keyword 1`] = `
-"var _worklet_5714930700718_init_data = {
+"const _worklet_5714930700718_init_data = {
   code: "function null1(){console.log('FadeIn');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-new FadeIn().withCallback(function null1Factory(_ref) {
-  var _worklet_5714930700718_init_data = _ref._worklet_5714930700718_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+new FadeIn().withCallback(function null1Factory({
+  _worklet_5714930700718_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     console.log('FadeIn');
   };
   null1.__closure = {};
@@ -370,29 +385,23 @@ new FadeIn().withCallback(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_5714930700718_init_data: _worklet_5714930700718_init_data
+  _worklet_5714930700718_init_data
 }));"
 `;
 
 exports[`babel plugin for async functions makes an async worklet factory 1`] = `
-"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
-var _worklet_14005565322850_init_data = {
+"const _worklet_14005565322850_init_data = {
   code: "async function foo_null1(){await Promise.resolve();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_14005565322850_init_data = _ref._worklet_14005565322850_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function () {
-    var _ref2 = (0, _asyncToGenerator2.default)(function* () {
-      yield Promise.resolve();
-    });
-    return function foo() {
-      return _ref2.apply(this, arguments);
-    };
-  }();
+const foo = function foo_null1Factory({
+  _worklet_14005565322850_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = async function () {
+    await Promise.resolve();
+  };
   foo.__closure = {};
   foo.__workletHash = 14005565322850;
   foo.__pluginVersion = "x.y.z";
@@ -400,29 +409,23 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_14005565322850_init_data: _worklet_14005565322850_init_data
+  _worklet_14005565322850_init_data
 });"
 `;
 
 exports[`babel plugin for async functions makes an async worklet string 1`] = `
-"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
-var _worklet_14005565322850_init_data = {
+"const _worklet_14005565322850_init_data = {
   code: "async function foo_null1(){await Promise.resolve();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_14005565322850_init_data = _ref._worklet_14005565322850_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function () {
-    var _ref2 = (0, _asyncToGenerator2.default)(function* () {
-      yield Promise.resolve();
-    });
-    return function foo() {
-      return _ref2.apply(this, arguments);
-    };
-  }();
+const foo = function foo_null1Factory({
+  _worklet_14005565322850_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = async function () {
+    await Promise.resolve();
+  };
   foo.__closure = {};
   foo.__workletHash = 14005565322850;
   foo.__pluginVersion = "x.y.z";
@@ -430,7 +433,7 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_14005565322850_init_data: _worklet_14005565322850_init_data
+  _worklet_14005565322850_init_data
 });"
 `;
 
@@ -665,25 +668,24 @@ var Foo = function () {
 `;
 
 exports[`babel plugin for closure capturing captures locally bound variables named like globals 1`] = `
-"var console = {
-  log: function log() {
-    return 42;
-  }
+"const console = {
+  log: () => 42
 };
-var _worklet_1380037982666_init_data = {
+const _worklet_1380037982666_init_data = {
   code: "function f_null1(){const{console}=this.__closure;console.log(console);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_1380037982666_init_data = _ref._worklet_1380037982666_init_data,
-    console = _ref.console;
-  var _e = [new global.Error(), -2, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_1380037982666_init_data,
+  console
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const f = function () {
     console.log(console);
   };
   f.__closure = {
-    console: console
+    console
   };
   f.__workletHash = 1380037982666;
   f.__pluginVersion = "x.y.z";
@@ -691,34 +693,35 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_1380037982666_init_data: _worklet_1380037982666_init_data,
-  console: console
+  _worklet_1380037982666_init_data,
+  console
 });"
 `;
 
 exports[`babel plugin for closure capturing captures worklets environment 1`] = `
-"var x = 5;
-var objX = {
-  x: x
+"const x = 5;
+const objX = {
+  x
 };
-var _worklet_10550735168277_init_data = {
+const _worklet_10550735168277_init_data = {
   code: "function f_null1(){const{x,objX}=this.__closure;return{res:x+objX.x};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_10550735168277_init_data = _ref._worklet_10550735168277_init_data,
-    x = _ref.x,
-    objX = _ref.objX;
-  var _e = [new global.Error(), -3, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_10550735168277_init_data,
+  x,
+  objX
+}) {
+  const _e = [new global.Error(), -3, -27];
+  const f = function () {
     return {
       res: x + objX.x
     };
   };
   f.__closure = {
-    x: x,
-    objX: objX
+    x,
+    objX
   };
   f.__workletHash = 10550735168277;
   f.__pluginVersion = "x.y.z";
@@ -726,22 +729,23 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_10550735168277_init_data: _worklet_10550735168277_init_data,
-  x: x,
-  objX: objX
+  _worklet_10550735168277_init_data,
+  x,
+  objX
 });"
 `;
 
 exports[`babel plugin for closure capturing doesn't capture arguments 1`] = `
-"var _worklet_11756143316246_init_data = {
+"const _worklet_11756143316246_init_data = {
   code: "function f_null1(a,b,c){console.log(arguments);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_11756143316246_init_data = _ref._worklet_11756143316246_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var f = function f(a, b, c) {
+const f = function f_null1Factory({
+  _worklet_11756143316246_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const f = function (a, b, c) {
     console.log(arguments);
   };
   f.__closure = {};
@@ -751,20 +755,21 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_11756143316246_init_data: _worklet_11756143316246_init_data
+  _worklet_11756143316246_init_data
 });"
 `;
 
 exports[`babel plugin for closure capturing doesn't capture custom globals 1`] = `
-"var _worklet_11658370598384_init_data = {
+"const _worklet_11658370598384_init_data = {
   code: "function f_null1(){console.log(foo);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_11658370598384_init_data = _ref._worklet_11658370598384_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_11658370598384_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const f = function () {
     console.log(foo);
   };
   f.__closure = {};
@@ -774,20 +779,21 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_11658370598384_init_data: _worklet_11658370598384_init_data
+  _worklet_11658370598384_init_data
 });"
 `;
 
 exports[`babel plugin for closure capturing doesn't capture default globals 1`] = `
-"var _worklet_9451494835104_init_data = {
+"const _worklet_9451494835104_init_data = {
   code: "function f_null1(){console.log('test');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_9451494835104_init_data = _ref._worklet_9451494835104_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_9451494835104_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const f = function () {
     console.log('test');
   };
   f.__closure = {};
@@ -797,26 +803,27 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_9451494835104_init_data: _worklet_9451494835104_init_data
+  _worklet_9451494835104_init_data
 });"
 `;
 
 exports[`babel plugin for closure capturing doesn't capture locally bound variables named like custom globals 1`] = `
-"var foo = 42;
-var _worklet_6398258314122_init_data = {
+"const foo = 42;
+const _worklet_6398258314122_init_data = {
   code: "function f_null1(){const{foo}=this.__closure;console.log(foo);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_6398258314122_init_data = _ref._worklet_6398258314122_init_data,
-    foo = _ref.foo;
-  var _e = [new global.Error(), -2, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_6398258314122_init_data,
+  foo
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const f = function () {
     console.log(foo);
   };
   f.__closure = {
-    foo: foo
+    foo
   };
   f.__workletHash = 6398258314122;
   f.__pluginVersion = "x.y.z";
@@ -824,29 +831,30 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_6398258314122_init_data: _worklet_6398258314122_init_data,
-  foo: foo
+  _worklet_6398258314122_init_data,
+  foo
 });"
 `;
 
 exports[`babel plugin for closure capturing doesn't capture objects' properties 1`] = `
-"var foo = {
+"const foo = {
   bar: 42
 };
-var _worklet_239990909653_init_data = {
+const _worklet_239990909653_init_data = {
   code: "function f_null1(){const{foo}=this.__closure;console.log(foo.bar);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var f = function f_null1Factory(_ref) {
-  var _worklet_239990909653_init_data = _ref._worklet_239990909653_init_data,
-    foo = _ref.foo;
-  var _e = [new global.Error(), -2, -27];
-  var f = function f() {
+const f = function f_null1Factory({
+  _worklet_239990909653_init_data,
+  foo
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const f = function () {
     console.log(foo.bar);
   };
   f.__closure = {
-    foo: foo
+    foo
   };
   f.__workletHash = 239990909653;
   f.__pluginVersion = "x.y.z";
@@ -854,156 +862,161 @@ var f = function f_null1Factory(_ref) {
   f.__stackDetails = _e;
   return f;
 }({
-  _worklet_239990909653_init_data: _worklet_239990909653_init_data,
-  foo: foo
+  _worklet_239990909653_init_data,
+  foo
 });"
 `;
 
 exports[`babel plugin for context objects creates factories 1`] = `
-"var _worklet_9226058452652_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
+"const _worklet_8827018554289_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar() {
+const foo = {
+  bar() {
     return 'bar';
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_9226058452652_init_data = _ref._worklet_9226058452652_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_8827018554289_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 9226058452652;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 8827018554289;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_8827018554289_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_9226058452652_init_data: _worklet_9226058452652_init_data
+    _worklet_8827018554289_init_data
   })
 };"
 `;
 
 exports[`babel plugin for context objects preserves bindings 1`] = `
-"var _worklet_4592588545601_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
+"const _worklet_11774637842588_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar() {
+const foo = {
+  bar() {
     return 'bar';
   },
-  foobar: function foobar() {
+  foobar() {
     return this.bar();
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_4592588545601_init_data = _ref._worklet_4592588545601_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_11774637842588_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         },
-        foobar: function foobar() {
+        foobar() {
           return this.bar();
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 4592588545601;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 11774637842588;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11774637842588_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_4592588545601_init_data: _worklet_4592588545601_init_data
+    _worklet_11774637842588_init_data
   })
 };"
 `;
 
 exports[`babel plugin for context objects removes marker 1`] = `
-"var _worklet_9226058452652_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
+"const _worklet_8827018554289_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar() {
+const foo = {
+  bar() {
     return 'bar';
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_9226058452652_init_data = _ref._worklet_9226058452652_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_8827018554289_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 9226058452652;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 8827018554289;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_8827018554289_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_9226058452652_init_data: _worklet_9226058452652_init_data
+    _worklet_8827018554289_init_data
   })
 };"
 `;
 
 exports[`babel plugin for context objects workletizes regardless of marker value 1`] = `
-"var _worklet_9226058452652_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';}};}",
+"const _worklet_8827018554289_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar() {
+const foo = {
+  bar() {
     return 'bar';
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_9226058452652_init_data = _ref._worklet_9226058452652_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_8827018554289_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 9226058452652;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_9226058452652_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 8827018554289;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_8827018554289_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_9226058452652_init_data: _worklet_9226058452652_init_data
+    _worklet_8827018554289_init_data
   })
 };"
 `;
 
 exports[`babel plugin for debugging does inject location for worklets in dev builds 1`] = `
-"var _worklet_8623346549410_init_data = {
+"const _worklet_8623346549410_init_data = {
   code: "function null1(){const x=1;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = useAnimatedStyle(function null1Factory(_ref) {
-  var _worklet_8623346549410_init_data = _ref._worklet_8623346549410_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
-    var x = 1;
+const foo = useAnimatedStyle(function null1Factory({
+  _worklet_8623346549410_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
+    const x = 1;
   };
   null1.__closure = {};
   null1.__workletHash = 8623346549410;
@@ -1012,56 +1025,59 @@ var foo = useAnimatedStyle(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_8623346549410_init_data: _worklet_8623346549410_init_data
+  _worklet_8623346549410_init_data
 }));"
 `;
 
 exports[`babel plugin for debugging doesn't inject location for worklets in production builds 1`] = `
-"var _worklet_8623346549410_init_data = {
+"const _worklet_8623346549410_init_data = {
   code: "function null1(){const x=1;}"
 };
-var foo = useAnimatedStyle(function null1Factory(_ref) {
-  var _worklet_8623346549410_init_data = _ref._worklet_8623346549410_init_data;
-  var null1 = function null1() {
-    var x = 1;
+const foo = useAnimatedStyle(function null1Factory({
+  _worklet_8623346549410_init_data
+}) {
+  const null1 = function () {
+    const x = 1;
   };
   null1.__closure = {};
   null1.__workletHash = 8623346549410;
   null1.__initData = _worklet_8623346549410_init_data;
   return null1;
 }({
-  _worklet_8623346549410_init_data: _worklet_8623346549410_init_data
+  _worklet_8623346549410_init_data
 }));"
 `;
 
 exports[`babel plugin for debugging doesn't inject version for worklets in production builds 1`] = `
-"var _worklet_8623346549410_init_data = {
+"const _worklet_8623346549410_init_data = {
   code: "function null1(){const x=1;}"
 };
-var foo = useAnimatedStyle(function null1Factory(_ref) {
-  var _worklet_8623346549410_init_data = _ref._worklet_8623346549410_init_data;
-  var null1 = function null1() {
-    var x = 1;
+const foo = useAnimatedStyle(function null1Factory({
+  _worklet_8623346549410_init_data
+}) {
+  const null1 = function () {
+    const x = 1;
   };
   null1.__closure = {};
   null1.__workletHash = 8623346549410;
   null1.__initData = _worklet_8623346549410_init_data;
   return null1;
 }({
-  _worklet_8623346549410_init_data: _worklet_8623346549410_init_data
+  _worklet_8623346549410_init_data
 }));"
 `;
 
 exports[`babel plugin for explicit worklets workletizes ArrowFunctionExpression 1`] = `
-"var _worklet_2294411833184_init_data = {
+"const _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null1Factory(_ref) {
-  var _worklet_2294411833184_init_data = _ref._worklet_2294411833184_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1(x) {
+const foo = function null1Factory({
+  _worklet_2294411833184_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function (x) {
     return x + 2;
   };
   null1.__closure = {};
@@ -1071,20 +1087,21 @@ var foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2294411833184_init_data: _worklet_2294411833184_init_data
+  _worklet_2294411833184_init_data
 });"
 `;
 
 exports[`babel plugin for explicit worklets workletizes FunctionDeclaration 1`] = `
-"var _worklet_2156194750585_init_data = {
+"const _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(x) {
+const foo = function foo_null1Factory({
+  _worklet_2156194750585_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (x) {
     return x + 2;
   };
   foo.__closure = {};
@@ -1094,21 +1111,22 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_2156194750585_init_data: _worklet_2156194750585_init_data
+  _worklet_2156194750585_init_data
 });"
 `;
 
 exports[`babel plugin for explicit worklets workletizes ObjectMethod 1`] = `
-"var _worklet_10686480819086_init_data = {
+"const _worklet_10686480819086_init_data = {
   code: "function bar_null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar_null1Factory(_ref) {
-    var _worklet_10686480819086_init_data = _ref._worklet_10686480819086_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var bar = function bar(x) {
+const foo = {
+  bar: function bar_null1Factory({
+    _worklet_10686480819086_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const bar = function (x) {
       return x + 2;
     };
     bar.__closure = {};
@@ -1118,21 +1136,22 @@ var foo = {
     bar.__stackDetails = _e;
     return bar;
   }({
-    _worklet_10686480819086_init_data: _worklet_10686480819086_init_data
+    _worklet_10686480819086_init_data
   })
 };"
 `;
 
 exports[`babel plugin for explicit worklets workletizes named FunctionExpression 1`] = `
-"var _worklet_2156194750585_init_data = {
+"const _worklet_2156194750585_init_data = {
   code: "function foo_null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_2156194750585_init_data = _ref._worklet_2156194750585_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(x) {
+const foo = function foo_null1Factory({
+  _worklet_2156194750585_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (x) {
     return x + 2;
   };
   foo.__closure = {};
@@ -1142,20 +1161,21 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_2156194750585_init_data: _worklet_2156194750585_init_data
+  _worklet_2156194750585_init_data
 });"
 `;
 
 exports[`babel plugin for explicit worklets workletizes unnamed FunctionExpression 1`] = `
-"var _worklet_2294411833184_init_data = {
+"const _worklet_2294411833184_init_data = {
   code: "function null1(x){return x+2;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null1Factory(_ref) {
-  var _worklet_2294411833184_init_data = _ref._worklet_2294411833184_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1(x) {
+const foo = function null1Factory({
+  _worklet_2294411833184_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function (x) {
     return x + 2;
   };
   null1.__closure = {};
@@ -1165,7 +1185,7 @@ var foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2294411833184_init_data: _worklet_2294411833184_init_data
+  _worklet_2294411833184_init_data
 });"
 `;
 
@@ -1178,15 +1198,16 @@ exports[`babel plugin for file workletization doesn't workletize function outsid
 `;
 
 exports[`babel plugin for file workletization moves CommonJS export to the bottom of the file 1`] = `
-"var _worklet_15780239751281_init_data = {
+"const _worklet_15780239751281_init_data = {
   code: "function foo_null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_15780239751281_init_data = _ref._worklet_15780239751281_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {};
+const foo = function foo_null1Factory({
+  _worklet_15780239751281_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {};
   foo.__closure = {};
   foo.__workletHash = 15780239751281;
   foo.__pluginVersion = "x.y.z";
@@ -1194,22 +1215,23 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_15780239751281_init_data: _worklet_15780239751281_init_data
+  _worklet_15780239751281_init_data
 });
-var bar = 1;
+const bar = 1;
 exports.foo = foo;"
 `;
 
 exports[`babel plugin for file workletization moves multiple CommonJS exports to the bottom of the file 1`] = `
-"var _worklet_15780239751281_init_data = {
+"const _worklet_15780239751281_init_data = {
   code: "function foo_null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_15780239751281_init_data = _ref._worklet_15780239751281_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {};
+const foo = function foo_null1Factory({
+  _worklet_15780239751281_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {};
   foo.__closure = {};
   foo.__workletHash = 15780239751281;
   foo.__pluginVersion = "x.y.z";
@@ -1217,17 +1239,18 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_15780239751281_init_data: _worklet_15780239751281_init_data
+  _worklet_15780239751281_init_data
 });
-var _worklet_552304524261_init_data = {
+const _worklet_552304524261_init_data = {
   code: "function bar_null2(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var bar = function bar_null2Factory(_ref2) {
-  var _worklet_552304524261_init_data = _ref2._worklet_552304524261_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var bar = function bar() {};
+const bar = function bar_null2Factory({
+  _worklet_552304524261_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const bar = function () {};
   bar.__closure = {};
   bar.__workletHash = 552304524261;
   bar.__pluginVersion = "x.y.z";
@@ -1235,17 +1258,18 @@ var bar = function bar_null2Factory(_ref2) {
   bar.__stackDetails = _e;
   return bar;
 }({
-  _worklet_552304524261_init_data: _worklet_552304524261_init_data
+  _worklet_552304524261_init_data
 });
-var _worklet_9955902016844_init_data = {
+const _worklet_9955902016844_init_data = {
   code: "function baz_null3(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var baz = function baz_null3Factory(_ref3) {
-  var _worklet_9955902016844_init_data = _ref3._worklet_9955902016844_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var baz = function baz() {};
+const baz = function baz_null3Factory({
+  _worklet_9955902016844_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const baz = function () {};
   baz.__closure = {};
   baz.__workletHash = 9955902016844;
   baz.__pluginVersion = "x.y.z";
@@ -1253,17 +1277,18 @@ var baz = function baz_null3Factory(_ref3) {
   baz.__stackDetails = _e;
   return baz;
 }({
-  _worklet_9955902016844_init_data: _worklet_9955902016844_init_data
+  _worklet_9955902016844_init_data
 });
-var _worklet_3271684035845_init_data = {
+const _worklet_3271684035845_init_data = {
   code: "function foobar_null4(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foobar = function foobar_null4Factory(_ref4) {
-  var _worklet_3271684035845_init_data = _ref4._worklet_3271684035845_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foobar = function foobar() {};
+const foobar = function foobar_null4Factory({
+  _worklet_3271684035845_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foobar = function () {};
   foobar.__closure = {};
   foobar.__workletHash = 3271684035845;
   foobar.__pluginVersion = "x.y.z";
@@ -1271,7 +1296,7 @@ var foobar = function foobar_null4Factory(_ref4) {
   foobar.__stackDetails = _e;
   return foobar;
 }({
-  _worklet_3271684035845_init_data: _worklet_3271684035845_init_data
+  _worklet_3271684035845_init_data
 });
 exports.foo = foo;
 exports.bar = bar;
@@ -1280,15 +1305,16 @@ exports.foobar = foobar;"
 `;
 
 exports[`babel plugin for file workletization workletizes ArrowFunctionExpression 1`] = `
-"var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+const foo = function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -1298,24 +1324,21 @@ var foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes ArrowFunctionExpression in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _default = exports.default = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+export default (function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -1324,25 +1347,22 @@ var _default = exports.default = function null1Factory(_ref) {
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
-}({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+})({
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes ArrowFunctionExpression in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.foo = void 0;
-var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = exports.foo = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+export const foo = function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -1352,46 +1372,47 @@ var foo = exports.foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes ClassDeclaration 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -1401,12 +1422,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -1423,18 +1445,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -1442,21 +1465,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -1464,20 +1488,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -1485,16 +1510,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -1505,68 +1531,65 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for file workletization workletizes ClassDeclaration in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = exports.default = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+export default (function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -1576,12 +1599,13 @@ var Clazz = exports.default = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -1598,18 +1622,19 @@ var Clazz = exports.default = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -1617,21 +1642,22 @@ var Clazz = exports.default = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -1639,20 +1665,21 @@ var Clazz = exports.default = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -1660,16 +1687,17 @@ var Clazz = exports.default = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -1680,68 +1708,65 @@ var Clazz = exports.default = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
-}();"
+})();"
 `;
 
 exports[`babel plugin for file workletization workletizes ClassDeclaration in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.Clazz = void 0;
-var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = exports.Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+export const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -1751,12 +1776,13 @@ var Clazz = exports.Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -1773,18 +1799,19 @@ var Clazz = exports.Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -1792,21 +1819,22 @@ var Clazz = exports.Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -1814,20 +1842,21 @@ var Clazz = exports.Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -1835,16 +1864,17 @@ var Clazz = exports.Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -1855,38 +1885,39 @@ var Clazz = exports.Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionDeclaration 1`] = `
-"var _worklet_5253890412305_init_data = {
+"const _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_null1Factory({
+  _worklet_5253890412305_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 'bar';
   };
   foo.__closure = {};
@@ -1896,24 +1927,21 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_5253890412305_init_data: _worklet_5253890412305_init_data
+  _worklet_5253890412305_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionDeclaration in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_5253890412305_init_data = {
+"const _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _default = exports.default = function foo_null1Factory(_ref) {
-  var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+export default (function foo_null1Factory({
+  _worklet_5253890412305_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 'bar';
   };
   foo.__closure = {};
@@ -1922,25 +1950,22 @@ var _default = exports.default = function foo_null1Factory(_ref) {
   foo.__initData = _worklet_5253890412305_init_data;
   foo.__stackDetails = _e;
   return foo;
-}({
-  _worklet_5253890412305_init_data: _worklet_5253890412305_init_data
+})({
+  _worklet_5253890412305_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionDeclaration in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.foo = void 0;
-var _worklet_5253890412305_init_data = {
+"const _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = exports.foo = function foo_null1Factory(_ref) {
-  var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+export const foo = function foo_null1Factory({
+  _worklet_5253890412305_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 'bar';
   };
   foo.__closure = {};
@@ -1950,20 +1975,21 @@ var foo = exports.foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_5253890412305_init_data: _worklet_5253890412305_init_data
+  _worklet_5253890412305_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionExpression 1`] = `
-"var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+const foo = function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -1973,24 +1999,21 @@ var foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionExpression in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _default = exports.default = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+export default (function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -1999,25 +2022,22 @@ var _default = exports.default = function null1Factory(_ref) {
   null1.__initData = _worklet_2420910284744_init_data;
   null1.__stackDetails = _e;
   return null1;
-}({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+})({
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes FunctionExpression in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.foo = void 0;
-var _worklet_2420910284744_init_data = {
+"const _worklet_2420910284744_init_data = {
   code: "function null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = exports.foo = function null1Factory(_ref) {
-  var _worklet_2420910284744_init_data = _ref._worklet_2420910284744_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+export const foo = function null1Factory({
+  _worklet_2420910284744_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'bar';
   };
   null1.__closure = {};
@@ -2027,21 +2047,22 @@ var foo = exports.foo = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2420910284744_init_data: _worklet_2420910284744_init_data
+  _worklet_2420910284744_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes ObjectMethod 1`] = `
-"var _worklet_17582834634406_init_data = {
+"const _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar_null1Factory(_ref) {
-    var _worklet_17582834634406_init_data = _ref._worklet_17582834634406_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var bar = function bar() {
+const foo = {
+  bar: function bar_null1Factory({
+    _worklet_17582834634406_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const bar = function () {
       return 'bar';
     };
     bar.__closure = {};
@@ -2051,26 +2072,23 @@ var foo = {
     bar.__stackDetails = _e;
     return bar;
   }({
-    _worklet_17582834634406_init_data: _worklet_17582834634406_init_data
+    _worklet_17582834634406_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes ObjectMethod in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_17582834634406_init_data = {
+"const _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _default = exports.default = {
-  bar: function bar_null1Factory(_ref) {
-    var _worklet_17582834634406_init_data = _ref._worklet_17582834634406_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var bar = function bar() {
+export default {
+  bar: function bar_null1Factory({
+    _worklet_17582834634406_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const bar = function () {
       return 'bar';
     };
     bar.__closure = {};
@@ -2080,26 +2098,23 @@ var _default = exports.default = {
     bar.__stackDetails = _e;
     return bar;
   }({
-    _worklet_17582834634406_init_data: _worklet_17582834634406_init_data
+    _worklet_17582834634406_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes ObjectMethod in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.foo = void 0;
-var _worklet_17582834634406_init_data = {
+"const _worklet_17582834634406_init_data = {
   code: "function bar_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = exports.foo = {
-  bar: function bar_null1Factory(_ref) {
-    var _worklet_17582834634406_init_data = _ref._worklet_17582834634406_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var bar = function bar() {
+export const foo = {
+  bar: function bar_null1Factory({
+    _worklet_17582834634406_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const bar = function () {
       return 'bar';
     };
     bar.__closure = {};
@@ -2109,21 +2124,22 @@ var foo = exports.foo = {
     bar.__stackDetails = _e;
     return bar;
   }({
-    _worklet_17582834634406_init_data: _worklet_17582834634406_init_data
+    _worklet_17582834634406_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes assigned FunctionDeclaration 1`] = `
-"var _worklet_5253890412305_init_data = {
+"const _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_null1Factory({
+  _worklet_5253890412305_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 'bar';
   };
   foo.__closure = {};
@@ -2133,142 +2149,138 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_5253890412305_init_data: _worklet_5253890412305_init_data
+  _worklet_5253890412305_init_data
 });"
 `;
 
 exports[`babel plugin for file workletization workletizes implicit WorkletContextObject 1`] = `
-"var _worklet_4592588545601_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
+"const _worklet_11774637842588_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = {
-  bar: function bar() {
+const foo = {
+  bar() {
     return 'bar';
   },
-  foobar: function foobar() {
+  foobar() {
     return this.bar();
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_4592588545601_init_data = _ref._worklet_4592588545601_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_11774637842588_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         },
-        foobar: function foobar() {
+        foobar() {
           return this.bar();
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 4592588545601;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 11774637842588;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11774637842588_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_4592588545601_init_data: _worklet_4592588545601_init_data
+    _worklet_11774637842588_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes implicit WorkletContextObject in default export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
-var _worklet_4592588545601_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
+"const _worklet_11774637842588_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _default = exports.default = {
-  bar: function bar() {
+export default {
+  bar() {
     return 'bar';
   },
-  foobar: function foobar() {
+  foobar() {
     return this.bar();
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_4592588545601_init_data = _ref._worklet_4592588545601_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_11774637842588_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         },
-        foobar: function foobar() {
+        foobar() {
           return this.bar();
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 4592588545601;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 11774637842588;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11774637842588_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_4592588545601_init_data: _worklet_4592588545601_init_data
+    _worklet_11774637842588_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes implicit WorkletContextObject in named export 1`] = `
-"Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.foo = void 0;
-var _worklet_4592588545601_init_data = {
-  code: "function __workletContextObjectFactory_null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
+"const _worklet_11774637842588_init_data = {
+  code: "function null1(){return{bar:function(){return'bar';},foobar:function(){return this.bar();}};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = exports.foo = {
-  bar: function bar() {
+export const foo = {
+  bar() {
     return 'bar';
   },
-  foobar: function foobar() {
+  foobar() {
     return this.bar();
   },
-  __workletContextObjectFactory: function __workletContextObjectFactory_null1Factory(_ref) {
-    var _worklet_4592588545601_init_data = _ref._worklet_4592588545601_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var __workletContextObjectFactory = function __workletContextObjectFactory() {
+  __workletContextObjectFactory: function null1Factory({
+    _worklet_11774637842588_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       return {
-        bar: function bar() {
+        bar() {
           return 'bar';
         },
-        foobar: function foobar() {
+        foobar() {
           return this.bar();
         }
       };
     };
-    __workletContextObjectFactory.__closure = {};
-    __workletContextObjectFactory.__workletHash = 4592588545601;
-    __workletContextObjectFactory.__pluginVersion = "x.y.z";
-    __workletContextObjectFactory.__initData = _worklet_4592588545601_init_data;
-    __workletContextObjectFactory.__stackDetails = _e;
-    return __workletContextObjectFactory;
+    null1.__closure = {};
+    null1.__workletHash = 11774637842588;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11774637842588_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_4592588545601_init_data: _worklet_4592588545601_init_data
+    _worklet_11774637842588_init_data
   })
 };"
 `;
 
 exports[`babel plugin for file workletization workletizes multiple functions 1`] = `
-"var _worklet_5253890412305_init_data = {
+"const _worklet_5253890412305_init_data = {
   code: "function foo_null1(){return'bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_5253890412305_init_data = _ref._worklet_5253890412305_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_null1Factory({
+  _worklet_5253890412305_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 'bar';
   };
   foo.__closure = {};
@@ -2278,17 +2290,18 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_5253890412305_init_data: _worklet_5253890412305_init_data
+  _worklet_5253890412305_init_data
 });
-var _worklet_17530869641357_init_data = {
+const _worklet_17530869641357_init_data = {
   code: "function null2(){return'foobar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var bar = function null2Factory(_ref2) {
-  var _worklet_17530869641357_init_data = _ref2._worklet_17530869641357_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null2 = function null2() {
+const bar = function null2Factory({
+  _worklet_17530869641357_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null2 = function () {
     return 'foobar';
   };
   null2.__closure = {};
@@ -2298,24 +2311,23 @@ var bar = function null2Factory(_ref2) {
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_17530869641357_init_data: _worklet_17530869641357_init_data
+  _worklet_17530869641357_init_data
 });"
 `;
 
 exports[`babel plugin for function hooks workletizes hook wrapped ArrowFunctionExpression automatically 1`] = `
-"var _worklet_1392490775014_init_data = {
+"const _worklet_1392490775014_init_data = {
   code: "function null1(){return{width:50};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
-  var _worklet_1392490775014_init_data = _ref._worklet_1392490775014_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
-    return {
-      width: 50
-    };
-  };
+const animatedStyle = useAnimatedStyle(function null1Factory({
+  _worklet_1392490775014_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = () => ({
+    width: 50
+  });
   null1.__closure = {};
   null1.__workletHash = 1392490775014;
   null1.__pluginVersion = "x.y.z";
@@ -2323,20 +2335,21 @@ var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_1392490775014_init_data: _worklet_1392490775014_init_data
+  _worklet_1392490775014_init_data
 }));"
 `;
 
 exports[`babel plugin for function hooks workletizes hook wrapped named FunctionExpression automatically 1`] = `
-"var _worklet_9984171279103_init_data = {
+"const _worklet_9984171279103_init_data = {
   code: "function foo_null1(){return{width:50};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var animatedStyle = useAnimatedStyle(function foo_null1Factory(_ref) {
-  var _worklet_9984171279103_init_data = _ref._worklet_9984171279103_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const animatedStyle = useAnimatedStyle(function foo_null1Factory({
+  _worklet_9984171279103_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return {
       width: 50
     };
@@ -2348,20 +2361,21 @@ var animatedStyle = useAnimatedStyle(function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_9984171279103_init_data: _worklet_9984171279103_init_data
+  _worklet_9984171279103_init_data
 }));"
 `;
 
 exports[`babel plugin for function hooks workletizes hook wrapped unnamed FunctionExpression automatically 1`] = `
-"var _worklet_1392490775014_init_data = {
+"const _worklet_1392490775014_init_data = {
   code: "function null1(){return{width:50};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
-  var _worklet_1392490775014_init_data = _ref._worklet_1392490775014_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+const animatedStyle = useAnimatedStyle(function null1Factory({
+  _worklet_1392490775014_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return {
       width: 50
     };
@@ -2373,48 +2387,49 @@ var animatedStyle = useAnimatedStyle(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_1392490775014_init_data: _worklet_1392490775014_init_data
+  _worklet_1392490775014_init_data
 }));"
 `;
 
 exports[`babel plugin for function hooks workletizes hook wrapped worklet reference automatically 1`] = `
-"var _worklet_3038192071896_init_data = {
-  code: "function style_null1(){return{color:'red',backgroundColor:'blue'};}",
+"const _worklet_16108251811600_init_data = {
+  code: "function null1(){return{color:'red',backgroundColor:'blue'};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var style = function style_null1Factory({
-  _worklet_3038192071896_init_data
+const style = function null1Factory({
+  _worklet_16108251811600_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const style = function () {
+  const null1 = function () {
     return {
       color: 'red',
       backgroundColor: 'blue'
     };
   };
-  style.__closure = {};
-  style.__workletHash = 3038192071896;
-  style.__pluginVersion = "x.y.z";
-  style.__initData = _worklet_3038192071896_init_data;
-  style.__stackDetails = _e;
-  return style;
+  null1.__closure = {};
+  null1.__workletHash = 16108251811600;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_16108251811600_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_3038192071896_init_data
+  _worklet_16108251811600_init_data
 });
-var animatedStyle = useAnimatedStyle(style);"
+const animatedStyle = useAnimatedStyle(style);"
 `;
 
 exports[`babel plugin for generators makes a generator worklet factory 1`] = `
-"var _worklet_4135278281851_init_data = {
+"const _worklet_4135278281851_init_data = {
   code: "function*foo_null1(){yield'hello';yield'world';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_4135278281851_init_data = _ref._worklet_4135278281851_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function* foo() {
+const foo = function foo_null1Factory({
+  _worklet_4135278281851_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function* () {
     yield 'hello';
     yield 'world';
   };
@@ -2425,20 +2440,21 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_4135278281851_init_data: _worklet_4135278281851_init_data
+  _worklet_4135278281851_init_data
 });"
 `;
 
 exports[`babel plugin for generators makes a generator worklet string 1`] = `
-"var _worklet_4135278281851_init_data = {
+"const _worklet_4135278281851_init_data = {
   code: "function*foo_null1(){yield'hello';yield'world';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_4135278281851_init_data = _ref._worklet_4135278281851_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function* foo() {
+const foo = function foo_null1Factory({
+  _worklet_4135278281851_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function* () {
     yield 'hello';
     yield 'world';
   };
@@ -2449,75 +2465,64 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_4135278281851_init_data: _worklet_4135278281851_init_data
+  _worklet_4135278281851_init_data
 });"
 `;
 
 exports[`babel plugin for inline styles doesn't show a warning if user writes something like style={styles.value} 1`] = `
-"var _jsxRuntime = require("react/jsx-runtime");
-function App() {
-  return (0, _jsxRuntime.jsx)(Animated.View, {
-    style: styles.value
-  });
+"function App() {
+  return <Animated.View style={styles.value} />;
 }"
 `;
 
 exports[`babel plugin for inline styles shows a warning if user uses .value inside inline style 1`] = `
-"var _jsxRuntime = require("react/jsx-runtime");
-function App() {
-  return (0, _jsxRuntime.jsx)(Animated.View, {
-    style: {
-      width: function () {
-        console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
-        return sharedValue.value;
-      }()
-    }
-  });
+"function App() {
+  return <Animated.View style={{
+    width: (() => {
+      console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
+      return sharedValue.value;
+    })()
+  }} />;
 }"
 `;
 
 exports[`babel plugin for inline styles shows a warning if user uses .value inside inline style, style array 1`] = `
-"var _jsxRuntime = require("react/jsx-runtime");
-function App() {
-  return (0, _jsxRuntime.jsx)(Animated.View, {
-    style: [style, {
-      width: function () {
-        console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
-        return sharedValue.value;
-      }()
-    }]
-  });
+"function App() {
+  return <Animated.View style={[style, {
+    width: (() => {
+      console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
+      return sharedValue.value;
+    })()
+  }]} />;
 }"
 `;
 
 exports[`babel plugin for inline styles shows a warning if user uses .value inside inline style, transforms 1`] = `
-"var _jsxRuntime = require("react/jsx-runtime");
-function App() {
-  return (0, _jsxRuntime.jsx)(Animated.View, {
-    style: {
-      transform: [{
-        translateX: function () {
-          console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
-          return sharedValue.value;
-        }()
-      }]
-    }
-  });
+"function App() {
+  return <Animated.View style={{
+    transform: [{
+      translateX: (() => {
+        console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
+        return sharedValue.value;
+      })()
+    }]
+  }} />;
 }"
 `;
 
 exports[`babel plugin for object hooks supports empty object in useAnimatedScrollHandler 1`] = `"useAnimatedScrollHandler({});"`;
 
 exports[`babel plugin for object hooks transforms ArrowFunctionExpression as argument of useAnimatedScrollHandler 1`] = `
-"var _worklet_6572201563503_init_data = {
+"const _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-useAnimatedScrollHandler(function null1Factory(_ref) {
-  var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1(event) {
+useAnimatedScrollHandler(function null1Factory({
+  _worklet_6572201563503_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function (event) {
     console.log(event);
   };
   null1.__closure = {};
@@ -2527,41 +2532,42 @@ useAnimatedScrollHandler(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_6572201563503_init_data: _worklet_6572201563503_init_data
+  _worklet_6572201563503_init_data
 }));"
 `;
 
 exports[`babel plugin for object hooks transforms each object property in useAnimatedScrollHandler 1`] = `
-"var _worklet_17107900483944_init_data = {
+"const _worklet_17107900483944_init_data = {
   code: "function null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_15612771346699_init_data = {
+const _worklet_15612771346699_init_data = {
   code: "function null2(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_3001796818986_init_data = {
+const _worklet_3001796818986_init_data = {
   code: "function null3(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_14370141256397_init_data = {
+const _worklet_14370141256397_init_data = {
   code: "function null4(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_16301592545772_init_data = {
+const _worklet_16301592545772_init_data = {
   code: "function null5(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
-  onScroll: function null1Factory(_ref) {
-    var _worklet_17107900483944_init_data = _ref._worklet_17107900483944_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null1 = function null1() {};
+  onScroll: function null1Factory({
+    _worklet_17107900483944_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {};
     null1.__closure = {};
     null1.__workletHash = 17107900483944;
     null1.__pluginVersion = "x.y.z";
@@ -2569,12 +2575,13 @@ useAnimatedScrollHandler({
     null1.__stackDetails = _e;
     return null1;
   }({
-    _worklet_17107900483944_init_data: _worklet_17107900483944_init_data
+    _worklet_17107900483944_init_data
   }),
-  onBeginDrag: function null2Factory(_ref2) {
-    var _worklet_15612771346699_init_data = _ref2._worklet_15612771346699_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null2 = function null2() {};
+  onBeginDrag: function null2Factory({
+    _worklet_15612771346699_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null2 = function () {};
     null2.__closure = {};
     null2.__workletHash = 15612771346699;
     null2.__pluginVersion = "x.y.z";
@@ -2582,12 +2589,13 @@ useAnimatedScrollHandler({
     null2.__stackDetails = _e;
     return null2;
   }({
-    _worklet_15612771346699_init_data: _worklet_15612771346699_init_data
+    _worklet_15612771346699_init_data
   }),
-  onEndDrag: function null3Factory(_ref3) {
-    var _worklet_3001796818986_init_data = _ref3._worklet_3001796818986_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null3 = function null3() {};
+  onEndDrag: function null3Factory({
+    _worklet_3001796818986_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null3 = function () {};
     null3.__closure = {};
     null3.__workletHash = 3001796818986;
     null3.__pluginVersion = "x.y.z";
@@ -2595,12 +2603,13 @@ useAnimatedScrollHandler({
     null3.__stackDetails = _e;
     return null3;
   }({
-    _worklet_3001796818986_init_data: _worklet_3001796818986_init_data
+    _worklet_3001796818986_init_data
   }),
-  onMomentumBegin: function null4Factory(_ref4) {
-    var _worklet_14370141256397_init_data = _ref4._worklet_14370141256397_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null4 = function null4() {};
+  onMomentumBegin: function null4Factory({
+    _worklet_14370141256397_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null4 = function () {};
     null4.__closure = {};
     null4.__workletHash = 14370141256397;
     null4.__pluginVersion = "x.y.z";
@@ -2608,12 +2617,13 @@ useAnimatedScrollHandler({
     null4.__stackDetails = _e;
     return null4;
   }({
-    _worklet_14370141256397_init_data: _worklet_14370141256397_init_data
+    _worklet_14370141256397_init_data
   }),
-  onMomentumEnd: function null5Factory(_ref5) {
-    var _worklet_16301592545772_init_data = _ref5._worklet_16301592545772_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null5 = function null5() {};
+  onMomentumEnd: function null5Factory({
+    _worklet_16301592545772_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null5 = function () {};
     null5.__closure = {};
     null5.__workletHash = 16301592545772;
     null5.__pluginVersion = "x.y.z";
@@ -2621,21 +2631,22 @@ useAnimatedScrollHandler({
     null5.__stackDetails = _e;
     return null5;
   }({
-    _worklet_16301592545772_init_data: _worklet_16301592545772_init_data
+    _worklet_16301592545772_init_data
   })
 });"
 `;
 
 exports[`babel plugin for object hooks transforms named FunctionExpression as argument of useAnimatedScrollHandler 1`] = `
-"var _worklet_13903338421046_init_data = {
+"const _worklet_13903338421046_init_data = {
   code: "function foo_null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-useAnimatedScrollHandler(function foo_null1Factory(_ref) {
-  var _worklet_13903338421046_init_data = _ref._worklet_13903338421046_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(event) {
+useAnimatedScrollHandler(function foo_null1Factory({
+  _worklet_13903338421046_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (event) {
     console.log(event);
   };
   foo.__closure = {};
@@ -2645,20 +2656,21 @@ useAnimatedScrollHandler(function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_13903338421046_init_data: _worklet_13903338421046_init_data
+  _worklet_13903338421046_init_data
 }));"
 `;
 
 exports[`babel plugin for object hooks transforms unnamed FunctionExpression as argument of useAnimatedScrollHandler 1`] = `
-"var _worklet_6572201563503_init_data = {
+"const _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-useAnimatedScrollHandler(function null1Factory(_ref) {
-  var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1(event) {
+useAnimatedScrollHandler(function null1Factory({
+  _worklet_6572201563503_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function (event) {
     console.log(event);
   };
   null1.__closure = {};
@@ -2668,21 +2680,22 @@ useAnimatedScrollHandler(function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_6572201563503_init_data: _worklet_6572201563503_init_data
+  _worklet_6572201563503_init_data
 }));"
 `;
 
 exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrapped ArrowFunctionExpression automatically 1`] = `
-"var _worklet_6572201563503_init_data = {
+"const _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
-  onScroll: function null1Factory(_ref) {
-    var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null1 = function null1(event) {
+  onScroll: function null1Factory({
+    _worklet_6572201563503_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function (event) {
       console.log(event);
     };
     null1.__closure = {};
@@ -2692,22 +2705,23 @@ useAnimatedScrollHandler({
     null1.__stackDetails = _e;
     return null1;
   }({
-    _worklet_6572201563503_init_data: _worklet_6572201563503_init_data
+    _worklet_6572201563503_init_data
   })
 });"
 `;
 
 exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrapped ObjectMethod automatically 1`] = `
-"var _worklet_11162089192476_init_data = {
+"const _worklet_11162089192476_init_data = {
   code: "function onScroll_null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
-  onScroll: function onScroll_null1Factory(_ref) {
-    var _worklet_11162089192476_init_data = _ref._worklet_11162089192476_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var onScroll = function onScroll(event) {
+  onScroll: function onScroll_null1Factory({
+    _worklet_11162089192476_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const onScroll = function (event) {
       console.log(event);
     };
     onScroll.__closure = {};
@@ -2717,22 +2731,23 @@ useAnimatedScrollHandler({
     onScroll.__stackDetails = _e;
     return onScroll;
   }({
-    _worklet_11162089192476_init_data: _worklet_11162089192476_init_data
+    _worklet_11162089192476_init_data
   })
 });"
 `;
 
 exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrapped named FunctionExpression automatically 1`] = `
-"var _worklet_11162089192476_init_data = {
+"const _worklet_11162089192476_init_data = {
   code: "function onScroll_null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
-  onScroll: function onScroll_null1Factory(_ref) {
-    var _worklet_11162089192476_init_data = _ref._worklet_11162089192476_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var onScroll = function onScroll(event) {
+  onScroll: function onScroll_null1Factory({
+    _worklet_11162089192476_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const onScroll = function (event) {
       console.log(event);
     };
     onScroll.__closure = {};
@@ -2742,22 +2757,23 @@ useAnimatedScrollHandler({
     onScroll.__stackDetails = _e;
     return onScroll;
   }({
-    _worklet_11162089192476_init_data: _worklet_11162089192476_init_data
+    _worklet_11162089192476_init_data
   })
 });"
 `;
 
 exports[`babel plugin for object hooks workletizes useAnimatedScrollHandler wrapped unnamed FunctionExpression automatically 1`] = `
-"var _worklet_6572201563503_init_data = {
+"const _worklet_6572201563503_init_data = {
   code: "function null1(event){console.log(event);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 useAnimatedScrollHandler({
-  onScroll: function null1Factory(_ref) {
-    var _worklet_6572201563503_init_data = _ref._worklet_6572201563503_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null1 = function null1(event) {
+  onScroll: function null1Factory({
+    _worklet_6572201563503_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function (event) {
       console.log(event);
     };
     null1.__closure = {};
@@ -2767,51 +2783,50 @@ useAnimatedScrollHandler({
     null1.__stackDetails = _e;
     return null1;
   }({
-    _worklet_6572201563503_init_data: _worklet_6572201563503_init_data
+    _worklet_6572201563503_init_data
   })
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler doesn't transform chained methods of objects containing Gesture property 1`] = `
-"var foo = Something.Gesture.Tap().onEnd(function () {
+"const foo = Something.Gesture.Tap().onEnd(() => {
   console.log('onEnd');
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler doesn't transform standard callback functions 1`] = `
-"var foo = Something.Tap().onEnd(function (_event, _success) {
+"const foo = Something.Tap().onEnd((_event, _success) => {
   console.log('onEnd');
 });"
 `;
 
-exports[`babel plugin for react-native-gesture-handler doesn't workletize irrelevant chained gesture object callback functions 1`] = `"var foo = Gesture.Tap().toString();"`;
+exports[`babel plugin for react-native-gesture-handler doesn't workletize irrelevant chained gesture object callback functions 1`] = `"const foo = Gesture.Tap().toString();"`;
 
 exports[`babel plugin for react-native-gesture-handler transforms spread operator in Animated component 1`] = `
-"var _jsxRuntime = require("react/jsx-runtime");
-function App() {
-  return (0, _jsxRuntime.jsx)(Animated.View, {
-    style: [style, Object.assign({}, styles.container, {
-      width: function () {
-        console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
-        return sharedValue.value;
-      }()
-    })]
-  });
+"function App() {
+  return <Animated.View style={[style, {
+    ...styles.container,
+    width: (() => {
+      console.warn(require("react-native-reanimated").getUseOfValueInStyleWarning());
+      return sharedValue.value;
+    })()
+  }]} />;
 }"
 `;
 
 exports[`babel plugin for react-native-gesture-handler transforms spread operator in worklets for arrays 1`] = `
-"var _worklet_10797201137439_init_data = {
+"const _worklet_10797201137439_init_data = {
   code: "function foo_null1(){const bar=[4,5];const baz=[1,...[2,3],...bar];}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_10797201137439_init_data = _ref._worklet_10797201137439_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
-    var bar = [4, 5];
-    var baz = [1].concat([2, 3], bar);
+const foo = function foo_null1Factory({
+  _worklet_10797201137439_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
+    const bar = [4, 5];
+    const baz = [1, ...[2, 3], ...bar];
   };
   foo.__closure = {};
   foo.__workletHash = 10797201137439;
@@ -2820,23 +2835,21 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_10797201137439_init_data: _worklet_10797201137439_init_data
+  _worklet_10797201137439_init_data
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler transforms spread operator in worklets for function arguments 1`] = `
-"var _worklet_7564534166424_init_data = {
+"const _worklet_7564534166424_init_data = {
   code: "function foo_null1(...args){console.log(args);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_7564534166424_init_data = _ref._worklet_7564534166424_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
-    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+const foo = function foo_null1Factory({
+  _worklet_7564534166424_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (...args) {
     console.log(args);
   };
   foo.__closure = {};
@@ -2846,24 +2859,22 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_7564534166424_init_data: _worklet_7564534166424_init_data
+  _worklet_7564534166424_init_data
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler transforms spread operator in worklets for function calls 1`] = `
-"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-var _worklet_14662302952728_init_data = {
+"const _worklet_14662302952728_init_data = {
   code: "function foo_null1(arg){console.log(...arg);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_14662302952728_init_data = _ref._worklet_14662302952728_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo(arg) {
-    var _console;
-    (_console = console).log.apply(_console, (0, _toConsumableArray2.default)(arg));
+const foo = function foo_null1Factory({
+  _worklet_14662302952728_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function (arg) {
+    console.log(...arg);
   };
   foo.__closure = {};
   foo.__workletHash = 14662302952728;
@@ -2872,30 +2883,33 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_14662302952728_init_data: _worklet_14662302952728_init_data
+  _worklet_14662302952728_init_data
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler transforms spread operator in worklets for objects 1`] = `
-"var _worklet_4831123253572_init_data = {
+"const _worklet_4831123253572_init_data = {
   code: "function foo_null1(){const bar={d:4,e:5};const baz={a:1,...{b:2,c:3},...bar};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_4831123253572_init_data = _ref._worklet_4831123253572_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
-    var bar = {
+const foo = function foo_null1Factory({
+  _worklet_4831123253572_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
+    const bar = {
       d: 4,
       e: 5
     };
-    var baz = Object.assign({
-      a: 1
-    }, {
-      b: 2,
-      c: 3
-    }, bar);
+    const baz = {
+      a: 1,
+      ...{
+        b: 2,
+        c: 3
+      },
+      ...bar
+    };
   };
   foo.__closure = {};
   foo.__workletHash = 4831123253572;
@@ -2904,32 +2918,33 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_4831123253572_init_data: _worklet_4831123253572_init_data
+  _worklet_4831123253572_init_data
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler workletizes gesture callbacks using the hooks api 1`] = `
-"var _worklet_13539781966089_init_data = {
+"const _worklet_13539781966089_init_data = {
   code: "function null1(){console.log('onBegin');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_16446448315454_init_data = {
+const _worklet_16446448315454_init_data = {
   code: "function null2(_event){console.log('onStart');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_16462958026656_init_data = {
+const _worklet_16462958026656_init_data = {
   code: "function null3(_event,_success){console.log('onEnd');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = useTapGesture({
+const foo = useTapGesture({
   numberOfTaps: 2,
-  onBegin: function null1Factory(_ref) {
-    var _worklet_13539781966089_init_data = _ref._worklet_13539781966089_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null1 = function null1() {
+  onBegin: function null1Factory({
+    _worklet_13539781966089_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null1 = function () {
       console.log('onBegin');
     };
     null1.__closure = {};
@@ -2939,12 +2954,13 @@ var foo = useTapGesture({
     null1.__stackDetails = _e;
     return null1;
   }({
-    _worklet_13539781966089_init_data: _worklet_13539781966089_init_data
+    _worklet_13539781966089_init_data
   }),
-  onStart: function null2Factory(_ref2) {
-    var _worklet_16446448315454_init_data = _ref2._worklet_16446448315454_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null2 = function null2(_event) {
+  onStart: function null2Factory({
+    _worklet_16446448315454_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null2 = function (_event) {
       console.log('onStart');
     };
     null2.__closure = {};
@@ -2954,12 +2970,13 @@ var foo = useTapGesture({
     null2.__stackDetails = _e;
     return null2;
   }({
-    _worklet_16446448315454_init_data: _worklet_16446448315454_init_data
+    _worklet_16446448315454_init_data
   }),
-  onEnd: function null3Factory(_ref3) {
-    var _worklet_16462958026656_init_data = _ref3._worklet_16462958026656_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var null3 = function null3(_event, _success) {
+  onEnd: function null3Factory({
+    _worklet_16462958026656_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const null3 = function (_event, _success) {
       console.log('onEnd');
     };
     null3.__closure = {};
@@ -2969,31 +2986,32 @@ var foo = useTapGesture({
     null3.__stackDetails = _e;
     return null3;
   }({
-    _worklet_16462958026656_init_data: _worklet_16462958026656_init_data
+    _worklet_16462958026656_init_data
   })
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler workletizes possibly chained gesture object callback functions automatically 1`] = `
-"var _worklet_2359797567586_init_data = {
+"const _worklet_2359797567586_init_data = {
   code: "function null1(_event,_success){console.log('onEnd');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_16446448315454_init_data = {
+const _worklet_16446448315454_init_data = {
   code: "function null2(_event){console.log('onStart');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_13974752356811_init_data = {
+const _worklet_13974752356811_init_data = {
   code: "function null3(){console.log('onBegin');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
-  var _worklet_13974752356811_init_data = _ref._worklet_13974752356811_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null3 = function null3() {
+const foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory({
+  _worklet_13974752356811_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null3 = function () {
     console.log('onBegin');
   };
   null3.__closure = {};
@@ -3003,11 +3021,12 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   null3.__stackDetails = _e;
   return null3;
 }({
-  _worklet_13974752356811_init_data: _worklet_13974752356811_init_data
-})).onStart(function null2Factory(_ref2) {
-  var _worklet_16446448315454_init_data = _ref2._worklet_16446448315454_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null2 = function null2(_event) {
+  _worklet_13974752356811_init_data
+})).onStart(function null2Factory({
+  _worklet_16446448315454_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null2 = function (_event) {
     console.log('onStart');
   };
   null2.__closure = {};
@@ -3017,11 +3036,12 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_16446448315454_init_data: _worklet_16446448315454_init_data
-})).onEnd(function null1Factory(_ref3) {
-  var _worklet_2359797567586_init_data = _ref3._worklet_2359797567586_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1(_event, _success) {
+  _worklet_16446448315454_init_data
+})).onEnd(function null1Factory({
+  _worklet_2359797567586_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function (_event, _success) {
     console.log('onEnd');
   };
   null1.__closure = {};
@@ -3031,129 +3051,124 @@ var foo = Gesture.Tap().numberOfTaps(2).onBegin(function null3Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_2359797567586_init_data: _worklet_2359797567586_init_data
+  _worklet_2359797567586_init_data
 }));"
 `;
 
 exports[`babel plugin for react-native-gesture-handler workletizes referenced callbacks 1`] = `
-"var _worklet_8764176270806_init_data = {
-  code: "function onStart_null1(){}",
+"const _worklet_17107900483944_init_data = {
+  code: "function null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var onStart = function onStart_null1Factory({
-  _worklet_8764176270806_init_data
+const onStart = function null1Factory({
+  _worklet_17107900483944_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const onStart = function () {};
-  onStart.__closure = {};
-  onStart.__workletHash = 8764176270806;
-  onStart.__pluginVersion = "x.y.z";
-  onStart.__initData = _worklet_8764176270806_init_data;
-  onStart.__stackDetails = _e;
-  return onStart;
+  const null1 = function () {};
+  null1.__closure = {};
+  null1.__workletHash = 17107900483944;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_17107900483944_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_8764176270806_init_data
+  _worklet_17107900483944_init_data
 });
-var foo = Gesture.Tap().onStart(onStart);"
+const foo = Gesture.Tap().onStart(onStart);"
 `;
 
 exports[`babel plugin for react-native-gesture-handler workletizes referenced gesture callbacks using the hooks api 1`] = `
-"var _worklet_12687812344336_init_data = {
-  code: "function onBegin_null1(){console.log('onBegin');}",
+"const _worklet_13539781966089_init_data = {
+  code: "function null1(){console.log('onBegin');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var onBegin = function onBegin_null1Factory({
-  _worklet_12687812344336_init_data
+const onBegin = function null1Factory({
+  _worklet_13539781966089_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const onBegin = function () {
+  const null1 = function () {
     console.log('onBegin');
   };
-  onBegin.__closure = {};
-  onBegin.__workletHash = 12687812344336;
-  onBegin.__pluginVersion = "x.y.z";
-  onBegin.__initData = _worklet_12687812344336_init_data;
-  onBegin.__stackDetails = _e;
-  return onBegin;
+  null1.__closure = {};
+  null1.__workletHash = 13539781966089;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_13539781966089_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_12687812344336_init_data
+  _worklet_13539781966089_init_data
 });
-var foo = useTapGesture({
+const foo = useTapGesture({
   numberOfTaps: 2,
   onBegin: onBegin
 });"
 `;
 
 exports[`babel plugin for react-native-gesture-handler workletizes referenced gesture callbacks using the hooks api and shorthand syntax 1`] = `
-"var _worklet_12687812344336_init_data = {
-  code: "function onBegin_null1(){console.log('onBegin');}",
+"const _worklet_13539781966089_init_data = {
+  code: "function null1(){console.log('onBegin');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var onBegin = function onBegin_null1Factory({
-  _worklet_12687812344336_init_data
+const onBegin = function null1Factory({
+  _worklet_13539781966089_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const onBegin = function () {
+  const null1 = function () {
     console.log('onBegin');
   };
-  onBegin.__closure = {};
-  onBegin.__workletHash = 12687812344336;
-  onBegin.__pluginVersion = "x.y.z";
-  onBegin.__initData = _worklet_12687812344336_init_data;
-  onBegin.__stackDetails = _e;
-  return onBegin;
+  null1.__closure = {};
+  null1.__workletHash = 13539781966089;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_13539781966089_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_12687812344336_init_data
+  _worklet_13539781966089_init_data
 });
-var foo = useTapGesture({
+const foo = useTapGesture({
   numberOfTaps: 2,
-  onBegin: onBegin
+  onBegin
 });"
 `;
 
 exports[`babel plugin for referenced worklets prefers AssignmentExpression over VariableDeclarator 1`] = `
-"var styleFactory = function styleFactory() {
-  return 1;
-};
-var _worklet_7165463824996_init_data = {
-  code: "function styleFactory_null1(){return'AssignmentExpression';}",
+"let styleFactory = () => 1;
+const _worklet_11678593259064_init_data = {
+  code: "function null1(){return'AssignmentExpression';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-styleFactory = function styleFactory_null1Factory({
-  _worklet_7165463824996_init_data
+styleFactory = function null1Factory({
+  _worklet_11678593259064_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
-    return 'AssignmentExpression';
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 7165463824996;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_7165463824996_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  const null1 = () => 'AssignmentExpression';
+  null1.__closure = {};
+  null1.__workletHash = 11678593259064;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11678593259064_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_7165463824996_init_data
+  _worklet_11678593259064_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets prefers FunctionDeclaration over AssignmentExpression 1`] = `
-"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-var _readOnlyError2 = _interopRequireDefault(require("@babel/runtime/helpers/readOnlyError"));
-var _worklet_2619465543015_init_data = {
+"const _worklet_2619465543015_init_data = {
   code: "function styleFactory_null1(){return'FunctionDeclaration';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var styleFactory = function styleFactory_null1Factory(_ref) {
-  var _worklet_2619465543015_init_data = _ref._worklet_2619465543015_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var styleFactory = function styleFactory() {
+const styleFactory = function styleFactory_null1Factory({
+  _worklet_2619465543015_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const styleFactory = function () {
     return 'FunctionDeclaration';
   };
   styleFactory.__closure = {};
@@ -3163,126 +3178,91 @@ var styleFactory = function styleFactory_null1Factory(_ref) {
   styleFactory.__stackDetails = _e;
   return styleFactory;
 }({
-  _worklet_2619465543015_init_data: _worklet_2619465543015_init_data
+  _worklet_2619465543015_init_data
 });
-(function styleFactory() {
-  return 'AssignmentExpression';
-}), (0, _readOnlyError2.default)("styleFactory");
+styleFactory = () => 'AssignmentExpression';
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ArrowFunctionExpression on its AssignmentExpression 1`] = `
-"var styleFactory;
-var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
+"let styleFactory;
+const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-styleFactory = function styleFactory_null1Factory({
-  _worklet_17388574355683_init_data
+styleFactory = function null1Factory({
+  _worklet_11855919716831_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
-    return {};
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 17388574355683;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_17388574355683_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  const null1 = () => ({});
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_17388574355683_init_data
+  _worklet_11855919716831_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ArrowFunctionExpression on its VariableDeclarator 1`] = `
-"var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
+"const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var styleFactory = function styleFactory_null1Factory({
-  _worklet_17388574355683_init_data
+let styleFactory = function null1Factory({
+  _worklet_11855919716831_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
-    return {};
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 17388574355683;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_17388574355683_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  const null1 = () => ({});
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_17388574355683_init_data
+  _worklet_11855919716831_init_data
 });
-var animatedStyle = useAnimatedStyle(styleFactory);"
+const animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ArrowFunctionExpression only on last AssignmentExpression 1`] = `
-"var styleFactory;
-styleFactory = function styleFactory() {
-  return 1;
-};
-var _worklet_7165463824996_init_data = {
-  code: "function styleFactory_null1(){return'AssignmentExpression';}",
+"let styleFactory;
+styleFactory = () => 1;
+const _worklet_11678593259064_init_data = {
+  code: "function null1(){return'AssignmentExpression';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-styleFactory = function styleFactory_null1Factory({
-  _worklet_7165463824996_init_data
+styleFactory = function null1Factory({
+  _worklet_11678593259064_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
-    return 'AssignmentExpression';
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 7165463824996;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_7165463824996_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  const null1 = () => 'AssignmentExpression';
+  null1.__closure = {};
+  null1.__workletHash = 11678593259064;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11678593259064_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_7165463824996_init_data
+  _worklet_11678593259064_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes FunctionDeclaration 1`] = `
-"var _worklet_17388574355683_init_data = {
+"const _worklet_17388574355683_init_data = {
   code: "function styleFactory_null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var styleFactory = function styleFactory_null1Factory(_ref) {
-  var _worklet_17388574355683_init_data = _ref._worklet_17388574355683_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var styleFactory = function styleFactory() {
-    return {};
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 17388574355683;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_17388574355683_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
-}({
-  _worklet_17388574355683_init_data: _worklet_17388574355683_init_data
-});
-var animatedStyle = useAnimatedStyle(styleFactory);"
-`;
-
-exports[`babel plugin for referenced worklets workletizes FunctionExpression on its AssignmentExpression 1`] = `
-"var styleFactory;
-var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
-  location: "/dev/null",
-  sourceMap: "\\"mock source map\\""
-};
-styleFactory = function styleFactory_null1Factory({
+const styleFactory = function styleFactory_null1Factory({
   _worklet_17388574355683_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
@@ -3297,162 +3277,183 @@ styleFactory = function styleFactory_null1Factory({
   return styleFactory;
 }({
   _worklet_17388574355683_init_data
+});
+const animatedStyle = useAnimatedStyle(styleFactory);"
+`;
+
+exports[`babel plugin for referenced worklets workletizes FunctionExpression on its AssignmentExpression 1`] = `
+"let styleFactory;
+const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
+  location: "/dev/null",
+  sourceMap: "\\"mock source map\\""
+};
+styleFactory = function null1Factory({
+  _worklet_11855919716831_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
+    return {};
+  };
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
+}({
+  _worklet_11855919716831_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes FunctionExpression on its VariableDeclarator 1`] = `
-"var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
+"const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var styleFactory = function styleFactory_null1Factory({
-  _worklet_17388574355683_init_data
+let styleFactory = function null1Factory({
+  _worklet_11855919716831_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
+  const null1 = function () {
     return {};
   };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 17388574355683;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_17388574355683_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_17388574355683_init_data
+  _worklet_11855919716831_init_data
 });
-var animatedStyle = useAnimatedStyle(styleFactory);"
+const animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes FunctionExpression only on last AssignmentExpression 1`] = `
-"var styleFactory;
-styleFactory = function styleFactory() {
+"let styleFactory;
+styleFactory = function () {
   return 1;
 };
-var _worklet_7165463824996_init_data = {
-  code: "function styleFactory_null1(){return'AssignmentExpression';}",
+const _worklet_11678593259064_init_data = {
+  code: "function null1(){return'AssignmentExpression';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-styleFactory = function styleFactory_null1Factory({
-  _worklet_7165463824996_init_data
+styleFactory = function null1Factory({
+  _worklet_11678593259064_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
+  const null1 = function () {
     return 'AssignmentExpression';
   };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 7165463824996;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_7165463824996_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  null1.__closure = {};
+  null1.__workletHash = 11678593259064;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11678593259064_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_7165463824996_init_data
+  _worklet_11678593259064_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ObjectExpression on its AssignmentExpression 1`] = `
-"var handler;
-var _worklet_10431207809979_init_data = {
-  code: "function onScroll_null1(){}",
+"let handler;
+const _worklet_17107900483944_init_data = {
+  code: "function null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 handler = {
-  onScroll: function onScroll_null1Factory({
-    _worklet_10431207809979_init_data
+  onScroll: function null1Factory({
+    _worklet_17107900483944_init_data
   }) {
     const _e = [new global.Error(), 1, -27];
-    const onScroll = function () {};
-    onScroll.__closure = {};
-    onScroll.__workletHash = 10431207809979;
-    onScroll.__pluginVersion = "x.y.z";
-    onScroll.__initData = _worklet_10431207809979_init_data;
-    onScroll.__stackDetails = _e;
-    return onScroll;
+    const null1 = function () {};
+    null1.__closure = {};
+    null1.__workletHash = 17107900483944;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_17107900483944_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_10431207809979_init_data
+    _worklet_17107900483944_init_data
   })
 };
-var scrollHandler = useAnimatedScrollHandler(handler);"
+const scrollHandler = useAnimatedScrollHandler(handler);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ObjectExpression on its VariableDeclarator 1`] = `
-"var _worklet_10431207809979_init_data = {
-  code: "function onScroll_null1(){}",
+"const _worklet_17107900483944_init_data = {
+  code: "function null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var handler = {
-  onScroll: function onScroll_null1Factory({
-    _worklet_10431207809979_init_data
+let handler = {
+  onScroll: function null1Factory({
+    _worklet_17107900483944_init_data
   }) {
     const _e = [new global.Error(), 1, -27];
-    const onScroll = function () {};
-    onScroll.__closure = {};
-    onScroll.__workletHash = 10431207809979;
-    onScroll.__pluginVersion = "x.y.z";
-    onScroll.__initData = _worklet_10431207809979_init_data;
-    onScroll.__stackDetails = _e;
-    return onScroll;
+    const null1 = function () {};
+    null1.__closure = {};
+    null1.__workletHash = 17107900483944;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_17107900483944_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_10431207809979_init_data
+    _worklet_17107900483944_init_data
   })
 };
-var scrollHandler = useAnimatedScrollHandler(handler);"
+const scrollHandler = useAnimatedScrollHandler(handler);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes ObjectExpression only on last AssignmentExpression 1`] = `
-"var handler;
+"let handler;
 handler = {
-  onScroll: function onScroll() {
-    return 1;
-  }
+  onScroll: () => 1
 };
-var _worklet_3006312818667_init_data = {
-  code: "function onScroll_null1(){return'AssignmentExpression';}",
+const _worklet_11678593259064_init_data = {
+  code: "function null1(){return'AssignmentExpression';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 handler = {
-  onScroll: function onScroll_null1Factory({
-    _worklet_3006312818667_init_data
+  onScroll: function null1Factory({
+    _worklet_11678593259064_init_data
   }) {
     const _e = [new global.Error(), 1, -27];
-    const onScroll = function () {
-      return 'AssignmentExpression';
-    };
-    onScroll.__closure = {};
-    onScroll.__workletHash = 3006312818667;
-    onScroll.__pluginVersion = "x.y.z";
-    onScroll.__initData = _worklet_3006312818667_init_data;
-    onScroll.__stackDetails = _e;
-    return onScroll;
+    const null1 = () => 'AssignmentExpression';
+    null1.__closure = {};
+    null1.__workletHash = 11678593259064;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11678593259064_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_3006312818667_init_data
+    _worklet_11678593259064_init_data
   })
 };
-var scrollHandler = useAnimatedScrollHandler(handler);"
+const scrollHandler = useAnimatedScrollHandler(handler);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes assignments that appear after the worklet is used 1`] = `
-"var styleFactory = function styleFactory() {
-  return {};
-};
+"let styleFactory = () => ({});
 animatedStyle = useAnimatedStyle(styleFactory);
-var _worklet_506044013293_init_data = {
+const _worklet_506044013293_init_data = {
   code: "function null1(){return'AssignmentAfterUse';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-styleFactory = function null1Factory(_ref) {
-  var _worklet_506044013293_init_data = _ref._worklet_506044013293_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+styleFactory = function null1Factory({
+  _worklet_506044013293_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 'AssignmentAfterUse';
   };
   null1.__closure = {};
@@ -3462,57 +3463,53 @@ styleFactory = function null1Factory(_ref) {
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_506044013293_init_data: _worklet_506044013293_init_data
+  _worklet_506044013293_init_data
 });"
 `;
 
 exports[`babel plugin for referenced worklets workletizes in immediate scope 1`] = `
-"var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
+"const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var styleFactory = function styleFactory_null1Factory({
-  _worklet_17388574355683_init_data
+let styleFactory = function null1Factory({
+  _worklet_11855919716831_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const styleFactory = function () {
-    return {};
-  };
-  styleFactory.__closure = {};
-  styleFactory.__workletHash = 17388574355683;
-  styleFactory.__pluginVersion = "x.y.z";
-  styleFactory.__initData = _worklet_17388574355683_init_data;
-  styleFactory.__stackDetails = _e;
-  return styleFactory;
+  const null1 = () => ({});
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_17388574355683_init_data
+  _worklet_11855919716831_init_data
 });
 animatedStyle = useAnimatedStyle(styleFactory);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes in nested scope 1`] = `
-"var _worklet_17388574355683_init_data = {
-  code: "function styleFactory_null1(){return{};}",
+"const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function outerScope() {
-  var styleFactory = function styleFactory_null1Factory({
-    _worklet_17388574355683_init_data
+  let styleFactory = function null1Factory({
+    _worklet_11855919716831_init_data
   }) {
     const _e = [new global.Error(), 1, -27];
-    const styleFactory = function () {
-      return {};
-    };
-    styleFactory.__closure = {};
-    styleFactory.__workletHash = 17388574355683;
-    styleFactory.__pluginVersion = "x.y.z";
-    styleFactory.__initData = _worklet_17388574355683_init_data;
-    styleFactory.__stackDetails = _e;
-    return styleFactory;
+    const null1 = () => ({});
+    null1.__closure = {};
+    null1.__workletHash = 11855919716831;
+    null1.__pluginVersion = "x.y.z";
+    null1.__initData = _worklet_11855919716831_init_data;
+    null1.__stackDetails = _e;
+    return null1;
   }({
-    _worklet_17388574355683_init_data
+    _worklet_11855919716831_init_data
   });
   function innerScope() {
     animatedStyle = useAnimatedStyle(styleFactory);
@@ -3521,80 +3518,80 @@ function outerScope() {
 `;
 
 exports[`babel plugin for referenced worklets workletizes multiple referencing 1`] = `
-"var _worklet_12252375123771_init_data = {
-  code: "function secondReference_null1(){return{};}",
+"const _worklet_11855919716831_init_data = {
+  code: "function null1(){return{};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var secondReference = function secondReference_null1Factory({
-  _worklet_12252375123771_init_data
+const secondReference = function null1Factory({
+  _worklet_11855919716831_init_data
 }) {
   const _e = [new global.Error(), 1, -27];
-  const secondReference = function () {
-    return {};
-  };
-  secondReference.__closure = {};
-  secondReference.__workletHash = 12252375123771;
-  secondReference.__pluginVersion = "x.y.z";
-  secondReference.__initData = _worklet_12252375123771_init_data;
-  secondReference.__stackDetails = _e;
-  return secondReference;
+  const null1 = () => ({});
+  null1.__closure = {};
+  null1.__workletHash = 11855919716831;
+  null1.__pluginVersion = "x.y.z";
+  null1.__initData = _worklet_11855919716831_init_data;
+  null1.__stackDetails = _e;
+  return null1;
 }({
-  _worklet_12252375123771_init_data
+  _worklet_11855919716831_init_data
 });
-var firstReference = secondReference;
-var animatedStyle = useAnimatedStyle(firstReference);"
+const firstReference = secondReference;
+const animatedStyle = useAnimatedStyle(firstReference);"
 `;
 
 exports[`babel plugin for referenced worklets workletizes recursion 1`] = `
-"var _worklet_14493084721304_init_data = {
+"const _worklet_14493084721304_init_data = {
   code: "function recursiveWorklet_null1(){const recursiveWorklet_null1=this._recur;const{runOnUI}=this.__closure;if(!globalThis._WORKLET){runOnUI(recursiveWorklet_null1)();}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var recursiveWorklet = function recursiveWorklet_null1Factory(_ref) {
-  var _worklet_14493084721304_init_data = _ref._worklet_14493084721304_init_data,
-    runOnUI = _ref.runOnUI;
-  var _e = [new global.Error(), -2, -27];
-  var _recursiveWorklet = function recursiveWorklet() {
+const recursiveWorklet = function recursiveWorklet_null1Factory({
+  _worklet_14493084721304_init_data,
+  runOnUI
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const recursiveWorklet = function () {
     if (!globalThis._WORKLET) {
-      runOnUI(_recursiveWorklet)();
+      runOnUI(recursiveWorklet)();
     }
   };
-  _recursiveWorklet.__closure = {
-    runOnUI: runOnUI
+  recursiveWorklet.__closure = {
+    runOnUI
   };
-  _recursiveWorklet.__workletHash = 14493084721304;
-  _recursiveWorklet.__pluginVersion = "x.y.z";
-  _recursiveWorklet.__initData = _worklet_14493084721304_init_data;
-  _recursiveWorklet.__stackDetails = _e;
-  return _recursiveWorklet;
+  recursiveWorklet.__workletHash = 14493084721304;
+  recursiveWorklet.__pluginVersion = "x.y.z";
+  recursiveWorklet.__initData = _worklet_14493084721304_init_data;
+  recursiveWorklet.__stackDetails = _e;
+  return recursiveWorklet;
 }({
-  _worklet_14493084721304_init_data: _worklet_14493084721304_init_data,
-  runOnUI: runOnUI
+  _worklet_14493084721304_init_data,
+  runOnUI
 });"
 `;
 
 exports[`babel plugin for sequence expressions supports SequenceExpression 1`] = `
 "function App() {
   (0, fun)({
-    onStart: function onStart() {}
+    onStart() {}
   }, []);
 }"
 `;
 
 exports[`babel plugin for sequence expressions supports SequenceExpression, many arguments 1`] = `
-"var _worklet_8764176270806_init_data = {
+"const _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, 3, fun)({
-    onStart: function onStart_null1Factory(_ref) {
-      var _worklet_8764176270806_init_data = _ref._worklet_8764176270806_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var onStart = function onStart() {};
+    onStart: function onStart_null1Factory({
+      _worklet_8764176270806_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const onStart = function () {};
       onStart.__closure = {};
       onStart.__workletHash = 8764176270806;
       onStart.__pluginVersion = "x.y.z";
@@ -3602,24 +3599,25 @@ function App() {
       onStart.__stackDetails = _e;
       return onStart;
     }({
-      _worklet_8764176270806_init_data: _worklet_8764176270806_init_data
+      _worklet_8764176270806_init_data
     })
   }, []);
 }"
 `;
 
 exports[`babel plugin for sequence expressions supports SequenceExpression, with objectHook 1`] = `
-"var _worklet_10431207809979_init_data = {
+"const _worklet_10431207809979_init_data = {
   code: "function onScroll_null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, useAnimatedScrollHandler)({
-    onScroll: function onScroll_null1Factory(_ref) {
-      var _worklet_10431207809979_init_data = _ref._worklet_10431207809979_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var onScroll = function onScroll() {};
+    onScroll: function onScroll_null1Factory({
+      _worklet_10431207809979_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const onScroll = function () {};
       onScroll.__closure = {};
       onScroll.__workletHash = 10431207809979;
       onScroll.__pluginVersion = "x.y.z";
@@ -3627,24 +3625,25 @@ function App() {
       onScroll.__stackDetails = _e;
       return onScroll;
     }({
-      _worklet_10431207809979_init_data: _worklet_10431207809979_init_data
+      _worklet_10431207809979_init_data
     })
   }, []);
 }"
 `;
 
 exports[`babel plugin for sequence expressions supports SequenceExpression, with worklet 1`] = `
-"var _worklet_8764176270806_init_data = {
+"const _worklet_8764176270806_init_data = {
   code: "function onStart_null1(){}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function App() {
   (0, fun)({
-    onStart: function onStart_null1Factory(_ref) {
-      var _worklet_8764176270806_init_data = _ref._worklet_8764176270806_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var onStart = function onStart() {};
+    onStart: function onStart_null1Factory({
+      _worklet_8764176270806_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const onStart = function () {};
       onStart.__closure = {};
       onStart.__workletHash = 8764176270806;
       onStart.__pluginVersion = "x.y.z";
@@ -3652,33 +3651,34 @@ function App() {
       onStart.__stackDetails = _e;
       return onStart;
     }({
-      _worklet_8764176270806_init_data: _worklet_8764176270806_init_data
+      _worklet_8764176270806_init_data
     })
   }, []);
 }"
 `;
 
 exports[`babel plugin for sequence expressions supports SequenceExpression, with worklet closure 1`] = `
-"var _worklet_10926786553639_init_data = {
+"const _worklet_10926786553639_init_data = {
   code: "function onStart_null1(){const{obj}=this.__closure;const a=obj.a;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function App() {
-  var obj = {
+  const obj = {
     a: 1,
     b: 2
   };
   (0, fun)({
-    onStart: function onStart_null1Factory(_ref) {
-      var _worklet_10926786553639_init_data = _ref._worklet_10926786553639_init_data,
-        obj = _ref.obj;
-      var _e = [new global.Error(), -2, -27];
-      var onStart = function onStart() {
-        var a = obj.a;
+    onStart: function onStart_null1Factory({
+      _worklet_10926786553639_init_data,
+      obj
+    }) {
+      const _e = [new global.Error(), -2, -27];
+      const onStart = function () {
+        const a = obj.a;
       };
       onStart.__closure = {
-        obj: obj
+        obj
       };
       onStart.__workletHash = 10926786553639;
       onStart.__pluginVersion = "x.y.z";
@@ -3686,31 +3686,32 @@ function App() {
       onStart.__stackDetails = _e;
       return onStart;
     }({
-      _worklet_10926786553639_init_data: _worklet_10926786553639_init_data,
-      obj: obj
+      _worklet_10926786553639_init_data,
+      obj
     })
   }, []);
 }"
 `;
 
 exports[`babel plugin for web configuration doesn't substitute isWeb and shouldBeUseWeb in worklets 1`] = `
-"var _worklet_8645270621312_init_data = {
+"const _worklet_8645270621312_init_data = {
   code: "function foo_null1(){const{isWeb,shouldBeUseWeb}=this.__closure;const x=isWeb();const y=shouldBeUseWeb();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_8645270621312_init_data = _ref._worklet_8645270621312_init_data,
-    isWeb = _ref.isWeb,
-    shouldBeUseWeb = _ref.shouldBeUseWeb;
-  var _e = [new global.Error(), -3, -27];
-  var foo = function foo() {
-    var x = true;
-    var y = true;
+const foo = function foo_null1Factory({
+  _worklet_8645270621312_init_data,
+  isWeb,
+  shouldBeUseWeb
+}) {
+  const _e = [new global.Error(), -3, -27];
+  const foo = function () {
+    const x = true;
+    const y = true;
   };
   foo.__closure = {
-    isWeb: isWeb,
-    shouldBeUseWeb: shouldBeUseWeb
+    isWeb,
+    shouldBeUseWeb
   };
   foo.__workletHash = 8645270621312;
   foo.__pluginVersion = "x.y.z";
@@ -3718,32 +3719,33 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_8645270621312_init_data: _worklet_8645270621312_init_data,
-  isWeb: isWeb,
-  shouldBeUseWeb: shouldBeUseWeb
+  _worklet_8645270621312_init_data,
+  isWeb,
+  shouldBeUseWeb
 });"
 `;
 
 exports[`babel plugin for web configuration doesn't substitute isWeb and shouldBeUseWeb with true when substituteWebPlatformChecks option is set to false 1`] = `
-"var x = isWeb();
-var y = shouldBeUseWeb();"
+"const x = isWeb();
+const y = shouldBeUseWeb();"
 `;
 
 exports[`babel plugin for web configuration doesn't substitute isWeb and shouldBeUseWeb with true when substituteWebPlatformChecks option is undefined 1`] = `
-"var x = isWeb();
-var y = shouldBeUseWeb();"
+"const x = isWeb();
+const y = shouldBeUseWeb();"
 `;
 
 exports[`babel plugin for web configuration includes initData when omitNativeOnlyData option is set to false 1`] = `
-"var _worklet_8266917884050_init_data = {
+"const _worklet_8266917884050_init_data = {
   code: "function foo_null1(){var bar='bar';}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_8266917884050_init_data = _ref._worklet_8266917884050_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_null1Factory({
+  _worklet_8266917884050_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     var bar = 'bar';
   };
   foo.__closure = {};
@@ -3753,17 +3755,14 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_8266917884050_init_data: _worklet_8266917884050_init_data
+  _worklet_8266917884050_init_data
 });"
 `;
 
 exports[`babel plugin for web configuration skips initData when omitNativeOnlyData option is set to true 1`] = `
-"var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-var _objectDestructuringEmpty2 = _interopRequireDefault(require("@babel/runtime/helpers/objectDestructuringEmpty"));
-var foo = function foo_null1Factory(_ref) {
-  (0, _objectDestructuringEmpty2.default)(_ref);
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+"const foo = function foo_null1Factory({}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     var foo = 'bar';
   };
   foo.__closure = {};
@@ -3775,46 +3774,47 @@ var foo = function foo_null1Factory(_ref) {
 `;
 
 exports[`babel plugin for web configuration substitutes isWeb and shouldBeUseWeb with true when substituteWebPlatformChecks option is set to true 1`] = `
-"var x = true;
-var y = true;"
+"const x = true;
+const y = true;"
 `;
 
 exports[`babel plugin for worklet classes appends polyfills 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -3824,12 +3824,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -3846,18 +3847,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -3865,21 +3867,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -3887,20 +3890,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -3908,16 +3912,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -3928,64 +3933,65 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet classes creates factories 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -3995,12 +4001,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -4017,18 +4024,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -4036,21 +4044,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -4058,20 +4067,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -4079,16 +4089,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -4099,40 +4110,41 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet classes injects class factory into worklets 1`] = `
-"var _worklet_3370991485663_init_data = {
+"const _worklet_3370991485663_init_data = {
   code: "function foo_null1(){const{Clazz__classFactory}=this.__closure;const Clazz=Clazz__classFactory();const clazz=new Clazz();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_3370991485663_init_data = _ref._worklet_3370991485663_init_data,
-    Clazz = _ref.Clazz;
-  var _e = [new global.Error(), -2, -27];
-  var foo = function foo() {
-    var clazz = new Clazz();
+const foo = function foo_null1Factory({
+  _worklet_3370991485663_init_data,
+  Clazz
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const foo = function () {
+    const clazz = new Clazz();
   };
   foo.__closure = {
     Clazz__classFactory: Clazz.Clazz__classFactory
@@ -4143,8 +4155,8 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_3370991485663_init_data: _worklet_3370991485663_init_data,
-  Clazz: Clazz
+  _worklet_3370991485663_init_data,
+  Clazz
 });"
 `;
 
@@ -4152,20 +4164,21 @@ exports[`babel plugin for worklet classes is disabled via option 1`] = `
 "function foo() {
   this.prop = 42;
 }
-var _worklet_6135491687917_init_data = {
+const _worklet_6135491687917_init_data = {
   code: "function bar_null1(){const{foo}=this.__closure;const instance=new foo();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var bar = function bar_null1Factory(_ref) {
-  var _worklet_6135491687917_init_data = _ref._worklet_6135491687917_init_data,
-    foo = _ref.foo;
-  var _e = [new global.Error(), -2, -27];
-  var bar = function bar() {
-    var instance = new foo();
+const bar = function bar_null1Factory({
+  _worklet_6135491687917_init_data,
+  foo
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const bar = function () {
+    const instance = new foo();
   };
   bar.__closure = {
-    foo: foo
+    foo
   };
   bar.__workletHash = 6135491687917;
   bar.__pluginVersion = "x.y.z";
@@ -4173,52 +4186,53 @@ var bar = function bar_null1Factory(_ref) {
   bar.__stackDetails = _e;
   return bar;
 }({
-  _worklet_6135491687917_init_data: _worklet_6135491687917_init_data,
-  foo: foo
+  _worklet_6135491687917_init_data,
+  foo
 });"
 `;
 
 exports[`babel plugin for worklet classes keeps this binding 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_2394858016888_init_data = {
+const _worklet_2394858016888_init_data = {
   code: "function _defineProperty_null6(e,r,t){const{_toPropertyKey}=this.__closure;return(r=_toPropertyKey(r))in e?Object.defineProperty(e,r,{value:t,enumerable:!0,configurable:!0,writable:!0}):e[r]=t,e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_11384144076188_init_data = {
+const _worklet_11384144076188_init_data = {
   code: "function Clazz__classFactory_null7(){const Clazz__classFactory_null7=this._recur;const{_classCallCheck,_defineProperty,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);_defineProperty(this,\\"member\\",1);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return this.member;}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null7;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -4228,12 +4242,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -4250,18 +4265,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -4269,21 +4285,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -4291,20 +4308,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -4312,14 +4330,15 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var _defineProperty = function _defineProperty_null6Factory(_ref6) {
-    var _worklet_2394858016888_init_data = _ref6._worklet_2394858016888_init_data,
-      _toPropertyKey = _ref6._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperty = function _defineProperty(e, r, t) {
+  const _defineProperty = function _defineProperty_null6Factory({
+    _worklet_2394858016888_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperty = function (e, r, t) {
       return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
         value: t,
         enumerable: !0,
@@ -4328,7 +4347,7 @@ var Clazz = function () {
       }) : e[r] = t, e;
     };
     _defineProperty.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperty.__workletHash = 2394858016888;
     _defineProperty.__pluginVersion = "x.y.z";
@@ -4336,17 +4355,18 @@ var Clazz = function () {
     _defineProperty.__stackDetails = _e;
     return _defineProperty;
   }({
-    _worklet_2394858016888_init_data: _worklet_2394858016888_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_2394858016888_init_data,
+    _toPropertyKey
   });
-  var Clazz__classFactory = function Clazz__classFactory_null7Factory(_ref7) {
-    var _worklet_11384144076188_init_data = _ref7._worklet_11384144076188_init_data,
-      _classCallCheck = _ref7._classCallCheck,
-      _defineProperty = _ref7._defineProperty,
-      _createClass = _ref7._createClass;
-    var _e = [new global.Error(), -4, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null7Factory({
+    _worklet_11384144076188_init_data,
+    _classCallCheck,
+    _defineProperty,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -4, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
           _defineProperty(this, "member", 1);
@@ -4358,42 +4378,43 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _defineProperty: _defineProperty,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _defineProperty,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 11384144076188;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_11384144076188_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 11384144076188;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_11384144076188_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_11384144076188_init_data: _worklet_11384144076188_init_data,
-    _classCallCheck: _classCallCheck,
-    _defineProperty: _defineProperty,
-    _createClass: _createClass
+    _worklet_11384144076188_init_data,
+    _classCallCheck,
+    _defineProperty,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet classes modifies closures 1`] = `
-"var _worklet_3370991485663_init_data = {
+"const _worklet_3370991485663_init_data = {
   code: "function foo_null1(){const{Clazz__classFactory}=this.__closure;const Clazz=Clazz__classFactory();const clazz=new Clazz();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_3370991485663_init_data = _ref._worklet_3370991485663_init_data,
-    Clazz = _ref.Clazz;
-  var _e = [new global.Error(), -2, -27];
-  var foo = function foo() {
-    var clazz = new Clazz();
+const foo = function foo_null1Factory({
+  _worklet_3370991485663_init_data,
+  Clazz
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const foo = function () {
+    const clazz = new Clazz();
   };
   foo.__closure = {
     Clazz__classFactory: Clazz.Clazz__classFactory
@@ -4404,47 +4425,48 @@ var foo = function foo_null1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_3370991485663_init_data: _worklet_3370991485663_init_data,
-  Clazz: Clazz
+  _worklet_3370991485663_init_data,
+  Clazz
 });"
 `;
 
 exports[`babel plugin for worklet classes removes marker 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -4454,12 +4476,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -4476,18 +4499,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -4495,21 +4519,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -4517,20 +4542,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -4538,16 +4564,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -4558,64 +4585,65 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet classes workletizes polyfills 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -4625,12 +4653,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -4647,18 +4676,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -4666,21 +4696,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -4688,20 +4719,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -4709,16 +4741,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -4729,64 +4762,65 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet classes workletizes regardless of marker value 1`] = `
-"var _worklet_14560075646677_init_data = {
+"const _worklet_14560075646677_init_data = {
   code: "function _classCallCheck_null1(a,n){if(!(a instanceof n))throw new TypeError(\\"Cannot call a class as a function\\");}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_12814759901173_init_data = {
+const _worklet_12814759901173_init_data = {
   code: "function _toPrimitive_null2(t,r){if(\\"object\\"!=typeof t||!t)return t;var e=t[Symbol.toPrimitive];if(void 0!==e){var i=e.call(t,r||\\"default\\");if(\\"object\\"!=typeof i)return i;throw new TypeError(\\"@@toPrimitive must return a primitive value.\\");}return(\\"string\\"===r?String:Number)(t);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_10645339112046_init_data = {
+const _worklet_10645339112046_init_data = {
   code: "function _toPropertyKey_null3(t){const{_toPrimitive}=this.__closure;var i=_toPrimitive(t,\\"string\\");return\\"symbol\\"==typeof i?i:i+\\"\\";}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_8234197014582_init_data = {
+const _worklet_8234197014582_init_data = {
   code: "function _defineProperties_null4(e,r){const{_toPropertyKey}=this.__closure;for(var t=0;t<r.length;t++){var o=r[t];o.enumerable=o.enumerable||!1,o.configurable=!0,\\"value\\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_405664377367_init_data = {
+const _worklet_405664377367_init_data = {
   code: "function _createClass_null5(e,r,t){const{_defineProperties}=this.__closure;return r&&_defineProperties(e.prototype,r),t&&_defineProperties(e,t),Object.defineProperty(e,\\"prototype\\",{writable:!1}),e;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_7066863147557_init_data = {
+const _worklet_7066863147557_init_data = {
   code: "function Clazz__classFactory_null6(){const Clazz__classFactory_null6=this._recur;const{_classCallCheck,_createClass}=this.__closure;const Clazz=function(){function Clazz(){_classCallCheck(this,Clazz);}return _createClass(Clazz,[{key:\\"foo\\",value:function foo(){return'bar';}}]);}();Clazz.Clazz__classFactory=Clazz__classFactory_null6;return Clazz;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var Clazz = function () {
-  var _classCallCheck = function _classCallCheck_null1Factory(_ref) {
-    var _worklet_14560075646677_init_data = _ref._worklet_14560075646677_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _classCallCheck = function _classCallCheck(a, n) {
+const Clazz = function () {
+  const _classCallCheck = function _classCallCheck_null1Factory({
+    _worklet_14560075646677_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _classCallCheck = function (a, n) {
       if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
     };
     _classCallCheck.__closure = {};
@@ -4796,12 +4830,13 @@ var Clazz = function () {
     _classCallCheck.__stackDetails = _e;
     return _classCallCheck;
   }({
-    _worklet_14560075646677_init_data: _worklet_14560075646677_init_data
+    _worklet_14560075646677_init_data
   });
-  var _toPrimitive = function _toPrimitive_null2Factory(_ref2) {
-    var _worklet_12814759901173_init_data = _ref2._worklet_12814759901173_init_data;
-    var _e = [new global.Error(), 1, -27];
-    var _toPrimitive = function _toPrimitive(t, r) {
+  const _toPrimitive = function _toPrimitive_null2Factory({
+    _worklet_12814759901173_init_data
+  }) {
+    const _e = [new global.Error(), 1, -27];
+    const _toPrimitive = function (t, r) {
       if ("object" != typeof t || !t) return t;
       var e = t[Symbol.toPrimitive];
       if (void 0 !== e) {
@@ -4818,18 +4853,19 @@ var Clazz = function () {
     _toPrimitive.__stackDetails = _e;
     return _toPrimitive;
   }({
-    _worklet_12814759901173_init_data: _worklet_12814759901173_init_data
+    _worklet_12814759901173_init_data
   });
-  var _toPropertyKey = function _toPropertyKey_null3Factory(_ref3) {
-    var _worklet_10645339112046_init_data = _ref3._worklet_10645339112046_init_data,
-      _toPrimitive = _ref3._toPrimitive;
-    var _e = [new global.Error(), -2, -27];
-    var _toPropertyKey = function _toPropertyKey(t) {
+  const _toPropertyKey = function _toPropertyKey_null3Factory({
+    _worklet_10645339112046_init_data,
+    _toPrimitive
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _toPropertyKey = function (t) {
       var i = _toPrimitive(t, "string");
       return "symbol" == typeof i ? i : i + "";
     };
     _toPropertyKey.__closure = {
-      _toPrimitive: _toPrimitive
+      _toPrimitive
     };
     _toPropertyKey.__workletHash = 10645339112046;
     _toPropertyKey.__pluginVersion = "x.y.z";
@@ -4837,21 +4873,22 @@ var Clazz = function () {
     _toPropertyKey.__stackDetails = _e;
     return _toPropertyKey;
   }({
-    _worklet_10645339112046_init_data: _worklet_10645339112046_init_data,
-    _toPrimitive: _toPrimitive
+    _worklet_10645339112046_init_data,
+    _toPrimitive
   });
-  var _defineProperties = function _defineProperties_null4Factory(_ref4) {
-    var _worklet_8234197014582_init_data = _ref4._worklet_8234197014582_init_data,
-      _toPropertyKey = _ref4._toPropertyKey;
-    var _e = [new global.Error(), -2, -27];
-    var _defineProperties = function _defineProperties(e, r) {
+  const _defineProperties = function _defineProperties_null4Factory({
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _defineProperties = function (e, r) {
       for (var t = 0; t < r.length; t++) {
         var o = r[t];
         o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
       }
     };
     _defineProperties.__closure = {
-      _toPropertyKey: _toPropertyKey
+      _toPropertyKey
     };
     _defineProperties.__workletHash = 8234197014582;
     _defineProperties.__pluginVersion = "x.y.z";
@@ -4859,20 +4896,21 @@ var Clazz = function () {
     _defineProperties.__stackDetails = _e;
     return _defineProperties;
   }({
-    _worklet_8234197014582_init_data: _worklet_8234197014582_init_data,
-    _toPropertyKey: _toPropertyKey
+    _worklet_8234197014582_init_data,
+    _toPropertyKey
   });
-  var _createClass = function _createClass_null5Factory(_ref5) {
-    var _worklet_405664377367_init_data = _ref5._worklet_405664377367_init_data,
-      _defineProperties = _ref5._defineProperties;
-    var _e = [new global.Error(), -2, -27];
-    var _createClass = function _createClass(e, r, t) {
+  const _createClass = function _createClass_null5Factory({
+    _worklet_405664377367_init_data,
+    _defineProperties
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const _createClass = function (e, r, t) {
       return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
         writable: !1
       }), e;
     };
     _createClass.__closure = {
-      _defineProperties: _defineProperties
+      _defineProperties
     };
     _createClass.__workletHash = 405664377367;
     _createClass.__pluginVersion = "x.y.z";
@@ -4880,16 +4918,17 @@ var Clazz = function () {
     _createClass.__stackDetails = _e;
     return _createClass;
   }({
-    _worklet_405664377367_init_data: _worklet_405664377367_init_data,
-    _defineProperties: _defineProperties
+    _worklet_405664377367_init_data,
+    _defineProperties
   });
-  var Clazz__classFactory = function Clazz__classFactory_null6Factory(_ref6) {
-    var _worklet_7066863147557_init_data = _ref6._worklet_7066863147557_init_data,
-      _classCallCheck = _ref6._classCallCheck,
-      _createClass = _ref6._createClass;
-    var _e = [new global.Error(), -3, -27];
-    var _Clazz__classFactory = function Clazz__classFactory() {
-      var Clazz = function () {
+  const Clazz__classFactory = function Clazz__classFactory_null6Factory({
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
+  }) {
+    const _e = [new global.Error(), -3, -27];
+    const Clazz__classFactory = function () {
+      const Clazz = /*#__PURE__*/function () {
         function Clazz() {
           _classCallCheck(this, Clazz);
         }
@@ -4900,37 +4939,38 @@ var Clazz = function () {
           }
         }]);
       }();
-      Clazz.Clazz__classFactory = _Clazz__classFactory;
+      Clazz.Clazz__classFactory = Clazz__classFactory;
       return Clazz;
     };
-    _Clazz__classFactory.__closure = {
-      _classCallCheck: _classCallCheck,
-      _createClass: _createClass
+    Clazz__classFactory.__closure = {
+      _classCallCheck,
+      _createClass
     };
-    _Clazz__classFactory.__workletHash = 7066863147557;
-    _Clazz__classFactory.__pluginVersion = "x.y.z";
-    _Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
-    _Clazz__classFactory.__stackDetails = _e;
-    return _Clazz__classFactory;
+    Clazz__classFactory.__workletHash = 7066863147557;
+    Clazz__classFactory.__pluginVersion = "x.y.z";
+    Clazz__classFactory.__initData = _worklet_7066863147557_init_data;
+    Clazz__classFactory.__stackDetails = _e;
+    return Clazz__classFactory;
   }({
-    _worklet_7066863147557_init_data: _worklet_7066863147557_init_data,
-    _classCallCheck: _classCallCheck,
-    _createClass: _createClass
+    _worklet_7066863147557_init_data,
+    _classCallCheck,
+    _createClass
   });
-  var Clazz = Clazz__classFactory();
+  const Clazz = Clazz__classFactory();
   return Clazz;
 }();"
 `;
 
 exports[`babel plugin for worklet names appends file name to function name 1`] = `
-"var _worklet_3008648901742_init_data = {
+"const _worklet_3008648901742_init_data = {
   code: "function foo_sourceJs1(){return 1;}",
   location: "/source.js"
 };
-var foo = function foo_sourceJs1Factory(_ref) {
-  var _worklet_3008648901742_init_data = _ref._worklet_3008648901742_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_sourceJs1Factory({
+  _worklet_3008648901742_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 1;
   };
   foo.__closure = {};
@@ -4940,19 +4980,20 @@ var foo = function foo_sourceJs1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_3008648901742_init_data: _worklet_3008648901742_init_data
+  _worklet_3008648901742_init_data
 });"
 `;
 
 exports[`babel plugin for worklet names appends library name to function name 1`] = `
-"var _worklet_1237424241422_init_data = {
+"const _worklet_1237424241422_init_data = {
   code: "function foo_library_sourceJs1(){return 1;}",
   location: "/node_modules/library/source.js"
 };
-var foo = function foo_library_sourceJs1Factory(_ref) {
-  var _worklet_1237424241422_init_data = _ref._worklet_1237424241422_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_library_sourceJs1Factory({
+  _worklet_1237424241422_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 1;
   };
   foo.__closure = {};
@@ -4962,19 +5003,20 @@ var foo = function foo_library_sourceJs1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_1237424241422_init_data: _worklet_1237424241422_init_data
+  _worklet_1237424241422_init_data
 });"
 `;
 
 exports[`babel plugin for worklet names handles names with illegal characters 1`] = `
-"var _worklet_16115589986830_init_data = {
+"const _worklet_16115589986830_init_data = {
   code: "function foo_SourceJs1(){return 1;}",
   location: "/-source.js"
 };
-var foo = function foo_SourceJs1Factory(_ref) {
-  var _worklet_16115589986830_init_data = _ref._worklet_16115589986830_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var foo = function foo() {
+const foo = function foo_SourceJs1Factory({
+  _worklet_16115589986830_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
     return 1;
   };
   foo.__closure = {};
@@ -4984,43 +5026,45 @@ var foo = function foo_SourceJs1Factory(_ref) {
   foo.__stackDetails = _e;
   return foo;
 }({
-  _worklet_16115589986830_init_data: _worklet_16115589986830_init_data
+  _worklet_16115589986830_init_data
 });"
 `;
 
 exports[`babel plugin for worklet names preserves recursion 1`] = `
-"var _worklet_13087563218653_init_data = {
+"const _worklet_13087563218653_init_data = {
   code: "function foo_null1(){const foo_null1=this._recur;foo_null1(1);}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_13087563218653_init_data = _ref._worklet_13087563218653_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var _foo = function foo() {
-    _foo(1);
+const foo = function foo_null1Factory({
+  _worklet_13087563218653_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const foo = function () {
+    foo(1);
   };
-  _foo.__closure = {};
-  _foo.__workletHash = 13087563218653;
-  _foo.__pluginVersion = "x.y.z";
-  _foo.__initData = _worklet_13087563218653_init_data;
-  _foo.__stackDetails = _e;
-  return _foo;
+  foo.__closure = {};
+  foo.__workletHash = 13087563218653;
+  foo.__pluginVersion = "x.y.z";
+  foo.__initData = _worklet_13087563218653_init_data;
+  foo.__stackDetails = _e;
+  return foo;
 }({
-  _worklet_13087563218653_init_data: _worklet_13087563218653_init_data
+  _worklet_13087563218653_init_data
 });"
 `;
 
 exports[`babel plugin for worklet names unnamed ArrowFunctionExpression 1`] = `
-"var _worklet_1420107288296_init_data = {
+"const _worklet_1420107288296_init_data = {
   code: "function null1(){return 1;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-(function null1Factory(_ref) {
-  var _worklet_1420107288296_init_data = _ref._worklet_1420107288296_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+(function null1Factory({
+  _worklet_1420107288296_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 1;
   };
   null1.__closure = {};
@@ -5030,20 +5074,21 @@ exports[`babel plugin for worklet names unnamed ArrowFunctionExpression 1`] = `
   null1.__stackDetails = _e;
   return null1;
 })({
-  _worklet_1420107288296_init_data: _worklet_1420107288296_init_data
+  _worklet_1420107288296_init_data
 });"
 `;
 
 exports[`babel plugin for worklet names unnamed FunctionExpression 1`] = `
-"var _worklet_1420107288296_init_data = {
+"const _worklet_1420107288296_init_data = {
   code: "function null1(){return 1;}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-[function null1Factory(_ref) {
-  var _worklet_1420107288296_init_data = _ref._worklet_1420107288296_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
+[function null1Factory({
+  _worklet_1420107288296_init_data
+}) {
+  const _e = [new global.Error(), 1, -27];
+  const null1 = function () {
     return 1;
   };
   null1.__closure = {};
@@ -5053,30 +5098,32 @@ exports[`babel plugin for worklet names unnamed FunctionExpression 1`] = `
   null1.__stackDetails = _e;
   return null1;
 }({
-  _worklet_1420107288296_init_data: _worklet_1420107288296_init_data
+  _worklet_1420107288296_init_data
 })]();"
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets 1`] = `
-"var _worklet_8064116599518_init_data = {
+"const _worklet_8064116599518_init_data = {
   code: "function null1(){console.log('bar');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_2538811677737_init_data = {
+const _worklet_2538811677737_init_data = {
   code: "function null2(){const{_worklet_8064116599518_init_data}=this.__closure;const bar=function null1Factory({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('bar');};null1.__closure={};null1.__workletHash=8064116599518;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_8064116599518_init_data;null1.__stackDetails=_e;return null1;}({_worklet_8064116599518_init_data:_worklet_8064116599518_init_data});bar();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null2Factory(_ref) {
-  var _worklet_2538811677737_init_data = _ref._worklet_2538811677737_init_data,
-    _worklet_8064116599518_init_data = _ref._worklet_8064116599518_init_data;
-  var _e = [new global.Error(), -2, -27];
-  var null2 = function null2() {
-    var bar = function null1Factory(_ref2) {
-      var _worklet_8064116599518_init_data = _ref2._worklet_8064116599518_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var null1 = function null1() {
+const foo = function null2Factory({
+  _worklet_2538811677737_init_data,
+  _worklet_8064116599518_init_data
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const null2 = function () {
+    const bar = function null1Factory({
+      _worklet_8064116599518_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const null1 = function () {
         console.log('bar');
       };
       null1.__closure = {};
@@ -5086,12 +5133,12 @@ var foo = function null2Factory(_ref) {
       null1.__stackDetails = _e;
       return null1;
     }({
-      _worklet_8064116599518_init_data: _worklet_8064116599518_init_data
+      _worklet_8064116599518_init_data
     });
     bar();
   };
   null2.__closure = {
-    _worklet_8064116599518_init_data: _worklet_8064116599518_init_data
+    _worklet_8064116599518_init_data
   };
   null2.__workletHash = 2538811677737;
   null2.__pluginVersion = "x.y.z";
@@ -5099,33 +5146,35 @@ var foo = function null2Factory(_ref) {
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_2538811677737_init_data: _worklet_2538811677737_init_data,
-  _worklet_8064116599518_init_data: _worklet_8064116599518_init_data
+  _worklet_2538811677737_init_data,
+  _worklet_8064116599518_init_data
 });"
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets embedded in runOnJS in runOnUI 1`] = `
-"var _worklet_5655279400236_init_data = {
+"const _worklet_5655279400236_init_data = {
   code: "function null1(){console.log('Hello from JS thread');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_13421160986429_init_data = {
+const _worklet_13421160986429_init_data = {
   code: "function null2(){const{runOnJS,_worklet_5655279400236_init_data}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Hello from JS thread');};null1.__closure={};null1.__workletHash=5655279400236;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_5655279400236_init_data;null1.__stackDetails=_e;return null1;}({_worklet_5655279400236_init_data:_worklet_5655279400236_init_data}))();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-runOnUI(function null2Factory(_ref) {
-  var _worklet_13421160986429_init_data = _ref._worklet_13421160986429_init_data,
-    runOnJS = _ref.runOnJS,
-    _worklet_5655279400236_init_data = _ref._worklet_5655279400236_init_data;
-  var _e = [new global.Error(), -3, -27];
-  var null2 = function null2() {
+runOnUI(function null2Factory({
+  _worklet_13421160986429_init_data,
+  runOnJS,
+  _worklet_5655279400236_init_data
+}) {
+  const _e = [new global.Error(), -3, -27];
+  const null2 = function () {
     console.log('Hello from UI thread');
-    runOnJS(function null1Factory(_ref2) {
-      var _worklet_5655279400236_init_data = _ref2._worklet_5655279400236_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var null1 = function null1() {
+    runOnJS(function null1Factory({
+      _worklet_5655279400236_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const null1 = function () {
         console.log('Hello from JS thread');
       };
       null1.__closure = {};
@@ -5135,12 +5184,12 @@ runOnUI(function null2Factory(_ref) {
       null1.__stackDetails = _e;
       return null1;
     }({
-      _worklet_5655279400236_init_data: _worklet_5655279400236_init_data
+      _worklet_5655279400236_init_data
     }))();
   };
   null2.__closure = {
-    runOnJS: runOnJS,
-    _worklet_5655279400236_init_data: _worklet_5655279400236_init_data
+    runOnJS,
+    _worklet_5655279400236_init_data
   };
   null2.__workletHash = 13421160986429;
   null2.__pluginVersion = "x.y.z";
@@ -5148,46 +5197,49 @@ runOnUI(function null2Factory(_ref) {
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_13421160986429_init_data: _worklet_13421160986429_init_data,
-  runOnJS: runOnJS,
-  _worklet_5655279400236_init_data: _worklet_5655279400236_init_data
+  _worklet_13421160986429_init_data,
+  runOnJS,
+  _worklet_5655279400236_init_data
 }))();"
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets embedded in runOnUI in runOnJS in runOnUI 1`] = `
-"var _worklet_7185083753711_init_data = {
+"const _worklet_7185083753711_init_data = {
   code: "function null1(){const{runOnUI}=this.__closure;console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_9142654516624_init_data = {
+const _worklet_9142654516624_init_data = {
   code: "function null2(){const{runOnJS,_worklet_7185083753711_init_data,runOnUI}=this.__closure;console.log('Hello from UI thread');runOnJS(function null1Factory({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}){const _e=[new global.Error(),-2,-27];const null1=function(){console.log('Hello from JS thread');runOnUI(function(){console.log('Hello from UI thread again');})();};null1.__closure={runOnUI:runOnUI};null1.__workletHash=7185083753711;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_7185083753711_init_data;null1.__stackDetails=_e;return null1;}({_worklet_7185083753711_init_data:_worklet_7185083753711_init_data,runOnUI:runOnUI}))();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_2520605269387_init_data = {
+const _worklet_2520605269387_init_data = {
   code: "function null3(){console.log('Hello from UI thread again');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-runOnUI(function null2Factory(_ref) {
-  var _worklet_9142654516624_init_data = _ref._worklet_9142654516624_init_data,
-    runOnJS = _ref.runOnJS,
-    _worklet_7185083753711_init_data = _ref._worklet_7185083753711_init_data,
-    runOnUI = _ref.runOnUI;
-  var _e = [new global.Error(), -4, -27];
-  var null2 = function null2() {
+runOnUI(function null2Factory({
+  _worklet_9142654516624_init_data,
+  runOnJS,
+  _worklet_7185083753711_init_data,
+  runOnUI
+}) {
+  const _e = [new global.Error(), -4, -27];
+  const null2 = function () {
     console.log('Hello from UI thread');
-    runOnJS(function null1Factory(_ref2) {
-      var _worklet_7185083753711_init_data = _ref2._worklet_7185083753711_init_data,
-        runOnUI = _ref2.runOnUI;
-      var _e = [new global.Error(), -2, -27];
-      var null1 = function null1() {
+    runOnJS(function null1Factory({
+      _worklet_7185083753711_init_data,
+      runOnUI
+    }) {
+      const _e = [new global.Error(), -2, -27];
+      const null1 = function () {
         console.log('Hello from JS thread');
-        runOnUI(function null3Factory(_ref3) {
-          var _worklet_2520605269387_init_data = _ref3._worklet_2520605269387_init_data;
-          var _e = [new global.Error(), 1, -27];
-          var null3 = function null3() {
+        runOnUI(function null3Factory({
+          _worklet_2520605269387_init_data
+        }) {
+          const _e = [new global.Error(), 1, -27];
+          const null3 = function () {
             console.log('Hello from UI thread again');
           };
           null3.__closure = {};
@@ -5197,11 +5249,11 @@ runOnUI(function null2Factory(_ref) {
           null3.__stackDetails = _e;
           return null3;
         }({
-          _worklet_2520605269387_init_data: _worklet_2520605269387_init_data
+          _worklet_2520605269387_init_data
         }))();
       };
       null1.__closure = {
-        runOnUI: runOnUI
+        runOnUI
       };
       null1.__workletHash = 7185083753711;
       null1.__pluginVersion = "x.y.z";
@@ -5209,14 +5261,14 @@ runOnUI(function null2Factory(_ref) {
       null1.__stackDetails = _e;
       return null1;
     }({
-      _worklet_7185083753711_init_data: _worklet_7185083753711_init_data,
-      runOnUI: runOnUI
+      _worklet_7185083753711_init_data,
+      runOnUI
     }))();
   };
   null2.__closure = {
-    runOnJS: runOnJS,
-    _worklet_7185083753711_init_data: _worklet_7185083753711_init_data,
-    runOnUI: runOnUI
+    runOnJS,
+    _worklet_7185083753711_init_data,
+    runOnUI
   };
   null2.__workletHash = 9142654516624;
   null2.__pluginVersion = "x.y.z";
@@ -5224,44 +5276,47 @@ runOnUI(function null2Factory(_ref) {
   null2.__stackDetails = _e;
   return null2;
 }({
-  _worklet_9142654516624_init_data: _worklet_9142654516624_init_data,
-  runOnJS: runOnJS,
-  _worklet_7185083753711_init_data: _worklet_7185083753711_init_data,
-  runOnUI: runOnUI
+  _worklet_9142654516624_init_data,
+  runOnJS,
+  _worklet_7185083753711_init_data,
+  runOnUI
 }))();"
 `;
 
 exports[`babel plugin for worklet nesting transpiles nested worklets with depth 3 1`] = `
-"var _worklet_3230974749144_init_data = {
+"const _worklet_3230974749144_init_data = {
   code: "function null1(){console.log('foobar');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_16149303679428_init_data = {
+const _worklet_16149303679428_init_data = {
   code: "function null2(){const{_worklet_3230974749144_init_data}=this.__closure;const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_975664358989_init_data = {
+const _worklet_975664358989_init_data = {
   code: "function null3(){const{_worklet_16149303679428_init_data,_worklet_3230974749144_init_data}=this.__closure;const bar=function null2Factory({_worklet_16149303679428_init_data:_worklet_16149303679428_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),-2,-27];const null2=function(){const foobar=function null1Factory({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('foobar');};null1.__closure={};null1.__workletHash=3230974749144;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_3230974749144_init_data;null1.__stackDetails=_e;return null1;}({_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});};null2.__closure={_worklet_3230974749144_init_data:_worklet_3230974749144_init_data};null2.__workletHash=16149303679428;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_16149303679428_init_data;null2.__stackDetails=_e;return null2;}({_worklet_16149303679428_init_data:_worklet_16149303679428_init_data,_worklet_3230974749144_init_data:_worklet_3230974749144_init_data});bar();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function null3Factory(_ref) {
-  var _worklet_975664358989_init_data = _ref._worklet_975664358989_init_data,
-    _worklet_16149303679428_init_data = _ref._worklet_16149303679428_init_data,
-    _worklet_3230974749144_init_data = _ref._worklet_3230974749144_init_data;
-  var _e = [new global.Error(), -3, -27];
-  var null3 = function null3() {
-    var bar = function null2Factory(_ref2) {
-      var _worklet_16149303679428_init_data = _ref2._worklet_16149303679428_init_data,
-        _worklet_3230974749144_init_data = _ref2._worklet_3230974749144_init_data;
-      var _e = [new global.Error(), -2, -27];
-      var null2 = function null2() {
-        var foobar = function null1Factory(_ref3) {
-          var _worklet_3230974749144_init_data = _ref3._worklet_3230974749144_init_data;
-          var _e = [new global.Error(), 1, -27];
-          var null1 = function null1() {
+const foo = function null3Factory({
+  _worklet_975664358989_init_data,
+  _worklet_16149303679428_init_data,
+  _worklet_3230974749144_init_data
+}) {
+  const _e = [new global.Error(), -3, -27];
+  const null3 = function () {
+    const bar = function null2Factory({
+      _worklet_16149303679428_init_data,
+      _worklet_3230974749144_init_data
+    }) {
+      const _e = [new global.Error(), -2, -27];
+      const null2 = function () {
+        const foobar = function null1Factory({
+          _worklet_3230974749144_init_data
+        }) {
+          const _e = [new global.Error(), 1, -27];
+          const null1 = function () {
             console.log('foobar');
           };
           null1.__closure = {};
@@ -5271,11 +5326,11 @@ var foo = function null3Factory(_ref) {
           null1.__stackDetails = _e;
           return null1;
         }({
-          _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
+          _worklet_3230974749144_init_data
         });
       };
       null2.__closure = {
-        _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
+        _worklet_3230974749144_init_data
       };
       null2.__workletHash = 16149303679428;
       null2.__pluginVersion = "x.y.z";
@@ -5283,14 +5338,14 @@ var foo = function null3Factory(_ref) {
       null2.__stackDetails = _e;
       return null2;
     }({
-      _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
-      _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
+      _worklet_16149303679428_init_data,
+      _worklet_3230974749144_init_data
     });
     bar();
   };
   null3.__closure = {
-    _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
-    _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
+    _worklet_16149303679428_init_data,
+    _worklet_3230974749144_init_data
   };
   null3.__workletHash = 975664358989;
   null3.__pluginVersion = "x.y.z";
@@ -5298,39 +5353,41 @@ var foo = function null3Factory(_ref) {
   null3.__stackDetails = _e;
   return null3;
 }({
-  _worklet_975664358989_init_data: _worklet_975664358989_init_data,
-  _worklet_16149303679428_init_data: _worklet_16149303679428_init_data,
-  _worklet_3230974749144_init_data: _worklet_3230974749144_init_data
+  _worklet_975664358989_init_data,
+  _worklet_16149303679428_init_data,
+  _worklet_3230974749144_init_data
 });"
 `;
 
 exports[`babel plugin for worklet nesting transpiles worklets with functions defined on UI thread to run them on JS 1`] = `
-"var _worklet_12864992966034_init_data = {
+"const _worklet_12864992966034_init_data = {
   code: "function null1(){console.log('Good morning from JS thread!');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_4437925222314_init_data = {
+const _worklet_4437925222314_init_data = {
   code: "function null2(){console.log('Good afternoon from JS thread');}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var _worklet_614202054968_init_data = {
+const _worklet_614202054968_init_data = {
   code: "function null3(){const{_worklet_12864992966034_init_data,_worklet_4437925222314_init_data,runOnJS}=this.__closure;const a=function null1Factory({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data}){const _e=[new global.Error(),1,-27];const null1=function(){console.log('Good morning from JS thread!');};null1.__closure={};null1.__workletHash=12864992966034;null1.__pluginVersion=\\"x.y.z\\";null1.__initData=_worklet_12864992966034_init_data;null1.__stackDetails=_e;return null1;}({_worklet_12864992966034_init_data:_worklet_12864992966034_init_data});const b=function null2Factory({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data}){const _e=[new global.Error(),1,-27];const null2=function(){console.log('Good afternoon from JS thread');};null2.__closure={};null2.__workletHash=4437925222314;null2.__pluginVersion=\\"x.y.z\\";null2.__initData=_worklet_4437925222314_init_data;null2.__stackDetails=_e;return null2;}({_worklet_4437925222314_init_data:_worklet_4437925222314_init_data});const func=Math.random()<0.5?a:b;runOnJS(func)();}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-runOnUI(function null3Factory(_ref) {
-  var _worklet_614202054968_init_data = _ref._worklet_614202054968_init_data,
-    _worklet_12864992966034_init_data = _ref._worklet_12864992966034_init_data,
-    _worklet_4437925222314_init_data = _ref._worklet_4437925222314_init_data,
-    runOnJS = _ref.runOnJS;
-  var _e = [new global.Error(), -4, -27];
-  var null3 = function null3() {
-    var a = function null1Factory(_ref2) {
-      var _worklet_12864992966034_init_data = _ref2._worklet_12864992966034_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var null1 = function null1() {
+runOnUI(function null3Factory({
+  _worklet_614202054968_init_data,
+  _worklet_12864992966034_init_data,
+  _worklet_4437925222314_init_data,
+  runOnJS
+}) {
+  const _e = [new global.Error(), -4, -27];
+  const null3 = function () {
+    const a = function null1Factory({
+      _worklet_12864992966034_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const null1 = function () {
         console.log('Good morning from JS thread!');
       };
       null1.__closure = {};
@@ -5340,12 +5397,13 @@ runOnUI(function null3Factory(_ref) {
       null1.__stackDetails = _e;
       return null1;
     }({
-      _worklet_12864992966034_init_data: _worklet_12864992966034_init_data
+      _worklet_12864992966034_init_data
     });
-    var b = function null2Factory(_ref3) {
-      var _worklet_4437925222314_init_data = _ref3._worklet_4437925222314_init_data;
-      var _e = [new global.Error(), 1, -27];
-      var null2 = function null2() {
+    const b = function null2Factory({
+      _worklet_4437925222314_init_data
+    }) {
+      const _e = [new global.Error(), 1, -27];
+      const null2 = function () {
         console.log('Good afternoon from JS thread');
       };
       null2.__closure = {};
@@ -5355,15 +5413,15 @@ runOnUI(function null3Factory(_ref) {
       null2.__stackDetails = _e;
       return null2;
     }({
-      _worklet_4437925222314_init_data: _worklet_4437925222314_init_data
+      _worklet_4437925222314_init_data
     });
-    var func = Math.random() < 0.5 ? a : b;
+    const func = Math.random() < 0.5 ? a : b;
     runOnJS(func)();
   };
   null3.__closure = {
-    _worklet_12864992966034_init_data: _worklet_12864992966034_init_data,
-    _worklet_4437925222314_init_data: _worklet_4437925222314_init_data,
-    runOnJS: runOnJS
+    _worklet_12864992966034_init_data,
+    _worklet_4437925222314_init_data,
+    runOnJS
   };
   null3.__workletHash = 614202054968;
   null3.__pluginVersion = "x.y.z";
@@ -5371,82 +5429,59 @@ runOnUI(function null3Factory(_ref) {
   null3.__stackDetails = _e;
   return null3;
 }({
-  _worklet_614202054968_init_data: _worklet_614202054968_init_data,
-  _worklet_12864992966034_init_data: _worklet_12864992966034_init_data,
-  _worklet_4437925222314_init_data: _worklet_4437925222314_init_data,
-  runOnJS: runOnJS
+  _worklet_614202054968_init_data,
+  _worklet_12864992966034_init_data,
+  _worklet_4437925222314_init_data,
+  runOnJS
 }))();"
 `;
 
-exports[`babel plugin generally removes comments from worklets 1`] = `
-"var _worklet_5099191671055_init_data = {
-  code: "function null1(){return true;}",
-  location: "/dev/null",
-  sourceMap: "\\"mock source map\\""
-};
-var f = function null1Factory(_ref) {
-  var _worklet_5099191671055_init_data = _ref._worklet_5099191671055_init_data;
-  var _e = [new global.Error(), 1, -27];
-  var null1 = function null1() {
-    return true;
-  };
-  null1.__closure = {};
-  null1.__workletHash = 5099191671055;
-  null1.__pluginVersion = "x.y.z";
-  null1.__initData = _worklet_5099191671055_init_data;
-  null1.__stackDetails = _e;
-  return null1;
-}({
-  _worklet_5099191671055_init_data: _worklet_5099191671055_init_data
-});"
-`;
-
 exports[`babel plugin generally supports recursive calls 1`] = `
-"var a = 1;
-var _worklet_12624627966719_init_data = {
+"const a = 1;
+const _worklet_12624627966719_init_data = {
   code: "function foo_null1(t){const foo_null1=this._recur;const{a}=this.__closure;if(t>0){return a+foo_null1(t-1);}}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
-var foo = function foo_null1Factory(_ref) {
-  var _worklet_12624627966719_init_data = _ref._worklet_12624627966719_init_data,
-    a = _ref.a;
-  var _e = [new global.Error(), -2, -27];
-  var _foo = function foo(t) {
+const foo = function foo_null1Factory({
+  _worklet_12624627966719_init_data,
+  a
+}) {
+  const _e = [new global.Error(), -2, -27];
+  const foo = function (t) {
     if (t > 0) {
-      return a + _foo(t - 1);
+      return a + foo(t - 1);
     }
   };
-  _foo.__closure = {
-    a: a
+  foo.__closure = {
+    a
   };
-  _foo.__workletHash = 12624627966719;
-  _foo.__pluginVersion = "x.y.z";
-  _foo.__initData = _worklet_12624627966719_init_data;
-  _foo.__stackDetails = _e;
-  return _foo;
+  foo.__workletHash = 12624627966719;
+  foo.__pluginVersion = "x.y.z";
+  foo.__initData = _worklet_12624627966719_init_data;
+  foo.__stackDetails = _e;
+  return foo;
 }({
-  _worklet_12624627966719_init_data: _worklet_12624627966719_init_data,
-  a: a
+  _worklet_12624627966719_init_data,
+  a
 });"
 `;
 
 exports[`babel plugin generally transforms 1`] = `
-"var _reactNativeReanimated = _interopRequireWildcard(require("react-native-reanimated"));
-var _jsxRuntime = require("react/jsx-runtime");
-function _interopRequireWildcard(e, t) { if ("function" == typeof WeakMap) var r = new WeakMap(), n = new WeakMap(); return (_interopRequireWildcard = function _interopRequireWildcard(e, t) { if (!t && e && e.__esModule) return e; var o, i, f = { __proto__: null, default: e }; if (null === e || "object" != typeof e && "function" != typeof e) return f; if (o = t ? n : r) { if (o.has(e)) return o.get(e); o.set(e, f); } for (var _t in e) "default" !== _t && {}.hasOwnProperty.call(e, _t) && ((i = (o = Object.defineProperty) && Object.getOwnPropertyDescriptor(e, _t)) && (i.get || i.set) ? o(f, _t, i) : f[_t] = e[_t]); return f; })(e, t); }
-var _worklet_6576407799916_init_data = {
+"import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+const _worklet_6576407799916_init_data = {
   code: "function null1(){const{offset}=this.__closure;return{transform:[{translateX:offset.value*255}]};}",
   location: "/dev/null",
   sourceMap: "\\"mock source map\\""
 };
 function Box() {
-  var offset = (0, _reactNativeReanimated.useSharedValue)(0);
-  var animatedStyles = (0, _reactNativeReanimated.useAnimatedStyle)(function null1Factory(_ref) {
-    var _worklet_6576407799916_init_data = _ref._worklet_6576407799916_init_data,
-      offset = _ref.offset;
-    var _e = [new global.Error(), -2, -27];
-    var null1 = function null1() {
+  const offset = useSharedValue(0);
+  const animatedStyles = useAnimatedStyle(function null1Factory({
+    _worklet_6576407799916_init_data,
+    offset
+  }) {
+    const _e = [new global.Error(), -2, -27];
+    const null1 = function () {
       return {
         transform: [{
           translateX: offset.value * 255
@@ -5454,7 +5489,7 @@ function Box() {
       };
     };
     null1.__closure = {
-      offset: offset
+      offset
     };
     null1.__workletHash = 6576407799916;
     null1.__pluginVersion = "x.y.z";
@@ -5462,18 +5497,12 @@ function Box() {
     null1.__stackDetails = _e;
     return null1;
   }({
-    _worklet_6576407799916_init_data: _worklet_6576407799916_init_data,
-    offset: offset
+    _worklet_6576407799916_init_data,
+    offset
   }));
-  return (0, _jsxRuntime.jsxs)(_jsxRuntime.Fragment, {
-    children: [(0, _jsxRuntime.jsx)(_reactNativeReanimated.default.View, {
-      style: [styles.box, animatedStyles]
-    }), (0, _jsxRuntime.jsx)(Button, {
-      onPress: function onPress() {
-        return offset.value = Math.random();
-      },
-      title: "Move"
-    })]
-  });
+  return <>
+              <Animated.View style={[styles.box, animatedStyles]} />
+              <Button onPress={() => offset.value = Math.random()} title="Move" />
+            </>;
 }"
 `;

--- a/packages/react-native-worklets/plugin/plugin-unit-test.babel.config.js
+++ b/packages/react-native-worklets/plugin/plugin-unit-test.babel.config.js
@@ -2,5 +2,5 @@
 // in their project by creating a new app from template.
 /** @type {import('@babel/core').TransformOptions} */
 module.exports = {
-  presets: ['module:@react-native/babel-preset'],
+  presets: ['@react-native/babel-preset'],
 };

--- a/packages/react-native-worklets/plugin/src/jestMatchers.ts
+++ b/packages/react-native-worklets/plugin/src/jestMatchers.ts
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-const WORKLET_REGEX = /^var _worklet_[0-9]+_init_data/gm;
+const WORKLET_REGEX = /^(const|var) _worklet_[0-9]+_init_data/gm;
 const INLINE_STYLE_WARNING_REGEX =
   /console\.warn\(require\("react-native-reanimated"\)\.getUseOfValueInStyleWarning\(\)\)/g;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14458,6 +14458,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress@patch:cypress@npm%3A15.4.0#~/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch":
+  version: 15.4.0
+  resolution: "cypress@patch:cypress@npm%3A15.4.0#~/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch::version=15.4.0&hash=5595d4"
+  dependencies:
+    "@cypress/request": "npm:^3.0.9"
+    "@cypress/xvfb": "npm:^1.2.4"
+    "@types/sinonjs__fake-timers": "npm:8.1.1"
+    "@types/sizzle": "npm:^2.3.2"
+    "@types/tmp": "npm:^0.2.3"
+    arch: "npm:^2.2.0"
+    blob-util: "npm:^2.0.2"
+    bluebird: "npm:^3.7.2"
+    buffer: "npm:^5.7.1"
+    cachedir: "npm:^2.3.0"
+    chalk: "npm:^4.1.0"
+    ci-info: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-table3: "npm:0.6.1"
+    commander: "npm:^6.2.1"
+    common-tags: "npm:^1.8.0"
+    dayjs: "npm:^1.10.4"
+    debug: "npm:^4.3.4"
+    enquirer: "npm:^2.3.6"
+    eventemitter2: "npm:6.4.7"
+    execa: "npm:4.1.0"
+    executable: "npm:^4.1.1"
+    extract-zip: "npm:2.0.1"
+    figures: "npm:^3.2.0"
+    fs-extra: "npm:^9.1.0"
+    hasha: "npm:5.2.2"
+    is-installed-globally: "npm:~0.4.0"
+    listr2: "npm:^3.8.3"
+    lodash: "npm:^4.17.21"
+    log-symbols: "npm:^4.0.0"
+    minimist: "npm:^1.2.8"
+    ospath: "npm:^1.2.2"
+    pretty-bytes: "npm:^5.6.0"
+    process: "npm:^0.11.10"
+    proxy-from-env: "npm:1.0.0"
+    request-progress: "npm:^3.0.0"
+    semver: "npm:^7.7.1"
+    supports-color: "npm:^8.1.1"
+    systeminformation: "npm:5.27.7"
+    tmp: "npm:~0.2.4"
+    tree-kill: "npm:1.2.2"
+    untildify: "npm:^4.0.0"
+    yauzl: "npm:^2.10.0"
+  bin:
+    cypress: bin/cypress
+  checksum: 10/24b49d65fdcc053a90888a26fffe250d785d0bf87804195a4e1e58a401f9f17b6b8b8890068dbb680a9c26e339a661cccab30c132621e536912cbd6fa30c4b82
+  languageName: node
+  linkType: hard
+
 "cytoscape-cose-bilkent@npm:^4.1.0":
   version: 4.1.0
   resolution: "cytoscape-cose-bilkent@npm:4.1.0"
@@ -25551,7 +25604,7 @@ __metadata:
     "@babel/core": "npm:7.28.4"
     "@expo/next-adapter": "npm:6.0.0"
     "@next/bundle-analyzer": "npm:15.5.4"
-    cypress: "npm:15.4.0"
+    cypress: "patch:cypress@npm%3A15.4.0#~/.yarn/patches/cypress-npm-15.4.0-c92384506d.patch"
     eslint: "npm:9.37.0"
     expo: "npm:54.0.13"
     next: "npm:15.5.4"


### PR DESCRIPTION
## Summary

We should always try to test Worklets Babel plugin in a minimalist environment, without unnecessary presets unless they are necessary.

## Test plan

CI
