### PR TITLE
docs: Add `withTargetValues` to Layout Animations docs

### DIFF
--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -206,8 +206,8 @@ FadeInDown.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Bounce
@@ -352,8 +352,8 @@ BounceInDown.duration(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Flip
@@ -562,8 +562,8 @@ FlipInEasyY.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## LightSpeed
@@ -709,8 +709,8 @@ LightSpeedInRight.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Pinwheel
@@ -846,8 +846,8 @@ PinwheelIn.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Roll
@@ -990,8 +990,8 @@ RollInRight.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Rotate
@@ -1158,8 +1158,8 @@ RotateInDownLeft.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Slide
@@ -1316,8 +1316,8 @@ SlideInDown.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Stretch
@@ -1466,8 +1466,8 @@ StretchInY.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Zoom
@@ -1682,8 +1682,8 @@ ZoomIn.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -112,7 +112,7 @@ Available fade animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name           | Config                            |
       | -------------- | --------------------------------- |
@@ -207,7 +207,7 @@ FadeInDown.delay(500)
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Bounce
@@ -291,7 +291,7 @@ Available bounce animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name             | Config                                 |
       | ---------------- | -------------------------------------- |
@@ -353,7 +353,7 @@ BounceInDown.duration(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Flip
@@ -443,7 +443,7 @@ Available flip animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name            | Config                                                                      |
       | --------------- | --------------------------------------------------------------------------- |
@@ -563,7 +563,7 @@ FlipInEasyY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## LightSpeed
@@ -631,7 +631,7 @@ Available lightspeed animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name                 | Config                                                             |
       | -------------------- | ------------------------------------------------------------------ |
@@ -710,7 +710,7 @@ LightSpeedInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Pinwheel
@@ -770,7 +770,7 @@ Available pinwheel animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name          | Config                                     |
       | ------------- | ------------------------------------------ |
@@ -847,7 +847,7 @@ PinwheelIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Roll
@@ -913,7 +913,7 @@ Available roll animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name           | Config                                                   |
       | -------------- | -------------------------------------------------------- |
@@ -991,7 +991,7 @@ RollInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Rotate
@@ -1071,7 +1071,7 @@ Available rotate animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name                 | Config                                                                                                                                                                  |
       | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1159,7 +1159,7 @@ RotateInDownLeft.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Slide
@@ -1237,7 +1237,7 @@ Available slide animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name            | Config                                                                                     |
       | --------------- | ------------------------------------------------------------------------------------------ |
@@ -1317,7 +1317,7 @@ SlideInDown.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Stretch
@@ -1383,7 +1383,7 @@ Available stretch animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name          | Config          |
       | ------------- | --------------- |
@@ -1467,7 +1467,7 @@ StretchInY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Zoom
@@ -1569,7 +1569,7 @@ Available zoom animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name              | Config                                            |
       | ----------------- | ------------------------------------------------- |
@@ -1683,7 +1683,7 @@ ZoomIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0"/> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -112,7 +112,7 @@ Available fade animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name           | Config                            |
       | -------------- | --------------------------------- |
@@ -207,7 +207,7 @@ FadeInDown.delay(500)
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Bounce
@@ -291,7 +291,7 @@ Available bounce animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name             | Config                                 |
       | ---------------- | -------------------------------------- |
@@ -353,7 +353,7 @@ BounceInDown.duration(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Flip
@@ -443,7 +443,7 @@ Available flip animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name            | Config                                                                      |
       | --------------- | --------------------------------------------------------------------------- |
@@ -563,7 +563,7 @@ FlipInEasyY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## LightSpeed
@@ -631,7 +631,7 @@ Available lightspeed animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name                 | Config                                                             |
       | -------------------- | ------------------------------------------------------------------ |
@@ -710,7 +710,7 @@ LightSpeedInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Pinwheel
@@ -770,7 +770,7 @@ Available pinwheel animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name          | Config                                     |
       | ------------- | ------------------------------------------ |
@@ -847,7 +847,7 @@ PinwheelIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Roll
@@ -913,7 +913,7 @@ Available roll animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name           | Config                                                   |
       | -------------- | -------------------------------------------------------- |
@@ -991,7 +991,7 @@ RollInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Rotate
@@ -1071,7 +1071,7 @@ Available rotate animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name                 | Config                                                                                                                                                                  |
       | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1159,7 +1159,7 @@ RotateInDownLeft.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Slide
@@ -1237,7 +1237,7 @@ Available slide animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name            | Config                                                                                     |
       | --------------- | ------------------------------------------------------------------------------------------ |
@@ -1317,7 +1317,7 @@ SlideInDown.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Stretch
@@ -1383,7 +1383,7 @@ Available stretch animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name          | Config          |
       | ------------- | --------------- |
@@ -1467,7 +1467,7 @@ StretchInY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Zoom
@@ -1569,7 +1569,7 @@ Available zoom animations:
     </TabItem>
 
     <TabItem value="target" label="Target values">
-      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
+      <AvailableFrom version="4.4.0" /> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
       | Name              | Config                                            |
       | ----------------- | ------------------------------------------------- |
@@ -1683,7 +1683,7 @@ ZoomIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- <AvailableFrom version="4.4.0" /> `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -91,7 +91,7 @@ Available fade animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -206,8 +206,8 @@ FadeInDown.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Bounce
@@ -270,7 +270,7 @@ Available bounce animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -352,8 +352,8 @@ BounceInDown.duration(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Flip
@@ -420,7 +420,7 @@ Available flip animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -562,8 +562,8 @@ FlipInEasyY.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## LightSpeed
@@ -616,7 +616,7 @@ Available lightspeed animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -709,8 +709,8 @@ LightSpeedInRight.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Pinwheel
@@ -757,7 +757,7 @@ Available pinwheel animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -846,8 +846,8 @@ PinwheelIn.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Roll
@@ -898,7 +898,7 @@ Available roll animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -990,8 +990,8 @@ RollInRight.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Rotate
@@ -1052,7 +1052,7 @@ Available rotate animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -1158,8 +1158,8 @@ RotateInDownLeft.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Slide
@@ -1218,7 +1218,7 @@ Available slide animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -1316,8 +1316,8 @@ SlideInDown.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Stretch
@@ -1368,7 +1368,7 @@ Available stretch animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -1466,8 +1466,8 @@ StretchInY.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Zoom
@@ -1542,7 +1542,7 @@ Available zoom animations:
 </Grid>
 
 <details>
-  <summary>Values &amp; Type definitions</summary>
+  <summary>Values & Type definitions</summary>
 
   <Tabs groupId="la-reference">
     <TabItem value="initial" label="Initial values">
@@ -1682,8 +1682,8 @@ ZoomIn.delay(500)
 - `.delay(durationMs: number)` is the delay before the animation starts (in milliseconds). Defaults to `0`.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
-- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
-- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the *Values & Type definitions* block above).
+- `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the _Values & Type definitions_ block above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -4,6 +4,8 @@ sidebar_position: 1
 
 # Entering/Exiting animations
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import { useEnteringExitingPlayground } from '@site/src/components/InteractivePlayground';
 
 Entering/Exiting animations let you animate elements when they are added to or removed from the view hierarchy.
@@ -19,9 +21,11 @@ Spring-based animations are yet to be introduced to the web. Due to that, playgr
 ## Remarks
 
 - We recommend using layout animation builders outside of components or with `useMemo` to ensure the best performance.
-- `withInitialValues` is typed per preset, so only props specific to the animation preset are accepted (see each section's Initial values table).
+- `withInitialValues` and `withTargetValues` are typed per preset, so only props specific to the animation preset are accepted (see each preset's _Values & Type definitions_ block).
 - <AvailableFrom version="4.4.0"/> For transforms, prefer flat top-level props like `{ translateX: 50 }` over `transform: [{ translateX: 50 }]`. The `transform: [{ ... }]` tuple form still works but is deprecated since `4.4.0`.
-- Type definition blocks after each animation preset show the exact `withInitialValues` type. The deprecated `transform` prop also shows the order in which transforms are applied. In the flat form, object key order is ignored and the preset applies transforms in its built-in order.
+- `withInitialValues` overrides the initial values of the animation (the state the element starts from).
+- <AvailableFrom version="4.4.0"/> `withTargetValues` overrides the target values of the animation (the state the element animates to).
+- _Values & Type definitions_ blocks after each animation preset show the exact type for both `withInitialValues` and `withTargetValues` (they accept the same props per preset). The deprecated `transform` prop also shows the order in which transforms are applied. In the flat form, object key order is ignored and the preset applies transforms in its built-in order.
 - If both forms are used, the flat prop wins for that transform slot; remaining slots fall back to the tuple value, then to the preset default. Mixing forms is supported but not recommended.
 - On the New Architecture:
   - `nativeID` is used internally to configure entering animations, so overwriting it will result in entering animations not running. Some components (e.g. TouchableWithoutFeedback) overwrite `nativeID` of its children. To work around this issue wrap your animated children with a `View`.
@@ -87,47 +91,66 @@ Available fade animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name           | Config                            |
-  | -------------- | --------------------------------- |
-  | `FadeIn`       | `{ opacity: 0 }`                  |
-  | `FadeInDown`   | `{ opacity: 0, translateY: 25 }`  |
-  | `FadeInLeft`   | `{ opacity: 0, translateX: -25 }` |
-  | `FadeInRight`  | `{ opacity: 0, translateX: 25 }`  |
-  | `FadeInUp`     | `{ opacity: 0, translateY: -25 }` |
-  | `FadeOut`      | `{ opacity: 1 }`                  |
-  | `FadeOutDown`  | `{ opacity: 1, translateY: 0 }`   |
-  | `FadeOutLeft`  | `{ opacity: 1, translateX: 0 }`   |
-  | `FadeOutRight` | `{ opacity: 1, translateX: 0 }`   |
-  | `FadeOutUp`    | `{ opacity: 1, translateY: 0 }`   |
-</details>
+      | Name           | Config                            |
+      | -------------- | --------------------------------- |
+      | `FadeIn`       | `{ opacity: 0 }`                  |
+      | `FadeInDown`   | `{ opacity: 0, translateY: 25 }`  |
+      | `FadeInLeft`   | `{ opacity: 0, translateX: -25 }` |
+      | `FadeInRight`  | `{ opacity: 0, translateX: 25 }`  |
+      | `FadeInUp`     | `{ opacity: 0, translateY: -25 }` |
+      | `FadeOut`      | `{ opacity: 1 }`                  |
+      | `FadeOutDown`  | `{ opacity: 1, translateY: 0 }`   |
+      | `FadeOutLeft`  | `{ opacity: 1, translateX: 0 }`   |
+      | `FadeOutRight` | `{ opacity: 1, translateX: 0 }`   |
+      | `FadeOutUp`    | `{ opacity: 1, translateY: 0 }`   |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // FadeIn, FadeOut
-  type FadeInitialValues = { opacity?: number };
+      | Name           | Config                            |
+      | -------------- | --------------------------------- |
+      | `FadeIn`       | `{ opacity: 1 }`                  |
+      | `FadeInDown`   | `{ opacity: 1, translateY: 0 }`   |
+      | `FadeInLeft`   | `{ opacity: 1, translateX: 0 }`   |
+      | `FadeInRight`  | `{ opacity: 1, translateX: 0 }`   |
+      | `FadeInUp`     | `{ opacity: 1, translateY: 0 }`   |
+      | `FadeOut`      | `{ opacity: 0 }`                  |
+      | `FadeOutDown`  | `{ opacity: 0, translateY: 25 }`  |
+      | `FadeOutLeft`  | `{ opacity: 0, translateX: -25 }` |
+      | `FadeOutRight` | `{ opacity: 0, translateX: 25 }`  |
+      | `FadeOutUp`    | `{ opacity: 0, translateY: -25 }` |
+    </TabItem>
 
-  // FadeInRight, FadeInLeft, FadeOutRight, FadeOutLeft
-  type FadeXInitialValues = {
-    opacity?: number;
-    translateX?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateX: number | `${number}%` }];
-  };
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // FadeIn, FadeOut
+      type FadeValues = { opacity?: number };
 
-  // FadeInUp, FadeInDown, FadeOutUp, FadeOutDown
-  type FadeYInitialValues = {
-    opacity?: number;
-    translateY?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateY: number | `${number}%` }];
-  };
-  ```
+      // FadeInRight, FadeInLeft, FadeOutRight, FadeOutLeft
+      type FadeXValues = {
+        opacity?: number;
+        translateX?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateX: number | `${number}%` }];
+      };
+
+      // FadeInUp, FadeInDown, FadeOutUp, FadeOutDown
+      type FadeYValues = {
+        opacity?: number;
+        translateY?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateY: number | `${number}%` }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -173,6 +196,7 @@ FadeInDown.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ translateY: 420 })
+  .withTargetValues({ translateY: 0 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -183,6 +207,7 @@ FadeInDown.delay(500)
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Bounce
@@ -245,49 +270,68 @@ Available bounce animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name             | Config                                 |
-  | ---------------- | -------------------------------------- |
-  | `BounceIn`       | `{ scale: 0 }`                         |
-  | `BounceInRight`  | `{ translateX: values.windowWidth }`   |
-  | `BounceInLeft`   | `{ translateX: -values.windowWidth }`  |
-  | `BounceInUp`     | `{ translateY: -values.windowHeight }` |
-  | `BounceInDown`   | `{ translateY: values.windowHeight }`  |
-  | `BounceOut`      | `{ scale: 1 }`                         |
-  | `BounceOutRight` | `{ translateX: 0 }`                    |
-  | `BounceOutLeft`  | `{ translateX: 0 }`                    |
-  | `BounceOutUp`    | `{ translateY: 0 }`                    |
-  | `BounceOutDown`  | `{ translateY: 0 }`                    |
-</details>
+      | Name             | Config                                 |
+      | ---------------- | -------------------------------------- |
+      | `BounceIn`       | `{ scale: 0 }`                         |
+      | `BounceInRight`  | `{ translateX: values.windowWidth }`   |
+      | `BounceInLeft`   | `{ translateX: -values.windowWidth }`  |
+      | `BounceInUp`     | `{ translateY: -values.windowHeight }` |
+      | `BounceInDown`   | `{ translateY: values.windowHeight }`  |
+      | `BounceOut`      | `{ scale: 1 }`                         |
+      | `BounceOutRight` | `{ translateX: 0 }`                    |
+      | `BounceOutLeft`  | `{ translateX: 0 }`                    |
+      | `BounceOutUp`    | `{ translateY: 0 }`                    |
+      | `BounceOutDown`  | `{ translateY: 0 }`                    |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // BounceIn, BounceOut
-  type BounceScaleInitialValues = {
-    scale?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scale: number }];
-  };
+      | Name             | Config                                 |
+      | ---------------- | -------------------------------------- |
+      | `BounceIn`       | `{ scale: 1 }`                         |
+      | `BounceInRight`  | `{ translateX: 0 }`                    |
+      | `BounceInLeft`   | `{ translateX: 0 }`                    |
+      | `BounceInUp`     | `{ translateY: 0 }`                    |
+      | `BounceInDown`   | `{ translateY: 0 }`                    |
+      | `BounceOut`      | `{ scale: 0 }`                         |
+      | `BounceOutRight` | `{ translateX: values.windowWidth }`   |
+      | `BounceOutLeft`  | `{ translateX: -values.windowWidth }`  |
+      | `BounceOutUp`    | `{ translateY: -values.windowHeight }` |
+      | `BounceOutDown`  | `{ translateY: values.windowHeight }`  |
+    </TabItem>
 
-  // BounceInRight, BounceInLeft, BounceOutRight, BounceOutLeft
-  type BounceXInitialValues = {
-    translateX?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateX: number | `${number}%` }];
-  };
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // BounceIn, BounceOut
+      type BounceScaleValues = {
+        scale?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scale: number }];
+      };
 
-  // BounceInUp, BounceInDown, BounceOutUp, BounceOutDown
-  type BounceYInitialValues = {
-    translateY?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateY: number | `${number}%` }];
-  };
-  ```
+      // BounceInRight, BounceInLeft, BounceOutRight, BounceOutLeft
+      type BounceXValues = {
+        translateX?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateX: number | `${number}%` }];
+      };
+
+      // BounceInUp, BounceInDown, BounceOutUp, BounceOutDown
+      type BounceYValues = {
+        translateY?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateY: number | `${number}%` }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers <Optional/>
@@ -298,6 +342,7 @@ BounceInDown.duration(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ translateY: -420 })
+  .withTargetValues({ translateY: 0 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -308,6 +353,7 @@ BounceInDown.duration(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Flip
@@ -374,72 +420,93 @@ Available flip animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name            | Config                                                                                  |
-  | --------------- | --------------------------------------------------------------------------------------- |
-  | `FlipInEasyX`   | `{ perspective: 500, rotateX: '90deg' }`                                                |
-  | `FlipInEasyY`   | `{ perspective: 500, rotateY: '90deg' }`                                                |
-  | `FlipInXDown`   | `{ perspective: 500, rotateX: '-90deg', translateY: targetValues.targetHeight }`        |
-  | `FlipInXUp`     | `{ perspective: 500, rotateX: '90deg', translateY: -targetValues.targetHeight }`        |
-  | `FlipInYLeft`   | `{ perspective: 500, rotateY: '-90deg', translateX: -targetValues.targetWidth }`        |
-  | `FlipInYRight`  | `{ perspective: 500, rotateY: '90deg', translateX: targetValues.targetWidth }`          |
-  | `FlipOutEasyX`  | `{ perspective: 500, rotateX: '0deg' }`                                                 |
-  | `FlipOutEasyY`  | `{ perspective: 500, rotateY: '0deg' }`                                                 |
-  | `FlipOutXDown`  | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                                  |
-  | `FlipOutXUp`    | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                                  |
-  | `FlipOutYLeft`  | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                                  |
-  | `FlipOutYRight` | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                                  |
-</details>
+      | Name            | Config                                                                                  |
+      | --------------- | --------------------------------------------------------------------------------------- |
+      | `FlipInEasyX`   | `{ perspective: 500, rotateX: '90deg' }`                                                |
+      | `FlipInEasyY`   | `{ perspective: 500, rotateY: '90deg' }`                                                |
+      | `FlipInXDown`   | `{ perspective: 500, rotateX: '-90deg', translateY: targetValues.targetHeight }`        |
+      | `FlipInXUp`     | `{ perspective: 500, rotateX: '90deg', translateY: -targetValues.targetHeight }`        |
+      | `FlipInYLeft`   | `{ perspective: 500, rotateY: '-90deg', translateX: -targetValues.targetWidth }`        |
+      | `FlipInYRight`  | `{ perspective: 500, rotateY: '90deg', translateX: targetValues.targetWidth }`          |
+      | `FlipOutEasyX`  | `{ perspective: 500, rotateX: '0deg' }`                                                 |
+      | `FlipOutEasyY`  | `{ perspective: 500, rotateY: '0deg' }`                                                 |
+      | `FlipOutXDown`  | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                                  |
+      | `FlipOutXUp`    | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                                  |
+      | `FlipOutYLeft`  | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                                  |
+      | `FlipOutYRight` | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                                  |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // FlipInEasyX, FlipOutEasyX
-  type FlipEasyXInitialValues = {
-    perspective?: number;
-    rotateX?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ perspective: number }, { rotateX: string }];
-  };
+      | Name            | Config                                                                      |
+      | --------------- | --------------------------------------------------------------------------- |
+      | `FlipInEasyX`   | `{ perspective: 500, rotateX: '0deg' }`                                     |
+      | `FlipInEasyY`   | `{ perspective: 500, rotateY: '0deg' }`                                     |
+      | `FlipInXDown`   | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                      |
+      | `FlipInXUp`     | `{ perspective: 500, rotateX: '0deg', translateY: 0 }`                      |
+      | `FlipInYLeft`   | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                      |
+      | `FlipInYRight`  | `{ perspective: 500, rotateY: '0deg', translateX: 0 }`                      |
+      | `FlipOutEasyX`  | `{ perspective: 500, rotateX: '90deg' }`                                    |
+      | `FlipOutEasyY`  | `{ perspective: 500, rotateY: '90deg' }`                                    |
+      | `FlipOutXDown`  | `{ perspective: 500, rotateX: '-90deg', translateY: values.currentHeight }` |
+      | `FlipOutXUp`    | `{ perspective: 500, rotateX: '90deg', translateY: -values.currentHeight }` |
+      | `FlipOutYLeft`  | `{ perspective: 500, rotateY: '-90deg', translateX: -values.currentWidth }` |
+      | `FlipOutYRight` | `{ perspective: 500, rotateY: '90deg', translateX: values.currentWidth }`   |
+    </TabItem>
 
-  // FlipInEasyY, FlipOutEasyY
-  type FlipEasyYInitialValues = {
-    perspective?: number;
-    rotateY?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ perspective: number }, { rotateY: string }];
-  };
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // FlipInEasyX, FlipOutEasyX
+      type FlipEasyXValues = {
+        perspective?: number;
+        rotateX?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ perspective: number }, { rotateX: string }];
+      };
 
