### PR TITLE
chore(Worklets): install serializer on UI Runtime

### DIFF
--- a/packages/react-native-worklets/src/initializers/initializers.native.ts
+++ b/packages/react-native-worklets/src/initializers/initializers.native.ts
@@ -172,9 +172,6 @@ function installRNBindingsOnUIRuntime() {
 
     /** In Bundle Mode the error is taken from the bundle. */
     runOnUISync(registerWorkletsError);
-
-    /** In Bundle Mode the serializer is taken from the bundle. */
-    runOnUISync(setupSerializer);
   }
 
   const runtimeBoundCapturableConsole = getMemorySafeCapturableConsole();
@@ -193,5 +190,6 @@ function installRNBindingsOnUIRuntime() {
     setupSetTimeout();
     setupSetImmediate();
     setupSetInterval();
+    setupSerializer();
   });
 }


### PR DESCRIPTION
## Summary

Required by #8673

We now explicitly install `globalThis._serializer` on every Worklet Runtime, including UI, not just Worker Runtimes.

This only affects the Bundle Mode.

## Test plan

🚀 
