### PR TITLE
Store `ShadowNodeFamily::Shared` instead of `ShadowNodeFamily *` in `PropsMap` and `ChildrenMap`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -7,10 +7,11 @@
 
 namespace reanimated {
 
-Props::Shared mergeProps(const ShadowNode &shadowNode, const PropsMap &propsMap, const ShadowNodeFamily &family) {
+Props::Shared
+mergeProps(const ShadowNode &shadowNode, const PropsMap &propsMap, const ShadowNodeFamily::Shared &family) {
   ReanimatedSystraceSection s("ShadowTreeCloner::mergeProps");
 
-  const auto it = propsMap.find(&family);
+  const auto it = propsMap.find(family);
 
   if (it == propsMap.end()) {
     return ShadowNodeFragment::propsPlaceholder();
@@ -41,7 +42,7 @@ std::shared_ptr<ShadowNode> cloneShadowTreeWithNewPropsRecursive(
     const ShadowNode &shadowNode,
     const ChildrenMap &childrenMap,
     const PropsMap &propsMap) {
-  const auto family = &shadowNode.getFamily();
+  const auto family = shadowNode.getFamilyShared();
   const auto affectedChildrenIt = childrenMap.find(family);
   auto children = shadowNode.getChildren();
 
@@ -52,7 +53,7 @@ std::shared_ptr<ShadowNode> cloneShadowTreeWithNewPropsRecursive(
   }
 
   return shadowNode.clone(
-      {mergeProps(shadowNode, propsMap, *family),
+      {mergeProps(shadowNode, propsMap, family),
        std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>(children),
        shadowNode.getState(),
        false});
@@ -66,11 +67,11 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(const RootShadowNode &oldRo
   {
     ReanimatedSystraceSection s("ShadowTreeCloner::prepareChildrenMap");
 
-    for (auto &[family, _] : propsMap) {
+    for (const auto &[family, _] : propsMap) {
       const auto ancestors = family->getAncestors(oldRootNode);
 
       for (const auto &[parentNode, index] : std::ranges::reverse_view(ancestors)) {
-        const auto parentFamily = &parentNode.get().getFamily();
+        const auto parentFamily = parentNode.get().getFamilyShared();
         auto &affectedChildren = childrenMap[parentFamily];
 
         if (affectedChildren.contains(index)) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/uimanager/UIManager.h>
 
-#include <memory>
-#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -14,8 +13,8 @@ using namespace react;
 
 namespace reanimated {
 
-using PropsMap = std::unordered_map<const ShadowNodeFamily *, std::vector<RawProps>>;
-using ChildrenMap = std::unordered_map<const ShadowNodeFamily *, std::unordered_set<int>>;
+using PropsMap = std::unordered_map<ShadowNodeFamily::Shared, std::vector<RawProps>>;
+using ChildrenMap = std::unordered_map<ShadowNodeFamily::Shared, std::unordered_set<int>>;
 
 RootShadowNode::Unshared cloneShadowTreeWithNewProps(const RootShadowNode &oldRootNode, const PropsMap &propsMap);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -56,12 +56,12 @@ void UpdatesRegistry::collectProps(PropsMap &propsMap) {
   auto copiedRegistry = updatesRegistry_;
   for (const auto &[tag, pair] : copiedRegistry) {
     const auto &[shadowNodeFamily, props] = pair;
-    auto it = propsMap.find(shadowNodeFamily.get());
+    const auto it = propsMap.find(shadowNodeFamily);
 
     if (it == propsMap.cend()) {
       auto propsVector = std::vector<RawProps>{};
       propsVector.emplace_back(RawProps(props));
-      propsMap.emplace(shadowNodeFamily.get(), propsVector);
+      propsMap.emplace(shadowNodeFamily, propsVector);
     } else {
       it->second.push_back(RawProps(props));
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
@@ -99,12 +99,12 @@ void UpdatesRegistryManager::addToPropsMap(
     PropsMap &propsMap,
     const ShadowNodeFamily::Shared &shadowNodeFamily,
     const folly::dynamic &props) {
-  auto it = propsMap.find(shadowNodeFamily.get());
+  auto it = propsMap.find(shadowNodeFamily);
 
   if (it == propsMap.cend()) {
     auto propsVector = std::vector<RawProps>{};
     propsVector.emplace_back(props);
-    propsMap.emplace(shadowNodeFamily.get(), propsVector);
+    propsMap.emplace(shadowNodeFamily, propsVector);
   } else {
     it->second.emplace_back(props);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -64,7 +64,7 @@ void LayoutAnimationsProxyCommon::restoreOpacityInCaseOfFlakyEnteringAnimation(S
             for (const auto &[opacity, tag] : opacityToRestore) {
               const auto *targetShadowNode = findInShadowTreeByTag(rootShadowNode, tag);
               if (targetShadowNode != nullptr) {
-                propsMap[&targetShadowNode->getFamily()].emplace_back(folly::dynamic::object("opacity", opacity));
+                propsMap[targetShadowNode->getFamilyShared()].emplace_back(folly::dynamic::object("opacity", opacity));
               }
             }
             return cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1195,7 +1195,7 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
   } else {
     for (auto const &[shadowNodeFamily, props] : updatesBatch) {
       SurfaceId surfaceId = shadowNodeFamily->getSurfaceId();
-      propsMapBySurface[surfaceId][shadowNodeFamily.get()].emplace_back(props);
+      propsMapBySurface[surfaceId][shadowNodeFamily].emplace_back(props);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR utilizes `ShadowNode::getFamilyShared()` method that was introduced in RN 0.81 to obtain `ShadowNodeFamily::Shared` and store it instead of `const ShadowNodeFamily *` in `PropsMap` and `ChildrenMap`.

## Test plan
