### PR TITLE
docs: add missing import at useAnimatedSensor.mdx

### DIFF
--- a/docs/docs-reanimated/docs/device/useAnimatedSensor.mdx
+++ b/docs/docs-reanimated/docs/device/useAnimatedSensor.mdx
@@ -21,7 +21,7 @@ import { useAnimatedSensorPlayground } from '@site/src/components/InteractivePla
 ## Reference
 
 ```javascript
-import { useAnimatedSensor, SensorType, useDerivedValue } from 'react-native-reanimated';
+import { useAnimatedSensor, useDerivedValue, SensorType } from 'react-native-reanimated';
 
 function App() {
   const gyroscope = useAnimatedSensor(SensorType.GYROSCOPE);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Provided example doesn't have working code - it requires an additional import of `useDerivedValue` from `react-native-reanimated`.

## Test plan

Copy and paste code to your TypeScript IDE or use `npx tsc --noEmit` to see whether it yields any errors.
