### PR TITLE
Fix the issue with next.js throwing errors while hydrating

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -515,7 +515,7 @@ export default class AnimatedComponent
         jestAnimatedStyle: this.jestAnimatedStyle,
         jestAnimatedProps: this.jestAnimatedProps,
       };
-    } else if (!skipEntering) {
+    } else if (!skipEntering && !IS_WEB) {
       nativeID = `${this.reanimatedID}`;
     }
 


### PR DESCRIPTION
## Summary

Fixing the issue with next.js throwing errors while hydrating: https://github.com/software-mansion/react-native-reanimated/issues/8842

I'm not proud of my solution. I tried to utilize `useId` from react as a source for the ID there, which would make the ID synchronized between the server and the browser, but it's producing a string ID, and it couldn't work there.
However, as I deleted the `nativeID` prop on web, everything seemed to be working (?). I don't know the possible edge cases well, so please confirm or reject my PR

## Test plan

One can run the `next-example` app which is provided in the repo with and without my change, refresh the page a couple of times while observing the console - hydration errors should disappear
