### PR TITLE
feat: C++ layer for CSS animation events support

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2456,7 +2456,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 4815a9b6c97de1f17c88b3cf7047fc0aa0018fb8
-  hermes-engine: 371db9921d7c37c3b2a8d04b8cbe31156f0a277a
+  hermes-engine: 8b25cc623de93c12f190eb2db7a4f5d9ab813d2d
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
   NitroMmkv: ca0b67493c62d3f2b29457569ee48d24a1f7afd5
   NitroModules: 42fb1740701d25672d7531652987eca15bbb181e
@@ -2468,7 +2468,7 @@ SPEC CHECKSUMS:
   React: ce3b89b04d579b21ba990ff07a1d4cf0a68588dd
   React-callinvoker: 30be38ed761abcb8ae7edaa39e34cb9aade4b33b
   React-Core: 59c718ce09b1b83d4f07c0112b9c5f99ea39ee94
-  React-Core-prebuilt: a76ea4e98bff53e6d1d86863e110eb50efc86fa8
+  React-Core-prebuilt: 97958473b5725670045e4f7929d96ecfae31a367
   React-CoreModules: bcb9314b39eaa9134487be0cb8c8ee4a6d2e5cd9
   React-cxxreact: fee24034f430cfbcbedced4157eacd2be7ced010
   React-debug: 5138aa953fe4a9db1690681de71577dd3b4f05b1
@@ -2530,7 +2530,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: dd8001caba9cb3fbe49a61d234262eaaa3d67aee
   ReactCodegen: 3e81858c6242de4bbde48ee222523fe45c41a21a
   ReactCommon: 2f76f91c78f14d4a2c3bc841842a6145d3e99038
-  ReactNativeDependencies: 1cc786bff619de11c58e19290cbdf3a38d0cadc7
+  ReactNativeDependencies: d3786998f83c8bc5c95d1796dedf158532d28851
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -46,6 +46,22 @@ AnimationProgressState CSSAnimation::getState(double timestamp) const {
   return progressProvider_->getState(timestamp);
 }
 
