### PR TITLE
chore: Add dynamic overloads for CSS Transitions

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 371db9921d7c37c3b2a8d04b8cbe31156f0a277a
+  hermes-engine: 3086d2d1b345833ccabb2cd7a9b5901dce9ee889
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: c415632e27be044f394e9fc7a793125a8142a980
+  React-Core-prebuilt: 1a9b9f36875e312a55576bb7b8dde72825ceab22
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: 95ba4684387b3cdfdfd15d8ed63c6ef1d7a9dbf8
+  ReactNativeDependencies: c198330b69972dd2fb7234e877410dc30c21f2cf
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2158,7 +2158,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: a3651a4af13997df8df1bcd5af1cc7507d51dc7b
-  hermes-engine: 1a90d530548371499b6b2b5edaa6fd617b834aac
+  hermes-engine: 0ed05cd1ca2beb028ece7a6085fc2a3b450687c7
   RCTDeprecation: e1d3de84bd12761f1a42ae433c805c84ce3e1447
   RCTRequired: 5f75a4215a8c9551b303a95b0394968ae7490f18
   RCTSwiftUI: 6cfd2a6b1506648cd96493d252069bd1b49bdea4
@@ -2167,7 +2167,7 @@ SPEC CHECKSUMS:
   React: b785d635f91eb1df402a0dbc0305546f139c8048
   React-callinvoker: 3e490bb38efd7cef31c17154d33d3cc294db880b
   React-Core: 35963efb0dff21849c40f81fd73d46f636de9d56
-  React-Core-prebuilt: 12c314b2249dc8f3db3d250b808243ce6f7f172a
+  React-Core-prebuilt: fd78c203c838838685c1b058aa8787dc6609d0df
   React-CoreModules: 3dd7061935350ba9bd5c2d3e7dbf52cdb5ebb47b
   React-cxxreact: ed404f7277d9558a63eb9991d09100a4362d33fa
   React-debug: a26fb9a83e45de87601236175f68e3f3b92ab8ac
@@ -2228,7 +2228,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 51e6ac892436c657aa7dfe118942aeacda08179f
   ReactCodegen: 3862d3679a3064814550db04f7a5366833d65eea
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
-  ReactNativeDependencies: 635ed2b5e70bb9d5a61864db27fda842e6d94ff6
+  ReactNativeDependencies: 268c41309687a66a6c162428898a05a7b0c4105f
   RNReanimated: 0b9638ce585d4dd6a1d4fd6215ab373ce8ca0f71
   RNWorklets: aabc37be2f0398ce6355ee99957cd12e21db0dd7
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
@@ -7,12 +7,12 @@ bool getAllowDiscrete(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "allowDiscrete").asBool();
 }
 
-CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config) {
+CSSTransitionConfig<jsi::Value> parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config) {
   const auto configObj = config.asObject(rt);
   const auto propertyNames = configObj.getPropertyNames(rt);
   const auto propertiesCount = propertyNames.size(rt);
 
-  CSSTransitionConfig result;
+  CSSTransitionConfig<jsi::Value> result;
 
   for (size_t i = 0; i < propertiesCount; ++i) {
     const auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
@@ -29,7 +29,7 @@ CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value 
 
       result.changedProperties.emplace(
           propertyName,
-          CSSTransitionPropertySettings{
+          CSSTransitionPropertySettings<jsi::Value>{
               std::make_pair(std::move(oldValue), std::move(newValue)),
               getDuration(rt, propertySettingsObj),
               getTimingFunction(rt, propertySettingsObj),
@@ -46,8 +46,8 @@ bool getAllowDiscrete(const folly::dynamic &config) {
   return config.at("allowDiscrete").asBool();
 }
 
-CSSTransitionDynamicConfig parseCSSTransitionConfig(const folly::dynamic &config) {
-  CSSTransitionDynamicConfig result;
+CSSTransitionConfig<folly::dynamic> parseCSSTransitionConfig(const folly::dynamic &config) {
+  CSSTransitionConfig<folly::dynamic> result;
 
   if (!config.isObject()) {
     return result;
@@ -63,7 +63,7 @@ CSSTransitionDynamicConfig parseCSSTransitionConfig(const folly::dynamic &config
 
       result.changedProperties.emplace(
           propertyName,
-          CSSTransitionDynamicPropertySettings{
+          CSSTransitionPropertySettings<folly::dynamic>{
               std::make_pair(valueArray[0], valueArray[1]),
               getDuration(propertyValue),
               getTimingFunction(propertyValue),

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.cpp
@@ -42,4 +42,38 @@ CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value 
   return result;
 }
 
+bool getAllowDiscrete(const folly::dynamic &config) {
+  return config.at("allowDiscrete").asBool();
+}
+
+CSSTransitionDynamicConfig parseCSSTransitionConfig(const folly::dynamic &config) {
+  CSSTransitionDynamicConfig result;
+
+  if (!config.isObject()) {
+    return result;
+  }
+
+  for (const auto &[keyDyn, propertyValue] : config.items()) {
+    const auto propertyName = keyDyn.asString();
+
+    if (propertyValue.isNull()) {
+      result.removedProperties.emplace_back(propertyName);
+    } else {
+      const auto &valueArray = propertyValue.at("value");
+
+      result.changedProperties.emplace(
+          propertyName,
+          CSSTransitionDynamicPropertySettings{
+              std::make_pair(valueArray[0], valueArray[1]),
+              getDuration(propertyValue),
+              getTimingFunction(propertyValue),
+              getDelay(propertyValue),
+              getAllowDiscrete(propertyValue),
+          });
+    }
+  }
+
+  return result;
+}
+
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
@@ -4,6 +4,7 @@
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
+#include <concepts>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -11,37 +12,28 @@
 
 namespace reanimated::css {
 
+template <typename T>
+concept CSSValueType = std::same_as<T, jsi::Value> || std::same_as<T, folly::dynamic>;
+
+template <CSSValueType ValueType>
 struct CSSTransitionPropertySettings {
-  std::pair<jsi::Value, jsi::Value> value;
+  std::pair<ValueType, ValueType> value;
   double duration;
   EasingFunction easingFunction;
   double delay;
   bool allowDiscrete;
 };
 
-using CSSTransitionPropertiesSettings = std::unordered_map<std::string, CSSTransitionPropertySettings>;
+template <CSSValueType ValueType>
+using CSSTransitionPropertiesSettings = std::unordered_map<std::string, CSSTransitionPropertySettings<ValueType>>;
 
+template <CSSValueType ValueType>
 struct CSSTransitionConfig {
-  CSSTransitionPropertiesSettings changedProperties;
+  CSSTransitionPropertiesSettings<ValueType> changedProperties;
   std::vector<std::string> removedProperties;
 };
 
-struct CSSTransitionDynamicPropertySettings {
-  std::pair<folly::dynamic, folly::dynamic> value;
-  double duration;
-  EasingFunction easingFunction;
-  double delay;
-  bool allowDiscrete;
-};
-
-using CSSTransitionDynamicPropertiesSettings = std::unordered_map<std::string, CSSTransitionDynamicPropertySettings>;
-
-struct CSSTransitionDynamicConfig {
-  CSSTransitionDynamicPropertiesSettings changedProperties;
-  std::vector<std::string> removedProperties;
-};
-
-CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config);
-CSSTransitionDynamicConfig parseCSSTransitionConfig(const folly::dynamic &config);
+CSSTransitionConfig<jsi::Value> parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config);
+CSSTransitionConfig<folly::dynamic> parseCSSTransitionConfig(const folly::dynamic &config);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
@@ -2,6 +2,7 @@
 
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
+#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <string>
 #include <unordered_map>
@@ -25,6 +26,22 @@ struct CSSTransitionConfig {
   std::vector<std::string> removedProperties;
 };
 
+struct CSSTransitionDynamicPropertySettings {
+  std::pair<folly::dynamic, folly::dynamic> value;
+  double duration;
+  EasingFunction easingFunction;
+  double delay;
+  bool allowDiscrete;
+};
+
+using CSSTransitionDynamicPropertiesSettings = std::unordered_map<std::string, CSSTransitionDynamicPropertySettings>;
+
+struct CSSTransitionDynamicConfig {
+  CSSTransitionDynamicPropertiesSettings changedProperties;
+  std::vector<std::string> removedProperties;
+};
+
 CSSTransitionConfig parseCSSTransitionConfig(jsi::Runtime &rt, const jsi::Value &config);
+CSSTransitionDynamicConfig parseCSSTransitionConfig(const folly::dynamic &config);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.cpp
@@ -10,12 +10,24 @@ double getDuration(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "duration").asNumber();
 }
 
+double getDuration(const folly::dynamic &config) {
+  return config.at("duration").asDouble();
+}
+
 EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config) {
   return createEasingFunction(rt, config.getProperty(rt, "timingFunction"));
 }
 
+EasingFunction getTimingFunction(const folly::dynamic &config) {
+  return createEasingFunction(config.at("timingFunction"));
+}
+
 double getDelay(jsi::Runtime &rt, const jsi::Object &config) {
   return config.getProperty(rt, "delay").asNumber();
+}
+
+double getDelay(const folly::dynamic &config) {
+  return config.at("delay").asDouble();
 }
 
 std::pair<std::string, std::string> splitCompoundComponentName(const std::string &compoundComponentName) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/common.h
@@ -1,18 +1,22 @@
 #pragma once
 
-#include <jsi/jsi.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
 
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
 #include <string>
 #include <utility>
 
 namespace reanimated::css {
 
 double getDuration(jsi::Runtime &rt, const jsi::Object &config);
+double getDuration(const folly::dynamic &config);
 
 EasingFunction getTimingFunction(jsi::Runtime &rt, const jsi::Object &config);
+EasingFunction getTimingFunction(const folly::dynamic &config);
 
 double getDelay(jsi::Runtime &rt, const jsi::Object &config);
+double getDelay(const folly::dynamic &config);
 
 std::pair<std::string, std::string> splitCompoundComponentName(const std::string &compoundComponentName);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -38,7 +38,7 @@ TransitionProperties CSSTransition::getProperties() const {
 
 folly::dynamic CSSTransition::run(
     jsi::Runtime &rt,
-    const CSSTransitionConfig &config,
+    const CSSTransitionConfig<jsi::Value> &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
   handleChangedProperties(rt, config, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
@@ -47,7 +47,7 @@ folly::dynamic CSSTransition::run(
 }
 
 folly::dynamic CSSTransition::run(
-    const CSSTransitionDynamicConfig &config,
+    const CSSTransitionConfig<folly::dynamic> &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
   handleChangedProperties(config, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
@@ -69,7 +69,7 @@ folly::dynamic CSSTransition::update(const double timestamp) {
 
 void CSSTransition::handleChangedProperties(
     jsi::Runtime &rt,
-    const CSSTransitionConfig &config,
+    const CSSTransitionConfig<jsi::Value> &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
   for (const auto &[propertyName, propertySettings] : config.changedProperties) {
@@ -93,19 +93,15 @@ void CSSTransition::handleChangedProperties(
           styleInterpolator_.createOrUpdateInterpolator(rt, propertyName, valueChange.first, valueChange.second);
     }
 
+    // We still pass allowDiscrete to use correct threshold for interpolation between incompatible values
+    // (e.g. when someone passes a keyword and a numeric value - in this case we interpolate them as discrete values)
     styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
-    progressProvider_.runProgressProvider(
-        propertyName,
-        propertySettings.duration,
-        propertySettings.delay,
-        propertySettings.easingFunction,
-        isReversed,
-        timestamp);
+    progressProvider_.runProgressProvider(propertyName, propertySettings, isReversed, timestamp);
   }
 }
 
 void CSSTransition::handleChangedProperties(
-    const CSSTransitionDynamicConfig &config,
+    const CSSTransitionConfig<folly::dynamic> &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
   for (const auto &[propertyName, propertySettings] : config.changedProperties) {
@@ -128,13 +124,7 @@ void CSSTransition::handleChangedProperties(
     }
 
     styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
-    progressProvider_.runProgressProvider(
-        propertyName,
-        propertySettings.duration,
-        propertySettings.delay,
-        propertySettings.easingFunction,
-        isReversed,
-        timestamp);
+    progressProvider_.runProgressProvider(propertyName, propertySettings, isReversed, timestamp);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -41,8 +41,11 @@ folly::dynamic CSSTransition::run(
     const CSSTransitionConfig<jsi::Value> &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
+  // Update interpolators and progress providers for changed properties
   handleChangedProperties(rt, config, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
+  // Remove interpolators and progress providers for no longer transitioned props
   handleRemovedProperties(config.removedProperties);
+  // Return the first transition frame
   return update(timestamp);
 }
 
@@ -82,6 +85,7 @@ void CSSTransition::handleChangedProperties(
 
     transitionProperties_.insert(propertyName);
 
+    // Update the transition style interpolator
     const auto &valueChange = propertySettings.value;
     bool isReversed;
     if (lastUpdateValue.count(propertyName)) {
@@ -96,6 +100,8 @@ void CSSTransition::handleChangedProperties(
     // We still pass allowDiscrete to use correct threshold for interpolation between incompatible values
     // (e.g. when someone passes a keyword and a numeric value - in this case we interpolate them as discrete values)
     styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
+
+    // Update the transition progress provider
     progressProvider_.runProgressProvider(propertyName, propertySettings, isReversed, timestamp);
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace reanimated::css {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -41,11 +41,17 @@ folly::dynamic CSSTransition::run(
     const CSSTransitionConfig &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
-  // Update interpolators and progress providers for changed properties
   handleChangedProperties(rt, config, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
-  // Remove interpolators and progress providers for no longer transitioned props
-  handleRemovedProperties(config);
-  // Return the first transition frame
+  handleRemovedProperties(config.removedProperties);
+  return update(timestamp);
+}
+
+folly::dynamic CSSTransition::run(
+    const CSSTransitionDynamicConfig &config,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  handleChangedProperties(config, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
+  handleRemovedProperties(config.removedProperties);
   return update(timestamp);
 }
 
@@ -66,8 +72,6 @@ void CSSTransition::handleChangedProperties(
     const CSSTransitionConfig &config,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
-  const auto null = folly::dynamic();
-
   for (const auto &[propertyName, propertySettings] : config.changedProperties) {
     const auto allowDiscrete = propertySettings.allowDiscrete;
 
@@ -78,9 +82,7 @@ void CSSTransition::handleChangedProperties(
 
     transitionProperties_.insert(propertyName);
 
-    // Update the transition style interpolator
     const auto &valueChange = propertySettings.value;
-
     bool isReversed;
     if (lastUpdateValue.count(propertyName)) {
       // TODO - get rid of lastValue dynamic in the future
@@ -91,17 +93,53 @@ void CSSTransition::handleChangedProperties(
           styleInterpolator_.createOrUpdateInterpolator(rt, propertyName, valueChange.first, valueChange.second);
     }
 
-    // We still pass allowDiscrete to use correct threshold for interpolation between incompatible values
-    // (e.g. when someone passes a keyword and a numeric value - in this case we interpolate them as discrete values)
     styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
-
-    // Update the transition progress provider
-    progressProvider_.runProgressProvider(propertyName, propertySettings, isReversed, timestamp);
+    progressProvider_.runProgressProvider(
+        propertyName,
+        propertySettings.duration,
+        propertySettings.delay,
+        propertySettings.easingFunction,
+        isReversed,
+        timestamp);
   }
 }
 
-void CSSTransition::handleRemovedProperties(const CSSTransitionConfig &config) {
-  for (const auto &propertyName : config.removedProperties) {
+void CSSTransition::handleChangedProperties(
+    const CSSTransitionDynamicConfig &config,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  for (const auto &[propertyName, propertySettings] : config.changedProperties) {
+    const auto allowDiscrete = propertySettings.allowDiscrete;
+
+    if (!allowDiscrete && isDiscreteProperty(propertyName, shadowNode_->getComponentName())) {
+      removeProperty(propertyName);
+      continue;
+    }
+
+    transitionProperties_.insert(propertyName);
+
+    const auto &valueChange = propertySettings.value;
+    bool isReversed;
+    if (lastUpdateValue.count(propertyName)) {
+      isReversed = styleInterpolator_.createOrUpdateInterpolator(
+          propertyName, lastUpdateValue.at(propertyName), valueChange.second);
+    } else {
+      isReversed = styleInterpolator_.createOrUpdateInterpolator(propertyName, valueChange.first, valueChange.second);
+    }
+
+    styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
+    progressProvider_.runProgressProvider(
+        propertyName,
+        propertySettings.duration,
+        propertySettings.delay,
+        propertySettings.easingFunction,
+        isReversed,
+        timestamp);
+  }
+}
+
+void CSSTransition::handleRemovedProperties(const std::vector<std::string> &removedProperties) {
+  for (const auto &propertyName : removedProperties) {
     removeProperty(propertyName);
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -26,6 +26,7 @@ class CSSTransition {
 
   folly::dynamic
   run(jsi::Runtime &rt, const CSSTransitionConfig &config, const folly::dynamic &lastUpdateValue, double timestamp);
+  folly::dynamic run(const CSSTransitionDynamicConfig &config, const folly::dynamic &lastUpdateValue, double timestamp);
   folly::dynamic update(double timestamp);
 
  private:
@@ -40,7 +41,11 @@ class CSSTransition {
       const CSSTransitionConfig &config,
       const folly::dynamic &lastUpdateValue,
       double timestamp);
-  void handleRemovedProperties(const CSSTransitionConfig &config);
+  void handleChangedProperties(
+      const CSSTransitionDynamicConfig &config,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
+  void handleRemovedProperties(const std::vector<std::string> &removedProperties);
   void removeProperty(const std::string &propertyName);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -24,9 +24,13 @@ class CSSTransition {
   TransitionProgressState getState() const;
   TransitionProperties getProperties() const;
 
+  folly::dynamic run(
+      jsi::Runtime &rt,
+      const CSSTransitionConfig<jsi::Value> &config,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
   folly::dynamic
-  run(jsi::Runtime &rt, const CSSTransitionConfig &config, const folly::dynamic &lastUpdateValue, double timestamp);
-  folly::dynamic run(const CSSTransitionDynamicConfig &config, const folly::dynamic &lastUpdateValue, double timestamp);
+  run(const CSSTransitionConfig<folly::dynamic> &config, const folly::dynamic &lastUpdateValue, double timestamp);
   folly::dynamic update(double timestamp);
 
  private:
@@ -38,11 +42,11 @@ class CSSTransition {
 
   void handleChangedProperties(
       jsi::Runtime &rt,
-      const CSSTransitionConfig &config,
+      const CSSTransitionConfig<jsi::Value> &config,
       const folly::dynamic &lastUpdateValue,
       double timestamp);
   void handleChangedProperties(
-      const CSSTransitionDynamicConfig &config,
+      const CSSTransitionConfig<folly::dynamic> &config,
       const folly::dynamic &lastUpdateValue,
       double timestamp);
   void handleRemovedProperties(const std::vector<std::string> &removedProperties);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -9,6 +9,7 @@
 #include <jsi/jsi.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace reanimated::css {
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.cpp
@@ -66,4 +66,40 @@ EasingFunction createParametrizedEasingFunction(jsi::Runtime &rt, const jsi::Obj
   }
 }
 
+EasingFunction createEasingFunction(const folly::dynamic &easingConfig) {
+  if (easingConfig.isString()) {
+    return getPredefinedEasingFunction(easingConfig.asString());
+  } else if (easingConfig.isObject()) {
+    return createParametrizedEasingFunction(easingConfig);
+  } else {
+    throw std::runtime_error(std::string("[Reanimated] Invalid easing function"));
+  }
+}
+
+EasingFunction createParametrizedEasingFunction(const folly::dynamic &easingConfig) {
+  const auto easingName = easingConfig.at("name").asString();
+
+  if (easingName == "cubicBezier") {
+    return cubicBezier(easingConfig);
+  }
+
+  std::vector<double> pointsX;
+  std::vector<double> pointsY;
+
+  const auto &points = easingConfig.at("points");
+  for (const auto &pointObj : points) {
+    pointsX.push_back(pointObj.at("x").asDouble());
+    pointsY.push_back(pointObj.at("y").asDouble());
+  }
+
+  if (easingName == "linear") {
+    return linear(pointsX, pointsY);
+  } else if (easingName == "steps") {
+    return steps(pointsX, pointsY);
+  } else {
+    throw std::runtime_error(
+        std::string("[Reanimated] Parametrized easing function with name '" + easingName + "' is not defined."));
+  }
+}
+
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/EasingFunctions.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/easing/linear.h>
 #include <reanimated/CSS/easing/steps.h>
 
+#include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <string>
 #include <unordered_map>
@@ -16,7 +17,9 @@ extern const std::unordered_map<std::string, EasingFunction> PREDEFINED_EASING_M
 
 EasingFunction getPredefinedEasingFunction(const std::string &name);
 EasingFunction createParametrizedEasingFunction(jsi::Runtime &rt, const jsi::Object &easingConfig);
+EasingFunction createParametrizedEasingFunction(const folly::dynamic &easingConfig);
 
 EasingFunction createEasingFunction(jsi::Runtime &rt, const jsi::Value &easingConfig);
+EasingFunction createEasingFunction(const folly::dynamic &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.cpp
@@ -63,4 +63,12 @@ EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig) {
   return cubicBezier(x1, y1, x2, y2);
 }
 
+EasingFunction cubicBezier(const folly::dynamic &easingConfig) {
+  const auto x1 = easingConfig.at("x1").asDouble();
+  const auto y1 = easingConfig.at("y1").asDouble();
+  const auto x2 = easingConfig.at("x2").asDouble();
+  const auto y2 = easingConfig.at("y2").asDouble();
+  return cubicBezier(x1, y1, x2, y2);
+}
+
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -2,6 +2,8 @@
 
 #include <reanimated/CSS/common/definitions.h>
 
+#include <folly/dynamic.h>
+
 namespace reanimated::css {
 
 double sampleCurveX(double t, double x1, double x2);
@@ -11,5 +13,6 @@ double solveCurveX(double x, double x1, double x2, double epsilon = 1e-6);
 
 EasingFunction cubicBezier(double x1, double y1, double x2, double y2);
 EasingFunction cubicBezier(jsi::Runtime &rt, const jsi::Object &easingConfig);
+EasingFunction cubicBezier(const folly::dynamic &easingConfig);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -26,6 +26,7 @@ class PropertyInterpolator {
 
   virtual void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) = 0;
   virtual bool updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) = 0;
+  virtual bool updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) = 0;
 
   virtual folly::dynamic interpolate(
       const std::shared_ptr<const ShadowNode> &shadowNode,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.cpp
@@ -49,6 +49,27 @@ bool ArrayPropertiesInterpolator::updateKeyframes(
   return areAllPropsReversed;
 }
 
+bool ArrayPropertiesInterpolator::updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  const auto emptyArr = folly::dynamic::array();
+  const auto &fromArray = fromValue.isNull() ? emptyArr : fromValue;
+  const auto &toArray = toValue.isNull() ? emptyArr : toValue;
+
+  const size_t fromSize = fromArray.size();
+  const size_t toSize = toArray.size();
+  const size_t valuesCount = std::max(fromSize, toSize);
+
+  resizeInterpolators(valuesCount);
+
+  bool areAllPropsReversed = true;
+
+  for (size_t i = 0; i < valuesCount; ++i) {
+    areAllPropsReversed &= interpolators_[i]->updateKeyframes(
+        i < fromSize ? fromArray[i] : folly::dynamic(), i < toSize ? toArray[i] : folly::dynamic());
+  }
+
+  return areAllPropsReversed;
+}
+
 folly::dynamic ArrayPropertiesInterpolator::mapInterpolators(
     const std::function<folly::dynamic(PropertyInterpolator &)> &callback) const {
   auto result = folly::dynamic::array();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/ArrayPropertiesInterpolator.h
@@ -17,6 +17,7 @@ class ArrayPropertiesInterpolator : public GroupPropertiesInterpolator {
 
   void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
   bool updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) override;
+  bool updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) override;
 
  protected:
   folly::dynamic mapInterpolators(const std::function<folly::dynamic(PropertyInterpolator &)> &callback) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.cpp
@@ -65,6 +65,31 @@ bool RecordPropertiesInterpolator::updateKeyframes(
   return areAllPropsReversed;
 }
 
+bool RecordPropertiesInterpolator::updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  const folly::dynamic emptyObj = folly::dynamic::object();
+  const folly::dynamic &fromObject = fromValue.isNull() ? emptyObj : fromValue;
+  const folly::dynamic &toObject = toValue.isNull() ? emptyObj : toValue;
+
+  std::unordered_set<std::string> propertyNamesSet;
+  for (const auto &[key, val] : fromObject.items()) {
+    propertyNamesSet.insert(key.asString());
+  }
+  for (const auto &[key, val] : toObject.items()) {
+    propertyNamesSet.insert(key.asString());
+  }
+
+  bool areAllPropsReversed = true;
+
+  for (const auto &propertyName : propertyNamesSet) {
+    maybeCreateInterpolator(propertyName);
+    const auto fromVal = fromObject.count(propertyName) ? fromObject.at(propertyName) : folly::dynamic();
+    const auto toVal = toObject.count(propertyName) ? toObject.at(propertyName) : folly::dynamic();
+    areAllPropsReversed &= interpolators_[propertyName]->updateKeyframes(fromVal, toVal);
+  }
+
+  return areAllPropsReversed;
+}
+
 folly::dynamic RecordPropertiesInterpolator::mapInterpolators(
     const std::function<folly::dynamic(PropertyInterpolator &)> &callback) const {
   folly::dynamic result = folly::dynamic::object;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h
@@ -18,6 +18,7 @@ class RecordPropertiesInterpolator : public GroupPropertiesInterpolator {
 
   void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
   bool updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) override;
+  bool updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) override;
 
  protected:
   folly::dynamic mapInterpolators(const std::function<folly::dynamic(PropertyInterpolator &)> &callback) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/operations/OperationsStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/operations/OperationsStyleInterpolator.cpp
@@ -119,6 +119,20 @@ bool OperationsStyleInterpolator::updateKeyframes(
   return equalsReversingAdjustedStartValue;
 }
 
+bool OperationsStyleInterpolator::updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  const auto fromOperations = parseStyleOperations(fromValue);
+  const auto toOperations = parseStyleOperations(toValue);
+
+  const auto equalsReversingAdjustedStartValue = areStyleOperationsEqual(toOperations, reversingAdjustedStartValue_);
+  reversingAdjustedStartValue_ = keyframes_.empty() ? fromOperations : keyframes_[0]->toOperations;
+
+  keyframes_.clear();
+  keyframes_.reserve(1);
+  keyframes_.emplace_back(createStyleOperationsKeyframe(0, 1, fromOperations, toOperations));
+
+  return equalsReversingAdjustedStartValue;
+}
+
 std::optional<StyleOperations> OperationsStyleInterpolator::parseStyleOperations(
     jsi::Runtime &rt,
     const jsi::Value &values) const {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/operations/OperationsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/operations/OperationsStyleInterpolator.h
@@ -45,6 +45,7 @@ class OperationsStyleInterpolator : public PropertyInterpolator {
 
   void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
   bool updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) override;
+  bool updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) override;
 
  protected:
   const std::shared_ptr<StyleOperationInterpolators> interpolators_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.cpp
@@ -34,6 +34,14 @@ bool TransitionStyleInterpolator::createOrUpdateInterpolator(
   return interpolator->updateKeyframes(rt, fromValue, toValue);
 }
 
+bool TransitionStyleInterpolator::createOrUpdateInterpolator(
+    const std::string &propertyName,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue) {
+  const auto &interpolator = getOrCreateInterpolator(propertyName);
+  return interpolator->updateKeyframes(fromValue, toValue);
+}
+
 void TransitionStyleInterpolator::setAllowDiscrete(const std::string &propertyName, const bool allowDiscrete) {
   if (allowDiscrete) {
     allowDiscreteProperties_.insert(propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
@@ -27,6 +27,10 @@ class TransitionStyleInterpolator {
       const std::string &propertyName,
       const jsi::Value &fromValue,
       const jsi::Value &toValue);
+  bool createOrUpdateInterpolator(
+      const std::string &propertyName,
+      const folly::dynamic &fromValue,
+      const folly::dynamic &toValue);
   void setAllowDiscrete(const std::string &propertyName, bool allowDiscrete);
   void removeProperty(const std::string &propertyName);
   void discardFinishedInterpolators(const TransitionProgressProvider &transitionProgressProvider);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.cpp
@@ -62,6 +62,18 @@ bool ValueInterpolator::updateKeyframes(jsi::Runtime &rt, const jsi::Value &from
   return equalsReversingAdjustedStartValue;
 }
 
+bool ValueInterpolator::updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  auto from = fromValue.isNull() ? defaultStyleValue_ : createValue(fromValue);
+  auto to = toValue.isNull() ? defaultStyleValue_ : createValue(toValue);
+
+  const auto equalsReversingAdjustedStartValue = reversingAdjustedStartValue_ && (*to == *reversingAdjustedStartValue_);
+  reversingAdjustedStartValue_ = keyframes_.empty() ? from : keyframes_[1].value.value();
+
+  keyframes_ = {ValueKeyframe{0, std::move(from)}, ValueKeyframe{1, std::move(to)}};
+
+  return equalsReversingAdjustedStartValue;
+}
+
 folly::dynamic ValueInterpolator::interpolate(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::shared_ptr<KeyframeProgressProvider> &progressProvider,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ValueInterpolator.h
@@ -35,6 +35,7 @@ class ValueInterpolator : public PropertyInterpolator {
 
   void updateKeyframes(jsi::Runtime &rt, const jsi::Value &keyframes) override;
   bool updateKeyframes(jsi::Runtime &rt, const jsi::Value &fromValue, const jsi::Value &toValue) override;
+  bool updateKeyframes(const folly::dynamic &fromValue, const folly::dynamic &toValue) override;
 
   folly::dynamic interpolate(
       const std::shared_ptr<const ShadowNode> &shadowNode,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -104,7 +104,9 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
 
 void TransitionProgressProvider::runProgressProvider(
     const std::string &propertyName,
-    const CSSTransitionPropertySettings &settings,
+    const double duration,
+    const double delay,
+    const EasingFunction &easingFunction,
     const bool isReversed,
     const double timestamp) {
   const auto it = propertyProgressProviders_.find(propertyName);
@@ -116,16 +118,15 @@ void TransitionProgressProvider::runProgressProvider(
     if (isReversed && progressProvider->getState() != TransitionProgressState::Finished) {
       // Create reversing shortening progress provider for interrupted reversing transition
       propertyProgressProviders_.insert_or_assign(
-          propertyName, createReversingShorteningProgressProvider(timestamp, settings, *progressProvider));
+          propertyName,
+          createReversingShorteningProgressProvider(timestamp, duration, delay, easingFunction, *progressProvider));
       return;
     }
   }
 
   // Create progress provider with the new settings
   propertyProgressProviders_.insert_or_assign(
-      propertyName,
-      std::make_shared<TransitionPropertyProgressProvider>(
-          timestamp, settings.duration, settings.delay, settings.easingFunction));
+      propertyName, std::make_shared<TransitionPropertyProgressProvider>(timestamp, duration, delay, easingFunction));
 }
 
 void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
@@ -156,7 +157,9 @@ void TransitionProgressProvider::update(const double timestamp) {
 std::shared_ptr<TransitionPropertyProgressProvider>
 TransitionProgressProvider::createReversingShorteningProgressProvider(
     const double timestamp,
-    const CSSTransitionPropertySettings &propertySettings,
+    const double duration,
+    const double delay,
+    const EasingFunction &easingFunction,
     const TransitionPropertyProgressProvider &existingProgressProvider) {
   const auto oldProgress = existingProgressProvider.getKeyframeProgress(0, 1);
   const auto oldReversingShorteningFactor = existingProgressProvider.getReversingShorteningFactor();
@@ -164,9 +167,9 @@ TransitionProgressProvider::createReversingShorteningProgressProvider(
 
   return std::make_shared<TransitionPropertyProgressProvider>(
       timestamp,
-      propertySettings.duration * newReversingShorteningFactor,
-      propertySettings.delay < 0 ? newReversingShorteningFactor * propertySettings.delay : propertySettings.delay,
-      propertySettings.easingFunction,
+      duration * newReversingShorteningFactor,
+      delay < 0 ? newReversingShorteningFactor * delay : delay,
+      easingFunction,
       newReversingShorteningFactor);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -102,11 +102,10 @@ std::unordered_set<std::string> TransitionProgressProvider::getRemovedProperties
   return removedProperties_;
 }
 
+template <CSSValueType ValueType>
 void TransitionProgressProvider::runProgressProvider(
     const std::string &propertyName,
-    const double duration,
-    const double delay,
-    const EasingFunction &easingFunction,
+    const CSSTransitionPropertySettings<ValueType> &settings,
     const bool isReversed,
     const double timestamp) {
   const auto it = propertyProgressProviders_.find(propertyName);
@@ -116,18 +115,28 @@ void TransitionProgressProvider::runProgressProvider(
     progressProvider->update(timestamp);
 
     if (isReversed && progressProvider->getState() != TransitionProgressState::Finished) {
-      // Create reversing shortening progress provider for interrupted reversing transition
       propertyProgressProviders_.insert_or_assign(
-          propertyName,
-          createReversingShorteningProgressProvider(timestamp, duration, delay, easingFunction, *progressProvider));
+          propertyName, createReversingShorteningProgressProvider(timestamp, settings, *progressProvider));
       return;
     }
   }
 
-  // Create progress provider with the new settings
   propertyProgressProviders_.insert_or_assign(
-      propertyName, std::make_shared<TransitionPropertyProgressProvider>(timestamp, duration, delay, easingFunction));
+      propertyName,
+      std::make_shared<TransitionPropertyProgressProvider>(
+          timestamp, settings.duration, settings.delay, settings.easingFunction));
 }
+
+template void TransitionProgressProvider::runProgressProvider<jsi::Value>(
+    const std::string &,
+    const CSSTransitionPropertySettings<jsi::Value> &,
+    bool,
+    double);
+template void TransitionProgressProvider::runProgressProvider<folly::dynamic>(
+    const std::string &,
+    const CSSTransitionPropertySettings<folly::dynamic> &,
+    bool,
+    double);
 
 void TransitionProgressProvider::removeProperty(const std::string &propertyName) {
   propertyProgressProviders_.erase(propertyName);
@@ -154,12 +163,11 @@ void TransitionProgressProvider::update(const double timestamp) {
   }
 }
 
+template <CSSValueType ValueType>
 std::shared_ptr<TransitionPropertyProgressProvider>
 TransitionProgressProvider::createReversingShorteningProgressProvider(
     const double timestamp,
-    const double duration,
-    const double delay,
-    const EasingFunction &easingFunction,
+    const CSSTransitionPropertySettings<ValueType> &propertySettings,
     const TransitionPropertyProgressProvider &existingProgressProvider) {
   const auto oldProgress = existingProgressProvider.getKeyframeProgress(0, 1);
   const auto oldReversingShorteningFactor = existingProgressProvider.getReversingShorteningFactor();
@@ -167,10 +175,21 @@ TransitionProgressProvider::createReversingShorteningProgressProvider(
 
   return std::make_shared<TransitionPropertyProgressProvider>(
       timestamp,
-      duration * newReversingShorteningFactor,
-      delay < 0 ? newReversingShorteningFactor * delay : delay,
-      easingFunction,
+      propertySettings.duration * newReversingShorteningFactor,
+      propertySettings.delay < 0 ? newReversingShorteningFactor * propertySettings.delay : propertySettings.delay,
+      propertySettings.easingFunction,
       newReversingShorteningFactor);
 }
+
+template std::shared_ptr<TransitionPropertyProgressProvider>
+TransitionProgressProvider::createReversingShorteningProgressProvider<jsi::Value>(
+    double,
+    const CSSTransitionPropertySettings<jsi::Value> &,
+    const TransitionPropertyProgressProvider &);
+template std::shared_ptr<TransitionPropertyProgressProvider>
+TransitionProgressProvider::createReversingShorteningProgressProvider<folly::dynamic>(
+    double,
+    const CSSTransitionPropertySettings<folly::dynamic> &,
+    const TransitionPropertyProgressProvider &);
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/CSS/configs/CSSTransitionConfig.h>
+#include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 #include <reanimated/CSS/progress/RawProgressProvider.h>
 #include <reanimated/CSS/utils/props.h>
@@ -56,7 +56,9 @@ class TransitionProgressProvider final {
 
   void runProgressProvider(
       const std::string &propertyName,
-      const CSSTransitionPropertySettings &settings,
+      double duration,
+      double delay,
+      const EasingFunction &easingFunction,
       bool isReversed,
       double timestamp);
   void removeProperty(const std::string &propertyName);
@@ -70,7 +72,9 @@ class TransitionProgressProvider final {
 
   std::shared_ptr<TransitionPropertyProgressProvider> createReversingShorteningProgressProvider(
       double timestamp,
-      const CSSTransitionPropertySettings &propertySettings,
+      double duration,
+      double delay,
+      const EasingFunction &easingFunction,
       const TransitionPropertyProgressProvider &existingProgressProvider);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <reanimated/CSS/easing/EasingFunctions.h>
+#include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 #include <reanimated/CSS/progress/RawProgressProvider.h>
 #include <reanimated/CSS/utils/props.h>
@@ -54,11 +54,10 @@ class TransitionProgressProvider final {
   TransitionPropertyProgressProviders getPropertyProgressProviders() const;
   std::unordered_set<std::string> getRemovedProperties() const;
 
+  template <CSSValueType ValueType>
   void runProgressProvider(
       const std::string &propertyName,
-      double duration,
-      double delay,
-      const EasingFunction &easingFunction,
+      const CSSTransitionPropertySettings<ValueType> &settings,
       bool isReversed,
       double timestamp);
   void removeProperty(const std::string &propertyName);
@@ -70,11 +69,10 @@ class TransitionProgressProvider final {
 
   std::unordered_set<std::string> removedProperties_;
 
+  template <CSSValueType ValueType>
   std::shared_ptr<TransitionPropertyProgressProvider> createReversingShorteningProgressProvider(
       double timestamp,
-      double duration,
-      double delay,
-      const EasingFunction &easingFunction,
+      const CSSTransitionPropertySettings<ValueType> &propertySettings,
       const TransitionPropertyProgressProvider &existingProgressProvider);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -23,7 +23,7 @@ bool CSSTransitionsRegistry::hasUpdates() const {
 void CSSTransitionsRegistry::run(
     jsi::Runtime &rt,
     const std::shared_ptr<const ShadowNode> &shadowNode,
-    const CSSTransitionConfig &config) {
+    const CSSTransitionConfig<jsi::Value> &config) {
   const auto viewTag = shadowNode->getTag();
 
   if (!registry_.contains(viewTag)) {
@@ -44,7 +44,7 @@ void CSSTransitionsRegistry::run(
 
 void CSSTransitionsRegistry::run(
     const std::shared_ptr<const ShadowNode> &shadowNode,
-    const CSSTransitionDynamicConfig &config) {
+    const CSSTransitionConfig<folly::dynamic> &config) {
   const auto viewTag = shadowNode->getTag();
 
   if (!registry_.contains(viewTag)) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -42,6 +42,26 @@ void CSSTransitionsRegistry::run(
   updateInUpdatesRegistry(transition, initialUpdate);
 }
 
+void CSSTransitionsRegistry::run(
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const CSSTransitionDynamicConfig &config) {
+  const auto viewTag = shadowNode->getTag();
+
+  if (!registry_.contains(viewTag)) {
+    auto transition = std::make_shared<CSSTransition>(shadowNode, viewStylesRepository_);
+    registry_.insert({viewTag, transition});
+  }
+
+  const auto &transition = registry_.at(viewTag);
+  const auto &lastUpdates = getUpdatesFromRegistry(shadowNode->getTag());
+  const auto timestamp = getCurrentTimestamp_();
+
+  auto initialUpdate = transition->run(config, lastUpdates, timestamp);
+
+  scheduleOrActivateTransition(transition);
+  updateInUpdatesRegistry(transition, initialUpdate);
+}
+
 void CSSTransitionsRegistry::remove(const Tag viewTag) {
   removeFromUpdatesRegistry(viewTag);
   delayedTransitionsManager_.remove(viewTag);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -25,8 +25,11 @@ class CSSTransitionsRegistry : public UpdatesRegistry, public std::enable_shared
   bool isEmpty() const override;
   bool hasUpdates() const;
 
-  void run(jsi::Runtime &rt, const std::shared_ptr<const ShadowNode> &shadowNode, const CSSTransitionConfig &config);
-  void run(const std::shared_ptr<const ShadowNode> &shadowNode, const CSSTransitionDynamicConfig &config);
+  void run(
+      jsi::Runtime &rt,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const CSSTransitionConfig<jsi::Value> &config);
+  void run(const std::shared_ptr<const ShadowNode> &shadowNode, const CSSTransitionConfig<folly::dynamic> &config);
   void remove(Tag viewTag) override;
 
   void update(double timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -26,6 +26,7 @@ class CSSTransitionsRegistry : public UpdatesRegistry, public std::enable_shared
   bool hasUpdates() const;
 
   void run(jsi::Runtime &rt, const std::shared_ptr<const ShadowNode> &shadowNode, const CSSTransitionConfig &config);
+  void run(const std::shared_ptr<const ShadowNode> &shadowNode, const CSSTransitionDynamicConfig &config);
   void remove(Tag viewTag) override;
 
   void update(double timestamp);


### PR DESCRIPTION
## Summary

Currently pseudoselectors have to parse folly dynamics to jsi::values just to be able to call a transition. This PR fixes this issue.