-  // FlipInXDown, FlipInXUp, FlipOutXDown, FlipOutXUp
-  type FlipXInitialValues = {
-    perspective?: number;
-    rotateX?: string;
-    translateY?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [
-      { perspective: number },
-      { rotateX: string },
-      { translateY: number | `${number}%` },
-    ];
-  };
+      // FlipInEasyY, FlipOutEasyY
+      type FlipEasyYValues = {
+        perspective?: number;
+        rotateY?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ perspective: number }, { rotateY: string }];
+      };
 
-  // FlipInYLeft, FlipInYRight, FlipOutYLeft, FlipOutYRight
-  type FlipYInitialValues = {
-    perspective?: number;
-    rotateY?: string;
-    translateX?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [
-      { perspective: number },
-      { rotateY: string },
-      { translateX: number | `${number}%` },
-    ];
-  };
-  ```
+      // FlipInXDown, FlipInXUp, FlipOutXDown, FlipOutXUp
+      type FlipXValues = {
+        perspective?: number;
+        rotateX?: string;
+        translateY?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [
+          { perspective: number },
+          { rotateX: string },
+          { translateY: number | `${number}%` },
+        ];
+      };
+
+      // FlipInYLeft, FlipInYRight, FlipOutYLeft, FlipOutYRight
+      type FlipYValues = {
+        perspective?: number;
+        rotateY?: string;
+        translateX?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [
+          { perspective: number },
+          { rotateY: string },
+          { translateX: number | `${number}%` },
+        ];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -485,6 +552,7 @@ FlipInEasyY.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ perspective: 100, rotateY: '123deg' })
+  .withTargetValues({ rotateY: '0deg' })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -495,6 +563,7 @@ FlipInEasyY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## LightSpeed
@@ -547,31 +616,44 @@ Available lightspeed animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name                 | Config                                                               |
-  | -------------------- | -------------------------------------------------------------------- |
-  | `LightSpeedInLeft`   | `{ opacity: 0, translateX: -values.windowWidth, skewX: '45deg' }`    |
-  | `LightSpeedInRight`  | `{ opacity: 0, translateX: values.windowWidth, skewX: '-45deg' }`    |
-  | `LightSpeedOutLeft`  | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                       |
-  | `LightSpeedOutRight` | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                       |
-</details>
+      | Name                 | Config                                                               |
+      | -------------------- | -------------------------------------------------------------------- |
+      | `LightSpeedInLeft`   | `{ opacity: 0, translateX: -values.windowWidth, skewX: '45deg' }`    |
+      | `LightSpeedInRight`  | `{ opacity: 0, translateX: values.windowWidth, skewX: '-45deg' }`    |
+      | `LightSpeedOutLeft`  | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                       |
+      | `LightSpeedOutRight` | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                       |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // All LightSpeed presets
-  type LightSpeedInitialValues = {
-    opacity?: number;
-    translateX?: number | `${number}%`;
-    skewX?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateX: number | `${number}%` }, { skewX: string }];
-  };
-  ```
+      | Name                 | Config                                                             |
+      | -------------------- | ------------------------------------------------------------------ |
+      | `LightSpeedInLeft`   | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                     |
+      | `LightSpeedInRight`  | `{ opacity: 1, translateX: 0, skewX: '0deg' }`                     |
+      | `LightSpeedOutLeft`  | `{ opacity: 0, translateX: -values.windowWidth, skewX: '45deg' }`  |
+      | `LightSpeedOutRight` | `{ opacity: 0, translateX: values.windowWidth, skewX: '-45deg' }`  |
+    </TabItem>
+
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // All LightSpeed presets
+      type LightSpeedValues = {
+        opacity?: number;
+        translateX?: number | `${number}%`;
+        skewX?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateX: number | `${number}%` }, { skewX: string }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -617,6 +699,7 @@ LightSpeedInRight.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ translateX: -100, skewX: '-10deg' })
+  .withTargetValues({ translateX: 0, skewX: '0deg' })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -627,6 +710,7 @@ LightSpeedInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Pinwheel
@@ -673,29 +757,40 @@ Available pinwheel animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name          | Config                                  |
-  | ------------- | --------------------------------------- |
-  | `PinwheelIn`  | `{ opacity: 0, scale: 0, rotate: '5' }` |
-  | `PinwheelOut` | `{ opacity: 1, scale: 1, rotate: '0' }` |
-</details>
+      | Name          | Config                                  |
+      | ------------- | --------------------------------------- |
+      | `PinwheelIn`  | `{ opacity: 0, scale: 0, rotate: '5' }` |
+      | `PinwheelOut` | `{ opacity: 1, scale: 1, rotate: '0' }` |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // PinwheelIn, PinwheelOut
-  type PinwheelInitialValues = {
-    opacity?: number;
-    scale?: number;
-    rotate?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scale: number }, { rotate: string }];
-  };
-  ```
+      | Name          | Config                                     |
+      | ------------- | ------------------------------------------ |
+      | `PinwheelIn`  | `{ opacity: 1, scale: 1, rotate: '0rad' }` |
+      | `PinwheelOut` | `{ opacity: 0, scale: 0, rotate: '5rad' }` |
+    </TabItem>
+
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // PinwheelIn, PinwheelOut
+      type PinwheelValues = {
+        opacity?: number;
+        scale?: number;
+        rotate?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scale: number }, { rotate: string }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -741,6 +836,7 @@ PinwheelIn.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ scale: 0.8, rotate: '3' })
+  .withTargetValues({ scale: 1, rotate: '0rad' })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -751,6 +847,7 @@ PinwheelIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Roll
@@ -801,30 +898,43 @@ Available roll animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name           | Config                                                   |
-  | -------------- | -------------------------------------------------------- |
-  | `RollInLeft`   | `{ translateX: -values.windowWidth, rotate: '-180deg' }` |
-  | `RollInRight`  | `{ translateX: values.windowWidth, rotate: '180deg' }`   |
-  | `RollOutLeft`  | `{ translateX: 0, rotate: '0deg' }`                      |
-  | `RollOutRight` | `{ translateX: 0, rotate: '0deg' }`                      |
-</details>
+      | Name           | Config                                                   |
+      | -------------- | -------------------------------------------------------- |
+      | `RollInLeft`   | `{ translateX: -values.windowWidth, rotate: '-180deg' }` |
+      | `RollInRight`  | `{ translateX: values.windowWidth, rotate: '180deg' }`   |
+      | `RollOutLeft`  | `{ translateX: 0, rotate: '0deg' }`                      |
+      | `RollOutRight` | `{ translateX: 0, rotate: '0deg' }`                      |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // All Roll presets
-  type RollInitialValues = {
-    translateX?: number | `${number}%`;
-    rotate?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateX: number | `${number}%` }, { rotate: string }];
-  };
-  ```
+      | Name           | Config                                                   |
+      | -------------- | -------------------------------------------------------- |
+      | `RollInLeft`   | `{ translateX: 0, rotate: '0deg' }`                      |
+      | `RollInRight`  | `{ translateX: 0, rotate: '0deg' }`                      |
+      | `RollOutLeft`  | `{ translateX: -values.windowWidth, rotate: '-180deg' }` |
+      | `RollOutRight` | `{ translateX: values.windowWidth, rotate: '180deg' }`   |
+    </TabItem>
+
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // All Roll presets
+      type RollValues = {
+        translateX?: number | `${number}%`;
+        rotate?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateX: number | `${number}%` }, { rotate: string }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -870,6 +980,7 @@ RollInRight.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ translateX: 100, rotate: '-45deg' })
+  .withTargetValues({ translateX: 0, rotate: '0deg' })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -880,6 +991,7 @@ RollInRight.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Rotate
@@ -940,40 +1052,57 @@ Available rotate animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name                 | Config                                                                                                                                                              |
-  | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `RotateInDownLeft`   | `{ opacity: 0, rotate: '-90deg', translateX: values.targetWidth / 2 - values.targetHeight / 2, translateY: -(values.targetWidth / 2 - values.targetHeight / 2) }`   |
-  | `RotateInDownRight`  | `{ opacity: 0, rotate: '90deg', translateX: -(values.targetWidth / 2 - values.targetHeight / 2), translateY: -(values.targetWidth / 2 - values.targetHeight / 2) }` |
-  | `RotateInUpLeft`     | `{ opacity: 0, rotate: '90deg', translateX: values.targetWidth / 2 - values.targetHeight / 2, translateY: values.targetWidth / 2 - values.targetHeight / 2 }`       |
-  | `RotateInUpRight`    | `{ opacity: 0, rotate: '-90deg', translateX: -(values.targetWidth / 2 - values.targetHeight / 2), translateY: values.targetWidth / 2 - values.targetHeight / 2 }`   |
-  | `RotateOutDownLeft`  | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
-  | `RotateOutDownRight` | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
-  | `RotateOutUpLeft`    | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
-  | `RotateOutUpRight`   | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
-</details>
+      | Name                 | Config                                                                                                                                                              |
+      | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+      | `RotateInDownLeft`   | `{ opacity: 0, rotate: '-90deg', translateX: values.targetWidth / 2 - values.targetHeight / 2, translateY: -(values.targetWidth / 2 - values.targetHeight / 2) }`   |
+      | `RotateInDownRight`  | `{ opacity: 0, rotate: '90deg', translateX: -(values.targetWidth / 2 - values.targetHeight / 2), translateY: -(values.targetWidth / 2 - values.targetHeight / 2) }` |
+      | `RotateInUpLeft`     | `{ opacity: 0, rotate: '90deg', translateX: values.targetWidth / 2 - values.targetHeight / 2, translateY: values.targetWidth / 2 - values.targetHeight / 2 }`       |
+      | `RotateInUpRight`    | `{ opacity: 0, rotate: '-90deg', translateX: -(values.targetWidth / 2 - values.targetHeight / 2), translateY: values.targetWidth / 2 - values.targetHeight / 2 }`   |
+      | `RotateOutDownLeft`  | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
+      | `RotateOutDownRight` | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
+      | `RotateOutUpLeft`    | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
+      | `RotateOutUpRight`   | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                      |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // All Rotate presets
-  type RotateInitialValues = {
-    opacity?: number;
-    rotate?: string;
-    translateX?: number | `${number}%`;
-    translateY?: number | `${number}%`;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [
-      { rotate: string },
-      { translateX: number | `${number}%` },
-      { translateY: number | `${number}%` },
-    ];
-  };
-  ```
+      | Name                 | Config                                                                                                                                                                  |
+      | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+      | `RotateInDownLeft`   | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                          |
+      | `RotateInDownRight`  | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                          |
+      | `RotateInUpLeft`     | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                          |
+      | `RotateInUpRight`    | `{ opacity: 1, rotate: '0deg', translateX: 0, translateY: 0 }`                                                                                                          |
+      | `RotateOutDownLeft`  | `{ opacity: 0, rotate: '90deg', translateX: values.currentWidth / 2 - values.currentHeight / 2, translateY: values.currentWidth / 2 - values.currentHeight / 2 }`       |
+      | `RotateOutDownRight` | `{ opacity: 0, rotate: '-90deg', translateX: -(values.currentWidth / 2 - values.currentHeight / 2), translateY: values.currentWidth / 2 - values.currentHeight / 2 }`   |
+      | `RotateOutUpLeft`    | `{ opacity: 0, rotate: '-90deg', translateX: values.currentWidth / 2 - values.currentHeight / 2, translateY: -(values.currentWidth / 2 - values.currentHeight / 2) }`   |
+      | `RotateOutUpRight`   | `{ opacity: 0, rotate: '90deg', translateX: -(values.currentWidth / 2 - values.currentHeight / 2), translateY: -(values.currentWidth / 2 - values.currentHeight / 2) }` |
+    </TabItem>
+
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // All Rotate presets
+      type RotateValues = {
+        opacity?: number;
+        rotate?: string;
+        translateX?: number | `${number}%`;
+        translateY?: number | `${number}%`;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [
+          { rotate: string },
+          { translateX: number | `${number}%` },
+          { translateY: number | `${number}%` },
+        ];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -1019,6 +1148,7 @@ RotateInDownLeft.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ rotate: '-90deg', translateX: 100, translateY: 100 })
+  .withTargetValues({ rotate: '0deg', translateX: 0, translateY: 0 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -1029,6 +1159,7 @@ RotateInDownLeft.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Slide
@@ -1087,32 +1218,49 @@ Available slide animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name            | Config                                                    |
-  | --------------- | --------------------------------------------------------- |
-  | `SlideInDown`   | `{ originY: values.targetOriginY + values.windowHeight }` |
-  | `SlideInLeft`   | `{ originX: values.targetOriginX - values.windowWidth }`  |
-  | `SlideInRight`  | `{ originX: values.targetOriginX + values.windowWidth }`  |
-  | `SlideInUp`     | `{ originY: -values.windowHeight }`                       |
-  | `SlideOutDown`  | `{ originY: values.currentOriginY }`                      |
-  | `SlideOutLeft`  | `{ originX: values.currentOriginX }`                      |
-  | `SlideOutRight` | `{ originX: values.currentOriginX }`                      |
-  | `SlideOutUp`    | `{ originY: values.currentOriginY }`                      |
-</details>
+      | Name            | Config                                                    |
+      | --------------- | --------------------------------------------------------- |
+      | `SlideInDown`   | `{ originY: values.targetOriginY + values.windowHeight }` |
+      | `SlideInLeft`   | `{ originX: values.targetOriginX - values.windowWidth }`  |
+      | `SlideInRight`  | `{ originX: values.targetOriginX + values.windowWidth }`  |
+      | `SlideInUp`     | `{ originY: -values.windowHeight }`                       |
+      | `SlideOutDown`  | `{ originY: values.currentOriginY }`                      |
+      | `SlideOutLeft`  | `{ originX: values.currentOriginX }`                      |
+      | `SlideOutRight` | `{ originX: values.currentOriginX }`                      |
+      | `SlideOutUp`    | `{ originY: values.currentOriginY }`                      |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight
-  type SlideXInitialValues = { originX?: number };
+      | Name            | Config                                                                                     |
+      | --------------- | ------------------------------------------------------------------------------------------ |
+      | `SlideInDown`   | `{ originY: values.targetOriginY }`                                                        |
+      | `SlideInLeft`   | `{ originX: values.targetOriginX }`                                                        |
+      | `SlideInRight`  | `{ originX: values.targetOriginX }`                                                        |
+      | `SlideInUp`     | `{ originY: values.targetOriginY }`                                                        |
+      | `SlideOutDown`  | `{ originY: Math.max(values.currentOriginY + values.windowHeight, values.windowHeight) }`  |
+      | `SlideOutLeft`  | `{ originX: Math.min(values.currentOriginX - values.windowWidth, -values.windowWidth) }`   |
+      | `SlideOutRight` | `{ originX: Math.max(values.currentOriginX + values.windowWidth, values.windowWidth) }`    |
+      | `SlideOutUp`    | `{ originY: Math.min(values.currentOriginY - values.windowHeight, -values.windowHeight) }` |
+    </TabItem>
 
-  // SlideInUp, SlideInDown, SlideOutUp, SlideOutDown
-  type SlideYInitialValues = { originY?: number };
-  ```
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight
+      type SlideXValues = { originX?: number };
+
+      // SlideInUp, SlideInDown, SlideOutUp, SlideOutDown
+      type SlideYValues = { originY?: number };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -1158,6 +1306,7 @@ SlideInDown.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ originY: 420 })
+  .withTargetValues({ originY: 0 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -1168,6 +1317,7 @@ SlideInDown.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Stretch
@@ -1218,36 +1368,49 @@ Available stretch animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name          | Config          |
-  | ------------- | --------------- |
-  | `StretchInX`  | `{ scaleX: 0 }` |
-  | `StretchInY`  | `{ scaleY: 0 }` |
-  | `StretchOutX` | `{ scaleX: 1 }` |
-  | `StretchOutY` | `{ scaleY: 1 }` |
-</details>
+      | Name          | Config          |
+      | ------------- | --------------- |
+      | `StretchInX`  | `{ scaleX: 0 }` |
+      | `StretchInY`  | `{ scaleY: 0 }` |
+      | `StretchOutX` | `{ scaleX: 1 }` |
+      | `StretchOutY` | `{ scaleY: 1 }` |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // StretchInX, StretchOutX
-  type StretchXInitialValues = {
-    scaleX?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scaleX: number }];
-  };
+      | Name          | Config          |
+      | ------------- | --------------- |
+      | `StretchInX`  | `{ scaleX: 1 }` |
+      | `StretchInY`  | `{ scaleY: 1 }` |
+      | `StretchOutX` | `{ scaleX: 0 }` |
+      | `StretchOutY` | `{ scaleY: 0 }` |
+    </TabItem>
 
