### PR TITLE
docs: add getAnimatableRef to createAnimatedComponent docs

### DIFF
--- a/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
+++ b/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
@@ -44,7 +44,7 @@ function createAnimatedComponent<P extends object>(
 
 #### `component`
 
-The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()` or support `ref` as a prop (from React 19 onwards) or expose `getAnimatableRef` using `useImperativeHandle`.
+The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()` or support `ref` as a prop (from React 19 onwards). If you want to animate a specific child of your component or have `useImperativeHandle` in a function component, expose a [`getAnimatableRef` function](https://github.com/software-mansion/react-native-reanimated/blob/main/apps/common-app/src/apps/reanimated/examples/AnimatableRefExample.tsx), which returns the ref to the animatable child.
 
 ### Returns
 

--- a/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
+++ b/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
@@ -44,7 +44,7 @@ function createAnimatedComponent<P extends object>(
 
 #### `component`
 
-The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()`, support `ref` as a prop (from React 19 onwards) or expose `getAnimatableRef` using `useImperativeHandle`.
+The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()` or support `ref` as a prop (from React 19 onwards) or expose `getAnimatableRef` using `useImperativeHandle`.
 
 ### Returns
 

--- a/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
+++ b/docs/docs-reanimated/docs/core/createAnimatedComponent.mdx
@@ -44,7 +44,7 @@ function createAnimatedComponent<P extends object>(
 
 #### `component`
 
-The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()`.
+The component you want to make animatable. Function components have to be wrapped with `React.forwardRef()`, support `ref` as a prop (from React 19 onwards) or expose `getAnimatableRef` using `useImperativeHandle`.
 
 ### Returns
 


### PR DESCRIPTION
## Summary

The requirement to make `createAnimatedComponent` work are very dense. Only through https://github.com/software-mansion/react-native-reanimated/issues/8381#issuecomment-3405232232 I've found out about `getAnimatableRef`

## Test plan

@tomekzaw do you think the [React 19 `ref` prop](https://react.dev/reference/react/forwardRef) is supported or are you internally somewhat specifically looking for `forwardRef`?