### PR TITLE
fix(Worklets): cascade raf callbacks with reanimated

### DIFF
--- a/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
+++ b/packages/react-native-worklets/src/runLoop/uiRuntime/requestAnimationFrame.ts
@@ -50,13 +50,17 @@ export function setupRequestAnimationFrame() {
     }
   }
 
+  function nativeFlushQueue(timestamp: number) {
+    flushQueue(timestamp);
+
+    /* Schedule next frame */
+    nativeRequestAnimationFrame(nativeFlushQueue);
+  }
+
   function flushQueue(timestamp: number) {
     globalThis.__frameTimestamp = timestamp;
     executeQueue(timestamp);
     globalThis.__frameTimestamp = undefined;
-
-    /* Schedule next frame */
-    nativeRequestAnimationFrame(flushQueue);
   }
 
   globalThis.requestAnimationFrame = requestAnimationFrame;
@@ -69,5 +73,5 @@ export function setupRequestAnimationFrame() {
   };
 
   /* Start the loop */
-  nativeRequestAnimationFrame(flushQueue);
+  nativeRequestAnimationFrame(nativeFlushQueue);
 }


### PR DESCRIPTION
## Summary

Fixing regression introduced in #9057. Reanimated imperative calls to `__flushAnimationFrame` would result in exponential scheduling of more native animation frame queue flushes.

With this change we make sure only one native flush is scheduled at most.

## Test plan

Stinky Header -> Bokeh Example no longer lags like crazy.
