### PR TITLE
chore: enable `exactOptionalPropertyTypes` support

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -303,7 +303,7 @@ function installTurboModule() {
   globalThis.__UI_WORKLET_RUNTIME_HOLDER = getUIRuntimeHolder();
   globalThis.__UI_SCHEDULER_HOLDER = getUISchedulerHolder();
   const status = ReanimatedTurboModule!.installTurboModule();
-  delete globalThis.__UI_WORKLET_RUNTIME_HOLDER;
-  delete globalThis.__UI_SCHEDULER_HOLDER;
+  globalThis.__UI_WORKLET_RUNTIME_HOLDER = undefined;
+  globalThis.__UI_SCHEDULER_HOLDER = undefined;
   return status;
 }

--- a/packages/react-native-reanimated/src/common/style/propsBuilder.ts
+++ b/packages/react-native-reanimated/src/common/style/propsBuilder.ts
@@ -18,7 +18,7 @@ type PropsBuilderPropertyConfig<
   | {
       // value can have any type as it is passed to CPP where we can expect a different
       // type than in the React Native stylesheet (e.g. number for colors instead of string)
-      process: ValueProcessor<Required<TProps>[K], unknown>; // for custom value processing
+      process: ValueProcessor<Exclude<Required<TProps>[K], undefined>, unknown>; // for custom value processing
     };
 
 export type PropsBuilderConfig<P extends UnknownRecord = UnknownRecord> = {

--- a/packages/react-native-reanimated/src/common/style/registry.ts
+++ b/packages/react-native-reanimated/src/common/style/registry.ts
@@ -16,7 +16,7 @@ const DEFAULT_SEPARATELY_INTERPOLATED_NESTED_PROPERTIES = new Set<string>([
 
 type PropsBuilderEntry = {
   builder: NativePropsBuilder;
-  separatelyInterpolatedNestedProperties?: ReadonlySet<string>;
+  separatelyInterpolatedNestedProperties?: ReadonlySet<string> | undefined;
 };
 
 const PROPS_BUILDERS = new Map<string, PropsBuilderEntry>();

--- a/packages/react-native-reanimated/src/common/style/types.ts
+++ b/packages/react-native-reanimated/src/common/style/types.ts
@@ -15,7 +15,7 @@ type PropsBuilderPropertyConfig<
       // type than in the React Native stylesheet (e.g. number for colors instead of string)
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      process: ValueProcessor<Required<P>[K], any>; // for custom value processing
+      process: ValueProcessor<Exclude<Required<P>[K], undefined>, any>; // for custom value processing
     };
 
 export type PropsBuilderConfig<P extends AnyRecord = AnyRecord> = {

--- a/packages/react-native-reanimated/src/common/types/style.ts
+++ b/packages/react-native-reanimated/src/common/types/style.ts
@@ -41,15 +41,15 @@ export type ParsedDropShadow = {
 };
 
 export type ParsedFilterFunction =
-  | { brightness?: number }
-  | { contrast?: number }
-  | { dropShadow?: ParsedDropShadow }
-  | { grayscale?: number }
-  | { hueRotate?: number }
-  | { invert?: number }
-  | { opacity?: number }
-  | { saturate?: number }
-  | { sepia?: number }
-  | { blur?: number };
+  | { brightness?: number | undefined }
+  | { contrast?: number | undefined }
+  | { dropShadow?: ParsedDropShadow | undefined }
+  | { grayscale?: number | undefined }
+  | { hueRotate?: number | undefined }
+  | { invert?: number | undefined }
+  | { opacity?: number | undefined }
+  | { saturate?: number | undefined }
+  | { sepia?: number | undefined }
+  | { blur?: number | undefined };
 
 export type FilterArray = ParsedFilterFunction[];

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -39,7 +39,7 @@ interface WindowDimensions {
 }
 
 export interface KeyframeProps extends StyleProps {
-  easing?: EasingFunction | EasingFunctionFactory;
+  easing?: (EasingFunction | EasingFunctionFactory) | undefined;
 }
 
 type FirstFrame =
@@ -68,7 +68,7 @@ export type MaybeInvalidKeyframeProps = Record<number, KeyframeProps> & {
 export type LayoutAnimation = {
   initialValues: StyleProps;
   animations: StyleProps;
-  callback?: (finished: boolean) => void;
+  callback?: ((finished: boolean) => void) | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -167,7 +167,7 @@ export interface LayoutAnimationBatchItem {
   viewTag: number;
   type: LayoutAnimationType;
   config: SerializableRef<Keyframe | LayoutAnimationFunction> | undefined;
-  sharedTransitionTag?: string;
+  sharedTransitionTag?: string | undefined;
 }
 
 export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>;
@@ -268,17 +268,17 @@ export type AnimatableValue = Animatable | AnimatableValueObject;
 export interface AnimationObject<T = AnimatableValue> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-  callback?: AnimationCallback;
-  current?: T;
+  callback?: AnimationCallback | undefined;
+  current?: T | undefined;
   toValue?: AnimationObject<T>['current'];
   startValue?: AnimationObject<T>['current'];
-  finished?: boolean;
-  strippedCurrent?: number;
-  cancelled?: boolean;
-  reduceMotion?: boolean;
+  finished?: boolean | undefined;
+  strippedCurrent?: number | undefined;
+  cancelled?: boolean | undefined;
+  reduceMotion?: boolean | undefined;
 
-  __prefix?: string;
-  __suffix?: string;
+  __prefix?: string | undefined;
+  __suffix?: string | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onFrame: (animation: any, timestamp: Timestamp) => boolean;
   onStart: (
@@ -411,8 +411,8 @@ export interface MeasuredDimensions {
 }
 
 export interface AnimatedKeyboardOptions {
-  isStatusBarTranslucentAndroid?: boolean;
-  isNavigationBarTranslucentAndroid?: boolean;
+  isStatusBarTranslucentAndroid?: boolean | undefined;
+  isNavigationBarTranslucentAndroid?: boolean | undefined;
 }
 
 /**

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -65,7 +65,7 @@ export default class AnimatedComponent
   >
   implements IAnimatedComponentInternal
 {
-  _options?: Options<InitialComponentProps>;
+  _options?: Options<InitialComponentProps> | undefined;
   _displayName: string;
   _animatedStyles: StyleProps[] = [];
   _prevAnimatedStyles: StyleProps[] = [];
@@ -77,13 +77,13 @@ export default class AnimatedComponent
   jestAnimatedProps: { value: AnimatedProps } = { value: {} };
   _InlinePropManager = new InlinePropManager();
   _PropsFilter = new PropsFilter();
-  _NativeEventsManager?: INativeEventsManager;
-  _hasWarnedAboutLayoutAnimationStyleOverwriting?: boolean;
+  _NativeEventsManager?: INativeEventsManager | undefined;
+  _hasWarnedAboutLayoutAnimationStyleOverwriting?: boolean | undefined;
   static contextType = SkipEnteringContext;
   context!: React.ContextType<typeof SkipEnteringContext>;
   reanimatedID = id++;
-  _sharedTransition?: SharedTransition;
-  _sharedTransitionTag?: string;
+  _sharedTransition?: SharedTransition | undefined;
+  _sharedTransitionTag?: string | undefined;
 
   constructor(
     ChildComponent: AnyComponent,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/NativeEventsManager.ts
@@ -12,7 +12,7 @@ import { has } from './utils';
 
 export class NativeEventsManager implements INativeEventsManager {
   readonly #managedComponent: ManagedAnimatedComponent;
-  readonly #componentOptions?: ComponentOptions;
+  readonly #componentOptions?: ComponentOptions | undefined;
   #eventViewTag = -1;
 
   constructor(component: ManagedAnimatedComponent, options?: ComponentOptions) {

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -27,8 +27,8 @@ export interface ViewInfo {
   // The React Native view class name for the host component
   // (e.g. "RCTText" for Text). See getViewInfo.ts for the full naming
   // convention used in CSS.
-  reactViewName?: string;
-  DOMElement?: HTMLElement | null;
+  reactViewName?: string | undefined;
+  DOMElement?: (HTMLElement | null) | undefined;
 }
 
 export interface IInlinePropManager {
@@ -128,7 +128,7 @@ export interface IAnimatedComponentInternalBase {
   ChildComponent: AnyComponent;
   _componentRef: AnimatedComponentRef | HTMLElement | null;
   _hasAnimatedRef: boolean;
-  _viewInfo?: ViewInfo;
+  _viewInfo?: ViewInfo | undefined;
 
   /**
    * Used for Layout Animations and Animated Styles. It is not related to event
@@ -150,7 +150,7 @@ export interface IAnimatedComponentInternal
   _InlinePropManager: IInlinePropManager;
   _PropsFilter: IPropsFilter;
   /** Doesn't exist on web. */
-  _NativeEventsManager?: INativeEventsManager;
+  _NativeEventsManager?: INativeEventsManager | undefined;
   context: React.ContextType<typeof SkipEnteringContext>;
   setNativeProps: (props: StyleProps) => void;
   _syncStylePropsBackToReact: (props: StyleProps) => void;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -16,8 +16,8 @@ import type { HostInstance } from '../platform-specific/types';
 //                         Can be obtained on the C++ side by converting
 //                         reactViewName via componentNameByReactViewName().
 export function getViewInfo(element: HostInstance): {
-  reactViewName?: string;
-  viewTag?: number;
+  reactViewName?: string | undefined;
+  viewTag?: number | undefined;
 } {
   return {
     reactViewName: (element?._viewConfig?.uiViewClassName ??

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -42,7 +42,7 @@ export default class AnimatedComponent<
 
   _CSSManager?: CSSManager;
 
-  _viewInfo?: ViewInfo;
+  _viewInfo?: ViewInfo | undefined;
   _cssStyle: CSSStyle = {}; // RN style object with Reanimated CSS properties
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
   _hasAnimatedRef = false;
@@ -100,12 +100,13 @@ export default class AnimatedComponent<
         hostInstance
       );
     }
-    this._viewInfo = { viewTag, shadowNodeWrapper, reactViewName };
+    const viewInfo: ViewInfo = { viewTag, shadowNodeWrapper, reactViewName };
     if (DOMElement) {
-      this._viewInfo.DOMElement = DOMElement;
+      viewInfo.DOMElement = DOMElement;
     }
+    this._viewInfo = viewInfo;
 
-    return this._viewInfo;
+    return viewInfo;
   }
 
   _setComponentRef = (ref: Component | HTMLElement) => {

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
@@ -72,7 +72,7 @@ export function normalizeKeyframeSelector(
 type ProcessedKeyframes = Array<{
   offset: number;
   props: UnknownRecord;
-  timingFunction?: CSSAnimationTimingFunction;
+  timingFunction?: CSSAnimationTimingFunction | undefined;
 }>;
 
 export function processKeyframes(

--- a/packages/react-native-reanimated/src/css/stylesheet/stylesheet.ts
+++ b/packages/react-native-reanimated/src/css/stylesheet/stylesheet.ts
@@ -32,7 +32,10 @@ export const create = <T extends NamedStyles<T>>(
   for (const key in styles) {
     const style = styles[key];
     if (style.animationName) {
-      style.animationName = parseAnimationName(style.animationName);
+      const parsedName = parseAnimationName(style.animationName);
+      if (parsedName !== undefined) {
+        style.animationName = parsedName;
+      }
     }
   }
 

--- a/packages/react-native-reanimated/src/culori/Colors.ts
+++ b/packages/react-native-reanimated/src/culori/Colors.ts
@@ -4,12 +4,12 @@ export interface LabColor {
   l: number;
   a: number;
   b: number;
-  alpha?: number;
+  alpha?: number | undefined;
 }
 
 export interface RgbColor {
   r: number;
   g: number;
   b: number;
-  alpha?: number;
+  alpha?: number | undefined;
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/BaseAnimationBuilder.ts
@@ -10,11 +10,11 @@ import type {
 import { ReduceMotion } from '../../commonTypes';
 
 export class BaseAnimationBuilder {
-  durationV?: number;
-  delayV?: number;
+  durationV?: number | undefined;
+  delayV?: number | undefined;
   reduceMotionV: ReduceMotion = ReduceMotion.System;
   randomizeDelay = false;
-  callbackV?: (finished: boolean) => void;
+  callbackV?: ((finished: boolean) => void) | undefined;
 
   static createInstance: <T extends typeof BaseAnimationBuilder>(
     this: T

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/Keyframe.ts
@@ -24,7 +24,7 @@ import { Easing } from '../../Easing';
 interface KeyframePoint {
   duration: number;
   value: number | string;
-  easing?: EasingFunction | EasingFunctionFactory;
+  easing?: (EasingFunction | EasingFunctionFactory) | undefined;
 }
 interface ParsedKeyframesDefinition {
   initialValues: StyleProps;
@@ -32,12 +32,12 @@ interface ParsedKeyframesDefinition {
 }
 
 class InnerKeyframe implements IEntryExitAnimationBuilder {
-  durationV?: number;
-  delayV?: number;
+  durationV?: number | undefined;
+  delayV?: number | undefined;
   reduceMotionV: ReduceMotion = ReduceMotion.System;
-  callbackV?: (finished: boolean) => void;
+  callbackV?: ((finished: boolean) => void) | undefined;
   definitions: MaybeInvalidKeyframeProps;
-  parsedAnimation?: EntryExitAnimationFunction;
+  parsedAnimation?: EntryExitAnimationFunction | undefined;
 
   /*
     Keyframe definition should be passed in the constructor as the map
@@ -131,7 +131,7 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       key: string;
       value: string | number;
       currentKeyPoint: number;
-      easing?: EasingFunction | EasingFunctionFactory;
+      easing?: (EasingFunction | EasingFunctionFactory) | undefined;
     }): void => {
       if (!(key in parsedKeyframes)) {
         throw new ReanimatedError(
@@ -238,11 +238,11 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
       return this.parsedAnimation;
     }
 
-    this.parsedAnimation = () => {
+    const parsedAnimation: EntryExitAnimationFunction = () => {
       'worklet';
       const animations: StylePropsWithArrayTransform = {};
 
-      /* 
+      /*
             For each style property, an animations sequence is created that corresponds with its key points.
             Transform style properties require special handling because of their nested structure.
       */
@@ -302,7 +302,8 @@ class InnerKeyframe implements IEntryExitAnimationBuilder {
         callback,
       };
     };
-    return this.parsedAnimation;
+    this.parsedAnimation = parsedAnimation;
+    return parsedAnimation;
   };
 }
 

--- a/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/web/createAnimation.ts
@@ -74,7 +74,9 @@ export function createCustomKeyFrameAnimation(
 ) {
   for (const value of Object.values(keyframeDefinitions)) {
     if (value.transform) {
-      value.transform = addPxToTransform(value.transform as TransformType);
+      value.transform = addPxToTransform(
+        value.transform as unknown as TransformType
+      );
     }
   }
 

--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -17,7 +17,7 @@ type Mapper = {
   dirty: boolean;
   worklet: () => void;
   inputs: MapperExtractedInputs;
-  outputs?: MapperOutputs;
+  outputs?: MapperOutputs | undefined;
 };
 
 function createMapperRegistry() {

--- a/packages/react-native-reanimated/tsconfig.native.json
+++ b/packages/react-native-reanimated/tsconfig.native.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "react-native-reanimated": ["./src"]
     }


### PR DESCRIPTION
## Summary

This PR enables TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) flag in `react-native-reanimated` and fixes all resulting type errors across 19 files.

`exactOptionalPropertyTypes` is a strict TypeScript flag (not included in `strict: true`) that distinguishes between "property is missing" and "property is explicitly `undefined`". When enabled, `prop?: T` means the property can be omitted but cannot be set to `undefined` — the fix is `prop?: T | undefined`.

This matters for downstream projects that enable this flag — without this change, they get type errors when using reanimated APIs. This is currently blocking [react-navigation from enabling the flag](https://github.com/react-navigation/react-navigation/pull/12995).

### What changed

Four categories of fixes:

1. **Core type declarations** (`commonTypes.ts`, `Colors.ts`, `mappers.ts`) — Added `| undefined` to optional properties in `AnimationObject`, `LayoutAnimation`, `AnimatedKeyboardOptions`, `LabColor`, `RgbColor`, etc.

2. **Style processing generics** (`common/style/types.ts`, `propsBuilder.ts`, `registry.ts`) — Used `Exclude<Required<P>[K], undefined>` to extract the non-undefined type from optional properties before passing to `PropsBuilderPropertyConfig<T>`

3. **AnimatedComponent class hierarchies** (`createAnimatedComponent/`, `css/component/`) — Updated class property types and `ViewInfo` interfaces, added type narrowing in `_getViewInfo()`

4. **Layout animation builders** (`BaseAnimationBuilder.ts`, `Keyframe.ts`) — Added `| undefined` to builder class properties (`durationV`, `delayV`, `callbackV`) and `KeyframePoint.easing`

All changes are type annotations only — zero runtime changes.

## Test plan

- `yarn workspace react-native-reanimated type:check:src:native` — 0 new errors (58 pre-existing TS2307/TS7017 from `react-native-worklets` module resolution remain unchanged)
- `yarn workspace react-native-reanimated type:check:src:web` — same as native
- Prettier check on all modified files — pass