### PR TITLE
fixed lint clang tidy error

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -80,13 +80,12 @@ inline jsi::Value createWorkletRuntime(
     jsi::Runtime &originRuntime,
     const std::shared_ptr<RuntimeManager> &runtimeManager,
     const std::shared_ptr<MessageQueueThread> &jsQueue,
-    std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
+    const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
     const std::string &name,
     std::shared_ptr<SerializableWorklet> &initializer,
     const std::shared_ptr<AsyncQueue> &queue,
     bool enableEventLoop) {
-  const auto workletRuntime =
-      runtimeManager->createWorkletRuntime(std::move(jsiWorkletsModuleProxy), name, initializer, queue);
+  const auto workletRuntime = runtimeManager->createWorkletRuntime(jsiWorkletsModuleProxy, name, initializer, queue);
   return jsi::Object::createFromHostObject(originRuntime, workletRuntime);
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::getUIRuntime() {
 }
 
 std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
-    std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
+    const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
     const std::string &name,
     const std::shared_ptr<SerializableWorklet> &initializer,
     const std::shared_ptr<AsyncQueue> &queue,
@@ -46,7 +46,7 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
 
   auto workletRuntime = std::make_shared<WorkletRuntime>(runtimeId, jsQueue, name, queue, enableEventLoop);
 
-  workletRuntime->init(std::move(jsiWorkletsModuleProxy));
+  workletRuntime->init(jsiWorkletsModuleProxy);
 
   if (initializer) {
     workletRuntime->runSync(initializer);

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -29,7 +29,7 @@ class RuntimeManager {
   std::shared_ptr<WorkletRuntime> getUIRuntime();
 
   std::shared_ptr<WorkletRuntime> createWorkletRuntime(
-      std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy,
+      const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
       const std::string &name,
       const std::shared_ptr<SerializableWorklet> &initializer = nullptr,
       const std::shared_ptr<AsyncQueue> &queue = nullptr,

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -86,7 +86,7 @@ WorkletRuntime::WorkletRuntime(
   }
 }
 
-void WorkletRuntime::init(std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy) {
+void WorkletRuntime::init(const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy) {
   jsi::Runtime &rt = *runtime_;
 
   rt.setRuntimeData(

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -137,7 +137,7 @@ class WorkletRuntime : public jsi::HostObject, public std::enable_shared_from_th
       const std::shared_ptr<AsyncQueue> &queue = nullptr,
       bool enableEventLoop = true);
 
-  void init(std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy);
+  void init(const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy);
 
   /* #region deprecated */
 


### PR DESCRIPTION
## Summary

fixed lint clang tidy error:
https://github.com/software-mansion/react-native-reanimated/actions/runs/24687243870/job/72199685986
```
/home/runner/work/react-native-reanimated/react-native-reanimated/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp:89:67: error: the parameter 'jsiWorkletsModuleProxy' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
   89 | void WorkletRuntime::init(std::shared_ptr<JSIWorkletsModuleProxy> jsiWorkletsModuleProxy) {
      |                                                                   ^
      |                           const                                  &
1870 warnings generated.
```
added const where needed

## Test plan
Run
```
clang-tidy-18 -header-filter=^.*/./.*\.h$ -p=. -quiet /home/runner/work/react-native-reanimated/react-native-reanimated/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
```
Check exit code
