### PR TITLE
fix: CSS transitions not working when a prop is added or removed

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2112,7 +2112,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNSVG (15.14.0):
+  - RNSVG (15.15.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2133,9 +2133,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNSVG/common (= 15.14.0)
+    - RNSVG/common (= 15.15.3)
     - Yoga
-  - RNSVG/common (15.14.0):
+  - RNSVG/common (15.15.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2494,7 +2494,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 53012435cc80627d41ad53d8c27ecc7efaef2f12
+  hermes-engine: 710bd1cf133cc57e1089dbfcbc58481904d3bc28
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: 7fe66a61d5acab6516098a64f42af575595e7566
   NitroModules: 70861471ee1cc5616462aef869a164dac12db7b9
@@ -2506,7 +2506,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: ea396d0e40644e9e46245e9b4b6db931b6be006b
+  React-Core-prebuilt: 062feda0bca7aa4ddf8318fc4b9af7f42cc11229
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2568,14 +2568,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: 2fe81bae8e7b638d8d9b78c3dc1ccc1eeabfc613
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: 554aa4807a73d8b65ad8147af7b2d6042b7787be
+  ReactNativeDependencies: 51176643ee242f0103d72c02acd062ff45a2bb85
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCClipboard: 88d7eeb555d1183915f0885bdbc5c97eb6f7f3ba
   RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
   RNGestureHandler: b28d8ee5f49e4fbdfdb16f552beb2e671e151889
   RNReanimated: 27442b4306f41251160d0eb951b4ea3698d6b077
   RNScreens: d012b22f77296a97629be41ff7fb7094450cf7fd
-  RNSVG: 75b62bb0d45f600686b897d6e22b93c45fd4daa4
+  RNSVG: 507bf2685de6b3d49449efd4aae7e7471bb9c433
   RNWorklets: 4f482774f3c5e36c545761f038596550925244fd
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
@@ -51,8 +51,8 @@ void ValueInterpolator::updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyf
 }
 
 bool ValueInterpolator::updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) {
-  auto from = fromValue.isNull() ? defaultStyleValue_ : createValue(rt, fromValue);
-  auto to = toValue.isNull() ? defaultStyleValue_ : createValue(rt, toValue);
+  auto from = fromValue.isUndefined() ? defaultStyleValue_ : createValue(rt, fromValue);
+  auto to = toValue.isUndefined() ? defaultStyleValue_ : createValue(rt, toValue);
 
   const auto equalsReversingAdjustedStartValue = reversingAdjustedStartValue_ && (*to == *reversingAdjustedStartValue_);
   reversingAdjustedStartValue_ = keyframes_.empty() ? from : keyframes_[1].value.value();


### PR DESCRIPTION
## Summary

I introduced a foolish bug in #8982 while migrating from the `folly::dynamic` to the `jsi::Value` usage as I forgot to update `isNull()` checks to `isUndefined()` (undefined values were automatically converted to nulls in `folly::dynamic` so we had to use `isNull` before).

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/32947faa-b0f8-4f72-80ee-5df2878caf38" /> | <video src="https://github.com/user-attachments/assets/146da9e1-cafc-4751-b03b-434c681ece81" /> |

It also displayed this warning before:

<img width="1199" height="329" alt="Screenshot 2026-02-26 at 01 04 16" src="https://github.com/user-attachments/assets/254110b1-3f04-45f5-95d8-ea6c92a852b0" />
