### PR TITLE
fix: Use `renderHook` corresponding for the platform on which jest test is run

### DIFF
--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import { renderHook } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react';
 
 import { logger } from '../../common';
 import { worklet } from '../../jestUtils';

--- a/packages/react-native-reanimated/src/hook/__tests__/useHandlerHelpers.ts
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandlerHelpers.ts
@@ -1,9 +1,16 @@
 'use strict';
-import { renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 
 import { ReanimatedError } from '../../common';
 import { worklet } from '../../jestUtils';
 import { useHandler } from '../useHandler';
+
+const renderHook =
+  Platform.OS === 'web'
+    ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      require('@testing-library/react').renderHook
+    : // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      require('@testing-library/react-native').renderHook;
 
 export function createUseHandlerError(
   handlerNames: string | string[],


### PR DESCRIPTION
## Summary

Before, sometimes we used the same `renderHook` function from the `@testing-library/react-native` for tests executed in the jsdom environment (web-specific unit tests). This incorrect usage resulted in the following error displayed when we ran tests:

<img width="947" height="386" alt="Screenshot 2026-02-26 at 01 23 29" src="https://github.com/user-attachments/assets/d3a3bdf2-e569-4f98-8317-3964e46a27df" />

Tests worked as intended but we got annoying errors in logs.