### PR TITLE
chore: fix building release FabricExample from CLI

### DIFF
--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    // hermesCommand = "./node_modules/react-native/sdks/hermesc/%OS-BIN%/hermesc"
+    hermesCommand = "../../node_modules/hermes-compiler/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
## Summary

Now RN is hoisted in the root of the monorepo and `hermesc` is no longer in `react-native/sdks`.

## Test plan

in `/apps/fabric-example/android` run `./gradlew assembleRelease`.
