### PR TITLE
fix: Attempt to fix `EXC_BAD_ACCESS` in `AnimatedPropsRegistry::update` via `AnimationFrameBatchinator::flush`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -170,6 +170,10 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
     }
 
     const auto timestamp = strongThis->getAnimationTimestamp_();
+    // Hold the registry mutex while update() mutates updatesBatch_ /
+    // timestampMap_; performOperations() on the main thread races otherwise.
+    // See https://github.com/software-mansion/react-native-reanimated/issues/9303
+    const auto lock = strongThis->animatedPropsRegistry_->lock();
     strongThis->animatedPropsRegistry_->update(rt, operations, timestamp);
   };
 


### PR DESCRIPTION
## Summary

Since the original issue is not reproducible, I can't guarantee that this PR actually fixes the issue. It adds one mutex that seems to be necessary.