### PR TITLE
Update Podfile.lock

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2119,7 +2119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.8.0-main):
+  - RNWorklets (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2141,10 +2141,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.0-main)
-    - RNWorklets/common (= 0.8.0-main)
+    - RNWorklets/apple (= 0.9.0-main)
+    - RNWorklets/common (= 0.9.0-main)
     - Yoga
-  - RNWorklets/apple (0.8.0-main):
+  - RNWorklets/apple (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2167,7 +2167,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.0-main):
+  - RNWorklets/common (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,7 +2538,7 @@ SPEC CHECKSUMS:
   RNReanimated: c2e7905ab97eb558cfe8e7f49f657559449af983
   RNScreens: 6ddda03d6564ca1dbde5754fe8effa9ac2cdb091
   RNSVG: f21bef0d41b6495cdd8db5cb010b18bee378152c
-  RNWorklets: 27192e240a1512153992300e6c75a4820d481fa4
+  RNWorklets: 023913e36f064002ac0a74e9817c9e443a2aa216
   Yoga: 1bf7ba0aa6156e76d0f34c1de341508d40855f9f
 
 PODFILE CHECKSUM: 5a5e231e2fd86b91c7e0a93852f5aa6de886161f

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -2574,7 +2574,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.8.0-main):
+  - RNWorklets (0.9.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -2601,11 +2601,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/apple (= 0.8.0-main)
-    - RNWorklets/common (= 0.8.0-main)
+    - RNWorklets/apple (= 0.9.0-main)
+    - RNWorklets/common (= 0.9.0-main)
     - SocketRocket
     - Yoga
-  - RNWorklets/apple (0.8.0-main):
+  - RNWorklets/apple (0.9.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -2634,7 +2634,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets/common (0.8.0-main):
+  - RNWorklets/common (0.9.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -2988,7 +2988,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
   RNReanimated: 33ab00806793c9df450b0b0b57d1e431009f6aba
   RNSVG: c4d5a438a1c96f7ed7dc66349a5b7e97616fd701
-  RNWorklets: 025716e77a62c245e511d7b3aeca0cb7189dc305
+  RNWorklets: 930db1fcda379e00797edc0812b6453cc7e587d4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 4e7825418aa0a50bdaa8dff6d3e5fa8a2994d308
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1855,7 +1855,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNWorklets (0.8.0-main):
+  - RNWorklets (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1876,10 +1876,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.0-main)
-    - RNWorklets/common (= 0.8.0-main)
+    - RNWorklets/apple (= 0.9.0-main)
+    - RNWorklets/common (= 0.9.0-main)
     - Yoga
-  - RNWorklets/apple (0.8.0-main):
+  - RNWorklets/apple (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,7 +1901,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.0-main):
+  - RNWorklets/common (0.9.0-main):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2230,7 +2230,7 @@ SPEC CHECKSUMS:
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
   ReactNativeDependencies: cc895992cbb09b34af5cc6040d846145a3dac87a
   RNReanimated: 0982f8bb04a5dde110fd7f57f0c97bc80e48983a
-  RNWorklets: 06e110ed87e01084dd1e31caeb6723ae7bb726aa
+  RNWorklets: ba6053e50f0b5df00075b11a632906f59eb69d66
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699


### PR DESCRIPTION
## Summary

This PR bumps `RNWorklets` version to `0.9.0-main` in `Podfile.lock` in fabric-example, tvos-example and macos-example.

## Test plan
