### PR TITLE
fix: OIDC releases not including type declarations

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 7cddd6384caaf534391b284de589eb1f50b44b53
+  hermes-engine: 0bf017423677ea0a7fa5f0eeb4c645d763c161e9
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 9e02bf2f3ad3cbdbaf97c91f2d7ccdd9a70b567d
+  React-Core-prebuilt: ba658ec8b6949a2459c5c405dec57fb1114252e4
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: 0c2292b29428efe15f533cd077dff04634587714
+  ReactNativeDependencies: a16bbb800f19fe01b8ad0525eb17a0f0879153fd
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "cd ios && bundle install && bundle exec pod update",
+    "build": "cd ios && bundle install && bundle exec pod update --no-repo-update",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "macos": "react-native run-macos",
-    "build": "cd macos && bundle install && bundle exec pod update",
+    "build": "cd macos && bundle install && bundle exec pod update --no-repo-update",
     "format": "prettier --write --list-different .",
     "lint": "eslint . --max-warnings 0",
     "start": "react-native start",

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2158,7 +2158,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: a3651a4af13997df8df1bcd5af1cc7507d51dc7b
-  hermes-engine: c8ac0852a68f3a5dc189a250e6419fd54a1a1123
+  hermes-engine: 21a27a020253d73ec0a50005a2d146e1b7ba70ed
   RCTDeprecation: e1d3de84bd12761f1a42ae433c805c84ce3e1447
   RCTRequired: 5f75a4215a8c9551b303a95b0394968ae7490f18
   RCTSwiftUI: 6cfd2a6b1506648cd96493d252069bd1b49bdea4
@@ -2167,7 +2167,7 @@ SPEC CHECKSUMS:
   React: b785d635f91eb1df402a0dbc0305546f139c8048
   React-callinvoker: 3e490bb38efd7cef31c17154d33d3cc294db880b
   React-Core: 35963efb0dff21849c40f81fd73d46f636de9d56
-  React-Core-prebuilt: d7fa74265477b493b4419b3f181186bca0ab1009
+  React-Core-prebuilt: 56f76ee5e223326cefe6309861ba27c1174071f4
   React-CoreModules: 3dd7061935350ba9bd5c2d3e7dbf52cdb5ebb47b
   React-cxxreact: ed404f7277d9558a63eb9991d09100a4362d33fa
   React-debug: a26fb9a83e45de87601236175f68e3f3b92ab8ac
@@ -2228,7 +2228,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 51e6ac892436c657aa7dfe118942aeacda08179f
   ReactCodegen: 3862d3679a3064814550db04f7a5366833d65eea
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
-  ReactNativeDependencies: 484aa199feec0e58e2791e8fb9065b20a0ca8691
+  ReactNativeDependencies: 34b8489e3e615d820fea42d70f086b9420ca4470
   RNReanimated: 0b9638ce585d4dd6a1d4fd6215ab373ce8ca0f71
   RNWorklets: aabc37be2f0398ce6355ee99957cd12e21db0dd7
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "cd ios && bundle install && bundle exec pod update",
+    "build": "cd ios && bundle install && bundle exec pod update --no-repo-update",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint . --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "private": true,
   "scripts": {
     "build": "husky && yarn build-packages",
-    "build-packages": "yarn workspace react-native-reanimated build",
     "build-all": "husky && yarn workspaces foreach --all --parallel --topological-dev run build",
+    "build-apps": "yarn workspaces foreach --all --parallel --topological-dev --include '{common-app,*-example}' run build",
+    "build-docs": "yarn workspaces foreach --all --parallel --topological-dev --include 'docs-*' run build",
+    "build-packages": "yarn workspace react-native-reanimated build",
     "format": "yarn format:root && yarn format:workspaces",
     "format:root": "prettier --cache --write --list-different --ignore-path .gitignore --ignore-path .prettierignore --ignore-path .prettiereslintignore .",
     "format:md": "remark --output --ext md . && remark --rc-path .remarkrc.mdx.mjs --output --ext mdx .",

--- a/packages/react-native-reanimated/createNPMPackage.sh
+++ b/packages/react-native-reanimated/createNPMPackage.sh
@@ -8,8 +8,6 @@ if [ $# -ge 1 ]; then
   fi
 fi
 
-yarn build
-
 npm pack
 
 if [ $# -ge 1 ]; then

--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -35,6 +35,7 @@
     "type:check:strict:src": "yarn tsc --noEmit --customConditions react-native-strict-api",
     "type:check:strict:app": "yarn workspace common-app type:check:strict",
     "build": "yarn workspace react-native-worklets build && yarn set-version && bob build",
+    "prepack": "yarn build",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "tree-shake:check:web": "yarn is-tree-shakable --resolution web",
     "validate-includes": "bash ./scripts/validate-worklets-includes.sh",

--- a/packages/react-native-worklets/createNPMPackage.sh
+++ b/packages/react-native-worklets/createNPMPackage.sh
@@ -8,8 +8,6 @@ if [ $# -ge 1 ]; then
   fi
 fi
 
-yarn build
-
 npm pack
 
 if [ $# -ge 1 ]; then

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -29,6 +29,7 @@
     "lint:clang-tidy": "../../scripts/clang-tidy-lint.sh \".\"",
     "lint:js": "eslint src && yarn prettier --check src",
     "lint:plugin": "yarn workspace babel-plugin-worklets lint",
+    "prepack": "yarn build",
     "set-version": "node scripts/set-version.js",
     "test": "jest",
     "type:check": "yarn type:check:src:native && yarn type:check:src:web && yarn type:check:plugin && yarn type:check:app && yarn type:check:tests",


### PR DESCRIPTION
## Summary

Adding `prepack` scripts to `react-native-worklets` and `react-native-reanimated` package so `build` would be actually triggered when publishing package with the OIDC action and the types would be included.

I also added a few QoL changes to build scripts in general.

## Test plan

With this change Worklets 0.8.3 were published with proper types.
