### PR TITLE
feat: use prebuilt React Native for iOS

### DIFF
--- a/apps/fabric-example/ios/Podfile
+++ b/apps/fabric-example/ios/Podfile
@@ -11,6 +11,12 @@ ENV['IS_REANIMATED_EXAMPLE_APP'] = '1'
 ENV['IS_REANIMATED_PROFILING'] = '1'
 ENV['IS_WORKLETS_PROFILING'] = '1'
 
+
+# Using prebuilt React Native iOS binaries for faster builds
+# disable if you need to dive in and tweak into React Native native code
+ENV['RCT_USE_PREBUILT_RNCORE'] = '1'
+ENV['RCT_USE_RN_DEP'] = '1'
+
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2494,7 +2494,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 53012435cc80627d41ad53d8c27ecc7efaef2f12
+  hermes-engine: 1e68e1c0ed52f0e23f8f95382844d35399647038
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: 7fe66a61d5acab6516098a64f42af575595e7566
   NitroModules: 70861471ee1cc5616462aef869a164dac12db7b9
@@ -2506,7 +2506,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: ea396d0e40644e9e46245e9b4b6db931b6be006b
+  React-Core-prebuilt: 14d09d3fcba02f13b2cbdebd3a70fd199dd2be06
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2568,7 +2568,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: 2fe81bae8e7b638d8d9b78c3dc1ccc1eeabfc613
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: 554aa4807a73d8b65ad8147af7b2d6042b7787be
+  ReactNativeDependencies: 7847e46aecdc4c8b89c706f1283b53d2950b18eb
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCClipboard: 88d7eeb555d1183915f0885bdbc5c97eb6f7f3ba
   RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
@@ -2579,6 +2579,6 @@ SPEC CHECKSUMS:
   RNWorklets: 4f482774f3c5e36c545761f038596550925244fd
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 
-PODFILE CHECKSUM: 26955e9ec1fb056773a730fb2bed32abc3f3e6c0
+PODFILE CHECKSUM: 5a5e231e2fd86b91c7e0a93852f5aa6de886161f
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Making FabricExample use iOS prebuilts by default.

I briefly checked debugging and it seems that debug symbols aren't available in XCode - meaning that for some more advanced debugging sessions we'd have to locally rollback to building from source.

If this change proves to be counterproductive we can revert it later.

## Test plan

Fabric Example works 🥳 
