### PR TITLE
chore: remove options for Worklets Babel plugin from quick start guide

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -32,10 +32,14 @@ Install `react-native-reanimated` and `react-native-worklets` packages from npm:
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm install react-native-reanimated ```
+    ```bash
+    npm install react-native-reanimated
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn add react-native-reanimated ```
+    ```bash
+    yarn add react-native-reanimated
+    ```
   </TabItem>
 </Tabs>
 
@@ -47,10 +51,14 @@ You can read more about Worklets in the [Worklets documentation](https://docs.sw
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     {/* TODO - add information about the necessity to specify a proper version of the library compatible with reanimated */}
-    ```bash npm install react-native-worklets ```
+    ```bash 
+    npm install react-native-worklets
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn add react-native-worklets ```
+    ```bash
+    yarn add react-native-worklets
+    ```
   </TabItem>
 </Tabs>
 
@@ -60,10 +68,14 @@ Run prebuild to update the native code in the `ios` and `android` directories.
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npx expo prebuild ```
+    ```bash
+    npx expo prebuild
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn expo prebuild ```
+    ```bash
+    yarn expo prebuild
+    ```
   </TabItem>
 </Tabs>
 
@@ -108,10 +120,14 @@ To learn more about the plugin head onto to [Worklets Babel plugin docs page](ht
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm start -- --reset-cache ```
+    ```bash
+    npm start -- --reset-cache
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn start --reset-cache ```
+    ```bash
+    yarn start --reset-cache
+    ```
   </TabItem>
 </Tabs>
 
@@ -135,10 +151,14 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm install @babel/plugin-proposal-export-namespace-from ```
+    ```bash
+    npm install @babel/plugin-proposal-export-namespace-from
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn add @babel/plugin-proposal-export-namespace-from ```
+    ```bash
+    yarn add @babel/plugin-proposal-export-namespace-from
+    ```
   </TabItem>
 </Tabs>
 

--- a/docs/docs-reanimated/prettier.config.js
+++ b/docs/docs-reanimated/prettier.config.js
@@ -1,4 +1,4 @@
-const defaultConfig = require("../../prettier.config");
+const defaultConfig = require('../../prettier.config');
 
 // We can't bump to Prettier 3.x because current version of Docusaurus
 // crashes on build with it.
@@ -7,4 +7,5 @@ module.exports = {
   ...defaultConfig,
   // Override plugins that don't work with Prettier 2.x
   plugins: [],
+  embeddedLanguageFormatting: 'off',
 };

--- a/docs/docs-worklets/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-worklets/docs/fundamentals/getting-started.mdx
@@ -47,10 +47,14 @@ Run prebuild to update the native code in the `ios` and `android` directories.
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npx expo prebuild ```
+    ```bash
+    npx expo prebuild
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn expo prebuild ```
+    ```bash
+    yarn expo prebuild
+    ```
   </TabItem>
 </Tabs>
 
@@ -89,10 +93,14 @@ To learn more about the plugin head onto to [Worklets babel plugin](/docs/workle
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
-    ```bash npm start -- --reset-cache ```
+    ```bash
+    npm start -- --reset-cache
+    ```
   </TabItem>
   <TabItem value="yarn" label="YARN">
-    ```bash yarn start --reset-cache ```
+    ```bash
+    yarn start --reset-cache
+    ```
   </TabItem>
 </Tabs>
 

--- a/docs/docs-worklets/prettier.config.js
+++ b/docs/docs-worklets/prettier.config.js
@@ -1,4 +1,4 @@
-const defaultConfig = require("../../prettier.config");
+const defaultConfig = require('../../prettier.config');
 
 // We can't bump to Prettier 3.x because current version of Docusaurus
 // crashes on build with it.
@@ -7,4 +7,5 @@ module.exports = {
   ...defaultConfig,
   // Override plugins that don't work with Prettier 2.x
   plugins: [],
+  embeddedLanguageFormatting: 'off',
 };


### PR DESCRIPTION
## Summary

It would confuse people who were unfamiliar with Babel config. Now the information about the options is below with a proper link. Also formatting got fixed.

Requires #8889

## Test plan

CI
