### PR TITLE
Fix 'Cannot find a KaModule for the VirtualFile' error

### DIFF
--- a/apps/fabric-example/android/gradle.properties
+++ b/apps/fabric-example/android/gradle.properties
@@ -52,3 +52,7 @@ enableWorkletsProfiling=true
 # https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
+
+# Workaround for lint K2 UAST crashing on .gradle.kts build scripts (AGP 9.x + Kotlin 2.x).
+# See: KotlinStandaloneProjectStructureProvider / Cannot find a KaModule for VirtualFile
+android.lint.useK2Uast=false

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -210,7 +210,8 @@ android {
 
     defaultConfig {
         minSdk = safeExtGet("minSdkVersion", 24) as Int
-        targetSdk = safeExtGet("targetSdkVersion", 36) as Int
+        testOptions.targetSdk = safeExtGet("targetSdkVersion", 36) as Int
+        lint.targetSdk = safeExtGet("targetSdkVersion", 36) as Int
 
         buildConfigField("boolean", "WORKLETS_PROFILING", WORKLETS_PROFILING.toString())
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")


### PR DESCRIPTION
## Summary

When building in release mode, we get Cannot find a KaModule for the VirtualFile error
This appears to be a known issue with K2 analyzer, so we disable it and fallback to K1
https://issuetracker.google.com/issues/432144179
Also we can't just `checkBuildScripts = false` as it's not available on AGP 9

Also, changed `targetSdk` assignment in worklets to `lint.targetSdk` and `testOptions.targetSdk` as I forgot to do that in a previous PR

## Test plan

Build & run
