### PR TITLE
feat: Strict TS types in LA `withInitialValues` method

### DIFF
--- a/packages/react-native-reanimated/__typetests__/common/layoutAnimationsTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/layoutAnimationsTest.tsx
@@ -1,0 +1,224 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react';
+import { View } from 'react-native';
+
+import Animated, {
+  BounceIn,
+  FadeIn,
+  FadeInDown,
+  FadeInRight,
+  FadeOut,
+  FadeOutDown,
+  FlipInXUp,
+  LightSpeedInRight,
+  PinwheelIn,
+  RollInLeft,
+  RotateInDownLeft,
+  SlideInRight,
+  StretchInX,
+  ZoomIn,
+  ZoomInRotate,
+} from '../..';
+
+function LayoutAnimationsTest() {
+  function LayoutAnimationsWithInitialValues() {
+    const fadeInWithOpacity = FadeIn.withInitialValues({ opacity: 0.5 });
+
+    const fadeOutWithOpacity = FadeOut.withInitialValues({ opacity: 0.2 });
+
+    const fadeInRightWithOpacityAndTranslate = FadeInRight.withInitialValues({
+      opacity: 0.5,
+      transform: [{ translateX: 50 }],
+    });
+
+    const fadeInRightWithPercentTranslate = FadeInRight.withInitialValues({
+      transform: [{ translateX: '50%' }],
+    });
+
+    const fadeInDownWithOpacityAndTranslate = FadeInDown.withInitialValues({
+      opacity: 0.1,
+      transform: [{ translateY: 100 }],
+    });
+
+    const fadeOutDownWithPercentTranslate = FadeOutDown.withInitialValues({
+      transform: [{ translateY: '25%' }],
+    });
+
+    const bounceInWithScale = BounceIn.withInitialValues({
+      transform: [{ scale: 0.25 }],
+    });
+
+    const zoomInWithScale = ZoomIn.withInitialValues({
+      transform: [{ scale: 0.5 }],
+    });
+
+    const zoomInRotateWithScaleAndRotate = ZoomInRotate.withInitialValues({
+      transform: [{ scale: 0 }, { rotate: '45deg' }],
+    });
+
+    const flipInXUpWithFullTransform = FlipInXUp.withInitialValues({
+      transform: [
+        { perspective: 1000 },
+        { rotateX: '90deg' },
+        { translateY: -100 },
+      ],
+    });
+
+    const lightSpeedInRightWithOpacityAndTransform =
+      LightSpeedInRight.withInitialValues({
+        opacity: 0,
+        transform: [{ translateX: 200 }, { skewX: '-45deg' }],
+      });
+
+    const pinwheelInWithOpacityAndTransform = PinwheelIn.withInitialValues({
+      opacity: 0,
+      transform: [{ scale: 0 }, { rotate: '5rad' }],
+    });
+
+    const rollInLeftWithTransform = RollInLeft.withInitialValues({
+      transform: [{ translateX: -200 }, { rotate: '-180deg' }],
+    });
+
+    const rotateInDownLeftWithOpacityAndTransform =
+      RotateInDownLeft.withInitialValues({
+        opacity: 0,
+        transform: [
+          { rotate: '-90deg' },
+          { translateX: 10 },
+          { translateY: -10 },
+        ],
+      });
+
+    const slideInRightWithOriginX = SlideInRight.withInitialValues({
+      originX: 100,
+    });
+
+    const stretchInXWithScaleX = StretchInX.withInitialValues({
+      transform: [{ scaleX: 0 }],
+    });
+
+    // Partial overrides should be allowed.
+    const fadeInRightWithOnlyOpacity = FadeInRight.withInitialValues({
+      opacity: 0.2,
+    });
+
+    const fadeInRightWithOnlyTransform = FadeInRight.withInitialValues({
+      transform: [{ translateX: 10 }],
+    });
+
+    // Should be chainable with other modifiers.
+    const fadeInChained = FadeIn.duration(300)
+      .withInitialValues({ opacity: 0.2 })
+      .delay(100);
+  }
+
+  function LayoutAnimationsWithInitialValuesRejectsTest() {
+    FadeIn.withInitialValues({
+      // @ts-expect-error opacity must be a number, not a string.
+      opacity: 'red',
+    });
+
+    FadeIn.withInitialValues({
+      // @ts-expect-error FadeIn has no transform in its initial values.
+      transform: [{ translateX: 0 }],
+    });
+
+    FadeIn.withInitialValues({
+      // @ts-expect-error Unknown property `color`.
+      color: 'red',
+    });
+
+    FadeInRight.withInitialValues({
+      transform: [
+        {
+          // @ts-expect-error FadeInRight expects `translateX`, not `translateY`.
+          translateY: 50,
+        },
+      ],
+    });
+
+    FadeInRight.withInitialValues({
+      transform: [
+        {
+          // @ts-expect-error `translateX` does not accept arbitrary strings (only number or `${number}%`).
+          translateX: 'left',
+        },
+      ],
+    });
+
+    FlipInXUp.withInitialValues({
+      // @ts-expect-error FlipInXUp expects a tuple of 3 transforms, not 2.
+      transform: [{ perspective: 500 }, { rotateX: '90deg' }],
+    });
+
+    // prettier-ignore
+    FlipInXUp.withInitialValues({
+      transform: [
+        // @ts-expect-error FlipInXUp transforms are ordered: perspective, rotateX, translateY.
+        { rotateX: '90deg' }, { perspective: 500 },
+        { translateY: 0 },
+      ],
+    });
+
+    FlipInXUp.withInitialValues({
+      transform: [
+        {
+          // @ts-expect-error `perspective` must be a number, not a CSS string.
+          perspective: '500px',
+        },
+        { rotateX: '90deg' },
+        { translateY: 0 },
+      ],
+    });
+
+    ZoomInRotate.withInitialValues({
+      transform: [
+        { scale: 0 },
+        {
+          // @ts-expect-error `rotate` must be a string, not a number.
+          rotate: 45,
+        },
+      ],
+    });
+
+    SlideInRight.withInitialValues({
+      // @ts-expect-error SlideInRight uses `originX`, not `originY`.
+      originY: 100,
+    });
+
+    StretchInX.withInitialValues({
+      transform: [
+        {
+          // @ts-expect-error StretchInX uses `scaleX`, not `scale`.
+          scale: 0,
+        },
+      ],
+    });
+
+    BounceIn.withInitialValues({
+      transform: [
+        {
+          // @ts-expect-error Unknown transform key `foo`.
+          foo: 1,
+        },
+      ],
+    });
+  }
+
+  function LayoutAnimationsAssignableToEnteringExitingTest() {
+    return (
+      <View>
+        <Animated.View
+          entering={FadeInRight.withInitialValues({
+            opacity: 0.1,
+            transform: [{ translateX: 20 }],
+          })}
+          exiting={FadeOutDown.withInitialValues({
+            opacity: 0,
+            transform: [{ translateY: 80 }],
+          })}
+        />
+      </View>
+    );
+  }
+}

