### PR TITLE
fix: improve worklets version resolution and error messages for monor…

### DIFF
--- a/packages/react-native-reanimated/scripts/validate-worklets-version.js
+++ b/packages/react-native-reanimated/scripts/validate-worklets-version.js
@@ -36,17 +36,29 @@ function validateVersion(reanimatedVersion) {
     const { version } = require('react-native-worklets/package.json');
     workletsVersion = version;
   } catch (_e) {
-    return {
-      ok: false,
-      message:
-        "react-native-worklets package isn't installed. Please install a version between " +
-        earliestSupportedVersion +
-        ' and ' +
-        latestSupportedVersion +
-        ' to use Reanimated ' +
-        reanimatedVersion +
-        '.',
-    };
+    // In pnpm monorepos, the standard require may not resolve correctly from
+    // Reanimated's install location. Try resolving from the project root.
+    try {
+      const resolvedPath = require.resolve('react-native-worklets/package.json', {
+        paths: [process.cwd()],
+      });
+      const { version } = require(resolvedPath);
+      workletsVersion = version;
+    } catch (_e2) {
+      return {
+        ok: false,
+        message:
+          "react-native-worklets package isn't installed. Please install a version between " +
+          earliestSupportedVersion +
+          ' and ' +
+          latestSupportedVersion +
+          ' to use Reanimated ' +
+          reanimatedVersion +
+          '.' +
+          ' If you are using a pnpm monorepo, ensure the package is installed' +
+          ' in your app directory (not just the workspace root).',
+      };
+    }
   }
 
   if (semverPrerelease(workletsVersion)) {
@@ -69,9 +81,15 @@ function validateVersion(reanimatedVersion) {
     ? `Please install the latest supported version of Worklets ${latestSupportedVersion} or older`
     : `Please install Worklets ${earliestSupportedVersion} or newer`;
 
+  const monorepoHint =
+    ' If you are using a monorepo (e.g. pnpm workspaces), make sure all apps' +
+    ' in the workspace use the same version of react-native-worklets. You can' +
+    ' enforce a consistent version using your package manager\'s overrides/' +
+    'resolutions field in the root package.json.';
+
   return {
     ok: false,
-    message: `Your installed version of Worklets (${workletsVersion}) is not compatible with installed version of Reanimated (${reanimatedVersion}). ${installMessage}. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/#supported-react-native-worklets-versions`,
+    message: `Your installed version of Worklets (${workletsVersion}) is not compatible with installed version of Reanimated (${reanimatedVersion}). ${installMessage}. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/#supported-react-native-worklets-versions${monorepoHint}`,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes worklets version resolution in pnpm monorepo setups.

In pnpm monorepos, `require('react-native-worklets/package.json')` resolves from Reanimated's own install location rather than the user's project. Due to pnpm's strict dependency isolation, this can fail even when worklets is correctly installed in the project, producing a misleading "package isn't installed" error during `pod install`.

This PR adds a fallback resolution path using `require.resolve` with `paths: [process.cwd()]` and improves error messages with monorepo-specific guidance (e.g., using package manager overrides/resolutions).

All changes are backwards compatible, existing resolution is tried first.

## Test plan

1. Create a pnpm monorepo with two apps sharing react-native-reanimated
2. Install react-native-worklets in each app's package.json
3. Run `cd apps/my-app && npx pod-install`
4. Before this fix: validation fails with "react-native-worklets package isn't installed"
5. After this fix: validation correctly finds the installed worklets version and succeeds

Manual verification: the fix was validated in a real pnpm monorepo where Reanimated 4.3.0 with worklets 0.8.1 was failing to resolve during pod install