### PR TITLE
feat: Common fallback style props builder for any unsupported component

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/InterpolatorRegistry.cpp
@@ -63,7 +63,8 @@ InterpolatorFactoriesRecord mergeInterpolators(const std::vector<InterpolatorFac
 // React Native Interpolators
 // ==========================
 
-const InterpolatorFactoriesRecord FLEX_INTERPOLATORS = {
+const InterpolatorFactoriesRecord STYLE_INTERPOLATORS = {
+    // Flexbox
     {"alignContent", value<CSSKeyword>("flex-start")},
     {"alignItems", value<CSSKeyword>("stretch")},
     {"alignSelf", value<CSSKeyword>("auto")},
@@ -119,15 +120,15 @@ const InterpolatorFactoriesRecord FLEX_INTERPOLATORS = {
     {"top", value<CSSLength, CSSKeyword>("auto", {RelativeTo::Parent, "height"})},
     {"width", value<CSSLength, CSSKeyword>("auto", {RelativeTo::Parent, "width"})},
     {"zIndex", value<CSSInteger>(0)},
-    {"direction", value<CSSKeyword>("inherit")}};
+    {"direction", value<CSSKeyword>("inherit")},
 
-const InterpolatorFactoriesRecord SHADOW_INTERPOLATORS_IOS = {
+    // Shadow (iOS)
     {"shadowColor", value<CSSColor>(BLACK)},
     {"shadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
     {"shadowRadius", value<CSSDouble>(0)},
-    {"shadowOpacity", value<CSSDouble>(1)}};
+    {"shadowOpacity", value<CSSDouble>(1)},
 
-const InterpolatorFactoriesRecord TRANSFORMS_INTERPOLATORS = {
+    // Transforms
     {"transformOrigin",
      array(
          {value<CSSLength>("50%", {RelativeTo::Self, "width"}),
@@ -148,9 +149,8 @@ const InterpolatorFactoriesRecord TRANSFORMS_INTERPOLATORS = {
           {"skewX", transformOp<SkewXOperation>("0deg")},
           {"skewY", transformOp<SkewYOperation>("0deg")},
           {"matrix", transformOp<MatrixOperation>(TransformMatrix2D())}})},
-};
 
-const InterpolatorFactoriesRecord FILTER_INTERPOLATORS = {
+    // Filters
     {"filter",
      filters(
          {{"blur", filterOp<BlurOperation>(0)},
@@ -162,94 +162,80 @@ const InterpolatorFactoriesRecord FILTER_INTERPOLATORS = {
           {"invert", filterOp<InvertOperation>(0)},
           {"opacity", filterOp<OpacityOperation>(1)},
           {"saturate", filterOp<SaturateOperation>(1)},
-          {"sepia", filterOp<SepiaOperation>(0)}})}};
+          {"sepia", filterOp<SepiaOperation>(0)}})},
 
-const InterpolatorFactoriesRecord VIEW_INTERPOLATORS = mergeInterpolators(
-    {FLEX_INTERPOLATORS,
-     SHADOW_INTERPOLATORS_IOS,
-     TRANSFORMS_INTERPOLATORS,
-     FILTER_INTERPOLATORS,
-     InterpolatorFactoriesRecord{
-         {"backfaceVisibility", value<CSSKeyword>("visible")},
-         {"backgroundColor", value<CSSColor>(TRANSPARENT)},
-         {"borderBlockColor", value<CSSColor>(BLACK)},
-         {"borderBlockEndColor", value<CSSColor>(BLACK)},
-         {"borderBlockStartColor", value<CSSColor>(BLACK)},
-         {"borderBottomColor", value<CSSColor>(BLACK)},
-         {"borderBottomEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderBottomLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderBottomRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderBottomStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderColor", value<CSSColor>(BLACK)},
-         {"borderCurve", value<CSSKeyword>("circular")},
-         {"borderEndColor", value<CSSColor>(BLACK)},
-         {"borderEndEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderEndStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderLeftColor", value<CSSColor>(BLACK)},
-         {"borderRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderRightColor", value<CSSColor>(BLACK)},
-         {"borderStartColor", value<CSSColor>(BLACK)},
-         {"borderStartEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderStartStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderStyle", value<CSSKeyword>("solid")},
-         {"borderTopColor", value<CSSColor>(BLACK)},
-         {"borderTopEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderTopLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderTopRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"borderTopStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
-         {"outlineColor", value<CSSColor>(BLACK)},
-         {"outlineOffset", value<CSSDouble>(0)},
-         {"outlineStyle", value<CSSKeyword>("solid")},
-         {"outlineWidth", value<CSSDouble>(0)},
-         {"opacity", value<CSSDouble>(1)},
-         {"elevation", value<CSSDouble>(0)},
-         {"pointerEvents", value<CSSKeyword>("auto")},
-         {"isolation", value<CSSKeyword>("auto")},
-         {"cursor", value<CSSKeyword>("auto")},
-         {"boxShadow", array({value<CSSBoxShadow>(CSSBoxShadow())})},
-         {"mixBlendMode", value<CSSKeyword>("normal")}}});
+    // View
+    {"backfaceVisibility", value<CSSKeyword>("visible")},
+    {"backgroundColor", value<CSSColor>(TRANSPARENT)},
+    {"borderBlockColor", value<CSSColor>(BLACK)},
+    {"borderBlockEndColor", value<CSSColor>(BLACK)},
+    {"borderBlockStartColor", value<CSSColor>(BLACK)},
+    {"borderBottomColor", value<CSSColor>(BLACK)},
+    {"borderBottomEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderBottomLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderBottomRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderBottomStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderColor", value<CSSColor>(BLACK)},
+    {"borderCurve", value<CSSKeyword>("circular")},
+    {"borderEndColor", value<CSSColor>(BLACK)},
+    {"borderEndEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderEndStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderLeftColor", value<CSSColor>(BLACK)},
+    {"borderRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderRightColor", value<CSSColor>(BLACK)},
+    {"borderStartColor", value<CSSColor>(BLACK)},
+    {"borderStartEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderStartStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderStyle", value<CSSKeyword>("solid")},
+    {"borderTopColor", value<CSSColor>(BLACK)},
+    {"borderTopEndRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderTopLeftRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderTopRightRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"borderTopStartRadius", value<CSSLength>(0, {RelativeTo::Self, "width"})},
+    {"outlineColor", value<CSSColor>(BLACK)},
+    {"outlineOffset", value<CSSDouble>(0)},
+    {"outlineStyle", value<CSSKeyword>("solid")},
+    {"outlineWidth", value<CSSDouble>(0)},
+    {"opacity", value<CSSDouble>(1)},
+    {"elevation", value<CSSDouble>(0)},
+    {"pointerEvents", value<CSSKeyword>("auto")},
+    {"isolation", value<CSSKeyword>("auto")},
+    {"cursor", value<CSSKeyword>("auto")},
+    {"boxShadow", array({value<CSSBoxShadow>(CSSBoxShadow())})},
+    {"mixBlendMode", value<CSSKeyword>("normal")},
 
-const InterpolatorFactoriesRecord TEXT_INTERPOLATORS_IOS = {
+    // Text
+    {"color", value<CSSColor>(BLACK)},
+    {"fontFamily", value<CSSKeyword>("inherit")},
+    {"fontSize", value<CSSDouble>(14)},
+    {"fontStyle", value<CSSKeyword>("normal")},
+    {"fontWeight", value<CSSKeyword>("normal")},
+    {"letterSpacing", value<CSSDouble>(0)},
+    {"lineHeight", value<CSSDouble>(14)}, // TODO - should inherit from fontSize
+    {"textAlign", value<CSSKeyword>("auto")},
+    {"textDecorationLine", value<CSSKeyword>("none")},
+    {"textShadowColor", value<CSSColor>(BLACK)},
+    {"textShadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
+    {"textShadowRadius", value<CSSDouble>(0)},
+    {"textTransform", value<CSSKeyword>("none")},
+    {"userSelect", value<CSSKeyword>("auto")},
+
+    // Text (iOS)
     {"fontVariant", value<CSSDiscreteArray<CSSKeyword>>(std::vector<CSSKeyword>{})},
     {"textDecorationColor", value<CSSColor>(BLACK)},
     {"textDecorationStyle", value<CSSKeyword>("solid")},
     {"writingDirection", value<CSSKeyword>("auto")},
-};
 
-const InterpolatorFactoriesRecord TEXT_INTERPOLATORS_ANDROID = {
+    // Text (Android)
     {"textAlignVertical", value<CSSKeyword>("auto")},
     {"verticalAlign", value<CSSKeyword>("auto")},
     {"includeFontPadding", value<CSSBoolean>(false)},
+
+    // Image
+    {"resizeMode", value<CSSKeyword>("cover")},
+    {"overlayColor", value<CSSColor>(BLACK)},
+    {"tintColor", value<CSSColor>(BLACK)},
 };
-
-const InterpolatorFactoriesRecord TEXT_INTERPOLATORS = mergeInterpolators(
-    {VIEW_INTERPOLATORS,
-     TEXT_INTERPOLATORS_IOS,
-     TEXT_INTERPOLATORS_ANDROID,
-     InterpolatorFactoriesRecord{
-         {"color", value<CSSColor>(BLACK)},
-         {"fontFamily", value<CSSKeyword>("inherit")},
-         {"fontSize", value<CSSDouble>(14)},
-         {"fontStyle", value<CSSKeyword>("normal")},
-         {"fontWeight", value<CSSKeyword>("normal")},
-         {"letterSpacing", value<CSSDouble>(0)},
-         {"lineHeight", value<CSSDouble>(14)}, // TODO - should inherit from fontSize
-         {"textAlign", value<CSSKeyword>("auto")},
-         {"textDecorationLine", value<CSSKeyword>("none")},
-         {"textShadowColor", value<CSSColor>(BLACK)},
-         {"textShadowOffset", record({{"width", value<CSSDouble>(0)}, {"height", value<CSSDouble>(0)}})},
-         {"textShadowRadius", value<CSSDouble>(0)},
-         {"textTransform", value<CSSKeyword>("none")},
-         {"userSelect", value<CSSKeyword>("auto")},
-     }});
-
-const InterpolatorFactoriesRecord IMAGE_INTERPOLATORS = mergeInterpolators(
-    {VIEW_INTERPOLATORS,
-     InterpolatorFactoriesRecord{
-         {"resizeMode", value<CSSKeyword>("cover")},
-         {"overlayColor", value<CSSColor>(BLACK)},
-         {"tintColor", value<CSSColor>(BLACK)},
-     }});
 
 // =================
 // SVG INTERPOLATORS
@@ -390,12 +376,7 @@ const InterpolatorFactoriesRecord SVG_RADIAL_GRADIENT_INTERPOLATORS = mergeInter
 // ==================
 
 ComponentInterpolatorsMap initializeRegistry() {
-  ComponentInterpolatorsMap registry = {
-      // React Native Components
-      {"View", VIEW_INTERPOLATORS},
-      {"Paragraph", TEXT_INTERPOLATORS},
-      {"Image", IMAGE_INTERPOLATORS},
-  };
+  ComponentInterpolatorsMap registry = {};
 
   if (StaticFeatureFlags::getFlag("EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS")) {
     // SVG Components
@@ -421,10 +402,9 @@ const InterpolatorFactoriesRecord &getComponentInterpolators(const std::string &
     return it->second;
   }
 
-  // Use View interpolators as a fallback for unknown components
-  // (e.g. we get the ScrollView component name for the ScrollView component
-  // but it should be styled in the same way as a View)
-  return VIEW_INTERPOLATORS;
+  // Use default style interpolators as a fallback for unknown components
+  // (e.g. ExpoImage, which is not a RN component but should support RN Image styles)
+  return STYLE_INTERPOLATORS;
 }
 
 void registerComponentInterpolators(

--- a/packages/react-native-reanimated/src/common/style/registry.ts
+++ b/packages/react-native-reanimated/src/common/style/registry.ts
@@ -1,18 +1,11 @@
 'use strict';
-import { ReanimatedError } from '../errors';
 import type { UnknownRecord } from '../types';
-import { isReactNativeViewName } from '../utils/guards';
 import {
   createNativePropsBuilder,
   type NativePropsBuilder,
   type PropsBuilderConfig,
   stylePropsBuilder,
 } from './propsBuilder';
-
-export const ERROR_MESSAGES = {
-  propsBuilderNotFound: (componentName: string) =>
-    `CSS props builder for component ${componentName} was not found`,
-};
 
 const DEFAULT_SEPARATELY_INTERPOLATED_NESTED_PROPERTIES = new Set<string>([
   'boxShadow',
@@ -28,12 +21,6 @@ const COMPONENT_SEPARATELY_INTERPOLATED_NESTED_PROPERTIES = new Map<
 
 const PROPS_BUILDERS = new Map<string, NativePropsBuilder>();
 
-export function hasPropsBuilder(componentName: string): boolean {
-  return (
-    !!PROPS_BUILDERS.get(componentName) || isReactNativeViewName(componentName)
-  );
-}
-
 export function getPropsBuilder(componentName: string): NativePropsBuilder {
   const componentPropsBuilder = PROPS_BUILDERS.get(componentName);
 
@@ -41,12 +28,8 @@ export function getPropsBuilder(componentName: string): NativePropsBuilder {
     return componentPropsBuilder;
   }
 
-  if (isReactNativeViewName(componentName)) {
-    // This captures all React Native components (prefixed with RCT)
-    return stylePropsBuilder;
-  }
-
-  throw new ReanimatedError(ERROR_MESSAGES.propsBuilderNotFound(componentName));
+  // Use a default style props builder for any component as a fallback
+  return stylePropsBuilder;
 }
 
 export function registerComponentPropsBuilder<P extends UnknownRecord>(

--- a/packages/react-native-reanimated/src/common/utils/guards.ts
+++ b/packages/react-native-reanimated/src/common/utils/guards.ts
@@ -41,9 +41,6 @@ export const isConfigPropertyAlias = <P extends AnyRecord>(
   'as' in value &&
   typeof value.as === 'string';
 
-export const isReactNativeViewName = (componentName: string): boolean =>
-  componentName.startsWith('RCT');
-
 export const hasValueProcessor = <T extends (params: unknown) => unknown>(
   configValue: unknown
 ): configValue is { process: T } =>

--- a/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/__tests__/registry.test.ts
@@ -1,34 +1,24 @@
 'use strict';
 import {
-  ERROR_MESSAGES,
   getPropsBuilder,
-  hasPropsBuilder,
+  getSeparatelyInterpolatedNestedProperties,
   registerComponentPropsBuilder,
   STYLE_PROPERTIES_CONFIG,
+  stylePropsBuilder,
 } from '../../../common';
 
 describe('registry', () => {
-  describe('hasPropsBuilder', () => {
-    test('returns true for registered component names', () => {
-      const componentName = 'CustomComponent';
-      const config = { width: true, height: true };
-
-      registerComponentPropsBuilder(componentName, config);
-
-      expect(hasPropsBuilder(componentName)).toBe(true);
-    });
-
-    test('returns true for RCT prefixed component names', () => {
-      expect(hasPropsBuilder('RCTView')).toBe(true);
-      expect(hasPropsBuilder('RCTText')).toBe(true);
-    });
-
-    test('returns false for unregistered component names', () => {
-      expect(hasPropsBuilder('UnregisteredComponent')).toBe(false);
-    });
-  });
-
   describe('getPropsBuilder', () => {
+    test('returns default style props builder for unregistered component', () => {
+      const propsBuilder = getPropsBuilder('UnregisteredComponent');
+      expect(propsBuilder).toBe(stylePropsBuilder);
+    });
+
+    test('returns default style props builder for RCT prefixed components', () => {
+      const propsBuilder = getPropsBuilder('RCTView');
+      expect(propsBuilder).toBe(stylePropsBuilder);
+    });
+
     test('returns registered props builder for custom component', () => {
       const componentName = 'CustomComponent';
       const config = { width: true, height: true };
@@ -36,42 +26,60 @@ describe('registry', () => {
       registerComponentPropsBuilder(componentName, config);
       const propsBuilder = getPropsBuilder(componentName);
 
-      expect(propsBuilder).toBeDefined();
       expect(typeof propsBuilder.build).toBe('function');
+      expect(propsBuilder).not.toBe(stylePropsBuilder);
     });
 
-    test('returns base props builder for RCT prefixed components', () => {
-      const propsBuilder = getPropsBuilder('RCTView');
-
-      expect(propsBuilder).toBeDefined();
-      expect(typeof propsBuilder.build).toBe('function');
-    });
-
-    test('throws error for unregistered component names', () => {
-      expect(() => {
-        getPropsBuilder('UnregisteredComponent');
-      }).toThrow(ERROR_MESSAGES.propsBuilderNotFound('UnregisteredComponent'));
-    });
-  });
-
-  describe('registerComponentPropsBuilder', () => {
-    test('registers a props builder', () => {
-      const componentName = 'TestComponent';
-      const config = { width: true, height: true };
-
-      registerComponentPropsBuilder(componentName, config);
-
-      expect(hasPropsBuilder(componentName)).toBe(true);
-      expect(getPropsBuilder(componentName)).toBeDefined();
-    });
-
-    test('works with base properties config', () => {
+    test('returns registered props builder using standard config', () => {
       const componentName = 'BaseConfigComponent';
 
       registerComponentPropsBuilder(componentName, STYLE_PROPERTIES_CONFIG);
+      const propsBuilder = getPropsBuilder(componentName);
 
-      expect(hasPropsBuilder(componentName)).toBe(true);
-      expect(getPropsBuilder(componentName)).toBeDefined();
+      expect(typeof propsBuilder.build).toBe('function');
+      expect(propsBuilder).not.toBe(stylePropsBuilder);
+    });
+
+    test('overwrites existing props builder when registered again', () => {
+      const componentName = 'OverwriteComponent';
+      registerComponentPropsBuilder(componentName, { width: true });
+      const firstBuilder = getPropsBuilder(componentName);
+
+      registerComponentPropsBuilder(componentName, { height: true });
+      const secondBuilder = getPropsBuilder(componentName);
+
+      expect(secondBuilder).not.toBe(firstBuilder);
+      expect(secondBuilder).not.toBe(stylePropsBuilder);
+    });
+  });
+
+  describe('getSeparatelyInterpolatedNestedProperties', () => {
+    test('returns default separately interpolated nested properties for unregistered component', () => {
+      const props = getSeparatelyInterpolatedNestedProperties(
+        'UnregisteredComponent'
+      );
+      expect(props).toEqual(
+        new Set([
+          'boxShadow',
+          'shadowOffset',
+          'textShadowOffset',
+          'transformOrigin',
+        ])
+      );
+    });
+
+    test('registers and retrieves separately interpolated nested properties', () => {
+      const componentName = 'NestedPropsComponent';
+      const config = { width: true };
+      const nestedProps = ['prop1', 'prop2'];
+
+      registerComponentPropsBuilder(componentName, config, {
+        separatelyInterpolatedNestedProperties: nestedProps,
+      });
+
+      const retrievedProps =
+        getSeparatelyInterpolatedNestedProperties(componentName);
+      expect(retrievedProps).toEqual(new Set(nestedProps));
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -1,9 +1,5 @@
 'use strict';
-import {
-  getPropsBuilder,
-  hasPropsBuilder,
-  ReanimatedError,
-} from '../../../common';
+import { getPropsBuilder } from '../../../common';
 import type { ShadowNodeWrapper } from '../../../commonTypes';
 import type { ViewInfo } from '../../../createAnimatedComponent/commonTypes';
 import type { CSSStyle } from '../../types';
@@ -17,19 +13,14 @@ export default class CSSManager implements ICSSManager {
   private readonly cssAnimationsManager: CSSAnimationsManager;
   private readonly cssTransitionsManager: CSSTransitionsManager;
   private readonly viewTag: number;
-  private readonly viewName: string;
-  private readonly propsBuilder: ReturnType<typeof getPropsBuilder> | null =
-    null;
+  private readonly propsBuilder: ReturnType<typeof getPropsBuilder>;
   private isFirstUpdate: boolean = true;
 
   constructor({ shadowNodeWrapper, viewTag, viewName = 'RCTView' }: ViewInfo) {
     const tag = (this.viewTag = viewTag as number);
     const wrapper = shadowNodeWrapper as ShadowNodeWrapper;
 
-    this.viewName = viewName;
-    this.propsBuilder = hasPropsBuilder(viewName)
-      ? getPropsBuilder(viewName)
-      : null;
+    this.propsBuilder = getPropsBuilder(viewName);
     this.cssAnimationsManager = new CSSAnimationsManager(
       wrapper,
       viewName,
@@ -42,13 +33,7 @@ export default class CSSManager implements ICSSManager {
     const [animationProperties, transitionProperties, filteredStyle] =
       filterCSSAndStyleProperties(style);
 
-    if (!this.propsBuilder && (animationProperties || transitionProperties)) {
-      throw new ReanimatedError(
-        `Tried to apply CSS animations to ${this.viewName} which is not supported`
-      );
-    }
-
-    const normalizedStyle = this.propsBuilder?.build(filteredStyle);
+    const normalizedStyle = this.propsBuilder.build(filteredStyle);
 
     // If the update is called during the first css style update, we won't
     // trigger CSS transitions and set styles before attaching CSS transitions


### PR DESCRIPTION
## Summary

The old implementation supported only RN components in the CSS animations/transitions implementation (plus SVGs when the respective feature flag was enabled). Since some third party components still support the RN's `style` property (for example the `expo-image`'s `Image` component), we can no longer rely on the old implementation checking for the native view name and throwing if it is not supported.

I decided to change the implementation to much more permissive. We now allow any component to be used and try to look for the specific configuration by its name (e.g. SVG components use custom configs), if the component is not found, then we use a single common config that supports all RN style properties (merged props for view, text, image from RN).