### PR TITLE
fix: Remove `withInitialValues` and `withTargetValues` from layout transitions

### DIFF
--- a/packages/react-native-reanimated/__typetests__/common/layoutAnimationsTest.tsx
+++ b/packages/react-native-reanimated/__typetests__/common/layoutAnimationsTest.tsx
@@ -4,16 +4,21 @@ import { View } from 'react-native';
 
 import Animated, {
   BounceIn,
+  CurvedTransition,
   FadeIn,
   FadeInDown,
   FadeInRight,
   FadeOut,
   FadeOutDown,
+  FadingTransition,
   FlipInXUp,
+  JumpingTransition,
   LightSpeedInRight,
+  LinearTransition,
   PinwheelIn,
   RollInLeft,
   RotateInDownLeft,
+  SequencedTransition,
   SlideInRight,
   StretchInX,
   ZoomIn,
@@ -429,5 +434,32 @@ function LayoutAnimationsTest() {
         />
       </View>
     );
+  }
+
+  function LayoutTransitionsRejectCustomInitialAndTargetValuesTest() {
+    // @ts-expect-error Layout transitions don't support custom initial values.
+    LinearTransition.withInitialValues({ originY: 420 });
+    // @ts-expect-error Layout transitions don't support custom target values.
+    LinearTransition.withTargetValues({ originY: 0 });
+
+    // @ts-expect-error Layout transitions don't support custom initial values.
+    SequencedTransition.withInitialValues({ originY: 420 });
+    // @ts-expect-error Layout transitions don't support custom target values.
+    SequencedTransition.withTargetValues({ originY: 0 });
+
+    // @ts-expect-error Layout transitions don't support custom initial values.
+    FadingTransition.withInitialValues({ originY: 420 });
+    // @ts-expect-error Layout transitions don't support custom target values.
+    FadingTransition.withTargetValues({ originY: 0 });
+
+    // @ts-expect-error Layout transitions don't support custom initial values.
+    JumpingTransition.withInitialValues({ originY: 420 });
+    // @ts-expect-error Layout transitions don't support custom target values.
+    JumpingTransition.withTargetValues({ originY: 0 });
+
+    // @ts-expect-error Layout transitions don't support custom initial values.
+    CurvedTransition.withInitialValues({ originY: 420 });
+    // @ts-expect-error Layout transitions don't support custom target values.
+    CurvedTransition.withTargetValues({ originY: 0 });
   }
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts
@@ -12,17 +12,14 @@ import type { EasingFunctionFactory } from '../../Easing';
 import { BaseAnimationBuilder } from './BaseAnimationBuilder';
 
 /**
- * `this` type for every static method on {@link ComplexAnimationBuilder}.
- * Represents a subclass constructor that preserves the concrete `TValues` type
- * argument while still exposing the static API inherited from
- * {@link BaseAnimationBuilder}.
+ * `this` type for static methods on {@link AnimationConfigBuilder}. Represents a
+ * subclass constructor exposing the shared config-only static API inherited
+ * from {@link BaseAnimationBuilder}.
  */
-type ComplexAnimationBuilderClass<TValues> = typeof BaseAnimationBuilder &
-  (new () => ComplexAnimationBuilder<TValues>);
+type AnimationConfigBuilderClass = typeof BaseAnimationBuilder &
+  (new () => AnimationConfigBuilder);
 
