### PR TITLE
fix: Guard for undefined style in Jest utils

### DIFF
--- a/packages/react-native-reanimated/src/jestUtils.ts
+++ b/packages/react-native-reanimated/src/jestUtils.ts
@@ -79,7 +79,7 @@ const getCurrentStyle = (component: TestComponent): DefaultStyle => {
 
   if (Array.isArray(jestInlineStyles)) {
     for (const obj of jestInlineStyles) {
-      if ('jestAnimatedValues' in obj) {
+      if (!obj || 'jestAnimatedValues' in obj) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

When writing a component it's common to have undefined as a value in array of styles. For example:

```tsx
interface Props {
  style?: ViewStyle
}

function MyComponent({ style }: Props) {
  const animatedStyles = useAnimatedStyles...

  return <Animated.View style={[style, animatedStyles]} />
}
```

Jest utils' getCurrentStyle will try to retrieve a value from undefined resulting in:
```
TypeError: Cannot use 'in' operator to search for 'jestAnimatedValues' in undefined
```
## Test plan

```tsx
interface Props {
  style?: ViewStyle
}

function MyComponent({ style }: Props) {
  const animatedStyles = useAnimatedStyles(() => ({ width: '100%' }});

  return <Animated.View testID="my-component" style={[style, animatedStyles]} />
}
```

```tsx
it('Should ignore undefined in array of styles', () => {
   const { getByTestId } = render(<MyComponent />);
   expect(getByTestId("my-component")).toHaveAnimatedStyle({ width: '100%' });
   // passes without type errors
});
```
