### PR TITLE
fix: Routes order in SVG examples screen in the example app

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/properties/svg.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/properties/svg.ts
@@ -1,55 +1,8 @@
+/* eslint-disable perfectionist/sort-objects */
 import { svgAnimatedProperties } from '@/apps/css/examples/animations/screens';
 import type { Routes } from '@/apps/css/navigation/types';
 
 export const svgPropertiesRoutes = {
-  Circle: {
-    Component: svgAnimatedProperties.Circle,
-    name: 'Circle',
-  },
-  Ellipse: {
-    Component: svgAnimatedProperties.Ellipse,
-    name: 'Ellipse',
-  },
-  Group: {
-    Component: svgAnimatedProperties.Group,
-    name: 'Group',
-  },
-  Image: {
-    Component: svgAnimatedProperties.Image,
-    name: 'Image',
-  },
-  Line: {
-    Component: svgAnimatedProperties.Line,
-    name: 'Line',
-  },
-  LinearGradient: {
-    Component: svgAnimatedProperties.LinearGradient,
-    name: 'LinearGradient',
-  },
-  Path: {
-    Component: svgAnimatedProperties.Path,
-    name: 'Path',
-  },
-  Polygon: {
-    Component: svgAnimatedProperties.Polygon,
-    name: 'Polygon',
-  },
-  Polyline: {
-    Component: svgAnimatedProperties.Polyline,
-    name: 'Polyline',
-  },
-  RadialGradient: {
-    Component: svgAnimatedProperties.RadialGradient,
-    name: 'RadialGradient',
-  },
-  Rect: {
-    Component: svgAnimatedProperties.Rect,
-    name: 'Rect',
-  },
-  Text: {
-    Component: svgAnimatedProperties.Text,
-    name: 'Text',
-  },
   Common: {
     name: 'Common',
     routes: {
@@ -60,6 +13,59 @@ export const svgPropertiesRoutes = {
       Stroke: {
         Component: svgAnimatedProperties.common.Stroke,
         name: 'Stroke',
+      },
+    },
+  },
+  Components: {
+    name: 'Components',
+    routes: {
+      Circle: {
+        Component: svgAnimatedProperties.Circle,
+        name: 'Circle',
+      },
+      Ellipse: {
+        Component: svgAnimatedProperties.Ellipse,
+        name: 'Ellipse',
+      },
+      Rect: {
+        Component: svgAnimatedProperties.Rect,
+        name: 'Rect',
+      },
+      Image: {
+        Component: svgAnimatedProperties.Image,
+        name: 'Image',
+      },
+      Line: {
+        Component: svgAnimatedProperties.Line,
+        name: 'Line',
+      },
+      Path: {
+        Component: svgAnimatedProperties.Path,
+        name: 'Path',
+      },
+      Polygon: {
+        Component: svgAnimatedProperties.Polygon,
+        name: 'Polygon',
+      },
+      Polyline: {
+        Component: svgAnimatedProperties.Polyline,
+        name: 'Polyline',
+      },
+      LinearGradient: {
+        Component: svgAnimatedProperties.LinearGradient,
+        name: 'LinearGradient',
+      },
+      RadialGradient: {
+        Component: svgAnimatedProperties.RadialGradient,
+        name: 'RadialGradient',
+      },
+      Group: {
+        Component: svgAnimatedProperties.Group,
+        name: 'Group',
+      },
+      Text: {
+        Component: svgAnimatedProperties.Text,
+        name: 'Text',
       },
     },
   },


### PR DESCRIPTION
## Summary

The order of examples was wrong before and component examples were mixed with common examples. I fixed the order and grouped component examples into a single section.

## Examples

| Before | After |
|-|-|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-25 at 03 32 03" src="https://github.com/user-attachments/assets/ee1cb83d-470d-46b8-8399-02376b2610e1" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-27 at 23 46 50" src="https://github.com/user-attachments/assets/d1e9b80b-7384-4598-a2a8-530ddf27635d" /> |
