### PR TITLE
fix: Add missing jsitooling dependency to podspecs

### DIFF
--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -64,6 +64,7 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/Headers/Private/React-Core"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"',
       '"$(PODS_ROOT)/Headers/Public/RNWorklets"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsitooling/JSITooling.framework/Headers"',
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
@@ -89,6 +90,7 @@ Pod::Spec.new do |s|
   install_modules_dependencies(s)
 
   s.dependency 'React-jsi'
+  s.dependency 'React-jsitooling'
   using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
   if using_hermes && !$config[:is_tvos_target]
     s.dependency 'React-hermes'

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
   install_modules_dependencies(s)
 
   s.dependency 'React-jsi'
+  s.dependency 'React-jsitooling'
   using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
   if using_hermes && !$worklets_config[:is_tvos_target]
     s.dependency 'React-hermes'
@@ -71,6 +72,7 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/DoubleConversion"',
       '"$(PODS_ROOT)/Headers/Private/React-Core"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsitooling/JSITooling.framework/Headers"',
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",


### PR DESCRIPTION
## Summary

In react-native 0.84 some of the common JSI binding utils were moved to jsitooling (https://github.com/facebook/react-native/pull/54406), requiring `jsitooling` to be declared as a dependency in podspec to ensure headers can be found.

 When using reanimated 4.2.2, building iOS release and not using precompiled React Native will result in the following error

```
In file included from /Users/gabriel/Desktop/expo/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp:6:
In file included from /Users/gabriel/Desktop/expo/node_modules/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h:5:
/Users/gabriel/Desktop/expo/node_modules/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h:15:10: fatal error: 'react/runtime/JSRuntimeBindings.h'
      file not found
   15 | #include <react/runtime/JSRuntimeBindings.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/gabriel/Desktop/expo/node_modules/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h:15:10: note: did not find header
      'runtime/JSRuntimeBindings.h' in framework 'react' (loaded from
      '/Users/gabriel/Desktop/expo/apps/brownfield-tester/expo-app/ios/build/Build/Products/Debug-iphoneos/React-Core')
1 error generated.
```

## Test plan

Run fabric-example locally and run in Expo's repo
