### PR TITLE
chore(4.2-stable): bump accepted worklets

### DIFF
--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
 
-      - name: Check if all versions are exact
-        working-directory: ${{ github.workspace }}
-        run: ./scripts/disallow-non-exact.sh
-
       - name: Install monorepo dependencies
         run: yarn install --immutable
 

--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -42,7 +42,7 @@
     "react-native-safe-area-context": "5.6.1",
     "react-native-screens": "4.19.0-nightly-20251125-46052f31e",
     "react-native-svg": "15.14.0",
-    "react-native-worklets": "0.8.0-nightly-20260211-96ab3f00d",
+    "react-native-worklets": "0.8.0",
     "react-strict-dom": "0.0.54"
   },
   "devDependencies": {

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -16,7 +16,7 @@
     "react-native": "0.79.6",
     "react-native-macos": "patch:react-native-macos@npm%3A0.79.0#~/.yarn/patches/react-native-macos-npm-0.79.0-449930c6bc.patch",
     "react-native-reanimated": "workspace:*",
-    "react-native-worklets": "0.8.0-nightly-20260211-96ab3f00d"
+    "react-native-worklets": "0.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.28.4",

--- a/apps/next-example/package.json
+++ b/apps/next-example/package.json
@@ -22,7 +22,7 @@
     "react-native": "0.84.0",
     "react-native-reanimated": "workspace:*",
     "react-native-web": "0.21.1",
-    "react-native-worklets": "0.8.0-nightly-20260211-96ab3f00d",
+    "react-native-worklets": "0.8.0",
     "webpack": "5.102.1"
   },
   "devDependencies": {

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -16,7 +16,7 @@
     "react": "19.1.0",
     "react-native": "npm:react-native-tvos@0.81.1-1",
     "react-native-reanimated": "workspace:*",
-    "react-native-worklets": "0.8.0-nightly-20260211-96ab3f00d"
+    "react-native-worklets": "0.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.28.4",

--- a/packages/react-native-reanimated/compatibility.json
+++ b/packages/react-native-reanimated/compatibility.json
@@ -6,7 +6,7 @@
     },
     "4.2.x": {
       "react-native": ["0.80", "0.81", "0.82", "0.83", "0.84"],
-      "react-native-worklets": ["0.7.x"]
+      "react-native-worklets": ["0.7.x", "0.8.x"]
     },
     "4.1.x": {
       "react-native": ["0.78", "0.79", "0.80", "0.81", "0.82"],

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -93,13 +93,13 @@
   },
   "homepage": "https://docs.swmansion.com/react-native-reanimated",
   "dependencies": {
-    "react-native-is-edge-to-edge": "1.2.1",
-    "semver": "7.7.3"
+    "react-native-is-edge-to-edge": "^1.2.1",
+    "semver": "^7.7.3"
   },
   "peerDependencies": {
     "react": "*",
     "react-native": "0.80 - 0.84",
-    "react-native-worklets": "0.7.x"
+    "react-native-worklets": "0.7 - 0.8"
   },
   "devDependencies": {
     "@babel/core": "7.28.4",
@@ -133,7 +133,7 @@
     "react-native-builder-bob": "0.40.13",
     "react-native-svg": "15.14.0",
     "react-native-web": "0.21.1",
-    "react-native-worklets": "0.8.0-nightly-20260211-96ab3f00d",
+    "react-native-worklets": "0.8.0",
     "react-test-renderer": "19.2.3",
     "typescript": "5.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13969,7 +13969,7 @@ __metadata:
     react-native-safe-area-context: "npm:5.6.1"
     react-native-screens: "npm:4.19.0-nightly-20251125-46052f31e"
     react-native-svg: "npm:15.14.0"
-    react-native-worklets: "npm:0.8.0-nightly-20260211-96ab3f00d"
+    react-native-worklets: "npm:0.8.0"
     react-strict-dom: "npm:0.0.54"
     react-test-renderer: "npm:19.2.3"
     typescript: "npm:5.8.3"
@@ -22502,7 +22502,7 @@ __metadata:
     react-native: "npm:0.79.6"
     react-native-macos: "patch:react-native-macos@npm%3A0.79.0#~/.yarn/patches/react-native-macos-npm-0.79.0-449930c6bc.patch"
     react-native-reanimated: "workspace:*"
-    react-native-worklets: "npm:0.8.0-nightly-20260211-96ab3f00d"
+    react-native-worklets: "npm:0.8.0"
     typescript: "npm:5.8.3"
   languageName: unknown
   linkType: soft
@@ -25862,7 +25862,7 @@ __metadata:
     react-native: "npm:0.84.0"
     react-native-reanimated: "workspace:*"
     react-native-web: "npm:0.21.1"
-    react-native-worklets: "npm:0.8.0-nightly-20260211-96ab3f00d"
+    react-native-worklets: "npm:0.8.0"
     start-server-and-test: "npm:2.1.2"
     typescript: "npm:5.8.3"
     webpack: "npm:5.102.1"
@@ -28836,6 +28836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-is-edge-to-edge@npm:^1.2.1":
+  version: 1.3.1
+  resolution: "react-native-is-edge-to-edge@npm:1.3.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/dc82d54e0bf8f89208a538bb0d14e4891af6efae27ed5b7b21be683a72c38c5219ab9be1ea9bd40aa1c905d481174e649d0b71aeceaa9946e6c707f251568282
+  languageName: node
+  linkType: hard
+
 "react-native-macos@npm:0.79.0":
   version: 0.79.0
   resolution: "react-native-macos@npm:0.79.0"
@@ -29086,17 +29096,17 @@ __metadata:
     react-dom: "npm:19.2.3"
     react-native: "npm:0.84.0"
     react-native-builder-bob: "npm:0.40.13"
-    react-native-is-edge-to-edge: "npm:1.2.1"
+    react-native-is-edge-to-edge: "npm:^1.2.1"
     react-native-svg: "npm:15.14.0"
     react-native-web: "npm:0.21.1"
-    react-native-worklets: "npm:0.8.0-nightly-20260211-96ab3f00d"
+    react-native-worklets: "npm:0.8.0"
     react-test-renderer: "npm:19.2.3"
-    semver: "npm:7.7.3"
+    semver: "npm:^7.7.3"
     typescript: "npm:5.8.3"
   peerDependencies:
     react: "*"
     react-native: 0.80 - 0.84
-    react-native-worklets: 0.7.x
+    react-native-worklets: 0.7 - 0.8
   languageName: unknown
   linkType: soft
 
@@ -32865,7 +32875,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:react-native-tvos@0.81.1-1"
     react-native-reanimated: "workspace:*"
-    react-native-worklets: "npm:0.8.0-nightly-20260211-96ab3f00d"
+    react-native-worklets: "npm:0.8.0"
     react-test-renderer: "npm:19.2.3"
     typescript: "npm:5.8.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

🚀 

## Test plan

I manually tested that Reanimated 4.2 works with Worklets 0.8.0
