### PR TITLE
fix: Fix native `matchVersion` not allowing patch version mismatches

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReanimatedVersion.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReanimatedVersion.cpp
@@ -26,25 +26,11 @@ void injectReanimatedCppVersion(jsi::Runtime &rnRuntime) {
 
 #ifndef NDEBUG
 bool matchVersion(const std::string &version1, const std::string &version2) {
-  std::regex pattern("^\\d+\\.\\d+\\.\\d+$");
-  if (std::regex_match(version1, pattern) && std::regex_match(version2, pattern)) {
-    auto majorPattern = std::regex("^\\d+");
-    std::smatch major1;
-    std::smatch major2;
-    std::regex_search(version1, major1, majorPattern);
-    std::regex_search(version2, major2, majorPattern);
-    if (major1 != major2) {
-      return false;
-    }
-    auto minorPattern = std::regex("\\.\\d+\\.");
-    std::smatch minor1;
-    std::smatch minor2;
-    std::regex_search(version1, minor1, minorPattern);
-    std::regex_search(version2, minor2, minorPattern);
-    if (minor1 != minor2) {
-      return false;
-    }
-    return true;
+  std::regex pattern("^(\\d+)\\.(\\d+)\\.\\d+$");
+  std::smatch mv1;
+  std::smatch mv2;
+  if (std::regex_match(version1, mv1, pattern) && std::regex_match(version2, mv2, pattern)) {
+    return mv1[1].str() == mv2[1].str() && mv1[2].str() == mv2[2].str();
   } else {
     return version1 == version2;
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/Tools/VersionUtils.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Tools/VersionUtils.cpp
@@ -10,25 +10,11 @@ using namespace facebook;
 namespace worklets {
 
 bool matchVersion(const std::string &version1, const std::string &version2) {
-  std::regex pattern("^\\d+\\.\\d+\\.\\d+$");
-  if (std::regex_match(version1, pattern) && std::regex_match(version2, pattern)) {
-    auto majorPattern = std::regex("^\\d+");
-    std::smatch major1;
-    std::smatch major2;
-    std::regex_search(version1, major1, majorPattern);
-    std::regex_search(version2, major2, majorPattern);
-    if (major1 != major2) {
-      return false;
-    }
-    auto minorPattern = std::regex("\\.\\d+\\.");
-    std::smatch minor1;
-    std::smatch minor2;
-    std::regex_search(version1, minor1, minorPattern);
-    std::regex_search(version2, minor2, minorPattern);
-    if (minor1 != minor2) {
-      return false;
-    }
-    return true;
+  std::regex pattern("^(\\d+)\\.(\\d+)\\.\\d+$");
+  std::smatch mv1;
+  std::smatch mv2;
+  if (std::regex_match(version1, mv1, pattern) && std::regex_match(version2, mv2, pattern)) {
+    return mv1[1].str() == mv2[1].str() && mv1[2].str() == mv2[2].str();
   } else {
     return version1 == version2;
   }


### PR DESCRIPTION
## Summary

While this looked correct and we looked at this for the SDK 54 release in September, we again found warnings when the patch versions mismatch, and assume that when we reviewed this, we missed something.

Coming back to this and looking closer, the old code compared `std::smatch` directly against each other from both searches. However, `std::smatch` is an iterator, and, presumably, the comparison is iterating all values and comparing them. The string at the zero-index, like in JS, is a full match string. If that match string contains the full `version` string, then the comparison can never succeed.

This means that this was always comparing exact version matches rather than allowing patch versions to differ.

Instead, the new version matches two explicit groups on major and minor versions for clarity, then compares index 1 and 2's (match 1 and 2's ) strings.

## Test plan

- Test of previously failing behaviour
  - Compile a native app with newer/older versions (e.g. `react-native-reanimated@4.2.2` and `react-native-worklets@0.7.2`
  - Then; use a bundle against different versions (e.g. `react-native-reanimated@4.2.1` and `react-native-worklets@0.7.4`
  - **Before:** C++ mismatch warning logs in console, although major & minor are compatible
  - **After:** No warning is logged
- Test to validate that the warning can still log after the change
  - Manually change JS versions in `package.json` to bump minor
  - Update hardcoded `jsVersion` to bump minor
  - Clear and rebundle JS, observing the warning in the console and a worklets error (not from Babel but in the runtime)