### PR TITLE
feat: Convert css easing configs to the intermediate config format instead of function

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSAnimationConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSAnimationConfig.cpp
@@ -59,7 +59,7 @@ CSSAnimationSettings parseCSSAnimationSettings(jsi::Runtime &rt, const jsi::Valu
 
   return {
       getDuration(rt, settingsObj),
-      getTimingFunction(rt, settingsObj),
+      getEasingConfig(rt, settingsObj),
       getDelay(rt, settingsObj),
       getIterationCount(rt, settingsObj),
       getDirection(rt, settingsObj),
@@ -76,7 +76,7 @@ PartialCSSAnimationSettings parsePartialCSSAnimationSettings(jsi::Runtime &rt, c
     result.duration = getDuration(rt, partialObj);
   }
   if (partialObj.hasProperty(rt, "timingFunction")) {
-    result.easingFunction = getTimingFunction(rt, partialObj);
+    result.easingConfig = getEasingConfig(rt, partialObj);
   }
   if (partialObj.hasProperty(rt, "delay")) {
     result.delay = getDelay(rt, partialObj);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSAnimationConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSAnimationConfig.h
@@ -2,7 +2,6 @@
 
 #include <reanimated/CSS/configs/CSSKeyframesConfig.h>
 #include <reanimated/CSS/configs/common.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
 
 #include <optional>
 #include <string>
@@ -17,7 +16,7 @@ enum class AnimationPlayState : std::uint8_t { Running, Paused };
 
 struct CSSAnimationSettings {
   double duration;
-  EasingFunction easingFunction;
+  EasingConfig easingConfig;
   double delay;
   double iterationCount;
   AnimationDirection direction;
@@ -27,7 +26,7 @@ struct CSSAnimationSettings {
 
 struct PartialCSSAnimationSettings {
   std::optional<double> duration;
-  std::optional<EasingFunction> easingFunction;
+  std::optional<EasingConfig> easingConfig;
   std::optional<double> delay;
   std::optional<double> iterationCount;
   std::optional<AnimationDirection> direction;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSKeyframesConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSKeyframesConfig.cpp
@@ -16,20 +16,20 @@ std::shared_ptr<AnimationStyleInterpolator> createStyleInterpolator(
       rt, config.getProperty(rt, "propKeyframes"), nativeComponentName, viewStylesRepository);
 }
 
-std::shared_ptr<KeyframeEasingFunctions> getKeyframeTimingFunctions(jsi::Runtime &rt, const jsi::Object &config) {
-  KeyframeEasingFunctions result;
-  const auto &keyframeTimingFunctions = config.getProperty(rt, "keyframeTimingFunctions").asObject(rt);
-  const auto timingFunctionOffsets = keyframeTimingFunctions.getPropertyNames(rt);
-  const auto timingFunctionsCount = timingFunctionOffsets.size(rt);
+std::shared_ptr<KeyframeEasingConfigs> getKeyframeTimingConfigs(jsi::Runtime &rt, const jsi::Object &config) {
+  KeyframeEasingConfigs result;
+  const auto &keyframeTimingConfigs = config.getProperty(rt, "keyframeTimingFunctions").asObject(rt);
+  const auto timingConfigOffsets = keyframeTimingConfigs.getPropertyNames(rt);
+  const auto timingConfigsCount = timingConfigOffsets.size(rt);
 
-  for (size_t i = 0; i < timingFunctionsCount; ++i) {
-    const auto offset = timingFunctionOffsets.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-    const auto easingFunction = createEasingFunction(rt, keyframeTimingFunctions.getProperty(rt, offset.c_str()));
+  for (size_t i = 0; i < timingConfigsCount; ++i) {
+    const auto offset = timingConfigOffsets.getValueAtIndex(rt, i).asString(rt).utf8(rt);
+    const auto easingConfig = getEasingConfig(rt, keyframeTimingConfigs.getProperty(rt, offset.c_str()));
 
-    result[std::stod(offset)] = easingFunction;
+    result[std::stod(offset)] = easingConfig;
   }
 
-  return std::make_shared<KeyframeEasingFunctions>(result);
+  return std::make_shared<KeyframeEasingConfigs>(result);
 }
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
@@ -42,7 +42,7 @@ CSSKeyframesConfig parseCSSAnimationKeyframesConfig(
 
   return {
       createStyleInterpolator(rt, configObj, nativeComponentName, viewStylesRepository),
-      getKeyframeTimingFunctions(rt, configObj)};
+      getKeyframeTimingConfigs(rt, configObj)};
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSKeyframesConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSKeyframesConfig.h
@@ -1,20 +1,17 @@
 #pragma once
 
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/EasingConfigs.h>
 #include <reanimated/CSS/interpolation/styles/AnimationStyleInterpolator.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace reanimated::css {
 
-using KeyframeEasingFunctions = std::unordered_map<double, EasingFunction>;
-
 struct CSSKeyframesConfig {
   std::shared_ptr<AnimationStyleInterpolator> styleInterpolator;
-  std::shared_ptr<KeyframeEasingFunctions> keyframeEasingFunctions;
+  std::shared_ptr<KeyframeEasingConfigs> keyframeEasingConfigs;
 };
 
 CSSKeyframesConfig parseCSSAnimationKeyframesConfig(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
@@ -31,7 +31,7 @@ CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value 
           propertyName,
           CSSTransitionPropertySettings{
               getDuration(rt, propertySettingsObj),
-              getTimingFunction(rt, propertySettingsObj),
+              getEasingConfig(rt, propertySettingsObj),
               getDelay(rt, propertySettingsObj),
               getAllowDiscrete(rt, propertySettingsObj),
           });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/configs/common.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
@@ -13,7 +13,7 @@ namespace reanimated::css {
 
 struct CSSTransitionPropertySettings {
   double duration;
-  EasingFunction easingFunction;
+  EasingConfig easingConfig;
   double delay;
   bool allowDiscrete;
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
@@ -1,13 +1,6 @@
 #include <reanimated/CSS/configs/common.h>
-#include <reanimated/CSS/easing/cubicBezier.h>
-#include <reanimated/CSS/easing/linear.h>
-#include <reanimated/CSS/easing/steps.h>
 
 #include <react/renderer/componentregistry/componentNameByReactViewName.h>
-
-#include <stdexcept>
-#include <type_traits>
-#include <unordered_map>
 
 using facebook::react::componentNameByReactViewName;
 
@@ -15,82 +8,6 @@ namespace reanimated::css {
 
 double getDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
-}
-
-EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig) {
-  return std::visit(
-      [](const auto &config) -> EasingFunction {
-        using T = std::decay_t<decltype(config)>;
-        if constexpr (std::is_same_v<T, LinearEasing>) {
-          return [](double x) {
-            return x;
-          };
-        } else if constexpr (std::is_same_v<T, CubicBezierEasing>) {
-          return cubicBezier(config.x1, config.y1, config.x2, config.y2);
-        } else if constexpr (std::is_same_v<T, StepsEasing>) {
-          return steps(config.pointsX, config.pointsY);
-        } else {
-          return linear(config.pointsX, config.pointsY);
-        }
-      },
-      easingConfig);
-}
-
-EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig) {
-  static const std::unordered_map<std::string, EasingConfig> PREDEFINED_EASING_CONFIGS = {
-      {"linear", LinearEasing{}},
-      {"ease", CubicBezierEasing{0.25, 0.1, 0.25, 1.0}},
-      {"ease-in", CubicBezierEasing{0.42, 0.0, 1.0, 1.0}},
-      {"ease-out", CubicBezierEasing{0.0, 0.0, 0.58, 1.0}},
-      {"ease-in-out", CubicBezierEasing{0.42, 0.0, 0.58, 1.0}},
-      {"step-start", StepsEasing{{0}, {1}}},
-      {"step-end", StepsEasing{{0, 1}, {0, 1}}}};
-
-  if (easingConfig.isString()) {
-    const auto easingName = easingConfig.asString(rt).utf8(rt);
-    const auto easingIt = PREDEFINED_EASING_CONFIGS.find(easingName);
-    if (easingIt != PREDEFINED_EASING_CONFIGS.end()) {
-      return easingIt->second;
-    }
-    throw std::runtime_error("[Reanimated] Easing function with name '" + easingName + "' is not defined.");
-  }
-
-  if (easingConfig.isObject()) {
-    const auto easingObj = easingConfig.asObject(rt);
-    const auto easingName = easingObj.getProperty(rt, "name").asString(rt).utf8(rt);
-    if (easingName == "cubicBezier") {
-      return CubicBezierEasing{
-          easingObj.getProperty(rt, "x1").asNumber(),
-          easingObj.getProperty(rt, "y1").asNumber(),
-          easingObj.getProperty(rt, "x2").asNumber(),
-          easingObj.getProperty(rt, "y2").asNumber()};
-    }
-
-    std::vector<double> pointsX;
-    std::vector<double> pointsY;
-
-    const auto points = easingObj.getProperty(rt, "points").asObject(rt).asArray(rt);
-    const auto pointsCount = points.size(rt);
-    pointsX.reserve(pointsCount);
-    pointsY.reserve(pointsCount);
-
-    for (size_t i = 0; i < pointsCount; i++) {
-      const auto pointObj = points.getValueAtIndex(rt, i).asObject(rt);
-      pointsX.emplace_back(pointObj.getProperty(rt, "x").asNumber());
-      pointsY.emplace_back(pointObj.getProperty(rt, "y").asNumber());
-    }
-
-    if (easingName == "linear") {
-      return LinearStopsEasing{std::move(pointsX), std::move(pointsY)};
-    }
-    if (easingName == "steps") {
-      return StepsEasing{std::move(pointsX), std::move(pointsY)};
-    }
-    throw std::runtime_error(
-        "[Reanimated] Parametrized easing function with name '" + easingName + "' is not defined.");
-  }
-
-  throw std::runtime_error("[Reanimated] Invalid easing function");
 }
 
 EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Object &config) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
@@ -1,6 +1,13 @@
 #include <reanimated/CSS/configs/common.h>
+#include <reanimated/CSS/easing/cubicBezier.h>
+#include <reanimated/CSS/easing/linear.h>
+#include <reanimated/CSS/easing/steps.h>
 
 #include <react/renderer/componentregistry/componentNameByReactViewName.h>
+
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
 
 using facebook::react::componentNameByReactViewName;
 
@@ -10,8 +17,84 @@ double getDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
 }
 
-EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config) {
-  return createEasingFunction(rt, config.getProperty(rt, "timingFunction"));
+EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig) {
+  return std::visit(
+      [](const auto &config) -> EasingFunction {
+        using T = std::decay_t<decltype(config)>;
+        if constexpr (std::is_same_v<T, LinearEasing>) {
+          return [](double x) {
+            return x;
+          };
+        } else if constexpr (std::is_same_v<T, CubicBezierEasing>) {
+          return cubicBezier(config.x1, config.y1, config.x2, config.y2);
+        } else if constexpr (std::is_same_v<T, StepsEasing>) {
+          return steps(config.pointsX, config.pointsY);
+        } else {
+          return linear(config.pointsX, config.pointsY);
+        }
+      },
+      easingConfig);
+}
+
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig) {
+  static const std::unordered_map<std::string, EasingConfig> PREDEFINED_EASING_CONFIGS = {
+      {"linear", LinearEasing{}},
+      {"ease", CubicBezierEasing{0.25, 0.1, 0.25, 1.0}},
+      {"ease-in", CubicBezierEasing{0.42, 0.0, 1.0, 1.0}},
+      {"ease-out", CubicBezierEasing{0.0, 0.0, 0.58, 1.0}},
+      {"ease-in-out", CubicBezierEasing{0.42, 0.0, 0.58, 1.0}},
+      {"step-start", StepsEasing{{0}, {1}}},
+      {"step-end", StepsEasing{{0, 1}, {0, 1}}}};
+
+  if (easingConfig.isString()) {
+    const auto easingName = easingConfig.asString(rt).utf8(rt);
+    const auto easingIt = PREDEFINED_EASING_CONFIGS.find(easingName);
+    if (easingIt != PREDEFINED_EASING_CONFIGS.end()) {
+      return easingIt->second;
+    }
+    throw std::runtime_error("[Reanimated] Easing function with name '" + easingName + "' is not defined.");
+  }
+
+  if (easingConfig.isObject()) {
+    const auto easingObj = easingConfig.asObject(rt);
+    const auto easingName = easingObj.getProperty(rt, "name").asString(rt).utf8(rt);
+    if (easingName == "cubicBezier") {
+      return CubicBezierEasing{
+          easingObj.getProperty(rt, "x1").asNumber(),
+          easingObj.getProperty(rt, "y1").asNumber(),
+          easingObj.getProperty(rt, "x2").asNumber(),
+          easingObj.getProperty(rt, "y2").asNumber()};
+    }
+
+    std::vector<double> pointsX;
+    std::vector<double> pointsY;
+
+    const auto points = easingObj.getProperty(rt, "points").asObject(rt).asArray(rt);
+    const auto pointsCount = points.size(rt);
+    pointsX.reserve(pointsCount);
+    pointsY.reserve(pointsCount);
+
+    for (size_t i = 0; i < pointsCount; i++) {
+      const auto pointObj = points.getValueAtIndex(rt, i).asObject(rt);
+      pointsX.emplace_back(pointObj.getProperty(rt, "x").asNumber());
+      pointsY.emplace_back(pointObj.getProperty(rt, "y").asNumber());
+    }
+
+    if (easingName == "linear") {
+      return LinearStopsEasing{std::move(pointsX), std::move(pointsY)};
+    }
+    if (easingName == "steps") {
+      return StepsEasing{std::move(pointsX), std::move(pointsY)};
+    }
+    throw std::runtime_error(
+        "[Reanimated] Parametrized easing function with name '" + easingName + "' is not defined.");
+  }
+
+  throw std::runtime_error("[Reanimated] Invalid easing function");
+}
+
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Object &config) {
+  return getEasingConfig(rt, config.getProperty(rt, "timingFunction"));
 }
 
 double getDelay(jsi::Runtime &rt, const jsi::Object &config) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
@@ -1,38 +1,16 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/easing/EasingConfigs.h>
 
 #include <string>
 #include <utility>
-#include <variant>
-#include <vector>
 
 namespace reanimated::css {
 
-struct LinearEasing {};
-
-struct CubicBezierEasing {
-  double x1, y1, x2, y2;
-};
-
-struct StepsEasing {
-  std::vector<double> pointsX;
-  std::vector<double> pointsY;
-};
-
-struct LinearStopsEasing {
-  std::vector<double> pointsX;
-  std::vector<double> pointsY;
-};
-
-using EasingConfig = std::variant<LinearEasing, CubicBezierEasing, StepsEasing, LinearStopsEasing>;
-
 double getDuration(jsi::Runtime &rt, const jsi::Object &config);
 
-EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig);
 EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Object &config);
-EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig);
 
 double getDelay(jsi::Runtime &rt, const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
@@ -5,12 +5,34 @@
 
 #include <string>
 #include <utility>
+#include <variant>
+#include <vector>
 
 namespace reanimated::css {
 
+struct LinearEasing {};
+
+struct CubicBezierEasing {
+  double x1, y1, x2, y2;
+};
+
+struct StepsEasing {
+  std::vector<double> pointsX;
+  std::vector<double> pointsY;
+};
+
+struct LinearStopsEasing {
+  std::vector<double> pointsX;
+  std::vector<double> pointsY;
+};
+
+using EasingConfig = std::variant<LinearEasing, CubicBezierEasing, StepsEasing, LinearStopsEasing>;
+
 double getDuration(jsi::Runtime &rt, const jsi::Object &config);
 
-EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig);
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Object &config);
+EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig);
 
 double getDelay(jsi::Runtime &rt, const jsi::Object &config);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -26,7 +26,7 @@ CSSAnimation::CSSAnimation(
           settings.iterationCount,
           settings.direction,
           getEasingFunctionFromConfig(settings.easingConfig),
-          cssKeyframesConfig.keyframeEasingFunctions)) {
+          cssKeyframesConfig.keyframeEasingConfigs)) {
   if (settings.playState == AnimationPlayState::Paused) {
     progressProvider_->pause(timestamp);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSAnimation.cpp
@@ -25,7 +25,7 @@ CSSAnimation::CSSAnimation(
           settings.delay,
           settings.iterationCount,
           settings.direction,
-          settings.easingFunction,
+          getEasingFunctionFromConfig(settings.easingConfig),
           cssKeyframesConfig.keyframeEasingFunctions)) {
   if (settings.playState == AnimationPlayState::Paused) {
     progressProvider_->pause(timestamp);
@@ -77,8 +77,8 @@ void CSSAnimation::updateConfig(const PartialCSSAnimationSettings &updatedSettin
   if (updatedSettings.duration.has_value()) {
     progressProvider_->setDuration(updatedSettings.duration.value());
   }
-  if (updatedSettings.easingFunction.has_value()) {
-    progressProvider_->setEasingFunction(updatedSettings.easingFunction.value());
+  if (updatedSettings.easingConfig.has_value()) {
+    progressProvider_->setEasingFunction(getEasingFunctionFromConfig(updatedSettings.easingConfig.value()));
   }
   if (updatedSettings.delay.has_value()) {
     progressProvider_->setDelay(updatedSettings.delay.value());

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.cpp
@@ -1,0 +1,89 @@
+#include <reanimated/CSS/easing/EasingConfigs.h>
+#include <reanimated/CSS/easing/cubicBezier.h>
+#include <reanimated/CSS/easing/linear.h>
+#include <reanimated/CSS/easing/steps.h>
+
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace reanimated::css {
+
+EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig) {
+  return std::visit(
+      [](const auto &config) -> EasingFunction {
+        using T = std::decay_t<decltype(config)>;
+        if constexpr (std::is_same_v<T, LinearEasing>) {
+          return [](double x) {
+            return x;
+          };
+        } else if constexpr (std::is_same_v<T, CubicBezierEasing>) {
+          return cubicBezier(config.x1, config.y1, config.x2, config.y2);
+        } else if constexpr (std::is_same_v<T, StepsEasing>) {
+          return steps(config.pointsX, config.pointsY);
+        } else {
+          return linear(config.pointsX, config.pointsY);
+        }
+      },
+      easingConfig);
+}
+
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig) {
+  static const std::unordered_map<std::string, EasingConfig> PREDEFINED_EASING_CONFIGS = {
+      {"linear", LinearEasing{}},
+      {"ease", CubicBezierEasing{0.25, 0.1, 0.25, 1.0}},
+      {"ease-in", CubicBezierEasing{0.42, 0.0, 1.0, 1.0}},
+      {"ease-out", CubicBezierEasing{0.0, 0.0, 0.58, 1.0}},
+      {"ease-in-out", CubicBezierEasing{0.42, 0.0, 0.58, 1.0}},
+      {"step-start", StepsEasing{{0}, {1}}},
+      {"step-end", StepsEasing{{0, 1}, {0, 1}}}};
+
+  if (easingConfig.isString()) {
+    const auto easingName = easingConfig.asString(rt).utf8(rt);
+    const auto easingIt = PREDEFINED_EASING_CONFIGS.find(easingName);
+    if (easingIt != PREDEFINED_EASING_CONFIGS.end()) {
+      return easingIt->second;
+    }
+    throw std::runtime_error("[Reanimated] Easing function with name '" + easingName + "' is not defined.");
+  }
+
+  if (easingConfig.isObject()) {
+    const auto easingObj = easingConfig.asObject(rt);
+    const auto easingName = easingObj.getProperty(rt, "name").asString(rt).utf8(rt);
+    if (easingName == "cubicBezier") {
+      return CubicBezierEasing{
+          easingObj.getProperty(rt, "x1").asNumber(),
+          easingObj.getProperty(rt, "y1").asNumber(),
+          easingObj.getProperty(rt, "x2").asNumber(),
+          easingObj.getProperty(rt, "y2").asNumber()};
+    }
+
+    std::vector<double> pointsX;
+    std::vector<double> pointsY;
+
+    const auto points = easingObj.getProperty(rt, "points").asObject(rt).asArray(rt);
+    const auto pointsCount = points.size(rt);
+    pointsX.reserve(pointsCount);
+    pointsY.reserve(pointsCount);
+
+    for (size_t i = 0; i < pointsCount; i++) {
+      const auto pointObj = points.getValueAtIndex(rt, i).asObject(rt);
+      pointsX.emplace_back(pointObj.getProperty(rt, "x").asNumber());
+      pointsY.emplace_back(pointObj.getProperty(rt, "y").asNumber());
+    }
+
+    if (easingName == "linear") {
+      return LinearStopsEasing{std::move(pointsX), std::move(pointsY)};
+    }
+    if (easingName == "steps") {
+      return StepsEasing{std::move(pointsX), std::move(pointsY)};
+    }
+    throw std::runtime_error(
+        "[Reanimated] Parametrized easing function with name '" + easingName + "' is not defined.");
+  }
+
+  throw std::runtime_error("[Reanimated] Invalid easing function");
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.h
@@ -4,6 +4,7 @@
 
 #include <jsi/jsi.h>
 #include <string>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -26,6 +27,8 @@ struct LinearStopsEasing {
 };
 
 using EasingConfig = std::variant<LinearEasing, CubicBezierEasing, StepsEasing, LinearStopsEasing>;
+
+using KeyframeEasingConfigs = std::unordered_map<double, EasingConfig>;
 
 EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig);
 EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingConfigs.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <reanimated/CSS/easing/EasingFunctions.h>
+
+#include <jsi/jsi.h>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace reanimated::css {
+
+struct LinearEasing {};
+
+struct CubicBezierEasing {
+  double x1, y1, x2, y2;
+};
+
+struct StepsEasing {
+  std::vector<double> pointsX;
+  std::vector<double> pointsY;
+};
+
+struct LinearStopsEasing {
+  std::vector<double> pointsX;
+  std::vector<double> pointsY;
+};
+
+using EasingConfig = std::variant<LinearEasing, CubicBezierEasing, StepsEasing, LinearStopsEasing>;
+
+EasingConfig getEasingConfig(jsi::Runtime &rt, const jsi::Value &easingConfig);
+EasingFunction getEasingFunctionFromConfig(const EasingConfig &easingConfig);
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.cpp
@@ -12,12 +12,12 @@ AnimationProgressProvider::AnimationProgressProvider(
     const double iterationCount,
     const AnimationDirection direction,
     EasingFunction easingFunction,
-    const std::shared_ptr<KeyframeEasingFunctions> &keyframeEasingFunctions)
+    const std::shared_ptr<KeyframeEasingConfigs> &keyframeEasingConfigs)
     : RawProgressProvider(timestamp, duration, delay),
       iterationCount_(iterationCount),
       direction_(direction),
       easingFunction_(std::move(easingFunction)),
-      keyframeEasingFunctions_(keyframeEasingFunctions) {}
+      keyframeEasingConfigs_(keyframeEasingConfigs) {}
 
 void AnimationProgressProvider::setIterationCount(double iterationCount) {
   iterationCount_ = iterationCount;
@@ -48,9 +48,9 @@ double AnimationProgressProvider::getKeyframeProgress(const double fromOffset, c
 
   // Use the overridden easing function if it was overridden for the
   // current keyframe
-  const auto easingFunctionIt = keyframeEasingFunctions_->find(fromOffset);
-  if (easingFunctionIt != keyframeEasingFunctions_->end()) {
-    return easingFunctionIt->second(keyframeProgress);
+  const auto easingConfigIt = keyframeEasingConfigs_->find(fromOffset);
+  if (easingConfigIt != keyframeEasingConfigs_->end()) {
+    return getEasingFunctionFromConfig(easingConfigIt->second)(keyframeProgress);
   }
 
   return easingFunction_(keyframeProgress);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/AnimationProgressProvider.h
@@ -26,7 +26,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
       double iterationCount,
       AnimationDirection direction,
       EasingFunction easingFunction,
-      const std::shared_ptr<KeyframeEasingFunctions> &keyframeEasingFunctions);
+      const std::shared_ptr<KeyframeEasingConfigs> &keyframeEasingConfigs);
 
   void setIterationCount(double iterationCount);
   void setDirection(AnimationDirection direction);
@@ -51,7 +51,7 @@ class AnimationProgressProvider final : public KeyframeProgressProvider, public 
   double iterationCount_;
   AnimationDirection direction_;
   EasingFunction easingFunction_;
-  std::shared_ptr<KeyframeEasingFunctions> keyframeEasingFunctions_;
+  std::shared_ptr<KeyframeEasingConfigs> keyframeEasingConfigs_;
 
   AnimationProgressState state_ = AnimationProgressState::Pending;
   unsigned currentIteration_ = 1;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -131,7 +131,7 @@ void TransitionProgressProvider::runProgressProvider(
   propertyProgressProviders_.insert_or_assign(
       propertyName,
       std::make_shared<TransitionPropertyProgressProvider>(
-          timestamp, settings.duration, settings.delay, settings.easingFunction));
+          timestamp, settings.duration, settings.delay, getEasingFunctionFromConfig(settings.easingConfig)));
 }
 
 void TransitionProgressProvider::removeProperties(const std::vector<std::string> &propertyNames) {
@@ -178,7 +178,7 @@ TransitionProgressProvider::createReversingShorteningProgressProvider(
       timestamp,
       propertySettings.duration * newReversingShorteningFactor,
       propertySettings.delay < 0 ? newReversingShorteningFactor * propertySettings.delay : propertySettings.delay,
-      propertySettings.easingFunction,
+      getEasingFunctionFromConfig(propertySettings.easingConfig),
       newReversingShorteningFactor);
 }
 


### PR DESCRIPTION
## Summary

This PR changes the easing parsing logic not to immediately convert configs to functions. It now converts them to the intermediate easing representation object in C++ and then converts to function only when necessary.

This PR is needed for the Core Animation rewrite, which requires a format that is easily transferrable to objective-c layer and can be used to set properties on the Core Animation object.