### PR TITLE
chore(Worklets): removed stackDetails from bundleMode

### DIFF
--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
@@ -4,7 +4,6 @@ exports[`babel plugin in bundleMode nested worklets extracts each nested worklet
 
 exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 2`] = `
 "export default (function testJs2Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const testJs2 = function () {
     const bar = require("react-native-worklets/.worklets/11336869676092.js").default({});
     return bar();
@@ -12,7 +11,6 @@ exports[`babel plugin in bundleMode nested worklets extracts each nested worklet
   testJs2.__closure = {};
   testJs2.__workletHash = 3455030333622;
   testJs2.__pluginVersion = "x.y.z";
-  testJs2.__stackDetails = _e;
   return testJs2;
 });"
 `;
@@ -30,7 +28,6 @@ exports[`babel plugin in bundleMode source replacement still captures closure ev
 "export default (function foo_testJs1Factory({
   x
 }) {
-  const _e = [new global.Error(), -2, -27];
   const foo = function () {
     return x;
   };
@@ -39,7 +36,6 @@ exports[`babel plugin in bundleMode source replacement still captures closure ev
   };
   foo.__workletHash = 16036484462760;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;
@@ -48,14 +44,24 @@ exports[`babel plugin in bundleMode worklet file emission does not emit init dat
 
 exports[`babel plugin in bundleMode worklet file emission does not emit init data 2`] = `
 "export default (function foo_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const foo = function () {
     var x = 1;
   };
   foo.__closure = {};
   foo.__workletHash = 10408705723983;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
+  return foo;
+});"
+`;
+
+exports[`babel plugin in bundleMode worklet file emission does not emit stack-trace machinery 1`] = `
+"export default (function foo_testJs1Factory({}) {
+  const foo = function () {
+    var x = 1;
+  };
+  foo.__closure = {};
+  foo.__workletHash = 10408705723983;
+  foo.__pluginVersion = "x.y.z";
   return foo;
 });"
 `;
@@ -74,7 +80,6 @@ exports[`babel plugin in bundleMode worklet file emission forwards closure varia
   a,
   b
 }) {
-  const _e = [new global.Error(), -3, -27];
   const foo = function () {
     return a + b;
   };
@@ -84,7 +89,6 @@ exports[`babel plugin in bundleMode worklet file emission forwards closure varia
   };
   foo.__workletHash = 227435842223;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;
@@ -97,21 +101,18 @@ const bar = require("react-native-worklets/.worklets/3872906538980.js").default(
 exports[`babel plugin in bundleMode worklet file emission preserves workletizable library imports in the written worklet file 2`] = `
 "import { foo } from "some-library";
 export default (function bar_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const bar = function () {
     return foo();
   };
   bar.__closure = {};
   bar.__workletHash = 3872906538980;
   bar.__pluginVersion = "x.y.z";
-  bar.__stackDetails = _e;
   return bar;
 });"
 `;
 
 exports[`babel plugin in bundleMode worklet file emission written file content has factory shape 1`] = `
 "export default (function foo_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const foo = function () {
     var x = 1;
     return x;
@@ -119,7 +120,6 @@ exports[`babel plugin in bundleMode worklet file emission written file content h
   foo.__closure = {};
   foo.__workletHash = 4225216281158;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;

--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin-shared.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin-shared.test.ts.snap
@@ -9,14 +9,12 @@ function Box() {
 
 exports[`babel plugin core (bundle mode) autoworkletization workletizes useAnimatedStyle callback 2`] = `
 "export default (function testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const testJs1 = () => ({
     width: 100
   });
   testJs1.__closure = {};
   testJs1.__workletHash = 1509422450054;
   testJs1.__pluginVersion = "x.y.z";
-  testJs1.__stackDetails = _e;
   return testJs1;
 });"
 `;
@@ -25,7 +23,6 @@ exports[`babel plugin core (bundle mode) closure handling captures locally bound
 "export default (function f_testJs1Factory({
   console
 }) {
-  const _e = [new global.Error(), -2, -27];
   const f = function () {
     console.log(console);
   };
@@ -34,7 +31,6 @@ exports[`babel plugin core (bundle mode) closure handling captures locally bound
   };
   f.__workletHash = 5363195507870;
   f.__pluginVersion = "x.y.z";
-  f.__stackDetails = _e;
   return f;
 });"
 `;
@@ -44,7 +40,6 @@ exports[`babel plugin core (bundle mode) closure handling captures multiple clos
   a,
   b
 }) {
-  const _e = [new global.Error(), -3, -27];
   const foo = function () {
     return a + b;
   };
@@ -54,14 +49,12 @@ exports[`babel plugin core (bundle mode) closure handling captures multiple clos
   };
   foo.__workletHash = 227435842223;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;
 
 exports[`babel plugin core (bundle mode) closure handling does not capture default globals 1`] = `
 "export default (function f_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const f = function () {
     console.log('hi');
     return Math.random();
@@ -69,7 +62,6 @@ exports[`babel plugin core (bundle mode) closure handling does not capture defau
   f.__closure = {};
   f.__workletHash = 12892866902550;
   f.__pluginVersion = "x.y.z";
-  f.__stackDetails = _e;
   return f;
 });"
 `;
@@ -84,14 +76,12 @@ exports[`babel plugin core (bundle mode) worklet shapes workletizes ArrowFunctio
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes ArrowFunctionExpression 2`] = `
 "export default (function testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const testJs1 = function (x) {
     return x + 2;
   };
   testJs1.__closure = {};
   testJs1.__workletHash = 919891681460;
   testJs1.__pluginVersion = "x.y.z";
-  testJs1.__stackDetails = _e;
   return testJs1;
 });"
 `;
@@ -100,14 +90,12 @@ exports[`babel plugin core (bundle mode) worklet shapes workletizes FunctionDecl
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes FunctionDeclaration 2`] = `
 "export default (function foo_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const foo = function (x) {
     return x + 2;
   };
   foo.__closure = {};
   foo.__workletHash = 11633341088429;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;
@@ -120,14 +108,12 @@ exports[`babel plugin core (bundle mode) worklet shapes workletizes ObjectMethod
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes ObjectMethod 2`] = `
 "export default (function bar_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const bar = function (x) {
     return x + 2;
   };
   bar.__closure = {};
   bar.__workletHash = 12638252513242;
   bar.__pluginVersion = "x.y.z";
-  bar.__stackDetails = _e;
   return bar;
 });"
 `;
@@ -136,14 +122,12 @@ exports[`babel plugin core (bundle mode) worklet shapes workletizes named Functi
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes named FunctionExpression 2`] = `
 "export default (function foo_testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const foo = function (x) {
     return x + 2;
   };
   foo.__closure = {};
   foo.__workletHash = 11633341088429;
   foo.__pluginVersion = "x.y.z";