--- a/packages/react-native-reanimated/src/common/types/index.ts
+++ b/packages/react-native-reanimated/src/common/types/index.ts
@@ -3,3 +3,4 @@
 export * from './config';
 export type * from './helpers';
 export type * from './style';
+export type * from './transforms';

--- a/packages/react-native-reanimated/src/common/types/transforms.ts
+++ b/packages/react-native-reanimated/src/common/types/transforms.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+export type TranslateX = { translateX: number | `${number}%` };
+export type TranslateY = { translateY: number | `${number}%` };
+export type Scale = { scale: number };
+export type ScaleX = { scaleX: number };
+export type ScaleY = { scaleY: number };
+export type Rotate = { rotate: string };
+export type RotateX = { rotateX: string };
+export type RotateY = { rotateY: string };
+export type SkewX = { skewX: string };
+export type Perspective = { perspective: number };

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -11,7 +11,9 @@ import type {
 import type { EasingFunctionFactory } from '../../Easing';
 import { BaseAnimationBuilder } from './BaseAnimationBuilder';
 
-export class ComplexAnimationBuilder extends BaseAnimationBuilder {
+export class ComplexAnimationBuilder<
+  TInitialValues = StyleProps,
+> extends BaseAnimationBuilder {
   easingV?: EasingFunction | EasingFunctionFactory;
   rotateV?: string;
   type?: AnimationFunction;
@@ -21,7 +23,7 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
   stiffnessV?: number;
   overshootClampingV?: number;
   energyThresholdV?: number;
-  initialValues?: StyleProps;
+  initialValues?: Partial<TInitialValues>;
 
   static createInstance: <T extends typeof BaseAnimationBuilder>(
     this: T
@@ -257,15 +259,15 @@ export class ComplexAnimationBuilder extends BaseAnimationBuilder {
    *
    * @param values - An object containing the styles to override.
    */
-  static withInitialValues<T extends typeof ComplexAnimationBuilder>(
-    this: T,
-    values: StyleProps
-  ) {
+  static withInitialValues<
+    T extends typeof ComplexAnimationBuilder,
+    TInitialValues,
+  >(this: T, values: Partial<TInitialValues>) {
     const instance = this.createInstance();
     return instance.withInitialValues(values);
   }
 
-  withInitialValues(values: StyleProps): this {
+  withInitialValues(values: Partial<TInitialValues>): this {
     this.initialValues = values;
     return this;
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -259,10 +259,14 @@ export class ComplexAnimationBuilder<
    *
    * @param values - An object containing the styles to override.
    */
-  static withInitialValues<
-    T extends typeof ComplexAnimationBuilder,
-    TInitialValues,
-  >(this: T, values: Partial<TInitialValues>) {
+  static withInitialValues<T extends typeof ComplexAnimationBuilder>(
+    this: T,
+    values: InstanceType<T> extends ComplexAnimationBuilder<
+      infer TInferredInitialValues
+    >
+      ? Partial<TInferredInitialValues>
+      : never
+  ) {
     const instance = this.createInstance();
     return instance.withInitialValues(values);
   }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -259,15 +259,13 @@ export class ComplexAnimationBuilder<
    *
    * @param values - An object containing the styles to override.
    */
-  static withInitialValues<T extends typeof ComplexAnimationBuilder>(
-    this: T,
-    values: InstanceType<T> extends ComplexAnimationBuilder<
-      infer TInferredInitialValues
-    >
-      ? Partial<TInferredInitialValues>
-      : never
+  static withInitialValues<TInitialValues>(
+    this: (new () => ComplexAnimationBuilder<TInitialValues>) &
+      typeof BaseAnimationBuilder,
+    values: Partial<TInitialValues>
   ) {
-    const instance = this.createInstance();
+    const instance =
+      this.createInstance() as ComplexAnimationBuilder<TInitialValues>;
     return instance.withInitialValues(values);
   }
 

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -11,6 +11,16 @@ import type {
 import type { EasingFunctionFactory } from '../../Easing';
 import { BaseAnimationBuilder } from './BaseAnimationBuilder';
 
+/**
+ * `this` type for every static method on {@link ComplexAnimationBuilder}.
+ * Represents a subclass constructor that preserves the concrete
+ * `TInitialValues` type argument while still exposing the static API inherited
+ * from {@link BaseAnimationBuilder}.
+ */
+type ComplexAnimationBuilderClass<TInitialValues> =
+  typeof BaseAnimationBuilder &
+    (new () => ComplexAnimationBuilder<TInitialValues>);
+
 export class ComplexAnimationBuilder<
   TInitialValues = StyleProps,
 > extends BaseAnimationBuilder {
@@ -37,10 +47,10 @@ export class ComplexAnimationBuilder<
    * @param easingFunction - An easing function which defines the animation
    *   curve.
    */
-  static easing<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static easing<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     easingFunction: EasingFunction | EasingFunctionFactory
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.easing(easingFunction);
   }
@@ -60,10 +70,10 @@ export class ComplexAnimationBuilder<
    *
    * @param degree - The rotation degree.
    */
-  static rotate<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static rotate<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     degree: string
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.rotate(degree);
   }
@@ -81,10 +91,10 @@ export class ComplexAnimationBuilder<
    * @param duration - An optional duration of the spring animation (in
    *   milliseconds).
    */
-  static springify<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static springify<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     duration?: number
-  ): ComplexAnimationBuilder {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.springify(duration);
   }
@@ -102,10 +112,10 @@ export class ComplexAnimationBuilder<
    *
    * @param dampingRatio - How damped the spring is.
    */
-  static dampingRatio<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static dampingRatio<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     dampingRatio: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.dampingRatio(dampingRatio);
   }
@@ -123,10 +133,10 @@ export class ComplexAnimationBuilder<
    * @param value - Decides how quickly a spring stops moving. Higher damping
    *   means the spring will come to rest faster.
    */
-  static damping<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static damping<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     value: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.damping(value);
   }
@@ -144,7 +154,10 @@ export class ComplexAnimationBuilder<
    * @param mass - The weight of the spring. Reducing this value makes the
    *   animation faster.
    */
-  static mass<T extends typeof ComplexAnimationBuilder>(this: T, mass: number) {
+  static mass<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
+    mass: number
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.mass(mass);
   }
@@ -161,10 +174,10 @@ export class ComplexAnimationBuilder<
    *
    * @param stiffness - How bouncy the spring is.
    */
-  static stiffness<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static stiffness<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     stiffness: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.stiffness(stiffness);
   }
@@ -182,10 +195,10 @@ export class ComplexAnimationBuilder<
    * @param overshootClamping - Whether a spring can bounce over the final
    *   position.
    */
-  static overshootClamping<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static overshootClamping<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     overshootClamping: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.overshootClamping(overshootClamping);
   }
@@ -199,10 +212,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in the upcoming major version.
    */
-  static restDisplacementThreshold<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static restDisplacementThreshold<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     _restDisplacementThreshold: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     return this.createInstance();
   }
 
@@ -218,10 +231,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in a future version.
    */
-  static restSpeedThreshold<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static restSpeedThreshold<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     _restSpeedThreshold: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     return this.createInstance();
   }
 
@@ -241,10 +254,10 @@ export class ComplexAnimationBuilder<
    * @param energyThreshold - Relative energy threshold below which the spring
    *   will snap to `toValue` without further oscillations. Defaults to 6e-9.
    */
-  static energyThreshold<T extends typeof ComplexAnimationBuilder>(
-    this: T,
+  static energyThreshold<TInitialValues>(
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     energyThreshold: number
-  ) {
+  ): ComplexAnimationBuilder<TInitialValues> {
     const instance = this.createInstance();
     return instance.energyThreshold(energyThreshold);
   }
@@ -260,12 +273,10 @@ export class ComplexAnimationBuilder<
    * @param values - An object containing the styles to override.
    */
   static withInitialValues<TInitialValues>(
-    this: (new () => ComplexAnimationBuilder<TInitialValues>) &
-      typeof BaseAnimationBuilder,
+    this: ComplexAnimationBuilderClass<TInitialValues>,
     values: Partial<TInitialValues>
-  ) {
-    const instance =
-      this.createInstance() as ComplexAnimationBuilder<TInitialValues>;
+  ): ComplexAnimationBuilder<TInitialValues> {
+    const instance = this.createInstance();
     return instance.withInitialValues(values);
   }
 

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Bounce.ts
@@ -1,5 +1,6 @@
 'use strict';
 import { withSequence, withTiming } from '../../animation';
+import type { Scale, TranslateX, TranslateY } from '../../common';
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
@@ -18,7 +19,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceIn
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceIn';
@@ -82,7 +83,7 @@ export class BounceIn
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceInDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceInDown';
@@ -150,7 +151,7 @@ export class BounceInDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceInUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceInUp';
@@ -214,7 +215,7 @@ export class BounceInUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceInLeft';
@@ -278,7 +279,7 @@ export class BounceInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceInRight';
@@ -342,7 +343,7 @@ export class BounceInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceOut
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceOut';
@@ -406,7 +407,7 @@ export class BounceOut
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceOutDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceOutDown';
@@ -472,7 +473,7 @@ export class BounceOutDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceOutUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceOutUp';
@@ -538,7 +539,7 @@ export class BounceOutUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceOutLeft';
@@ -604,7 +605,7 @@ export class BounceOutLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#bounce
  */
 export class BounceOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'BounceOutRight';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Fade.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { TranslateX, TranslateY } from '../../common';
 import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
@@ -16,7 +17,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeIn
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ opacity: number }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeIn';
@@ -59,7 +60,10 @@ export class FadeIn
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeInRight';
@@ -107,7 +111,10 @@ export class FadeInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeInLeft';
@@ -155,7 +162,10 @@ export class FadeInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeInUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateY];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeInUp';
@@ -203,7 +213,10 @@ export class FadeInUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeInDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateY];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeInDown';
@@ -251,7 +264,7 @@ export class FadeInDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeOut
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ opacity: number }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeOut';
@@ -295,7 +308,10 @@ export class FadeOut
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeOutRight';
@@ -343,7 +359,10 @@ export class FadeOutRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeOutLeft';
@@ -390,7 +409,10 @@ export class FadeOutLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeOutUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateY];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeOutUp';
@@ -438,7 +460,10 @@ export class FadeOutUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#fade
  */
 export class FadeOutDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateY];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FadeOutDown';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Flip.ts
