### PR TITLE
fix: Reanimated synchronous events

### DIFF
--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -67,6 +67,7 @@ declare global {
   var __customSerializationRegistry: CustomSerializationRegistry;
   var __customSerializableUnpacker: CustomSerializableUnpacker;
   var __callGuardDEV: typeof callGuardDEV | undefined;
+  /** @deprecated Don't flush animation frames imperatively. Don't use. */
   var __flushAnimationFrame: (timestamp: number) => void;
   var __frameTimestamp: number | undefined;
   var _log: (value: unknown) => void;

--- a/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
+++ b/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
@@ -62,8 +62,10 @@ export function setupRequestAnimationFrame() {
   globalThis.requestAnimationFrame = requestAnimationFrame;
   globalThis.cancelAnimationFrame =
     cancelAnimationFrame as typeof globalThis.cancelAnimationFrame;
-  globalThis.__flushAnimationFrame = () => {
-    // NOOP for backwards compatibility
+  globalThis.__flushAnimationFrame = (eventTimestamp: number) => {
+    // TODO: Remove this in the future.
+    // Reanimated uses this method to trigger event synchronously.
+    flushQueue(eventTimestamp);
   };
 
   /* Start the loop */


### PR DESCRIPTION
## Summary

I introduced a regression in
- #8900
where Reanimated wouldn't be able to imperatively flush the animation frame queue anymore, resulting in using "wrong" timestamps for animation updates coming from events.

This is more of a band-aid fix as imperative flushes have always had other issues...

## Test plan

Stinky header example works again
