### PR TITLE
Migrate example apps from async-storage to mmkv

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -21,7 +21,6 @@
     "@fortawesome/react-native-fontawesome": "0.3.2",
     "@gorhom/bottom-sheet": "patch:@gorhom/bottom-sheet@npm%3A5.2.8#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.8-1ad4b8f529.patch",
     "@gorhom/portal": "1.0.14",
-    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "1.16.3",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-navigation/bottom-tabs": "7.4.8",

--- a/apps/common-app/src/App.tsx
+++ b/apps/common-app/src/App.tsx
@@ -1,5 +1,4 @@
 import { PortalProvider } from '@gorhom/portal';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import type { NavigationState } from '@react-navigation/native';
 import {
@@ -9,6 +8,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Linking, LogBox, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { createMMKV } from 'react-native-mmkv';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { colors, flex, radius, text } from '@/theme';
@@ -131,6 +131,8 @@ function Navigator() {
 // copied from https://reactnavigation.org/docs/state-persistence/
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
+const storage = createMMKV();
+
 function useNavigationState() {
   const [isReady, setIsReady] = useState(!__DEV__);
 
@@ -139,7 +141,10 @@ function useNavigationState() {
   >();
 
   const updateNavigationState = useCallback((state?: NavigationState) => {
-    AsyncStorage.setItem(PERSISTENCE_KEY, JSON.stringify(state)).catch(noop);
+    if (state === undefined) {
+      return;
+    }
+    storage.set(PERSISTENCE_KEY, JSON.stringify(state));
   }, []);
 
   useEffect(() => {
@@ -149,10 +154,10 @@ function useNavigationState() {
 
         if (!IS_MACOS && !IS_WEB && initialUrl === null) {
           // Only restore state if there's no deep link and we're not on web
-          const savedStateString = await AsyncStorage.getItem(PERSISTENCE_KEY);
+          const savedStateString = storage.getString(PERSISTENCE_KEY);
           // Erase the state immediately after fetching it.
           // This prevents the app to boot on the screen that previously crashed.
-          updateNavigationState();
+          storage.remove(PERSISTENCE_KEY);
           const state = savedStateString
             ? (JSON.parse(savedStateString) as NavigationState)
             : undefined;

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1865,28 +1865,6 @@ PODS:
     - React-utils (= 0.85.0-rc.6)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.0-rc.6)
-  - RNCAsyncStorage (2.2.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
   - RNCClipboard (1.16.3):
     - hermes-engine
     - RCTRequired
@@ -2269,7 +2247,6 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../../../node_modules/react-native/ReactCommon`)
   - ReactNativeDependencies (from `../../../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)
-  - "RNCAsyncStorage (from `../../../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../../../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../../../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
@@ -2435,8 +2412,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon"
   ReactNativeDependencies:
     :podspec: "../../../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec"
-  RNCAsyncStorage:
-    :path: "../../../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../../../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
@@ -2531,7 +2506,6 @@ SPEC CHECKSUMS:
   ReactCodegen: e1764e805847c92020111dfc813438df23976aed
   ReactCommon: a49b7d75789e31e4c7f3e13bdcae28cd77bf1e11
   ReactNativeDependencies: 17af5d9adea41774e9d3166810458712b116b69c
-  RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: 29bcf14a2d2562a1d698c6b33d94a74096c6e1ad

--- a/apps/macos-example/macos/MacOSExample.xcodeproj/project.pbxproj
+++ b/apps/macos-example/macos/MacOSExample.xcodeproj/project.pbxproj
@@ -309,7 +309,6 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MacOSExample-macOS/Pods-MacOSExample-macOS-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
@@ -319,7 +318,6 @@
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -2341,34 +2341,6 @@ PODS:
     - React-perflogger (= 0.81.4)
     - React-utils (= 0.81.4)
     - SocketRocket
-  - RNCAsyncStorage (2.2.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNCClipboard (1.16.3):
     - boost
     - DoubleConversion
@@ -2739,7 +2711,6 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
-  - "RNCAsyncStorage (from `../../../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../../../node_modules/@react-native-clipboard/clipboard`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -2896,8 +2867,6 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native-macos/ReactCommon"
-  RNCAsyncStorage:
-    :path: "../../../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../../../node_modules/@react-native-clipboard/clipboard"
   RNGestureHandler:
@@ -2983,7 +2952,6 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 81faffd1e23962bc11e006b2a8c975cc0cfce2f5
   ReactCodegen: 7ab7a68e6cfbf489e5da68f272c9a8b4ee99c0b7
   ReactCommon: 4702457a560d38a9b96a98a728100cae76820edc
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
   RNReanimated: 35b06c248e48afe0f4b928676a4b80ad59b139eb

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2158,7 +2158,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: a3651a4af13997df8df1bcd5af1cc7507d51dc7b
-  hermes-engine: 1a90d530548371499b6b2b5edaa6fd617b834aac
+  hermes-engine: dab5c5ec4e735a4f3f48d84acb5bd64e19d08e39
   RCTDeprecation: e1d3de84bd12761f1a42ae433c805c84ce3e1447
   RCTRequired: 5f75a4215a8c9551b303a95b0394968ae7490f18
   RCTSwiftUI: 6cfd2a6b1506648cd96493d252069bd1b49bdea4
@@ -2167,7 +2167,7 @@ SPEC CHECKSUMS:
   React: b785d635f91eb1df402a0dbc0305546f139c8048
   React-callinvoker: 3e490bb38efd7cef31c17154d33d3cc294db880b
   React-Core: 35963efb0dff21849c40f81fd73d46f636de9d56
-  React-Core-prebuilt: 12c314b2249dc8f3db3d250b808243ce6f7f172a
+  React-Core-prebuilt: c37a4b72bd70a41a7a8f0e41ac815e41c07ccf63
   React-CoreModules: 3dd7061935350ba9bd5c2d3e7dbf52cdb5ebb47b
   React-cxxreact: ed404f7277d9558a63eb9991d09100a4362d33fa
   React-debug: a26fb9a83e45de87601236175f68e3f3b92ab8ac
@@ -2228,7 +2228,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 51e6ac892436c657aa7dfe118942aeacda08179f
   ReactCodegen: 3862d3679a3064814550db04f7a5366833d65eea
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
-  ReactNativeDependencies: 635ed2b5e70bb9d5a61864db27fda842e6d94ff6
+  ReactNativeDependencies: cc895992cbb09b34af5cc6040d846145a3dac87a
   RNReanimated: 0b9638ce585d4dd6a1d4fd6215ab373ce8ca0f71
   RNWorklets: aabc37be2f0398ce6355ee99957cd12e21db0dd7
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da

--- a/yarn.lock
+++ b/yarn.lock
@@ -6354,17 +6354,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-async-storage/async-storage@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@react-native-async-storage/async-storage@npm:2.2.0"
-  dependencies:
-    merge-options: "npm:^3.0.4"
-  peerDependencies:
-    react-native: ^0.0.0-0 || >=0.65 <1.0
-  checksum: 10/625e42134f0c487acfd4ba9b3ba182e6f6f29581485004cc658850ef024372cdb7381b7399393f4416fda39df2d822e3008427d7671d635a7363f9a65430a2dd
-  languageName: node
-  linkType: hard
-
 "@react-native-clipboard/clipboard@npm:1.16.3":
   version: 1.16.3
   resolution: "@react-native-clipboard/clipboard@npm:1.16.3"
@@ -13703,7 +13692,6 @@ __metadata:
     "@fortawesome/react-native-fontawesome": "npm:0.3.2"
     "@gorhom/bottom-sheet": "patch:@gorhom/bottom-sheet@npm%3A5.2.8#~/.yarn/patches/@gorhom-bottom-sheet-npm-5.2.8-1ad4b8f529.patch"
     "@gorhom/portal": "npm:1.0.14"
-    "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-clipboard/clipboard": "npm:1.16.3"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native-community/cli-platform-android": "npm:20.1.0"
@@ -20047,13 +20035,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-plain-obj@npm:2.1.0"
-  checksum: 10/cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-plain-obj@npm:3.0.0"
@@ -22698,15 +22679,6 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10/52117adbe0313d5defa771c9993fe081e2d2df9b840597e966aadafde04ae8d0e3da46bac7ca4efc37d4d2b839436582659cd49c6a43eacb3fe3050896a105d1
-  languageName: node
-  linkType: hard
-
-"merge-options@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "merge-options@npm:3.0.4"
-  dependencies:
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10/d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR migrates common-app persistence from `@react-native-async-storage/async-storage` (and removes it) to `react-native-mmkv` (already installed).

## Test plan
