### PR TITLE
docs: Fix typo (relay -> rely)

### DIFF
--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -113,7 +113,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 FadeOutLeft.duration(500).easing(Easing.ease);
@@ -127,7 +127,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 FadeInUp.springify()
@@ -366,7 +366,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 FlipOutYLeft.duration(500).easing(Easing.ease);
@@ -380,7 +380,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 FlipInXUp.springify()
@@ -493,7 +493,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 LightSpeedOutLeft.duration(500).easing(Easing.ease);
@@ -507,7 +507,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 LightSpeedInLeft.springify()
@@ -612,7 +612,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 PinwheelOut.duration(500).easing(Easing.ease);
@@ -626,7 +626,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 PinwheelIn.springify()
@@ -737,7 +737,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 RollOutLeft.duration(500).easing(Easing.ease);
@@ -751,7 +751,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 RollInLeft.springify()
@@ -874,7 +874,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 RotateOutDownRight.duration(500).easing(Easing.ease);
@@ -888,7 +888,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 RotateInUpLeft.springify()
@@ -1011,7 +1011,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 SlideOutLeft.duration(500).easing(Easing.ease);
@@ -1025,7 +1025,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 SlideInUp.springify()
@@ -1135,7 +1135,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 StretchOutX.duration(500).easing(Easing.ease);
@@ -1149,7 +1149,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 StretchInX.springify()
@@ -1294,7 +1294,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 ZoomOutLeft.duration(500).easing(Easing.ease);
@@ -1308,7 +1308,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 ZoomInRotate.springify()

--- a/docs/docs-reanimated/docs/layout-animations/layout-transitions.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/layout-transitions.mdx
@@ -33,7 +33,7 @@ function App() {
 
 #### Easing <Optional/>
 
-Easing modifiers are time-based modifiers that relay on [`withTiming`](/docs/animations/withTiming) function.
+Easing modifiers are time-based modifiers that rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 LinearTransition.easing(Easing.ease);
@@ -47,7 +47,7 @@ The `.easing(...)` modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 Just as in `withSpring` config, spring-based modifiers can be physics-based (have `mass` and `damping` modifiers) or duration-based (have `duration` and `dampingRatio` modifiers).
 
 :::info

--- a/docs/docs-reanimated/versioned_docs/version-3.x/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/versioned_docs/version-3.x/layout-animations/entering-exiting-animations.mdx
@@ -113,7 +113,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 FadeOutLeft.duration(500).easing(Easing.ease);
@@ -127,7 +127,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 FadeInUp.springify()
@@ -368,7 +368,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 FlipOutYLeft.duration(500).easing(Easing.ease);
@@ -382,7 +382,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 FlipInXUp.springify()
@@ -497,7 +497,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 LightSpeedOutLeft.duration(500).easing(Easing.ease);
@@ -511,7 +511,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 LightSpeedInLeft.springify()
@@ -618,7 +618,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 PinwheelOut.duration(500).easing(Easing.ease);
@@ -632,7 +632,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 PinwheelIn.springify()
@@ -745,7 +745,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 RollOutLeft.duration(500).easing(Easing.ease);
@@ -759,7 +759,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 RollInLeft.springify()
@@ -884,7 +884,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 RotateOutDownRight.duration(500).easing(Easing.ease);
@@ -898,7 +898,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 RotateInUpLeft.springify()
@@ -1023,7 +1023,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 SlideOutLeft.duration(500).easing(Easing.ease);
@@ -1037,7 +1037,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 SlideInUp.springify()
@@ -1149,7 +1149,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 StretchOutX.duration(500).easing(Easing.ease);
@@ -1163,7 +1163,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 StretchInX.springify()
@@ -1310,7 +1310,7 @@ These are the initial values for each animation that can be customized with the 
 
 #### Time-based <Optional/>
 
-Time-based modifiers relay on [`withTiming`](/docs/animations/withTiming) function.
+Time-based modifiers rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 ZoomOutLeft.duration(500).easing(Easing.ease);
@@ -1324,7 +1324,7 @@ Time-based modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 
 ```javascript
 ZoomInRotate.springify()

--- a/docs/docs-reanimated/versioned_docs/version-3.x/layout-animations/layout-transitions.mdx
+++ b/docs/docs-reanimated/versioned_docs/version-3.x/layout-animations/layout-transitions.mdx
@@ -33,7 +33,7 @@ function App() {
 
 #### Easing <Optional/>
 
-Easing modifiers are time-based modifiers that relay on [`withTiming`](/docs/animations/withTiming) function.
+Easing modifiers are time-based modifiers that rely on [`withTiming`](/docs/animations/withTiming) function.
 
 ```javascript
 LinearTransition.easing(Easing.ease);
@@ -47,7 +47,7 @@ The `.easing(...)` modifiers have no effect when `.springify()` is used.
 
 #### Spring-based <Optional/>
 
-Spring-based modifiers relay on [`withSpring`](/docs/animations/withSpring) function.
+Spring-based modifiers rely on [`withSpring`](/docs/animations/withSpring) function.
 Just as in `withSpring` config, spring-based modifiers can be physics-based (have `mass` and `damping` modifiers) or duration-based (have `duration` and `dampingRatio` modifiers).
 
 :::info


### PR DESCRIPTION
## Summary

I noticed that there were multiple places where `relay on withTiming` was used in the docs, while the intended meaning was likely `rely on withTiming`.

## Test plan

- [Relay](https://www.merriam-webster.com/dictionary/relay)
- [Rely](https://www.merriam-webster.com/dictionary/rely)
