### PR TITLE
Add 'hermes-compiler' to preapproved packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,7 @@ npmMinimalAgeGate: 8d
 
 npmPreapprovedPackages:
   - 'expo'
+  - 'hermes-compiler'
   - 'metro'
   - 'metro-babel-transformer'
   - 'metro-cache'


### PR DESCRIPTION
## Summary

There is an action failing because hermes-compiler is not preapproved: https://github.com/software-mansion/react-native-reanimated/actions/runs/24637693223/job/72035981039#step:6:149
## Test plan

See if action passes
