### PR TITLE
fix(worklets): avoid HERMES_V1_ENABLED macro redefinition on RN 0.84+

### DIFF
--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -18,8 +18,8 @@ string(
     -DWORKLETS_VERSION=${WORKLETS_VERSION}\
     -DWORKLETS_FEATURE_FLAGS=\"${WORKLETS_FEATURE_FLAGS}\"")
 
-# HERMES_V1_ENABLED is centralized in react-native-flags.cmake for RN >= 84
-# Only define manually for older versions to avoid macro redefinition error
+# HERMES_V1_ENABLED is centralized in react-native-flags.cmake for RN >= 84.
+# Only define manually for older versions to avoid macro redefinition error.
 if(REACT_NATIVE_MINOR_VERSION LESS 84)
   string(APPEND CMAKE_CXX_FLAGS " -DHERMES_V1_ENABLED=${HERMES_V1_ENABLED}")
 endif()

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -14,7 +14,7 @@ def safeAppExtGet(prop, fallback) {
 
 def isNewArchitectureEnabled() {
     // In React Native 0.82+, users can no longer opt-out of the New Architecture.
-    if(getReactNativeMinorVersion() >= 82){
+    if (getReactNativeMinorVersion() >= 82) {
         return true
     }
 
@@ -53,6 +53,19 @@ def getReactNativeVersion() {
 def getReactNativeMinorVersion() {
     def reactNativeVersion = getReactNativeVersion()
     return reactNativeVersion.startsWith("0.0.0-") ? 1000 : reactNativeVersion.split("\\.")[1].toInteger()
+}
+
+def getHermesV1Enabled() {
+    // Even though `HERMES_V1_ENABLED` is now centralized
+    // in `react-native-flags.cmake` for React Native >= 0.84
+    // that CMake file depends on definitions provided
+    // in local `externalNativeBuild` configuration of the LIBRARY.
+    // I hope this is only a temporary workaround.
+    if (getReactNativeMinorVersion() >= 84) {
+        return safeAppExtGet("hermesV1Enabled", true)
+    } else {
+        return safeAppExtGet("hermesV1Enabled", false)
+    }
 }
 
 def getWorkletsVersion() {
@@ -112,7 +125,7 @@ def IS_REANIMATED_EXAMPLE_APP = safeAppExtGet("isReanimatedExampleApp", false)
 def BUNDLE_MODE_ENABLED = isFlagEnabled(featureFlags, "BUNDLE_MODE_ENABLED");
 def FETCH_PREVIEW_ENABLED = isFlagEnabled(featureFlags, "FETCH_PREVIEW_ENABLED");
 def WORKLETS_FEATURE_FLAGS = getStaticFeatureFlagsString(featureFlags)
-def HERMES_V1_ENABLED = safeAppExtGet("hermesV1Enabled", false)
+def HERMES_V1_ENABLED = getHermesV1Enabled()
 def WORKLETS_PROFILING = safeAppExtGet("enableWorkletsProfiling", false)
 
 // Set version for prefab
@@ -284,7 +297,7 @@ android {
             }
         }
     }
-    if(project != rootProject) {
+    if (project != rootProject) {
         kotlinOptions {
             jvmTarget = '17'
         }


### PR DESCRIPTION
## Summary

React Native 0.84 centralized the `HERMES_V1_ENABLED` define into `target_compile_reactnative_options()` in `react-native-flags.cmake` ([commit](https://github.com/facebook/react-native/commit/9f7f6b7f882959c9f8f80e40a993aa5407edcd01)).

When worklets defines `-DHERMES_V1_ENABLED=${HERMES_V1_ENABLED}` and then calls `target_compile_reactnative_options()`, the macro gets defined twice with different values (`true` vs `1`), causing:

```
error: 'HERMES_V1_ENABLED' macro redefined [-Werror,-Wmacro-redefined]
   #define HERMES_V1_ENABLED true
<command line>:1:9: note: previous definition is here
   #define HERMES_V1_ENABLED 1
```

Requires
- #8909

## Solution

Only define `HERMES_V1_ENABLED` manually for RN < 84, since RN 84+ handles it via `target_compile_reactnative_options()`.

## Test plan

- Tested with Expo SDK 55 canary + React Native 0.84.0-rc.4
- Android build succeeds after this fix