### PR TITLE
fix(Reanimated): remove unnecessary locks

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -203,6 +203,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
   };
   ProgressLayoutAnimationFunction progressLayoutAnimation =
       [weakThis = weak_from_this()](jsi::Runtime &rt, int tag, const jsi::Object &newStyle) {
+        // Always on UI thread.
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
@@ -211,10 +212,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
         if (!surfaceId) {
           return;
         }
-        {
-          std::lock_guard<std::mutex> lock(strongThis->flushRequestsMutex_);
-          strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
-        }
+        strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
       };
 
   auto requestLayoutAnimationRender = [weakThis = weak_from_this()](double) {
@@ -227,6 +225,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
 
   EndLayoutAnimationFunction endLayoutAnimation = [weakThis = weak_from_this(), requestLayoutAnimationRender](
                                                       int tag, bool shouldRemove) {
+    // Always on UI thread.
     auto strongThis = weakThis.lock();
     if (!strongThis) {
       return;
@@ -234,17 +233,17 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
 
     auto surfaceId = strongThis->layoutAnimationsProxy_->endLayoutAnimation(tag, shouldRemove);
 
-    if (!strongThis->layoutAnimationRenderRequested_.exchange(true)) {
+    if (!strongThis->layoutAnimationRenderRequested_) {
       // if an animation has duration 0, performOperations would not get
       // called for it so we call requestRender to have it called in the
       // next frame
+      strongThis->layoutAnimationRenderRequested_ = true;
       strongThis->requestRender_(requestLayoutAnimationRender);
     }
 
     if (!surfaceId) {
       return;
     }
-    std::lock_guard<std::mutex> lock(strongThis->flushRequestsMutex_);
     strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
   };
 
@@ -621,13 +620,10 @@ bool ReanimatedModuleProxy::handleRawEvent(const RawEvent &rawEvent, double curr
 }
 
 void ReanimatedModuleProxy::performOperations() {
+  // Always on UI thread.
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performOperations");
 
-  std::set<SurfaceId> flushRequestsCopy;
-  {
-    std::lock_guard<std::mutex> lock(flushRequestsMutex_);
-    flushRequestsCopy.swap(layoutAnimationFlushRequests_);
-  }
+  std::set<SurfaceId> flushRequestsCopy = std::move(layoutAnimationFlushRequests_);
   for (const auto surfaceId : flushRequestsCopy) {
     uiManager_->getShadowTreeRegistry().visit(
         surfaceId, [](const ShadowTree &shadowTree) { shadowTree.notifyDelegatesOfUpdates(); });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -202,9 +202,10 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
-  std::mutex flushRequestsMutex_;
+  /// Access only on UI thread.
   std::set<SurfaceId> layoutAnimationFlushRequests_;
-  std::atomic<bool> layoutAnimationRenderRequested_{false};
+  /// Access only on UI thread.
+  bool layoutAnimationRenderRequested_;
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;


### PR DESCRIPTION
## Summary

Removing locks introduced in #9308 - after discussion with @bartlomiejbloniarz we assessed that the guarded resources were only used on the UI thread.

I'm also adding some comments so we wouldn't fall into this pitfall again.

## Test plan

🚀 
