### PR TITLE
docs: Add separate entry for versions starting from `4.2.2` in compatibility

### DIFF
--- a/packages/react-native-reanimated/compatibility.json
+++ b/packages/react-native-reanimated/compatibility.json
@@ -4,8 +4,12 @@
       "react-native": ["0.80", "0.81", "0.82", "0.83", "0.84"],
       "react-native-worklets": ["nightly"]
     },
-    "4.2.x": {
+    "4.2.2 - 4.2.x": {
       "react-native": ["0.80", "0.81", "0.82", "0.83", "0.84"],
+      "react-native-worklets": ["0.7.x"]
+    },
+    "4.2.0 - 4.2.1": {
+      "react-native": ["0.80", "0.81", "0.82", "0.83"],
       "react-native-worklets": ["0.7.x"]
     },
     "4.1.x": {


### PR DESCRIPTION
## Before

<img width="888" height="335" alt="Screenshot 2026-02-21 at 10 27 13" src="https://github.com/user-attachments/assets/e1a595ea-ea5d-494d-91af-285e54693a88" />

## After

<img width="989" height="439" alt="Screenshot 2026-02-21 at 10 24 23" src="https://github.com/user-attachments/assets/d59c87e5-f8a7-42e1-80bc-2fc4f0f7d0f1" />
