### PR TITLE
feat: `CSSLoopTransition` abstraction for reanimated-loop updated CSS animation properties

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
+  hermes-engine: 8b25cc623de93c12f190eb2db7a4f5d9ab813d2d
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 3f3b29d3397ee033fc3082bd43d8287ceae3b4d9
+  React-Core-prebuilt: 27ea9cf9fca4acd471598b473b4ea9b4db403dfe
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: 8866d6164a71eae10eb7477a6f7a30589a1b6194
+  ReactNativeDependencies: 71754178430ecc55b86331832ce4068c5eb0c635
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopTransition.cpp
@@ -1,0 +1,168 @@
+#include <reanimated/CSS/core/CSSLoopTransition.h>
+
+#include <jsi/JSIDynamic.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+CSSLoopTransition::CSSLoopTransition(
+    const Tag viewTag,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    CSSTransition::Observer &observer)
+    : viewTag_(viewTag),
+      componentName_(componentName),
+      observer_(observer),
+      styleInterpolator_(TransitionStyleInterpolator(componentName_, viewStylesRepository)),
+      progressProvider_(TransitionProgressProvider()) {}
+
+double CSSLoopTransition::getMinDelay(double timestamp) const {
+  return progressProvider_.getMinDelay(timestamp);
+}
+
+TransitionProgressState CSSLoopTransition::getState() const {
+  return progressProvider_.getState();
+}
+
+bool CSSLoopTransition::update(const double timestamp, OperationsLoop &loop) {
+  progressProvider_.update(timestamp);
+  observer_.onTransitionUpdate(viewTag_);
+
+  if (progressProvider_.getState() == TransitionProgressState::Pending) {
+    loop.schedule(shared_from_this(), timestamp + progressProvider_.getMinDelay(timestamp));
+  }
+
+  return progressProvider_.getState() == TransitionProgressState::Running;
+}
+
+folly::dynamic CSSLoopTransition::run(
+    jsi::Runtime &rt,
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const PropertyValueDiffsMap &propertiesDiffs,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  // Update interpolators and progress providers for changed properties
+  handleChangedProperties(
+      rt, propertiesDiffs, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
+  // Advance progress and return the first transition frame
+  progressProvider_.update(timestamp);
+  return computeCurrentStyle(shadowNode);
+}
+
+folly::dynamic CSSLoopTransition::run(
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const PropertyValueDynamicDiffsMap &propertiesDiffs,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  handleChangedProperties(
+      propertiesDiffs, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
+  progressProvider_.update(timestamp);
+  return computeCurrentStyle(shadowNode);
+}
+
+void CSSLoopTransition::updateSettings(
+    const PropertiesSettingsMap &changedPropertiesSettings,
+    const std::vector<std::string> &removedProperties) {
+
+  // Remove interpolators and progress providers for no longer transitioned props
+  removeProperties(removedProperties);
+
+  // Update the settings saved in progress provider
+  progressProvider_.setPropertySettings(changedPropertiesSettings);
+}
+
+folly::dynamic CSSLoopTransition::computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode) {
+  auto result = styleInterpolator_.interpolate(shadowNode, progressProvider_);
+  // Remove interpolators for which interpolation has finished
+  // (we won't need them anymore in the current transition)
+  styleInterpolator_.discardFinishedInterpolators(progressProvider_);
+  // And remove finished progress providers after they were used to calculate
+  // the last frame of the transition
+  progressProvider_.discardFinishedProgressProviders();
+  return result;
+}
+
+void CSSLoopTransition::handleChangedProperties(
+    jsi::Runtime &rt,
+    const PropertyValueDiffsMap &propertiesDiffs,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  const auto null = folly::dynamic();
+
+  for (const auto &[propertyName, propertyDiff] : propertiesDiffs) {
+    const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
+
+    if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
+      removeProperty(propertyName);
+      continue;
+    }
+
+    properties_.insert(propertyName);
+
+    // Update the transition style interpolator
+    bool isReversed;
+    if (lastUpdateValue.count(propertyName)) {
+      // TODO - get rid of lastValue dynamic in the future
+      isReversed = styleInterpolator_.createOrUpdateInterpolator(
+          rt, propertyName, jsi::valueFromDynamic(rt, lastUpdateValue.at(propertyName)), propertyDiff.second);
+    } else {
+      isReversed =
+          styleInterpolator_.createOrUpdateInterpolator(rt, propertyName, propertyDiff.first, propertyDiff.second);
+    }
+
+    // We still pass allowDiscrete to use correct threshold for interpolation between incompatible values
+    // (e.g. when someone passes a keyword and a numeric value - in this case we interpolate them as discrete values)
+    styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
+
+    // Update the transition progress provider
+    progressProvider_.runProgressProvider(propertyName, isReversed, timestamp);
+  }
+}
+
+void CSSLoopTransition::handleChangedProperties(
+    const PropertyValueDynamicDiffsMap &propertiesDiffs,
+    const folly::dynamic &lastUpdateValue,
+    const double timestamp) {
+  for (const auto &[propertyName, propertyDiff] : propertiesDiffs) {
+    const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
+
+    if (!allowDiscrete && isDiscreteProperty(propertyName, componentName_)) {
+      removeProperty(propertyName);
+      continue;
+    }
+
+    properties_.insert(propertyName);
+
+    bool isReversed;
+    if (lastUpdateValue.count(propertyName)) {
+      isReversed = styleInterpolator_.createOrUpdateInterpolator(
+          propertyName, lastUpdateValue.at(propertyName), propertyDiff.second);
+    } else {
+      isReversed = styleInterpolator_.createOrUpdateInterpolator(propertyName, propertyDiff.first, propertyDiff.second);
+    }
+
+    styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
+
+    progressProvider_.runProgressProvider(propertyName, isReversed, timestamp);
+  }
+}
+
+void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames) {
+  styleInterpolator_.removeProperties(propertyNames);
+  progressProvider_.removeProperties(propertyNames);
+  for (const auto &propertyName : propertyNames) {
+    properties_.erase(propertyName);
+  }
+}
+
+void CSSLoopTransition::removeProperty(const std::string &propertyName) {
+  styleInterpolator_.removeProperty(propertyName);
+  progressProvider_.removeProperty(propertyName);
+  properties_.erase(propertyName);
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSLoopTransition.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <reanimated/CSS/configs/CSSTransitionConfig.h>
+#include <reanimated/CSS/core/CSSTransition.h>
+#include <reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h>
+#include <reanimated/CSS/progress/TransitionProgressProvider.h>
+#include <reanimated/Fabric/updates/OperationsLoop.h>
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace reanimated::css {
+
+class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enable_shared_from_this<CSSLoopTransition> {
+ public:
+  CSSLoopTransition(
+      Tag viewTag,
+      const std::string &componentName,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+      CSSTransition::Observer &observer);
+
+  TransitionProperties getProperties() const {
+    return properties_;
+  }
+
+  double getMinDelay(double timestamp) const;
+  TransitionProgressState getState() const;
+
+  bool update(double timestamp, OperationsLoop &loop) override;
+
+  folly::dynamic run(
+      jsi::Runtime &rt,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const PropertyValueDiffsMap &propertiesDiffs,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
+  /** TODO: unify folly::dynamic and jsi::value versions */
+  folly::dynamic run(
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const PropertyValueDynamicDiffsMap &propertiesDiffs,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
+  void updateSettings(
+      const PropertiesSettingsMap &changedPropertiesSettings,
+      const std::vector<std::string> &removedProperties);
+
+  folly::dynamic computeCurrentStyle(const std::shared_ptr<const ShadowNode> &shadowNode);
+
+ private:
+  const Tag viewTag_;
+  const std::string componentName_;
+  CSSTransition::Observer &observer_;
+
+  TransitionProperties properties_;
+  TransitionStyleInterpolator styleInterpolator_;
+  TransitionProgressProvider progressProvider_;
+
+  void handleChangedProperties(
+      jsi::Runtime &rt,
+      const PropertyValueDiffsMap &propertiesDiffs,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
+  /** TODO: unify folly::dynamic and jsi::value versions */
+  void handleChangedProperties(
+      const PropertyValueDynamicDiffsMap &propertiesDiffs,
+      const folly::dynamic &lastUpdateValue,
+      double timestamp);
+  void removeProperties(const std::vector<std::string> &propertyNames);
+  void removeProperty(const std::string &propertyName);
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.cpp
@@ -1,7 +1,6 @@
+#include <reanimated/CSS/core/CSSLoopTransition.h>
 #include <reanimated/CSS/core/CSSTransition.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
-
-#include <jsi/JSIDynamic.h>
 
 #include <memory>
 #include <string>
@@ -15,28 +14,31 @@ CSSTransition::CSSTransition(
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
     Observer &observer)
     : shadowNode_(std::move(shadowNode)),
-      viewStylesRepository_(viewStylesRepository),
-      observer_(observer),
-      styleInterpolator_(TransitionStyleInterpolator(shadowNode_->getComponentName(), viewStylesRepository)),
-      progressProvider_(TransitionProgressProvider()) {}
+      loopTransition_(std::make_shared<CSSLoopTransition>(
+          shadowNode_->getTag(),
+          shadowNode_->getComponentName(),
+          viewStylesRepository,
+          observer)) {}
+
+TransitionProperties CSSTransition::getProperties() const {
+  return loopTransition_->getProperties();
+}
 
 double CSSTransition::getMinDelay(double timestamp) const {
-  return progressProvider_.getMinDelay(timestamp);
+  return loopTransition_->getMinDelay(timestamp);
 }
 
 TransitionProgressState CSSTransition::getState() const {
-  return progressProvider_.getState();
+  return loopTransition_->getState();
 }
 
-bool CSSTransition::update(const double timestamp, OperationsLoop &loop) {
-  progressProvider_.update(timestamp);
-  observer_.onTransitionUpdate(shadowNode_->getTag());
+void CSSTransition::schedule(OperationsLoop &loop) {
+  const auto timestamp = loop.resolveTimestamp();
+  loop.schedule(loopTransition_, timestamp + loopTransition_->getMinDelay(timestamp));
+}
 
-  if (progressProvider_.getState() == TransitionProgressState::Pending) {
-    loop.schedule(shared_from_this(), timestamp + progressProvider_.getMinDelay(timestamp));
-  }
-
-  return progressProvider_.getState() == TransitionProgressState::Running;
+void CSSTransition::unschedule(OperationsLoop &loop) {
+  loop.remove(loopTransition_);
 }
 
 folly::dynamic CSSTransition::run(
@@ -44,123 +46,24 @@ folly::dynamic CSSTransition::run(
     const PropertyValueDiffsMap &propertiesDiffs,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
-  // Update interpolators and progress providers for changed properties
-  handleChangedProperties(
-      rt, propertiesDiffs, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
-  // Advance progress and return the first transition frame
-  progressProvider_.update(timestamp);
-  return computeCurrentStyle();
+  return loopTransition_->run(rt, shadowNode_, propertiesDiffs, lastUpdateValue, timestamp);
 }
 
 folly::dynamic CSSTransition::run(
     const PropertyValueDynamicDiffsMap &propertiesDiffs,
     const folly::dynamic &lastUpdateValue,
     const double timestamp) {
-  handleChangedProperties(
-      propertiesDiffs, lastUpdateValue.empty() ? folly::dynamic::object() : lastUpdateValue, timestamp);
-  progressProvider_.update(timestamp);
-  return computeCurrentStyle();
+  return loopTransition_->run(shadowNode_, propertiesDiffs, lastUpdateValue, timestamp);
 }
 
-void CSSTransition::updateConfig(
+void CSSTransition::updateSettings(
     const PropertiesSettingsMap &changedPropertiesSettings,
     const std::vector<std::string> &removedProperties) {
-
-  // Remove interpolators and progress providers for no longer transitioned props
-  removeProperties(removedProperties);
-
-  // Update the settings saved in progress provider
-  progressProvider_.setPropertySettings(changedPropertiesSettings);
+  loopTransition_->updateSettings(changedPropertiesSettings, removedProperties);
 }
 
 folly::dynamic CSSTransition::computeCurrentStyle() {
-  auto result = styleInterpolator_.interpolate(shadowNode_, progressProvider_);
-  // Remove interpolators for which interpolation has finished
-  // (we won't need them anymore in the current transition)
-  styleInterpolator_.discardFinishedInterpolators(progressProvider_);
-  // And remove finished progress providers after they were used to calculate
-  // the last frame of the transition
-  progressProvider_.discardFinishedProgressProviders();
-  return result;
-}
-
-void CSSTransition::handleChangedProperties(
-    jsi::Runtime &rt,
-    const PropertyValueDiffsMap &propertiesDiffs,
-    const folly::dynamic &lastUpdateValue,
-    const double timestamp) {
-  const auto null = folly::dynamic();
-
-  for (const auto &[propertyName, propertyDiff] : propertiesDiffs) {
-    const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
-
-    if (!allowDiscrete && isDiscreteProperty(propertyName, shadowNode_->getComponentName())) {
-      removeProperty(propertyName);
-      continue;
-    }
-
-    transitionProperties_.insert(propertyName);
-
-    // Update the transition style interpolator
-    bool isReversed;
-    if (lastUpdateValue.count(propertyName)) {
-      // TODO - get rid of lastValue dynamic in the future
-      isReversed = styleInterpolator_.createOrUpdateInterpolator(
-          rt, propertyName, jsi::valueFromDynamic(rt, lastUpdateValue.at(propertyName)), propertyDiff.second);
-    } else {
-      isReversed =
-          styleInterpolator_.createOrUpdateInterpolator(rt, propertyName, propertyDiff.first, propertyDiff.second);
-    }
-
-    // We still pass allowDiscrete to use correct threshold for interpolation between incompatible values
-    // (e.g. when someone passes a keyword and a numeric value - in this case we interpolate them as discrete values)
-    styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
-
-    // Update the transition progress provider
-    progressProvider_.runProgressProvider(propertyName, isReversed, timestamp);
-  }
-}
-
-void CSSTransition::handleChangedProperties(
-    const PropertyValueDynamicDiffsMap &propertiesDiffs,
-    const folly::dynamic &lastUpdateValue,
-    const double timestamp) {
-  for (const auto &[propertyName, propertyDiff] : propertiesDiffs) {
-    const auto allowDiscrete = progressProvider_.getPropertySettings(propertyName).allowDiscrete;
-
-    if (!allowDiscrete && isDiscreteProperty(propertyName, shadowNode_->getComponentName())) {
-      removeProperty(propertyName);
-      continue;
-    }
-
-    transitionProperties_.insert(propertyName);
-
-    bool isReversed;
-    if (lastUpdateValue.count(propertyName)) {
-      isReversed = styleInterpolator_.createOrUpdateInterpolator(
-          propertyName, lastUpdateValue.at(propertyName), propertyDiff.second);
-    } else {
-      isReversed = styleInterpolator_.createOrUpdateInterpolator(propertyName, propertyDiff.first, propertyDiff.second);
-    }
-
-    styleInterpolator_.setAllowDiscrete(propertyName, allowDiscrete);
-
-    progressProvider_.runProgressProvider(propertyName, isReversed, timestamp);
-  }
-}
-
-void CSSTransition::removeProperties(const std::vector<std::string> &propertyNames) {
-  styleInterpolator_.removeProperties(propertyNames);
-  progressProvider_.removeProperties(propertyNames);
-  for (const auto &propertyName : propertyNames) {
-    transitionProperties_.erase(propertyName);
-  }
-}
-
-void CSSTransition::removeProperty(const std::string &propertyName) {
-  styleInterpolator_.removeProperty(propertyName);
-  progressProvider_.removeProperty(propertyName);
-  transitionProperties_.erase(propertyName);
+  return loopTransition_->computeCurrentStyle(shadowNode_);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/CSSTransition.h
@@ -2,9 +2,11 @@
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingFunctions.h>
-#include <reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/progress/TransitionProgressProvider.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
+
+#include <react/renderer/core/ShadowNode.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
@@ -14,7 +16,9 @@
 
 namespace reanimated::css {
 
-class CSSTransition : public OperationsLoop::LoopOperation, public std::enable_shared_from_this<CSSTransition> {
+class CSSLoopTransition;
+
+class CSSTransition {
  public:
   class Observer {
    public:
@@ -39,14 +43,12 @@ class CSSTransition : public OperationsLoop::LoopOperation, public std::enable_s
     return shadowNode_->getFamilyShared();
   }
 
-  TransitionProperties getProperties() const {
-    return transitionProperties_;
-  }
-
+  TransitionProperties getProperties() const;
   double getMinDelay(double timestamp) const;
   TransitionProgressState getState() const;
 
-  bool update(double timestamp, OperationsLoop &loop) override;
+  void schedule(OperationsLoop &loop);
+  void unschedule(OperationsLoop &loop);
 
   folly::dynamic run(
       jsi::Runtime &rt,
@@ -56,7 +58,7 @@ class CSSTransition : public OperationsLoop::LoopOperation, public std::enable_s
   /** TODO: unify folly::dynamic and jsi::value versions */
   folly::dynamic
   run(const PropertyValueDynamicDiffsMap &propertiesDiffs, const folly::dynamic &lastUpdateValue, double timestamp);
-  void updateConfig(
+  void updateSettings(
       const PropertiesSettingsMap &changedPropertiesSettings,
       const std::vector<std::string> &removedProperties);
 
@@ -64,26 +66,7 @@ class CSSTransition : public OperationsLoop::LoopOperation, public std::enable_s
 
  private:
   const std::shared_ptr<const ShadowNode> shadowNode_;
-  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
-
-  Observer &observer_;
-
-  TransitionProperties transitionProperties_;
-  TransitionStyleInterpolator styleInterpolator_;
-  TransitionProgressProvider progressProvider_;
-
-  void handleChangedProperties(
-      jsi::Runtime &rt,
-      const PropertyValueDiffsMap &propertiesDiffs,
-      const folly::dynamic &lastUpdateValue,
-      double timestamp);
-  /** TODO: unify folly::dynamic and jsi::value versions */
-  void handleChangedProperties(
-      const PropertyValueDynamicDiffsMap &propertiesDiffs,
-      const folly::dynamic &lastUpdateValue,
-      double timestamp);
-  void removeProperties(const std::vector<std::string> &propertyNames);
-  void removeProperty(const std::string &propertyName);
+  const std::shared_ptr<CSSLoopTransition> loopTransition_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -34,7 +34,7 @@ void CSSTransitionsRegistry::updateConfigOrRun(
   const auto &transition = registry_.at(viewTag);
 
   if (config.changedPropertiesSettings.size() || config.removedProperties.size()) {
-    transition->updateConfig(config.changedPropertiesSettings, config.removedProperties);
+    transition->updateSettings(config.changedPropertiesSettings, config.removedProperties);
   }
   if (config.changedProperties.size()) {
     runTransition(rt, transition, viewTag, config.changedProperties);
@@ -64,7 +64,7 @@ void CSSTransitionsRegistry::run(
 
   auto initialUpdate = transition->run(propertyDiffs, lastUpdates, timestamp);
 
-  loop_->schedule(transition, timestamp + transition->getMinDelay(timestamp));
+  transition->schedule(*loop_);
 
   updateInUpdatesRegistry(transition, initialUpdate);
   updatedTags_.insert(viewTag);
@@ -124,7 +124,7 @@ void CSSTransitionsRegistry::TransitionObserver::onTransitionUpdate(const Tag vi
 void CSSTransitionsRegistry::removeTag(const Tag viewTag) {
   const auto it = registry_.find(viewTag);
   if (it != registry_.end()) {
-    loop_->remove(it->second);
+    it->second->unschedule(*loop_);
   }
   removeFromUpdatesRegistry(viewTag);
   registry_.erase(viewTag);
@@ -165,7 +165,7 @@ void CSSTransitionsRegistry::runTransition(
 
   auto initialUpdate = transition->run(rt, propertyDiffs, lastUpdates, timestamp);
 
-  loop_->schedule(transition, timestamp + transition->getMinDelay(timestamp));
+  transition->schedule(*loop_);
   updateInUpdatesRegistry(transition, initialUpdate);
   updatedTags_.insert(viewTag);
 }


### PR DESCRIPTION
This PR adds abstraction for reanimated-updated CSS properties in CSS animations. I will add a separate `CSSPlatformAnimation` for platform-updated properties in the future.