### PR TITLE
Fix sync props back to React mechanism

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -217,7 +217,9 @@ export default class AnimatedComponent
 
   _syncStylePropsBackToReact(props: StyleProps) {
     if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
-      this.setState({ settledProps: props });
+      this.setState((state) => ({
+        settledProps: { ...state.settledProps, ...props },
+      }));
       // TODO(future): revert changes when animated styles are detached
     }
   }


### PR DESCRIPTION
## Summary

This PR fixes a bug present in a repro provided by @j-piasecki.

## Test plan

1. Open the app
2. Wait for 5 seconds so that the initial animation state is pushed back to React
3. Press "Expand" button
4. Wait for another 5 seconds so that the final animation state is pushed back to React
5. Make sure the border radius doesn't change

```tsx
import { Button, View } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withSpring,
} from 'react-native-reanimated';

export default function App() {
  const isExpanded = useSharedValue(false);

  const expand = () => {
    isExpanded.value = true;
  };

  const collapse = () => {
    isExpanded.value = false;
  };

  const layoutAnimatedStyle = useAnimatedStyle(() => {
    return {
      width: withSpring(isExpanded.value ? 300 : 0),
      height: withSpring(isExpanded.value ? 60 : 40),
    };
  });

  const borderRadiusAnimatedStyle = useAnimatedStyle(() => {
    return {
      borderRadius: withSpring(16),
    };
  });

  return (
    <View style={{ flex: 1, paddingTop: 100 }}>
      <Button title="Expand" onPress={expand} />
      <Button title="Collapse" onPress={collapse} />
      <Animated.View
        style={[
          { backgroundColor: 'red' },
          layoutAnimatedStyle,
          borderRadiusAnimatedStyle,
        ]}
      />
    </View>
  );
}
```
