### PR TITLE
Remove dead code in build.gradle

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -43,24 +43,6 @@ def resolveReactNativeDirectory() {
     throw new GradleException("[Reanimated] Unable to resolve react-native location in node_modules. You should set project extension property (in `app/build.gradle`) named `REACT_NATIVE_NODE_MODULES_DIR` with the path to react-native in node_modules.")
 }
 
-def resolveReactNativeWorkletsDirectory() {
-    def reactNativeWorkletsLocation = safeAppExtGet("REACT_NATIVE_WORKLETS_NODE_MODULES_DIR", null)
-    if (reactNativeWorkletsLocation != null) {
-        return file(reactNativeWorkletsLocation)
-    }
-
-    // Fallback to node resolver for custom directory structures like monorepos.
-    def reactNativeWorkletsPackage = file(providers.exec {
-        workingDir(rootDir)
-        commandLine("node", "--print", "require.resolve('react-native-worklets/package.json')")
-    }.standardOutput.asText.get().trim())
-    if (reactNativeWorkletsPackage.exists()) {
-        return reactNativeWorkletsPackage.parentFile
-    }
-
-    throw new GradleException("[Reanimated] Unable to resolve react-native-worklets location in node_modules. You should set project extension property (in `app/build.gradle`) named `REACT_NATIVE_WORKLETS_NODE_MODULES_DIR` with the path to react-native-worklets in node_modules.")
-}
-
 def getReactNativeVersion() {
     def reactNativeRootDir = resolveReactNativeDirectory()
     def reactProperties = new Properties()
@@ -112,7 +94,6 @@ if (isNewArchitectureEnabled() && project != rootProject) {
 
 def packageDir = project.projectDir.parentFile
 def reactNativeRootDir = resolveReactNativeDirectory()
-def reactNativeWorkletsRootDir = resolveReactNativeWorkletsDirectory()
 def REACT_NATIVE_MINOR_VERSION = getReactNativeMinorVersion()
 def REACT_NATIVE_VERSION = getReactNativeVersion()
 def REANIMATED_VERSION = getReanimatedVersion()
@@ -138,7 +119,6 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.13.1"
-        classpath "de.undercouch:gradle-download-task:5.6.0"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:8.1.0"
     }
 }
@@ -149,7 +129,6 @@ if (project == rootProject) {
 
 apply plugin: "com.android.library"
 apply plugin: "maven-publish"
-apply plugin: "de.undercouch.download"
 
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 36)

--- a/packages/react-native-worklets/android/build.gradle
+++ b/packages/react-native-worklets/android/build.gradle
@@ -160,14 +160,12 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.13.1"
-        classpath "de.undercouch:gradle-download-task:5.6.0"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:8.1.0"
     }
 }
 
 apply plugin: "com.android.library"
 apply plugin: "maven-publish"
-apply plugin: "de.undercouch.download"
 
 if (project == rootProject) {
     apply from: "spotless.gradle"


### PR DESCRIPTION
## Summary

* Removed unused variable `reactNativeWorkletsRootDir` and function `resolveReactNativeWorkletsDirectory`
* Removed unused `de.undercouch.download` task and `de.undercouch:gradle-download-task:5.6.0` dependency 

## Test plan
