### PR TITLE
chore: Add .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -24,18 +24,14 @@ CompileFlags:
     - -clang-vendor-feature=*
     - -fno-odr-hash-protocols
     - -code-extended-block-signature
-
 ---
-
 If:
   PathMatch: packages/react-native-reanimated/.*
 CompileFlags:
   CompilationDatabase: packages/react-native-reanimated
 
 ---
- 
 If:
   PathMatch: packages/react-native-worklets/.*
 CompileFlags:
   CompilationDatabase: packages/react-native-worklets
-


### PR DESCRIPTION
## Summary

Currently, after compilation for IOS, if you open any cpp file in your IDE, clangd will show you errors regarding unknown compilation flags. I find it rather inconvenient so I created a .clangd with a configuration that tells clangd to skip all those native apple flags.

  
  
<img width="777" height="449" alt="image" src="https://github.com/user-attachments/assets/046f0760-8d0d-456c-8c73-9f220c072b67" />

The image above shows what I see in all cpp files without the .clangd after compilation for IOS.

## Test plan

Compile IOS and open some cpp file with and without the .clangd (remember to restart clangd server in between).