### PR TITLE
fix(Fabric): null-safe getNativeScrollRef in getShadowNodeWrapperFromRef

### DIFF
--- a/packages/react-native-reanimated/src/fabricUtils.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.ts
@@ -15,11 +15,16 @@ export function getShadowNodeWrapperFromRef(
 
   if (!resolvedInstance) {
     if (ref.getNativeScrollRef) {
-      resolvedInstance = (ref.getNativeScrollRef() as any)
-        .__internalInstanceHandle;
-    } else if ((ref as any)._reactInternals) {
+      const nativeScrollRef = ref.getNativeScrollRef();
+      if (nativeScrollRef) {
+        resolvedInstance = (nativeScrollRef as any)
+          .__internalInstanceHandle;
+      }
+    }
+    if (!resolvedInstance && (ref as any)._reactInternals) {
       resolvedInstance = findHostInstance(ref).__internalInstanceHandle;
-    } else {
+    }
+    if (!resolvedInstance) {
       throw new ReanimatedError(`Failed to find host instance for a ref.}`);
     }
   }


### PR DESCRIPTION
## Summary

`getShadowNodeWrapperFromRef()` in `fabricUtils.ts` crashes under Fabric (New Architecture) when used with `Animated.createAnimatedComponent(FlatList)` or `Animated.createAnimatedComponent(SectionList)`:

```
TypeError: Cannot read property '__internalInstanceHandle' of null
```

## Root Cause

The `else if` chain introduced in #8301 assumes `ref.getNativeScrollRef()` always returns a non-null value when the method exists:

```ts
if (ref.getNativeScrollRef) {
  resolvedInstance = (ref.getNativeScrollRef() as any).__internalInstanceHandle;
} else if ((ref as any)._reactInternals) {
  resolvedInstance = findHostInstance(ref).__internalInstanceHandle;
}
```

Under Fabric, `ref.getNativeScrollRef` is truthy (the method exists on the ref), but `ref.getNativeScrollRef()` returns **null**. The code dereferences `null.__internalInstanceHandle` and crashes. Because of the `else if` structure, it never falls through to the `findHostInstance` fallback which works correctly.

## Fix

- Add a null check on the return value of `getNativeScrollRef()`
- Convert the `else if` chain to independent `if` blocks so `findHostInstance` is reached as a fallback

```ts
if (ref.getNativeScrollRef) {
  const nativeScrollRef = ref.getNativeScrollRef();
  if (nativeScrollRef) {
    resolvedInstance = (nativeScrollRef as any).__internalInstanceHandle;
  }
}
if (!resolvedInstance && (ref as any)._reactInternals) {
  resolvedInstance = findHostInstance(ref).__internalInstanceHandle;
}
if (!resolvedInstance) {
  throw new ReanimatedError(`Failed to find host instance for a ref.}`);
}
```

## Reproduction

1. Enable Fabric / New Architecture (e.g. Expo SDK 54)
2. Use `Animated.createAnimatedComponent(FlatList)` or `SectionList` with `useAnimatedRef`
3. App crashes on mount with `TypeError: Cannot read property '__internalInstanceHandle' of null`

## Test Plan

- Verified on iOS with Expo SDK 54 (Fabric enabled) that the crash no longer occurs
- Animated FlatList and SectionList render and scroll correctly
- `useAnimatedRef` + `scrollTo` works as expected
- No regressions on standard (non-scroll) animated components