### PR TITLE
Remove linking `ReactAndroid::hermestooling` prefab

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -223,7 +223,6 @@ android {
                 "**/libjsi.so",
                 "**/libhermes.so",
                 "**/libhermesvm.so",
-                "**/libhermestooling.so",
                 "**/libreactnative.so",
                 "**/libjscexecutor.so",
                 "**/libworklets.so",

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -104,8 +104,6 @@ if(${JS_RUNTIME} STREQUAL "hermes")
 
   if(${HERMES_ENABLE_DEBUGGER})
     string(APPEND CMAKE_CXX_FLAGS " -DHERMES_ENABLE_DEBUGGER=1")
-
-    target_link_libraries(worklets ReactAndroid::hermestooling)
   endif()
 elseif(${JS_RUNTIME} STREQUAL "jsc")
   target_link_libraries(worklets ReactAndroid::jsctooling)

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -274,7 +274,6 @@ android {
                 "**/libjsi.so",
                 "**/libhermes.so",
                 "**/libhermesvm.so",
-                "**/libhermestooling.so",
                 "**/libreactnative.so",
                 "**/libjscexecutor.so",
             )


### PR DESCRIPTION
## Summary

This PR removes linking against `ReactAndroid::hermestooling` prefab which is unused now.

## Test plan
