### PR TITLE
Allowed empty error constructors in eslint plugin

### DIFF
--- a/packages/eslint-plugin-reanimated/index.js
+++ b/packages/eslint-plugin-reanimated/index.js
@@ -364,6 +364,7 @@ function createErrorPrefixRule(prefix, messageId) {
   var _a;
   return {
     create: function (context) {
+      var sourceCode = context.getSourceCode();
       return {
         NewExpression: function (node) {
           var _a2;
@@ -375,17 +376,6 @@ function createErrorPrefixRule(prefix, messageId) {
           }
           var args = node.arguments;
           if (args.length === 0) {
-            context.report({
-              node,
-              messageId,
-              fix: function (fixer) {
-                var closeParen = context.sourceCode.getLastToken(node);
-                return fixer.insertTextBefore(
-                  closeParen,
-                  "'".concat(prefix, "'")
-                );
-              },
-            });
             return;
           }
           var first = args[0];
@@ -432,7 +422,7 @@ function createErrorPrefixRule(prefix, messageId) {
               node,
               messageId,
               fix: function (fixer) {
-                var exprText = context.sourceCode.getText(first);
+                var exprText = sourceCode.getText(first);
                 return fixer.replaceText(
                   first,
                   '`'.concat(prefix, ' ${').concat(exprText, '}`')

--- a/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
+++ b/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
@@ -21,14 +21,8 @@ export function createErrorPrefixRule<MessageId extends string>(
           const args = node.arguments;
 
           if (args.length === 0) {
-            context.report({
-              node,
-              messageId,
-              fix(fixer) {
-                const closeParen = sourceCode.getLastToken(node)!;
-                return fixer.insertTextBefore(closeParen, `'${prefix}'`);
-              },
-            });
+            // Empty `new Error()` is used for stack capture, not as a thrown
+            // error with a user-facing message, so the prefix doesn't apply.
             return;
           }
 

--- a/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
+++ b/packages/eslint-plugin-reanimated/src/createErrorPrefixRule.ts
@@ -21,8 +21,9 @@ export function createErrorPrefixRule<MessageId extends string>(
           const args = node.arguments;
 
           if (args.length === 0) {
-            // Empty `new Error()` is used for stack capture, not as a thrown
-            // error with a user-facing message, so the prefix doesn't apply.
+            // Empty `new Error()` may be used for stack capture or when the
+            // message/stack is assigned after construction (for example, during
+            // error cloning), so the prefix doesn't apply here.
             return;
           }
 

--- a/packages/react-native-worklets/src/bundleMode/metroOverrides.native.ts
+++ b/packages/react-native-worklets/src/bundleMode/metroOverrides.native.ts
@@ -49,7 +49,6 @@ export function disallowRNImports() {
             `You tried to import '${String(
               prop
             )}' from 'react-native' module on a Worklet Runtime. Using 'react-native' module on a Worklet Runtime is not allowed.`,
-            // eslint-disable-next-line reanimated/use-worklets-error
             new Error().stack
           );
           return {

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -624,7 +624,6 @@ function cloneError<TValue extends Error>(
   const handle = cloneInitializer({
     __init: () => {
       'worklet';
-      // eslint-disable-next-line reanimated/use-worklets-error
       const error = new Error();
       error.name = name;
       error.message = message;


### PR DESCRIPTION
## Summary

Allowed empty error constructors in eslint plugin
Before new Error().stack would raise a lint error
Now it doesn't

## Test plan

Build plugin, verify it works
