### PR TITLE
cherry-pick(Worklets): Fix bundle mode on windows (#8910)

### DIFF
--- a/.yarn/patches/metro-npm-0.83.2-d09f48ca84.patch
+++ b/.yarn/patches/metro-npm-0.83.2-d09f48ca84.patch
@@ -1,12 +1,24 @@
 diff --git a/src/node-haste/DependencyGraph.js b/src/node-haste/DependencyGraph.js
-index bd42485a8a6647757c0f5b2f2c4a5e659125fcdd..417de6c997067b4b1c686c35fe5007ba199b3897 100644
+index bd42485a8a6647757c0f5b2f2c4a5e659125fcdd..c6b28aac45cfa757468ad9b064638c5b7ca78153 100644
 --- a/src/node-haste/DependencyGraph.js
 +++ b/src/node-haste/DependencyGraph.js
-@@ -186,6 +186,14 @@ class DependencyGraph extends _events.default {
+@@ -32,6 +32,11 @@ function getOrCreateMap(map, field) {
+   }
+   return subMap;
+ }
++
++const workletsDirPath = _path.default.join(
++  "react-native-worklets",
++  ".worklets",
++);
+ class DependencyGraph extends _events.default {
+   #packageCache;
+   constructor(config, options) {
+@@ -186,6 +191,14 @@ class DependencyGraph extends _events.default {
      return (0, _nullthrows.default)(this._fileSystem).getAllFiles();
    }
    async getOrComputeSha1(mixedPath) {
-+    if (mixedPath.includes("react-native-worklets/.worklets/")) {
++    if (mixedPath.includes(workletsDirPath)) {
 +      const createHash = require("crypto").createHash;
 +      return {
 +        sha1: createHash("sha1")

--- a/packages/react-native-worklets/bundleMode/index.js
+++ b/packages/react-native-worklets/bundleMode/index.js
@@ -28,6 +28,8 @@ function getEntryPoints() {
   return entryPoints;
 }
 
+const workletsDirPath = path.join('react-native-worklets', '.worklets');
+
 module.exports = {
   bundleModeMetroConfig: {
     serializer: {
@@ -44,7 +46,7 @@ module.exports = {
           if (idFileMap.has(moduleName)) {
             return idFileMap.get(moduleName);
           }
-          if (moduleName.includes('react-native-worklets/.worklets/')) {
+          if (moduleName.includes(workletsDirPath)) {
             const base = path.basename(moduleName, '.js');
             const id = Number(base);
             idFileMap.set(moduleName, id);


### PR DESCRIPTION
Metro passes absolute paths to the moduleId factory. This means that on Windows (where `\` is used as a path separator), the worklet subpath check (which expects a `/` separator) failed, so worklets didn't end up getting the expected moduleId, resulting in a crash in the hermes VM.

Still not sure why this resulted in a crash instead of a runtime error (possibly broke some assumption in native bundle mode code?), but this at least fixes this in this use case by normalizing the path prior to the check.
