### PR TITLE
feat: Add short-circuit for `scheduleOnUI` called from the UI thread on Android

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 0bf017423677ea0a7fa5f0eeb4c645d763c161e9
+  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: ba658ec8b6949a2459c5c405dec57fb1114252e4
+  React-Core-prebuilt: 3f3b29d3397ee033fc3082bd43d8287ceae3b4d9
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: a16bbb800f19fe01b8ad0525eb17a0f0879153fd
+  ReactNativeDependencies: 8866d6164a71eae10eb7477a6f7a30589a1b6194
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -1,5 +1,7 @@
 #include <worklets/android/AndroidUIScheduler.h>
 
+#include <pthread.h>
+#include <atomic>
 #include <utility>
 
 namespace worklets {
@@ -10,17 +12,32 @@ using namespace react;
 class UISchedulerWrapper : public UIScheduler {
  private:
   jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler_;
+  std::atomic<pthread_t> uiThreadId_{0};
+
+  bool isOnUIThread() const {
+    const auto cached = uiThreadId_.load(std::memory_order_acquire);
+    return cached != 0 && pthread_equal(pthread_self(), cached);
+  }
 
  public:
   explicit UISchedulerWrapper(jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler)
       : androidUiScheduler_(std::move(androidUiScheduler)) {}
 
   void scheduleOnUI(std::function<void()> job) override {
+    if (isOnUIThread()) {
+      job();
+      return;
+    }
     UIScheduler::scheduleOnUI(job);
     if (!scheduledOnUI_) {
       scheduledOnUI_ = true;
       androidUiScheduler_->cthis()->scheduleTriggerOnUI();
     }
+  }
+
+  void triggerUI() override {
+    uiThreadId_.store(pthread_self(), std::memory_order_release);
+    UIScheduler::triggerUI();
   }
 };
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -1,7 +1,5 @@
 #include <worklets/android/AndroidUIScheduler.h>
 
-#include <pthread.h>
-#include <atomic>
 #include <utility>
 
 namespace worklets {
@@ -9,22 +7,18 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
+static thread_local bool tls_isOnUIThread = false;
+
 class UISchedulerWrapper : public UIScheduler {
  private:
   jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler_;
-  std::atomic<pthread_t> uiThreadId_{0};
-
-  bool isOnUIThread() const {
-    const auto cached = uiThreadId_.load(std::memory_order_acquire);
-    return cached != 0 && pthread_equal(pthread_self(), cached);
-  }
 
  public:
   explicit UISchedulerWrapper(jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler)
       : androidUiScheduler_(std::move(androidUiScheduler)) {}
 
   void scheduleOnUI(std::function<void()> job) override {
-    if (isOnUIThread()) {
+    if (tls_isOnUIThread) {
       job();
       return;
     }
@@ -36,7 +30,7 @@ class UISchedulerWrapper : public UIScheduler {
   }
 
   void triggerUI() override {
-    uiThreadId_.store(pthread_self(), std::memory_order_release);
+    tls_isOnUIThread = true;
     UIScheduler::triggerUI();
   }
 };


### PR DESCRIPTION
## Summary

On Android, `UISchedulerWrapper::scheduleOnUI` always posts back through `scheduleTriggerOnUI` (a JNI round-trip), even when the caller is already on the UI thread. This PR caches the UI thread's `pthread_t` the first time `triggerUI()` runs and runs the job inline in `scheduleOnUI` when the calling thread matches.
