### PR TITLE
Remove deprecated `react-test-renderer` type from published declarations

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -91,7 +91,6 @@
   },
   "homepage": "https://docs.swmansion.com/react-native-reanimated",
   "dependencies": {
-    "@types/react-test-renderer": "19.1.0",
     "react-native-is-edge-to-edge": "1.2.1",
     "semver": "7.7.3"
   },
@@ -117,6 +116,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "24.0.14",
     "@types/react": "19.2.2",
+    "@types/react-test-renderer": "19.1.0",
     "@types/semver": "7.7.1",
     "clang-format-node": "1.3.5",
     "eslint": "9.37.0",

--- a/packages/react-native-reanimated/src/jestUtils/index.ts
+++ b/packages/react-native-reanimated/src/jestUtils/index.ts
@@ -2,7 +2,6 @@
 'use strict';
 
 import type React from 'react';
-import type { ReactTestInstance } from 'react-test-renderer';
 
 import { IS_JEST, logger, ReanimatedError } from '../common';
 import type {
@@ -347,12 +346,10 @@ type TestComponent = React.Component<
   }
 >;
 
-export const getAnimatedStyle = (component: ReactTestInstance) => {
-  return getCurrentStyle(
-    // This type assertion is needed to get type checking in the following
-    // functions since `ReactTestInstance` has its `props` defined as `any`.
-    component as unknown as TestComponent
-  );
+export const getAnimatedStyle = (component: {
+  props: Record<string, unknown>;
+}) => {
+  return getCurrentStyle(component as unknown as TestComponent);
 };
 
 export { worklet } from './common';


### PR DESCRIPTION
## Summary

Remove the `import type { ReactTestInstance } from 'react-test-renderer'` from `jestUtils/index.ts` and replace the parameter with a minimal structural type.

`react-test-renderer` is [deprecated in React 19](https://react.dev/warnings/react-test-renderer), and `@testing-library/react-native` v14 [replaces it](https://oss.callstack.com/react-native-testing-library/14.x/docs/start/migration-v14) with the new [`test-renderer`](https://github.com/mdjastrzebski/test-renderer) package (and its `TestInstance` type). The `ReactTestInstance` type was only used as the `getAnimatedStyle` parameter, which immediately casts it away via `as unknown as TestComponent` — making it purely decorative.

The structural replacement `{ props: Record<string, unknown> }` is compatible with both `ReactTestInstance` (RNTL v13) and `TestInstance` (RNTL v14) via TypeScript's structural typing — I verified both compile cleanly. No consumer code changes needed.

**Before:** Published `jestUtils/index.d.ts` imports from `react-test-renderer`, which isn't in `dependencies` — breaks consumers with `skipLibCheck: false`.

**After:** No external type import in `jestUtils`. Works for all consumers regardless of `skipLibCheck` setting.

## Test plan

**Structural type compatibility** — tested with both `ReactTestInstance` (`@types/react-test-renderer@19.1.0`) and `TestInstance` (`test-renderer@0.15.0`). Both accepted by the structural type. Invalid inputs (missing `props`, wrong type, `null`) correctly rejected.

**Consumer reproduction** — patched the published `lib/typescript/jestUtils/index.d.ts` in a consumer project with `skipLibCheck: false` and no `@types/react-test-renderer` installed. Before: `TS2307: Cannot find module 'react-test-renderer'`. After: gone.

**Upstream quality gates:**
```
yarn workspace react-native-reanimated type:check:src:native
```
Zero regressions (same pre-existing `react-native-worklets` errors only).
