### PR TITLE
worklets plugin: allow react-native imports in bundle mode

### DIFF
--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -302,6 +302,31 @@ describe('babel plugin in bundleMode', () => {
       assert(transformed?.code);
       expect(transformed.code).toMatchSnapshot();
     });
+
+    test('allows react-native imports when explicitly configured', () => {
+      const input = html`<script>
+        globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED = false;
+      </script>`;
+
+      const pluginOpts = { workletizableModules: ['react-native'] };
+      const result = runPlugin(input, {}, pluginOpts, MOCK_WORKLET_RUNTIME_ENTRY);
+
+      expect(result.code).toContain(
+        'globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED = true;'
+      );
+    });
+
+    test("doesn't allow react-native imports by default", () => {
+      const input = html`<script>
+        globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED = false;
+      </script>`;
+
+      const result = runPlugin(input, {}, {}, MOCK_WORKLET_RUNTIME_ENTRY);
+
+      expect(result.code).toContain(
+        'globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED = false;'
+      );
+    });
   });
 
   describe('nested worklets', () => {

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1398,17 +1398,30 @@ var require_bundleMode = __commonJS({
       if (!expressionPath.isAssignmentExpression()) {
         return;
       }
+      const propertyName = getGlobalPropertyName(expressionPath);
+      if (propertyName === "_WORKLETS_BUNDLE_MODE_ENABLED") {
+        expressionPath.get("right").replaceWith((0, types_12.booleanLiteral)(true));
+        return;
+      }
+      if (propertyName === "_WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED" && areReactNativeImportsAllowed(state)) {
+        expressionPath.get("right").replaceWith((0, types_12.booleanLiteral)(true));
+      }
+    }
+    function getGlobalPropertyName(expressionPath) {
       const left = expressionPath.get("left");
       if (!left.isMemberExpression()) {
-        return;
+        return null;
       }
       const object = left.get("object");
       const property = left.get("property");
-      if (!object.isIdentifier() || object.node.name !== "globalThis" || !property.isIdentifier() || property.node.name !== "_WORKLETS_BUNDLE_MODE_ENABLED") {
-        return;
+      if (!object.isIdentifier() || object.node.name !== "globalThis" || !property.isIdentifier()) {
+        return null;
       }
-      const right = expressionPath.get("right");
-      right.replaceWith((0, types_12.booleanLiteral)(true));
+      return property.node.name;
+    }
+    function areReactNativeImportsAllowed(state) {
+      var _a, _b;
+      return (_b = (_a = state.opts.workletizableModules) === null || _a === void 0 ? void 0 : _a.includes("react-native")) !== null && _b !== void 0 ? _b : false;
     }
   }
 });

--- a/packages/react-native-worklets/plugin/src/bundleMode.ts
+++ b/packages/react-native-worklets/plugin/src/bundleMode.ts
@@ -44,10 +44,28 @@ export function toggleBundleMode(
     return;
   }
 
+  const propertyName = getGlobalPropertyName(expressionPath);
+
+  if (propertyName === '_WORKLETS_BUNDLE_MODE_ENABLED') {
+    expressionPath.get('right').replaceWith(booleanLiteral(true));
+    return;
+  }
+
+  if (
+    propertyName === '_WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED' &&
+    areReactNativeImportsAllowed(state)
+  ) {
+    expressionPath.get('right').replaceWith(booleanLiteral(true));
+  }
+}
+
+function getGlobalPropertyName(
+  expressionPath: NodePath<ExpressionStatement['expression']>
+) {
   const left = expressionPath.get('left');
 
   if (!left.isMemberExpression()) {
-    return;
+    return null;
   }
 
   const object = left.get('object');
@@ -56,13 +74,14 @@ export function toggleBundleMode(
   if (
     !object.isIdentifier() ||
     object.node.name !== 'globalThis' ||
-    !property.isIdentifier() ||
-    property.node.name !== '_WORKLETS_BUNDLE_MODE_ENABLED'
+    !property.isIdentifier()
   ) {
-    return;
+    return null;
   }
 
-  const right = expressionPath.get('right');
+  return property.node.name;
+}
 
-  right.replaceWith(booleanLiteral(true));
+function areReactNativeImportsAllowed(state: WorkletsPluginPass) {
+  return state.opts.workletizableModules?.includes('react-native') ?? false;
 }

--- a/packages/react-native-worklets/src/index.ts
+++ b/packages/react-native-worklets/src/index.ts
@@ -5,6 +5,7 @@ import { init } from './initializers/initializers';
 // Worklets Babel Plugin replaces `false` with `true` here
 // when Bundle Mode is enabled.
 globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
+globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED = false;
 
 // is-tree-shakable-suppress
 init();

--- a/packages/react-native-worklets/src/initializers/initializers.native.ts
+++ b/packages/react-native-worklets/src/initializers/initializers.native.ts
@@ -174,7 +174,9 @@ function initializeWorkletRuntime() {
   if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
     if (__DEV__) {
       silenceHMRWarnings();
-      disallowRNImports();
+      if (!globalThis._WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED) {
+        disallowRNImports();
+      }
     }
 
     if (getStaticFeatureFlag('FETCH_PREVIEW_ENABLED')) {

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -32,6 +32,7 @@ declare global {
   var _toString: (value: unknown) => string;
   var __workletsModuleProxy: WorkletsModuleProxy;
   var _WORKLETS_BUNDLE_MODE_ENABLED: boolean | undefined;
+  var _WORKLETS_REACT_NATIVE_IMPORTS_ALLOWED: boolean | undefined;
   var _WORKLETS_VERSION_CPP: string | undefined;
   var _WORKLETS_VERSION_JS: string | undefined;
   var _createSerializableString: (value: string) => FlatSerializableRef<string>;


### PR DESCRIPTION
## Summary

In worklets bundle mode you have some good reasons to disallow any imports from react-native, which makes sense for the average user. I am trying to build something more custom with worklets right now, where i want to run certain code from react-native in my worklets in bundle mode.

Adding `workletizableModules: ["react-native"]` will make the plugin include the code, but at runtime due to `disallowRNImports()` it will never work.

This PR passes a global value at runtime if bundle mode && `workletizableModules: ["react-native"]`. If the user explicitly adds this, i feel like we should allow the imports. Let me know what you think?

Alternatively we could also hide this behind a feature flag if that's preferred?
It would be awesome to allow RN code to work in worklets (for users that know what they are doing), otherwise i would always need to patch react-native-worklets :/

## Test plan

I added unit tests for that:

- `yarn jest __tests__/plugin.test.ts --runInBand`
- `yarn workspace react-native-worklets type:check:src:native`
