### PR TITLE
fix(Worklets): duplicate definitions to call microtasks

### DIFF
--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -85,7 +85,6 @@ declare global {
   var _microtaskQueueFinalizers: (() => void)[];
   var _scheduleTimeoutCallback: (delay: number, handlerId: number) => void;
   var __runTimeoutCallback: (handlerId: number) => void;
-  var __flushMicrotasks: () => void;
   var _taskQueue: Queue;
   /** Only in Debug builds. */
   var __hasNativeState: (value: object) => boolean;

--- a/packages/react-native-worklets/src/runLoop/workletRuntime/requestAnimationFramePolyfill.ts
+++ b/packages/react-native-worklets/src/runLoop/workletRuntime/requestAnimationFramePolyfill.ts
@@ -27,7 +27,7 @@ export function setupRequestAnimationFrame(animationQueuePollingRate: number) {
 
     for (const callback of flushedCallbacks) {
       callback(timestamp);
-      globalThis.__flushMicrotasks();
+      globalThis.__callMicrotasks();
     }
 
     flushedCallbacksBegin = flushedCallbacksEnd;

--- a/packages/react-native-worklets/src/runLoop/workletRuntime/taskQueue.ts
+++ b/packages/react-native-worklets/src/runLoop/workletRuntime/taskQueue.ts
@@ -19,10 +19,10 @@ export function setupTaskQueue() {
     const task = queue.timeoutCallbacks.get(handlerId);
     task?.();
     queue.timeoutCallbacks.delete(handlerId);
-    globalThis.__flushMicrotasks();
+    globalThis.__callMicrotasks();
   };
 
-  globalThis.__flushMicrotasks = function () {
+  globalThis.__callMicrotasks = function callMicrotasks() {
     for (let i = 0; i < queue.microtasks.length; i++) {
       queue.microtasks[i]();
     }

--- a/packages/react-native-worklets/src/runtimes.native.ts
+++ b/packages/react-native-worklets/src/runtimes.native.ts
@@ -160,7 +160,7 @@ export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
     createSerializable(() => {
       'worklet';
       worklet(...args);
-      globalThis.__flushMicrotasks?.();
+      globalThis.__callMicrotasks?.();
     })
   );
 }
@@ -183,7 +183,7 @@ if (!globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
       globalThis.__serializer(() => {
         'worklet';
         worklet(...args);
-        globalThis.__flushMicrotasks?.();
+        globalThis.__callMicrotasks?.();
       })
     );
   }
@@ -237,7 +237,7 @@ export function scheduleOnRuntimeWithId<Args extends unknown[], ReturnValue>(
     createSerializable(() => {
       'worklet';
       worklet(...args);
-      globalThis.__flushMicrotasks?.();
+      globalThis.__callMicrotasks?.();
     })
   );
 }
@@ -260,7 +260,7 @@ if (!globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
       globalThis.__serializer(() => {
         'worklet';
         worklet(...args);
-        globalThis.__flushMicrotasks?.();
+        globalThis.__callMicrotasks?.();
       })
     );
   }
@@ -452,7 +452,7 @@ export function runOnRuntimeAsync<Args extends unknown[], ReturnValue>(
         } catch (error) {
           scheduleOnRN(reject, error);
         }
-        globalThis.__flushMicrotasks?.();
+        globalThis.__callMicrotasks?.();
       })
     );
   });


### PR DESCRIPTION
## Summary

Turns out that the UI Runtime would declare `__flushMicrotasks` as the method to call microtasks but the other runtimes with event loop would declare it to be `__callMicrotasks`, which would result in some microtasks not triggering under specific circumstances.

## Test plan

`scheduleOnRuntimeWithId` now triggers microtasks.
