### PR TITLE
Prevent style detachment for components frozen by Suspense

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -11,12 +11,15 @@ namespace reanimated {
 
 using namespace facebook::react;
 
+class ReanimatedModuleProxy;
+
 class ReanimatedMountHook : public UIManagerMountHook {
  public:
   ReanimatedMountHook(
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-      const std::function<void()> &requestFlush);
+      const std::function<void()> &requestFlush,
+      const std::weak_ptr<ReanimatedModuleProxy> &moduleProxy);
   ~ReanimatedMountHook() noexcept override;
 
   void shadowTreeDidMount(
@@ -32,6 +35,7 @@ class ReanimatedMountHook : public UIManagerMountHook {
   const std::shared_ptr<UIManager> uiManager_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::function<void()> requestFlush_;
+  const std::weak_ptr<ReanimatedModuleProxy> moduleProxy_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
@@ -6,6 +6,7 @@
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
 
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -35,7 +36,8 @@ class UpdatesRegistryManager {
 
   void markNodeAsRemovable(const std::shared_ptr<const ShadowNode> &shadowNode);
   void unmarkNodeAsRemovable(Tag viewTag);
-  void handleNodeRemovals(const RootShadowNode &rootShadowNode);
+  using NodeRemovalCallback = std::function<void(Tag, bool)>;
+  void handleNodeRemovals(const RootShadowNode &rootShadowNode, const NodeRemovalCallback &callback = {});
   PropsMap collectProps();
 
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -362,6 +362,22 @@ void ReanimatedModuleProxy::unmarkNodeAsRemovable(jsi::Runtime &rt, const jsi::V
   updatesRegistryManager_->unmarkNodeAsRemovable(viewTag.asNumber());
 }
 
+void ReanimatedModuleProxy::setNodeRemovalCallback(jsi::Runtime &rt, const jsi::Value &callback) {
+  if (callback.isObject() && callback.asObject(rt).isFunction(rt)) {
+    nodeRemovalCallback_ =
+        react::AsyncCallback<>(rt, callback.asObject(rt).asFunction(rt), jsInvoker_);
+  }
+}
+
+void ReanimatedModuleProxy::onNodeRemovalDecision(Tag tag, bool isFrozen) {
+  if (nodeRemovalCallback_) {
+    // Use custom lambda to manually convert to JSI values (JSI supports int/bool via jsi::Value)
+    nodeRemovalCallback_->call([tag, isFrozen](jsi::Runtime &rt, jsi::Function &callback) {
+      callback.call(rt, jsi::Value(static_cast<int>(tag)), jsi::Value(isFrozen));
+    });
+  }
+}
+
 void ReanimatedModuleProxy::registerCSSKeyframes(
     jsi::Runtime &rt,
     const jsi::Value &animationName,
@@ -1299,7 +1315,8 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
 
     strongThis->requestFlushRegistry();
   };
-  mountHook_ = std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, request);
+  mountHook_ =
+      std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, request, weak_from_this());
   commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -20,6 +20,7 @@
 #include <reanimated/NativeModules/ReanimatedModuleProxySpec.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
+#include <react/bridging/Function.h>
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/Registries/EventHandlerRegistry.h>
 #include <worklets/Tools/JSScheduler.h>
@@ -31,6 +32,7 @@
 #include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -105,6 +107,8 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
 
   void markNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper) override;
   void unmarkNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &viewTag) override;
