### PR TITLE
Store `ShadowNodeFamily::Shared` instead of `ShadowNodeFamily &` in `UpdatesRegistry`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
@@ -215,7 +215,7 @@ void CSSAnimationsRegistry::updateViewAnimations(
   }
 
   if (hasUpdates) {
-    addUpdatesToBatch(shadowNode, result);
+    addUpdatesToBatch(shadowNode->getFamilyShared(), result);
   }
 }
 
@@ -288,7 +288,7 @@ void CSSAnimationsRegistry::applyViewAnimationsStyle(const Tag viewTag, const do
     }
   }
 
-  setInUpdatesRegistry(shadowNode, updatedStyle);
+  setInUpdatesRegistry(shadowNode->getFamilyShared(), updatedStyle);
 }
 
 void CSSAnimationsRegistry::activateDelayedAnimations(const double timestamp) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -60,7 +60,7 @@ void CSSTransitionsRegistry::update(const double timestamp) {
 
     const folly::dynamic &updates = transition->update(timestamp);
     if (!updates.empty()) {
-      addUpdatesToBatch(transition->getShadowNode(), updates);
+      addUpdatesToBatch(transition->getShadowNode()->getFamilyShared(), updates);
     }
 
     // We remove transition from running and schedule it when animation of one
@@ -109,6 +109,7 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
     const std::shared_ptr<CSSTransition> &transition,
     const folly::dynamic &updates) {
   const auto &shadowNode = transition->getShadowNode();
+  const auto family = shadowNode->getFamilyShared();
   const auto &lastUpdates = getUpdatesFromRegistry(shadowNode->getTag());
   const auto &transitionProperties = transition->getProperties();
 
@@ -127,7 +128,7 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   // updated object contains only allowed properties so we don't need
   // to do additional filtering here
   filteredUpdates.update(updates);
-  setInUpdatesRegistry(shadowNode, filteredUpdates);
+  setInUpdatesRegistry(family, filteredUpdates);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -7,10 +7,13 @@
 
 namespace reanimated {
 
-Props::Shared mergeProps(const ShadowNode &shadowNode, const PropsMap &propsMap, const ShadowNodeFamily &family) {
+Props::Shared mergeProps(
+    const ShadowNode &shadowNode,
+    const PropsMap &propsMap,
+    const std::shared_ptr<const ShadowNodeFamily> &family) {
   ReanimatedSystraceSection s("ShadowTreeCloner::mergeProps");
 
-  const auto it = propsMap.find(&family);
+  const auto it = propsMap.find(family);
 
   if (it == propsMap.end()) {
     return ShadowNodeFragment::propsPlaceholder();
@@ -41,7 +44,7 @@ std::shared_ptr<ShadowNode> cloneShadowTreeWithNewPropsRecursive(
     const ShadowNode &shadowNode,
     const ChildrenMap &childrenMap,
     const PropsMap &propsMap) {
-  const auto family = &shadowNode.getFamily();
+  const auto family = shadowNode.getFamilyShared();
   const auto affectedChildrenIt = childrenMap.find(family);
   auto children = shadowNode.getChildren();
 
@@ -52,7 +55,7 @@ std::shared_ptr<ShadowNode> cloneShadowTreeWithNewPropsRecursive(
   }
 
   return shadowNode.clone(
-      {mergeProps(shadowNode, propsMap, *family),
+      {mergeProps(shadowNode, propsMap, family),
        std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>(children),
        shadowNode.getState(),
        false});
@@ -70,7 +73,7 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(const RootShadowNode &oldRo
       const auto ancestors = family->getAncestors(oldRootNode);
 
       for (const auto &[parentNode, index] : std::ranges::reverse_view(ancestors)) {
-        const auto parentFamily = &parentNode.get().getFamily();
+        const auto parentFamily = parentNode.get().getFamilyShared();
         auto &affectedChildren = childrenMap[parentFamily];
 
         if (affectedChildren.contains(index)) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
@@ -14,8 +15,8 @@ using namespace react;
 
 namespace reanimated {
 
-using PropsMap = std::unordered_map<const ShadowNodeFamily *, std::vector<RawProps>>;
-using ChildrenMap = std::unordered_map<const ShadowNodeFamily *, std::unordered_set<int>>;
+using PropsMap = std::unordered_map<std::shared_ptr<const ShadowNodeFamily>, std::vector<RawProps>>;
+using ChildrenMap = std::unordered_map<std::shared_ptr<const ShadowNodeFamily>, std::unordered_set<int>>;
 
 RootShadowNode::Unshared cloneShadowTreeWithNewProps(const RootShadowNode &oldRootNode, const PropsMap &propsMap);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -21,12 +21,13 @@ void AnimatedPropsRegistry::update(jsi::Runtime &rt, const jsi::Value &operation
     auto item = operationsArray.getValueAtIndex(rt, i).asObject(rt);
     auto shadowNodeWrapper = item.getProperty(rt, "shadowNodeWrapper");
     auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
+    auto family = shadowNode->getFamilyShared();
 
     const jsi::Value &updates = item.getProperty(rt, "updates");
-    addUpdatesToBatch(shadowNode, jsi::dynamicFromValue(rt, updates));
+    addUpdatesToBatch(family, jsi::dynamicFromValue(rt, updates));
 
     if constexpr (StaticFeatureFlags::getFlag("FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS")) {
-      timestampMap_[shadowNode->getTag()] = timestamp;
+      timestampMap_[family->getTag()] = timestamp;
     }
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
@@ -2,7 +2,7 @@
 
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 
-#include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
 
 #include <jsi/jsi.h>
 #include <memory>
@@ -17,12 +17,12 @@ namespace reanimated {
 using namespace facebook;
 using namespace react;
 
-using UpdatesBatch = std::vector<std::pair<std::shared_ptr<const ShadowNode>, folly::dynamic>>;
-using RegistryMap = std::unordered_map<Tag, std::pair<std::shared_ptr<const ShadowNode>, folly::dynamic>>;
+using UpdatesBatch = std::vector<std::pair<std::shared_ptr<const ShadowNodeFamily>, folly::dynamic>>;
+using RegistryMap = std::unordered_map<Tag, std::pair<std::shared_ptr<const ShadowNodeFamily>, folly::dynamic>>;
 
 #ifdef ANDROID
 struct PropsToRevert {
-  std::shared_ptr<const ShadowNode> shadowNode;
+  std::shared_ptr<const ShadowNodeFamily> family;
   std::unordered_set<std::string> props;
 };
 
@@ -51,9 +51,9 @@ class UpdatesRegistry {
   mutable std::mutex mutex_;
   RegistryMap updatesRegistry_;
 
-  void addUpdatesToBatch(const std::shared_ptr<const ShadowNode> &shadowNode, const folly::dynamic &props);
+  void addUpdatesToBatch(const std::shared_ptr<const ShadowNodeFamily> &family, const folly::dynamic &props);
   folly::dynamic getUpdatesFromRegistry(const Tag tag) const;
-  void setInUpdatesRegistry(const std::shared_ptr<const ShadowNode> &shadowNode, const folly::dynamic &props);
+  void setInUpdatesRegistry(const std::shared_ptr<const ShadowNodeFamily> &family, const folly::dynamic &props);
   void removeFromUpdatesRegistry(Tag tag);
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
@@ -57,8 +57,10 @@ class UpdatesRegistryManager {
 #ifdef ANDROID
   PropsToRevertMap propsToRevertMap_;
 
-  static void
-  addToPropsMap(PropsMap &propsMap, const std::shared_ptr<const ShadowNode> &shadowNode, const folly::dynamic &props);
+  static void addToPropsMap(
+      PropsMap &propsMap,
+      const std::shared_ptr<const ShadowNodeFamily> &family,
+      const folly::dynamic &props);
 #endif
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -64,7 +64,7 @@ void LayoutAnimationsProxyCommon::restoreOpacityInCaseOfFlakyEnteringAnimation(S
             for (const auto &[opacity, tag] : opacityToRestore) {
               const auto *targetShadowNode = findInShadowTreeByTag(rootShadowNode, tag);
               if (targetShadowNode != nullptr) {
-                propsMap[&targetShadowNode->getFamily()].emplace_back(folly::dynamic::object("opacity", opacity));
+                propsMap[targetShadowNode->getFamilyShared()].emplace_back(folly::dynamic::object("opacity", opacity));
               }
             }
             return cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -862,7 +862,7 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
 
       UpdatesBatch synchronousUpdatesBatch, shadowTreeUpdatesBatch;
 
-      for (const auto &[shadowNode, props] : updatesBatch) {
+      for (const auto &[family, props] : updatesBatch) {
         bool hasOnlySynchronousProps = true;
         for (const auto &[key, value] : props.items()) {
           const auto keyStr = key.asString();
@@ -873,9 +873,9 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
           }
         }
         if (hasOnlySynchronousProps) {
-          synchronousUpdatesBatch.emplace_back(shadowNode, props);
+          synchronousUpdatesBatch.emplace_back(family, props);
         } else {
-          shadowTreeUpdatesBatch.emplace_back(shadowNode, props);
+          shadowTreeUpdatesBatch.emplace_back(family, props);
         }
       }
 
@@ -885,9 +885,9 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
         intBuffer.reserve(1024);
         doubleBuffer.reserve(1024);
 
-        for (const auto &[shadowNode, props] : synchronousUpdatesBatch) {
+        for (const auto &[family, props] : synchronousUpdatesBatch) {
           intBuffer.push_back(CMD_START_OF_VIEW);
-          intBuffer.push_back(shadowNode->getTag());
+          intBuffer.push_back(family->getTag());
           for (const auto &[key, value] : props.items()) {
             const auto command = propNameToCommand(key.getString());
             switch (command) {
@@ -1063,7 +1063,7 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
 
       UpdatesBatch synchronousUpdatesBatch, shadowTreeUpdatesBatch;
 
-      for (const auto &[shadowNode, props] : updatesBatch) {
+      for (const auto &[family, props] : updatesBatch) {
         bool hasOnlySynchronousProps = true;
         for (const auto &key : props.keys()) {
           const auto keyStr = key.asString();
@@ -1073,14 +1073,14 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
           }
         }
         if (hasOnlySynchronousProps) {
-          synchronousUpdatesBatch.emplace_back(shadowNode, props);
+          synchronousUpdatesBatch.emplace_back(family, props);
         } else {
-          shadowTreeUpdatesBatch.emplace_back(shadowNode, props);
+          shadowTreeUpdatesBatch.emplace_back(family, props);
         }
       }
 
-      for (const auto &[shadowNode, props] : synchronousUpdatesBatch) {
-        synchronouslyUpdateUIPropsFunction_(shadowNode->getTag(), props);
+      for (const auto &[family, props] : synchronousUpdatesBatch) {
+        synchronouslyUpdateUIPropsFunction_(family->getTag(), props);
       }
 
       updatesBatch = std::move(shadowTreeUpdatesBatch);
@@ -1139,10 +1139,8 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
       }
     }
   } else {
-    for (auto const &[shadowNode, props] : updatesBatch) {
-      SurfaceId surfaceId = shadowNode->getSurfaceId();
-      auto family = &shadowNode->getFamily();
-      react_native_assert(family->getSurfaceId() == surfaceId);
+    for (auto const &[family, props] : updatesBatch) {
+      SurfaceId surfaceId = family->getSurfaceId();
       propsMapBySurface[surfaceId][family].emplace_back(props);
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <react/renderer/componentregistry/componentNameByReactViewName.h>
-#include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
@@ -36,9 +36,10 @@
 namespace reanimated {
 
 using namespace facebook;
+using namespace react;
 using namespace css;
 
-using UpdatesBatch = std::vector<std::pair<std::shared_ptr<const ShadowNode>, folly::dynamic>>;
+using UpdatesBatch = std::vector<std::pair<std::shared_ptr<const ShadowNodeFamily>, folly::dynamic>>;
 
 class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
                               public std::enable_shared_from_this<ReanimatedModuleProxy> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR utilizes `ShadowNode::getFamilyShared()` method that was introduced in RN 0.81 to obtain `ShadowNodeFamily::Shared` from `ShadowNode` and store the shared pointer instead of a raw pointer (basically an address) in the updates registry map.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
