### PR TITLE
speed-up fabric-example app for Android

### DIFF
--- a/apps/fabric-example/android/gradle.properties
+++ b/apps/fabric-example/android/gradle.properties
@@ -53,7 +53,6 @@ enableWorkletsProfiling=true
 # Build cache and optimization
 org.gradle.caching=true
 org.gradle.build.cache.debug=false
-android.enableBuildCache=true
 
 # Uncomment the next line to enable bundle mode.
 # workletsBundleMode=true


### PR DESCRIPTION
## Summary

This PR modifies the gradle.properties file of the fabric-example Android app to enhance build performance and efficiency. The changes include:
- Increasing the maximum heap size for the Gradle daemon to 4096 MB and MaxMetaspaceSize to 1024 MB, allowing for better handling of larger builds.
- Enabling parallel project execution with `org.gradle.parallel=true`
- Setting the maximum number of worker threads to 8 with `org.gradle.workers.max=8`
- Activating build caching with `org.gradle.caching=true` and `android.enableBuildCache=true` to speed up subsequent builds by reusing outputs from previous builds.

## Test plan

I took the gradle timer process as a benchmark: `BUILD SUCCESSFUL in Xmin Ys`

0. Setup fabric-example android app 
1. build fabric-example android app 
   - It took me about 20mins on the first build
2. git clone new reanimated repo, so no cache is present
3. Add these changes to gradle.properties
4. build fabric-example android app 
   - `BUILD SUCCESSFUL in 1m 8s`