### PR TITLE
cherry-pick(Reanimated): fix `useHandler` not working on web without babel plugin

### DIFF
--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.test.tsx
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.test.tsx
@@ -1,0 +1,181 @@
+'use strict';
+import { renderHook } from '@testing-library/react-native';
+
+import { worklet } from '../../jestUtils';
+import { useHandler } from '../useHandler';
+import {
+  createHandlers,
+  createUseHandlerError,
+  renderHookWithHandlers,
+} from './useHandlerHelpers';
+
+describe('useHandler (native)', () => {
+  describe('valid cases', () => {
+    describe('worklets without dependencies', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const { handlers } = createHandlers();
+
+        const { result } = renderHook(() => useHandler(handlers));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        expect(result.current.useWeb).toBeDefined();
+      });
+
+      test('should indicate no change when re-rendering with same handlers object or worklet references', () => {
+        const { worklets, handlers } = createHandlers();
+
+        const { result, rerender } = renderHookWithHandlers(handlers);
+
+        // Initial render
+        expect(result.current.doDependenciesDiffer).toBe(true);
+
+        // Re-render with same handlers object
+        rerender({ handlers });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+
+        // Re-render with new handlers object but same worklet references
+        rerender({
+          handlers: { onScroll: worklets.worklet1, onPress: worklets.worklet2 },
+        });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+      });
+    });
+
+    describe('worklets with dependencies', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const { handlers } = createHandlers();
+        const dependencies = ['someValue'];
+
+        const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate change when handler is replaced', () => {
+        const { worklets, handlers } = createHandlers();
+
+        const { result, rerender } = renderHookWithHandlers(handlers);
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+
+        // Replace one handler with a new worklet
+        const newWorklet1 = worklet();
+
+        rerender({
+          handlers: { onScroll: newWorklet1, onPress: worklets.worklet2 },
+        });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate change when handler is added', () => {
+        const { worklets } = createHandlers();
+        const handlers = {
+          onScroll: worklets.worklet1,
+        };
+
+        const { result, rerender } = renderHookWithHandlers(handlers);
+
+        // Add a new handler
+        rerender({
+          handlers: { onScroll: worklets.worklet1, onPress: worklets.worklet2 },
+        });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate change when handler is removed', () => {
+        const { worklets, handlers } = createHandlers();
+
+        const { result, rerender } = renderHookWithHandlers(handlers);
+
+        // Remove a handler
+        rerender({
+          handlers: { onScroll: worklets.worklet1 },
+        });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should track dependency changes', () => {
+        const { handlers } = createHandlers();
+        const dependencies = ['value1'];
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+        rerender({ handlers, deps: ['value2'] });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+  });
+
+  describe('invalid cases (native only allows worklets)', () => {
+    test('should throw error when non-worklet function is passed without dependencies', () => {
+      const regularHandler = jest.fn();
+      const handlers = {
+        onPress: regularHandler,
+      };
+
+      expect(() => {
+        renderHook(() => useHandler(handlers));
+      }).toThrow(createUseHandlerError('onPress', false));
+    });
+
+    test('should throw error when non-worklet function is passed with dependencies', () => {
+      const regularHandler = jest.fn();
+      const handlers = {
+        onPress: regularHandler,
+      };
+      const dependencies = [regularHandler];
+
+      // On native, even with dependencies, non-worklets are not allowed
+      expect(() => {
+        renderHook(() => useHandler(handlers, dependencies));
+      }).toThrow(createUseHandlerError('onPress', false));
+    });
+
+    test('should throw error when mixed worklet and non-worklet functions are passed', () => {
+      const workletHandler = worklet();
+      const regularHandler = jest.fn();
+      const handlers = {
+        onScroll: workletHandler,
+        onPress: regularHandler,
+      };
+
+      expect(() => {
+        renderHook(() => useHandler(handlers));
+      }).toThrow(createUseHandlerError('onPress', false));
+    });
+
+    test('should throw error when mixed worklet and non-worklet functions are passed with dependencies', () => {
+      const workletHandler = worklet();
+      const regularHandler = jest.fn();
+      const handlers = {
+        onScroll: workletHandler,
+        onPress: regularHandler,
+      };
+      const dependencies = [regularHandler];
+
+      // On native, even with dependencies, non-worklets are not allowed
+      expect(() => {
+        renderHook(() => useHandler(handlers, dependencies));
+      }).toThrow(createUseHandlerError('onPress', false));
+    });
+
+    test('should throw error with handler names in error message (multiple handlers)', () => {
+      const regularHandler1 = jest.fn();
+      const regularHandler2 = jest.fn();
+      const handlers = {
+        onScroll: regularHandler1,
+        onPress: regularHandler2,
+      };
+
+      expect(() => {
+        renderHook(() => useHandler(handlers));
+      }).toThrow(createUseHandlerError(['onScroll', 'onPress'], false));
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
@@ -1,0 +1,369 @@
+'use strict';
+import { renderHook } from '@testing-library/react-native';
+
+import { logger } from '../../common';
+import { worklet } from '../../jestUtils';
+import { useHandler } from '../useHandler';
+import { renderHookWithHandlers } from './useHandlerHelpers';
+
+jest.mock('../../common', () => {
+  const originalModule = jest.requireActual('../../common');
+  return {
+    ...originalModule,
+    logger: {
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+describe('useHandler (web)', () => {
+  describe('valid cases', () => {
+    describe('non-worklets with dependencies (all handlers in deps)', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1, handler2];
+
+        const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate no change when re-rendering with same dependencies', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1, handler2];
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+      });
+
+      test('should indicate change when re-rendering with different dependency references', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1, handler2];
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+
+        const newHandler1 = jest.fn();
+        rerender({ handlers, deps: [newHandler1, handler2] });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+
+    describe('non-worklets with dependencies (some handlers in deps)', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1]; // Only handler1 in deps
+
+        const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate no change when re-rendering with same dependencies', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1]; // Only handler1 in deps
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+      });
+
+      test('should indicate change when re-rendering with different dependency reference', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = [handler1]; // Only handler1 in deps
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+
+        const newHandler1 = jest.fn();
+        rerender({ handlers, deps: [newHandler1] });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+
+    describe('non-worklets with dependencies (no handlers in deps)', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = ['someOtherValue', 42]; // No handlers in deps
+
+        const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate no change when re-rendering with same dependencies', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = ['someOtherValue', 42]; // No handlers in deps
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+      });
+
+      test('should indicate change when re-rendering with different dependency values', () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const handlers = {
+          onScroll: handler1,
+          onPress: handler2,
+        };
+        const dependencies = ['someOtherValue', 42]; // No handlers in deps
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+
+        rerender({ handlers, deps: ['newValue', 100] });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+
+    describe('mixed worklet and non-worklet functions with dependencies', () => {
+      test('should indicate dependencies differ on initial render', () => {
+        const workletHandler = worklet();
+        const regularHandler = jest.fn();
+        const handlers = {
+          onScroll: workletHandler,
+          onPress: regularHandler,
+        };
+        const dependencies = [regularHandler];
+
+        const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+
+      test('should indicate no change when re-rendering with same dependencies', () => {
+        const workletHandler = worklet();
+        const regularHandler = jest.fn();
+        const handlers = {
+          onScroll: workletHandler,
+          onPress: regularHandler,
+        };
+        const dependencies = [regularHandler];
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+      });
+
+      test('should indicate change when re-rendering with different dependencies', () => {
+        const workletHandler = worklet();
+        const regularHandler = jest.fn();
+        const handlers = {
+          onScroll: workletHandler,
+          onPress: regularHandler,
+        };
+        const dependencies = [regularHandler];
+
+        const { result, rerender } = renderHookWithHandlers(
+          handlers,
+          dependencies
+        );
+
+        expect(result.current.doDependenciesDiffer).toBe(true);
+        rerender({ handlers, deps: dependencies });
+        expect(result.current.doDependenciesDiffer).toBe(false);
+
+        const newRegularHandler = jest.fn();
+        rerender({ handlers, deps: [newRegularHandler] });
+        expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+
+    test('should work with empty array as dependencies', () => {
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const handlers = {
+        onScroll: handler1,
+        onPress: handler2,
+      };
+      const dependencies: unknown[] = [];
+
+      const { result } = renderHook(() => useHandler(handlers, dependencies));
+
+      // On first render, savedDependencies is initialized to [], so empty array []
+      // matches and doDependenciesDiffer is false
+      expect(result.current.doDependenciesDiffer).toBe(false);
+    });
+  });
+
+  describe('non-worklets without dependencies (web warnings and re-renders)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('should warn and indicate dependencies differ when non-worklet handler is passed without dependencies', () => {
+      const regularHandler = jest.fn();
+      const handlers = {
+        onPress: regularHandler,
+      };
+
+      const { result } = renderHook(() => useHandler(handlers));
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Non-worklet handlers ("onPress") were passed without a dependency array. This will cause the hook to update on every render. Please provide a dependency array or use only worklet functions instead.'
+      );
+      expect(result.current.doDependenciesDiffer).toBe(true);
+    });
+
+    test('should warn and indicate dependencies differ on every render', () => {
+      const regularHandler = jest.fn();
+      const handlers = {
+        onPress: regularHandler,
+      };
+
+      const { result, rerender } = renderHookWithHandlers(handlers);
+
+      expect(result.current.doDependenciesDiffer).toBe(true);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+
+      rerender({ handlers });
+      expect(result.current.doDependenciesDiffer).toBe(true);
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+
+      rerender({ handlers });
+      expect(result.current.doDependenciesDiffer).toBe(true);
+      expect(logger.warn).toHaveBeenCalledTimes(3);
+    });
+
+    test('should warn when multiple non-worklet handlers are passed without dependencies', () => {
+      const regularHandler1 = jest.fn();
+      const regularHandler2 = jest.fn();
+      const handlers = {
+        onScroll: regularHandler1,
+        onPress: regularHandler2,
+      };
+
+      const { result } = renderHook(() => useHandler(handlers));
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Non-worklet handlers ("onScroll, onPress") were passed without a dependency array. This will cause the hook to update on every render. Please provide a dependency array or use only worklet functions instead.'
+      );
+      expect(result.current.doDependenciesDiffer).toBe(true);
+    });
+
+    test('should warn and indicate dependencies differ on re-render when handlers change from valid to ones without dependencies', () => {
+      const workletHandler = worklet();
+      const regularHandler = jest.fn();
+      const validHandlers = {
+        onScroll: workletHandler,
+      };
+      const invalidHandlers = {
+        onScroll: workletHandler,
+        onPress: regularHandler,
+      };
+
+      const { result, rerender } = renderHookWithHandlers(validHandlers);
+
+      expect(result.current.doDependenciesDiffer).toBe(true);
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      rerender({ handlers: invalidHandlers });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Non-worklet handlers ("onPress") were passed without a dependency array. This will cause the hook to update on every render. Please provide a dependency array or use only worklet functions instead.'
+      );
+      expect(result.current.doDependenciesDiffer).toBe(true);
+    });
+
+    test('should NOT warn or indicate frequent change when empty array is provided as dependencies', () => {
+      const regularHandler = jest.fn();
+      const handlers = {
+        onPress: regularHandler,
+      };
+      const dependencies: unknown[] = [];
+
+      const { result, rerender } = renderHookWithHandlers(
+        handlers,
+        dependencies
+      );
+
+      expect(logger.warn).not.toHaveBeenCalled();
+      // On first render, savedDependencies is [], so it matches and doDependenciesDiffer is false
+      expect(result.current.doDependenciesDiffer).toBe(false);
+
+      rerender({ handlers, deps: dependencies });
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(result.current.doDependenciesDiffer).toBe(false);
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/hook/__tests__/useHandlerHelpers.ts
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandlerHelpers.ts
@@ -1,0 +1,55 @@
+'use strict';
+import { renderHook } from '@testing-library/react-native';
+
+import { ReanimatedError } from '../../common';
+import { worklet } from '../../jestUtils';
+import { useHandler } from '../useHandler';
+
+export function createUseHandlerError(
+  handlerNames: string | string[],
+  isWeb: boolean
+): ReanimatedError {
+  const names =
+    typeof handlerNames === 'string' ? handlerNames : handlerNames.join(', ');
+  const handlerList = `Handlers "${names}" are not worklets.`;
+
+  if (isWeb) {
+    return new ReanimatedError(
+      `Passed handlers that are not worklets. Please provide a dependency array to use non-worklet handlers or pass only worklet functions. ${handlerList}`
+    );
+  }
+
+  return new ReanimatedError(
+    `Passed handlers that are not worklets. Only worklet functions are allowed. ${handlerList}`
+  );
+}
+
+export function createHandlers() {
+  const worklet1 = worklet();
+  const worklet2 = worklet();
+  return {
+    worklets: { worklet1, worklet2 },
+    handlers: {
+      onScroll: worklet1,
+      onPress: worklet2,
+    },
+  };
+}
+
+export function renderHookWithHandlers(
+  handlers: Record<string, unknown>,
+  dependencies?: unknown[]
+) {
+  return renderHook(
+    ({
+      handlers: h,
+      deps,
+    }: {
+      handlers: Record<string, unknown>;
+      deps?: unknown[];
+    }) => useHandler(h as Parameters<typeof useHandler>[0], deps),
+    {
+      initialProps: { handlers, deps: dependencies },
+    }
+  );
+}

--- a/packages/react-native-reanimated/src/hook/useComposedEventHandler.ts
+++ b/packages/react-native-reanimated/src/hook/useComposedEventHandler.ts
@@ -72,7 +72,7 @@ export function useComposedEventHandler<
       }
     });
 
-  const { doDependenciesDiffer } = useHandler(workletsRecord);
+  const { doDependenciesDiffer } = useHandler(workletsRecord, handlers);
 
   return useEvent<Event, Context>(
     (event) => {

--- a/packages/react-native-reanimated/src/hook/useHandler.ts
+++ b/packages/react-native-reanimated/src/hook/useHandler.ts
@@ -1,9 +1,9 @@
 'use strict';
 import { useEffect, useRef } from 'react';
 import type { WorkletFunction } from 'react-native-worklets';
-import { isWorkletFunction, makeShareable } from 'react-native-worklets';
+import { makeShareable } from 'react-native-worklets';
 
-import { IS_JEST, IS_WEB, ReanimatedError } from '../common';
+import { IS_JEST, IS_WEB } from '../common';
 import type { DependencyList, ReanimatedEvent } from './commonTypes';
 import { areDependenciesEqual, buildDependencies } from './utils';
 
@@ -83,23 +83,13 @@ export function useHandler<
 
   const { context, savedDependencies } = initRef.current;
 
-  for (const handlerName in handlers) {
-    if (!isWorkletFunction(handlers[handlerName])) {
-      throw new ReanimatedError(
-        'Passed a function that is not a worklet. Please provide a worklet function.'
-      );
-    }
-  }
-
   dependencies = buildDependencies(
     dependencies,
     handlers as Record<string, WorkletFunction>
   );
 
-  const doDependenciesDiffer = !areDependenciesEqual(
-    dependencies,
-    savedDependencies
-  );
+  const doDependenciesDiffer =
+    !areDependenciesEqual(dependencies, savedDependencies) || !dependencies;
   initRef.current.savedDependencies = dependencies;
   const useWeb = IS_WEB || IS_JEST;
 


### PR DESCRIPTION
Cherry-pick of the #8883