@@ -1,5 +1,12 @@
 'use strict';
 import type {
+  Perspective,
+  RotateX,
+  RotateY,
+  TranslateX,
+  TranslateY,
+} from '../../common';
+import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
   EntryExitAnimationFunction,
@@ -21,7 +28,9 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInXUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'FlipInXUp';
@@ -73,7 +82,9 @@ export class FlipInXUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInYLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateY, TranslateX];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'FlipInYLeft';
@@ -125,7 +136,9 @@ export class FlipInYLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInXDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'FlipInXDown';
@@ -177,7 +190,9 @@ export class FlipInXDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInYRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateY, TranslateX];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'FlipInYRight';
@@ -229,7 +244,7 @@ export class FlipInYRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInEasyX
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Perspective, RotateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FlipInEasyX';
@@ -276,7 +291,7 @@ export class FlipInEasyX
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipInEasyY
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Perspective, RotateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FlipInEasyY';
@@ -323,7 +338,9 @@ export class FlipInEasyY
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutXUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'FlipOutXUp';
@@ -380,7 +397,9 @@ export class FlipOutXUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutYLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateY, TranslateX];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'FlipOutYLeft';
@@ -437,7 +456,9 @@ export class FlipOutYLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutXDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'FlipOutXDown';
@@ -494,7 +515,9 @@ export class FlipOutXDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutYRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    transform: [Perspective, RotateY, TranslateX];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'FlipOutYRight';
@@ -551,7 +574,7 @@ export class FlipOutYRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutEasyX
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Perspective, RotateX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FlipOutEasyX';
@@ -598,7 +621,7 @@ export class FlipOutEasyX
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#flip
  */
 export class FlipOutEasyY
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Perspective, RotateY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'FlipOutEasyY';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Lightspeed.ts
@@ -1,5 +1,6 @@
 'use strict';
 import { withSequence, withTiming } from '../../animation';
