### PR TITLE
fix: Simplify run-loop and always attach JNI on Android

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/RunLoop/AsyncQueueImpl.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/RunLoop/AsyncQueueImpl.cpp
@@ -1,8 +1,8 @@
 #include <worklets/RunLoop/AsyncQueueImpl.h>
 
-#if defined(ANDROID)
+#ifdef ANDROID
 #include <fbjni/fbjni.h>
-#endif // defined(ANDROID)
+#endif // ANDROID
 
 #include <memory>
 #include <string>
@@ -32,13 +32,13 @@ void AsyncQueueImpl::runLoop(const std::shared_ptr<AsyncQueueState> &state) {
 
 AsyncQueueImpl::AsyncQueueImpl(const std::string &name) : state_(std::make_shared<AsyncQueueState>()) {
   auto thread = std::thread([name, state = state_] {
-#if defined(ANDROID)
+#ifdef ANDROID
     pthread_setname_np(pthread_self(), name.c_str());
     jni::ThreadScope::WithClassLoader([state]() { AsyncQueueImpl::runLoop(state); });
 #else
     pthread_setname_np(name.c_str());
     AsyncQueueImpl::runLoop(state);
-#endif // defined(ANDROID)
+#endif // ANDROID
   });
   thread.detach();
 }


### PR DESCRIPTION
## Summary

On Android, without bundle mode and fetch preview, the `AsyncQueue` doesn't attach the newly created Thread to JNI, which causes any native method calls that go into Java/Kotlin (i.e. Native Modules, or Nitro Modules methods) to fail because the Thread isn't attached.

This PR simplifies the runloop creation to always attach a `jni::ThreadScope` on Android to wrap the run loop with.

## Test plan

1. Create a new worklet runtime using Worklet's APIs (**no** custom async queue)
2. Call a Nitro Modules method on it that lives in Java/Kotlin
3. See how it fails. With this PR, it doesn't.