+  void setNodeRemovalCallback(jsi::Runtime &rt, const jsi::Value &callback) override;
+  void onNodeRemovalDecision(Tag tag, bool isFrozen);
 
   void registerCSSKeyframes(
       jsi::Runtime &rt,
@@ -218,6 +222,8 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;
+
+  std::optional<react::AsyncCallback<>> nodeRemovalCallback_;
 
 #ifndef NDEBUG
   worklets::SingleInstanceChecker<ReanimatedModuleProxy> singleInstanceChecker_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -93,6 +93,12 @@ static jsi::Value REANIMATED_SPEC_PREFIX(
 }
 
 static jsi::Value REANIMATED_SPEC_PREFIX(
+    setNodeRemovalCallback)(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value *args, size_t) {
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)->setNodeRemovalCallback(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
+static jsi::Value REANIMATED_SPEC_PREFIX(
     registerCSSKeyframes)(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value *args, size_t) {
   static_cast<ReanimatedModuleProxySpec *>(&turboModule)
       ->registerCSSKeyframes(rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
@@ -158,6 +164,7 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(const std::shared_ptr<CallI
 
   methodMap_["markNodeAsRemovable"] = MethodMetadata{1, REANIMATED_SPEC_PREFIX(markNodeAsRemovable)};
   methodMap_["unmarkNodeAsRemovable"] = MethodMetadata{1, REANIMATED_SPEC_PREFIX(unmarkNodeAsRemovable)};
+  methodMap_["setNodeRemovalCallback"] = MethodMetadata{1, REANIMATED_SPEC_PREFIX(setNodeRemovalCallback)};
 
   methodMap_["registerCSSKeyframes"] = MethodMetadata{3, REANIMATED_SPEC_PREFIX(registerCSSKeyframes)};
   methodMap_["unregisterCSSKeyframes"] = MethodMetadata{2, REANIMATED_SPEC_PREFIX(unregisterCSSKeyframes)};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -66,6 +66,7 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
   // Cleanup
   virtual void markNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper) = 0;
   virtual void unmarkNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &viewTag) = 0;
+  virtual void setNodeRemovalCallback(jsi::Runtime &rt, const jsi::Value &callback) = 0;
 
   // CSS animation keyframes
   virtual void registerCSSKeyframes(

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -199,6 +199,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     this.#reanimatedModuleProxy.unmarkNodeAsRemovable(viewTag);
   }
 
+  setNodeRemovalCallback(callback: (tag: number, isFrozen: boolean) => void) {
+    this.#reanimatedModuleProxy.setNodeRemovalCallback(callback);
+  }
+
   registerCSSKeyframes(
     animationName: string,
     viewName: string,
@@ -263,6 +267,7 @@ class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
   setViewStyle(): void {}
   markNodeAsRemovable(): void {}
   unmarkNodeAsRemovable(): void {}
+  setNodeRemovalCallback(): void {}
   registerCSSKeyframes(): void {}
   unregisterCSSKeyframes(): void {}
   applyCSSAnimations(): void {}

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -287,6 +287,12 @@ class JSReanimated implements IReanimatedModule {
     );
   }
 
+  setNodeRemovalCallback(_callback: (tag: number, isFrozen: boolean) => void): void {
+    throw new ReanimatedError(
+      'setNodeRemovalCallback is not available in JSReanimated.'
+    );
+  }
+
   registerCSSKeyframes(
     _animationName: string,
     _viewName: string,

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -64,6 +64,7 @@ export interface ReanimatedModuleProxy {
 
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper): void;
   unmarkNodeAsRemovable(viewTag: number): void;
+  setNodeRemovalCallback(callback: (tag: number, isFrozen: boolean) => void): void;
 
   registerCSSKeyframes(
     animationName: string,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -5,7 +5,7 @@ import type React from 'react';
 import { StyleSheet } from 'react-native';
 
 import { checkStyleOverwriting, maybeBuild } from '../animationBuilder';
-import { IS_JEST, IS_WEB, logger } from '../common';
+import { IS_JEST, IS_WEB, logger, SHOULD_BE_USE_WEB } from '../common';
 import type { StyleProps } from '../commonTypes';
 import { LayoutAnimationType } from '../commonTypes';
 import { SkipEnteringContext } from '../component/LayoutAnimationConfig';
@@ -25,6 +25,7 @@ import type { CustomConfig } from '../layoutReanimation/web/config';
 import { addHTMLMutationObserver } from '../layoutReanimation/web/domUtils';
 import { PropsRegistryGarbageCollector } from '../PropsRegistryGarbageCollector';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
+import { ReanimatedModule } from '../ReanimatedModule';
 import { updateLayoutAnimations } from '../UpdateLayoutAnimations';
 import type {
   AnimatedComponentProps,
@@ -51,6 +52,32 @@ if (IS_WEB) {
 
 const FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS =
   getStaticFeatureFlag('FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS') && !IS_WEB;
+
+const componentRegistry = new Map<number, IAnimatedComponentInternal>();
+
+// Register callback for freeze detection (native only)
+if (!SHOULD_BE_USE_WEB) {
+  ReanimatedModule.setNodeRemovalCallback((tag: number, isFrozen: boolean) => {
+    const component = componentRegistry.get(tag);
+    if (!component || !component._willUnmount) {
+      // Skip if component doesn't exist or already handled (remounted before callback fired)
+      return;
+    }
+
+    if (!isFrozen) {
+      // Component truly unmounted - safe to clean up
+      component._detachStyles();
+      if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
+        PropsRegistryGarbageCollector.unregisterView(tag);
+      }
+      jsPropsUpdater.unregisterComponent(component);
+      componentRegistry.delete(tag);
+    }
+
+    // Always clear flag whether frozen or unmounted
+    component._willUnmount = false;
+  });
+}
 
 export type Options<P> = {
   setNativeProps?: (ref: AnimatedComponentRef, props: P) => void;
@@ -120,11 +147,12 @@ export default class AnimatedComponent
     this._updateAnimatedStylesAndProps();
     this._InlinePropManager.attachInlineProps(this, this._getViewInfo());
 
-    if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
-      const viewTag = this.getComponentViewTag();
-      if (viewTag !== -1) {
-        PropsRegistryGarbageCollector.registerView(viewTag, this);
-      }
+    const viewTag = this.getComponentViewTag();
+    if (!SHOULD_BE_USE_WEB && viewTag !== -1) {
+      componentRegistry.set(viewTag, this);
+    }
+    if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS && viewTag !== -1) {
+      PropsRegistryGarbageCollector.registerView(viewTag, this);
     }
 
     if (this._options?.jsProps?.length) {
@@ -182,18 +210,19 @@ export default class AnimatedComponent
   componentWillUnmount() {
     super.componentWillUnmount();
     this._NativeEventsManager?.detachEvents();
-    this._detachStyles();
     this._InlinePropManager.detachInlineProps();
 
-    if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
-      const viewTag = this.getComponentViewTag();
-      if (viewTag !== -1) {
+    const viewTag = this.getComponentViewTag();
+    const shouldDeferCleanup = !SHOULD_BE_USE_WEB;
+    if (!shouldDeferCleanup) {
+      this._detachStyles();
+      if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS && viewTag !== -1) {
         PropsRegistryGarbageCollector.unregisterView(viewTag);
       }
-    }
-
-    if (this._options?.jsProps?.length) {
       jsPropsUpdater.unregisterComponent(this);
+      if (viewTag !== -1) {
+        componentRegistry.delete(viewTag);
+      }
     }
 
     const exiting = this.props.exiting;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -156,6 +156,8 @@ export interface IAnimatedComponentInternal
   context: React.ContextType<typeof SkipEnteringContext>;
   setNativeProps: (props: StyleProps) => void;
   _syncStylePropsBackToReact: (props: StyleProps) => void;
+  _detachStyles: () => void;
+  _willUnmount: boolean;
 }
 
 export type NestedArray<T> = T | NestedArray<T>[];


### PR DESCRIPTION
## Summary
Defer JS-side cleanup when Fabric components are frozen by Suspense to avoid detaching animated styles mid-freeze.

# Prevent style detachment for components frozen by Suspense

## Problem

When React Suspense freezes components (using `react-freeze`), `componentWillUnmount` is called but the component will be remounted later. Reanimated's current behavior detaches all styles and unregisters from `ComponentRegistry` during `componentWillUnmount`, causing issues when the component is remounted.

## Solution

Distinguish between truly unmounted components and frozen components by checking if the component still has ancestors in the shadow tree during native shadow tree operations.

## Freeze Detection Logic

The key insight is in `PropsRegistry::handleNodeRemovals`:

1. **If `ancestors.empty()`**: Component is truly unmounted (no parent in shadow tree)
2. **If ancestors exist**: Component is frozen (has parent but hidden by Suspense)

This works because:
- Suspense with `mode: "hidden"` removes children from the shadow tree but keeps them in memory
- Frozen components still have ancestors (the Suspense component itself)
- Truly unmounted components have no ancestors in the current shadow tree

The additional check for "Suspense" in the parent chain provides extra confirmation, but the presence of ancestors is the primary indicator of a frozen component.
