### PR TITLE
fix(types): make props optional when provided via animatedProps

### DIFF
--- a/packages/react-native-reanimated/src/helperTypes.ts
+++ b/packages/react-native-reanimated/src/helperTypes.ts
@@ -99,17 +99,66 @@ type SharedTransitionProps = {
   sharedTransitionStyle?: SharedTransition;
 };
 
-export type AnimatedProps<Props extends object> = RestProps<Props> &
-  AnimatedStyleProps<Props> &
-  LayoutProps & {
-    /**
-     * Lets you animate component props.
-     *
-     * @see https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedProps
-     */
-    animatedProps?: NestedArray<
-      CSSStyle<ComponentPropsWithoutStyle<Partial<Props>>>
-    >; // TODO - improve type once useAnimatedProps is typed properly. For now it is typed in the same way as the normal style prop, so it is assignable to the CSSStyle type
-  } & SharedTransitionProps;
+/**
+ * Type representing what can be passed to animatedProps. Exported for use with
+ * AnimatedComponentType.
+ */
+export type AnimatedPropsProp<Props extends object> = CSSStyle<
+  ComponentPropsWithoutStyle<Partial<Props>>
+>;
+
+export type AnimatedProps<
+  Props extends object,
+  AP extends Partial<AnimatedPropsProp<Props>> = never,
+> = [AP] extends [never]
+  ? // Default: all props remain as-is
+    RestProps<Props> &
+      AnimatedStyleProps<Props> &
+      LayoutProps &
+      SharedTransitionProps & {
+        /**
+         * Lets you animate component props.
+         *
+         * @see https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedProps
+         */
+        animatedProps?: NestedArray<AnimatedPropsProp<Props>>;
+      }
+  : // When AP is provided: props in AP become optional
+    Omit<RestProps<Props>, keyof AP> &
+      Partial<Pick<RestProps<Props>, keyof AP & keyof RestProps<Props>>> &
+      Omit<AnimatedStyleProps<Props>, keyof AP> &
+      Partial<
+        Pick<
+          AnimatedStyleProps<Props>,
+          keyof AP & keyof AnimatedStyleProps<Props>
+        >
+      > &
+      LayoutProps &
+      SharedTransitionProps & {
+        /**
+         * Lets you animate component props.
+         *
+         * @see https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedProps
+         */
+        animatedProps?: AP;
+      };
+
+/**
+ * Props type when animatedProps is provided with a specific type. Props that
+ * are keys of AP become optional.
+ */
+export type AnimatedPropsWithInference<
+  Props extends object,
+  AP extends object,
+> = Omit<RestProps<Props>, keyof AP> &
+  Partial<Pick<RestProps<Props>, keyof AP & keyof RestProps<Props>>> &
+  Omit<AnimatedStyleProps<Props>, keyof AP> &
+  Partial<
+    Pick<AnimatedStyleProps<Props>, keyof AP & keyof AnimatedStyleProps<Props>>
+  > &
+  LayoutProps &
+  SharedTransitionProps & {
+    animatedProps: AP;
+  };
 
 // THE LAND OF THE DEPRECATED

--- a/packages/react-native-reanimated/src/hook/useAnimatedProps.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedProps.ts
@@ -5,15 +5,18 @@ import { useAnimatedStyle } from './useAnimatedStyle';
 
 // TODO: we should make sure that when useAP is used we are not assigning styles
 
-type UseAnimatedProps = <Props extends object>(
-  updater: () => Partial<Props>,
+type UseAnimatedProps = <
+  Props extends object,
+  TResult extends Partial<Props> = Partial<Props>,
+>(
+  updater: () => TResult,
   dependencies?: DependencyList | null,
   adapters?:
     | AnimatedPropsAdapterFunction
     | AnimatedPropsAdapterFunction[]
     | null,
   isAnimatedProps?: boolean
-) => Partial<Props>;
+) => TResult;
 
 function useAnimatedPropsInternal<Props extends object>(
   updater: () => Props,


### PR DESCRIPTION
## Summary

> [!WARNING]
> 100% vibe coded. Let me know if you feel like this needs any human changes somewhere! So far from my tests this seems to work fine!

When using createAnimatedComponent with useAnimatedProps, props that are provided through animatedProps now become optional on the component itself.

This fixes the TypeScript error where required props would still be required on the component even when they were being provided via animatedProps.

Example:
```tsx
interface ViewProps {
  requiredBorderRadius: number;
}
function MyComp(props: ViewProps) {}
const AnimatedComp = Animated.createAnimatedComponent(MyComp);

const animatedProps = useAnimatedProps(() => ({
  requiredBorderRadius: sharedValue.get()
}));

// Previously errored, now works correctly
<AnimatedComp animatedProps={animatedProps} />
```

Changes:
- AnimatedProps<Props, AP> now takes optional second type parameter
- useAnimatedProps preserves exact return type for better inference
- AnimatedComponentType uses overloads to infer animatedProps type
- Added AnimatedPropsWithInference helper type

## Test plan

I let the AI add test cases to verify this is working correctly.
