### PR TITLE
fix(Reanimated): not flushing updates without mapper runs

### DIFF
--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -91,21 +91,26 @@ function createMapperRegistry() {
     mapperRunFinalizers.push(finalizer);
   };
 
+  let anyMapperDirty = false;
+
   function mapperRun() {
     if (processingMappers) {
       return;
     }
     try {
       processingMappers = true;
-      if (mappers.size !== sortedMappers.length) {
-        updateMappersOrder();
-      }
-      for (const mapper of sortedMappers) {
-        if (mapper.dirty) {
-          mapper.dirty = false;
-          mapper.worklet();
+      if (anyMapperDirty) {
+        if (mappers.size !== sortedMappers.length) {
+          updateMappersOrder();
+        }
+        for (const mapper of sortedMappers) {
+          if (mapper.dirty) {
+            mapper.dirty = false;
+            mapper.worklet();
+          }
         }
       }
+      anyMapperDirty = false;
     } finally {
       processingMappers = false;
       const finalizers = mapperRunFinalizers;
@@ -119,7 +124,10 @@ function createMapperRegistry() {
   function scheduledMapperRun() {
     runRequested = false;
     mapperRun();
+    globalThis.requestAnimationFrameFinalizer(scheduledMapperRun);
   }
+
+  globalThis.requestAnimationFrameFinalizer(scheduledMapperRun);
 
   global.__mapperRun = mapperRun;
 
@@ -132,28 +140,23 @@ function createMapperRegistry() {
       // immediately for testing purposes and only expect test to advance timers
       // if they want to make any assertions on the effects of animations being run.
       mapperRun();
-    } else if (!runRequested) {
-      if (IS_WEB) {
-        if (processingMappers) {
-          // In general, we should avoid having mappers trigger updates as this may
-          // result in unpredictable behavior. Specifically, the updated value can
-          // be read by mappers that run later in the same frame but previous mappers
-          // would access the old value. Updating mappers during the mapper-run phase
-          // breaks the order in which we should execute the mappers. However, doing
-          // that is still a possibility and there are some instances where people use
-          // the API in that way, hence we need to prevent mapper-run phase falling into
-          // an infinite loop. We do that by detecting when mapper-run is requested while
-          // we are already in mapper-run phase, and in that case we use `requestAnimationFrame`
-          // instead of `queueMicrotask` which will schedule mapper run for the next
-          // frame instead of queuing another set of updates in the same frame.
-          requestAnimationFrame(scheduledMapperRun);
-        } else {
-          queueMicrotask(scheduledMapperRun);
-        }
+    } else if (!runRequested && IS_WEB) {
+      if (processingMappers) {
+        // In general, we should avoid having mappers trigger updates as this may
+        // result in unpredictable behavior. Specifically, the updated value can
+        // be read by mappers that run later in the same frame but previous mappers
+        // would access the old value. Updating mappers during the mapper-run phase
+        // breaks the order in which we should execute the mappers. However, doing
+        // that is still a possibility and there are some instances where people use
+        // the API in that way, hence we need to prevent mapper-run phase falling into
+        // an infinite loop. We do that by detecting when mapper-run is requested while
+        // we are already in mapper-run phase, and in that case we use `requestAnimationFrame`
+        // instead of `queueMicrotask` which will schedule mapper run for the next
+        // frame instead of queuing another set of updates in the same frame.
+        requestAnimationFrame(scheduledMapperRun);
       } else {
-        globalThis.requestAnimationFrameFinalizer(scheduledMapperRun);
+        queueMicrotask(scheduledMapperRun);
       }
-      runRequested = true;
     }
   }
 
@@ -198,9 +201,11 @@ function createMapperRegistry() {
       };
       mappers.set(mapper.id, mapper);
       sortedMappers = [];
+      anyMapperDirty = true;
       for (const sv of mapper.inputs) {
         sv.addListener(mapper.id, () => {
           mapper.dirty = true;
+          anyMapperDirty = true;
           maybeRequestUpdates();
         });
       }
@@ -211,6 +216,7 @@ function createMapperRegistry() {
       if (mapper) {
         mappers.delete(mapper.id);
         sortedMappers = [];
+        anyMapperDirty = true;
         for (const sv of mapper.inputs) {
           sv.removeListener(mapper.id);
         }

--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -91,7 +91,7 @@ function createMapperRegistry() {
     mapperRunFinalizers.push(finalizer);
   };
 
-  let anyMapperDirty = false;
+  let isAnyMapperDirty = false;
 
   function mapperRun() {
     if (processingMappers) {
@@ -102,14 +102,14 @@ function createMapperRegistry() {
       if (mappers.size !== sortedMappers.length) {
         updateMappersOrder();
       }
-      if (anyMapperDirty) {
+      if (isAnyMapperDirty) {
         for (const mapper of sortedMappers) {
           if (mapper.dirty) {
             mapper.dirty = false;
             mapper.worklet();
           }
         }
-        anyMapperDirty = false;
+        isAnyMapperDirty = false;
       }
     } finally {
       processingMappers = false;
@@ -209,11 +209,11 @@ function createMapperRegistry() {
       };
       mappers.set(mapper.id, mapper);
       sortedMappers = [];
-      anyMapperDirty = true;
+      isAnyMapperDirty = true;
       for (const sv of mapper.inputs) {
         sv.addListener(mapper.id, () => {
           mapper.dirty = true;
-          anyMapperDirty = true;
+          isAnyMapperDirty = true;
           maybeRequestUpdates();
         });
       }
@@ -224,7 +224,7 @@ function createMapperRegistry() {
       if (mapper) {
         mappers.delete(mapper.id);
         sortedMappers = [];
-        anyMapperDirty = true;
+        isAnyMapperDirty = true;
         for (const sv of mapper.inputs) {
           sv.removeListener(mapper.id);
         }

--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -2,7 +2,7 @@
 
 import { scheduleOnUI } from 'react-native-worklets';
 
-import { IS_JEST, IS_WEB } from './common';
+import { IS_JEST, IS_WEB, SHOULD_BE_USE_WEB } from './common';
 import type {
   MapperOutputs,
   MapperRawInputs,
@@ -99,18 +99,18 @@ function createMapperRegistry() {
     }
     try {
       processingMappers = true;
+      if (mappers.size !== sortedMappers.length) {
+        updateMappersOrder();
+      }
       if (anyMapperDirty) {
-        if (mappers.size !== sortedMappers.length) {
-          updateMappersOrder();
-        }
         for (const mapper of sortedMappers) {
           if (mapper.dirty) {
             mapper.dirty = false;
             mapper.worklet();
           }
         }
+        anyMapperDirty = false;
       }
-      anyMapperDirty = false;
     } finally {
       processingMappers = false;
       const finalizers = mapperRunFinalizers;
@@ -121,13 +121,20 @@ function createMapperRegistry() {
     }
   }
 
+  const schedulingFunction = IS_WEB
+    ? requestAnimationFrame
+    : requestAnimationFrameFinalizer;
+
   function scheduledMapperRun() {
     runRequested = false;
     mapperRun();
-    globalThis.requestAnimationFrameFinalizer(scheduledMapperRun);
+    if (!SHOULD_BE_USE_WEB) {
+      // We always run mappers on native.
+      schedulingFunction(scheduledMapperRun);
+    }
   }
 
-  globalThis.requestAnimationFrameFinalizer(scheduledMapperRun);
+  schedulingFunction(scheduledMapperRun);
 
   global.__mapperRun = mapperRun;
 
@@ -140,7 +147,7 @@ function createMapperRegistry() {
       // immediately for testing purposes and only expect test to advance timers
       // if they want to make any assertions on the effects of animations being run.
       mapperRun();
-    } else if (!runRequested && IS_WEB) {
+    } else if (IS_WEB && !runRequested) {
       if (processingMappers) {
         // In general, we should avoid having mappers trigger updates as this may
         // result in unpredictable behavior. Specifically, the updated value can
@@ -153,10 +160,11 @@ function createMapperRegistry() {
         // we are already in mapper-run phase, and in that case we use `requestAnimationFrame`
         // instead of `queueMicrotask` which will schedule mapper run for the next
         // frame instead of queuing another set of updates in the same frame.
-        requestAnimationFrame(scheduledMapperRun);
+        schedulingFunction(scheduledMapperRun);
       } else {
         queueMicrotask(scheduledMapperRun);
       }
+      runRequested = true;
     }
   }
 

--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -2,7 +2,7 @@
 
 import { scheduleOnUI } from 'react-native-worklets';
 
-import { IS_JEST, IS_WEB, SHOULD_BE_USE_WEB } from './common';
+import { IS_JEST, SHOULD_BE_USE_WEB } from './common';
 import type {
   MapperOutputs,
   MapperRawInputs,
@@ -121,9 +121,9 @@ function createMapperRegistry() {
     }
   }
 
-  const schedulingFunction = IS_WEB
+  const schedulingFunction = SHOULD_BE_USE_WEB
     ? requestAnimationFrame
-    : requestAnimationFrameFinalizer;
+    : globalThis.requestAnimationFrameFinalizer;
 
   function scheduledMapperRun() {
     runRequested = false;
@@ -134,7 +134,9 @@ function createMapperRegistry() {
     }
   }
 
-  schedulingFunction(scheduledMapperRun);
+  if (!SHOULD_BE_USE_WEB) {
+    schedulingFunction(scheduledMapperRun);
+  }
 
   global.__mapperRun = mapperRun;
 
@@ -147,7 +149,7 @@ function createMapperRegistry() {
       // immediately for testing purposes and only expect test to advance timers
       // if they want to make any assertions on the effects of animations being run.
       mapperRun();
-    } else if (IS_WEB && !runRequested) {
+    } else if (!runRequested) {
       if (processingMappers) {
         // In general, we should avoid having mappers trigger updates as this may
         // result in unpredictable behavior. Specifically, the updated value can
@@ -214,10 +216,14 @@ function createMapperRegistry() {
         sv.addListener(mapper.id, () => {
           mapper.dirty = true;
           isAnyMapperDirty = true;
-          maybeRequestUpdates();
+          if (SHOULD_BE_USE_WEB) {
+            maybeRequestUpdates();
+          }
         });
       }
-      maybeRequestUpdates();
+      if (SHOULD_BE_USE_WEB) {
+        maybeRequestUpdates();
+      }
     },
     stop: (mapperID: number) => {
       const mapper = mappers.get(mapperID);


### PR DESCRIPTION
## Summary

In #9244 I assumed that `updateProps` is always called alongside mappers - however when using non-shared.value driven animations, i.e.:

```ts
const animatedStyles = useAnimatedStyle(() => ({
    transform: [{ translateX: withSpring(translateX.value * 2) }],
  }));
```

we might have no mapper runs but we should be pushing updates. Due to that in these scenarios updates were not applied.

I fixed it by always running mappers per animation frame queue run but just bailing early when necessary.

## Test plan

Animation in `SyncBackToReact` example works again, both on native and web.
