### PR TITLE
Remove unnecessary `react_native_assert` for `surfaceId`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1196,7 +1196,6 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
     for (auto const &[shadowNode, props] : updatesBatch) {
       SurfaceId surfaceId = shadowNode->getSurfaceId();
       auto family = &shadowNode->getFamily();
-      react_native_assert(family->getSurfaceId() == surfaceId);
       propsMapBySurface[surfaceId][family].emplace_back(props);
     }
   }


### PR DESCRIPTION
## Summary

This PR removes `react_native_assert(family->getSurfaceId() == surfaceId);` which is unnecessary because the condition is always true.

When Reanimated supported only one surface, there was an assert for `surfaceId_` field. In https://github.com/software-mansion/react-native-reanimated/pull/6647 we added support for multiple surfaces and the check is no longer needed. 

## Test plan
