### PR TITLE
chore(Worklets): fix runAsync mock signature

### DIFF
--- a/packages/react-native-worklets/src/mock.ts
+++ b/packages/react-native-worklets/src/mock.ts
@@ -40,7 +40,7 @@ const WorkletAPI = {
     worklet: (...args: Args) => ReturnValue,
     ...args: Args
   ): Promise<ReturnValue> {
-    return WorkletAPI.runOnUIAsync(worklet)(...args);
+    return WorkletAPI.runOnUIAsync(worklet, ...args);
   },
   scheduleOnRuntime: IMMEDIATE_CALLBACK_INVOCATION,
   createSerializable: ID,
@@ -78,16 +78,15 @@ const WorkletAPI = {
     };
   },
   runOnUIAsync<Args extends unknown[], ReturnValue>(
-    worklet: (...args: Args) => ReturnValue
-  ): (...args: Args) => Promise<ReturnValue> {
-    return (...args: Args) => {
-      return new Promise<ReturnValue>((resolve) => {
-        mockedRequestAnimationFrame(() => {
-          const result = worklet(...args);
-          resolve(result);
-        });
+    worklet: (...args: Args) => ReturnValue,
+    ...args: Args
+  ): Promise<ReturnValue> {
+    return new Promise<ReturnValue>((resolve) => {
+      mockedRequestAnimationFrame(() => {
+        const result = worklet(...args);
+        resolve(result);
       });
-    };
+    });
   },
   runOnUISync: IMMEDIATE_CALLBACK_INVOCATION,
   scheduleOnRN<Args extends unknown[], ReturnValue>(


### PR DESCRIPTION
## Summary

I realized that mocks for `runOnUIAsync` and `runOnRuntimeAsync` have old-type signatures with double `()()`.

## Test plan

CI
