### PR TITLE
Resolve worklets via gradle

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -45,6 +45,7 @@ file(GLOB_RECURSE REANIMATED_ANDROID_CPP_SOURCES CONFIGURE_DEPENDS
 
 find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
+find_package(react-native-worklets REQUIRED CONFIG)
 
 add_library(reanimated SHARED ${REANIMATED_COMMON_CPP_SOURCES}
                               ${REANIMATED_ANDROID_CPP_SOURCES})
@@ -80,15 +81,6 @@ else()
   set(BUILD_TYPE "release")
 endif()
 
-add_library(worklets SHARED IMPORTED)
-
-set_target_properties(
-  worklets
-  PROPERTIES
-    IMPORTED_LOCATION
-    "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"
-)
-
 set_target_properties(reanimated PROPERTIES LINKER_LANGUAGE CXX)
 # remove dead code sections
 set_target_properties(reanimated PROPERTIES LINK_FLAGS "-Wl,--gc-sections")
@@ -108,4 +100,4 @@ target_link_libraries(
   ReactAndroid::jsi
   fbjni::fbjni
   android
-  worklets)
+  react-native-worklets::worklets)


### PR DESCRIPTION
## Summary

This PR changes the way react-native-reanimated depends on react-native-worklets in its Android native build. Instead of directly linking to the worklets .so file (hardcoded path), it uses CMake's find_package to locate the worklets config package.

This approach leverages CMake's package management capabilities. It ensures that the worklets library is properly found and linked during the build process, even if the build output paths change. This also aligns with best practices for managing dependencies in CMake-based projects.  
Also resolves the build order issues in [RNRepo](https://github.com/software-mansion/rnrepo) when libraries configuration is changed with precompiled packages.

NOTE: tested on basic RN apps, not in more complex setups like monorepos or other.

## Test plan

- run the example apps and ensure reanimated features work as expected