### PR TITLE
cherry-pick(Reanimated): Attempt to fix `EXC_BAD_ACCESS` in `ReanimatedModuleProxy::performOperations` during `AnimationFrameBatchinator::flush` (#9308)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -203,7 +203,10 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
         if (!surfaceId) {
           return;
         }
-        strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
+        {
+          std::lock_guard<std::mutex> lock(strongThis->flushRequestsMutex_);
+          strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
+        }
       };
 
   auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double) {
@@ -223,8 +226,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
 
     auto surfaceId = strongThis->layoutAnimationsProxy_->endLayoutAnimation(tag, shouldRemove);
 
-    if (!strongThis->layoutAnimationRenderRequested_) {
-      strongThis->layoutAnimationRenderRequested_ = true;
+    if (!strongThis->layoutAnimationRenderRequested_.exchange(true)) {
       // if an animation has duration 0, performOperations would not get
       // called for it so we call requestRender to have it called in the
       // next frame
@@ -234,6 +236,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
     if (!surfaceId) {
       return;
     }
+    std::lock_guard<std::mutex> lock(strongThis->flushRequestsMutex_);
     strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
   };
 
@@ -386,8 +389,7 @@ bool ReanimatedModuleProxy::isAnyHandlerWaitingForEvent(const std::string &event
 }
 
 void ReanimatedModuleProxy::maybeRequestRender() {
-  if (!renderRequested_) {
-    renderRequested_ = true;
+  if (!renderRequested_.exchange(true)) {
     requestRender_(onRenderCallback_);
   }
 }
@@ -668,7 +670,11 @@ double ReanimatedModuleProxy::getCssTimestamp() {
 void ReanimatedModuleProxy::performOperations() {
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performOperations");
 
-  auto flushRequestsCopy = std::move(layoutAnimationFlushRequests_);
+  std::set<SurfaceId> flushRequestsCopy;
+  {
+    std::lock_guard<std::mutex> lock(flushRequestsMutex_);
+    flushRequestsCopy.swap(layoutAnimationFlushRequests_);
+  }
   for (const auto surfaceId : flushRequestsCopy) {
     uiManager_->getShadowTreeRegistry().visit(
         surfaceId, [](const ShadowTree &shadowTree) { shadowTree.notifyDelegatesOfUpdates(); });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -158,7 +158,6 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
       return;
     }
 
-    strongThis->renderRequested_ = false;
     strongThis->onRender(timestampMs);
   };
   onRenderCallback_ = std::move(onRenderCallback);
@@ -386,12 +385,6 @@ void ReanimatedModuleProxy::setShouldAnimateExiting(
 
 bool ReanimatedModuleProxy::isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag) {
   return eventHandlerRegistry_->isAnyHandlerWaitingForEvent(eventName, emitterReactTag);
-}
-
-void ReanimatedModuleProxy::maybeRequestRender() {
-  if (!renderRequested_.exchange(true)) {
-    requestRender_(onRenderCallback_);
-  }
 }
 
 void ReanimatedModuleProxy::onRender(double timestampMs) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -26,7 +26,9 @@
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 #include <reanimated/Tools/SingleInstanceChecker.h>
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <utility>
@@ -181,7 +183,7 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
 
   std::unique_ptr<UIEventHandlerRegistry> eventHandlerRegistry_;
   const RequestRenderFunction requestRender_;
-  volatile bool renderRequested_{false};
+  std::atomic<bool> renderRequested_{false};
   std::function<void(const double)> onRenderCallback_;
   AnimatedSensorModule animatedSensorModule_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
@@ -208,8 +210,9 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
+  std::mutex flushRequestsMutex_;
   std::set<SurfaceId> layoutAnimationFlushRequests_;
-  bool layoutAnimationRenderRequested_;
+  std::atomic<bool> layoutAnimationRenderRequested_{false};
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -82,8 +82,6 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
 
   bool isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag);
 
-  void maybeRequestRender();
-
   bool
   handleEvent(const std::string &eventName, const int emitterReactTag, const jsi::Value &payload, double currentTime);
 
@@ -183,7 +181,6 @@ class ReanimatedModuleProxy : public ReanimatedModuleProxySpec,
 
   std::unique_ptr<UIEventHandlerRegistry> eventHandlerRegistry_;
   const RequestRenderFunction requestRender_;
-  std::atomic<bool> renderRequested_{false};
   std::function<void(const double)> onRenderCallback_;
   AnimatedSensorModule animatedSensorModule_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;


### PR DESCRIPTION
## Summary

Cherry-picking:
	- #9308 

and follow-up:
	- #9357