-export class ComplexAnimationBuilder<
-  TValues = StyleProps,
-> extends BaseAnimationBuilder {
+export class AnimationConfigBuilder extends BaseAnimationBuilder {
   easingV?: EasingFunction | EasingFunctionFactory;
   rotateV?: string;
   type?: AnimationFunction;
@@ -32,9 +29,6 @@ export class ComplexAnimationBuilder<
   stiffnessV?: number;
   overshootClampingV?: number;
   energyThresholdV?: number;
-  initialValues?: Partial<TValues>;
-  targetValues?: Partial<TValues>;
-
   static createInstance: <T extends typeof BaseAnimationBuilder>(
     this: T
   ) => InstanceType<T>;
@@ -47,10 +41,10 @@ export class ComplexAnimationBuilder<
    * @param easingFunction - An easing function which defines the animation
    *   curve.
    */
-  static easing<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static easing(
+    this: AnimationConfigBuilderClass,
     easingFunction: EasingFunction | EasingFunctionFactory
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.easing(easingFunction);
   }
@@ -70,10 +64,10 @@ export class ComplexAnimationBuilder<
    *
    * @param degree - The rotation degree.
    */
-  static rotate<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static rotate(
+    this: AnimationConfigBuilderClass,
     degree: string
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.rotate(degree);
   }
@@ -91,10 +85,10 @@ export class ComplexAnimationBuilder<
    * @param duration - An optional duration of the spring animation (in
    *   milliseconds).
    */
-  static springify<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static springify(
+    this: AnimationConfigBuilderClass,
     duration?: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.springify(duration);
   }
@@ -112,10 +106,10 @@ export class ComplexAnimationBuilder<
    *
    * @param dampingRatio - How damped the spring is.
    */
-  static dampingRatio<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static dampingRatio(
+    this: AnimationConfigBuilderClass,
     dampingRatio: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.dampingRatio(dampingRatio);
   }
@@ -133,10 +127,10 @@ export class ComplexAnimationBuilder<
    * @param value - Decides how quickly a spring stops moving. Higher damping
    *   means the spring will come to rest faster.
    */
-  static damping<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static damping(
+    this: AnimationConfigBuilderClass,
     value: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.damping(value);
   }
@@ -154,10 +148,10 @@ export class ComplexAnimationBuilder<
    * @param mass - The weight of the spring. Reducing this value makes the
    *   animation faster.
    */
-  static mass<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static mass(
+    this: AnimationConfigBuilderClass,
     mass: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.mass(mass);
   }
@@ -174,10 +168,10 @@ export class ComplexAnimationBuilder<
    *
    * @param stiffness - How bouncy the spring is.
    */
-  static stiffness<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static stiffness(
+    this: AnimationConfigBuilderClass,
     stiffness: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.stiffness(stiffness);
   }
@@ -195,10 +189,10 @@ export class ComplexAnimationBuilder<
    * @param overshootClamping - Whether a spring can bounce over the final
    *   position.
    */
-  static overshootClamping<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static overshootClamping(
+    this: AnimationConfigBuilderClass,
     overshootClamping: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.overshootClamping(overshootClamping);
   }
@@ -212,10 +206,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in the upcoming major version.
    */
-  static restDisplacementThreshold<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static restDisplacementThreshold(
+    this: AnimationConfigBuilderClass,
     _restDisplacementThreshold: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     return this.createInstance();
   }
 
@@ -231,10 +225,10 @@ export class ComplexAnimationBuilder<
    * @deprecated Use {@link energyThreshold} instead. This method currently does
    *   nothing and will be removed in a future version.
    */
-  static restSpeedThreshold<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static restSpeedThreshold(
+    this: AnimationConfigBuilderClass,
     _restSpeedThreshold: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     return this.createInstance();
   }
 
@@ -254,52 +248,16 @@ export class ComplexAnimationBuilder<
    * @param energyThreshold - Relative energy threshold below which the spring
    *   will snap to `toValue` without further oscillations. Defaults to 6e-9.
    */
-  static energyThreshold<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
+  static energyThreshold(
+    this: AnimationConfigBuilderClass,
     energyThreshold: number
-  ): ComplexAnimationBuilder<TValues> {
+  ): AnimationConfigBuilder {
     const instance = this.createInstance();
     return instance.energyThreshold(energyThreshold);
   }
 
   energyThreshold(energyThreshold: number): this {
     this.energyThresholdV = energyThreshold;
-    return this;
-  }
-
-  /**
-   * Lets you override the initial properties of the animation
-   *
-   * @param values - An object containing the styles to override.
-   */
-  static withInitialValues<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
-    values: Partial<TValues>
-  ): ComplexAnimationBuilder<TValues> {
-    const instance = this.createInstance();
-    return instance.withInitialValues(values);
-  }
-
-  withInitialValues(values: Partial<TValues>): this {
-    this.initialValues = values;
-    return this;
-  }
-
-  /**
-   * Lets you override the target properties of the animation
-   *
-   * @param values - An object containing the styles to override.
-   */
-  static withTargetValues<TValues>(
-    this: ComplexAnimationBuilderClass<TValues>,
-    values: Partial<TValues>
-  ): ComplexAnimationBuilder<TValues> {
-    const instance = this.createInstance();
-    return instance.withTargetValues(values);
-  }
-
-  withTargetValues(values: Partial<TValues>): this {
-    this.targetValues = values;
     return this;
   }
 
@@ -348,5 +306,56 @@ export class ComplexAnimationBuilder<
     );
 
     return [animation, config];
