### PR TITLE
fix: guard against null styleProps in PropsRegistry GC

### DIFF
--- a/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
+++ b/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
@@ -42,6 +42,9 @@ export const PropsRegistryGarbageCollector = {
   syncPropsBackToReact() {
     const settledUpdates = ReanimatedModule.getSettledUpdates();
     for (const { viewTag, styleProps } of settledUpdates) {
+      if (styleProps === null) {
+        continue;
+      }
       const component = this.viewsMap.get(viewTag);
       unprocessProps(styleProps);
       component?._syncStylePropsBackToReact(styleProps);
@@ -64,9 +67,6 @@ export const PropsRegistryGarbageCollector = {
 };
 
 function unprocessProps(props: StyleProps) {
-  if (!props) {
-    return;
-  }
   unprocessColorsInProps(props);
   unprocessBoxShadow(props);
 }

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -374,7 +374,7 @@ export type ShadowNodeWrapper = {
 
 export type SettledUpdate = {
   viewTag: number;
-  styleProps: StyleProps;
+  styleProps: StyleProps | null;
 };
 
 export enum KeyboardState {


### PR DESCRIPTION

## Summary

`getSettledUpdates()` can return entries with null `styleProps` when an Animated.View unmounts while its animation is still settling. The native side GCs the view's props but the settled update is already queued, so `styleProps` arrives as null.

Without this guard, `unprocessBoxShadow` dereferences null trying to read `props.boxShadow`

