### PR TITLE
feat: better link coloring in docs

### DIFF
--- a/docs/docs-reanimated/src/css/colors.css
+++ b/docs/docs-reanimated/src/css/colors.css
@@ -121,6 +121,8 @@
   /* Typography */
   --ifm-heading-color: var(--ifm-color-primary);
   --ifm-font-color-base: var(--swm-navy-light-100);
+  --ifm-link-color: var(--swm-blue-light-100);
+  --ifm-link-hover-color: var(--swm-blue-light-60);
 
   /* Tabs */
   --swm-tab: var(--swm-navy-light-20);
@@ -327,6 +329,8 @@
 
   /* Typography */
   --ifm-font-color-base: var(--swm-navy-light-10);
+  --ifm-link-color: var(--swm-blue-dark-80);
+  --ifm-link-hover-color: var(--swm-blue-dark-60);
 
   /* Tabs */
   --swm-tab: var(--swm-navy-light-60);

--- a/docs/docs-reanimated/src/css/typography.css
+++ b/docs/docs-reanimated/src/css/typography.css
@@ -167,8 +167,7 @@ code {
 .markdown a {
   font-weight: 500;
   text-decoration: none;
-
-  border-bottom: 1px solid var(--ifm-font-color-base);
+  border-bottom: 1px solid var(--ifm-link-color);
 }
 
 /* Sidebar */

--- a/docs/docs-worklets/src/css/colors.css
+++ b/docs/docs-worklets/src/css/colors.css
@@ -121,6 +121,8 @@
   /* Typography */
   --ifm-heading-color: var(--ifm-color-primary);
   --ifm-font-color-base: var(--swm-navy-light-100);
+  --ifm-link-color: var(--swm-blue-light-100);
+  --ifm-link-hover-color: var(--swm-blue-light-60);
 
   /* Tabs */
   --swm-tab: var(--swm-navy-light-20);
@@ -343,6 +345,8 @@
 
   /* Typography */
   --ifm-font-color-base: var(--swm-navy-light-10);
+  --ifm-link-color: var(--swm-blue-dark-80);
+  --ifm-link-hover-color: var(--swm-blue-dark-60);
 
   /* Tabs */
   --swm-tab: var(--swm-navy-dark-60);

--- a/docs/docs-worklets/src/css/typography.css
+++ b/docs/docs-worklets/src/css/typography.css
@@ -172,8 +172,7 @@ code {
 .markdown a {
   font-weight: 500;
   text-decoration: none;
-
-  border-bottom: 1px solid var(--ifm-font-color-base);
+  border-bottom: 1px solid var(--ifm-link-color);
 }
 
 /* Sidebar */


### PR DESCRIPTION
## Summary

I noticed that links in our docs didn't really look like links and they didn't respond to hover events. I made them more intuitive.

| Before | After |
|--------|--------|
| <img width="1107" height="314" alt="Screenshot 2026-01-28 at 16 42 04" src="https://github.com/user-attachments/assets/241dd02f-9dff-4d37-ad65-13a3bb7075d9" /> | <img width="1107" height="314" alt="Screenshot 2026-01-28 at 16 42 38" src="https://github.com/user-attachments/assets/3789fcb9-5f5a-4305-aaf9-e4cb3909c255" /> | 
| <img width="1107" height="314" alt="Screenshot 2026-01-28 at 16 42 00" src="https://github.com/user-attachments/assets/db4cc19c-dbeb-45f0-bdbe-329689cba237" /> | <img width="1107" height="314" alt="Screenshot 2026-01-28 at 16 42 33" src="https://github.com/user-attachments/assets/b6823249-cc52-4feb-b3c0-fb506588ed73" /> | 

## Test plan

CI
