### PR TITLE
fix: `noplugin` option being ignored in the web-example

### DIFF
--- a/apps/web-example/babel.config.js
+++ b/apps/web-example/babel.config.js
@@ -22,12 +22,23 @@ module.exports = function (api) {
   api.cache.invalidate(() => disableBabelPlugin);
   if (disableBabelPlugin) {
     console.log('Starting Web example without Babel plugin.');
+    console.log('DISABLE_BABEL_PLUGIN env var:', process.env.DISABLE_BABEL_PLUGIN);
   } else {
     plugins.push(['react-native-worklets/plugin', workletsPluginOptions]);
   }
 
   return {
-    presets: ['babel-preset-expo', 'react-strict-dom/babel-preset'],
+    presets: [
+      [
+        'babel-preset-expo',
+        {
+          // Disable worklets and reanimated plugins from babel-preset-expo when DISABLE_BABEL_PLUGIN is set
+          worklets: !disableBabelPlugin,
+          reanimated: !disableBabelPlugin,
+        },
+      ],
+      'react-strict-dom/babel-preset',
+    ],
     plugins,
   };
 };


### PR DESCRIPTION
## Summary

The `noplugin` option was ignored at all before and didn't make any change when used while starting the web example.

## Examples

**Expected behavior:**

- should crash when babel plugin is **disabled** on the web and `useAnimatedStyle` hook is used without dependencies,
- should **not** crash when babel plugin is **enabled** on the web and `useAnimatedStyle` hook is used without dependencies,

### Before

#### With plugin

```
yarn workspace web-example start --reset-cache
```

https://github.com/user-attachments/assets/c538e286-0982-4d1b-982f-cad33053e24d

#### Without plugin

```
yarn workspace web-example start:noplugin --reset-cache
```

https://github.com/user-attachments/assets/9a808d3d-9242-47a0-a9bc-d2aaf5aa62e0

---

### After

#### With plugin

```
yarn workspace web-example start --reset-cache
```

https://github.com/user-attachments/assets/5d83ae9e-2c07-46cc-985a-d2332f295fdb


#### Without plugin

```
yarn workspace web-example start:noplugin --reset-cache
```

https://github.com/user-attachments/assets/9f7f4a46-aada-4451-b258-68d9d3634019
