### PR TITLE
fix: lint-clang-tidy CI triggering on each merge

### DIFF
--- a/.github/workflows/lint-clang-tidy.yml
+++ b/.github/workflows/lint-clang-tidy.yml
@@ -3,8 +3,15 @@ env:
   YARN_ENABLE_HARDENED_MODE: 0
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/lint-clang-tidy.yml'
+
+  merge_group:
+    branches:
+      - main
+
   pull_request:
     paths:
       - '.github/workflows/lint-clang-tidy.yml'


### PR DESCRIPTION
## Summary

The CI now triggers on each merge to main, regardless of what PR was merged.

It's supposed to only be ran only if the workflow file contents are changed, triggered via nightly by workflow_call or manually by workflow_dispatch.

## Test plan

Next merge will tell us the truth
