### PR TITLE
fix: useHandler cleanup on fast refresh

### DIFF
--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.test.tsx
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.test.tsx
@@ -1,7 +1,15 @@
 'use strict';
 
 import { worklet } from '../../jestUtils';
+import { useIsFastRefresh } from '../utils';
 import { renderUseHandler, runCommonTests } from './useHandler.shared';
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  useIsFastRefresh: jest.fn(() => false),
+}));
+
+const mockFastRefresh = useIsFastRefresh as jest.Mock;
 
 function nonWorkletError(...names: string[]) {
   return new Error(
@@ -86,6 +94,41 @@ describe('useHandler (native)', () => {
       // handler changes - true despite empty deps array
       rerender({ handlers: { onScroll: worklet() }, deps: [] });
       expect(result.current.doDependenciesDiffer).toBe(true);
+    });
+  });
+
+  describe('fast refresh', () => {
+    test('flips doDependenciesDiffer to true even when worklet is unchanged', () => {
+      const w = worklet();
+      const { result, rerender } = renderUseHandler({ onScroll: w });
+
+      // We expect doDependenciesDiffer to be true on the first render.
+      expect(result.current.doDependenciesDiffer).toBe(true);
+
+      // Rerender with the same worklet handler - doDependenciesDiffer should be false.
+      rerender({ handlers: { onScroll: w } });
+      expect(result.current.doDependenciesDiffer).toBe(false);
+
+      // Next render is a fast refresh - doDependenciesDiffer should be true (behave as if it was a first render).
+      mockFastRefresh.mockReturnValueOnce(true);
+      rerender({ handlers: { onScroll: w } });
+      expect(result.current.doDependenciesDiffer).toBe(true);
+
+      // Subsequent renders return to normal behavior - doDependenciesDiffer should be false.
+      rerender({ handlers: { onScroll: w } });
+      expect(result.current.doDependenciesDiffer).toBe(false);
+    });
+
+    test('context is reinitialized after fast refresh', () => {
+      const w = worklet();
+      const { result, rerender } = renderUseHandler({ onScroll: w });
+
+      const firstContext = result.current.context;
+
+      mockFastRefresh.mockReturnValueOnce(true);
+      rerender({ handlers: { onScroll: w } });
+
+      expect(result.current.context).not.toBe(firstContext);
     });
   });
 });

--- a/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
+++ b/packages/react-native-reanimated/src/hook/__tests__/useHandler.web.test.tsx
@@ -1,6 +1,14 @@
 'use strict';
 
+import { useIsFastRefresh } from '../utils';
 import { renderUseHandler, runCommonTests } from './useHandler.shared';
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  useIsFastRefresh: jest.fn(() => false),
+}));
+
+const mockFastRefresh = useIsFastRefresh as jest.Mock;
 
 describe('useHandler (web)', () => {
   runCommonTests();
@@ -91,6 +99,86 @@ describe('useHandler (web)', () => {
 
         rerender({ handlers: { onScroll: handler } });
         expect(result.current.doDependenciesDiffer).toBe(true);
+      });
+    });
+  });
+
+  describe('fast refresh', () => {
+    describe('without babel plugin', () => {
+      const fastRefreshCases: Array<{
+        caseName: string;
+        initialDeps: number[] | undefined;
+        nextDeps: number[] | undefined;
+        expected: [boolean, boolean, boolean, boolean];
+      }> = [
+        {
+          caseName: 'undefined deps',
+          initialDeps: undefined,
+          nextDeps: undefined,
+          expected: [true, true, true, true],
+        },
+        {
+          caseName: 'empty deps array',
+          initialDeps: [],
+          nextDeps: [],
+          expected: [false, false, true, false],
+        },
+        {
+          caseName: 'non-empty deps array',
+          initialDeps: [1],
+          nextDeps: [1],
+          expected: [true, false, true, false],
+        },
+        {
+          caseName: 'changing deps between renders',
+          initialDeps: [1],
+          nextDeps: [2],
+          expected: [true, true, true, false],
+        },
+      ];
+
+      fastRefreshCases.forEach(
+        ({
+          caseName,
+          initialDeps,
+          nextDeps,
+          expected: [
+            firstRenderValue,
+            secondRenderValue,
+            fastRefreshValue,
+            postRefreshValue,
+          ],
+        }) => {
+          test(`handles fast-refresh behavior for ${caseName}`, () => {
+            const handler = jest.fn();
+            const { result, rerender } = renderUseHandler(
+              { onScroll: handler },
+              initialDeps
+            );
+
+            // Initial render.
+            expect(result.current.doDependenciesDiffer).toBe(firstRenderValue);
+
+            // Second render can keep deps stable or change them.
+            rerender({ handlers: { onScroll: handler }, deps: nextDeps });
+            expect(result.current.doDependenciesDiffer).toBe(secondRenderValue);
+
+            // Fast refresh render.
+            mockFastRefresh.mockReturnValueOnce(true);
+            rerender({ handlers: { onScroll: handler }, deps: nextDeps });
+            expect(result.current.doDependenciesDiffer).toBe(fastRefreshValue);
+
+            // Post-fast-refresh render.
+            rerender({ handlers: { onScroll: handler }, deps: nextDeps });
+            expect(result.current.doDependenciesDiffer).toBe(postRefreshValue);
+          });
+        }
+      );
+
+      test('first-mount `[]` spec is still preserved (no false positive)', () => {
+        // Guard against false positives on initial mount with [] deps.
+        const { result } = renderUseHandler({ onScroll: jest.fn() }, []);
+        expect(result.current.doDependenciesDiffer).toBe(false);
       });
     });
   });

