### PR TITLE
fix: box-shadow runtime test example animating inset

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/props/boxShadow.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/props/boxShadow.test.tsx
@@ -114,7 +114,6 @@ describe('animation of BoxShadow', () => {
     const passiveBoxShadowFinal = JSON.parse(
       await passiveComponent.getAnimatedStyle('boxShadow'),
     ) as unknown as BoxShadowValue[];
-
     const activeBoxShadowFinal = JSON.parse(
       await activeComponent.getAnimatedStyle('boxShadow'),
     ) as unknown as BoxShadowValue[];


### PR DESCRIPTION
## Summary

## Test plan
