### PR TITLE
release(Worklets): 0.8.3

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2119,7 +2119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.8.2):
+  - RNWorklets (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2141,10 +2141,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.2)
-    - RNWorklets/common (= 0.8.2)
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
     - Yoga
-  - RNWorklets/apple (0.8.2):
+  - RNWorklets/apple (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2167,7 +2167,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.2):
+  - RNWorklets/common (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,7 +2538,7 @@ SPEC CHECKSUMS:
   RNReanimated: c2e7905ab97eb558cfe8e7f49f657559449af983
   RNScreens: 6ddda03d6564ca1dbde5754fe8effa9ac2cdb091
   RNSVG: f21bef0d41b6495cdd8db5cb010b18bee378152c
-  RNWorklets: d54c6d519fb66df068fd4c007ed55b4d0639a194
+  RNWorklets: 197a512ab672a43929d76b465933e512320953c4
   Yoga: 1bf7ba0aa6156e76d0f34c1de341508d40855f9f
 
 PODFILE CHECKSUM: 5a5e231e2fd86b91c7e0a93852f5aa6de886161f

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -2574,7 +2574,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.8.2):
+  - RNWorklets (0.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2601,11 +2601,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/apple (= 0.8.2)
-    - RNWorklets/common (= 0.8.2)
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
     - SocketRocket
     - Yoga
-  - RNWorklets/apple (0.8.2):
+  - RNWorklets/apple (0.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2634,7 +2634,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets/common (0.8.2):
+  - RNWorklets/common (0.8.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2988,7 +2988,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
   RNReanimated: 33ab00806793c9df450b0b0b57d1e431009f6aba
   RNSVG: c4d5a438a1c96f7ed7dc66349a5b7e97616fd701
-  RNWorklets: 02303cc91d5094b577353796dce5a693cfd0b9c1
+  RNWorklets: 013e5998e8a6dee29c74b9889c50412e30117c47
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 4e7825418aa0a50bdaa8dff6d3e5fa8a2994d308
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1855,7 +1855,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNWorklets (0.8.2):
+  - RNWorklets (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1876,10 +1876,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.8.2)
-    - RNWorklets/common (= 0.8.2)
+    - RNWorklets/apple (= 0.8.3)
+    - RNWorklets/common (= 0.8.3)
     - Yoga
-  - RNWorklets/apple (0.8.2):
+  - RNWorklets/apple (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,7 +1901,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.8.2):
+  - RNWorklets/common (0.8.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2230,7 +2230,7 @@ SPEC CHECKSUMS:
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
   ReactNativeDependencies: 34b8489e3e615d820fea42d70f086b9420ca4470
   RNReanimated: 0982f8bb04a5dde110fd7f57f0c97bc80e48983a
-  RNWorklets: 1aaf8e3cda78eab3cab7ea2505c630a45bb05291
+  RNWorklets: 7dd324cf6d0148b73f32d6407e005ee75abf0af6
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699

--- a/packages/react-native-worklets/createNPMPackage.sh
+++ b/packages/react-native-worklets/createNPMPackage.sh
@@ -8,8 +8,6 @@ if [ $# -ge 1 ]; then
   fi
 fi
 
-yarn build
-
 npm pack
 
 if [ $# -ge 1 ]; then

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-worklets",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "The React Native multithreading library",
   "keywords": [
     "react-native",
@@ -30,6 +30,7 @@
     "lint:clang-tidy": "find Common -iname \"*.h\" -o -iname \"*.cpp\" | xargs ../../scripts/clang-tidy-lint.sh",
     "lint:js": "eslint src && yarn prettier --check src",
     "lint:plugin": "yarn workspace babel-plugin-worklets lint",
+    "prepack": "yarn build",
     "set-version": "node scripts/set-version.js",
     "test": "jest",
     "type:check": "yarn type:check:src:native && yarn type:check:src:web && yarn type:check:plugin && yarn type:check:app && yarn type:check:tests",

--- a/packages/react-native-worklets/src/debug/jsVersion.ts
+++ b/packages/react-native-worklets/src/debug/jsVersion.ts
@@ -5,4 +5,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '0.8.2';
+export const jsVersion = '0.8.3';


### PR DESCRIPTION
## Summary

Due to a bug in integration with OIDC we didn't emit types for `react-native-worklets` (missing `lib` directory).

## Test plan

Lib is going to be packed this time https://github.com/software-mansion/react-native-reanimated/actions/runs/25324549320/job/74241809701#step:4:1022
