### PR TITLE
fix: RN 0.81 TS errors

### DIFF
--- a/apps/common-app/src/apps/css/components/cards/ExpandableCard.tsx
+++ b/apps/common-app/src/apps/css/components/cards/ExpandableCard.tsx
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
     color: colors.primary,
   },
   gradient: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     pointerEvents: 'none',
   },
   overlay: {

--- a/apps/common-app/src/apps/css/components/examples/ExampleCard.tsx
+++ b/apps/common-app/src/apps/css/components/examples/ExampleCard.tsx
@@ -163,7 +163,7 @@ export default function ExampleCard({
 const styles = StyleSheet.create({
   collapsedCodeOverlay: {
     ...Platform.select<ViewStyle>({
-      default: StyleSheet.absoluteFill,
+      default: StyleSheet.absoluteFill as object,
       web: { height: '100%', position: 'absolute', width: '100%' },
     }),
     backgroundColor: colors.background2,

--- a/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
+++ b/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
@@ -213,7 +213,7 @@ const styles = StyleSheet.create({
     color: colors.white,
   },
   buttons: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -145,7 +145,7 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
 
 const styles = StyleSheet.create({
   tab: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
   },
   tabBar: {
     backgroundColor: colors.white,

--- a/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
@@ -368,7 +368,7 @@ function Backdrop({ handleClose }: BackdropProps): JSX.Element {
 
 const styles = StyleSheet.create({
   backdrop: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     backgroundColor: 'rgba(0, 0, 0, 0.2)',
   },
   scrollBarThumb: {

--- a/apps/common-app/src/apps/css/components/misc/Label.tsx
+++ b/apps/common-app/src/apps/css/components/misc/Label.tsx
@@ -72,7 +72,7 @@ export default function Label({ size = 'small', type }: LabelProps) {
 
 const styles = StyleSheet.create({
   background: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     opacity: 0.05,
   },
   label: {

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowColor.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowColor.tsx
@@ -22,7 +22,7 @@ export default function TextShadowColor() {
             animation,
             Platform.select({
               android: {
-                ...StyleSheet.absoluteFill,
+                ...(StyleSheet.absoluteFill as object),
                 textAlign: 'center',
                 textAlignVertical: 'center',
               },

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowOffset.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowOffset.tsx
@@ -22,7 +22,7 @@ export default function TextShadowOffset() {
             animation,
             Platform.select({
               android: {
-                ...StyleSheet.absoluteFill,
+                ...(StyleSheet.absoluteFill as object),
                 textAlign: 'center',
                 textAlignVertical: 'center',
               },

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowRadius.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/shadows/TextShadowRadius.tsx
@@ -22,7 +22,7 @@ export default function TextShadowRadius() {
             animation,
             Platform.select({
               android: {
-                ...StyleSheet.absoluteFill,
+                ...(StyleSheet.absoluteFill as object),
                 textAlign: 'center',
                 textAlignVertical: 'center',
               },

--- a/apps/common-app/src/apps/css/examples/animations/screens/realWorldExamples/SpinnersAndLoaders.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/realWorldExamples/SpinnersAndLoaders.tsx
@@ -159,7 +159,7 @@ const ringPart = css.keyframes({
 
 const ringStyles = css.create({
   part: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     animationDuration: '1.2s',
     animationIterationCount: 'infinite',
     animationName: ringPart,
@@ -455,7 +455,7 @@ const dualRing = css.keyframes({
 
 const dualRingStyles = css.create({
   ring: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     animationDuration: '0.6s',
     animationIterationCount: 'infinite',
     animationName: dualRing,
@@ -573,7 +573,7 @@ const doublePulse = css.keyframes({
 
 const doublePulseStyles = css.create({
   pulse: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     animationDuration: '1.5s',
     animationIterationCount: 'infinite',
     animationName: doublePulse,
@@ -778,7 +778,7 @@ const diamondStyles = css.create({
     justifyContent: 'center',
   },
   part: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     animationDuration: '2.4s',
     animationIterationCount: 'infinite',
     animationName: diamond,

--- a/apps/common-app/src/apps/css/examples/transitions/components/TransitionStyleChange.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/components/TransitionStyleChange.tsx
@@ -139,7 +139,7 @@ export default memo(TransitionStyleChange);
 
 const styles = StyleSheet.create({
   activeCardBackground: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     backgroundColor: colors.primary,
     borderRadius: radius.md,
   },

--- a/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/AppSettings.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/realWorldExamples/AppSettings.tsx
@@ -281,7 +281,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.xl,
   },
   fontSizeBackground: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     backgroundColor: 'rgba(255, 255, 255, 0.1)',
     borderColor: 'rgba(255, 255, 255, 0.5)',
     borderRadius: radius.full,
@@ -324,7 +324,7 @@ const styles = StyleSheet.create({
     width: sizes.md,
   },
   switchBackground: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     borderRadius: radius.full,
   },
   switchThumb: {
@@ -334,7 +334,7 @@ const styles = StyleSheet.create({
     width: 20,
   },
   thumbPressIndicator: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     backgroundColor: colors.white,
     borderRadius: radius.full,
   },

--- a/apps/common-app/src/apps/reanimated/examples/LightBoxExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LightBoxExample.tsx
@@ -302,7 +302,7 @@ const styles = StyleSheet.create({
   },
 
   backdrop: {
-    ...StyleSheet.absoluteFill,
+    ...(StyleSheet.absoluteFill as object),
     backgroundColor: 'black',
   },
 });


### PR DESCRIPTION
## Summary

The type of `absoluteFill` is a bit broken in RN 0.81 and differs from the type in later version.

Fixes https://github.com/software-mansion/react-native-reanimated/actions/runs/22639901636/job/65612814183

## Test plan

TS Compatibility CI: https://github.com/software-mansion/react-native-reanimated/actions/runs/22678205431
