### PR TITLE
Add missing `@DoNotStrip` annotations

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/AnimationFrameCallback.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/AnimationFrameCallback.kt
@@ -13,6 +13,5 @@ class AnimationFrameCallback : NodesManager.OnAnimationFrame {
         mHybridData = hybridData
     }
 
-    @DoNotStrip
     external override fun onAnimationFrame(timestampMs: Double)
 }

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameCallback.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/runloop/AnimationFrameCallback.kt
@@ -3,6 +3,7 @@ package com.swmansion.worklets.runloop
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 
+@DoNotStrip
 @Suppress("KotlinJniMissingFunction")
 class AnimationFrameCallback
     @DoNotStrip

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletRuntimeWrapper.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletRuntimeWrapper.kt
@@ -5,6 +5,7 @@ import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableNativeArray
 
+@DoNotStrip
 @Suppress("KotlinJniMissingFunction")
 class WorkletRuntimeWrapper
     @DoNotStrip

--- a/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/networking/com/swmansion/worklets/WorkletsModule.kt
@@ -99,6 +99,7 @@ class WorkletsModule(
         return true
     }
 
+    @DoNotStrip
     fun abortRequest(
         runtimeId: Int,
         requestIdAsDouble: Double,
@@ -106,10 +107,12 @@ class WorkletsModule(
         mWorkletsNetworking.jsiAbortRequest(runtimeId, requestIdAsDouble)
     }
 
+    @DoNotStrip
     fun clearCookies(callback: Callback) {
         mWorkletsNetworking.jsiClearCookies(callback)
     }
 
+    @DoNotStrip
     fun sendRequest(
         runtimeWrapper: WorkletRuntimeWrapper,
         method: String,
@@ -136,6 +139,7 @@ class WorkletsModule(
         )
     }
 
+    @DoNotStrip
     fun requestAnimationFrame(animationFrameCallback: AnimationFrameCallback) {
         mAnimationFrameQueue.requestAnimationFrame(animationFrameCallback)
     }

--- a/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
+++ b/packages/react-native-worklets/android/src/no-networking/com/swmansion/worklets/WorkletsModule.kt
@@ -95,6 +95,7 @@ class WorkletsModule(
         return true
     }
 
+    @DoNotStrip
     fun requestAnimationFrame(animationFrameCallback: AnimationFrameCallback) {
         mAnimationFrameQueue.requestAnimationFrame(animationFrameCallback)
     }


### PR DESCRIPTION
## Summary

This PR audits the Android JNI surface and reconciles `@DoNotStrip` annotations with the actual set of methods/fields/constructors crossing the C++→Kotlin boundary. Adds missing annotations, removes one redundant annotation, and fixes two consistency gaps in the worklets package.

While the package-wide `-keep class com.swmansion.{reanimated,worklets}.** { *; }` rules in `proguard-rules.pro` already preserve everything functionally, the annotations document JNI coupling and provide defense-in-depth if a downstream app or future cleanup tightens the ProGuard config.

## Changes

### Added `@DoNotStrip` on JNI-callable methods that were missing it

These Kotlin methods are invoked from C++ via `getMethod<...>` in `WorkletsModule.cpp` but were not annotated:

- `WorkletsModule.kt` (networking variant): `abortRequest`, `clearCookies`, `sendRequest`, `requestAnimationFrame`
- `WorkletsModule.kt` (no-networking variant): `requestAnimationFrame`

`abortRequest`/`clearCookies`/`sendRequest` are guarded by `WORKLETS_FETCH_PREVIEW_ENABLED` on the C++ side, which is why only the networking variant needs them. `requestAnimationFrame` is called unconditionally and needs the annotation in both variants.

### Added class-level `@DoNotStrip` to two HybridClass JNI bridges

These classes are instantiated from C++ via `newObjectCxxArgs` and looked up by their fully-qualified name (`kJavaDescriptor`). Their reanimated counterparts (`AnimationFrameCallback`, `SensorSetter`, `EventHandler`, `KeyboardWorkletWrapper`) all carry class-level `@DoNotStrip`; these two were the inconsistent outliers:

- `worklets/runloop/AnimationFrameCallback.kt`
- `WorkletRuntimeWrapper.kt`

### Removed one redundant `@DoNotStrip`

`nativeProxy/AnimationFrameCallback.kt`: dropped `@DoNotStrip` from `external override fun onAnimationFrame`. R8 preserves `native` methods of kept classes by default, and every other `external fun` across our HybridClass bridges (`SensorSetter.sensorSetter`, `EventHandler.receiveEvent`, `KeyboardWorkletWrapper.invoke`, both worklets `AnimationFrameCallback`s, `WorkletRuntimeWrapper.cxxEmitDeviceEvent`/`cxxGetRuntimeId`) is already unannotated. This was the only outlier.

## Audit result

After this change, every C++→Kotlin JNI access point — 20 method calls plus all `HybridData` field reads and `HybridClass` constructor invocations — has the corresponding `@DoNotStrip`/`@field:DoNotStrip`/`@set:DoNotStrip`, and no annotation is applied to anything that isn't crossing the JNI boundary.

## Test plan

- [ ] Android Debug build of the example app passes
- [ ] Android Release (R8/minified) build passes and the app runs without `NoSuchMethodError`/`NoSuchFieldError` on JNI lookup
- [ ] Networking and no-networking worklets variants both build
