### PR TITLE
fix - passing negative values to `filter` crashes on iOS

### DIFF
--- a/packages/react-native-reanimated/src/common/style/processors/__tests__/filter.test.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/__tests__/filter.test.ts
@@ -1,8 +1,7 @@
 'use strict';
-import { ReanimatedError } from '../../../errors';
 import type { FilterArray } from '../../../types';
 import { ValueProcessorTarget } from '../../../types';
-import { ERROR_MESSAGES, processFilter } from '../filter';
+import { processFilter } from '../filter';
 
 describe(processFilter, () => {
   test('returns the same object if not a string', () => {
@@ -199,54 +198,113 @@ describe(processFilter, () => {
     });
   });
 
+  test('numeric hueRotate in array input is treated as degrees', () => {
+    expect(processFilter([{ hueRotate: 90 }])).toEqual([{ hueRotate: 90 }]);
+  });
+
   describe('returns empty array for invalid filter values', () => {
-    test('negative blur returns empty array', () => {
-      expect(processFilter('blur(-5px)')).toEqual([]);
+    describe('string inputs', () => {
+      const invalidStringCases: { name: string; input: string }[] = [
+        {
+          name: 'negative blur string',
+          input: 'blur(-5px)',
+        },
+        {
+          name: 'negative percentage filter',
+          input: 'brightness(-0.5)',
+        },
+        {
+          name: 'invalidates all filters if any is invalid',
+          input: 'brightness(0.5) blur(-5)',
+        },
+        {
+          name: 'missing filter value',
+          input: 'brightness()',
+        },
+        {
+          name: 'non-numeric filter value',
+          input: 'contrast(two)',
+        },
+        {
+          name: 'hueRotate string without units',
+          input: 'hueRotate(90)',
+        },
+        {
+          name: 'unknown filter name',
+          input: 'unknownFilter(5)',
+        },
+        {
+          name: 'completely invalid string',
+          input: 'not a filter',
+        },
+      ];
+
+      test.each(invalidStringCases)(
+        '$name returns empty array',
+        ({ input }) => {
+          expect(processFilter(input)).toEqual([]);
+        }
+      );
     });
 
-    test('negative blur in array input returns empty array', () => {
-      expect(processFilter([{ blur: -5 }])).toEqual([]);
-    });
+    describe('array/object filter inputs', () => {
+      const invalidArrayCases: {
+        name: string;
+        input: Parameters<typeof processFilter>[0];
+      }[] = [
+        {
+          name: 'negative blur in array input',
+          input: [{ blur: -5 }],
+        },
+        {
+          name: 'negative brightness in array input',
+          input: [{ brightness: -0.5 }],
+        },
+        {
+          name: 'hueRotate string without units in array input',
+          input: [{ hueRotate: '90' }],
+        },
+        {
+          name: 'negative dropShadow standardDeviation in array input',
+          input: [
+            {
+              dropShadow: {
+                color: 'red',
+                offsetX: 1,
+                offsetY: 1,
+                standardDeviation: -1,
+              },
+            },
+          ],
+        },
+        {
+          name: 'invalidates all array filters if any is invalid',
+          input: [{ brightness: 0.5 }, { blur: -5 }],
+        },
+      ];
 
-    test('negative percentage filter returns empty array', () => {
-      expect(processFilter('brightness(-0.5)')).toEqual([]);
-    });
-
-    test('invalidates all filters if any is invalid', () => {
-      expect(processFilter('brightness(0.5) blur(-5)')).toEqual([]);
+      test.each(invalidArrayCases)('$name returns empty array', ({ input }) => {
+        expect(processFilter(input)).toEqual([]);
+      });
     });
   });
 
-  describe('error handling', () => {
-    const cases: { input: string; errorMessage: string }[] = [
-      {
-        input: 'brightness()', // missing value
-        errorMessage: ERROR_MESSAGES.invalidFilter('brightness()'),
-      },
-      {
-        input: 'contrast(two)', // invalid number
-        errorMessage: ERROR_MESSAGES.invalidFilter('contrast(two)'),
-      },
-      {
-        input: 'blur()', // missing value
-        errorMessage: ERROR_MESSAGES.invalidFilter('blur()'),
-      },
-      {
-        input: 'hueRotate(90)', // missing units
-        errorMessage: ERROR_MESSAGES.invalidFilter('hueRotate(90)'),
-      },
-      {
-        input: 'unknownFilter(5)',
-        errorMessage: ERROR_MESSAGES.invalidFilter('unknownFilter(5)'),
-      },
+  describe('returns empty array for non-filter input type', () => {
+    // Helper to bypass type checking for the function to allow passing
+    // invalid input types
+    const processFilterUntyped = processFilter as (value: unknown) => unknown;
+
+    const invalidInputTypeCases = [
+      { name: 'number input', input: 123 },
+      { name: 'object input', input: {} },
+      { name: 'null input', input: null },
+      { name: 'undefined input', input: undefined },
     ];
 
-    test.each(cases)(
-      'throws an error for invalid input: $input',
-      ({ input, errorMessage }) => {
-        expect(() => processFilter(input)).toThrow(
-          new ReanimatedError(errorMessage)
-        );
+    test.each(invalidInputTypeCases)(
+      'returns empty array for $name',
+      ({ input }) => {
+        expect(processFilterUntyped(input)).toEqual([]);
       }
     );
   });

--- a/packages/react-native-reanimated/src/common/style/processors/filter.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/filter.ts
@@ -2,7 +2,6 @@
 'worklet';
 import type { DropShadowValue, FilterFunction } from 'react-native';
 
-import { ReanimatedError } from '../../errors';
 import type {
   FilterArray,
   ParsedDropShadow,
@@ -20,67 +19,52 @@ const FILTER_VALUE_REGEX = /^([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)([a-z%]*)$/;
 // Capture drop-shadow parts "10px 5px 5px #888888" => ["10px", "5px", "5px", "#888888"]
 const DROP_SHADOW_REGEX = /[^,\s()]+(?:\([^()]*\))?/g;
 
-export const ERROR_MESSAGES = {
-  invalidFilter: (filter: string) => `Invalid filter property: ${filter}`,
-  invalidFilterType: (filter: readonly FilterFunction[]) =>
-    `Invalid filter input type: ${typeof filter}. Expected string or array.`,
-};
-
 type SingleFilterValue = {
   numberValue: number;
   unit: string;
 };
 
-const parseHueRotate = (value: SingleFilterValue): number | undefined => {
+const parseHueRotate = (value: SingleFilterValue): number | null => {
   const { numberValue, unit } = value;
-  if (numberValue === 0) {
-    return 0;
-  }
-  if (unit !== 'deg' && unit !== 'rad') {
-    throw new ReanimatedError(
-      ERROR_MESSAGES.invalidFilter(`hueRotate(${numberValue}${unit})`)
-    );
+  if (numberValue !== 0 && unit !== 'deg' && unit !== 'rad') {
+    return null;
   }
   return unit === 'rad' ? (180 * numberValue) / Math.PI : numberValue;
 };
 
-const parseBlur = (value: SingleFilterValue): number | undefined => {
+const parseBlur = (value: SingleFilterValue): number | null => {
   const { numberValue, unit } = value;
   if ((unit && unit !== 'px') || numberValue < 0) {
-    return undefined;
+    return null;
   }
   return numberValue;
 };
 
-const parsePercentageFilter = (
-  value: SingleFilterValue
-): number | undefined => {
+const parsePercentageFilter = (value: SingleFilterValue): number | null => {
   const { numberValue, unit } = value;
   if ((unit && unit !== '%') || numberValue < 0) {
-    return undefined;
+    return null;
   }
   return unit === '%' ? numberValue / 100 : numberValue;
 };
 
 const LENGTH_MAPPINGS = ['offsetX', 'offsetY', 'standardDeviation'] as const;
 
-const parseDropShadowString = (value: string) => {
+const parseDropShadowString = (value: string): DropShadowValue | null => {
   const match = value.match(DROP_SHADOW_REGEX) ?? [];
   const result: DropShadowValue = { offsetX: 0, offsetY: 0 };
   let foundLengthsCount = 0;
 
-  match.forEach((part) => {
+  for (const part of match) {
     if (isLength(part)) {
-      if (__DEV__ && !part.trim().match(FILTER_VALUE_REGEX)) {
-        throw new ReanimatedError(
-          ERROR_MESSAGES.invalidFilter(`dropShadow(${value})`)
-        );
+      if (!part.trim().match(FILTER_VALUE_REGEX)) {
+        return null;
       }
       result[LENGTH_MAPPINGS[foundLengthsCount++]] = parseFloat(part);
     } else {
       result.color = part.trim();
     }
-  });
+  }
 
   return result;
 };
@@ -91,6 +75,9 @@ const parseDropShadow = (
 ): ParsedDropShadow | null => {
   const dropShadow =
     typeof value === 'string' ? parseDropShadowString(value) : value;
+  if (dropShadow === null) {
+    return null;
+  }
   const {
     color = '#000',
     offsetX = 0,
@@ -104,7 +91,7 @@ const parseDropShadow = (
   }
 
   const processedColor = processColor(color, context);
-  if (processedColor == null) {
+  if (processedColor === null) {
     return null;
   }
 
@@ -123,12 +110,12 @@ const parseFilterProperty = (
   context: ValueProcessorContext | undefined
 ): ParsedFilterFunction | null => {
   // We need to handle dropShadow separately because of its complex structure
-  if (filterName == 'dropShadow') {
+  if (filterName === 'dropShadow') {
     const dropShadow = parseDropShadow(
       filterValue as string | DropShadowValue,
       context
     );
-    if (dropShadow == null) {
+    if (dropShadow === null) {
       return null;
     }
     return { dropShadow };
@@ -138,24 +125,28 @@ const parseFilterProperty = (
   let unit: string;
 
   if (isNumber(filterValue)) {
+    // Numeric hueRotate values are treated as degrees.
+    // Unit validation only applies to string values like 'hueRotate(90deg)'.
+    if (filterName === 'hueRotate') {
+      return { hueRotate: filterValue };
+    }
     numberValue = filterValue;
     unit = '';
   } else {
     const stringValue = filterValue as string;
     const match = stringValue.match(FILTER_VALUE_REGEX);
     if (!match) {
-      throw new ReanimatedError(
-        ERROR_MESSAGES.invalidFilter(`${filterName}(${stringValue})`)
-      );
+      return null;
     }
     numberValue = parseFloat(match[1]);
     unit = match[2];
   }
 
-  let amount: number | undefined;
+  let amount: number | null;
   switch (filterName) {
     case 'hueRotate':
-      return { hueRotate: parseHueRotate({ numberValue, unit }) };
+      amount = parseHueRotate({ numberValue, unit });
+      break;
     case 'blur':
       amount = parseBlur({ numberValue, unit });
       break;
@@ -169,12 +160,10 @@ const parseFilterProperty = (
       amount = parsePercentageFilter({ numberValue, unit });
       break;
     default:
-      throw new ReanimatedError(
-        ERROR_MESSAGES.invalidFilter(`${filterName}(${numberValue}${unit})`)
-      );
+      return null;
   }
 
-  if (amount == null) {
+  if (amount === null) {
     return null;
   }
 
@@ -187,19 +176,15 @@ const parseFilterString = (
 ): FilterArray => {
   const matches = Array.from(value.matchAll(FILTER_REGEX));
 
-  if (matches.length === 0) {
-    throw new ReanimatedError(ERROR_MESSAGES.invalidFilter(value));
-  }
-
   const filterArray: FilterArray = [];
   for (const match of matches) {
-    const [filter, name, content] = match;
+    const [, name, content] = match;
     if (!name || !content) {
-      throw new ReanimatedError(ERROR_MESSAGES.invalidFilter(filter));
+      return [];
     }
 
     const parsed = parseFilterProperty(name, content, context);
-    if (parsed == null) {
+    if (parsed === null) {
       return [];
     }
     filterArray.push(parsed);
@@ -220,7 +205,7 @@ export const processFilter: ValueProcessor<
     for (const filter of value) {
       const filterKey = Object.keys(filter)[0];
       const parsed = parseFilterProperty(filterKey, filter[filterKey], context);
-      if (parsed == null) {
+      if (parsed === null) {
         return [];
       }
       filterArray.push(parsed);
@@ -228,5 +213,5 @@ export const processFilter: ValueProcessor<
     return filterArray;
   }
 
-  throw new ReanimatedError(ERROR_MESSAGES.invalidFilterType(value));
+  return [];
 };


### PR DESCRIPTION
## Summary

Issue reported by @eds2002 - https://x.com/trpfsu/status/2035440749739696595

When invalid map is passed to RN e.g. `[{blur: undefined}]` (passed by reanimated processor for invalid values). It triggers a crash on iOS because of missing null check [here](https://github.com/facebook/react-native/blob/56908a74c7f79a45dae9c2f651e437399e7465fe/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h#L48). This issue does not happen on RN because [RN's processor](https://github.com/facebook/react-native/blob/56908a74c7f79a45dae9c2f651e437399e7465fe/packages/react-native/Libraries/StyleSheet/processFilter.js#L115) does not pass `filter` object to native in case of invalid values. The null check should also be added to RN's prop conversion layer just for added safety, will make a PR for that.


## Test plan

Test fix in repro. https://github.com/eds2002/blur-issue . Also, simply passing `filter: blur(-5px)` in `useAnimatedStyle` is enough to trigger the crash.

