### PR TITLE
chore(Worklets): stabilize Serializable enum

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<Serializable> extractSerializableOrThrow(
       auto nativeState = object.getNativeState(rt);
       return std::dynamic_pointer_cast<SerializableJSRef>(nativeState)->value();
     }
-    throw std::runtime_error("[Worklets] Attempted to extract from a Object that wasn't converted to a Serializable.");
+    throw std::runtime_error("[Worklets] Attempted to extract from an Object that wasn't converted to a Serializable.");
   } else if (maybeSerializableValue.isUndefined()) {
     return Serializable::undefined();
   }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -50,7 +50,6 @@ class Serializable {
     NullType,
     BooleanType,
     NumberType,
-    // SymbolType, TODO
     BigIntType,
     StringType,
     ObjectType,
@@ -67,6 +66,7 @@ class Serializable {
     ImportType,
     SynchronizableType,
     CustomType,
+    SymbolType, /* unused */
   };
 
   explicit Serializable(ValueType valueType) : valueType_(valueType) {}


### PR DESCRIPTION
## Summary

In #8996 `SerializableType` enum will have to be locked. For that reason we should already add the `SymbolType` to the enum to not break ABI in the future if we want to implement it.

## Test plan

🚀 
