### PR TITLE
fix(Worklets): misplaced else when cloning remote function

### DIFF
--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -183,10 +183,9 @@ export function createSerializable<TValue>(
       if ((value as WorkletImport).__bundleData) {
         return cloneImport(value as WorkletImport) as SerializableRef<TValue>;
       }
-    } else {
-      if (!isWorkletFunction(value)) {
-        return cloneRemoteFunction(value);
-      }
+    }
+    if (!isWorkletFunction(value)) {
+      return cloneRemoteFunction(value);
     }
   }
   // RN has introduced a new representation of TurboModules as a JS object whose prototype is the host object


### PR DESCRIPTION
## Summary

Fixing error where remote functions would never be properly cloned in Bundle Mode.

This is what happens when you first test the code then clean it up...

Closes #9140

## Test plan

Runtime tests work again.
