### PR TITLE
fix: Unistyles flattening regression in `4.3.0`

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -534,10 +534,7 @@ export default class AnimatedComponent
       }
     }
 
-    if (
-      FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS &&
-      Object.keys(this.state.settledProps).length > 0
-    ) {
+    if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
       return super.render({
         nativeID,
         ...filteredProps,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -3,7 +3,6 @@ import '../layoutReanimation/animationsManager';
 
 import type React from 'react';
 import { Fragment } from 'react';
-import { StyleSheet } from 'react-native';
 
 import { checkStyleOverwriting, maybeBuild } from '../animationBuilder';
 import { IS_JEST, IS_WEB, logger } from '../common';
@@ -535,17 +534,15 @@ export default class AnimatedComponent
       }
     }
 
-    if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS) {
-      const flatStyles = StyleSheet.flatten(filteredProps.style as object);
-      const mergedStyles = {
-        ...flatStyles,
-        ...this.state.settledProps,
-      };
+    if (
+      FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS &&
+      Object.keys(this.state.settledProps).length > 0
+    ) {
       return super.render({
         nativeID,
         ...filteredProps,
         ...this.state.settledProps,
-        style: mergedStyles,
+        style: [...flattenArray(filteredProps.style), this.state.settledProps],
         ...jestProps,
       });
     }


### PR DESCRIPTION
## Summary

Fixes #9265

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/598b43f8-dce3-4de9-8ba0-2bce9613e199" /> | <video src="https://github.com/user-attachments/assets/f34c4032-3eb4-4946-a74a-4ac22ccfbe39" /> |

## Test plan

- Install Unistyles in the example apps:
  - `apps/common-app/package.json` — add `react-native-unistyles@3.2.3` and `react-native-edge-to-edge@1.6.2` to `dependencies`
  - `apps/fabric-example/package.json` — add the same two packages to `dependencies` (needed for autolinking)
- Register the Unistyles babel plugin in `apps/fabric-example/babel.config.js`:
  ```js
  ['react-native-unistyles/plugin', { root: '../common-app/src' }],
  ```
- Reinstall pods: `cd apps/fabric-example/ios && pod install`
- Replace `apps/common-app/src/apps/reanimated/examples/EmptyExample.tsx` with the snippet below
- Run the app and navigate to **Reanimated → EmptyExample**

Without the fix, Metro logs:
> we detected style object with 2 unistyles styles. This might cause no updates or unpredictable behavior. Please check style prop for 'View' and use array syntax instead of object syntax.

With the fix, no warning fires.

<details>
<summary>Code Snippet</summary>

```tsx
import React from 'react';
import Animated from 'react-native-reanimated';
import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
import { StyleSheet } from 'react-native-unistyles';

StyleSheet.configure({
  themes: { light: {} },
  settings: { initialTheme: 'light' },
});

export default function EmptyExample() {
  return (
    <SafeAreaProvider>
      <SafeAreaView style={styles.container}>
        <Animated.View style={[styles.box, styles.red]} />
      </SafeAreaView>
    </SafeAreaProvider>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
  box: { width: 120, height: 120, borderRadius: 16 },
  red: { backgroundColor: 'red' },
});
```

</details>