### PR TITLE
Remove `useInterpolateConfig` function and `InterpolateConfig` and `ColorSpace` types

### DIFF
--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -147,17 +147,14 @@ export {
   useSharedValue,
 } from './hook';
 export type {
-  InterpolateConfig,
   InterpolateHSV,
   InterpolateRGB,
   InterpolationOptions,
 } from './interpolateColor';
 export {
-  ColorSpace,
   /** @deprecated Please use {@link Extrapolation} instead. */
   Extrapolate,
   interpolateColor,
-  useInterpolateConfig,
 } from './interpolateColor';
 export type { ExtrapolationConfig, ExtrapolationType } from './interpolation';
 export { clamp, Extrapolation, interpolate } from './interpolation';

--- a/packages/react-native-reanimated/src/interpolateColor.ts
+++ b/packages/react-native-reanimated/src/interpolateColor.ts
@@ -9,10 +9,7 @@ import {
   RGBtoHSV,
 } from './Colors';
 import { processColor, ReanimatedError } from './common';
-import type { SharedValue } from './commonTypes';
-import { makeMutable } from './core';
 import culori from './culori';
-import { useSharedValue } from './hook/useSharedValue';
 import { Extrapolation, interpolate } from './interpolation';
 
 /** @deprecated Please use Extrapolation instead */
@@ -415,33 +412,4 @@ export function interpolateColor(
       colorSpace as string
     }. Supported values are: ['RGB', 'HSV', 'LAB'].`
   );
-}
-
-export enum ColorSpace {
-  RGB = 0,
-  HSV = 1,
-  LAB = 2,
-}
-
-export interface InterpolateConfig {
-  inputRange: readonly number[];
-  outputRange: readonly (string | number)[];
-  colorSpace: ColorSpace;
-  cache: SharedValue<InterpolateRGB | InterpolateHSV | null>;
-  options: InterpolationOptions;
-}
-
-export function useInterpolateConfig(
-  inputRange: readonly number[],
-  outputRange: readonly (string | number)[],
-  colorSpace = ColorSpace.RGB,
-  options: InterpolationOptions = {}
-): SharedValue<InterpolateConfig> {
-  return useSharedValue<InterpolateConfig>({
-    inputRange,
-    outputRange,
-    colorSpace,
-    cache: makeMutable<InterpolateRGB | InterpolateHSV | null>(null),
-    options,
-  });
 }

--- a/packages/react-native-reanimated/src/mock.ts
+++ b/packages/react-native-reanimated/src/mock.ts
@@ -20,7 +20,6 @@ import type {
 import {
   advanceAnimationByFrame,
   advanceAnimationByTime,
-  ColorSpace,
   Extrapolation,
   getAnimatedStyle,
   InterfaceOrientation,
@@ -161,9 +160,7 @@ const interpolation = {
 const interpolateColor = {
   Extrapolate: Extrapolation,
   Extrapolation,
-  ColorSpace,
   interpolateColor: NOOP,
-  // useInterpolateConfig: ADD ME IF NEEDED
 };
 
 const Easing = {


### PR DESCRIPTION
## Summary

This PR removes `useInterpolateConfig` function as well as `InterpolateConfig` and `ColorSpace` types which are no longed used.

`useInterpolateConfig` was introduced in this PR:
* https://github.com/software-mansion/react-native-reanimated/pull/2796

## Test plan
