### PR TITLE
chore: Mock console in tests that polluted logs

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stops.test.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stops.test.ts
@@ -4,6 +4,10 @@ import { type CSSGradientStop } from '../../../../types';
 import { processSVGGradientStops } from '../stops';
 
 describe(processSVGGradientStops, () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
+
   test('returns empty array for invalid input', () => {
     // @ts-expect-error improper argument
     expect(processSVGGradientStops(null)).toEqual([]);

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -4,6 +4,10 @@ import type { CSSStyle, CSSTransitionProperty } from '../../types';
 import { filterCSSAndStyleProperties } from '../props';
 
 describe(filterCSSAndStyleProperties, () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
+
   describe('animation config', () => {
     test('returns null if there is no animationName', () => {
       const style: CSSStyle = {


### PR DESCRIPTION
## Summary

This PR mocks `console` in tests that logged things during execution and polluted the output console.

This is how it looked before:

- `src/css/svg/native/processors/__tests__/stops.test.ts`

<img width="650" height="558" alt="Screenshot 2026-03-15 at 11 01 57" src="https://github.com/user-attachments/assets/89f4090b-4a64-424e-bc12-9931072e66a2" />

- `src/css/utils/__tests__/props.test.ts`

<img width="752" height="688" alt="Screenshot 2026-03-15 at 11 01 44" src="https://github.com/user-attachments/assets/2364093c-e1d7-4cbe-aaa9-409665bfc721" />