+import type { SkewX, TranslateX } from '../../common';
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
@@ -17,7 +18,10 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#lightspeed
  */
 export class LightSpeedInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX, SkewX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'LightSpeedInRight';
@@ -81,7 +85,10 @@ export class LightSpeedInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#lightspeed
  */
 export class LightSpeedInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX, SkewX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'LightSpeedInLeft';
@@ -145,7 +152,10 @@ export class LightSpeedInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#lightspeed
  */
 export class LightSpeedOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX, SkewX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'LightSpeedOutRight';
@@ -201,7 +211,10 @@ export class LightSpeedOutRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#lightspeed
  */
 export class LightSpeedOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [TranslateX, SkewX];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'LightSpeedOutLeft';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Pinwheel.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { Rotate, Scale } from '../../common';
 import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
@@ -16,7 +17,10 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#pinwheel
  */
 export class PinwheelIn
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Scale, Rotate];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'PinwheelIn';
@@ -76,7 +80,10 @@ export class PinwheelIn
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#pinwheel
  */
 export class PinwheelOut
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Scale, Rotate];
+  }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'PinwheelOut';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Roll.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { Rotate, TranslateX } from '../../common';
 import type {
   EntryExitAnimationFunction,
   EntryExitAnimationsValues,
@@ -17,7 +18,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#roll
  */
 export class RollInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'RollInLeft';
@@ -67,7 +68,7 @@ export class RollInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#roll
  */
 export class RollInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'RollInRight';
@@ -114,7 +115,7 @@ export class RollInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#roll
  */
 export class RollOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'RollOutLeft';
@@ -166,7 +167,7 @@ export class RollOutLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#roll
  */
 export class RollOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'RollOutRight';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Rotate.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { Rotate, TranslateX, TranslateY } from '../../common';
 import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
@@ -19,7 +20,10 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateInDownLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'RotateInDownLeft';
@@ -73,7 +77,10 @@ export class RotateInDownLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateInDownRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'RotateInDownRight';
@@ -127,7 +134,10 @@ export class RotateInDownRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateInUpLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'RotateInUpLeft';
@@ -181,7 +191,10 @@ export class RotateInUpLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateInUpRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'RotateInUpRight';
@@ -235,7 +248,10 @@ export class RotateInUpRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateOutDownLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'RotateOutDownLeft';
@@ -301,7 +317,10 @@ export class RotateOutDownLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateOutDownRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'RotateOutDownRight';
@@ -367,7 +386,10 @@ export class RotateOutDownRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateOutUpLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'RotateOutUpLeft';
@@ -433,7 +455,10 @@ export class RotateOutUpLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#rotate
  */
 export class RotateOutUpRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    opacity: number;
+    transform: [Rotate, TranslateX, TranslateY];
+  }>
   implements IExitAnimationBuilder
 {
   static presetName = 'RotateOutUpRight';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Slide.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Slide.ts
@@ -19,7 +19,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originX: number }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'SlideInRight';
@@ -66,7 +66,7 @@ export class SlideInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originX: number }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'SlideInLeft';
@@ -113,7 +113,7 @@ export class SlideInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originX: number }>
   implements IExitAnimationBuilder
 {
   static presetName = 'SlideOutRight';
@@ -166,7 +166,7 @@ export class SlideOutRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originX: number }>
   implements IExitAnimationBuilder
 {
   static presetName = 'SlideOutLeft';
@@ -219,7 +219,7 @@ export class SlideOutLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideInUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originY: number }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'SlideInUp';
@@ -266,7 +266,7 @@ export class SlideInUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideInDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originY: number }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'SlideInDown';
@@ -313,7 +313,7 @@ export class SlideInDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideOutUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originY: number }>
   implements IExitAnimationBuilder
 {
   static presetName = 'SlideOutUp';
@@ -363,7 +363,7 @@ export class SlideOutUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations#slide
  */
 export class SlideOutDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ originY: number }>
   implements IExitAnimationBuilder
 {
   static presetName = 'SlideOutDown';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Stretch.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { ScaleX, ScaleY } from '../../common';
 import type {
   EntryExitAnimationFunction,
   IEntryExitAnimationBuilder,
@@ -16,7 +17,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#stretch
  */
 export class StretchInX
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [ScaleX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'StretchInX';
@@ -60,7 +61,7 @@ export class StretchInX
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#stretch
  */
 export class StretchInY
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [ScaleY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'StretchInY';
@@ -104,7 +105,7 @@ export class StretchInY
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#stretch
  */
 export class StretchOutX
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [ScaleX] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'StretchOutX';
@@ -148,7 +149,7 @@ export class StretchOutX
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#stretch
  */
 export class StretchOutY
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [ScaleY] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'StretchOutY';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultAnimations/Zoom.ts
@@ -1,4 +1,5 @@
 'use strict';
+import type { Rotate, Scale, TranslateX, TranslateY } from '../../common';
 import type {
   AnimationConfigFunction,
   EntryAnimationsValues,
@@ -22,7 +23,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomIn
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomIn';
@@ -66,7 +67,7 @@ export class ZoomIn
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInRotate
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomInRotate';
@@ -114,7 +115,7 @@ export class ZoomInRotate
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomInLeft';
@@ -161,7 +162,7 @@ export class ZoomInLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomInRight';
@@ -208,7 +209,7 @@ export class ZoomInRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomInUp';
@@ -255,7 +256,7 @@ export class ZoomInUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomInDown';
@@ -302,7 +303,7 @@ export class ZoomInDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInEasyUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'ZoomInEasyUp';
@@ -349,7 +350,7 @@ export class ZoomInEasyUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomInEasyDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryAnimationBuilder
 {
   static presetName = 'ZoomInEasyDown';
@@ -396,7 +397,7 @@ export class ZoomInEasyDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOut
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOut';
@@ -440,7 +441,7 @@ export class ZoomOut
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutRotate
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [Scale, Rotate] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOutRotate';
@@ -488,7 +489,7 @@ export class ZoomOutRotate
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutLeft
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOutLeft';
@@ -540,7 +541,7 @@ export class ZoomOutLeft
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutRight
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateX, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOutRight';
@@ -592,7 +593,7 @@ export class ZoomOutRight
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOutUp';
@@ -644,7 +645,7 @@ export class ZoomOutUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IEntryExitAnimationBuilder
 {
   static presetName = 'ZoomOutDown';
@@ -696,7 +697,7 @@ export class ZoomOutDown
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutEasyUp
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IExitAnimationBuilder
 {
   static presetName = 'ZoomOutEasyUp';
@@ -748,7 +749,7 @@ export class ZoomOutEasyUp
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/entering-exiting-animations/#zoom
  */
 export class ZoomOutEasyDown
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{ transform: [TranslateY, Scale] }>
   implements IExitAnimationBuilder
 {
   static presetName = 'ZoomOutEasyDown';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/LinearTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/LinearTransition.ts
@@ -16,7 +16,12 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions#linear-transition
  */
 export class LinearTransition
-  extends ComplexAnimationBuilder
+  extends ComplexAnimationBuilder<{
+    originX: number;
+    originY: number;
+    width: number;
+    height: number;
+  }>
   implements ILayoutAnimationBuilder
 {
   static presetName = 'LinearTransition';


### PR DESCRIPTION
## Summary

This PR replaces the old `StyleProps` type, that accepted any arbitrary props not related to the particular LA instance, with strict types ensuring that only properties animated in the layout animation can be passed to the `withInitialValues` method call.