### PR TITLE
cherry-pick(Worklets): chore(Worklets): Bundle Mode setup improvements (#9082)

### DIFF
--- a/.github/workflows/example-android-build-check.yml
+++ b/.github/workflows/example-android-build-check.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn install --immutable
       - name: Toggle Bundle Mode
         if: ${{ inputs.bundleMode }}
-        run: ./scripts/toggle-bundle-mode.sh
+        run: yarn toggle-bundle-mode
       - name: Build Reanimated package
         working-directory: ${{ env.REANIMATED_DIR }}
         run: yarn build

--- a/.github/workflows/example-ios-build-check.yml
+++ b/.github/workflows/example-ios-build-check.yml
@@ -61,7 +61,7 @@ jobs:
         run: yarn install --immutable
       - name: Toggle Bundle Mode
         if: ${{ inputs.bundleMode }}
-        run: ./scripts/toggle-bundle-mode.sh
+        run: yarn toggle-bundle-mode
       - name: Build Reanimated package
         working-directory: ${{ env.REANIMATED_DIR }}
         run: yarn build

--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -56,26 +56,45 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
 
 2. **Modify your Metro configuration**. Metro needs to be configured pre-load Bundle Mode entry points into your JavaScript bundle. In your `metro.config.js` file, apply the config required for the bundle mode. For example:
 
-   ```javascript {6-8,16}
-   const {
-     getDefaultConfig,
-     mergeConfig,
-   } = require('@react-native/metro-config');
+<Tabs groupId="framework">
+  <TabItem value="expo" label="Expo">
+    ```javascript {4,9}
+    // Learn more https://docs.expo.io/guides/customizing-metro
+    const { getDefaultConfig, mergeConfig } = require("expo/metro-config");
 
-   const {
-     bundleModeMetroConfig,
-   } = require('react-native-worklets/bundleMode');
+    @type {import('expo/metro-config').MetroConfig} */
+    let config = getDefaultConfig(__dirname);
 
-   const config = {
-     // Your Metro config
-   };
+    // Your modifications to the config
 
-   module.exports = mergeConfig(
-     getDefaultConfig(__dirname),
-     bundleModeMetroConfig,
-     config
-   );
-   ```
+    config = getBundleModeMetroConfig(config);
+
+    module.exports = config;
+    ```
+
+  </TabItem>
+  <TabItem value="react-native-community" label="React Native Community">
+    ```javascript {6,12-16}
+    const {
+      getDefaultConfig,
+      mergeConfig,
+    } = require('@react-native/metro-config');
+
+    const { bundleModeMetroConfig } = require('react-native-worklets/bundleMode');
+
+    const config = {
+      // Your Metro config
+    };
+
+    module.exports = mergeConfig(
+      getDefaultConfig(__dirname),
+      bundleModeMetroConfig,
+      config
+    );
+    ```
+
+  </TabItem>
+</Tabs>
 
 ## Configure your app
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "format:workspaces": "yarn workspaces foreach --all --exclude \"react-native-reanimated-monorepo\" --parallel --topological-dev run format",
     "lint": "yarn lint:root && yarn lint:workspaces",
     "lint:workspaces": "yarn workspaces foreach --all --exclude \"react-native-reanimated-monorepo\" --parallel --topological-dev run lint",
-    "lint:root": "eslint . --ignore-pattern 'packages/**' --ignore-pattern 'apps/**' --ignore-pattern 'docs/**' && yarn prettier --check --ignore-path .gitignore --ignore-path .prettierignore --ignore-path .prettiereslintignore ."
+    "lint:root": "eslint . --ignore-pattern 'packages/**' --ignore-pattern 'apps/**' --ignore-pattern 'docs/**' && yarn prettier --check --ignore-path .gitignore --ignore-path .prettierignore --ignore-path .prettiereslintignore .",
+    "toggle-bundle-mode": "bash ./scripts/toggle-bundle-mode.sh"
   },
   "devDependencies": {
     "@babel/core": "7.28.4",

--- a/packages/react-native-worklets/.gitignore
+++ b/packages/react-native-worklets/.gitignore
@@ -62,4 +62,5 @@ apple/generated
 android/generated
 
 # worklets
-.worklets/
+.worklets/*
+!.worklets/dummy.md

--- a/packages/react-native-worklets/.worklets/dummy.md
+++ b/packages/react-native-worklets/.worklets/dummy.md
@@ -1,0 +1,1 @@
+The purpose of this file is always have `.worklets` directory in the package, as some environments have trouble creating it dynamically.

--- a/packages/react-native-worklets/bundleMode/index.d.ts
+++ b/packages/react-native-worklets/bundleMode/index.d.ts
@@ -1,3 +1,6 @@
 declare module 'react-native-worklets/bundleMode' {
+  /** Use in React Native Community projects. */
   export const bundleModeMetroConfig: any;
+  /** Use in Expo projects. */
+  export function getBundleModeMetroConfig(): any;
 }

