### PR TITLE
chore: skip pre-commit on merge commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,11 @@ print() {
   echo "    [PRECOMMIT]: $1" >&2
 }
 
+if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
+  print "Merge commit detected. Skipping pre-commit hooks."
+  exit 0
+fi
+
 check_and_lint_docs() {
   local staged_files="$1"
   local docs_path="$2"


### PR DESCRIPTION
## Summary

QoL change. When merging main to your branch sometimes the merge commit is so big that the pre-commit takes either super long or will always fail.

## Test plan

🚀 
