### PR TITLE
Adds useTimestamp hook

### DIFF
--- a/docs/docs-reanimated/docs/advanced/useTimestamp.mdx
+++ b/docs/docs-reanimated/docs/advanced/useTimestamp.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 10
+---
+
+# useTimestamp
+
+`useTimestamp` lets you access the current frame timestamp as a [Shared Value](/docs/fundamentals/glossary#shared-value). It's a convenience wrapper around [`useFrameCallback`](/docs/advanced/useFrameCallback) for the common case of driving animations or shaders from the current time.
+
+## Reference
+
+```javascript
+import { useTimestamp } from 'react-native-reanimated';
+
+function App() {
+  const timestamp = useTimestamp();
+
+  // timestamp.value is the time (in ms) elapsed since
+  // the first frame. It updates on every frame.
+}
+```
+
+<details>
+  <summary>Type definitions</summary>
+
+  ```typescript
+  function useTimestamp(isActive?: boolean): SharedValue<number>;
+  ```
+
+</details>
+
+### Arguments
+
+#### `isActive` <Optional/>
+
+Whether the timestamp should update. Defaults to `true`.
+
+### Returns
+
+`useTimestamp` returns a [Shared Value](/docs/fundamentals/glossary#shared-value) that updates every frame with the time (in milliseconds) elapsed since the first frame after the hook was activated.
+
+## Example
+
+```javascript
+function PulsingDot({ visible }) {
+  const timestamp = useTimestamp(visible);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: 0.5 + 0.5 * Math.sin(timestamp.value / 300),
+  }));
+
+  return <Animated.View style={[styles.dot, animatedStyle]} />;
+}
+```
+
+## Remarks
+
+- Internally wraps [`useFrameCallback`](/docs/advanced/useFrameCallback).
+- For best performance, prefer to re-use a single `useTimestamp` instance (for example, by lifting it up and passing it via props or React context) instead of calling `useTimestamp` in many components.
+
+## Platform compatibility
+
+<PlatformCompatibility android ios web/>

--- a/docs/docs-reanimated/docs/advanced/useTimestamp.mdx
+++ b/docs/docs-reanimated/docs/advanced/useTimestamp.mdx
@@ -25,7 +25,6 @@ function App() {
   ```typescript
   function useTimestamp(isActive?: boolean): SharedValue<number>;
   ```
-
 </details>
 
 ### Arguments

--- a/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
+++ b/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import Animated, { useTimestamp } from '../src';
+
+const mockSetActive = jest.fn();
+const mockFrameCallback = {
+  setActive: mockSetActive,
+  isActive: false,
+  callbackId: -1,
+};
+
+jest.mock('../src/hook/useFrameCallback', () => {
+  const original = jest.requireActual('../src/hook/useFrameCallback');
+  return {
+    ...original,
+    useFrameCallback: jest.fn(() => mockFrameCallback),
+  };
+});
+
+describe('useTimestamp', () => {
+  beforeEach(() => {
+    mockSetActive.mockClear();
+  });
+
+  test('initializes to 0', () => {
+    function TestComponent() {
+      const timestamp = useTimestamp(false);
+      return (
+        <Animated.View
+          style={{ opacity: timestamp.value }}
+          testID={'AnimatedView'}
+        />
+      );
+    }
+
+    const component = render(<TestComponent />);
+    const view = component.getByTestId('AnimatedView');
+    expect(view.props.style[0].opacity).toBe(0);
+  });
+
+  test('defaults isActive to true', () => {
+    function TestComponent() {
+      useTimestamp();
+      return <Animated.View testID={'AnimatedView'} />;
+    }
+
+    render(<TestComponent />);
+    expect(mockSetActive).toHaveBeenCalledWith(true);
+  });
+
+  test('respects isActive=false', () => {
+    function TestComponent() {
+      useTimestamp(false);
+      return <Animated.View testID={'AnimatedView'} />;
+    }
+
+    render(<TestComponent />);
+    expect(mockSetActive).toHaveBeenCalledWith(false);
+  });
+
+  test('calls setActive when isActive toggles', () => {
+    function TestComponent({ active }: { active: boolean }) {
+      useTimestamp(active);
+      return <Animated.View testID={'AnimatedView'} />;
+    }
+
+    const component = render(<TestComponent active={false} />);
+    expect(mockSetActive).toHaveBeenLastCalledWith(false);
+
+    mockSetActive.mockClear();
+    component.update(<TestComponent active={true} />);
+    expect(mockSetActive).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
+++ b/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
@@ -1,50 +1,66 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-native';
 
 import { useTimestamp } from '../src';
 
-const mockSetActive = jest.fn();
-const mockFrameCallback = {
-  setActive: mockSetActive,
-  isActive: false,
-  callbackId: -1,
-};
-
-jest.mock('../src/hook/useFrameCallback', () => {
-  const original = jest.requireActual('../src/hook/useFrameCallback');
-  return {
-    ...original,
-    useFrameCallback: jest.fn(() => mockFrameCallback),
-  };
-});
-
 describe('useTimestamp', () => {
-  beforeEach(() => {
-    mockSetActive.mockClear();
+  beforeAll(() => {
+    jest.useFakeTimers();
   });
+
+  function flushFrames(count: number) {
+    for (let i = 0; i < count; i++) {
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+    }
+  }
 
   test('initializes to 0', () => {
     const { result } = renderHook(() => useTimestamp(false));
+
     expect(result.current.value).toBe(0);
   });
 
-  test('defaults isActive to true', () => {
-    renderHook(() => useTimestamp());
-    expect(mockSetActive).toHaveBeenCalledWith(true);
+  test('does not update .value when isActive is false', () => {
+    const { result } = renderHook(() => useTimestamp(false));
+    flushFrames(20);
+
+    expect(result.current.value).toBe(0);
   });
 
-  test('respects isActive=false', () => {
-    renderHook(() => useTimestamp(false));
-    expect(mockSetActive).toHaveBeenCalledWith(false);
+  test('updates .value across frames when active', () => {
+    const { result } = renderHook(() => useTimestamp());
+    flushFrames(20);
+
+    expect(result.current.value).toBeGreaterThan(0);
   });
 
-  test('calls setActive when isActive toggles', () => {
-    const { rerender } = renderHook(({ active }) => useTimestamp(active), {
-      initialProps: { active: false },
-    });
-    expect(mockSetActive).toHaveBeenLastCalledWith(false);
+  test('stops updating after isActive toggles to false', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useTimestamp(active),
+      { initialProps: { active: true } }
+    );
+    flushFrames(20);
+    const valueWhileActive = result.current.value;
+    expect(valueWhileActive).toBeGreaterThan(0);
 
-    mockSetActive.mockClear();
+    rerender({ active: false });
+    flushFrames(20);
+
+    expect(result.current.value).toBe(valueWhileActive);
+  });
+
+  test('resumes updating after isActive toggles back to true', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useTimestamp(active),
+      { initialProps: { active: false } }
+    );
+    flushFrames(20);
+    expect(result.current.value).toBe(0);
+
     rerender({ active: true });
-    expect(mockSetActive).toHaveBeenCalledWith(true);
+    flushFrames(20);
+
+    expect(result.current.value).toBeGreaterThan(0);
   });
 });

--- a/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
+++ b/packages/react-native-reanimated/__tests__/hooks.useTimestamp.test.tsx
@@ -1,7 +1,6 @@
-import { render } from '@testing-library/react-native';
-import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
 
-import Animated, { useTimestamp } from '../src';
+import { useTimestamp } from '../src';
 
 const mockSetActive = jest.fn();
 const mockFrameCallback = {
@@ -24,52 +23,28 @@ describe('useTimestamp', () => {
   });
 
   test('initializes to 0', () => {
-    function TestComponent() {
-      const timestamp = useTimestamp(false);
-      return (
-        <Animated.View
-          style={{ opacity: timestamp.value }}
-          testID={'AnimatedView'}
-        />
-      );
-    }
-
-    const component = render(<TestComponent />);
-    const view = component.getByTestId('AnimatedView');
-    expect(view.props.style[0].opacity).toBe(0);
+    const { result } = renderHook(() => useTimestamp(false));
+    expect(result.current.value).toBe(0);
   });
 
   test('defaults isActive to true', () => {
-    function TestComponent() {
-      useTimestamp();
-      return <Animated.View testID={'AnimatedView'} />;
-    }
-
-    render(<TestComponent />);
+    renderHook(() => useTimestamp());
     expect(mockSetActive).toHaveBeenCalledWith(true);
   });
 
   test('respects isActive=false', () => {
-    function TestComponent() {
-      useTimestamp(false);
-      return <Animated.View testID={'AnimatedView'} />;
-    }
-
-    render(<TestComponent />);
+    renderHook(() => useTimestamp(false));
     expect(mockSetActive).toHaveBeenCalledWith(false);
   });
 
   test('calls setActive when isActive toggles', () => {
-    function TestComponent({ active }: { active: boolean }) {
-      useTimestamp(active);
-      return <Animated.View testID={'AnimatedView'} />;
-    }
-
-    const component = render(<TestComponent active={false} />);
+    const { rerender } = renderHook(({ active }) => useTimestamp(active), {
+      initialProps: { active: false },
+    });
     expect(mockSetActive).toHaveBeenLastCalledWith(false);
 
     mockSetActive.mockClear();
-    component.update(<TestComponent active={true} />);
+    rerender({ active: true });
     expect(mockSetActive).toHaveBeenCalledWith(true);
   });
 });

--- a/packages/react-native-reanimated/src/hook/index.ts
+++ b/packages/react-native-reanimated/src/hook/index.ts
@@ -28,3 +28,4 @@ export { useHandler } from './useHandler';
 export { useReducedMotion } from './useReducedMotion';
 export { useScrollOffset } from './useScrollOffset';
 export { useSharedValue } from './useSharedValue';
+export { useTimestamp } from './useTimestamp';

--- a/packages/react-native-reanimated/src/hook/useFrameCallback.ts
+++ b/packages/react-native-reanimated/src/hook/useFrameCallback.ts
@@ -20,8 +20,7 @@ export type FrameCallback = {
 const frameCallbackRegistry = new FrameCallbackRegistryJS();
 
 /**
- * Lets you run a function on every frame update. This is expensive, so don't
- * create multiple timers if you can use one and share it.
+ * Lets you run a function on every frame update.
  *
  * @param callback - A function executed on every frame update.
  * @param autostart - Whether the callback should start automatically. Defaults

--- a/packages/react-native-reanimated/src/hook/useFrameCallback.ts
+++ b/packages/react-native-reanimated/src/hook/useFrameCallback.ts
@@ -20,7 +20,8 @@ export type FrameCallback = {
 const frameCallbackRegistry = new FrameCallbackRegistryJS();
 
 /**
- * Lets you run a function on every frame update.
+ * Lets you run a function on every frame update. This is expensive, so don't
+ * create multiple timers if you can use one and share it.
  *
  * @param callback - A function executed on every frame update.
  * @param autostart - Whether the callback should start automatically. Defaults

--- a/packages/react-native-reanimated/src/hook/useTimestamp.ts
+++ b/packages/react-native-reanimated/src/hook/useTimestamp.ts
@@ -1,0 +1,27 @@
+'use strict';
+import { useEffect } from 'react';
+
+import type { SharedValue } from '../commonTypes';
+import { useFrameCallback } from './useFrameCallback';
+import { useSharedValue } from './useSharedValue';
+
+/**
+ * Lets you access the current frame timestamp as a shared value.
+ *
+ * @param isActive - Whether the timestamp should update. Defaults to `true`.
+ * @returns A shared value that updates every frame with the time elapsed since
+ *   the first frame.
+ */
+export function useTimestamp(isActive = true): SharedValue<number> {
+  const timestamp = useSharedValue(0);
+  const frameCallback = useFrameCallback((info) => {
+    'worklet';
+    timestamp.value = info.timeSinceFirstFrame;
+  }, isActive);
+
+  useEffect(() => {
+    frameCallback.setActive(isActive);
+  }, [isActive, frameCallback]);
+
+  return timestamp;
+}

--- a/packages/react-native-reanimated/src/hook/useTimestamp.ts
+++ b/packages/react-native-reanimated/src/hook/useTimestamp.ts
@@ -6,17 +6,22 @@ import { useFrameCallback } from './useFrameCallback';
 import { useSharedValue } from './useSharedValue';
 
 /**
- * Lets you access the current frame timestamp as a shared value.
+ * Lets you access the current frame timestamp as a [Shared
+ * Value](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#shared-value).
+ *
+ * For best performance, prefer to re-use a single `useTimestamp` timer instead
+ * of creating multiple ones.
  *
  * @param isActive - Whether the timestamp should update. Defaults to `true`.
  * @returns A shared value that updates every frame with the time elapsed since
  *   the first frame.
+ * @see https://docs.swmansion.com/react-native-reanimated/docs/advanced/useTimestamp
  */
 export function useTimestamp(isActive = true): SharedValue<number> {
   const timestamp = useSharedValue(0);
-  const frameCallback = useFrameCallback((info) => {
+  const frameCallback = useFrameCallback(({ timeSinceFirstFrame }) => {
     'worklet';
-    timestamp.value = info.timeSinceFirstFrame;
+    timestamp.value = timeSinceFirstFrame;
   }, isActive);
 
   useEffect(() => {

--- a/packages/react-native-reanimated/src/index.ts
+++ b/packages/react-native-reanimated/src/index.ts
@@ -146,6 +146,7 @@ export {
   /** @deprecated Please use {@link useScrollOffset} instead. */
   useScrollOffset as useScrollViewOffset,
   useSharedValue,
+  useTimestamp,
 } from './hook';
 export type {
   InterpolateHSV,


### PR DESCRIPTION
## Summary

When driving animations or shaders based on the current time, I had to use this kind of code locally. It adds a bit of complexity to a component that already had a lot of complexity, and it was suggested to me that others could benefit from this.

The code accepts an `isActive` parameter which you could change based on your react-navigation focus state, for example. This pauses the animations while they're off screen.

## Test plan

Equivalent code is working in production for me (I didn't patch the library, but I'm using the same calls). I also added thorough unit tests.