-  // StretchInY, StretchOutY
-  type StretchYInitialValues = {
-    scaleY?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scaleY: number }];
-  };
-  ```
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // StretchInX, StretchOutX
+      type StretchXValues = {
+        scaleX?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scaleX: number }];
+      };
+
+      // StretchInY, StretchOutY
+      type StretchYValues = {
+        scaleY?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scaleY: number }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -1293,6 +1456,7 @@ StretchInY.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ scaleY: 0.5 })
+  .withTargetValues({ scaleY: 1 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -1303,6 +1467,7 @@ StretchInY.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Zoom
@@ -1377,66 +1542,91 @@ Available zoom animations:
 </Grid>
 
 <details>
-  <summary>Initial values</summary>
+  <summary>Values &amp; Type definitions</summary>
 
-  These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
+  <Tabs groupId="la-reference">
+    <TabItem value="initial" label="Initial values">
+      These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
-  | Name              | Config                                            |
-  | ----------------- | ------------------------------------------------- |
-  | `ZoomIn`          | `{ scale: 0 }`                                    |
-  | `ZoomInDown`      | `{ translateY: values.windowHeight, scale: 0 }`   |
-  | `ZoomInEasyDown`  | `{ translateY: values.targetHeight, scale: 0 }`   |
-  | `ZoomInEasyUp`    | `{ translateY: -values.targetHeight, scale: 0 }`  |
-  | `ZoomInLeft`      | `{ translateX: -values.windowWidth, scale: 0 }`   |
-  | `ZoomInRight`     | `{ translateX: values.windowWidth, scale: 0 }`    |
-  | `ZoomInRotate`    | `{ scale: 0, rotate: rotate }`                    |
-  | `ZoomInUp`        | `{ translateY: -values.windowHeight, scale: 0 }`  |
-  | `ZoomOut`         | `{ scale: 1 }`                                    |
-  | `ZoomOutDown`     | `{ translateY: 0, scale: 1 }`                     |
-  | `ZoomOutEasyDown` | `{ translateY: 0, scale: 1 }`                     |
-  | `ZoomOutEasyUp`   | `{ translateY: 0, scale: 1 }`                     |
-  | `ZoomOutLeft`     | `{ translateX: 0, scale: 1 }`                     |
-  | `ZoomOutRight`    | `{ translateX: 0, scale: 1 }`                     |
-  | `ZoomOutRotate`   | `{ scale: 1, rotate: '0' }`                       |
-  | `ZoomOutUp`       | `{ translateY: 0, scale: 1 }`                     |
-</details>
+      | Name              | Config                                            |
+      | ----------------- | ------------------------------------------------- |
+      | `ZoomIn`          | `{ scale: 0 }`                                    |
+      | `ZoomInDown`      | `{ translateY: values.windowHeight, scale: 0 }`   |
+      | `ZoomInEasyDown`  | `{ translateY: values.targetHeight, scale: 0 }`   |
+      | `ZoomInEasyUp`    | `{ translateY: -values.targetHeight, scale: 0 }`  |
+      | `ZoomInLeft`      | `{ translateX: -values.windowWidth, scale: 0 }`   |
+      | `ZoomInRight`     | `{ translateX: values.windowWidth, scale: 0 }`    |
+      | `ZoomInRotate`    | `{ scale: 0, rotate: rotate }`                    |
+      | `ZoomInUp`        | `{ translateY: -values.windowHeight, scale: 0 }`  |
+      | `ZoomOut`         | `{ scale: 1 }`                                    |
+      | `ZoomOutDown`     | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomOutEasyDown` | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomOutEasyUp`   | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomOutLeft`     | `{ translateX: 0, scale: 1 }`                     |
+      | `ZoomOutRight`    | `{ translateX: 0, scale: 1 }`                     |
+      | `ZoomOutRotate`   | `{ scale: 1, rotate: '0' }`                       |
+      | `ZoomOutUp`       | `{ translateY: 0, scale: 1 }`                     |
+    </TabItem>
 