+  }
+}
+
+/**
+ * `this` type for static methods on {@link ComplexAnimationBuilder}. Represents
+ * a subclass constructor preserving the concrete `TValues` type for
+ * initial/target value override methods.
+ */
+type ComplexAnimationBuilderClass<TValues> = typeof BaseAnimationBuilder &
+  (new () => ComplexAnimationBuilder<TValues>);
+
+export class ComplexAnimationBuilder<
+  TValues = StyleProps,
+> extends AnimationConfigBuilder {
+  initialValues?: Partial<TValues>;
+  targetValues?: Partial<TValues>;
+
+  /**
+   * Lets you override the initial properties of the animation
+   *
+   * @param values - An object containing the styles to override.
+   */
+  static withInitialValues<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
+    values: Partial<TValues>
+  ): ComplexAnimationBuilder<TValues> {
+    const instance = this.createInstance();
+    return instance.withInitialValues(values);
+  }
+
+  withInitialValues(values: Partial<TValues>): this {
+    this.initialValues = values;
+    return this;
+  }
+
+  /**
+   * Lets you override the target properties of the animation
+   *
+   * @param values - An object containing the styles to override.
+   */
+  static withTargetValues<TValues>(
+    this: ComplexAnimationBuilderClass<TValues>,
+    values: Partial<TValues>
+  ): ComplexAnimationBuilder<TValues> {
+    const instance = this.createInstance();
+    return instance.withTargetValues(values);
+  }
+
+  withTargetValues(values: Partial<TValues>): this {
+    this.targetValues = values;
+    return this;
   }
 }

--- a/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/index.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationBuilder/index.ts
@@ -1,4 +1,7 @@
 'use strict';
 export { BaseAnimationBuilder } from './BaseAnimationBuilder';
-export { ComplexAnimationBuilder } from './ComplexAnimationBuilder';
+export {
+  AnimationConfigBuilder,
+  ComplexAnimationBuilder,
+} from './ComplexAnimationBuilder';
 export { Keyframe, type ReanimatedKeyframe } from './Keyframe';

--- a/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/LinearTransition.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/defaultTransitions/LinearTransition.ts
@@ -4,7 +4,7 @@ import type {
   LayoutAnimationFunction,
 } from '../../commonTypes';
 import type { BaseAnimationBuilder } from '../animationBuilder';
-import { ComplexAnimationBuilder } from '../animationBuilder';
+import { AnimationConfigBuilder } from '../animationBuilder';
 
 /**
  * Linearly transforms the layout from one position to another. You can modify
@@ -16,12 +16,7 @@ import { ComplexAnimationBuilder } from '../animationBuilder';
  * @see https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions#linear-transition
  */
 export class LinearTransition
-  extends ComplexAnimationBuilder<{
-    originX: number;
-    originY: number;
-    width: number;
-    height: number;
-  }>
+  extends AnimationConfigBuilder
   implements ILayoutAnimationBuilder
 {
   static presetName = 'LinearTransition';


### PR DESCRIPTION
## Summary

This PR fixes types of layout transition presets. Since `withInitialValues` and `withTargetValues` were essentially no-ops for transitions, I decided to remove these to prevent confusion. There is a separate PR (#9258) that removes `withInitialValues` mention from layout transition docs.