--- a/packages/react-native-worklets/bundleMode/index.js
+++ b/packages/react-native-worklets/bundleMode/index.js
@@ -1,9 +1,91 @@
-const { getDefaultConfig } = require('@react-native/metro-config');
+/* eslint-disable */
+// @ts-nocheck
 const path = require('path');
+
+let getDefaultConfig = () => ({});
+try {
+  getDefaultConfig = require('@react-native/metro-config').getDefaultConfig;
+} catch {
+  /* empty */
+}
 
 const workletsPackageParentDir = path.resolve(__dirname, '../..');
 
 const defaults = getDefaultConfig(__dirname);
+
+const workletsDirPath = path.join('react-native-worklets', '.worklets');
+
+function bundleModeResolveRequest(
+  /** @type {any} */ context,
+  /** @type {string} */ moduleName,
+  /** @type {any} */ platform
+) {
+  if (moduleName.startsWith(workletsDirPath)) {
+    const fullModuleName = path.join(workletsPackageParentDir, moduleName);
+    return { type: 'sourceFile', filePath: fullModuleName };
+  }
+  return context.resolveRequest(context, moduleName, platform);
+}
+
+/** Use in React Native Community projects. */
+const bundleModeMetroConfig = {
+  serializer: {
+    getModulesRunBeforeMainModule(/** @type {string} dirname */ dirname) {
+      return [
+        ...getEntryPoints(),
+        ...(defaults?.serializer?.getModulesRunBeforeMainModule?.(dirname) ||
+          []),
+      ];
+    },
+    createModuleIdFactory: bundleModeCreateModuleIdFactory,
+  },
+  resolver: {
+    resolveRequest: (
+      /** @type {any} */ context,
+      /** @type {string} */ moduleName,
+      /** @type {any} */ platform
+    ) => {
+      if (moduleName.startsWith(workletsDirPath)) {
+        const fullModuleName = path.join(workletsPackageParentDir, moduleName);
+        return { type: 'sourceFile', filePath: fullModuleName };
+      }
+      return context.resolveRequest(context, moduleName, platform);
+    },
+  },
+};
+
+/** Use in Expo projects. */
+function getBundleModeMetroConfig(config) {
+  const currentGetModulesRunBeforeMainModule =
+    config?.serializer?.getModulesRunBeforeMainModule;
+
+  config.serializer.getModulesRunBeforeMainModule = (
+    /** @type {string} dirname */ dirname
+  ) => [
+    ...getEntryPoints(),
+    ...(currentGetModulesRunBeforeMainModule?.(dirname) || []),
+  ];
+
+  config.serializer.createModuleIdFactory = bundleModeCreateModuleIdFactory;
+
+  config.resolver.resolveRequest = bundleModeResolveRequest;
+
+  const currentGetTransformOptions = config?.transformer?.getTransformOptions;
+  config.transformer.getTransformOptions = async () => {
+    const options = currentGetTransformOptions
+      ? await currentGetTransformOptions()
+      : {};
+    return {
+      ...options,
+      transform: {
+        ...options.transform,
+        inlineRequires: true,
+      },
+    };
+  };
+
+  return config;
+}
 
 function getEntryPoints() {
   const entryPoints = [];
@@ -28,50 +110,25 @@ function getEntryPoints() {
   return entryPoints;
 }
 
-const workletsDirPath = path.join('react-native-worklets', '.worklets');
+function bundleModeCreateModuleIdFactory() {
+  let nextId = 0;
+  const idFileMap = new Map();
+  return (/** @type {string} */ moduleName) => {
+    if (idFileMap.has(moduleName)) {
+      return idFileMap.get(moduleName);
+    }
+    if (moduleName.includes(workletsDirPath)) {
+      const base = path.basename(moduleName, '.js');
+      const id = Number(base);
+      idFileMap.set(moduleName, id);
+      return id;
+    }
+    idFileMap.set(moduleName, nextId++);
+    return idFileMap.get(moduleName);
+  };
+}
 
 module.exports = {
-  bundleModeMetroConfig: {
-    serializer: {
-      getModulesRunBeforeMainModule(/** @type {string} dirname */ dirname) {
-        return [
-          ...getEntryPoints(),
-          ...defaults.serializer.getModulesRunBeforeMainModule(dirname),
-        ];
-      },
-      createModuleIdFactory() {
-        let nextId = 0;
-        const idFileMap = new Map();
-        return (/** @type {string} */ moduleName) => {
-          if (idFileMap.has(moduleName)) {
-            return idFileMap.get(moduleName);
-          }
-          if (moduleName.includes(workletsDirPath)) {
-            const base = path.basename(moduleName, '.js');
-            const id = Number(base);
-            idFileMap.set(moduleName, id);
-            return id;
-          }
-          idFileMap.set(moduleName, nextId++);
-          return idFileMap.get(moduleName);
-        };
-      },
-    },
-    resolver: {
-      resolveRequest: (
-        /** @type {any} */ context,
-        /** @type {string} */ moduleName,
-        /** @type {any} */ platform
-      ) => {
-        if (moduleName.startsWith('react-native-worklets/.worklets/')) {
-          const fullModuleName = path.join(
-            workletsPackageParentDir,
-            moduleName
-          );
-          return { type: 'sourceFile', filePath: fullModuleName };
-        }
-        return context.resolveRequest(context, moduleName, platform);
-      },
-    },
-  },
+  getBundleModeMetroConfig,
+  bundleModeMetroConfig,
 };

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -52,6 +52,7 @@
   "homepage": "https://docs.swmansion.com/react-native-worklets",
   "peerDependencies": {
     "@babel/core": "*",
+    "@react-native/metro-config": "*",
     "react": "*",
     "react-native": "*"
   },
@@ -115,6 +116,8 @@
     "!android/gradlew",
     "!android/gradlew.bat",
     "!android/local.properties",
+    "!.worklets",
+    ".worklets/dummy.md",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
@@ -149,13 +152,6 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.swmansion.worklets"
-    },
-    "ios": {
-      "modulesConformingToProtocol": {
-        "RCTBundleConsumer": [
-          "WorkletsModule"
-        ]
-      }
     }
   }
 }

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -689,9 +689,6 @@ var require_generate = __commonJS({
         comments: false
       })) === null || _a === void 0 ? void 0 : _a.code;
       (0, assert_1.default)(transformedProg, "[Worklets] `transformedProg` is undefined.");
