### PR TITLE
Remove legacy CDP debugger setup via `HermesExecutorRuntimeAdapter`

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeInitialization.md
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeInitialization.md
@@ -64,23 +64,6 @@ We run jest tests in release mode, because source maps will contain absolute
 paths, which will be different on every machine and therefore would also alter
 worklet hashes. Running in release mode prevents this.
 
-2. Enable debugging on the runtime object
-
-This is done by creating an adapter (`HermesExecutorRuntimeAdapter` inside of
-`WorkletHermesRuntime.cpp`) which holds the runtime and allows the debugger
-to communicate with it. The adapter is managed by a `Connection` (`ConnectionDemux`)
-object, but this is not important in our case. We just have to make a call
-to `facebook::hermes::inspector::chrome::enableDebugging()` and pass the adapter
-and runtime name as parameters.
-
-It is important to also `disableDebugging()` before the runtime is destroyed.
-Failing to do so will probably crash the app as the debugger will try to
-connect to a non-existent runtime.
-
-The runtime should also be destroyed before the Reanimated module, because
-otherwise there might be weird BAD\_ACCESS errors when the gc gets it
-hand on the runtime.
-
 ## Metro endpoint
 
 Flipper and Chrome DevTools in general use the `localhost:8081/json` (where `8081`

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.cpp
@@ -16,57 +16,12 @@ namespace worklets {
 
 using namespace facebook;
 using namespace react;
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-using namespace facebook::hermes::inspector_modern;
-#endif // HERMES_ENABLE_DEBUGGER  && !defined(HERMES_V1_ENABLED)
-
-#if HERMES_ENABLE_DEBUGGER
-
-class HermesExecutorRuntimeAdapter
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-    : public RuntimeAdapter
-#endif // HERMES_ENABLE_DEBUGGER  && !defined(HERMES_V1_ENABLED)
-{
- public:
-  explicit HermesExecutorRuntimeAdapter(
-      facebook::hermes::HermesRuntime &hermesRuntime,
-      const std::shared_ptr<MessageQueueThread> &thread)
-      : hermesRuntime_(hermesRuntime), thread_(thread) {}
-
-  virtual ~HermesExecutorRuntimeAdapter() {
-    // This is required by iOS, because there is an assertion in the destructor
-    // that the thread was indeed `quit` before
-    thread_->quitSynchronous();
-  }
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-  facebook::hermes::HermesRuntime &getRuntime() override {
-    return hermesRuntime_;
-  }
-
-  // This is not empty in the original implementation, but we decided to tickle
-  // the runtime by running a small piece of code on every frame as using this
-  // required us to hold a refernce to the runtime inside this adapter which
-  // caused issues while reloading the app.
-  void tickleJs() override {}
-#endif // HERMES_ENABLE_DEBUGGER  && !defined(HERMES_V1_ENABLED)
-
- public:
-  facebook::hermes::HermesRuntime &hermesRuntime_;
-  std::shared_ptr<MessageQueueThread> thread_;
-};
-
-#endif // HERMES_ENABLE_DEBUGGER
 
 WorkletHermesRuntime::WorkletHermesRuntime(
     std::unique_ptr<facebook::hermes::HermesRuntime> runtime,
     const std::shared_ptr<MessageQueueThread> &jsQueue,
     const std::string &name)
     : jsi::WithRuntimeDecorator<WorkletsReentrancyCheck>(*runtime, reentrancyCheck_), runtime_(std::move(runtime)) {
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-  auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(*runtime_, jsQueue);
-  debugToken_ = chrome::enableDebugging(std::move(adapter), name);
-#endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-
 #ifndef NDEBUG
   facebook::hermes::HermesRuntime *wrappedRuntime = runtime_.get();
   jsi::Value evalWithSourceMap = jsi::Function::createFromHostFunction(
@@ -90,12 +45,7 @@ WorkletHermesRuntime::WorkletHermesRuntime(
 #endif // NDEBUG
 }
 
-WorkletHermesRuntime::~WorkletHermesRuntime() {
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-  // We have to disable debugging before the runtime is destroyed.
-  chrome::disableDebugging(debugToken_);
-#endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-}
+WorkletHermesRuntime::~WorkletHermesRuntime() = default;
 
 } // namespace worklets
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletHermesRuntime.h
@@ -17,17 +17,10 @@
 #include <string>
 #include <thread>
 
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-#include <hermes/inspector-modern/chrome/Registration.h>
-#endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-
 namespace worklets {
 
 using namespace facebook;
 using namespace react;
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-using namespace facebook::hermes::inspector_modern;
-#endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
 
 // ReentrancyCheck is copied from React Native
 // from ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -114,9 +107,6 @@ class WorkletHermesRuntime : public jsi::WithRuntimeDecorator<WorkletsReentrancy
  private:
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime_;
   WorkletsReentrancyCheck reentrancyCheck_;
-#if HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
-  chrome::DebugSessionToken debugToken_;
-#endif // HERMES_ENABLE_DEBUGGER && !defined(HERMES_V1_ENABLED)
 };
 
 } // namespace worklets


### PR DESCRIPTION
## Summary

This PR removes the setup for legacy CDP Hermes debugger because it no longer works as expected and also it is known to cause problems with Network inspection panel on certain configurations:
* https://github.com/react-native-community/discussions-and-proposals/discussions/954#discussioncomment-16707157

Instead, we're migrating to the modern CDP inspector:
* https://github.com/software-mansion/react-native-reanimated/pull/9199

## Test plan
