### PR TITLE
cherry-pick(Worklets): fix(Worklets): Synchronizable serialization for objects outside of BundleMode

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -42,7 +42,7 @@ export default function RuntimeTestsExample() {
           },
         },
         {
-          testSuiteName: 'serializable',
+          testSuiteName: 'memory',
           importTest: () => {
             require('./tests/memory/createSerializable.test');
             require('./tests/memory/createSerializableOnUI.test');

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/synchronizable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/synchronizable.test.tsx
@@ -319,3 +319,35 @@ describe('Test Synchronizable access', () => {
     expect(Math.max(valueRN, valueUI, valueBG)).toBe(targetValue * 3);
   });
 });
+
+describe('Test Synchronizable serialization', () => {
+  test('Synchronizable accepts primitives', () => {
+    const synchronizable = createSynchronizable(0);
+
+    // RN Runtime
+    synchronizable.setBlocking(1);
+    expect(synchronizable.getBlocking()).toBe(1);
+
+    // UI Runtime
+    runOnUISync(() => {
+      'worklet';
+      synchronizable.setBlocking(2);
+    });
+    expect(synchronizable.getBlocking()).toBe(2);
+  });
+
+  test('Synchronizable accepts objects', () => {
+    const synchronizable = createSynchronizable({ a: 0 });
+
+    // RN Runtime
+    synchronizable.setBlocking({ a: 1 });
+    expect(synchronizable.getBlocking().a).toBe(1);
+
+    // UI Runtime
+    runOnUISync(() => {
+      'worklet';
+      synchronizable.setBlocking({ a: 2 });
+    });
+    expect(synchronizable.getBlocking().a).toBe(2);
+  });
+});

--- a/packages/react-native-worklets/Common/cpp/worklets/Resources/SynchronizableUnpacker.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Resources/SynchronizableUnpacker.cpp
@@ -8,9 +8,9 @@ namespace worklets {
 
 const char SynchronizableUnpackerCode[] =
     R"DELIMITER__((function () {
-  var serializer = !globalThis._WORKLET || globalThis._WORKLETS_BUNDLE_MODE ? function (value, _) {
-    return (0, _serializable.createSerializable)(value);
-  } : globalThis._createSerializable;
+  var serializer = !globalThis._WORKLET || globalThis._WORKLETS_BUNDLE_MODE ? _serializable.createSerializable : function (value) {
+    return globalThis.__serializer(value);
+  };
   function synchronizableUnpacker(synchronizableRef) {
     var synchronizable = synchronizableRef;
     var proxy = globalThis.__workletsModuleProxy;
@@ -28,12 +28,12 @@ const char SynchronizableUnpackerCode[] =
         synchronizable.lock();
         var prev = synchronizable.getBlocking();
         newValue = func(prev);
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue, undefined));
+        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
         synchronizable.unlock();
       } else {
         var value = valueOrFunction;
         newValue = value;
-        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue, undefined));
+        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
       }
     };
     synchronizable.lock = function () {

--- a/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
@@ -7,15 +7,15 @@ export function __installUnpacker() {
   // TODO: Add cache for synchronizables.
   const serializer =
     !globalThis._WORKLET || globalThis._WORKLETS_BUNDLE_MODE
-      ? (value: unknown, _: unknown) => createSerializable(value)
-      : globalThis._createSerializable;
+      ? createSerializable
+      : (value: unknown) => globalThis.__serializer(value);
 
   function synchronizableUnpacker<TValue>(
     synchronizableRef: SynchronizableRef<TValue>
   ): Synchronizable<TValue> {
     const synchronizable =
       synchronizableRef as unknown as Synchronizable<TValue>;
-    const proxy = globalThis.__workletsModuleProxy!;
+    const proxy = globalThis.__workletsModuleProxy;
 
     synchronizable.__synchronizableRef = true;
     synchronizable.getDirty = () => {
@@ -34,19 +34,13 @@ export function __installUnpacker() {
         const prev = synchronizable.getBlocking();
         newValue = func(prev);
 
-        proxy.synchronizableSetBlocking(
-          synchronizable,
-          serializer(newValue, undefined)
-        );
+        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
 
         synchronizable.unlock();
       } else {
         const value = valueOrFunction;
         newValue = value;
-        proxy.synchronizableSetBlocking(
-          synchronizable,
-          serializer(newValue, undefined)
-        );
+        proxy.synchronizableSetBlocking(synchronizable, serializer(newValue));
       }
     };
     synchronizable.lock = () => {

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -5,6 +5,7 @@
 import type { callGuardDEV } from './callGuard';
 import type { reportFatalRemoteError } from './debug/errors';
 import type { CustomSerializableUnpacker } from './memory/customSerializableUnpacker';
+import type { makeShareableCloneOnUIRecursive } from './memory/serializable';
 import type { SynchronizableUnpacker } from './memory/synchronizableUnpacker';
 import type { CustomSerializationRegistry } from './memory/types';
 import type { Queue } from './runLoop/workletRuntime/taskQueue';
@@ -17,7 +18,7 @@ declare global {
     Record<string, unknown>;
 
   var _toString: (value: unknown) => string;
-  var __workletsModuleProxy: WorkletsModuleProxy | undefined;
+  var __workletsModuleProxy: WorkletsModuleProxy;
   var _WORKLETS_BUNDLE_MODE: boolean | undefined;
   var _WORKLETS_VERSION_CPP: string | undefined;
   var _WORKLETS_VERSION_JS: string | undefined;
@@ -54,6 +55,8 @@ declare global {
   var _createSerializableSynchronizable: (
     value: object
   ) => FlatShareableRef<object>;
+  /** Only outside of Bundle Mode on Worklet Runtimes. */
+  var __serializer: typeof makeShareableCloneOnUIRecursive;
   var __callMicrotasks: () => void;
   var _scheduleHostFunctionOnJS: (fun: (...args: A) => R, args?: A) => void;
   var _scheduleRemoteFunctionOnJS: (fun: (...args: A) => R, args?: A) => void;

--- a/packages/react-native-worklets/src/runtimes.native.ts
+++ b/packages/react-native-worklets/src/runtimes.native.ts
@@ -5,6 +5,7 @@ import { registerWorkletsError, WorkletsError } from './debug/WorkletsError';
 import {
   getMemorySafeCapturableConsole,
   setupConsole,
+  setupSerializer,
 } from './initializers/initializers';
 import {
   createSerializable,
@@ -91,6 +92,7 @@ export function createWorkletRuntime(
     createSerializable(() => {
       'worklet';
       setupCallGuard();
+      setupSerializer();
       registerWorkletsError();
       setupConsole(runtimeBoundCapturableConsole);
       if (enableEventLoop) {


### PR DESCRIPTION
Cherry-picking
- #8887

## Summary

When implementing Synchronizable I used `global._createSerializable` as a serialization function - which was a mistake, because it was non-recursive and using `setBlocking` with an object would lead to errors due to unconverted props.

This PR makes it so a recursive serializer is used instead.

This issue applies only outside of Bundle Mode.

Fixes
https://github.com/software-mansion/react-native-reanimated/discussions/8750

## Test plan

I added a new runtime test suite.