### PR TITLE
chore(Worklets): update docs for Bundle Mode

### DIFF
--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -45,7 +45,6 @@
     "staticFeatureFlags": {
       "RUNTIME_TEST_FLAG": true,
       "IOS_DYNAMIC_FRAMERATE_ENABLED": true,
-      "BUNDLE_MODE_ENABLED": false,
       "FETCH_PREVIEW_ENABLED": false
     }
   }

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -55,7 +55,6 @@
     "staticFeatureFlags": {
       "RUNTIME_TEST_FLAG": true,
       "IOS_DYNAMIC_FRAMERATE_ENABLED": true,
-      "BUNDLE_MODE_ENABLED": false,
       "FETCH_PREVIEW_ENABLED": false
     }
   }

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -58,7 +58,6 @@
     "staticFeatureFlags": {
       "RUNTIME_TEST_FLAG": true,
       "IOS_DYNAMIC_FRAMERATE_ENABLED": true,
-      "BUNDLE_MODE_ENABLED": false,
       "FETCH_PREVIEW_ENABLED": false
     }
   }

--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -32,7 +32,7 @@ Install `react-native-worklets` package with the `bundle-mode-preview` tag:
 
 To use `react-native-worklets`'s Bundle Mode feature, you need to make the following changes in your repository:
 
-1. **Modify your Babel configuration**. [Worklets Babel Plugin](/docs/worklets-babel-plugin/about) needs to know that it has to prepare your code for the Bundle Mode. In your `babel.config.js` file, add the following:
+1. **Modify your Babel configuration**. [Worklets Babel Plugin](/docs/worklets-babel-plugin/about) needs to know that it has to prepare your code for the Bundle Mode. This is also the source of truth for your app to know if the Bundle Mode is enabled. In your `babel.config.js` file, add the following:
 
    ```javascript {2-5,13}
    /** @type {import('react-native-worklets/plugin').PluginOptions} */
@@ -96,10 +96,6 @@ To use `react-native-worklets`'s Bundle Mode feature, you need to make the follo
 
   </TabItem>
 </Tabs>
-
-## Configure your app
-
-For Worklets to know that it should run in Bundle Mode, you need to toggle on `WORKLETS_BUNDLE_MODE_ENABLED` static feature flag in your app's `package.json`. You can find instructions on how to enable it [here](/docs/guides/feature-flags).
 
 ## Enable seamless Metro bundling
 

--- a/docs/docs-worklets/docs/guides/feature-flags.md
+++ b/docs/docs-worklets/docs/guides/feature-flags.md
@@ -10,7 +10,6 @@ Feature flags allow developers to opt-in for experimental changes or opt-out fro
 
 | Feature flag name                                                  |              Type               | Added in | Removed in | Default value |
 | ------------------------------------------------------------------ | :-----------------------------: | :------: | :--------: | :-----------: |
-| [`BUNDLE_MODE_ENABLED`](#bundle_mode_enabled-)                     | [static](#static-feature-flags) |  0.8.0   |  &ndash;   |    `false`    |
 | [`FETCH_PREVIEW_ENABLED`](#fetch_preview_enabled-)                 | [static](#static-feature-flags) |  0.8.0   |  &ndash;   |    `false`    |
 | [`IOS_DYNAMIC_FRAMERATE_ENABLED`](#ios_dynamic_framerate_enabled-) | [static](#static-feature-flags) |  0.6.0   |  &ndash;   |    `true`     |
 
@@ -22,14 +21,10 @@ Feature flags available in `react-native-reanimated` are listed [on this page](h
 
 ## Description of available feature flags
 
-### `BUNDLE_MODE_ENABLED` <AvailableFrom version="0.8.0" />
-
-This feature flag enables [the Bundle Mode](/docs/bundleMode/). Make sure to follow the rest of the [setup instructions](/docs/bundleMode/setup/) after enabling this flag.
-
 ### `FETCH_PREVIEW_ENABLED` <AvailableFrom version="0.8.0" />
 
 This feature flag enables the [preview of fetch API on Worklet Runtimes](/docs/bundleMode/usage#running-network-requests-in-worklets) in the [Bundle Mode](/docs/bundleMode/). Make sure to follow the rest of the [setup instructions](/docs/bundleMode/setup/) after enabling this flag.
-**This flag requires `BUNDLE_MODE_ENABLED` flag to be enabled as well.**
+**This flag only takes effect in Bundle Mode.**
 
 ### `IOS_DYNAMIC_FRAMERATE_ENABLED` <AvailableFrom version="0.6.0" />
 

--- a/scripts/patches/bundle-mode.patch
+++ b/scripts/patches/bundle-mode.patch
@@ -29,14 +29,13 @@ index afe4c07b49..eece71ae7f 100644
  module.exports = wrapWithReanimatedMetroConfig(
    mergeConfig(defaultConfig, config)
 diff --git a/apps/fabric-example/package.json b/apps/fabric-example/package.json
-index 3413d160ce..e449361b2f 100644
+index e95d944cc1..e449361b2f 100644
 --- a/apps/fabric-example/package.json
 +++ b/apps/fabric-example/package.json
-@@ -45,8 +45,7 @@
+@@ -45,7 +45,7 @@
      "staticFeatureFlags": {
        "RUNTIME_TEST_FLAG": true,
        "IOS_DYNAMIC_FRAMERATE_ENABLED": true,
--      "BUNDLE_MODE_ENABLED": false,
 -      "FETCH_PREVIEW_ENABLED": false
 +      "FETCH_PREVIEW_ENABLED": true
      }


### PR DESCRIPTION
## Summary

Updating the docs since `BUNDLE_MODE_ENABLED` is no longer a static feature flag with #9064, also cleaning up a bit in the repo.

## Test plan

CI