-<details>
-  <summary>Type definitions</summary>
+    <TabItem value="target" label="Target values">
+      <AvailableFrom version="4.4.0"/> These are the default target values for each animation that can be customized with the `withTargetValues` modifier.
 
-  ```typescript
-  // ZoomIn, ZoomOut
-  type ZoomScaleInitialValues = {
-    scale?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scale: number }];
-  };
+      | Name              | Config                                            |
+      | ----------------- | ------------------------------------------------- |
+      | `ZoomIn`          | `{ scale: 1 }`                                    |
+      | `ZoomInDown`      | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomInEasyDown`  | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomInEasyUp`    | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomInLeft`      | `{ translateX: 0, scale: 1 }`                     |
+      | `ZoomInRight`     | `{ translateX: 0, scale: 1 }`                     |
+      | `ZoomInRotate`    | `{ scale: 1, rotate: '0rad' }`                    |
+      | `ZoomInUp`        | `{ translateY: 0, scale: 1 }`                     |
+      | `ZoomOut`         | `{ scale: 0 }`                                    |
+      | `ZoomOutDown`     | `{ translateY: values.windowHeight, scale: 0 }`   |
+      | `ZoomOutEasyDown` | `{ translateY: values.currentHeight, scale: 0 }`  |
+      | `ZoomOutEasyUp`   | `{ translateY: -values.currentHeight, scale: 0 }` |
+      | `ZoomOutLeft`     | `{ translateX: -values.windowWidth, scale: 0 }`   |
+      | `ZoomOutRight`    | `{ translateX: values.windowWidth, scale: 0 }`    |
+      | `ZoomOutRotate`   | `{ scale: 0, rotate: '0.3' }`                     |
+      | `ZoomOutUp`       | `{ translateY: -values.windowHeight, scale: 0 }`  |
+    </TabItem>
 
