### PR TITLE
fix: Add check for `onStart` and improve `valueSetter` implementation

### DIFF
--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -1,6 +1,32 @@
 'use strict';
 import type { AnimationObject, Mutable } from './commonTypes';
 
+function isAnimationObject<Value>(
+  value: unknown
+): value is AnimationObject<Value> {
+  'worklet';
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'onFrame' in value &&
+    'onStart' in value
+  );
+}
+
+function resolveAnimation<Value>(
+  value: unknown
+): AnimationObject<Value> | undefined {
+  'worklet';
+  if (typeof value === 'function') {
+    // Call the factory function and store the result in value to check
+    // if the value returned by the factory function is an AnimationObject
+    value = value();
+  }
+  if (isAnimationObject<Value>(value)) {
+    return value;
+  }
+}
+
 export function valueSetter<Value>(
   mutable: Mutable<Value>,
   value: Value,
@@ -8,80 +34,76 @@ export function valueSetter<Value>(
 ): void {
   'worklet';
   const previousAnimation = mutable._animation;
+  const animation = resolveAnimation<Value>(value);
+
   if (previousAnimation) {
     previousAnimation.cancelled = true;
     mutable._animation = null;
   }
-  if (
-    typeof value === 'function' ||
-    (value !== null &&
-      typeof value === 'object' &&
-      // TODO TYPESCRIPT fix this after fixing AnimationObject type
-      (value as unknown as AnimationObject).onFrame !== undefined)
-  ) {
-    const animation: AnimationObject<Value> =
-      typeof value === 'function'
-        ? // TODO TYPESCRIPT fix this after fixing AnimationObject type
-          (value as () => AnimationObject<Value>)()
-        : // TODO TYPESCRIPT fix this after fixing AnimationObject type
-          (value as unknown as AnimationObject<Value>);
-    // prevent setting again to the same value
-    // and triggering the mappers that treat this value as an input
-    // this happens when the animation's target value(stored in animation.current until animation.onStart is called) is set to the same value as a current one(this._value)
-    // built in animations that are not higher order(withTiming, withSpring) hold target value in .current
-    if (
-      mutable._value === animation.current &&
-      !animation.isHigherOrder &&
-      !forceUpdate
-    ) {
-      animation.callback?.(true);
-      return;
+
+  if (!animation) {
+    // update the value of the mutable only if it's different from the current
+    // value or if forceUpdate is true to prevent triggering mappers that treat
+    // this value as an input
+    if (mutable._value !== value || forceUpdate) {
+      mutable._value = value;
     }
-    // animated set
-    const initializeAnimation = (timestamp: number) => {
-      animation.onStart(animation, mutable.value, timestamp, previousAnimation);
-    };
-    const currentTimestamp =
-      global.__frameTimestamp || global._getAnimationTimestamp();
-    initializeAnimation(currentTimestamp);
-
-    const step = (newTimestamp: number) => {
-      // Function `requestAnimationFrame` adds callback to an array, all the callbacks are flushed with function `__flushAnimationFrame`
-      // Usually we flush them inside function `nativeRequestAnimationFrame` and then the given timestamp is the timestamp of end of the current frame.
-      // However function `__flushAnimationFrame` may also be called inside `registerEventHandler` - then we get actual timestamp which is earlier than the end of the frame.
-
-      const timestamp =
-        newTimestamp < (animation.timestamp || 0)
-          ? animation.timestamp
-          : newTimestamp;
-
-      if (animation.cancelled) {
-        animation.callback?.(false /* finished */);
-        return;
-      }
-      const finished = animation.onFrame(animation, timestamp);
-      animation.finished = true;
-      animation.timestamp = timestamp;
-      // TODO TYPESCRIPT
-      // For now I'll assume that `animation.current` is always defined
-      // but actually need to dive into animations to understand it
-      mutable._value = animation.current!;
-      if (finished) {
-        animation.callback?.(true /* finished */);
-      } else {
-        requestAnimationFrame(step);
-      }
-    };
-
-    mutable._animation = animation;
-
-    step(currentTimestamp);
-  } else {
-    // prevent setting again to the same value
-    // and triggering the mappers that treat this value as an input
-    if (mutable._value === value && !forceUpdate) {
-      return;
-    }
-    mutable._value = value;
+    return;
   }
+
+  // prevent setting again to the same value and triggering the mappers that
+  // treat this value as an input this happens when the animation's target value
+  // (stored in animation.current until animation.onStart is called) is set to
+  // the same value as a current one(this._value) built in animations that are
+  // not higher order(withTiming, withSpring) hold target value in .current
+  if (
+    mutable._value === animation.current &&
+    !animation.isHigherOrder &&
+    !forceUpdate
+  ) {
+    animation.callback?.(true);
+    return;
+  }
+
+  const currentTimestamp =
+    global.__frameTimestamp || global._getAnimationTimestamp();
+  animation.onStart(
+    animation,
+    mutable.value,
+    currentTimestamp,
+    previousAnimation
+  );
+
+  const step = (newTimestamp: number) => {
+    // `requestAnimationFrame` function adds callback to an array, all callbacks
+    // are flushed with function `__flushAnimationFrame`.
+    // Usually we flush them inside the `nativeRequestAnimationFrame` function
+    // and then the given timestamp is the timestamp of end of the current frame.
+    // However, function `__flushAnimationFrame` may also be called inside `registerEventHandler`
+    // - then we get actual timestamp which is earlier than the end of the frame.
+    const timestamp = Math.max(newTimestamp, animation.timestamp ?? 0);
+
+    if (animation.cancelled) {
+      animation.callback?.(false /* finished */);
+      return;
+    }
+
+    const finished = animation.onFrame(animation, timestamp);
+    animation.finished = true;
+    animation.timestamp = timestamp;
+
+    // TODO TYPESCRIPT
+    // For now I'll assume that `animation.current` is always defined
+    // but actually need to dive into animations to understand it
+    mutable._value = animation.current!;
+    if (finished) {
+      animation.callback?.(true /* finished */);
+    } else {
+      requestAnimationFrame(step);
+    }
+  };
+
+  mutable._animation = animation;
+
+  step(currentTimestamp);
 }

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -3,7 +3,7 @@ import type { AnimationObject, Mutable } from './commonTypes';
 
 export function valueSetter<Value = unknown>(
   mutable: Mutable<Value>,
-  valueOrFactory: Value,
+  value: Value,
   forceUpdate = false
 ): void {
   'worklet';
@@ -16,11 +16,10 @@ export function valueSetter<Value = unknown>(
 
   // Call the factory function and store the result in value to check
   // if the value returned by the factory function is an AnimationObject
-  const value: Value =
-    typeof valueOrFactory === 'function' ? valueOrFactory() : valueOrFactory;
+  const unwrappedValue: Value = typeof value === 'function' ? value() : value;
   const valueObject =
-    typeof value === 'object' && value !== null
-      ? (value as Record<string, unknown>)
+    typeof unwrappedValue === 'object' && unwrappedValue !== null
+      ? (unwrappedValue as Record<string, unknown>)
       : {};
 
   // Check if the value returned by the factory function is not an AnimationObject
@@ -34,7 +33,7 @@ export function valueSetter<Value = unknown>(
     return;
   }
 
-  const animation = value as AnimationObject<Value>;
+  const animation = unwrappedValue as AnimationObject<Value>;
 
   // prevent setting again to the same value and triggering the mappers that
   // treat this value as an input this happens when the animation's target value

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -17,13 +17,17 @@ export function valueSetter<Value = unknown>(
   // Call the factory function and store the result in value to check
   // if the value returned by the factory function is an AnimationObject
   const unwrappedValue: Value = typeof value === 'function' ? value() : value;
-  const valueObject =
-    typeof unwrappedValue === 'object' && unwrappedValue !== null
-      ? (unwrappedValue as Record<string, unknown>)
-      : {};
+  let animation: AnimationObject<Value> | null = null;
 
-  // Check if the value returned by the factory function is not an AnimationObject
-  if (valueObject.onFrame === undefined || valueObject.onStart === undefined) {
+  if (unwrappedValue && typeof unwrappedValue === 'object') {
+    const valueObject = unwrappedValue as Record<string, unknown>;
+    // Check if the object has onFrame and onStart properties (is an AnimationObject)
+    if (valueObject.onFrame && valueObject.onStart) {
+      animation = valueObject as AnimationObject<Value>;
+    }
+  }
+
+  if (!animation) {
     // update the value of the mutable only if it's different from the current
     // value or if forceUpdate is true to prevent triggering mappers that treat
     // this value as an input
@@ -32,8 +36,6 @@ export function valueSetter<Value = unknown>(
     }
     return;
   }
-
-  const animation = unwrappedValue as AnimationObject<Value>;
 
   // prevent setting again to the same value and triggering the mappers that
   // treat this value as an input this happens when the animation's target value

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -14,25 +14,17 @@ export function valueSetter<Value>(
     mutable._animation = null;
   }
 
-  let animation: AnimationObject<Value> | undefined;
+  // Call the factory function and store the result in value to check
+  // if the value returned by the factory function is an AnimationObject
+  const maybeAnimation = typeof value === 'function' ? value() : value;
 
-  if (typeof value === 'function') {
-    // Call the factory function and store the result in value to check
-    // if the value returned by the factory function is an AnimationObject
-    value = value();
-  }
-
-  // Check if the value is an AnimationObject
+  // Check if the value returned by the factory function is not an AnimationObject
   if (
-    value !== null &&
-    typeof value === 'object' &&
-    'onFrame' in value &&
-    'onStart' in value
+    maybeAnimation === null ||
+    typeof maybeAnimation !== 'object' ||
+    !('onFrame' in maybeAnimation) ||
+    !('onStart' in maybeAnimation)
   ) {
-    animation = value as AnimationObject<Value>;
-  }
-
-  if (!animation) {
     // update the value of the mutable only if it's different from the current
     // value or if forceUpdate is true to prevent triggering mappers that treat
     // this value as an input
@@ -41,6 +33,8 @@ export function valueSetter<Value>(
     }
     return;
   }
+
+  const animation = maybeAnimation as AnimationObject<Value>;
 
   // prevent setting again to the same value and triggering the mappers that
   // treat this value as an input this happens when the animation's target value


### PR DESCRIPTION
## Summary

This PR improves the `valueSetter` in terms of:
- code quality and readability (less nesting, better code separation),
- TS usage (removes multiple type casts),
- implementation safety (added check for `onStart` presence in the `AnimationObject` (see #8974) and adds a check whether the value returned by the animation factory function is really an `AnimationObject` - before we just checked if a value is a function and assumed that the value it returns is `AnimationObject` without performing any additional checks)