### PR TITLE
fix: logger mock in jest unit tests

### DIFF
--- a/packages/react-native-reanimated/__tests__/logger.test.ts
+++ b/packages/react-native-reanimated/__tests__/logger.test.ts
@@ -1,0 +1,71 @@
+import { configureReanimatedLogger } from '../src';
+import { logger, ReanimatedLogLevel } from '../src/common';
+
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+afterEach(() => {
+  warnSpy.mockClear();
+  errorSpy.mockClear();
+});
+
+const containing = (msg: string) => expect.stringContaining(msg);
+
+describe('default settings', () => {
+  test.each([
+    ['warn', (msg: string) => logger.warn(msg), warnSpy, errorSpy],
+    ['error', (msg: string) => logger.error(msg), errorSpy, warnSpy],
+  ] as const)(
+    'logger.%s forwards to matching console method',
+    (_level, log, expectedSpy, otherSpy) => {
+      log('test message');
+
+      expect(expectedSpy).toHaveBeenCalledWith(containing('test message'));
+      expect(otherSpy).not.toHaveBeenCalled();
+    }
+  );
+});
+
+describe('level: error', () => {
+  beforeEach(() => {
+    configureReanimatedLogger({ level: ReanimatedLogLevel.error });
+  });
+
+  test('suppresses warnings but not errors', () => {
+    logger.warn('suppressed');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    logger.error('visible');
+    expect(errorSpy).toHaveBeenCalledWith(containing('visible'));
+  });
+});
+
+describe('strict: true', () => {
+  beforeEach(() => {
+    configureReanimatedLogger({ strict: true });
+  });
+
+  test.each([
+    ['warn', (msg: string) => logger.warn(msg, { strict: true }), warnSpy],
+    ['error', (msg: string) => logger.error(msg, { strict: true }), errorSpy],
+  ] as const)('forwards strict %s with docs reference', (_level, log, spy) => {
+    log('strict message');
+
+    expect(spy).toHaveBeenCalledWith(containing('strict message'));
+    expect(spy).toHaveBeenCalledWith(containing('https://docs.swmansion.com'));
+  });
+});
+
+describe('strict: false', () => {
+  beforeEach(() => {
+    configureReanimatedLogger({ strict: false });
+  });
+
+  test('suppresses strict messages but not regular ones', () => {
+    logger.warn('strict-only', { strict: true });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    logger.warn('regular');
+    expect(warnSpy).toHaveBeenCalledWith(containing('regular'));
+  });
+});

--- a/packages/react-native-reanimated/jest/setup.js
+++ b/packages/react-native-reanimated/jest/setup.js
@@ -4,18 +4,16 @@ require('../src/jestUtils').setUpTests();
 global.__reanimatedLoggerConfig = {
   logFunction: (data) => {
     switch (data.level) {
-      case 'warn':
+      case 1: // ReanimatedLogLevel.warn
         // eslint-disable-next-line reanimated/use-logger
-        console.warn(data.message.content);
+        console.warn(data.message);
         break;
-      case 'error':
-      case 'fatal':
-      case 'syntax':
+      case 2: // ReanimatedLogLevel.error
         // eslint-disable-next-line reanimated/use-logger
-        console.error(data.message.content);
+        console.error(data.message);
         break;
     }
   },
-  level: 'warn',
+  level: 1, // ReanimatedLogLevel.warn
   strict: false,
 };


### PR DESCRIPTION
## Summary

The old mock wasn't really working. The new one works properly. I also added unit tests to ensure that the mock for the logger works as expeted.