### PR TITLE
fix: slack notify script not picking up all nightlies

### DIFF
--- a/.github/workflows/helper/nightly-fail-notification.ts
+++ b/.github/workflows/helper/nightly-fail-notification.ts
@@ -16,7 +16,7 @@ type BadgeResult = BadgeInfo & {
 
 const GITHUB_ACTIONS_BADGE_REGEX =
   // @ts-expect-error It's fine to use capture groups here.
-  /\[!\[(?<name>[^\]]+)\]\((?<badgeUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+\/badge\.svg[^)]*)\)\]\((?<workflowUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+)\)/g;
+  /\[!\[(?<name>(?:[^[\]]|\[[^\]]*\])+)\]\((?<badgeUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+\/badge\.svg[^)]*)\)\]\((?<workflowUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+)\)/g;
 
 function parseBadgeStatus(svg: string): BadgeStatus {
   const normalized = svg.toLowerCase();


### PR DESCRIPTION
## Summary

Turns out that the regexp wasn't vibecoded enough to pick-up ﻿square brackets in names of CI labels.

## Test plan

https://regex101.com/r/JsLIDM/1
