### PR TITLE
chore: Remove no longer used `StaticPropsRegistry` methods and props

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 7cddd6384caaf534391b284de589eb1f50b44b53
+  hermes-engine: 8b25cc623de93c12f190eb2db7a4f5d9ab813d2d
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: e4297da59c9b7756b640c1a23117173487e85a05
+  React-Core-prebuilt: 78cca101eacd058571f4603c2ac16470a7501f0e
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: c19d82c85f20f1233c1944464105e9c381445c29
+  ReactNativeDependencies: 858d935daf670e37bb6c9565475449d2ed9cd1b1
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
@@ -1,18 +1,12 @@
 #include <reanimated/CSS/registries/StaticPropsRegistry.h>
 
-#include <utility>
-
 namespace reanimated::css {
 
 void StaticPropsRegistry::set(jsi::Runtime &rt, const Tag viewTag, const jsi::Value &props) {
   if (props.isNull() || props.isUndefined()) {
     remove(viewTag);
   } else {
-    const auto newProps = dynamicFromValue(rt, props);
-    if (has(viewTag)) {
-      notifyObservers(viewTag, get(viewTag), newProps);
-    }
-    registry_[viewTag] = newProps;
+    registry_[viewTag] = dynamicFromValue(rt, props);
   }
 }
 
@@ -24,38 +18,12 @@ folly::dynamic StaticPropsRegistry::get(const Tag viewTag) const {
   return it->second;
 }
 
-bool StaticPropsRegistry::has(const Tag viewTag) const {
-  return registry_.find(viewTag) != registry_.end();
-}
-
 void StaticPropsRegistry::remove(const Tag viewTag) {
   registry_.erase(viewTag);
 }
 
 bool StaticPropsRegistry::isEmpty() const {
-  return registry_.empty() && observers_.empty();
-}
-
-bool StaticPropsRegistry::hasObservers(const Tag viewTag) const {
-  return observers_.find(viewTag) != observers_.end();
-}
-
-void StaticPropsRegistry::setObserver(const Tag viewTag, PropsObserver observer) {
-  observers_[viewTag] = std::move(observer);
-}
-
-void StaticPropsRegistry::removeObserver(const Tag viewTag) {
-  observers_.erase(viewTag);
-}
-
-void StaticPropsRegistry::notifyObservers(
-    const Tag viewTag,
-    const folly::dynamic &oldProps,
-    const folly::dynamic &newProps) {
-  auto observerIt = observers_.find(viewTag);
-  if (observerIt != observers_.end()) {
-    observerIt->second(oldProps, newProps);
-  }
+  return registry_.empty();
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.h
@@ -9,25 +9,15 @@ namespace reanimated::css {
 using namespace facebook;
 using namespace react;
 
-using PropsObserver = std::function<void(const folly::dynamic &oldProps, const folly::dynamic &newProps)>;
-
 class StaticPropsRegistry {
  public:
   void set(jsi::Runtime &rt, Tag viewTag, const jsi::Value &props);
   folly::dynamic get(Tag viewTag) const;
-  bool has(Tag viewTag) const;
   void remove(Tag viewTag);
   bool isEmpty() const;
 
-  bool hasObservers(Tag viewTag) const;
-  void setObserver(Tag viewTag, PropsObserver observer);
-  void removeObserver(Tag viewTag);
-
  private:
   std::unordered_map<Tag, folly::dynamic> registry_;
-  std::unordered_map<Tag, PropsObserver> observers_;
-
-  void notifyObservers(Tag viewTag, const folly::dynamic &oldProps, const folly::dynamic &newProps);
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -416,11 +416,7 @@ void ReanimatedModuleProxy::cleanupSensors() {
 }
 
 void ReanimatedModuleProxy::setViewStyle(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &viewStyle) {
-  const auto tag = viewTag.asNumber();
-  staticPropsRegistry_->set(rt, tag, viewStyle);
-  if (staticPropsRegistry_->hasObservers(tag)) {
-    maybeRunCSSLoop();
-  }
+  staticPropsRegistry_->set(rt, viewTag.asNumber(), viewStyle);
 }
 
 void ReanimatedModuleProxy::markNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper) {


### PR DESCRIPTION
As the title states.