### PR TITLE
cherry-pick(0.8-stable): misplaced else when cloning remote function (#9141)

### DIFF
--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -183,10 +183,9 @@ export function createSerializable<TValue>(
       if ((value as WorkletImport).__bundleData) {
         return cloneImport(value as WorkletImport) as SerializableRef<TValue>;
       }
-    } else {
-      if (!isWorkletFunction(value)) {
-        return cloneRemoteFunction(value);
-      }
+    }
+    if (!isWorkletFunction(value)) {
+      return cloneRemoteFunction(value);
     }
   }
   // RN has introduced a new representation of TurboModules as a JS object whose prototype is the host object


### PR DESCRIPTION
## Summary

Cherry-picking
- #9141

for 0.8.1 release of Worklets
