### PR TITLE
Remove checks for new arch enabled

### DIFF
--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -5,9 +5,6 @@ reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json"
 $config = find_config()
 assert_minimal_react_native_version($config)
 
-$new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] != '0'
-assert_new_architecture_enabled($new_arch_enabled)
-
 boost_compiler_flags = '-Wno-documentation'
 example_flag = $config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 reanimated_profiling_flag = ENV['IS_REANIMATED_PROFILING'] ? '-DREANIMATED_PROFILING' : ''

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -24,19 +24,6 @@ fun safeAppExtGet(prop: String, fallback: Any?): Any? {
         fallback
 }
 
-fun isNewArchitectureEnabled(): Boolean {
-    // In React Native 0.82+, users can no longer opt-out of the New Architecture.
-    if (getReactNativeMinorVersion() >= 82) {
-        return true
-    }
-
-    // In older versions, to opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.property("newArchEnabled") == "true"
-}
-
 fun resolveReactNativeDirectory(): File {
     val reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null) as String?
     if (reactNativeLocation != null) {
@@ -121,7 +108,7 @@ fun validateConflictingFeatureFlags(featureFlags: HashMap<String, String>) {
     }
 }
 
-if (isNewArchitectureEnabled() && project != rootProject) {
+if (project != rootProject) {
     apply(plugin = "com.facebook.react")
 }
 
@@ -130,7 +117,6 @@ val reactNativeRootDir: File = resolveReactNativeDirectory()
 val REACT_NATIVE_MINOR_VERSION: Int = getReactNativeMinorVersion()
 val REACT_NATIVE_VERSION: String = getReactNativeVersion()
 val REANIMATED_VERSION: String = getReanimatedVersion()
-val IS_NEW_ARCHITECTURE_ENABLED: Boolean = isNewArchitectureEnabled()
 val IS_REANIMATED_EXAMPLE_APP: Boolean = safeAppExtGet("isReanimatedExampleApp", false)?.toString()?.toBoolean() ?: false
 val REANIMATED_PROFILING: Boolean = safeAppExtGet("enableReanimatedProfiling", false)?.toString()?.toBoolean() ?: false
 val REANIMATED_FEATURE_FLAGS: String = getReanimatedStaticFeatureFlags()
@@ -304,16 +290,6 @@ tasks.register("assertMinimalReactNativeVersionTask") {
 }
 
 tasks.named("preBuild") { dependsOn("assertMinimalReactNativeVersionTask") }
-
-tasks.register("assertNewArchitectureEnabledTask") {
-    val isNewArch = IS_NEW_ARCHITECTURE_ENABLED
-    onlyIf { !isNewArch }
-    doFirst {
-        throw GradleException("[Reanimated] Reanimated requires new architecture to be enabled. Please enable it by setting `newArchEnabled` to `true` in `gradle.properties`.")
-    }
-}
-
-tasks.named("preBuild") { dependsOn("assertNewArchitectureEnabledTask") }
 
 val validateWorkletsBuildResult = providers.exec {
     workingDir(projectDir.path)

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -59,12 +59,6 @@ def assert_minimal_react_native_version(config)
   end
 end
 
-def assert_new_architecture_enabled(new_arch_enabled)
-  if !new_arch_enabled
-    raise "[Reanimated] Reanimated requires the New Architecture to be enabled. If you have `RCT_NEW_ARCH_ENABLED=0` set in your environment you should remove it."
-  end
-end
-
 def assert_conflicting_feature_flags(feature_flags)
   ios_sync_ui_props = feature_flags['IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS'] == 'true'
   shared_element_transitions = feature_flags['ENABLE_SHARED_ELEMENT_TRANSITIONS'] == 'true'

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -5,9 +5,6 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 $worklets_config = worklets_find_config()
 worklets_assert_minimal_react_native_version($worklets_config)
 
-$new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] != '0'
-worklets_assert_new_architecture_enabled($new_arch_enabled)
-
 ios_min_version = '13.4'
 
 # Directory in which data for further processing for clangd will be stored.

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -24,19 +24,6 @@ fun safeAppExtGet(prop: String, fallback: Any?): Any? {
         fallback
 }
 
-fun isNewArchitectureEnabled(): Boolean {
-    // In React Native 0.82+, users can no longer opt-out of the New Architecture.
-    if (getReactNativeMinorVersion() >= 82) {
-        return true
-    }
-
-    // In older versions, to opt-in for the New Architecture, you can either:
-    // - Set `newArchEnabled` to true inside the `gradle.properties` file
-    // - Invoke gradle with `-newArchEnabled=true`
-    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
-    return project.hasProperty("newArchEnabled") && project.property("newArchEnabled") == "true"
-}
-
 fun resolveReactNativeDirectory(): File {
     val reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null) as String?
     if (reactNativeLocation != null) {
@@ -127,7 +114,7 @@ fun getStaticFeatureFlagsString(featureFlags: Map<String, String>): String =
 fun isFlagEnabled(featureFlags: Map<String, String>, flagName: String): Boolean =
     featureFlags.containsKey(flagName) && featureFlags[flagName] == "true"
 
-if (isNewArchitectureEnabled() && project != rootProject) {
+if (project != rootProject) {
     apply(plugin = "com.facebook.react")
 }
 
@@ -138,7 +125,6 @@ val reactNativeRootDir: File = resolveReactNativeDirectory()
 val REACT_NATIVE_MINOR_VERSION: Int = getReactNativeMinorVersion()
 val REACT_NATIVE_VERSION: String = getReactNativeVersion()
 val WORKLETS_VERSION: String = getWorkletsVersion()
-val IS_NEW_ARCHITECTURE_ENABLED: Boolean = isNewArchitectureEnabled()
 val IS_REANIMATED_EXAMPLE_APP: Boolean = safeAppExtGet("isReanimatedExampleApp", false)?.toString()?.toBoolean() ?: false
 val FETCH_PREVIEW_ENABLED: Boolean = isFlagEnabled(featureFlags, "FETCH_PREVIEW_ENABLED")
 val WORKLETS_FEATURE_FLAGS: String = getStaticFeatureFlagsString(featureFlags)
@@ -366,16 +352,6 @@ tasks.register("assertMinimalReactNativeVersionTask") {
 }
 
 tasks.named("preBuild") { dependsOn("assertMinimalReactNativeVersionTask") }
-
-tasks.register("assertNewArchitectureEnabledTask") {
-    val isNewArch = IS_NEW_ARCHITECTURE_ENABLED
-    onlyIf { !isNewArch }
-    doFirst {
-        throw GradleException("[Worklets] Worklets require new architecture to be enabled. Please enable it by setting `newArchEnabled` to `true` in `gradle.properties`.")
-    }
-}
-
-tasks.named("preBuild") { dependsOn("assertNewArchitectureEnabledTask") }
 
 // Workaround for AGP 9 + Kotlin 2.x lint K2 UAST crash on .gradle.kts build scripts.
 // See: https://issuetracker.google.com/issues/432144179

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -59,12 +59,6 @@ def worklets_assert_minimal_react_native_version(config)
   end
 end
 
-def worklets_assert_new_architecture_enabled(new_arch_enabled)
-  if !new_arch_enabled
-    raise "[Worklets] Worklets require the New Architecture to be enabled. If you have `RCT_NEW_ARCH_ENABLED=0` set in your environment you should remove it."
-  end
-end
-
 def worklets_get_flag_from_feature_flags(feature_flags, flag_name)
   if feature_flags[flag_name] == 'true'
     return "-DWORKLETS_#{flag_name}"


### PR DESCRIPTION
## Summary

This PR removes checks for New Architecture because starting from RN 0.82 it is the only supported architecture.

## Test plan
