### PR TITLE
fix: Freeze example crash and different timings

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/FreezeExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/FreezeExample.tsx
@@ -10,11 +10,12 @@ import Animated, {
   Easing,
   useAnimatedStyle,
   useSharedValue,
-  withDelay,
   withTiming,
 } from 'react-native-reanimated';
 
 import { NukeContext } from '@/components';
+
+const DEMO_DURATION_MS = 10_000;
 
 type RootStackParamList = {
   screen1: undefined;
@@ -83,10 +84,10 @@ const AnimatedStyleAnimation = () => {
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateX: withDelay(
-          1000,
-          withTiming(sv.value, { duration: 10000, easing: Easing.linear })
-        ),
+        translateX: withTiming(sv.value, {
+          duration: DEMO_DURATION_MS,
+          easing: Easing.linear,
+        }),
       },
     ],
   }));
@@ -178,15 +179,7 @@ type StackParamList = {
   screen3: undefined;
 };
 
-const Stack = createNativeStackNavigator<StackParamList>({
-  initialRouteName: 'home',
-  screens: {
-    home: HomeScreen,
-    screen1: Screen1,
-    screen2: Screen2,
-    screen3: Screen3,
-  },
-});
+const Stack = createNativeStackNavigator<StackParamList>();
 
 export default function App() {
   return (
@@ -224,9 +217,8 @@ const styles = css.create({
   animationBox: {
     width: 100,
     height: 50,
-    animationDelay: '1s',
-    animationDuration: '10s',
-    animationFillMode: 'forwards',
+    animationDuration: DEMO_DURATION_MS,
+    animationFillMode: 'both',
     animationTimingFunction: 'linear',
     animationName: {
       from: {
@@ -243,8 +235,7 @@ const styles = css.create({
     width: 100,
     height: 50,
     backgroundColor: 'blue',
-    transitionDelay: '1s',
-    transitionDuration: '10s',
+    transitionDuration: DEMO_DURATION_MS,
     transitionProperty: 'left',
     transitionTimingFunction: 'linear',
   },

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
+  hermes-engine: 8b25cc623de93c12f190eb2db7a4f5d9ab813d2d
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: ad07fe339524525c313184c766caa0364d134d48
+  React-Core-prebuilt: 78cca101eacd058571f4603c2ac16470a7501f0e
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 46220a81f19873e7d14e2b34e2b31df5c8dc3078
+  ReactNativeDependencies: 858d935daf670e37bb6c9565475449d2ed9cd1b1
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 8b25cc623de93c12f190eb2db7a4f5d9ab813d2d
+  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: 78cca101eacd058571f4603c2ac16470a7501f0e
+  React-Core-prebuilt: ad07fe339524525c313184c766caa0364d134d48
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: d07ee3c8db75b43d1cbe479ae6affebf9925c733
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 858d935daf670e37bb6c9565475449d2ed9cd1b1
+  ReactNativeDependencies: 46220a81f19873e7d14e2b34e2b31df5c8dc3078
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec


### PR DESCRIPTION
## Summary

This PR fixes crash in runtime when the `FreezeExample` was entered and different timings of animations during navigation between screens (seems that unfreeze of worklet based animation activates another delay, thus animation is not continuing at the same stage as CSS animations - to align behavior of animations, I removed the additional delay and left just timing animation)

## Before (crash)

https://github.com/user-attachments/assets/372a10b9-608b-4e63-a845-2bab79da9f14

## Timing comparison

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/1dff520a-878a-4bef-ab75-712086e47160" /> | <video src="https://github.com/user-attachments/assets/2d80019e-451e-4448-ba75-a4c1427fa444" /> |