+unsigned CSSAnimation::getCurrentIteration() const {
+  return progressProvider_->getCurrentIteration();
+}
+
+double CSSAnimation::getDuration() const {
+  return progressProvider_->getDuration();
+}
+
+double CSSAnimation::getDelay() const {
+  return progressProvider_->getDelay();
+}
+
+double CSSAnimation::getIterationCount() const {
+  return progressProvider_->getIterationCount();
+}
+
 bool CSSAnimation::isReversed() const {
   const auto direction = progressProvider_->getDirection();
   return direction == AnimationDirection::Reverse || direction == AnimationDirection::AlternateReverse;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.h
@@ -26,6 +26,10 @@ class CSSAnimation {
 
   double getStartTimestamp(double timestamp) const;
   AnimationProgressState getState(double timestamp) const;
+  unsigned getCurrentIteration() const;
+  double getDuration() const;
+  double getDelay() const;
+  double getIterationCount() const;
   bool isReversed() const;
 
   bool hasForwardsFillMode() const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.cpp
@@ -1,0 +1,31 @@
+#include <reanimated/CSS/core/CSSAnimation.h>
+#include <reanimated/CSS/events/CSSAnimationEvent.h>
+
+#include <algorithm>
+
+namespace reanimated::css {
+
+CSSAnimationEvent createAnimationStartEvent(
+    const facebook::react::Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation) {
+  const auto activeDuration = animation->getDuration() * animation->getIterationCount();
+  const auto elapsedTime = std::min(std::max(-animation->getDelay(), 0.0), activeDuration);
+  return {viewTag, CSSAnimationEventType::AnimationStart, animation->getName(), elapsedTime};
+}
+
+CSSAnimationEvent createAnimationIterationEvent(
+    const facebook::react::Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation,
+    const unsigned iteration) {
+  const auto elapsedTime = static_cast<double>(iteration - 1) * animation->getDuration();
+  return {viewTag, CSSAnimationEventType::AnimationIteration, animation->getName(), elapsedTime};
+}
+
+CSSAnimationEvent createAnimationEndEvent(
+    const facebook::react::Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation) {
+  const auto elapsedTime = animation->getDuration() * animation->getIterationCount();
+  return {viewTag, CSSAnimationEventType::AnimationEnd, animation->getName(), elapsedTime};
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.cpp
@@ -5,27 +5,23 @@
 
 namespace reanimated::css {
 
-CSSAnimationEvent createAnimationStartEvent(
-    const facebook::react::Tag viewTag,
-    const std::shared_ptr<CSSAnimation> &animation) {
+CSSEvent createAnimationStartEvent(const facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation) {
   const auto activeDuration = animation->getDuration() * animation->getIterationCount();
   const auto elapsedTime = std::min(std::max(-animation->getDelay(), 0.0), activeDuration);
-  return {viewTag, CSSAnimationEventType::AnimationStart, animation->getName(), elapsedTime};
+  return {viewTag, "animationstart", animation->getName(), elapsedTime};
 }
 
-CSSAnimationEvent createAnimationIterationEvent(
+CSSEvent createAnimationIterationEvent(
     const facebook::react::Tag viewTag,
     const std::shared_ptr<CSSAnimation> &animation,
     const unsigned iteration) {
   const auto elapsedTime = static_cast<double>(iteration - 1) * animation->getDuration();
-  return {viewTag, CSSAnimationEventType::AnimationIteration, animation->getName(), elapsedTime};
+  return {viewTag, "animationiteration", animation->getName(), elapsedTime};
 }
 
-CSSAnimationEvent createAnimationEndEvent(
-    const facebook::react::Tag viewTag,
-    const std::shared_ptr<CSSAnimation> &animation) {
+CSSEvent createAnimationEndEvent(const facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation) {
   const auto elapsedTime = animation->getDuration() * animation->getIterationCount();
-  return {viewTag, CSSAnimationEventType::AnimationEnd, animation->getName(), elapsedTime};
+  return {viewTag, "animationend", animation->getName(), elapsedTime};
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace reanimated::css {
+
+class CSSAnimation;
+
+enum class CSSAnimationEventType : std::uint8_t {
+  AnimationStart = 1 << 0,
+  AnimationEnd = 1 << 1,
+  AnimationIteration = 1 << 2
+};
+
+// Bitmask of CSSAnimationEventType values representing which events a view
+// is listening for. A value of 0 means no listeners are registered.
+using CSSAnimationEventListeners = std::uint8_t;
+
+inline bool hasListener(CSSAnimationEventListeners listeners, CSSAnimationEventType type) {
+  return (listeners & static_cast<std::uint8_t>(type)) != 0;
+}
+
+struct CSSAnimationEvent {
+  facebook::react::Tag viewTag;
+  CSSAnimationEventType type;
+  std::string animationName;
+  double elapsedTime; // in milliseconds (convert to seconds at dispatch time)
+};
+
+CSSAnimationEvent createAnimationStartEvent(
+    facebook::react::Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation);
+CSSAnimationEvent createAnimationIterationEvent(
+    facebook::react::Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation,
+    unsigned iteration);
+CSSAnimationEvent createAnimationEndEvent(facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation);
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSAnimationEvent.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <react/renderer/core/ReactPrimitives.h>
+#include <reanimated/CSS/events/CSSEvent.h>
 
 #include <cstdint>
 #include <memory>
-#include <string>
 
 namespace reanimated::css {
 
@@ -24,20 +23,11 @@ inline bool hasListener(CSSAnimationEventListeners listeners, CSSAnimationEventT
   return (listeners & static_cast<std::uint8_t>(type)) != 0;
 }
 
-struct CSSAnimationEvent {
-  facebook::react::Tag viewTag;
-  CSSAnimationEventType type;
-  std::string animationName;
-  double elapsedTime; // in milliseconds (convert to seconds at dispatch time)
-};
-
-CSSAnimationEvent createAnimationStartEvent(
-    facebook::react::Tag viewTag,
-    const std::shared_ptr<CSSAnimation> &animation);
-CSSAnimationEvent createAnimationIterationEvent(
+CSSEvent createAnimationStartEvent(facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation);
+CSSEvent createAnimationIterationEvent(
     facebook::react::Tag viewTag,
     const std::shared_ptr<CSSAnimation> &animation,
     unsigned iteration);
-CSSAnimationEvent createAnimationEndEvent(facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation);
+CSSEvent createAnimationEndEvent(facebook::react::Tag viewTag, const std::shared_ptr<CSSAnimation> &animation);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEvent.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <string>
+
+namespace reanimated::css {
+
+struct CSSEvent {
+  facebook::react::Tag viewTag;
+  std::string type; // e.g. "animationstart", "transitionend"
+  std::string targetName; // animation name or property name
+  double elapsedTime; // in milliseconds (convert to seconds at dispatch time)
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.cpp
@@ -1,0 +1,58 @@
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
+
+#include <utility>
+
+using namespace facebook;
+
+namespace reanimated::css {
+
+namespace {
+
+jsi::Object eventToJSIObject(jsi::Runtime &rt, const CSSEvent &event) {
+  auto obj = jsi::Object(rt);
+  obj.setProperty(rt, "viewTag", event.viewTag);
+  obj.setProperty(rt, "type", jsi::String::createFromUtf8(rt, event.type));
+  obj.setProperty(rt, "animationName", jsi::String::createFromUtf8(rt, event.targetName));
+  obj.setProperty(rt, "elapsedTime", event.elapsedTime);
+  return obj;
+}
+
+jsi::Array eventsToJSIArray(jsi::Runtime &rt, const std::vector<CSSEvent> &events) {
+  auto array = jsi::Array(rt, events.size());
+  for (size_t i = 0; i < events.size(); ++i) {
+    array.setValueAtIndex(rt, i, eventToJSIObject(rt, events[i]));
+  }
+  return array;
+}
+
+} // namespace
+
+CSSEventsEmitter::CSSEventsEmitter(const std::shared_ptr<react::CallInvoker> &jsInvoker) : jsInvoker_(jsInvoker) {}
+
+void CSSEventsEmitter::setEmitFunction(std::shared_ptr<jsi::Function> emitFunction) {
+  emitFunction_ = std::move(emitFunction);
+}
+
+void CSSEventsEmitter::schedule(CSSEvent event) {
+  pendingEvents_.emplace_back(std::move(event));
+}
+
+void CSSEventsEmitter::emit() {
+  if (pendingEvents_.empty() || !emitFunction_) {
+    return;
+  }
+
+  auto events = std::make_shared<std::vector<CSSEvent>>();
+  events->swap(pendingEvents_);
+  auto emitFunction = emitFunction_;
+
+  jsInvoker_->invokeAsync([events = std::move(events), emitFunction = std::move(emitFunction)](jsi::Runtime &rt) {
+    emitFunction->call(rt, eventsToJSIArray(rt, *events));
+  });
+}
+
+bool CSSEventsEmitter::hasEvents() const {
+  return !pendingEvents_.empty();
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/events/CSSEventsEmitter.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <reanimated/CSS/events/CSSEvent.h>
+
+#include <ReactCommon/CallInvoker.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <vector>
+
+using namespace facebook;
+
+namespace reanimated::css {
+
+class CSSEventsEmitter {
+ public:
+  explicit CSSEventsEmitter(const std::shared_ptr<react::CallInvoker> &jsInvoker);
+
+  void setEmitFunction(std::shared_ptr<jsi::Function> emitFunction);
+  void schedule(CSSEvent event);
+  void emit();
+  bool hasEvents() const;
+
+ private:
+  const std::shared_ptr<react::CallInvoker> jsInvoker_;
+  std::shared_ptr<jsi::Function> emitFunction_;
+  std::vector<CSSEvent> pendingEvents_;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -35,6 +35,14 @@ AnimationDirection AnimationProgressProvider::getDirection() const {
   return direction_;
 }
 
+unsigned AnimationProgressProvider::getCurrentIteration() const {
+  return currentIteration_;
+}
+
+double AnimationProgressProvider::getIterationCount() const {
+  return iterationCount_;
+}
+
 double AnimationProgressProvider::getGlobalProgress() const {
   return applyAnimationDirection(rawProgress_.value_or(0));
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -33,6 +33,8 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   void setEasingFunction(const EasingFunction &easingFunction);
 
   AnimationDirection getDirection() const;
+  unsigned getCurrentIteration() const;
+  double getIterationCount() const;
   double getGlobalProgress() const override;
   double getKeyframeProgress(double fromOffset, double toOffset) const override;
   AnimationProgressState getState(double timestamp) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.cpp
@@ -5,6 +5,14 @@ namespace reanimated::css {
 RawProgressProvider::RawProgressProvider(const double timestamp, const double duration, const double delay)
     : duration_(duration), delay_(delay), creationTimestamp_(timestamp) {}
 
+double RawProgressProvider::getDuration() const {
+  return duration_;
+}
+
+double RawProgressProvider::getDelay() const {
+  return delay_;
+}
+
 void RawProgressProvider::setDuration(double duration) {
   duration_ = duration;
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/RawProgressProvider.h
@@ -7,6 +7,8 @@ class RawProgressProvider {
  public:
   RawProgressProvider(double timestamp, double duration, double delay);
 
+  double getDuration() const;
+  double getDelay() const;
   void setDuration(double duration);
   void setDelay(double delay);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
@@ -8,6 +8,9 @@
 
 namespace reanimated::css {
 
+CSSAnimationsRegistry::CSSAnimationsRegistry(const std::shared_ptr<CSSEventsEmitter> &eventsEmitter)
+    : eventsEmitter_(eventsEmitter) {}
+
 bool CSSAnimationsRegistry::isEmpty() const {
   // The registry is empty if has no registered animations and no updates
   // stored in the updates registry
@@ -90,12 +93,6 @@ void CSSAnimationsRegistry::update(const double timestamp) {
       ++it;
     }
   }
-}
-
-std::vector<CSSAnimationEvent> CSSAnimationsRegistry::flushEvents() {
-  std::vector<CSSAnimationEvent> events;
-  events.swap(pendingEvents_);
-  return events;
 }
 
 CSSAnimationsVector CSSAnimationsRegistry::buildAnimationsVector(
@@ -211,7 +208,7 @@ void CSSAnimationsRegistry::updateViewAnimations(
 
     if (detectEvents) {
       const AnimationStateSnapshot afterSnapshot = {newState, animation->getCurrentIteration()};
-      detectAnimationEvents(viewTag, animation, beforeSnapshot, afterSnapshot);
+      scheduleAnimationEvents(viewTag, animation, beforeSnapshot, afterSnapshot);
     }
 
     if (newState == AnimationProgressState::Finished) {
@@ -344,7 +341,7 @@ void CSSAnimationsRegistry::handleAnimationsToRevert(const double timestamp) {
   animationsToRevertMap_.clear();
 }
 
-void CSSAnimationsRegistry::detectAnimationEvents(
+void CSSAnimationsRegistry::scheduleAnimationEvents(
     const Tag viewTag,
     const std::shared_ptr<CSSAnimation> &animation,
     const AnimationStateSnapshot &before,
@@ -353,17 +350,17 @@ void CSSAnimationsRegistry::detectAnimationEvents(
 
   if (hasListener(listeners, CSSAnimationEventType::AnimationStart) &&
       before.state == AnimationProgressState::Pending && after.state != AnimationProgressState::Pending) {
-    pendingEvents_.emplace_back(createAnimationStartEvent(viewTag, animation));
+    eventsEmitter_->schedule(createAnimationStartEvent(viewTag, animation));
   }
 
   if (hasListener(listeners, CSSAnimationEventType::AnimationIteration) &&
       after.state == AnimationProgressState::Running && after.iteration > before.iteration) {
-    pendingEvents_.emplace_back(createAnimationIterationEvent(viewTag, animation, after.iteration));
+    eventsEmitter_->schedule(createAnimationIterationEvent(viewTag, animation, after.iteration));
   }
 
   if (hasListener(listeners, CSSAnimationEventType::AnimationEnd) && before.state != AnimationProgressState::Finished &&
       after.state == AnimationProgressState::Finished) {
-    pendingEvents_.emplace_back(createAnimationEndEvent(viewTag, animation));
+    eventsEmitter_->schedule(createAnimationEndEvent(viewTag, animation));
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
@@ -24,10 +24,19 @@ void CSSAnimationsRegistry::apply(
     const std::optional<std::vector<std::string>> &animationNames,
     const CSSAnimationsMap &newAnimations,
     const CSSAnimationSettingsUpdatesMap &settingsUpdates,
-    double timestamp) {
+    const CSSAnimationEventListeners eventListeners,
+    const double timestamp) {
   auto animationsVector = buildAnimationsVector(rt, shadowNode, animationNames, newAnimations);
 
   const auto viewTag = shadowNode->getTag();
+
+  // Update event listener tracking based on current callback props
+  if (eventListeners != 0) {
+    eventListenersMap_[viewTag] = eventListeners;
+  } else {
+    eventListenersMap_.erase(viewTag);
+  }
+
   if (animationsVector.empty()) {
     remove(viewTag);
     return;
@@ -60,6 +69,7 @@ void CSSAnimationsRegistry::remove(const Tag viewTag) {
   removeViewAnimations(viewTag);
   removeFromUpdatesRegistry(viewTag);
   registry_.erase(viewTag);
+  eventListenersMap_.erase(viewTag);
 }
 
 void CSSAnimationsRegistry::update(const double timestamp) {
@@ -80,6 +90,12 @@ void CSSAnimationsRegistry::update(const double timestamp) {
       ++it;
     }
   }
+}
+
+std::vector<CSSAnimationEvent> CSSAnimationsRegistry::flushEvents() {
+  std::vector<CSSAnimationEvent> events;
+  events.swap(pendingEvents_);
+  return events;
 }
 
 CSSAnimationsVector CSSAnimationsRegistry::buildAnimationsVector(
@@ -175,18 +191,28 @@ void CSSAnimationsRegistry::updateViewAnimations(
   std::shared_ptr<const ShadowNode> shadowNode = nullptr;
   bool hasUpdates = false;
 
+  const bool detectEvents = eventListenersMap_.count(viewTag) > 0;
+
   for (const auto animationIndex : animationIndices) {
     const auto &animation = registry_[viewTag].animationsVector[animationIndex];
     if (!shadowNode) {
       shadowNode = animation->getShadowNode();
     }
-    if (animation->getState(timestamp) == AnimationProgressState::Pending) {
+
+    const AnimationStateSnapshot beforeSnapshot = {animation->getState(timestamp), animation->getCurrentIteration()};
+
+    if (beforeSnapshot.state == AnimationProgressState::Pending) {
       animation->run(timestamp);
     }
 
     bool updatesAddedToBatch = false;
     const auto updates = animation->update(timestamp);
     const auto newState = animation->getState(timestamp);
+
+    if (detectEvents) {
+      const AnimationStateSnapshot afterSnapshot = {newState, animation->getCurrentIteration()};
+      detectAnimationEvents(viewTag, animation, beforeSnapshot, afterSnapshot);
+    }
 
     if (newState == AnimationProgressState::Finished) {
       // Revert changes applied during animation if there is no forwards fill
@@ -316,6 +342,29 @@ void CSSAnimationsRegistry::handleAnimationsToRevert(const double timestamp) {
     applyViewAnimationsStyle(viewTag, timestamp);
   }
   animationsToRevertMap_.clear();
+}
+
+void CSSAnimationsRegistry::detectAnimationEvents(
+    const Tag viewTag,
+    const std::shared_ptr<CSSAnimation> &animation,
+    const AnimationStateSnapshot &before,
+    const AnimationStateSnapshot &after) {
+  const auto listeners = eventListenersMap_.at(viewTag);
+
+  if (hasListener(listeners, CSSAnimationEventType::AnimationStart) &&
+      before.state == AnimationProgressState::Pending && after.state != AnimationProgressState::Pending) {
+    pendingEvents_.emplace_back(createAnimationStartEvent(viewTag, animation));
+  }
+
+  if (hasListener(listeners, CSSAnimationEventType::AnimationIteration) &&
+      after.state == AnimationProgressState::Running && after.iteration > before.iteration) {
+    pendingEvents_.emplace_back(createAnimationIterationEvent(viewTag, animation, after.iteration));
+  }
+
+  if (hasListener(listeners, CSSAnimationEventType::AnimationEnd) && before.state != AnimationProgressState::Finished &&
+      after.state == AnimationProgressState::Finished) {
+    pendingEvents_.emplace_back(createAnimationEndEvent(viewTag, animation));
+  }
 }
 
 bool CSSAnimationsRegistry::addStyleUpdates(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/configs/CSSAnimationConfig.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
+#include <reanimated/CSS/events/CSSAnimationEvent.h>
 #include <reanimated/CSS/utils/DelayedItemsManager.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
@@ -32,12 +33,19 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
       const std::optional<std::vector<std::string>> &animationNames,
       const CSSAnimationsMap &newAnimations,
       const CSSAnimationSettingsUpdatesMap &settingsUpdates,
+      CSSAnimationEventListeners eventListeners,
       double timestamp);
   void remove(Tag viewTag) override;
 
   void update(double timestamp);
+  std::vector<CSSAnimationEvent> flushEvents();
 
  private:
+  struct AnimationStateSnapshot {
+    AnimationProgressState state;
+    unsigned iteration;
+  };
+
   using AnimationToIndexMap = std::unordered_map<std::shared_ptr<CSSAnimation>, size_t>;
   using RunningAnimationIndicesMap = std::unordered_map<Tag, std::set<size_t>>;
   using AnimationsToRevertMap = std::unordered_map<Tag, std::unordered_set<size_t>>;
@@ -53,6 +61,9 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
   RunningAnimationIndicesMap runningAnimationIndicesMap_;
   AnimationsToRevertMap animationsToRevertMap_;
   DelayedItemsManager<std::shared_ptr<CSSAnimation>> delayedAnimationsManager_;
+
+  std::unordered_map<Tag, CSSAnimationEventListeners> eventListenersMap_;
+  std::vector<CSSAnimationEvent> pendingEvents_;
 
   CSSAnimationsVector buildAnimationsVector(
       jsi::Runtime &rt,
@@ -73,6 +84,12 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
   void applyViewAnimationsStyle(Tag viewTag, double timestamp);
   void activateDelayedAnimations(double timestamp);
   void handleAnimationsToRevert(double timestamp);
+
+  void detectAnimationEvents(
+      Tag viewTag,
+      const std::shared_ptr<CSSAnimation> &animation,
+      const AnimationStateSnapshot &before,
+      const AnimationStateSnapshot &after);
 
   static bool addStyleUpdates(folly::dynamic &target, const folly::dynamic &updates, bool shouldOverride);
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.h
@@ -3,6 +3,7 @@
 #include <reanimated/CSS/configs/CSSAnimationConfig.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/events/CSSAnimationEvent.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/utils/DelayedItemsManager.h>
 #include <reanimated/CSS/utils/props.h>
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
@@ -24,6 +25,8 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
  public:
   using SettingsUpdates = std::vector<std::pair<size_t, PartialCSSAnimationSettings>>;
 
+  explicit CSSAnimationsRegistry(const std::shared_ptr<CSSEventsEmitter> &eventsEmitter);
+
   bool isEmpty() const override;
   bool hasUpdates() const;
 
@@ -38,7 +41,6 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
   void remove(Tag viewTag) override;
 
   void update(double timestamp);
-  std::vector<CSSAnimationEvent> flushEvents();
 
  private:
   struct AnimationStateSnapshot {
@@ -56,6 +58,8 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
 
   using Registry = std::unordered_map<Tag, RegistryEntry>;
 
+  const std::shared_ptr<CSSEventsEmitter> eventsEmitter_;
+
   Registry registry_;
 
   RunningAnimationIndicesMap runningAnimationIndicesMap_;
@@ -63,7 +67,6 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
   DelayedItemsManager<std::shared_ptr<CSSAnimation>> delayedAnimationsManager_;
 
   std::unordered_map<Tag, CSSAnimationEventListeners> eventListenersMap_;
-  std::vector<CSSAnimationEvent> pendingEvents_;
 
   CSSAnimationsVector buildAnimationsVector(
       jsi::Runtime &rt,
@@ -85,7 +88,7 @@ class CSSAnimationsRegistry : public UpdatesRegistry, std::enable_shared_from_th
   void activateDelayedAnimations(double timestamp);
   void handleAnimationsToRevert(double timestamp);
 
-  void detectAnimationEvents(
+  void scheduleAnimationEvents(
       Tag viewTag,
       const std::shared_ptr<CSSAnimation> &animation,
       const AnimationStateSnapshot &before,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -498,7 +498,14 @@ void ReanimatedModuleProxy::applyCSSAnimations(
   {
     auto lock = cssAnimationsRegistry_->lock();
     cssAnimationsRegistry_->apply(
-        rt, shadowNode, updates.animationNames, newAnimations, updates.settingsUpdates, timestamp);
+        rt,
+        shadowNode,
+        updates.animationNames,
+        newAnimations,
+        updates.settingsUpdates,
+        // TODO: replace this placeholder with the actual event listeners
+        0,
+        timestamp);
   }
 
   maybeRunCSSLoop();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -135,7 +135,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>(viewStylesRepository_)),
-      cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>()),
+      cssEventsEmitter_(std::make_shared<CSSEventsEmitter>(jsCallInvoker)),
+      cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(cssEventsEmitter_)),
       cssTransitionsRegistry_(std::make_shared<CSSTransitionsRegistry>(getAnimationTimestamp_, viewStylesRepository_)),
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -6,6 +6,7 @@
 #include <reanimated/AnimatedSensor/AnimatedSensorModule.h>
 #include <reanimated/CSS/core/CSSAnimation.h>
 #include <reanimated/CSS/core/CSSTransition.h>
+#include <reanimated/CSS/events/CSSEventsEmitter.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/registries/CSSAnimationsRegistry.h>
 #include <reanimated/CSS/registries/CSSKeyframesRegistry.h>
@@ -199,6 +200,7 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
+  const std::shared_ptr<CSSEventsEmitter> cssEventsEmitter_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;
   const std::shared_ptr<CSSTransitionsRegistry> cssTransitionsRegistry_;
 


### PR DESCRIPTION
## Summary

This PR is the first one of the CSS animation/transition callbacks support series. It adds the base logic responsible for detecting which event to emit and when in CSS animations, adds a `CSSEventsEmitter` class responsible for emitting a batch of events from the last `performOperations` call and other necessary changes necessary to get durations/timings from the animation object.

I decided to support: `onAnimationStart`, `onAnimationEnd` and `onAnimationIteration` events for now (I don't support `onAnimationCancel` yet as it doesn't seem to be much useful - animation is cancelled only when removed from the style object so the user already knows when it should be cancelled - maybe we will add support for this one later on).

## Test plan

Build the app, see that it compiles and pre-existing CSS animations aren't broken.
