### PR TITLE
chore(Reanimated): remove maybeRequestRender dead code

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -159,7 +159,6 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
       return;
     }
 
-    strongThis->renderRequested_ = false;
     strongThis->onRender(timestampMs);
   };
   onRenderCallback_ = std::move(onRenderCallback);
@@ -395,12 +394,6 @@ void ReanimatedModuleProxy::setShouldAnimateExiting(
 
 bool ReanimatedModuleProxy::isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag) {
   return eventHandlerRegistry_->isAnyHandlerWaitingForEvent(eventName, emitterReactTag);
-}
-
-void ReanimatedModuleProxy::maybeRequestRender() {
-  if (!renderRequested_.exchange(true)) {
-    requestRender_(onRenderCallback_);
-  }
 }
 
 void ReanimatedModuleProxy::onRender(double timestampMs) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -84,8 +84,6 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   bool isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag);
 
-  void maybeRequestRender();
-
   bool
   handleEvent(const std::string &eventName, const int emitterReactTag, const jsi::Value &payload, double currentTime);
 
@@ -180,7 +178,6 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   std::unique_ptr<UIEventHandlerRegistry> eventHandlerRegistry_;
   const RequestRenderFunction requestRender_;
-  std::atomic<bool> renderRequested_{false};
   std::function<void(const double)> onRenderCallback_;
   AnimatedSensorModule animatedSensorModule_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;


### PR DESCRIPTION
## Summary

In #9308 I fixed atomicity of `renderRequest_` but it turns out it's not used anymore and can be removed.

## Test plan

<img width="305" height="345" alt="Screenshot 2026-05-07 at 15 35 44" src="https://github.com/user-attachments/assets/6cf3b106-d647-4b1f-9ec5-430763d17740" />

