### PR TITLE
docs: Say that v3 is no longer actively maintained

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -18,7 +18,7 @@ With Reanimated, you can easily create smooth animations and interactions that r
 ## Prerequisites
 
 Reanimated 4.x works only with [the React Native New Architecture (Fabric)](https://reactnative.dev/architecture/landing-page).
-If your app still uses the old architecture, you can use Reanimated in version 3 which is still actively maintained.
+If your app still uses the old architecture, you can use Reanimated in version 3 (which is no longer actively maintained).
 
 Alternatively, you can dive into [our examples](https://github.com/software-mansion/react-native-reanimated/tree/main/apps/common-app/src/apps) on GitHub.
 

--- a/docs/docs-reanimated/docs/guides/compatibility.mdx
+++ b/docs/docs-reanimated/docs/guides/compatibility.mdx
@@ -6,7 +6,7 @@ sidebar_label: Compatibility
 # Compatibility table
 
 :::info
-Reanimated 4 works only with the React Native New Architecture. If your app still uses the old architecture, you can use Reanimated in version 3 which is still actively maintained.
+Reanimated 4 works only with the React Native New Architecture. If your app still uses the old architecture, you can use Reanimated in version 3 (which is no longer actively maintained).
 :::
 
 ### Supported React Native versions


### PR DESCRIPTION
## Summary

We had inconsistent info about v3 maintenance in docs. I unified the v3 maintenance info text.

The issue was originally reported in this discussion: #9051