### PR TITLE
fix: CSS animation box-shadow crashes

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2494,7 +2494,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
-  hermes-engine: b0c1c9077a7d24f282b91f77b7c16d86eae33260
+  hermes-engine: a07e0374b16896db9d1d3de0bb2c556670126c25
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: 7fe66a61d5acab6516098a64f42af575595e7566
   NitroModules: 70861471ee1cc5616462aef869a164dac12db7b9
@@ -2506,7 +2506,7 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: ae019eafec3dd5b68b56e7fba6fec533108a5078
+  React-Core-prebuilt: d672e768c6c0e6ac95eb5d1aee6803245b362c1d
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
   React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
@@ -2568,7 +2568,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
   ReactCodegen: f66521b131699d6af0790f10653933b3f1f79a6f
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
-  ReactNativeDependencies: b37302389d5b73b0beb45af0348b24ea15e51e3e
+  ReactNativeDependencies: 09194d6c899ffd06c690fe018b7101b20e920ab8
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCClipboard: 88d7eeb555d1183915f0885bdbc5c97eb6f7f3ba
   RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
@@ -9,7 +9,6 @@ import {
   getSeparatelyInterpolatedNestedProperties,
   isDefined,
   isNumber,
-  isRecord,
   ReanimatedError,
 } from '../../../../common';
 import { PERCENTAGE_REGEX } from '../../../constants';
@@ -110,7 +109,7 @@ export function processKeyframes(
 
 function processProps(
   offset: number,
-  props: UnknownRecord,
+  props: object,
   keyframeProps: AnyRecord,
   separatelyInterpolatedNestedProperties: ReadonlySet<string>
 ) {
@@ -120,7 +119,8 @@ function processProps(
     }
 
     if (
-      isRecord(value) &&
+      /* this object type check is correct as it accepts records and arrays */
+      typeof value === 'object' &&
       separatelyInterpolatedNestedProperties.has(property)
     ) {
       if (!keyframeProps[property]) {


### PR DESCRIPTION
## Summary

This PR fixes the issue introduced in the #8757 PR where I changed the `typeof value === 'object'` check to `isRecord(value)`. We need to keep the object type check to ensure the if statement is entered also when an array value is passed (not only for records).

## Test plan

Open the **Box Shadow** CSS example (under **Animated Properties**) and see that it works now.