### PR TITLE
cherry-pick(Reanimated): Stop passing nativeID to component in jest unit tests

### DIFF
--- a/packages/react-native-reanimated/__tests__/__snapshots__/Animation.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/Animation.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`Tests of animations withTiming animation 1`] = `
         },
       ]
     }
-    nativeID="1"
     style={
       [
         {
@@ -144,7 +143,6 @@ exports[`Tests of animations withTiming animation, change shared value outside c
         },
       ]
     }
-    nativeID="11"
     style={
       [
         {
@@ -255,7 +253,6 @@ exports[`Tests of animations withTiming animation, compare all styles 1`] = `
         },
       ]
     }
-    nativeID="7"
     style={
       [
         {
@@ -366,7 +363,6 @@ exports[`Tests of animations withTiming animation, define shared value outside c
         },
       ]
     }
-    nativeID="9"
     style={
       [
         {
@@ -477,7 +473,6 @@ exports[`Tests of animations withTiming animation, get animated style 1`] = `
         },
       ]
     }
-    nativeID="3"
     style={
       [
         {
@@ -588,7 +583,6 @@ exports[`Tests of animations withTiming animation, width in a middle of animatio
         },
       ]
     }
-    nativeID="5"
     style={
       [
         {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/InterpolateColor.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/InterpolateColor.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`colors interpolation interpolates with withTiming animation 1`] = `
       }
     }
     jestInlineStyle={{}}
-    nativeID="1"
     style={
       [
         {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/animatedProps.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/animatedProps.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`animatedProps Multiple animated props objects matches snapshot 1`] = `
         "value": {},
       }
     }
-    nativeID="3"
     placeholder="Click count: 0"
     testID="text"
     text="Box width: 20"
@@ -104,7 +103,6 @@ exports[`animatedProps Single animated props object matches snapshot 1`] = `
         "value": {},
       }
     }
-    nativeID="0"
     testID="text"
     text="Box width: 20"
   />

--- a/packages/react-native-reanimated/__tests__/__snapshots__/dynamicColorIOS.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/dynamicColorIOS.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`DynamicColorIOS test colors are animating 1`] = `
       },
     ]
   }
-  nativeID="1"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}

--- a/packages/react-native-reanimated/__tests__/__snapshots__/hooks.useAnimatedStyle.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/hooks.useAnimatedStyle.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`Tests of inline styles useAnimatedStyle 1`] = `
       }
     }
     jestInlineStyle={{}}
-    nativeID="1"
     style={
       [
         {
@@ -120,7 +119,6 @@ exports[`Tests of inline styles useAnimatedStyle with withTiming 1`] = `
       }
     }
     jestInlineStyle={{}}
-    nativeID="3"
     style={
       [
         {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/hooks.useSharedValue.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/hooks.useSharedValue.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`useSharedValue retains value on rerender 1`] = `
       "opacity": 1,
     }
   }
-  nativeID="1"
   style={
     [
       {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/inlineStyles.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/inlineStyles.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`Tests of inline styles Double inline styles (array) 1`] = `
         },
       ]
     }
-    nativeID="7"
     style={
       [
         {
@@ -133,7 +132,6 @@ exports[`Tests of inline styles Double inline styles (single object) 1`] = `
         "width": "100",
       }
     }
-    nativeID="5"
     style={
       [
         {
@@ -236,7 +234,6 @@ exports[`Tests of inline styles Inline & useAnimatedStyle() 1`] = `
         },
       ]
     }
-    nativeID="9"
     style={
       [
         {
@@ -337,7 +334,6 @@ exports[`Tests of inline styles Inline styles 1`] = `
         "width": "100",
       }
     }
-    nativeID="1"
     style={
       [
         {
@@ -437,7 +433,6 @@ exports[`Tests of inline styles Inline styles with withTiming 1`] = `
         "width": "100",
       }
     }
-    nativeID="3"
     style={
       [
         {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/jestUtils.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/jestUtils.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`jestUtils differentiates matching with shouldMatchAllProps option with 
         },
       ]
     }
-    nativeID="1"
     style={
       [
         {

--- a/packages/react-native-reanimated/__tests__/__snapshots__/props.test.tsx.snap
+++ b/packages/react-native-reanimated/__tests__/__snapshots__/props.test.tsx.snap
@@ -50,7 +50,6 @@ exports[`Test of boxShadow prop boxShadow prop animation 1`] = `
         },
       ]
     }
-    nativeID="2"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -121,7 +120,6 @@ exports[`Test of boxShadow prop boxShadow prop animation 1`] = `
         },
       ]
     }
-    nativeID="3"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -203,7 +201,6 @@ exports[`Test of boxShadow prop boxShadow prop animation, get animated style 1`]
         },
       ]
     }
-    nativeID="8"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -274,7 +271,6 @@ exports[`Test of boxShadow prop boxShadow prop animation, get animated style 1`]
         },
       ]
     }
-    nativeID="9"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -356,7 +352,6 @@ exports[`Test of boxShadow prop one boxShadow string parsing 1`] = `
         },
       ]
     }
-    nativeID="12"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -427,7 +422,6 @@ exports[`Test of boxShadow prop one boxShadow string parsing 1`] = `
         },
       ]
     }
-    nativeID="13"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -506,16 +506,18 @@ export default class AnimatedComponent
     }
 
     const skipEntering = this.context?.current;
-    const nativeID = skipEntering ? undefined : `${this.reanimatedID}`;
+    let nativeID, jestProps;
 
-    const jestProps = IS_JEST
-      ? {
-          jestInlineStyle:
-            this.props.style && filterOutAnimatedStyles(this.props.style),
-          jestAnimatedStyle: this.jestAnimatedStyle,
-          jestAnimatedProps: this.jestAnimatedProps,
-        }
-      : {};
+    if (IS_JEST) {
+      jestProps = {
+        jestInlineStyle:
+          this.props.style && filterOutAnimatedStyles(this.props.style),
+        jestAnimatedStyle: this.jestAnimatedStyle,
+        jestAnimatedProps: this.jestAnimatedProps,
+      };
+    } else if (!skipEntering) {
+      nativeID = `${this.reanimatedID}`;
+    }
 
     if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
       const flatStyles = StyleSheet.flatten(filteredProps.style as object);


### PR DESCRIPTION
Cherry-pick of the #8881