--- a/packages/react-native-reanimated/src/hook/useHandler.ts
+++ b/packages/react-native-reanimated/src/hook/useHandler.ts
@@ -7,6 +7,7 @@ import type { WorkletClosure } from 'react-native-worklets/lib/typescript/types'
 import type { UnknownRecord } from '../common';
 import { IS_WEB } from '../common';
 import type { DependencyList, ReanimatedEvent } from './commonTypes';
+import { useIsFastRefresh } from './utils';
 
 interface GeneralHandler<
   TEvent extends object,
@@ -147,11 +148,25 @@ export function useHandler<Event extends object, Context extends UnknownRecord>(
     prevDependencies: DependencyList;
   } | null>(null);
 
+  // On fast refresh we want the hook to behave as a first render rather
+  // than a re-render, so `doDependenciesDiffer` is reported as true and
+  // consumers can rebuild native bindings tied to pre-refresh JS identities.
+  // See https://github.com/software-mansion/react-native-reanimated/pull/9075.
+  const isFastRefresh = useIsFastRefresh();
+  if (isFastRefresh) {
+    stateRef.current = null;
+  }
+
   if (stateRef.current === null) {
     stateRef.current = {
       context: makeShareable({} as Context),
       prevHandlers: undefined,
-      prevDependencies: [],
+      // Only matters on the web/no-plugin path, where `areDependenciesEqual`
+      // drives the result. Without the ternary, `deps=[]` consumers would
+      // miss the fast-refresh behavior because `areDependenciesEqual([], [])`
+      // is true. `undefined` ensures that the comparison returns `true` so
+      // that consumers can re-register handlers.
+      prevDependencies: isFastRefresh ? undefined : [],
     };
   }
 

--- a/packages/react-native-reanimated/src/hook/utils.ts
+++ b/packages/react-native-reanimated/src/hook/utils.ts
@@ -1,4 +1,29 @@
 'use strict';
+import { useMemo, useRef } from 'react';
+
+/**
+ * Returns `true` on the render immediately following a fast refresh.
+ *
+ * Relies on `useMemo`'s cached value being reset when the component's hook
+ * signature is refreshed while `useRef` is preserved - a mismatch between the
+ * two proves the module was re-executed. Always `false` outside `__DEV__` since
+ * fast refresh is a development-only mechanism.
+ */
+/* eslint-disable react-hooks/rules-of-hooks -- __DEV__ is build-constant */
+export function useIsFastRefresh(): boolean {
+  'use no memo';
+  if (!__DEV__) {
+    return false;
+  }
+  const signal = useMemo(() => ({}), []);
+  const prev = useRef(signal);
+  if (prev.current === signal) {
+    return false;
+  }
+  prev.current = signal;
+  return true;
+}
+/* eslint-enable react-hooks/rules-of-hooks */
 
 export function isAnimated(prop: unknown) {
   'worklet';


### PR DESCRIPTION
## Summary

The `doDependenciesDiffer` flag is set to false after the first hot reload (it is true after all other reloads). This PR adds a check whether we have a hot reload, and set `doDependenciesDiffer` to true in that case.

Moreover, I noticed that the cleanup in the `useEffect` doesn't check whether the ref it cleans is the one it started with. Due to some race conditions after a hot reload the cleanup runs just after the mount, cleaning the newly attached ref. I added a check in cleanup.

The motivation for the fix is that RNGH relies on the `doDependenciesDiffer` flag to rebuild its handlers. See PR with a workaround in RNGH: https://github.com/software-mansion/react-native-gesture-handler/pull/3997

## Test plan

Tested on the following example:

<details>

```tsx

import React from 'react';
import { View, Text } from 'react-native';
import { useHandler } from 'react-native-reanimated';

export default function TestComponent() {

  const handlers = {
    onEvent: () => {
      'worklet';
      console.log("run!");
    }
  };

  const { doDependenciesDiffer } = useHandler(handlers, []);

  // const testString = "comment this out";

  return (
    <View style={{ marginTop: 100, alignItems: 'center' }}>
      <Text style={{ fontSize: 20, marginVertical: 30, fontWeight: 'bold' }}>
        doDependenciesDiffer: <Text style={{ color: doDependenciesDiffer ? 'green' : 'red' }}>{String(doDependenciesDiffer)}</Text>
      </Text>
    </View>
  );
}

```

</details>

Before the fix, on first reload the `doDependenciesDiffer` flag was set to false after first hot reload, this caused issues in RNGH (see https://github.com/software-mansion/react-native-gesture-handler/pull/3997).
After the fix it is true on every hot reload.