-  // ZoomInLeft, ZoomInRight, ZoomOutLeft, ZoomOutRight
-  type ZoomXInitialValues = {
-    translateX?: number | `${number}%`;
-    scale?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateX: number | `${number}%` }, { scale: number }];
-  };
+    <TabItem value="types" label="Type definitions">
+      ```typescript
+      // ZoomIn, ZoomOut
+      type ZoomScaleValues = {
+        scale?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scale: number }];
+      };
 
-  // ZoomInUp, ZoomInDown, ZoomInEasyUp, ZoomInEasyDown,
-  // ZoomOutUp, ZoomOutDown, ZoomOutEasyUp, ZoomOutEasyDown
-  type ZoomYInitialValues = {
-    translateY?: number | `${number}%`;
-    scale?: number;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ translateY: number | `${number}%` }, { scale: number }];
-  };
+      // ZoomInLeft, ZoomInRight, ZoomOutLeft, ZoomOutRight
+      type ZoomXValues = {
+        translateX?: number | `${number}%`;
+        scale?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateX: number | `${number}%` }, { scale: number }];
+      };
 
-  // ZoomInRotate, ZoomOutRotate
-  type ZoomRotateInitialValues = {
-    scale?: number;
-    rotate?: string;
-    /** @deprecated Prefer flat top-level props. */
-    transform?: [{ scale: number }, { rotate: string }];
-  };
-  ```
+      // ZoomInUp, ZoomInDown, ZoomInEasyUp, ZoomInEasyDown,
+      // ZoomOutUp, ZoomOutDown, ZoomOutEasyUp, ZoomOutEasyDown
+      type ZoomYValues = {
+        translateY?: number | `${number}%`;
+        scale?: number;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ translateY: number | `${number}%` }, { scale: number }];
+      };
+
+      // ZoomInRotate, ZoomOutRotate
+      type ZoomRotateValues = {
+        scale?: number;
+        rotate?: string;
+        /** @deprecated Prefer flat top-level props. */
+        transform?: [{ scale: number }, { rotate: string }];
+      };
+      ```
+    </TabItem>
+  </Tabs>
 </details>
 
 ### Modifiers
@@ -1482,6 +1672,7 @@ ZoomIn.delay(500)
   .randomDelay()
   .reduceMotion(ReduceMotion.Never)
   .withInitialValues({ scale: 0.5 })
+  .withTargetValues({ scale: 1 })
   .withCallback((finished) => {
     console.log(`finished without interruptions: ${finished}`);
   });
@@ -1492,6 +1683,7 @@ ZoomIn.delay(500)
 - `.randomDelay()` randomizes the delay of the animation between `0` and the provided delay. Uses 1000 ms if delay wasn't provided.
 - `.reduceMotion(reduceMotion: ReduceMotion)` determines how the animation responds to the device's reduced motion accessibility setting.
 - `.withInitialValues(values)` overrides the initial values of the animation. Each preset accepts only the properties it animates (see the Initial values table above).
+- `.withTargetValues(values)` overrides the target values of the animation (the state the element animates to). Each preset accepts only the properties it animates (see the Target values table above).
 - `.withCallback(callback: (finished: boolean) => void)` is the callback that will fire after the animation ends. Sets `finished` to `true` when animation ends without interruptions, and `false` otherwise.
 
 ## Platform compatibility

--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -93,7 +93,7 @@ Available fade animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -272,7 +272,7 @@ Available bounce animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -422,7 +422,7 @@ Available flip animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -618,7 +618,7 @@ Available lightspeed animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -759,7 +759,7 @@ Available pinwheel animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -900,7 +900,7 @@ Available roll animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -1054,7 +1054,7 @@ Available rotate animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -1220,7 +1220,7 @@ Available slide animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -1370,7 +1370,7 @@ Available stretch animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 
@@ -1544,7 +1544,7 @@ Available zoom animations:
 <details>
   <summary>Values & Type definitions</summary>
 
-  <Tabs groupId="la-reference">
+  <Tabs>
     <TabItem value="initial" label="Initial values">
       These are the initial values for each animation that can be customized with the `withInitialValues` modifier.
 

--- a/docs/docs-reanimated/src/css/overrides.css
+++ b/docs/docs-reanimated/src/css/overrides.css
@@ -147,3 +147,18 @@ button[class*='DocSearch-Button'] {
 .navbar__brand img {
   vertical-align: middle;
 }
+
+/* Tabs nested inside details: bump label contrast against the purple details background. */
+details .tabs__item {
+  color: var(--swm-details-color) !important;
+  opacity: 0.7;
+}
+
+details .tabs__item:hover {
+  opacity: 1;
+}
+
+details .tabs__item--active {
+  opacity: 1;
+  border-bottom-color: var(--swm-details-color) !important;
+}


### PR DESCRIPTION
## Summary

Adds docs for [PR adding withTargetValues modifier for default animations](https://github.com/software-mansion/react-native-reanimated/pull/8848)

## Example recording

https://github.com/user-attachments/assets/3585d6bd-2621-431a-953c-08877ad5b688