-      if (!(0, fs_1.existsSync)(filesDirPath)) {
-        (0, fs_1.mkdirSync)(filesDirPath, {});
-      }
       const dedicatedFilePath = (0, path_1.resolve)(filesDirPath, `${workletHash}.js`);
       (0, fs_1.writeFileSync)(dedicatedFilePath, transformedProg);
     }

--- a/packages/react-native-worklets/plugin/src/generate.ts
+++ b/packages/react-native-worklets/plugin/src/generate.ts
@@ -13,7 +13,7 @@ import {
   stringLiteral,
 } from '@babel/types';
 import assert from 'assert';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { dirname, relative, resolve } from 'path';
 
 import type { WorkletsPluginPass } from './types';
@@ -82,10 +82,6 @@ export function generateWorkletFile(
   })?.code;
 
   assert(transformedProg, '[Worklets] `transformedProg` is undefined.');
-
-  if (!existsSync(filesDirPath)) {
-    mkdirSync(filesDirPath, {});
-  }
 
   const dedicatedFilePath = resolve(filesDirPath, `${workletHash}.js`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29213,6 +29213,7 @@ __metadata:
     typescript: "npm:5.8.3"
   peerDependencies:
     "@babel/core": "*"
+    "@react-native/metro-config": "*"
     react: "*"
     react-native: "*"
   languageName: unknown


### PR DESCRIPTION
Fixing a bunch of setup issues in Bundle Mode
- Better expo integration with separate instructions for the Metro Config
- Adding dummy file `.worklets/dummy.md` for environments where `.worklets` directory couldn't be created ad-hoc. Thanks to that the directory always exists now.
- Removed code responsible for creating `.worklets` directory from the plugin.

I tested it both in our app and in an expo app and the Bundle Mode worked 👍