### PR TITLE
chore(Worklets): export unpackers in prod env

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2112,7 +2112,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNSVG (15.15.3):
+  - RNSVG (15.14.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2133,9 +2133,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNSVG/common (= 15.15.3)
+    - RNSVG/common (= 15.14.0)
     - Yoga
-  - RNSVG/common (15.15.3):
+  - RNSVG/common (15.14.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2494,7 +2494,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 710bd1cf133cc57e1089dbfcbc58481904d3bc28
+  hermes-engine: 1e68e1c0ed52f0e23f8f95382844d35399647038
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: 7fe66a61d5acab6516098a64f42af575595e7566
   NitroModules: 70861471ee1cc5616462aef869a164dac12db7b9
@@ -2506,7 +2506,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: 062feda0bca7aa4ddf8318fc4b9af7f42cc11229
+  React-Core-prebuilt: 14d09d3fcba02f13b2cbdebd3a70fd199dd2be06
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2568,14 +2568,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: 2fe81bae8e7b638d8d9b78c3dc1ccc1eeabfc613
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: 51176643ee242f0103d72c02acd062ff45a2bb85
+  ReactNativeDependencies: 7847e46aecdc4c8b89c706f1283b53d2950b18eb
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCClipboard: 88d7eeb555d1183915f0885bdbc5c97eb6f7f3ba
   RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
   RNGestureHandler: b28d8ee5f49e4fbdfdb16f552beb2e671e151889
   RNReanimated: 27442b4306f41251160d0eb951b4ea3698d6b077
   RNScreens: d012b22f77296a97629be41ff7fb7094450cf7fd
-  RNSVG: 507bf2685de6b3d49449efd4aae7e7471bb9c433
+  RNSVG: 75b62bb0d45f600686b897d6e22b93c45fd4daa4
   RNWorklets: 4f482774f3c5e36c545761f038596550925244fd
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 

--- a/packages/react-native-worklets/Common/cpp/worklets/Resources/SynchronizableUnpacker.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/Resources/SynchronizableUnpacker.cpp
@@ -8,7 +8,7 @@ namespace worklets {
 
 const char SynchronizableUnpackerCode[] =
     R"DELIMITER__((function () {
-  var serializer = !globalThis._WORKLET || globalThis._WORKLETS_BUNDLE_MODE_ENABLED ? _serializable.createSerializable : function (value) {
+  var serializer = globalThis.__RUNTIME_KIND === 1 || globalThis._WORKLETS_BUNDLE_MODE_ENABLED ? createSerializable : function (value) {
     return globalThis.__serializer(value);
   };
   function synchronizableUnpacker(synchronizableRef) {

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "yarn workspace babel-plugin-worklets build && bob build && yarn build:unpackers",
-    "build:unpackers": "node ./scripts/export-unpackers.js",
+    "build:unpackers": "NODE_ENV='production' node ./scripts/export-unpackers.js",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "find-unused-code:js": "knip",
     "format": "yarn format:js && yarn format:plugin && yarn format:common && yarn format:android && yarn format:apple",

--- a/packages/react-native-worklets/scripts/export-unpackers.js
+++ b/packages/react-native-worklets/scripts/export-unpackers.js
@@ -9,6 +9,10 @@ const generate = require('@babel/generator').default;
 const path = require('path');
 const fs = require('fs');
 const assert = require('assert').strict;
+const workletsBabelPlugin = require('../plugin');
+
+/** @type {import('../plugin/').PluginOptions} */
+const workletsBabelPluginOptions = {};
 
 exportToCpp('valueUnpacker.native.ts', 'ValueUnpacker');
 exportToCpp('synchronizableUnpacker.native.ts', 'SynchronizableUnpacker');
@@ -31,10 +35,12 @@ function exportToCpp(sourceFilePath, outputFilename) {
         ['@babel/preset-env', { modules: false }],
         '@babel/preset-typescript',
       ],
+      plugins: [[workletsBabelPlugin, workletsBabelPluginOptions]],
       sourceType: 'unambiguous',
       code: false,
       ast: true,
       comments: false,
+      configFile: false,
     }
   );
 
@@ -90,4 +96,6 @@ const char ${cstrName}[] =
 `,
     'utf8'
   );
+
+  console.log(`✅ Exported ${sourceFilePath} to ${outputFilename}.cpp`);
 }

--- a/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
@@ -6,7 +6,7 @@ import { type Synchronizable, type SynchronizableRef } from './types';
 export function __installUnpacker() {
   // TODO: Add cache for synchronizables.
   const serializer =
-    !globalThis._WORKLET || globalThis._WORKLETS_BUNDLE_MODE_ENABLED
+    globalThis.__RUNTIME_KIND === 1 || globalThis._WORKLETS_BUNDLE_MODE_ENABLED
       ? createSerializable
       : (value: unknown) => globalThis.__serializer(value);
 


### PR DESCRIPTION
## Summary

Required for #8673

Setting `NODE_ENV` to production when exporting unpackers. This has no impact on the current unpackers behavior but will come handy in the mentioned PR.

## Test plan

Synchronizable runtime tests pass, other unpackers exported code didn't change.
