### PR TITLE
Remove special handling of react-native-tvos in podspecs

### DIFF
--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1794,6 +1794,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -1819,6 +1820,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -1842,6 +1844,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -1865,6 +1868,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -1889,6 +1893,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -1911,6 +1916,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -2229,8 +2235,8 @@ SPEC CHECKSUMS:
   ReactCodegen: 3862d3679a3064814550db04f7a5366833d65eea
   ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
   ReactNativeDependencies: cc895992cbb09b34af5cc6040d846145a3dac87a
-  RNReanimated: 19be16245d6121538ce5c68d4c43daf26be72a7b
-  RNWorklets: 0f8aedfa30b21cd2796326c7edd3efdf59f58b1d
+  RNReanimated: c849e25c0b42196a1f78215707187543e050b7d0
+  RNWorklets: c200bd4689ef719889e6fe299926ce74bc534407
   Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699

--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -89,7 +89,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-jsi'
   using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
-  if using_hermes && !$config[:is_tvos_target]
+  if using_hermes
     s.dependency 'React-hermes'
   end
 end

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -10,7 +10,6 @@ def find_config()
   result = {
     :is_reanimated_example_app => nil,
     :react_native_version => nil,
-    :is_tvos_target => nil,
     :react_native_node_modules_dir => nil,
     :react_native_common_dir => nil,
   }
@@ -35,7 +34,6 @@ def find_config()
 
 
   result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
-  result[:is_tvos_target] = react_native_json['name'] == 'react-native-tvos'
   result[:react_native_version] = react_native_json['version']
   result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
 

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-jsi'
   using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
-  if using_hermes && !$worklets_config[:is_tvos_target]
+  if using_hermes
     s.dependency 'React-hermes'
   end
   

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -11,7 +11,6 @@ def worklets_find_config()
     :feature_flags_flag => nil,
     :fetch_preview_flag => nil,
     :is_reanimated_example_app => nil,
-    :is_tvos_target => nil,
     :react_native_version => nil,
     :react_native_node_modules_dir => nil,
     :react_native_common_dir => nil,
@@ -31,7 +30,6 @@ def worklets_find_config()
   end
 
   result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
-  result[:is_tvos_target] = react_native_json['name'] == 'react-native-tvos'
   result[:react_native_version] = react_native_json['version']
   result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
 


### PR DESCRIPTION
## Summary

This PR removes `&& !$config[:is_tvos_target]` from the condition for adding `React-hermes` dependency as well as removes `config[:is_tvos_target]` which is now unused.

## Test plan
