### PR TITLE
Replace `isInt` with `isNumber` in synchronous props check

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -69,7 +69,7 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
         const auto keyStr = key.asString();
         const bool isColorProp = keyStr == "color" || keyStr.find("Color") != std::string::npos;
         const bool isSynchronous =
-            synchronousPropNames.contains(keyStr) && (!shouldRequireIntegerColors || !isColorProp || value.isInt());
+            synchronousPropNames.contains(keyStr) && (!shouldRequireIntegerColors || !isColorProp || value.isNumber());
         if (isSynchronous) {
           synchronousProps[keyStr] = value;
         } else {
@@ -91,7 +91,7 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
         const auto keyStr = key.asString();
         const bool isColorProp = keyStr == "color" || keyStr.find("Color") != std::string::npos;
         const bool isSynchronous =
-            synchronousPropNames.contains(keyStr) && (!shouldRequireIntegerColors || !isColorProp || value.isInt());
+            synchronousPropNames.contains(keyStr) && (!shouldRequireIntegerColors || !isColorProp || value.isNumber());
         if (!isSynchronous) {
           hasOnlySynchronousProps = false;
           break;


### PR DESCRIPTION
## Summary

I found out that `backgroundColor` can also be a double which makes the current `value.isInt()` check fail. Because of this, the fast synchronous path of updating styles is not used which results in poor performance.

This PR replaces `value.isInt()` check with `value.isNumber()`. The conversion from double to int is handled by `value.asInt()` call in the next stage.

This check was introduced in https://github.com/software-mansion/react-native-reanimated/pull/8687 because of `PlatformColor` which is not supported by the fast synchronous path and needs to fallback to the default way of updating props via `ShadowTree::commit`.

## Test plan
