### PR TITLE
fix(Worklets): remote function re-serialization

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
@@ -70,13 +70,11 @@ describe('runOnRuntimeSyncWithId', () => {
       value = 0;
       scheduleOnUI(() => {
         'worklet';
-        // @ts-expect-error TODO: fix RemoteFunction re-serialization.
-        const remoteFunction = callbackPass.__remoteFunction as typeof callbackPass;
         const result = runOnRuntimeSyncWithId(UIRuntimeId, () => {
           'worklet';
           return 42;
         });
-        scheduleOnRN(remoteFunction, result);
+        scheduleOnRN(callbackPass, result);
       });
       await waitForNotification(PASS_NOTIFICATION);
       expect(value).toBe(42);
@@ -85,14 +83,11 @@ describe('runOnRuntimeSyncWithId', () => {
     test('from UI Runtime to Worker Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';
-        // @ts-expect-error TODO: fix RemoteFunction re-serialization.
-        const remoteFunction = callbackPass.__remoteFunction as typeof callbackPass;
-
         const result = runOnRuntimeSyncWithId(workletRuntime1.runtimeId, () => {
           'worklet';
           return 42;
         });
-        scheduleOnRN(remoteFunction, result);
+        scheduleOnRN(callbackPass, result);
       });
       await waitForNotification(PASS_NOTIFICATION);
       expect(value).toBe(42);
@@ -101,14 +96,12 @@ describe('runOnRuntimeSyncWithId', () => {
     test('from UI Runtime to non-existing Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';
-        // @ts-expect-error TODO: fix RemoteFunction re-serialization.
-        const remoteFunction = callbackPass.__remoteFunction as typeof callbackPass;
         try {
           const result = runOnRuntimeSyncWithId(9999, () => {
             'worklet';
             return 42;
           });
-          scheduleOnRN(remoteFunction, result);
+          scheduleOnRN(callbackPass, result);
         } catch (error) {
           scheduleOnRN(callbackFail, error instanceof Error ? error.message : String(error));
         }

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntime.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntime.test.tsx
@@ -8,7 +8,7 @@ import {
 import { beforeEach, describe, expect, notify, test, waitForNotification } from '../../ReJest/RuntimeTestsApi';
 
 type localGlobal = typeof globalThis & {
-  __notifyPass(num: number): void;
+  scheduleOnRN: typeof scheduleOnRN;
 };
 
 describe('scheduleOnRuntime', () => {
@@ -30,13 +30,10 @@ describe('scheduleOnRuntime', () => {
       value = 0;
 
       [workletRuntime1, workletRuntime2].forEach(runtime => {
-        // TODO: fix RemoteFunction re-serialization.
         runOnRuntimeSync(runtime, () => {
           'worklet';
-          (globalThis as localGlobal).__notifyPass = (num: number) => {
-            'worklet';
-            scheduleOnRN(callbackPass, num);
-          };
+          // TODO: fix worklet re-serialization outside of Bundle Mode
+          (globalThis as localGlobal).scheduleOnRN = scheduleOnRN;
         });
       });
     });
@@ -58,7 +55,7 @@ describe('scheduleOnRuntime', () => {
 
       scheduleOnRuntime(workletRuntime1, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
 
@@ -72,7 +69,7 @@ describe('scheduleOnRuntime', () => {
 
       scheduleOnRuntime(workletRuntime2, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntimeWithId.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnRuntimeWithId.test.tsx
@@ -13,8 +13,7 @@ const PASS_NOTIFICATION = 'PASS';
 const FAIL_NOTIFICATION = 'FAIL';
 
 type localGlobal = typeof globalThis & {
-  __notifyPass(num: number): void;
-  __notifyFail(rea: string): void;
+  scheduleOnRN: typeof scheduleOnRN;
 };
 
 describe('scheduleOnRuntimeWithId', () => {
@@ -42,17 +41,10 @@ describe('scheduleOnRuntimeWithId', () => {
       reason = '';
 
       [UIRuntimeId, workletRuntime1.runtimeId, workletRuntime2.runtimeId].forEach(runtimeId => {
-        // TODO: fix RemoteFunction re-serialization.
         runOnRuntimeSyncWithId(runtimeId, () => {
           'worklet';
-          (globalThis as localGlobal).__notifyPass = (num: number) => {
-            'worklet';
-            scheduleOnRN(callbackPass, num);
-          };
-          (globalThis as localGlobal).__notifyFail = (rea: string) => {
-            'worklet';
-            scheduleOnRN(callbackFail, rea);
-          };
+          // TODO: fix worklet re-serialization outside of Bundle Mode
+          (globalThis as localGlobal).scheduleOnRN = scheduleOnRN;
         });
       });
     });
@@ -95,7 +87,7 @@ describe('scheduleOnRuntimeWithId', () => {
       'worklet';
       scheduleOnRuntimeWithId(UIRuntimeId, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
     await waitForNotification(PASS_NOTIFICATION);
@@ -107,7 +99,7 @@ describe('scheduleOnRuntimeWithId', () => {
       'worklet';
       scheduleOnRuntimeWithId(workletRuntime1.runtimeId, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
     await waitForNotification(PASS_NOTIFICATION);
@@ -120,10 +112,10 @@ describe('scheduleOnRuntimeWithId', () => {
       try {
         scheduleOnRuntimeWithId(9999, () => {
           'worklet';
-          (globalThis as localGlobal).__notifyPass(42);
+          scheduleOnRN(callbackPass, 42);
         });
       } catch (error) {
-        (globalThis as localGlobal).__notifyFail(error instanceof Error ? error.message : String(error));
+        scheduleOnRN(callbackFail, error instanceof Error ? error.message : String(error));
       }
     });
 
@@ -136,7 +128,7 @@ describe('scheduleOnRuntimeWithId', () => {
       'worklet';
       scheduleOnRuntimeWithId(UIRuntimeId, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
     await waitForNotification(PASS_NOTIFICATION);
@@ -147,7 +139,7 @@ describe('scheduleOnRuntimeWithId', () => {
       'worklet';
       scheduleOnRuntimeWithId(workletRuntime1.runtimeId, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
     await waitForNotification(PASS_NOTIFICATION);
@@ -158,7 +150,7 @@ describe('scheduleOnRuntimeWithId', () => {
       'worklet';
       scheduleOnRuntimeWithId(workletRuntime2.runtimeId, () => {
         'worklet';
-        (globalThis as localGlobal).__notifyPass(42);
+        (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
       });
     });
     await waitForNotification(PASS_NOTIFICATION);
@@ -170,10 +162,10 @@ describe('scheduleOnRuntimeWithId', () => {
       try {
         scheduleOnRuntimeWithId(9999, () => {
           'worklet';
-          (globalThis as localGlobal).__notifyPass(42);
+          (globalThis as localGlobal).scheduleOnRN(callbackPass, 42);
         });
       } catch (error) {
-        (globalThis as localGlobal).__notifyFail(error instanceof Error ? error.message : String(error));
+        scheduleOnRN(callbackFail, error instanceof Error ? error.message : String(error));
       }
     });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
@@ -42,12 +42,9 @@ describe('scheduleOnUI', () => {
     test('schedules on UI Runtime to UI Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';
-        // @ts-expect-error TODO: fix RemoteFunction re-serialization.
-        const remoteFunction = callbackPass.__remoteFunction as typeof callbackPass;
-
         scheduleOnUI(() => {
           'worklet';
-          scheduleOnRN(remoteFunction, 42);
+          scheduleOnRN(callbackPass, 42);
         });
       });
 
@@ -58,12 +55,9 @@ describe('scheduleOnUI', () => {
     test('schedules on Worker Runtime to UI Runtime', async () => {
       scheduleOnRuntime(workletRuntime, () => {
         'worklet';
-        // @ts-expect-error TODO: fix RemoteFunction re-serialization.
-        const remoteFunction = callbackPass.__remoteFunction as typeof callbackPass;
-
         scheduleOnUI(() => {
           'worklet';
-          scheduleOnRN(remoteFunction, 42);
+          scheduleOnRN(callbackPass, 42);
         });
       });
 

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -173,15 +173,21 @@ export function createSerializable<TValue>(
   if (Array.isArray(value)) {
     return cloneArray(value, shouldPersistRemote, depth);
   }
-  if (
-    globalThis._WORKLETS_BUNDLE_MODE_ENABLED &&
-    isFunction &&
-    (value as WorkletImport).__bundleData
-  ) {
-    return cloneImport(value as WorkletImport) as SerializableRef<TValue>;
-  }
-  if (isFunction && !isWorkletFunction(value)) {
-    return cloneRemoteFunction(value);
+  if (isFunction) {
+    if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+      if ((value as RemoteFunction).__remoteFunction) {
+        // Remote functions are already serialized.
+        return (value as RemoteFunction)
+          .__remoteFunction as SerializableRef<TValue>;
+      }
+      if ((value as WorkletImport).__bundleData) {
+        return cloneImport(value as WorkletImport) as SerializableRef<TValue>;
+      }
+    } else {
+      if (!isWorkletFunction(value)) {
+        return cloneRemoteFunction(value);
+      }
+    }
   }
   // RN has introduced a new representation of TurboModules as a JS object whose prototype is the host object
   // More details: https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp#L182
@@ -732,7 +738,7 @@ function getWorkletCode(value: WorkletFunction) {
   return code;
 }
 
-type RemoteFunction<TValue> = {
+type RemoteFunction<TValue = unknown> = {
   __remoteFunction: FlatSerializableRef<TValue>;
 };
 


### PR DESCRIPTION
## Summary

In Bundle Mode we always use `createSerializable` function which had no path for re-serializing remote functions. This PR adds such paths so remote function can be now passed freely between runtimes more than once.

## Test plan

Runtime tests pass in Bundle mode and outside of Bundle Mode.
