### PR TITLE
Fix/Fixed typo in code and docs description in Fundamentals/Your First Animation Section

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/your-first-animation.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/your-first-animation.mdx
@@ -88,7 +88,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = Math.random() * 100 + 50;
+    width.value = width.value + 50;
   };
 
   return (
@@ -114,7 +114,7 @@ It's a common mistake to modify a shared value directly like this: ~~`sv = sv + 
 
 ## Using an animation function
 
-Finally, import `withSpring` function and wrap around `Math.random() * 100 + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `Math.random() * 100 + 50`).
+Finally, import `withSpring` function and wrap around `width.value + 50` in the `handlePress` function so that the value which `withSpring` returns modifies the shared value. This will create a bouncy spring animation that transitions the width of the element from its current value (here `width.value`) to the new one (here `width.value + 50`).
 
 ```jsx {2,8}
 import { Button, View } from 'react-native';
@@ -124,7 +124,7 @@ export default function App() {
   const width = useSharedValue(100);
 
   const handlePress = () => {
-    width.value = withSpring(Math.random() * 100 + 50);
+    width.value = withSpring(width.value + 50);
   };
 
   return (


### PR DESCRIPTION
## Summary
Previously There was a typo in [](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation/)
In the following example.. we have to increase the width of the box by 50px which can be easily done by width.value = **width.value + 50** but it is wriiten  like **width.value = Math.random() * 100 + 50** which is wrong.

So i fixed it. Honestly this is my first PR ever so i don't know much about testing.. and i don't think testing is needed so i am just opening a pull request.
Any feedback will be appreciated. Thanks

<img width="903" height="548" alt="image" src="https://github.com/user-attachments/assets/2d4c9448-60c2-4af4-8b2b-d3eab2382e13" />