-  foo.__stackDetails = _e;
   return foo;
 });"
 `;
@@ -152,14 +136,12 @@ exports[`babel plugin core (bundle mode) worklet shapes workletizes unnamed Func
 
 exports[`babel plugin core (bundle mode) worklet shapes workletizes unnamed FunctionExpression 2`] = `
 "export default (function testJs1Factory({}) {
-  const _e = [new global.Error(), 1, -27];
   const testJs1 = function (x) {
     return x + 2;
   };
   testJs1.__closure = {};
   testJs1.__workletHash = 919891681460;
   testJs1.__pluginVersion = "x.y.z";
-  testJs1.__stackDetails = _e;
   return testJs1;
 });"
 `;

--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -152,6 +152,20 @@ describe('babel plugin in bundleMode', () => {
       expect(files[0].content).toMatchSnapshot();
     });
 
+    test('does not emit stack-trace machinery', () => {
+      const input = html`<script>
+        function foo() {
+          'worklet';
+          var x = 1;
+        }
+      </script>`;
+
+      const { files } = runPlugin(input);
+      expect(files).toHaveLength(1);
+      expect(files[0].content).not.toContain('__stackDetails');
+      expect(files[0].content).toMatchSnapshot();
+    });
+
     test('forwards closure variables from source to factory', () => {
       const input = html`<script>
         const a = 1;

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1003,7 +1003,7 @@ var require_workletFactory = __commonJS({
       if (shouldIncludeInitData && !state.opts.bundleMode) {
         statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__initData"), false), (0, types_12.cloneNode)(initDataId, true))));
       }
-      if (!(0, utils_1.isRelease)()) {
+      if (!(0, utils_1.isRelease)() && !state.opts.bundleMode) {
         statements.unshift((0, types_12.variableDeclaration)("const", [
           (0, types_12.variableDeclarator)((0, types_12.identifier)("_e"), (0, types_12.arrayExpression)([
             (0, types_12.newExpression)((0, types_12.memberExpression)((0, types_12.identifier)("global"), (0, types_12.identifier)("Error")), []),

--- a/packages/react-native-worklets/plugin/src/workletFactory.ts
+++ b/packages/react-native-worklets/plugin/src/workletFactory.ts
@@ -305,7 +305,7 @@ export function makeWorkletFactory(
     );
   }
 
-  if (!isRelease()) {
+  if (!isRelease() && !state.opts.bundleMode) {
     statements.unshift(
       variableDeclaration('const', [
         variableDeclarator(


### PR DESCRIPTION
## Summary
In bundle mode, we do not use __stackDetails, this PR makes sure they are not created and not passed if bundle mode is on

## Test plan

Run test
