### PR TITLE
chore: Bump RN versions in tvos-example to 0.85.3

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -35,6 +35,7 @@ npmPreapprovedPackages:
   - 'react-native'
   - 'react-native-web'
   - 'react-native-macos'
+  - '@react-native-tvos/*'
   - 'react-native-tvos'
   - 'react-native-reanimated'
   - 'react-native-worklets'

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1,35 +1,35 @@
 PODS:
-  - FBLazyVector (0.84.1-0)
-  - hermes-engine (250829098.0.9):
-    - hermes-engine/Pre-built (= 250829098.0.9)
-  - hermes-engine/Pre-built (250829098.0.9)
-  - RCTDeprecation (0.84.1-0)
-  - RCTRequired (0.84.1-0)
-  - RCTSwiftUI (0.84.1-0)
-  - RCTSwiftUIWrapper (0.84.1-0):
+  - FBLazyVector (0.85.2-0)
+  - hermes-engine (250829098.0.10):
+    - hermes-engine/Pre-built (= 250829098.0.10)
+  - hermes-engine/Pre-built (250829098.0.10)
+  - RCTDeprecation (0.85.2-0)
+  - RCTRequired (0.85.2-0)
+  - RCTSwiftUI (0.85.2-0)
+  - RCTSwiftUIWrapper (0.85.2-0):
     - RCTSwiftUI
-  - RCTTypeSafety (0.84.1-0):
-    - FBLazyVector (= 0.84.1-0)
-    - RCTRequired (= 0.84.1-0)
-    - React-Core (= 0.84.1-0)
-  - React (0.84.1-0):
-    - React-Core (= 0.84.1-0)
-    - React-Core/DevSupport (= 0.84.1-0)
-    - React-Core/RCTWebSocket (= 0.84.1-0)
-    - React-RCTActionSheet (= 0.84.1-0)
-    - React-RCTAnimation (= 0.84.1-0)
-    - React-RCTBlob (= 0.84.1-0)
-    - React-RCTImage (= 0.84.1-0)
-    - React-RCTLinking (= 0.84.1-0)
-    - React-RCTNetwork (= 0.84.1-0)
-    - React-RCTSettings (= 0.84.1-0)
-    - React-RCTText (= 0.84.1-0)
-  - React-callinvoker (0.84.1-0)
-  - React-Core (0.84.1-0):
+  - RCTTypeSafety (0.85.2-0):
+    - FBLazyVector (= 0.85.2-0)
+    - RCTRequired (= 0.85.2-0)
+    - React-Core (= 0.85.2-0)
+  - React (0.85.2-0):
+    - React-Core (= 0.85.2-0)
+    - React-Core/DevSupport (= 0.85.2-0)
+    - React-Core/RCTWebSocket (= 0.85.2-0)
+    - React-RCTActionSheet (= 0.85.2-0)
+    - React-RCTAnimation (= 0.85.2-0)
+    - React-RCTBlob (= 0.85.2-0)
+    - React-RCTImage (= 0.85.2-0)
+    - React-RCTLinking (= 0.85.2-0)
+    - React-RCTNetwork (= 0.85.2-0)
+    - React-RCTSettings (= 0.85.2-0)
+    - React-RCTText (= 0.85.2-0)
+  - React-callinvoker (0.85.2-0)
+  - React-Core (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.84.1-0)
+    - React-Core/Default (= 0.85.2-0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -44,66 +44,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.84.1-0):
+  - React-Core-prebuilt (0.85.2-0):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.84.1-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.84.1-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.84.1-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.84.1-0)
-    - React-Core/RCTWebSocket (= 0.84.1-0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.84.1-0):
+  - React-Core/CoreModulesHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -122,7 +65,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.84.1-0):
+  - React-Core/Default (0.85.2-0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.85.2-0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.85.2-0)
+    - React-Core/RCTWebSocket (= 0.85.2-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -141,7 +122,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.84.1-0):
+  - React-Core/RCTAnimationHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -160,7 +141,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.84.1-0):
+  - React-Core/RCTBlobHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -179,7 +160,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.84.1-0):
+  - React-Core/RCTImageHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -198,7 +179,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.84.1-0):
+  - React-Core/RCTLinkingHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -217,7 +198,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.84.1-0):
+  - React-Core/RCTNetworkHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -236,7 +217,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.84.1-0):
+  - React-Core/RCTSettingsHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -255,7 +236,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.84.1-0):
+  - React-Core/RCTTextHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -274,11 +255,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.84.1-0):
+  - React-Core/RCTVibrationHeaders (0.85.2-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.84.1-0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -293,43 +274,63 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.84.1-0):
-    - RCTTypeSafety (= 0.84.1-0)
+  - React-Core/RCTWebSocket (0.85.2-0):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.84.1-0)
+    - React-Core/Default (= 0.85.2-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.85.2-0):
+    - RCTTypeSafety (= 0.85.2-0)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.85.2-0)
     - React-debug
-    - React-jsi (= 0.84.1-0)
+    - React-jsi (= 0.85.2-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.84.1-0)
+    - React-RCTImage (= 0.85.2-0)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.84.1-0):
+  - React-cxxreact (0.85.2-0):
     - hermes-engine
-    - React-callinvoker (= 0.84.1-0)
+    - React-callinvoker (= 0.85.2-0)
     - React-Core-prebuilt
-    - React-debug (= 0.84.1-0)
-    - React-jsi (= 0.84.1-0)
+    - React-debug (= 0.85.2-0)
+    - React-jsi (= 0.85.2-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.84.1-0)
-    - React-perflogger (= 0.84.1-0)
+    - React-logger (= 0.85.2-0)
+    - React-perflogger (= 0.85.2-0)
     - React-runtimeexecutor
-    - React-timing (= 0.84.1-0)
+    - React-timing (= 0.85.2-0)
     - React-utils
     - ReactNativeDependencies
-  - React-debug (0.84.1-0)
-  - React-defaultsnativemodule (0.84.1-0):
+  - React-debug (0.85.2-0)
+  - React-defaultsnativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
+    - React-Fabric/animated
     - React-featureflags
     - React-featureflagsnativemodule
     - React-idlecallbacksnativemodule
@@ -341,7 +342,7 @@ PODS:
     - React-webperformancenativemodule
     - ReactNativeDependencies
     - Yoga
-  - React-domnativemodule (0.84.1-0):
+  - React-domnativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -355,7 +356,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.84.1-0):
+  - React-Fabric (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -363,25 +364,24 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.84.1-0)
-    - React-Fabric/animationbackend (= 0.84.1-0)
-    - React-Fabric/animations (= 0.84.1-0)
-    - React-Fabric/attributedstring (= 0.84.1-0)
-    - React-Fabric/bridging (= 0.84.1-0)
-    - React-Fabric/componentregistry (= 0.84.1-0)
-    - React-Fabric/componentregistrynative (= 0.84.1-0)
-    - React-Fabric/components (= 0.84.1-0)
-    - React-Fabric/consistency (= 0.84.1-0)
-    - React-Fabric/core (= 0.84.1-0)
-    - React-Fabric/dom (= 0.84.1-0)
-    - React-Fabric/imagemanager (= 0.84.1-0)
-    - React-Fabric/leakchecker (= 0.84.1-0)
-    - React-Fabric/mounting (= 0.84.1-0)
-    - React-Fabric/observers (= 0.84.1-0)
-    - React-Fabric/scheduler (= 0.84.1-0)
-    - React-Fabric/telemetry (= 0.84.1-0)
-    - React-Fabric/templateprocessor (= 0.84.1-0)
-    - React-Fabric/uimanager (= 0.84.1-0)
+    - React-Fabric/animated (= 0.85.2-0)
+    - React-Fabric/animationbackend (= 0.85.2-0)
+    - React-Fabric/animations (= 0.85.2-0)
+    - React-Fabric/attributedstring (= 0.85.2-0)
+    - React-Fabric/bridging (= 0.85.2-0)
+    - React-Fabric/componentregistry (= 0.85.2-0)
+    - React-Fabric/componentregistrynative (= 0.85.2-0)
+    - React-Fabric/components (= 0.85.2-0)
+    - React-Fabric/consistency (= 0.85.2-0)
+    - React-Fabric/core (= 0.85.2-0)
+    - React-Fabric/dom (= 0.85.2-0)
+    - React-Fabric/imagemanager (= 0.85.2-0)
+    - React-Fabric/leakchecker (= 0.85.2-0)
+    - React-Fabric/mounting (= 0.85.2-0)
+    - React-Fabric/observers (= 0.85.2-0)
+    - React-Fabric/scheduler (= 0.85.2-0)
+    - React-Fabric/telemetry (= 0.85.2-0)
+    - React-Fabric/uimanager (= 0.85.2-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -393,7 +393,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animated (0.84.1-0):
+  - React-Fabric/animated (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -401,6 +401,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
+    - React-Fabric/animationbackend
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -412,26 +413,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animationbackend (0.84.1-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/animations (0.84.1-0):
+  - React-Fabric/animationbackend (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -450,7 +432,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.84.1-0):
+  - React-Fabric/animations (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -469,7 +451,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.84.1-0):
+  - React-Fabric/attributedstring (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -488,7 +470,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.84.1-0):
+  - React-Fabric/bridging (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -507,7 +489,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.84.1-0):
+  - React-Fabric/componentregistry (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -526,30 +508,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.84.1-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.84.1-0)
-    - React-Fabric/components/root (= 0.84.1-0)
-    - React-Fabric/components/scrollview (= 0.84.1-0)
-    - React-Fabric/components/view (= 0.84.1-0)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.84.1-0):
+  - React-Fabric/componentregistrynative (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -568,7 +527,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.84.1-0):
+  - React-Fabric/components (0.85.2-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.85.2-0)
+    - React-Fabric/components/root (= 0.85.2-0)
+    - React-Fabric/components/scrollview (= 0.85.2-0)
+    - React-Fabric/components/view (= 0.85.2-0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -587,7 +569,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.84.1-0):
+  - React-Fabric/components/root (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -606,7 +588,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.84.1-0):
+  - React-Fabric/components/scrollview (0.85.2-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -627,7 +628,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.84.1-0):
+  - React-Fabric/consistency (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -646,7 +647,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.84.1-0):
+  - React-Fabric/core (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -665,7 +666,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.84.1-0):
+  - React-Fabric/dom (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -684,7 +685,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.84.1-0):
+  - React-Fabric/imagemanager (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -703,7 +704,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.84.1-0):
+  - React-Fabric/leakchecker (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -722,7 +723,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.84.1-0):
+  - React-Fabric/mounting (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -741,7 +742,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.84.1-0):
+  - React-Fabric/observers (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -749,8 +750,8 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.84.1-0)
-    - React-Fabric/observers/intersection (= 0.84.1-0)
+    - React-Fabric/observers/events (= 0.85.2-0)
+    - React-Fabric/observers/intersection (= 0.85.2-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -762,26 +763,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.84.1-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/observers/intersection (0.84.1-0):
+  - React-Fabric/observers/events (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -800,7 +782,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.84.1-0):
+  - React-Fabric/observers/intersection (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -808,6 +790,26 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/scheduler (0.85.2-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/animationbackend
     - React-Fabric/observers/events
     - React-featureflags
     - React-graphics
@@ -822,7 +824,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.84.1-0):
+  - React-Fabric/telemetry (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -841,7 +843,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.84.1-0):
+  - React-Fabric/uimanager (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -849,26 +851,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/uimanager (0.84.1-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/uimanager/consistency (= 0.84.1-0)
+    - React-Fabric/uimanager/consistency (= 0.85.2-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -881,7 +864,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.84.1-0):
+  - React-Fabric/uimanager/consistency (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -901,7 +884,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.84.1-0):
+  - React-FabricComponents (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -910,8 +893,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.84.1-0)
-    - React-FabricComponents/textlayoutmanager (= 0.84.1-0)
+    - React-FabricComponents/components (= 0.85.2-0)
+    - React-FabricComponents/textlayoutmanager (= 0.85.2-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -924,7 +907,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.84.1-0):
+  - React-FabricComponents/components (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -933,18 +916,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.84.1-0)
-    - React-FabricComponents/components/iostextinput (= 0.84.1-0)
-    - React-FabricComponents/components/modal (= 0.84.1-0)
-    - React-FabricComponents/components/rncore (= 0.84.1-0)
-    - React-FabricComponents/components/safeareaview (= 0.84.1-0)
-    - React-FabricComponents/components/scrollview (= 0.84.1-0)
-    - React-FabricComponents/components/switch (= 0.84.1-0)
-    - React-FabricComponents/components/text (= 0.84.1-0)
-    - React-FabricComponents/components/textinput (= 0.84.1-0)
-    - React-FabricComponents/components/unimplementedview (= 0.84.1-0)
-    - React-FabricComponents/components/virtualview (= 0.84.1-0)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.84.1-0)
+    - React-FabricComponents/components/inputaccessory (= 0.85.2-0)
+    - React-FabricComponents/components/iostextinput (= 0.85.2-0)
+    - React-FabricComponents/components/modal (= 0.85.2-0)
+    - React-FabricComponents/components/rncore (= 0.85.2-0)
+    - React-FabricComponents/components/safeareaview (= 0.85.2-0)
+    - React-FabricComponents/components/scrollview (= 0.85.2-0)
+    - React-FabricComponents/components/switch (= 0.85.2-0)
+    - React-FabricComponents/components/text (= 0.85.2-0)
+    - React-FabricComponents/components/textinput (= 0.85.2-0)
+    - React-FabricComponents/components/unimplementedview (= 0.85.2-0)
+    - React-FabricComponents/components/virtualview (= 0.85.2-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -957,28 +939,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.84.1-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.84.1-0):
+  - React-FabricComponents/components/inputaccessory (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -999,7 +960,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.84.1-0):
+  - React-FabricComponents/components/iostextinput (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1020,7 +981,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.84.1-0):
+  - React-FabricComponents/components/modal (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1041,7 +1002,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.84.1-0):
+  - React-FabricComponents/components/rncore (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1062,7 +1023,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.84.1-0):
+  - React-FabricComponents/components/safeareaview (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1083,7 +1044,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.84.1-0):
+  - React-FabricComponents/components/scrollview (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1104,7 +1065,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.84.1-0):
+  - React-FabricComponents/components/switch (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1125,7 +1086,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.84.1-0):
+  - React-FabricComponents/components/text (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1146,7 +1107,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.84.1-0):
+  - React-FabricComponents/components/textinput (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1167,7 +1128,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.84.1-0):
+  - React-FabricComponents/components/unimplementedview (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1188,7 +1149,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.84.1-0):
+  - React-FabricComponents/components/virtualview (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1209,7 +1170,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.84.1-0):
+  - React-FabricComponents/textlayoutmanager (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1230,27 +1191,27 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.84.1-0):
+  - React-FabricImage (0.85.2-0):
     - hermes-engine
-    - RCTRequired (= 0.84.1-0)
-    - RCTTypeSafety (= 0.84.1-0)
+    - RCTRequired (= 0.85.2-0)
+    - RCTTypeSafety (= 0.85.2-0)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.84.1-0)
+    - React-jsiexecutor (= 0.85.2-0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.84.1-0):
+  - React-featureflags (0.85.2-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.84.1-0):
+  - React-featureflagsnativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1259,28 +1220,29 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.84.1-0):
+  - React-graphics (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
+    - React-featureflags
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.84.1-0):
+  - React-hermes (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.84.1-0)
+    - React-cxxreact (= 0.85.2-0)
     - React-jsi
-    - React-jsiexecutor (= 0.84.1-0)
+    - React-jsiexecutor (= 0.85.2-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-jsitooling
     - React-oscompat
-    - React-perflogger (= 0.84.1-0)
+    - React-perflogger (= 0.85.2-0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.84.1-0):
+  - React-idlecallbacksnativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1290,7 +1252,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.84.1-0):
+  - React-ImageManager (0.85.2-0):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1299,7 +1261,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-intersectionobservernativemodule (0.84.1-0):
+  - React-intersectionobservernativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1314,7 +1276,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-jserrorhandler (0.84.1-0):
+  - React-jserrorhandler (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1323,11 +1285,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.84.1-0):
+  - React-jsi (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.84.1-0):
+  - React-jsiexecutor (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1342,7 +1304,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspector (0.84.1-0):
+  - React-jsinspector (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1351,18 +1313,18 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.84.1-0)
+    - React-perflogger (= 0.85.2-0)
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.84.1-0):
+  - React-jsinspectorcdp (0.85.2-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.84.1-0):
+  - React-jsinspectornetwork (0.85.2-0):
     - React-Core-prebuilt
     - React-jsinspectorcdp
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.84.1-0):
+  - React-jsinspectortracing (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1370,28 +1332,28 @@ PODS:
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.84.1-0):
+  - React-jsitooling (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.84.1-0)
+    - React-cxxreact (= 0.85.2-0)
     - React-debug
-    - React-jsi (= 0.84.1-0)
+    - React-jsi (= 0.85.2-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsitracing (0.84.1-0):
+  - React-jsitracing (0.85.2-0):
     - React-jsi
-  - React-logger (0.84.1-0):
+  - React-logger (0.85.2-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.84.1-0):
+  - React-Mapbuffer (0.85.2-0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.84.1-0):
+  - React-microtasksnativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1399,7 +1361,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.84.1-0):
+  - React-NativeModulesApple (0.85.2-0):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1414,18 +1376,18 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-networking (0.84.1-0):
+  - React-networking (0.85.2-0):
     - React-Core-prebuilt
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-oscompat (0.84.1-0)
-  - React-perflogger (0.84.1-0):
+  - React-oscompat (0.85.2-0)
+  - React-perflogger (0.85.2-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.84.1-0):
+  - React-performancecdpmetrics (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1433,7 +1395,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.84.1-0):
+  - React-performancetimeline (0.85.2-0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspector
@@ -1441,9 +1403,9 @@ PODS:
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.84.1-0):
-    - React-Core/RCTActionSheetHeaders (= 0.84.1-0)
-  - React-RCTAnimation (0.84.1-0):
+  - React-RCTActionSheet (0.85.2-0):
+    - React-Core/RCTActionSheetHeaders (= 0.85.2-0)
+  - React-RCTAnimation (0.85.2-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1454,7 +1416,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.84.1-0):
+  - React-RCTAppDelegate (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1482,7 +1444,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.84.1-0):
+  - React-RCTBlob (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1495,7 +1457,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.84.1-0):
+  - React-RCTFabric (0.85.2-0):
     - hermes-engine
     - RCTSwiftUIWrapper
     - React-Core
@@ -1526,7 +1488,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.84.1-0):
+  - React-RCTFBReactNativeSpec (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1534,10 +1496,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.84.1-0)
+    - React-RCTFBReactNativeSpec/components (= 0.85.2-0)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.84.1-0):
+  - React-RCTFBReactNativeSpec/components (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1554,7 +1516,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.84.1-0):
+  - React-RCTImage (0.85.2-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1564,14 +1526,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.84.1-0):
-    - React-Core/RCTLinkingHeaders (= 0.84.1-0)
-    - React-jsi (= 0.84.1-0)
+  - React-RCTLinking (0.85.2-0):
+    - React-Core/RCTLinkingHeaders (= 0.85.2-0)
+    - React-jsi (= 0.85.2-0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.84.1-0)
-  - React-RCTNetwork (0.84.1-0):
+    - ReactCommon/turbomodule/core (= 0.85.2-0)
+  - React-RCTNetwork (0.85.2-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1585,7 +1547,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.84.1-0):
+  - React-RCTRuntime (0.85.2-0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1601,7 +1563,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - ReactNativeDependencies
-  - React-RCTSettings (0.84.1-0):
+  - React-RCTSettings (0.85.2-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1610,10 +1572,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.84.1-0):
-    - React-Core/RCTTextHeaders (= 0.84.1-0)
+  - React-RCTText (0.85.2-0):
+    - React-Core/RCTTextHeaders (= 0.85.2-0)
     - Yoga
-  - React-RCTVibration (0.84.1-0):
+  - React-RCTVibration (0.85.2-0):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1621,15 +1583,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.84.1-0)
-  - React-renderercss (0.84.1-0):
+  - React-rendererconsistency (0.85.2-0)
+  - React-renderercss (0.85.2-0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.84.1-0):
+  - React-rendererdebug (0.85.2-0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.84.1-0):
+  - React-RuntimeApple (0.85.2-0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1652,7 +1614,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.84.1-0):
+  - React-RuntimeCore (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1668,14 +1630,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.84.1-0):
+  - React-runtimeexecutor (0.85.2-0):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.84.1-0)
+    - React-jsi (= 0.85.2-0)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.84.1-0):
+  - React-RuntimeHermes (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1690,7 +1652,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.84.1-0):
+  - React-runtimescheduler (0.85.2-0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1706,15 +1668,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.84.1-0):
+  - React-timing (0.85.2-0):
     - React-debug
-  - React-utils (0.84.1-0):
+  - React-utils (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.84.1-0)
+    - React-jsi (= 0.85.2-0)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.84.1-0):
+  - React-webperformancenativemodule (0.85.2-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1725,9 +1687,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.84.1-0):
+  - ReactAppDependencyProvider (0.85.2-0):
     - ReactCodegen
-  - ReactCodegen (0.84.1-0):
+  - ReactCodegen (0.85.2-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1747,43 +1709,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.84.1-0):
+  - ReactCommon (0.85.2-0):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.84.1-0)
+    - ReactCommon/turbomodule (= 0.85.2-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.84.1-0):
+  - ReactCommon/turbomodule (0.85.2-0):
     - hermes-engine
-    - React-callinvoker (= 0.84.1-0)
+    - React-callinvoker (= 0.85.2-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.84.1-0)
-    - React-jsi (= 0.84.1-0)
-    - React-logger (= 0.84.1-0)
-    - React-perflogger (= 0.84.1-0)
-    - ReactCommon/turbomodule/bridging (= 0.84.1-0)
-    - ReactCommon/turbomodule/core (= 0.84.1-0)
+    - React-cxxreact (= 0.85.2-0)
+    - React-jsi (= 0.85.2-0)
+    - React-logger (= 0.85.2-0)
+    - React-perflogger (= 0.85.2-0)
+    - ReactCommon/turbomodule/bridging (= 0.85.2-0)
+    - ReactCommon/turbomodule/core (= 0.85.2-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.84.1-0):
+  - ReactCommon/turbomodule/bridging (0.85.2-0):
     - hermes-engine
-    - React-callinvoker (= 0.84.1-0)
+    - React-callinvoker (= 0.85.2-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.84.1-0)
-    - React-jsi (= 0.84.1-0)
-    - React-logger (= 0.84.1-0)
-    - React-perflogger (= 0.84.1-0)
+    - React-cxxreact (= 0.85.2-0)
+    - React-jsi (= 0.85.2-0)
+    - React-logger (= 0.85.2-0)
+    - React-perflogger (= 0.85.2-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.84.1-0):
+  - ReactCommon/turbomodule/core (0.85.2-0):
     - hermes-engine
-    - React-callinvoker (= 0.84.1-0)
+    - React-callinvoker (= 0.85.2-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.84.1-0)
-    - React-debug (= 0.84.1-0)
-    - React-featureflags (= 0.84.1-0)
-    - React-jsi (= 0.84.1-0)
-    - React-logger (= 0.84.1-0)
-    - React-perflogger (= 0.84.1-0)
-    - React-utils (= 0.84.1-0)
+    - React-cxxreact (= 0.85.2-0)
+    - React-debug (= 0.85.2-0)
+    - React-featureflags (= 0.85.2-0)
+    - React-jsi (= 0.85.2-0)
+    - React-logger (= 0.85.2-0)
+    - React-perflogger (= 0.85.2-0)
+    - React-utils (= 0.85.2-0)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.84.1)
+  - ReactNativeDependencies (0.85.2)
   - RNReanimated (4.4.0-main):
     - hermes-engine
     - RCTRequired
@@ -2014,7 +1976,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-v250829098.0.9
+    :tag: hermes-v250829098.0.10
   RCTDeprecation:
     :path: "../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
   RCTRequired:
@@ -2163,81 +2125,81 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  FBLazyVector: a3651a4af13997df8df1bcd5af1cc7507d51dc7b
-  hermes-engine: dab5c5ec4e735a4f3f48d84acb5bd64e19d08e39
-  RCTDeprecation: e1d3de84bd12761f1a42ae433c805c84ce3e1447
-  RCTRequired: 5f75a4215a8c9551b303a95b0394968ae7490f18
-  RCTSwiftUI: 6cfd2a6b1506648cd96493d252069bd1b49bdea4
-  RCTSwiftUIWrapper: 43b2ab66e70f43768c147a53a76c7ed8f9b70de5
-  RCTTypeSafety: b8b083a6cb2cdc8d3bd38b4a309d93c98ba72326
-  React: b785d635f91eb1df402a0dbc0305546f139c8048
-  React-callinvoker: 3e490bb38efd7cef31c17154d33d3cc294db880b
-  React-Core: 35963efb0dff21849c40f81fd73d46f636de9d56
-  React-Core-prebuilt: c37a4b72bd70a41a7a8f0e41ac815e41c07ccf63
-  React-CoreModules: 3dd7061935350ba9bd5c2d3e7dbf52cdb5ebb47b
-  React-cxxreact: ed404f7277d9558a63eb9991d09100a4362d33fa
-  React-debug: a26fb9a83e45de87601236175f68e3f3b92ab8ac
-  React-defaultsnativemodule: 703acd1df29542176121ab86f011510955608047
-  React-domnativemodule: 949c919619914ba65b033e9d60a3b92b23fe6d2d
-  React-Fabric: 67820926debc38c990addcb5b303e44df3a7b9ce
-  React-FabricComponents: 4c38b522d4d798faf63b48aaaf172dbf39423cd3
-  React-FabricImage: 67f679fa978861e9365549e648e64c285caf013e
-  React-featureflags: e19f4a52a077ca2f547034cbf8690f87cf5f1053
-  React-featureflagsnativemodule: af1c5b8290fe142b8fe31bb09a14826dc8f6f0df
-  React-graphics: 820dfd969d38d853e0c7c26a29f84973fc549970
-  React-hermes: f798fa872d55eaee17ab70098734d1e7e970da16
-  React-idlecallbacksnativemodule: 3b059d927c36c234217c38d546f6ad7eac11ca3f
-  React-ImageManager: 4cebdb6b11d005a0ad2a52f995b41987df1dabe0
-  React-intersectionobservernativemodule: 71db08a7d6a95e610343b03e742b53adb742232b
-  React-jserrorhandler: e3e7e2507f4d68152c445e69465a03d027e4dcf9
-  React-jsi: acb8a8dc979b563971c52086e817116e039d7f90
-  React-jsiexecutor: 6b664ece202b30f609668c1cd734cf618951732c
-  React-jsinspector: cc1deb69ceac3a505e49220a535d9a76dafdd57b
-  React-jsinspectorcdp: 553148ef6e4ebec6c7a7ed9591f1e30677b03994
-  React-jsinspectornetwork: 7113c50f160f0d56ffe4e56c04a5a637bb4487a4
-  React-jsinspectortracing: 726dff5089e7f016befdc82f2637680d3c063e71
-  React-jsitooling: 8f8e99a5bc116e6df19521d7bb3d79b72068f6ed
-  React-jsitracing: a226cfca27a29d2c35780c7d2ee7ca96a16406ad
-  React-logger: ef59921295e846ff225f75946cc31b99ab128ce5
-  React-Mapbuffer: e297df2c883ccacaedeedbc9ad3e9539dccd78f3
-  React-microtasksnativemodule: 2697edfe09c06340aa1a3edac62adcb12b617c4d
-  React-NativeModulesApple: 4d953905e90a3fb0ae33d6a2a38b4617b4ea0caa
-  React-networking: c54d68d98efc47b3d1bd5e7f949864a6306240bd
-  React-oscompat: 2124e2fc8f45ded3d1f2b2aa4ac913f2e9c0f842
-  React-perflogger: 6cb09b590a9faf2d47725e6a69b58d14ec6da678
-  React-performancecdpmetrics: dae51088609541ef5e51c07a36a0fa857419db65
-  React-performancetimeline: 333bd6ffb766edee0385318cc5fd14c28eea80d3
-  React-RCTActionSheet: e0b4cdcd5958f8adee10da0acf7eb83749c40dcb
-  React-RCTAnimation: 4e1e9185188b82681493a2e104fcc806c2c1bbe3
-  React-RCTAppDelegate: 57601c18736c62cf7a93cf0ccb5236a0b5011f6b
-  React-RCTBlob: 6bc37bedd1bb9785132c73ecfc9bba61bfcb4ac5
-  React-RCTFabric: ba0625aa124c7891eeedf88d93d52b0ba18ac0f7
-  React-RCTFBReactNativeSpec: dc172d91f6a1838ea5ac3b40dc61143a0a44f13a
-  React-RCTImage: 739ccf85e168f12d7ec068855334ddeea26a629d
-  React-RCTLinking: 85402146ed01010540ca24b3385b5c736bc1125c
-  React-RCTNetwork: a7aecc6494cdd371547b88fe02f06a87625faa46
-  React-RCTRuntime: 3d628260c822bb1f7be2012ccf92b4638b6b286e
-  React-RCTSettings: 2245fc29780ec993a03ec2b60370c4d33d40a94a
-  React-RCTText: 58041fae13e883e32380f9cec629d7319bc5fe5b
-  React-RCTVibration: e38ea63c253f23c0e9c4ec95931604a0314d106f
-  React-rendererconsistency: e9a1d9bb73fdf1ea9a93b6aed17ac2391ffd69eb
-  React-renderercss: 7980ac2fd5c4c2daac35237c55f412eb31c0a2ca
-  React-rendererdebug: 298d7eb5ccd754e7f0b1458720e8f35019a0a813
-  React-RuntimeApple: 48ef2e8dd6c102564501768979df101b8ddcc579
-  React-RuntimeCore: 856c17c5e7015dcdf6ff95412d60f9b04c38dec1
-  React-runtimeexecutor: f465af69356be8c78c0b6c89ce318b2452b52b40
-  React-RuntimeHermes: e5353611c7705b29c1a0d6aa170c387cb81debc1
-  React-runtimescheduler: 076bca5eb8205dc92f2f0f3293bd22d20faaf556
-  React-timing: 0c9a9aec17af107c146feea4183aab2a7cce1b81
-  React-utils: 361ec134b4485d7dc88a0b8ad7b6b4219408fd84
-  React-webperformancenativemodule: c145545197f59159999cb3483f43770bbdf7ba23
-  ReactAppDependencyProvider: 51e6ac892436c657aa7dfe118942aeacda08179f
-  ReactCodegen: 3862d3679a3064814550db04f7a5366833d65eea
-  ReactCommon: c315584be8ff201e245f9d8cc4b380154235ef2d
-  ReactNativeDependencies: cc895992cbb09b34af5cc6040d846145a3dac87a
-  RNReanimated: c849e25c0b42196a1f78215707187543e050b7d0
-  RNWorklets: c200bd4689ef719889e6fe299926ce74bc534407
-  Yoga: e2029bb72b7cb951e09aa1ee1316c9f5f28409da
+  FBLazyVector: 1298e5a48100ebce439c698f6c7d88bd884a8cc6
+  hermes-engine: 87822f3169a0820afbe6155fc2a9e700c97d7fd7
+  RCTDeprecation: cc5c5a8ac471917a23e24443ef54ed5027fa38f2
+  RCTRequired: 5042192e05d2377c135ea27faf8124f75761011d
+  RCTSwiftUI: a8ade5a407cedd041f827f0af6ab75207676df1d
+  RCTSwiftUIWrapper: ed52b209d3dfaf7d1cfca5d06dca3abcf81407c0
+  RCTTypeSafety: 585f3f0eecf3d23aa8cc7b6d6a1ac0d6749e0d09
+  React: 31adb0959d01ecb34d3b4df75aeb8c86cc8017b9
+  React-callinvoker: 0ac6beada44d88e34f56ea8984220698f3eed3e0
+  React-Core: e9f38d53509d9a967f190ef78c197ece5d7fe9b7
+  React-Core-prebuilt: 0d4acd0b519927a875214915ddd012307fd2be42
+  React-CoreModules: 0d0e045799993811884133d9d4a69b09f8e53355
+  React-cxxreact: d68cd579f9444ae50fb50cdffecb5fae60af15a3
+  React-debug: 1f5715693c6597d6f066d0b0854d6cc60f42cb6b
+  React-defaultsnativemodule: 7e333f1cea394baf4161f6deafd73a5252117655
+  React-domnativemodule: 0769a620be56b79381366c01f1f11e3757b63f82
+  React-Fabric: 54f99cb1e2ea5488c0ee893d13541c64d68bfd38
+  React-FabricComponents: 5526f48aa0ed7c1ac3954a0d16f6571bd6ed4f6e
+  React-FabricImage: 81c79b77fbdf02a5b505a16811d8d890031aff61
+  React-featureflags: 3f0442d23faf1919d220f029a9feba8cff92769b
+  React-featureflagsnativemodule: c251fe29cbf2406b217655dc51f44a62e70963fa
+  React-graphics: bf56efdc9e3b940c5bab4cfb8e576e68247c2762
+  React-hermes: d9cb77a34e455d67b795a8a098b69b95dc075284
+  React-idlecallbacksnativemodule: a6228591bcc45006ac458f6453f5f0530659b178
+  React-ImageManager: cf649ac123323380c48d63ff25c893600fb6a970
+  React-intersectionobservernativemodule: 604b9bea93393b4aa835c897687f294b7765a5f5
+  React-jserrorhandler: a662316e29936519d69b28630b2c19c780662acb
+  React-jsi: 646bdf173c428ec2191c14fe266f7cafdf0acc95
+  React-jsiexecutor: dd052f63ce5e083832af87f2419beb5a4f302825
+  React-jsinspector: feca34b743f8d80c685e696e7268a2e855e6fbde
+  React-jsinspectorcdp: cc97cc7855bbaa5d37b0d02e0f1a27ca8ab4524d
+  React-jsinspectornetwork: f382e362901d8ca8683b28aadd30957c9a07693b
+  React-jsinspectortracing: d3425f7dac05e26700a64d3125bb3e5eb739ac9a
+  React-jsitooling: 629db8cfceb7ac4964fbb3cc251b8b5343dba4a8
+  React-jsitracing: b5798d14fdc9c27aafa6dacbac3cd2d8b1581032
+  React-logger: c141663d6cf07f3de02e6554f679e00552fb4e27
+  React-Mapbuffer: 0f3d4545af28f467fede3dbe41bfb4d50ddb7f77
+  React-microtasksnativemodule: 7386938a559cb307c850f48572aa7a8466bb7483
+  React-NativeModulesApple: 46d42362b7b9c77313894fe6511cc4af3038b751
+  React-networking: 61889738ce12b264a4053f2327cb9086f7d7e4cc
+  React-oscompat: c645c481d6d7a91f6a01796aefd4b713b47ace3b
+  React-perflogger: 96d35fbaba8f832691ae8cf8e3cdd00ca3f35976
+  React-performancecdpmetrics: 1c1f7fe35bcd6af0c14a9c91aca89e4eeaf7f091
+  React-performancetimeline: d92eed5febe1e7a71628ce4d3d05c0b03468afdb
+  React-RCTActionSheet: 3d35fe3c1fd1fa75059dcb2e49e20a3dce7f2c05
+  React-RCTAnimation: 649e006014417ec02c46451b21b9455623a94abc
+  React-RCTAppDelegate: 40cc950eb1e3a46299f7fe2f02f6218ec1219c67
+  React-RCTBlob: b016c1cdad3db1cec508fc291d68485a369043fc
+  React-RCTFabric: 0b6ebfa91a8a98fbfedd2925a8e5770bb9383c12
+  React-RCTFBReactNativeSpec: d955a1d0b81dae87693ac1ade5b00a991e9b5246
+  React-RCTImage: 880af2f27c676eaec8fba05276701d9d4c11f2b4
+  React-RCTLinking: 16251e94073f7574aeade1d13858d227d037991c
+  React-RCTNetwork: 775bf1f8287c283a3afc1bc148d5013cddd67b51
+  React-RCTRuntime: f60a4911a12674a0a8b894395575565be566a410
+  React-RCTSettings: 4ede22a00cd61ca253959892180fa0238508e74c
+  React-RCTText: 24a0f47a1bf30efc562fefaf418525c267984c3b
+  React-RCTVibration: d743b204cfcdb612dc62a24a5cb965948bd7bac5
+  React-rendererconsistency: 1a4b40b91df588e9545a64303b004fff0cdb1686
+  React-renderercss: dfad1a0621e07f9e13f55c948971c5818cf86e01
+  React-rendererdebug: 7979828bf5e69244a4e88901fd0985f4d79c5f5d
+  React-RuntimeApple: beddd187deed0f7a11690d5b2d463f52fbec5f43
+  React-RuntimeCore: 2c8970270122a95e8014a8e4c87056f544795acd
+  React-runtimeexecutor: 9ccc65a53f0c3c198f6f5bfe37daa27243fc8153
+  React-RuntimeHermes: a89a04c7190b0b0458b0c57876764483a12385ca
+  React-runtimescheduler: 4c344824760e9487678a80b9a93b20f0570d64d8
+  React-timing: 92a94f96039bab851ead246e44633255199ba6a4
+  React-utils: 9299c32104b14a1ec9122a25deca27beff441bef
+  React-webperformancenativemodule: e2d0f92ca8aec2a7dcdea480e986a957b2dc7d08
+  ReactAppDependencyProvider: 89edbd104ab7bfb27facf85cf088f6007fe0fc0e
+  ReactCodegen: da84907e710db854188019052c4bced558ccb053
+  ReactCommon: 1216bd5b81bc7e17ef77902bb6b8780fbb296d0b
+  ReactNativeDependencies: 23430fb78e51509594dcc3ee54ecfd52c692f6e4
+  RNReanimated: 252cb421bd573cd6e6bc3de5b1496f534f361f00
+  RNWorklets: b285ab513ca8a0fbaa7c028d594b4e72c3cae42d
+  Yoga: 7115df1b265f29df3a34d13cc7218770a00e0af7
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699
 

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1,35 +1,35 @@
 PODS:
-  - FBLazyVector (0.85.2-0)
+  - FBLazyVector (0.85.3-0)
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - RCTDeprecation (0.85.2-0)
-  - RCTRequired (0.85.2-0)
-  - RCTSwiftUI (0.85.2-0)
-  - RCTSwiftUIWrapper (0.85.2-0):
+  - RCTDeprecation (0.85.3-0)
+  - RCTRequired (0.85.3-0)
+  - RCTSwiftUI (0.85.3-0)
+  - RCTSwiftUIWrapper (0.85.3-0):
     - RCTSwiftUI
-  - RCTTypeSafety (0.85.2-0):
-    - FBLazyVector (= 0.85.2-0)
-    - RCTRequired (= 0.85.2-0)
-    - React-Core (= 0.85.2-0)
-  - React (0.85.2-0):
-    - React-Core (= 0.85.2-0)
-    - React-Core/DevSupport (= 0.85.2-0)
-    - React-Core/RCTWebSocket (= 0.85.2-0)
-    - React-RCTActionSheet (= 0.85.2-0)
-    - React-RCTAnimation (= 0.85.2-0)
-    - React-RCTBlob (= 0.85.2-0)
-    - React-RCTImage (= 0.85.2-0)
-    - React-RCTLinking (= 0.85.2-0)
-    - React-RCTNetwork (= 0.85.2-0)
-    - React-RCTSettings (= 0.85.2-0)
-    - React-RCTText (= 0.85.2-0)
-  - React-callinvoker (0.85.2-0)
-  - React-Core (0.85.2-0):
+  - RCTTypeSafety (0.85.3-0):
+    - FBLazyVector (= 0.85.3-0)
+    - RCTRequired (= 0.85.3-0)
+    - React-Core (= 0.85.3-0)
+  - React (0.85.3-0):
+    - React-Core (= 0.85.3-0)
+    - React-Core/DevSupport (= 0.85.3-0)
+    - React-Core/RCTWebSocket (= 0.85.3-0)
+    - React-RCTActionSheet (= 0.85.3-0)
+    - React-RCTAnimation (= 0.85.3-0)
+    - React-RCTBlob (= 0.85.3-0)
+    - React-RCTImage (= 0.85.3-0)
+    - React-RCTLinking (= 0.85.3-0)
+    - React-RCTNetwork (= 0.85.3-0)
+    - React-RCTSettings (= 0.85.3-0)
+    - React-RCTText (= 0.85.3-0)
+  - React-callinvoker (0.85.3-0)
+  - React-Core (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.85.2-0)
+    - React-Core/Default (= 0.85.3-0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -44,66 +44,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.85.2-0):
+  - React-Core-prebuilt (0.85.3-0):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.85.2-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.85.2-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.85.2-0):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.85.2-0)
-    - React-Core/RCTWebSocket (= 0.85.2-0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.85.2-0):
+  - React-Core/CoreModulesHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -122,7 +65,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.85.2-0):
+  - React-Core/Default (0.85.3-0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.85.3-0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.85.3-0)
+    - React-Core/RCTWebSocket (= 0.85.3-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -141,7 +122,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.85.2-0):
+  - React-Core/RCTAnimationHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -160,7 +141,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.85.2-0):
+  - React-Core/RCTBlobHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -179,7 +160,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.85.2-0):
+  - React-Core/RCTImageHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -198,7 +179,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.85.2-0):
+  - React-Core/RCTLinkingHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -217,7 +198,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.85.2-0):
+  - React-Core/RCTNetworkHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -236,7 +217,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.85.2-0):
+  - React-Core/RCTSettingsHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -255,7 +236,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.85.2-0):
+  - React-Core/RCTTextHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -274,11 +255,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.85.2-0):
+  - React-Core/RCTVibrationHeaders (0.85.3-0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.85.2-0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -293,40 +274,62 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.85.2-0):
-    - RCTTypeSafety (= 0.85.2-0)
+  - React-Core/RCTWebSocket (0.85.3-0):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.85.2-0)
+    - React-Core/Default (= 0.85.3-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.85.3-0):
+    - RCTTypeSafety (= 0.85.3-0)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.85.3-0)
     - React-debug
-    - React-jsi (= 0.85.2-0)
+    - React-featureflags
+    - React-jsi (= 0.85.3-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.85.2-0)
+    - React-RCTImage (= 0.85.3-0)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.85.2-0):
+  - React-cxxreact (0.85.3-0):
     - hermes-engine
-    - React-callinvoker (= 0.85.2-0)
+    - React-callinvoker (= 0.85.3-0)
     - React-Core-prebuilt
-    - React-debug (= 0.85.2-0)
-    - React-jsi (= 0.85.2-0)
+    - React-debug (= 0.85.3-0)
+    - React-jsi (= 0.85.3-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.85.2-0)
-    - React-perflogger (= 0.85.2-0)
+    - React-logger (= 0.85.3-0)
+    - React-perflogger (= 0.85.3-0)
     - React-runtimeexecutor
-    - React-timing (= 0.85.2-0)
+    - React-timing (= 0.85.3-0)
     - React-utils
     - ReactNativeDependencies
-  - React-debug (0.85.2-0)
-  - React-defaultsnativemodule (0.85.2-0):
+  - React-debug (0.85.3-0):
+    - React-debug/redbox (= 0.85.3-0)
+  - React-debug/redbox (0.85.3-0)
+  - React-defaultsnativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -338,11 +341,12 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-microtasksnativemodule
+    - React-mutationobservernativemodule
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - ReactNativeDependencies
     - Yoga
-  - React-domnativemodule (0.85.2-0):
+  - React-domnativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -356,7 +360,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.85.2-0):
+  - React-Fabric (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -364,24 +368,24 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.85.2-0)
-    - React-Fabric/animationbackend (= 0.85.2-0)
-    - React-Fabric/animations (= 0.85.2-0)
-    - React-Fabric/attributedstring (= 0.85.2-0)
-    - React-Fabric/bridging (= 0.85.2-0)
-    - React-Fabric/componentregistry (= 0.85.2-0)
-    - React-Fabric/componentregistrynative (= 0.85.2-0)
-    - React-Fabric/components (= 0.85.2-0)
-    - React-Fabric/consistency (= 0.85.2-0)
-    - React-Fabric/core (= 0.85.2-0)
-    - React-Fabric/dom (= 0.85.2-0)
-    - React-Fabric/imagemanager (= 0.85.2-0)
-    - React-Fabric/leakchecker (= 0.85.2-0)
-    - React-Fabric/mounting (= 0.85.2-0)
-    - React-Fabric/observers (= 0.85.2-0)
-    - React-Fabric/scheduler (= 0.85.2-0)
-    - React-Fabric/telemetry (= 0.85.2-0)
-    - React-Fabric/uimanager (= 0.85.2-0)
+    - React-Fabric/animated (= 0.85.3-0)
+    - React-Fabric/animationbackend (= 0.85.3-0)
+    - React-Fabric/animations (= 0.85.3-0)
+    - React-Fabric/attributedstring (= 0.85.3-0)
+    - React-Fabric/bridging (= 0.85.3-0)
+    - React-Fabric/componentregistry (= 0.85.3-0)
+    - React-Fabric/componentregistrynative (= 0.85.3-0)
+    - React-Fabric/components (= 0.85.3-0)
+    - React-Fabric/consistency (= 0.85.3-0)
+    - React-Fabric/core (= 0.85.3-0)
+    - React-Fabric/dom (= 0.85.3-0)
+    - React-Fabric/imagemanager (= 0.85.3-0)
+    - React-Fabric/leakchecker (= 0.85.3-0)
+    - React-Fabric/mounting (= 0.85.3-0)
+    - React-Fabric/observers (= 0.85.3-0)
+    - React-Fabric/scheduler (= 0.85.3-0)
+    - React-Fabric/telemetry (= 0.85.3-0)
+    - React-Fabric/uimanager (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -393,7 +397,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animated (0.85.2-0):
+  - React-Fabric/animated (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -413,7 +417,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animationbackend (0.85.2-0):
+  - React-Fabric/animationbackend (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -432,7 +436,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.85.2-0):
+  - React-Fabric/animations (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -451,7 +455,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.85.2-0):
+  - React-Fabric/attributedstring (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -470,7 +474,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.85.2-0):
+  - React-Fabric/bridging (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -489,7 +493,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.85.2-0):
+  - React-Fabric/componentregistry (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -508,7 +512,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.85.2-0):
+  - React-Fabric/componentregistrynative (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -527,7 +531,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.85.2-0):
+  - React-Fabric/components (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -535,10 +539,10 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.85.2-0)
-    - React-Fabric/components/root (= 0.85.2-0)
-    - React-Fabric/components/scrollview (= 0.85.2-0)
-    - React-Fabric/components/view (= 0.85.2-0)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.85.3-0)
+    - React-Fabric/components/root (= 0.85.3-0)
+    - React-Fabric/components/scrollview (= 0.85.3-0)
+    - React-Fabric/components/view (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -550,26 +554,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.85.2-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/root (0.85.2-0):
+  - React-Fabric/components/legacyviewmanagerinterop (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -588,7 +573,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.85.2-0):
+  - React-Fabric/components/root (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -607,7 +592,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.85.2-0):
+  - React-Fabric/components/scrollview (0.85.3-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -628,7 +632,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.85.2-0):
+  - React-Fabric/consistency (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -647,7 +651,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.85.2-0):
+  - React-Fabric/core (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -666,7 +670,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.85.2-0):
+  - React-Fabric/dom (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -685,7 +689,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.85.2-0):
+  - React-Fabric/imagemanager (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -704,7 +708,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.85.2-0):
+  - React-Fabric/leakchecker (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -723,7 +727,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.85.2-0):
+  - React-Fabric/mounting (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -742,7 +746,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.85.2-0):
+  - React-Fabric/observers (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -750,8 +754,9 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.85.2-0)
-    - React-Fabric/observers/intersection (= 0.85.2-0)
+    - React-Fabric/observers/events (= 0.85.3-0)
+    - React-Fabric/observers/intersection (= 0.85.3-0)
+    - React-Fabric/observers/mutation (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -763,26 +768,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.85.2-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/observers/intersection (0.85.2-0):
+  - React-Fabric/observers/events (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -801,7 +787,45 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.85.2-0):
+  - React-Fabric/observers/intersection (0.85.3-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/observers/mutation (0.85.3-0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/scheduler (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -824,7 +848,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.85.2-0):
+  - React-Fabric/telemetry (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -843,7 +867,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.85.2-0):
+  - React-Fabric/uimanager (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -851,7 +875,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.85.2-0)
+    - React-Fabric/uimanager/consistency (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -864,7 +888,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.85.2-0):
+  - React-Fabric/uimanager/consistency (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -884,7 +908,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.85.2-0):
+  - React-FabricComponents (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -893,8 +917,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.85.2-0)
-    - React-FabricComponents/textlayoutmanager (= 0.85.2-0)
+    - React-FabricComponents/components (= 0.85.3-0)
+    - React-FabricComponents/textlayoutmanager (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -907,7 +931,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.85.2-0):
+  - React-FabricComponents/components (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -916,17 +940,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.85.2-0)
-    - React-FabricComponents/components/iostextinput (= 0.85.2-0)
-    - React-FabricComponents/components/modal (= 0.85.2-0)
-    - React-FabricComponents/components/rncore (= 0.85.2-0)
-    - React-FabricComponents/components/safeareaview (= 0.85.2-0)
-    - React-FabricComponents/components/scrollview (= 0.85.2-0)
-    - React-FabricComponents/components/switch (= 0.85.2-0)
-    - React-FabricComponents/components/text (= 0.85.2-0)
-    - React-FabricComponents/components/textinput (= 0.85.2-0)
-    - React-FabricComponents/components/unimplementedview (= 0.85.2-0)
-    - React-FabricComponents/components/virtualview (= 0.85.2-0)
+    - React-FabricComponents/components/inputaccessory (= 0.85.3-0)
+    - React-FabricComponents/components/iostextinput (= 0.85.3-0)
+    - React-FabricComponents/components/modal (= 0.85.3-0)
+    - React-FabricComponents/components/rncore (= 0.85.3-0)
+    - React-FabricComponents/components/safeareaview (= 0.85.3-0)
+    - React-FabricComponents/components/scrollview (= 0.85.3-0)
+    - React-FabricComponents/components/switch (= 0.85.3-0)
+    - React-FabricComponents/components/text (= 0.85.3-0)
+    - React-FabricComponents/components/textinput (= 0.85.3-0)
+    - React-FabricComponents/components/unimplementedview (= 0.85.3-0)
+    - React-FabricComponents/components/virtualview (= 0.85.3-0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -939,28 +963,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.85.2-0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.85.2-0):
+  - React-FabricComponents/components/inputaccessory (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -981,7 +984,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.85.2-0):
+  - React-FabricComponents/components/iostextinput (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1002,7 +1005,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.85.2-0):
+  - React-FabricComponents/components/modal (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1023,7 +1026,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.85.2-0):
+  - React-FabricComponents/components/rncore (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,7 +1047,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.85.2-0):
+  - React-FabricComponents/components/safeareaview (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1065,7 +1068,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.85.2-0):
+  - React-FabricComponents/components/scrollview (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1086,7 +1089,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.85.2-0):
+  - React-FabricComponents/components/switch (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1107,7 +1110,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.85.2-0):
+  - React-FabricComponents/components/text (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1128,7 +1131,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.85.2-0):
+  - React-FabricComponents/components/textinput (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1149,7 +1152,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.85.2-0):
+  - React-FabricComponents/components/unimplementedview (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1170,7 +1173,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.85.2-0):
+  - React-FabricComponents/components/virtualview (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1191,27 +1194,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.85.2-0):
+  - React-FabricComponents/textlayoutmanager (0.85.3-0):
     - hermes-engine
-    - RCTRequired (= 0.85.2-0)
-    - RCTTypeSafety (= 0.85.2-0)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.85.3-0):
+    - hermes-engine
+    - RCTRequired (= 0.85.3-0)
+    - RCTTypeSafety (= 0.85.3-0)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.85.2-0)
+    - React-jsiexecutor (= 0.85.3-0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.85.2-0):
+  - React-featureflags (0.85.3-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.85.2-0):
+  - React-featureflagsnativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1220,7 +1244,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.85.2-0):
+  - React-graphics (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1228,21 +1252,21 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.85.2-0):
+  - React-hermes (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.85.2-0)
+    - React-cxxreact (= 0.85.3-0)
     - React-jsi
-    - React-jsiexecutor (= 0.85.2-0)
+    - React-jsiexecutor (= 0.85.3-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-jsitooling
     - React-oscompat
-    - React-perflogger (= 0.85.2-0)
+    - React-perflogger (= 0.85.3-0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.85.2-0):
+  - React-idlecallbacksnativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1252,7 +1276,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.85.2-0):
+  - React-ImageManager (0.85.3-0):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1261,7 +1285,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-intersectionobservernativemodule (0.85.2-0):
+  - React-intersectionobservernativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1276,7 +1300,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-jserrorhandler (0.85.2-0):
+  - React-jserrorhandler (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1285,11 +1309,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.85.2-0):
+  - React-jsi (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.85.2-0):
+  - React-jsiexecutor (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1304,7 +1328,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspector (0.85.2-0):
+  - React-jsinspector (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1313,47 +1337,48 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.85.2-0)
+    - React-perflogger (= 0.85.3-0)
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.85.2-0):
+  - React-jsinspectorcdp (0.85.3-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.85.2-0):
+  - React-jsinspectornetwork (0.85.3-0):
     - React-Core-prebuilt
     - React-jsinspectorcdp
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.85.2-0):
+  - React-jsinspectortracing (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsinspectornetwork
     - React-oscompat
     - React-timing
+    - React-utils
     - ReactNativeDependencies
-  - React-jsitooling (0.85.2-0):
+  - React-jsitooling (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.85.2-0)
+    - React-cxxreact (= 0.85.3-0)
     - React-debug
-    - React-jsi (= 0.85.2-0)
+    - React-jsi (= 0.85.3-0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsitracing (0.85.2-0):
+  - React-jsitracing (0.85.3-0):
     - React-jsi
-  - React-logger (0.85.2-0):
+  - React-logger (0.85.3-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.85.2-0):
+  - React-Mapbuffer (0.85.3-0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.85.2-0):
+  - React-microtasksnativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1361,7 +1386,22 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.85.2-0):
+  - React-mutationobservernativemodule (0.85.3-0):
+    - hermes-engine
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-Fabric
+    - React-Fabric/bridging
+    - React-Fabric/observers/mutation
+    - React-featureflags
+    - React-jsi
+    - React-jsiexecutor
+    - React-RCTFBReactNativeSpec
+    - React-runtimeexecutor
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-NativeModulesApple (0.85.3-0):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1376,18 +1416,18 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-networking (0.85.2-0):
+  - React-networking (0.85.3-0):
     - React-Core-prebuilt
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-oscompat (0.85.2-0)
-  - React-perflogger (0.85.2-0):
+  - React-oscompat (0.85.3-0)
+  - React-perflogger (0.85.3-0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.85.2-0):
+  - React-performancecdpmetrics (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1395,7 +1435,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.85.2-0):
+  - React-performancetimeline (0.85.3-0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspector
@@ -1403,9 +1443,9 @@ PODS:
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.85.2-0):
-    - React-Core/RCTActionSheetHeaders (= 0.85.2-0)
-  - React-RCTAnimation (0.85.2-0):
+  - React-RCTActionSheet (0.85.3-0):
+    - React-Core/RCTActionSheetHeaders (= 0.85.3-0)
+  - React-RCTAnimation (0.85.3-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1416,7 +1456,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.85.2-0):
+  - React-RCTAppDelegate (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1444,7 +1484,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.85.2-0):
+  - React-RCTBlob (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1457,7 +1497,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.85.2-0):
+  - React-RCTFabric (0.85.3-0):
     - hermes-engine
     - RCTSwiftUIWrapper
     - React-Core
@@ -1488,7 +1528,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.85.2-0):
+  - React-RCTFBReactNativeSpec (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1496,10 +1536,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.85.2-0)
+    - React-RCTFBReactNativeSpec/components (= 0.85.3-0)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.85.2-0):
+  - React-RCTFBReactNativeSpec/components (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1516,7 +1556,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.85.2-0):
+  - React-RCTImage (0.85.3-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1526,14 +1566,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.85.2-0):
-    - React-Core/RCTLinkingHeaders (= 0.85.2-0)
-    - React-jsi (= 0.85.2-0)
+  - React-RCTLinking (0.85.3-0):
+    - React-Core/RCTLinkingHeaders (= 0.85.3-0)
+    - React-jsi (= 0.85.3-0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.85.2-0)
-  - React-RCTNetwork (0.85.2-0):
+    - ReactCommon/turbomodule/core (= 0.85.3-0)
+  - React-RCTNetwork (0.85.3-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1547,7 +1587,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.85.2-0):
+  - React-RCTRuntime (0.85.3-0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1563,7 +1603,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - ReactNativeDependencies
-  - React-RCTSettings (0.85.2-0):
+  - React-RCTSettings (0.85.3-0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1572,10 +1612,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.85.2-0):
-    - React-Core/RCTTextHeaders (= 0.85.2-0)
+  - React-RCTText (0.85.3-0):
+    - React-Core/RCTTextHeaders (= 0.85.3-0)
     - Yoga
-  - React-RCTVibration (0.85.2-0):
+  - React-RCTVibration (0.85.3-0):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1583,15 +1623,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.85.2-0)
-  - React-renderercss (0.85.2-0):
+  - React-rendererconsistency (0.85.3-0)
+  - React-renderercss (0.85.3-0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.85.2-0):
+  - React-rendererdebug (0.85.3-0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.85.2-0):
+  - React-RuntimeApple (0.85.3-0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1614,7 +1654,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.85.2-0):
+  - React-RuntimeCore (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1630,14 +1670,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.85.2-0):
+  - React-runtimeexecutor (0.85.3-0):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.85.2-0)
+    - React-jsi (= 0.85.3-0)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.85.2-0):
+  - React-RuntimeHermes (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1652,7 +1692,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.85.2-0):
+  - React-runtimescheduler (0.85.3-0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1668,15 +1708,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.85.2-0):
+  - React-timing (0.85.3-0):
     - React-debug
-  - React-utils (0.85.2-0):
+  - React-utils (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.85.2-0)
+    - React-jsi (= 0.85.3-0)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.85.2-0):
+  - React-webperformancenativemodule (0.85.3-0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1687,9 +1727,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.85.2-0):
+  - ReactAppDependencyProvider (0.85.3-0):
     - ReactCodegen
-  - ReactCodegen (0.85.2-0):
+  - ReactCodegen (0.85.3-0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1709,43 +1749,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.85.2-0):
+  - ReactCommon (0.85.3-0):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.85.2-0)
+    - ReactCommon/turbomodule (= 0.85.3-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.85.2-0):
+  - ReactCommon/turbomodule (0.85.3-0):
     - hermes-engine
-    - React-callinvoker (= 0.85.2-0)
+    - React-callinvoker (= 0.85.3-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.85.2-0)
-    - React-jsi (= 0.85.2-0)
-    - React-logger (= 0.85.2-0)
-    - React-perflogger (= 0.85.2-0)
-    - ReactCommon/turbomodule/bridging (= 0.85.2-0)
-    - ReactCommon/turbomodule/core (= 0.85.2-0)
+    - React-cxxreact (= 0.85.3-0)
+    - React-jsi (= 0.85.3-0)
+    - React-logger (= 0.85.3-0)
+    - React-perflogger (= 0.85.3-0)
+    - ReactCommon/turbomodule/bridging (= 0.85.3-0)
+    - ReactCommon/turbomodule/core (= 0.85.3-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.85.2-0):
+  - ReactCommon/turbomodule/bridging (0.85.3-0):
     - hermes-engine
-    - React-callinvoker (= 0.85.2-0)
+    - React-callinvoker (= 0.85.3-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.85.2-0)
-    - React-jsi (= 0.85.2-0)
-    - React-logger (= 0.85.2-0)
-    - React-perflogger (= 0.85.2-0)
+    - React-cxxreact (= 0.85.3-0)
+    - React-jsi (= 0.85.3-0)
+    - React-logger (= 0.85.3-0)
+    - React-perflogger (= 0.85.3-0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.85.2-0):
+  - ReactCommon/turbomodule/core (0.85.3-0):
     - hermes-engine
-    - React-callinvoker (= 0.85.2-0)
+    - React-callinvoker (= 0.85.3-0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.85.2-0)
-    - React-debug (= 0.85.2-0)
-    - React-featureflags (= 0.85.2-0)
-    - React-jsi (= 0.85.2-0)
-    - React-logger (= 0.85.2-0)
-    - React-perflogger (= 0.85.2-0)
-    - React-utils (= 0.85.2-0)
+    - React-cxxreact (= 0.85.3-0)
+    - React-debug (= 0.85.3-0)
+    - React-featureflags (= 0.85.3-0)
+    - React-jsi (= 0.85.3-0)
+    - React-logger (= 0.85.3-0)
+    - React-perflogger (= 0.85.3-0)
+    - React-utils (= 0.85.3-0)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.85.2)
+  - ReactNativeDependencies (0.85.3)
   - RNReanimated (4.4.0-main):
     - hermes-engine
     - RCTRequired
@@ -1933,6 +1973,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - React-mutationobservernativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -2049,6 +2090,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  React-mutationobservernativemodule:
+    :path: "../node_modules/react-native/ReactCommon/react/nativemodule/mutationobserver"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-networking:
@@ -2125,81 +2168,82 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  FBLazyVector: 1298e5a48100ebce439c698f6c7d88bd884a8cc6
+  FBLazyVector: d530cbf79a7670e8620cacb47d1804e66685f3c5
   hermes-engine: 87822f3169a0820afbe6155fc2a9e700c97d7fd7
-  RCTDeprecation: cc5c5a8ac471917a23e24443ef54ed5027fa38f2
-  RCTRequired: 5042192e05d2377c135ea27faf8124f75761011d
-  RCTSwiftUI: a8ade5a407cedd041f827f0af6ab75207676df1d
-  RCTSwiftUIWrapper: ed52b209d3dfaf7d1cfca5d06dca3abcf81407c0
-  RCTTypeSafety: 585f3f0eecf3d23aa8cc7b6d6a1ac0d6749e0d09
-  React: 31adb0959d01ecb34d3b4df75aeb8c86cc8017b9
-  React-callinvoker: 0ac6beada44d88e34f56ea8984220698f3eed3e0
-  React-Core: e9f38d53509d9a967f190ef78c197ece5d7fe9b7
-  React-Core-prebuilt: 0d4acd0b519927a875214915ddd012307fd2be42
-  React-CoreModules: 0d0e045799993811884133d9d4a69b09f8e53355
-  React-cxxreact: d68cd579f9444ae50fb50cdffecb5fae60af15a3
-  React-debug: 1f5715693c6597d6f066d0b0854d6cc60f42cb6b
-  React-defaultsnativemodule: 7e333f1cea394baf4161f6deafd73a5252117655
-  React-domnativemodule: 0769a620be56b79381366c01f1f11e3757b63f82
-  React-Fabric: 54f99cb1e2ea5488c0ee893d13541c64d68bfd38
-  React-FabricComponents: 5526f48aa0ed7c1ac3954a0d16f6571bd6ed4f6e
-  React-FabricImage: 81c79b77fbdf02a5b505a16811d8d890031aff61
-  React-featureflags: 3f0442d23faf1919d220f029a9feba8cff92769b
-  React-featureflagsnativemodule: c251fe29cbf2406b217655dc51f44a62e70963fa
-  React-graphics: bf56efdc9e3b940c5bab4cfb8e576e68247c2762
-  React-hermes: d9cb77a34e455d67b795a8a098b69b95dc075284
-  React-idlecallbacksnativemodule: a6228591bcc45006ac458f6453f5f0530659b178
-  React-ImageManager: cf649ac123323380c48d63ff25c893600fb6a970
-  React-intersectionobservernativemodule: 604b9bea93393b4aa835c897687f294b7765a5f5
-  React-jserrorhandler: a662316e29936519d69b28630b2c19c780662acb
-  React-jsi: 646bdf173c428ec2191c14fe266f7cafdf0acc95
-  React-jsiexecutor: dd052f63ce5e083832af87f2419beb5a4f302825
-  React-jsinspector: feca34b743f8d80c685e696e7268a2e855e6fbde
-  React-jsinspectorcdp: cc97cc7855bbaa5d37b0d02e0f1a27ca8ab4524d
-  React-jsinspectornetwork: f382e362901d8ca8683b28aadd30957c9a07693b
-  React-jsinspectortracing: d3425f7dac05e26700a64d3125bb3e5eb739ac9a
-  React-jsitooling: 629db8cfceb7ac4964fbb3cc251b8b5343dba4a8
-  React-jsitracing: b5798d14fdc9c27aafa6dacbac3cd2d8b1581032
-  React-logger: c141663d6cf07f3de02e6554f679e00552fb4e27
-  React-Mapbuffer: 0f3d4545af28f467fede3dbe41bfb4d50ddb7f77
-  React-microtasksnativemodule: 7386938a559cb307c850f48572aa7a8466bb7483
-  React-NativeModulesApple: 46d42362b7b9c77313894fe6511cc4af3038b751
-  React-networking: 61889738ce12b264a4053f2327cb9086f7d7e4cc
-  React-oscompat: c645c481d6d7a91f6a01796aefd4b713b47ace3b
-  React-perflogger: 96d35fbaba8f832691ae8cf8e3cdd00ca3f35976
-  React-performancecdpmetrics: 1c1f7fe35bcd6af0c14a9c91aca89e4eeaf7f091
-  React-performancetimeline: d92eed5febe1e7a71628ce4d3d05c0b03468afdb
-  React-RCTActionSheet: 3d35fe3c1fd1fa75059dcb2e49e20a3dce7f2c05
-  React-RCTAnimation: 649e006014417ec02c46451b21b9455623a94abc
-  React-RCTAppDelegate: 40cc950eb1e3a46299f7fe2f02f6218ec1219c67
-  React-RCTBlob: b016c1cdad3db1cec508fc291d68485a369043fc
-  React-RCTFabric: 0b6ebfa91a8a98fbfedd2925a8e5770bb9383c12
-  React-RCTFBReactNativeSpec: d955a1d0b81dae87693ac1ade5b00a991e9b5246
-  React-RCTImage: 880af2f27c676eaec8fba05276701d9d4c11f2b4
-  React-RCTLinking: 16251e94073f7574aeade1d13858d227d037991c
-  React-RCTNetwork: 775bf1f8287c283a3afc1bc148d5013cddd67b51
-  React-RCTRuntime: f60a4911a12674a0a8b894395575565be566a410
-  React-RCTSettings: 4ede22a00cd61ca253959892180fa0238508e74c
-  React-RCTText: 24a0f47a1bf30efc562fefaf418525c267984c3b
-  React-RCTVibration: d743b204cfcdb612dc62a24a5cb965948bd7bac5
-  React-rendererconsistency: 1a4b40b91df588e9545a64303b004fff0cdb1686
-  React-renderercss: dfad1a0621e07f9e13f55c948971c5818cf86e01
-  React-rendererdebug: 7979828bf5e69244a4e88901fd0985f4d79c5f5d
-  React-RuntimeApple: beddd187deed0f7a11690d5b2d463f52fbec5f43
-  React-RuntimeCore: 2c8970270122a95e8014a8e4c87056f544795acd
-  React-runtimeexecutor: 9ccc65a53f0c3c198f6f5bfe37daa27243fc8153
-  React-RuntimeHermes: a89a04c7190b0b0458b0c57876764483a12385ca
-  React-runtimescheduler: 4c344824760e9487678a80b9a93b20f0570d64d8
-  React-timing: 92a94f96039bab851ead246e44633255199ba6a4
-  React-utils: 9299c32104b14a1ec9122a25deca27beff441bef
-  React-webperformancenativemodule: e2d0f92ca8aec2a7dcdea480e986a957b2dc7d08
-  ReactAppDependencyProvider: 89edbd104ab7bfb27facf85cf088f6007fe0fc0e
-  ReactCodegen: da84907e710db854188019052c4bced558ccb053
-  ReactCommon: 1216bd5b81bc7e17ef77902bb6b8780fbb296d0b
-  ReactNativeDependencies: 23430fb78e51509594dcc3ee54ecfd52c692f6e4
+  RCTDeprecation: 40ab3b5cc410e721785f9f7a720f54332b23a83f
+  RCTRequired: f43f0af2c182ffd928a63484083f9c6085be0cc3
+  RCTSwiftUI: 259305c2d96dd73682562215eba9e1b30486cfe5
+  RCTSwiftUIWrapper: 6031c973132e41f5d9f3ad6b5b55136698f6e4d6
+  RCTTypeSafety: f4cf310b8b844aa6700b8282c738547b8ecf0533
+  React: e8b7bd0882e50d8e4d37f79c8b1ed99b464e8345
+  React-callinvoker: d5690d217d7290d423416a8b2c98c20316e301ff
+  React-Core: 4b7a3357649ca6d11b50e0d86683cb19677a43c9
+  React-Core-prebuilt: f1212c3bfd4f421eb96bd348b555f781846cfa17
+  React-CoreModules: 81eefd4e15b21a862e56e5028dbdb693f253f8a4
+  React-cxxreact: 3db9d82778f0fc639bca1342cb0c84617a55181c
+  React-debug: b2870555dbee7129cf332c7ffaf80e9643a23afb
+  React-defaultsnativemodule: f7b8229a7694fdd75a355775ef5af035002befa0
+  React-domnativemodule: 642192e5d441097b8aae1989fdac473cc3e3d029
+  React-Fabric: c7afb2696ee8818b9a69a349bcc340ec6fb6e9b5
+  React-FabricComponents: 8eca73cbaebedd2b58aa33fba48947fa41650606
+  React-FabricImage: 7fed1028a6ffbe34bdefb30973a1df849afedadd
+  React-featureflags: 163e8dd32598ca66061b5d704565ae43ce715f7b
+  React-featureflagsnativemodule: 9709e90954b5638e1d144ad9900604dae8400071
+  React-graphics: a9390be0ac80c0b2978b19fe21c92532b7a090a6
+  React-hermes: 986c79f7ba84ba040888dfd6e82e76a087d5d1ec
+  React-idlecallbacksnativemodule: 3b3021ee75e6d72f6bad7c4ccaf3cd26299a6d3e
+  React-ImageManager: 8a02910746b654e3e9d35b74a86bdbc04a95595f
+  React-intersectionobservernativemodule: 5083796d43e8bd3a001a0c92ba49986763993ebf
+  React-jserrorhandler: 930e050e3143f3d27b99db8726c7e9b498bc3126
+  React-jsi: c26c59728ea728795994147344e2ff113e19f92a
+  React-jsiexecutor: 0ca1fd6e27e5f7e79d9e315b0e0dfa51835b8c1f
+  React-jsinspector: 842a37ce291e7e47d5f001c11d560e6b0ec61e5f
+  React-jsinspectorcdp: 5a8926fe0a445bc229fdd3eb8d8c3ab14d11b7bf
+  React-jsinspectornetwork: 3a05c5372e56c01b8c3bfdfb040482b6921cf63d
+  React-jsinspectortracing: ffd7d3b14d3629f3259c1e30da9178d47d94ef3c
+  React-jsitooling: 7bc1ae7c67bdfb6c8a4cb9478df49d7a4628220f
+  React-jsitracing: da9ccad8efc409fa7a6a4b791c6cbf8e6ae03a53
+  React-logger: 9e6ffec8c6994734f2092beab7864612f9c3180d
+  React-Mapbuffer: 687e170c693f548b16d22513b8135990a0f76d45
+  React-microtasksnativemodule: d0742b0f5bfd76169ce022b97b005d725df36469
+  React-mutationobservernativemodule: 5dfd04c4069ff03d4c376011e0ca43f7bd34ab43
+  React-NativeModulesApple: f6d5715e420d99058c419a18702d7caa9c642f39
+  React-networking: 646179afc242c1a83c49f340850db91a0c92f882
+  React-oscompat: 0238f8c0efd47351f5986b35dba99b845abb8f56
+  React-perflogger: 23b5ca5fe7a3259a57857f36e4b65d30b1f8c1c5
+  React-performancecdpmetrics: 4c8574c75414d41a93769988497edbc331a736b8
+  React-performancetimeline: 7978a90b41d799d18d39c1c23738f0491f5971b3
+  React-RCTActionSheet: 0ec05a5e39d173355e3482150ec143cb79e8e245
+  React-RCTAnimation: dba35cae88994571c4edd45caf613ad80451385b
+  React-RCTAppDelegate: 0726173e80a24c9f0010350747a242e4c01efa65
+  React-RCTBlob: 51716cec396b4bd793a14e44ad95720024edb149
+  React-RCTFabric: b9f9de9297eca6ca4f33dca6877f771e340aaa1a
+  React-RCTFBReactNativeSpec: f8c6f9a96ec0f77f12c73c1b4d5eb95e9a5a587f
+  React-RCTImage: 1182b748c72f4c35daa8f6900fd550916ac2d041
+  React-RCTLinking: 81e638e09e77c1bf87ce26e0d62891675b9b79b8
+  React-RCTNetwork: 961c2ab8071e581a138359eece52f8a824d43ce5
+  React-RCTRuntime: 73c765350cb9d84920723c1d19f1e84589074aa6
+  React-RCTSettings: f9f666d516b03f34958442d9e1c35b3c6f92b12e
+  React-RCTText: 17027ee6b29f47352ee2e16793ae946cf75fd3bc
+  React-RCTVibration: 11f057720506c564de82aea1387d5724165ed9fb
+  React-rendererconsistency: 83ddc61fa38b5e4eae0df802ef87a9f82cde1e44
+  React-renderercss: 4a7f344c1b124ed37695a2207572d76d6553771e
+  React-rendererdebug: 6f638887feedb56c7dca2bedb17324d13d9513d3
+  React-RuntimeApple: 73a05a9ca84a34ac8488f8e35d03e323c9c9d490
+  React-RuntimeCore: fee2686b0f4962cf7e6a71d90141509fe7357ab9
+  React-runtimeexecutor: 46bfd8b771982a8cf298ff732fa4592cabbdff68
+  React-RuntimeHermes: d774c21f4497997600651a60378bb29aae2b3c97
+  React-runtimescheduler: 1fea241459c007c857d107d14184b920a8c08afa
+  React-timing: 46d90f23d596a08b63674f9bd48d9efc1f7ecd10
+  React-utils: 1b16834d3eff98ca80dbff2818df24ceef7d9746
+  React-webperformancenativemodule: cdff07956ab6e45325fc23818fdeb3eec4aa7488
+  ReactAppDependencyProvider: 96408f4be2ec6b31bcae9c3571b58d6bff9f7e4a
+  ReactCodegen: 01efb0e862440b4a3e183301c4049638d5e4ac1d
+  ReactCommon: 52f9c5c30dda0eb591550d5d1adb265176e1ecc8
+  ReactNativeDependencies: a6bc5d14e7538f98c97f275b62ec842b1e8c8ac8
   RNReanimated: 252cb421bd573cd6e6bc3de5b1496f534f361f00
   RNWorklets: b285ab513ca8a0fbaa7c028d594b4e72c3cae42d
-  Yoga: 7115df1b265f29df3a34d13cc7218770a00e0af7
+  Yoga: 861ef0ae75949f7330bfa80d9ce24250e963f66c
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699
 

--- a/apps/tvos-example/metro.config.js
+++ b/apps/tvos-example/metro.config.js
@@ -10,6 +10,8 @@ const defaultConfig = getDefaultConfig(__dirname);
 const { blockList, extraNodeModules } = getMonorepoMetroOptions(
   modulesToFilter,
   __dirname,
+  // @ts-expect-error type discrepancy between metro types resolved inside
+  // tvos-example's hoisted node_modules and the ones used in `getMonorepoMetroOptions`
   defaultConfig
 );
 

--- a/apps/tvos-example/metro.config.js
+++ b/apps/tvos-example/metro.config.js
@@ -10,8 +10,6 @@ const defaultConfig = getDefaultConfig(__dirname);
 const { blockList, extraNodeModules } = getMonorepoMetroOptions(
   modulesToFilter,
   __dirname,
-  // @ts-expect-error type discrepancy between older metro types
-  // in tvos-example and newer used in `getMonorepoMetroOptions`
   defaultConfig
 );
 

--- a/apps/tvos-example/metro.config.js
+++ b/apps/tvos-example/metro.config.js
@@ -10,8 +10,6 @@ const defaultConfig = getDefaultConfig(__dirname);
 const { blockList, extraNodeModules } = getMonorepoMetroOptions(
   modulesToFilter,
   __dirname,
-  // @ts-expect-error type discrepancy between metro types resolved inside
-  // tvos-example's hoisted node_modules and the ones used in `getMonorepoMetroOptions`
   defaultConfig
 );
 

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "react": "19.2.3",
-    "react-native": "npm:react-native-tvos@0.84.1-0",
+    "react-native": "npm:react-native-tvos@0.85.2-0",
     "react-native-reanimated": "workspace:*",
     "react-native-worklets": "workspace:*"
   },
@@ -22,10 +22,10 @@
     "@babel/core": "7.28.4",
     "@babel/preset-env": "7.28.3",
     "@babel/runtime": "7.28.4",
-    "@react-native/babel-preset": "0.84.1",
-    "@react-native/eslint-config": "0.84.1",
-    "@react-native/metro-config": "0.84.1",
-    "@react-native/typescript-config": "0.84.1",
+    "@react-native/babel-preset": "0.85.2",
+    "@react-native/eslint-config": "0.85.2",
+    "@react-native/metro-config": "0.85.2",
+    "@react-native/typescript-config": "0.85.2",
     "@types/react": "19.2.2",
     "@types/react-test-renderer": "19.1.0",
     "babel-jest": "30.2.0",

--- a/apps/tvos-example/package.json
+++ b/apps/tvos-example/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "react": "19.2.3",
-    "react-native": "npm:react-native-tvos@0.85.2-0",
+    "react-native": "npm:react-native-tvos@0.85.3-0",
     "react-native-reanimated": "workspace:*",
     "react-native-worklets": "workspace:*"
   },
@@ -22,10 +22,10 @@
     "@babel/core": "7.28.4",
     "@babel/preset-env": "7.28.3",
     "@babel/runtime": "7.28.4",
-    "@react-native/babel-preset": "0.85.2",
-    "@react-native/eslint-config": "0.85.2",
-    "@react-native/metro-config": "0.85.2",
-    "@react-native/typescript-config": "0.85.2",
+    "@react-native/babel-preset": "0.85.3",
+    "@react-native/eslint-config": "0.85.3",
+    "@react-native/metro-config": "0.85.3",
+    "@react-native/typescript-config": "0.85.3",
     "@types/react": "19.2.2",
     "@types/react-test-renderer": "19.1.0",
     "babel-jest": "30.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6795,20 +6795,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-tvos/virtualized-lists@npm:0.84.1-0":
-  version: 0.84.1-0
-  resolution: "@react-native-tvos/virtualized-lists@npm:0.84.1-0"
+"@react-native-tvos/virtualized-lists@npm:0.85.2-0":
+  version: 0.85.2-0
+  resolution: "@react-native-tvos/virtualized-lists@npm:0.85.2-0"
   dependencies:
     invariant: "npm:^2.2.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
     "@types/react": ^19.2.0
     react: "*"
-    react-native: "*"
+    react-native: 0.85.2
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5986bdcd6f1e48a2284c4377a47169853a0e91123319bacc176a2e2b699cedcd33a4100a9d95a4ada5192e007976bff62415c02cf841c7d2817e4fe25b6e97a7
+  checksum: 10/ce974c9f67aee60b3e4c59c7c26a1a8d11e81e24317c1f7d724b09397746bcd3aec0b79f287e021f026603dff1ac019515dadd76221d9aa6eecdf0f55ce31e9e
   languageName: node
   linkType: hard
 
@@ -6830,13 +6830,6 @@ __metadata:
   version: 0.83.0
   resolution: "@react-native/assets-registry@npm:0.83.0"
   checksum: 10/9c314a311739e5ea555155df54821f888f3c61de6bcd71db60a253b27aefb42116892d487efb57a5ba99998c9835e1b123019bfe4397c087d0bcef38bad43c8c
-  languageName: node
-  linkType: hard
-
-"@react-native/assets-registry@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/assets-registry@npm:0.84.1"
-  checksum: 10/1f31c649090c3d569115dfa5f1620a6e124e6e88f8eeb857f3db406b61663d3820b4c669edbc62049ce5de460f5dc224d28560f590e9759c4ee055618a8aa8dc
   languageName: node
   linkType: hard
 
@@ -6864,16 +6857,6 @@ __metadata:
     "@babel/traverse": "npm:^7.25.3"
     "@react-native/codegen": "npm:0.81.5"
   checksum: 10/e8a4bb4c0d6f79e1162aeadb45e0495cb7515f75adda35de77c2b21be345b0e0e45ff7c4710a0ea285b9a42a8354ac66995f7bb5e7fbb144dbff3c67e1b6c9c7
-  languageName: node
-  linkType: hard
-
-"@react-native/babel-plugin-codegen@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/babel-plugin-codegen@npm:0.84.1"
-  dependencies:
-    "@babel/traverse": "npm:^7.25.3"
-    "@react-native/codegen": "npm:0.84.1"
-  checksum: 10/59f2571e2855755f3fbc99a05e9956a150d8f10343219d88641160bfae956e8d8703a9e9c6c3df0ee758bdb6672bf512aac0f04034b3ea4cf91769a86e076ccc
   languageName: node
   linkType: hard
 
@@ -6997,49 +6980,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/babel-preset@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/babel-preset@npm:0.84.1"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@babel/plugin-proposal-export-default-from": "npm:^7.24.7"
-    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
-    "@babel/plugin-syntax-export-default-from": "npm:^7.24.7"
-    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
-    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
-    "@babel/plugin-transform-async-generator-functions": "npm:^7.25.4"
-    "@babel/plugin-transform-async-to-generator": "npm:^7.24.7"
-    "@babel/plugin-transform-block-scoping": "npm:^7.25.0"
-    "@babel/plugin-transform-class-properties": "npm:^7.25.4"
-    "@babel/plugin-transform-classes": "npm:^7.25.4"
-    "@babel/plugin-transform-destructuring": "npm:^7.24.8"
-    "@babel/plugin-transform-flow-strip-types": "npm:^7.25.2"
-    "@babel/plugin-transform-for-of": "npm:^7.24.7"
-    "@babel/plugin-transform-modules-commonjs": "npm:^7.24.8"
-    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.24.7"
-    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.24.7"
-    "@babel/plugin-transform-optional-catch-binding": "npm:^7.24.7"
-    "@babel/plugin-transform-optional-chaining": "npm:^7.24.8"
-    "@babel/plugin-transform-private-methods": "npm:^7.24.7"
-    "@babel/plugin-transform-private-property-in-object": "npm:^7.24.7"
-    "@babel/plugin-transform-react-display-name": "npm:^7.24.7"
-    "@babel/plugin-transform-react-jsx": "npm:^7.25.2"
-    "@babel/plugin-transform-react-jsx-self": "npm:^7.24.7"
-    "@babel/plugin-transform-react-jsx-source": "npm:^7.24.7"
-    "@babel/plugin-transform-regenerator": "npm:^7.24.7"
-    "@babel/plugin-transform-runtime": "npm:^7.24.7"
-    "@babel/plugin-transform-typescript": "npm:^7.25.2"
-    "@babel/plugin-transform-unicode-regex": "npm:^7.24.7"
-    "@react-native/babel-plugin-codegen": "npm:0.84.1"
-    babel-plugin-syntax-hermes-parser: "npm:0.32.0"
-    babel-plugin-transform-flow-enums: "npm:^0.0.2"
-    react-refresh: "npm:^0.14.0"
-  peerDependencies:
-    "@babel/core": "*"
-  checksum: 10/9d362f7fa72a6b2abb9adb67cdc5dca1fe9f8a38bfd66cef01e5d99ef6b715df8842446d74859151829d883aad7ffcc46faa7cdf4b67aef9a787270a7600974c
-  languageName: node
-  linkType: hard
-
 "@react-native/babel-preset@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/babel-preset@npm:0.85.2"
@@ -7151,23 +7091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/codegen@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/codegen@npm:0.84.1"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@babel/parser": "npm:^7.25.3"
-    hermes-parser: "npm:0.32.0"
-    invariant: "npm:^2.2.4"
-    nullthrows: "npm:^1.1.1"
-    tinyglobby: "npm:^0.2.15"
-    yargs: "npm:^17.6.2"
-  peerDependencies:
-    "@babel/core": "*"
-  checksum: 10/2fa65f813c56afd4deafce8adcfaa31c5b87fb5b4ee66b625dd1171c745c6114ac192b3dd7f028e71c5ccaae752a9096b12d70d980d99bd71806b043e9234078
-  languageName: node
-  linkType: hard
-
 "@react-native/codegen@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/codegen@npm:0.85.2"
@@ -7254,29 +7177,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/community-cli-plugin@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/community-cli-plugin@npm:0.84.1"
-  dependencies:
-    "@react-native/dev-middleware": "npm:0.84.1"
-    debug: "npm:^4.4.0"
-    invariant: "npm:^2.2.4"
-    metro: "npm:^0.83.3"
-    metro-config: "npm:^0.83.3"
-    metro-core: "npm:^0.83.3"
-    semver: "npm:^7.1.3"
-  peerDependencies:
-    "@react-native-community/cli": "*"
-    "@react-native/metro-config": "*"
-  peerDependenciesMeta:
-    "@react-native-community/cli":
-      optional: true
-    "@react-native/metro-config":
-      optional: true
-  checksum: 10/561bcb26af1c391144b71ca0fa3024896d8a74f52dcef856c1bc0b59aaa13560e244ae791039e25ab665c51f913556fc854d69ed0fffc3ed27a099cf3476b2c5
-  languageName: node
-  linkType: hard
-
 "@react-native/community-cli-plugin@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/community-cli-plugin@npm:0.85.2"
@@ -7321,13 +7221,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/debugger-frontend@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/debugger-frontend@npm:0.84.1"
-  checksum: 10/841386dcbb6964b3e256777ddb0bab26c2c1efa34059ba2bf5533ba2e257130eaefe68a5c557a220aa7c742045c27b158df63aaed7313dfecba48c6c31ae5451
-  languageName: node
-  linkType: hard
-
 "@react-native/debugger-frontend@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/debugger-frontend@npm:0.85.2"
@@ -7342,17 +7235,6 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     fb-dotslash: "npm:0.5.8"
   checksum: 10/51b61131b90a9e09f259a5999759b77d9384cf9b0f38e4c4da1b63a1a729126349f9d20f51d599e527ebe5430945e2e1ddde17d933aa30c0775e2437694db50f
-  languageName: node
-  linkType: hard
-
-"@react-native/debugger-shell@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/debugger-shell@npm:0.84.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.4.0"
-    fb-dotslash: "npm:0.5.8"
-  checksum: 10/0ce7acd2161b3911089d75907182fb4357cb1069b19fd0d9d0262632a7eb3aeb3aac4c911b682e90f74a6de5cc1c158366182ded9b4f5d727f113227d304f656
   languageName: node
   linkType: hard
 
@@ -7425,26 +7307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/dev-middleware@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/dev-middleware@npm:0.84.1"
-  dependencies:
-    "@isaacs/ttlcache": "npm:^1.4.1"
-    "@react-native/debugger-frontend": "npm:0.84.1"
-    "@react-native/debugger-shell": "npm:0.84.1"
-    chrome-launcher: "npm:^0.15.2"
-    chromium-edge-launcher: "npm:^0.2.0"
-    connect: "npm:^3.6.5"
-    debug: "npm:^4.4.0"
-    invariant: "npm:^2.2.4"
-    nullthrows: "npm:^1.1.1"
-    open: "npm:^7.0.3"
-    serve-static: "npm:^1.16.2"
-    ws: "npm:^7.5.10"
-  checksum: 10/7c6e588e6f6a36d57d318487437bcafc8a3c5d3959512e75f7133e92e71ddc4cc6af4e359b0098cf6151f28c01b8136077b801d7539231b2b95b56fbb4dd0f74
-  languageName: node
-  linkType: hard
-
 "@react-native/dev-middleware@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/dev-middleware@npm:0.85.2"
@@ -7511,29 +7373,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/eslint-config@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/eslint-config@npm:0.84.1"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@babel/eslint-parser": "npm:^7.25.1"
-    "@react-native/eslint-plugin": "npm:0.84.1"
-    "@typescript-eslint/eslint-plugin": "npm:^8.36.0"
-    "@typescript-eslint/parser": "npm:^8.36.0"
-    eslint-config-prettier: "npm:^8.5.0"
-    eslint-plugin-eslint-comments: "npm:^3.2.0"
-    eslint-plugin-ft-flow: "npm:^2.0.1"
-    eslint-plugin-jest: "npm:^29.0.1"
-    eslint-plugin-react: "npm:^7.30.1"
-    eslint-plugin-react-hooks: "npm:^7.0.1"
-    eslint-plugin-react-native: "npm:^5.0.0"
-  peerDependencies:
-    eslint: ^8.0.0 || ^9.0.0
-    prettier: ">=2"
-  checksum: 10/37b6e632d43fbc9ffd7f126c90aecc9d3acb018f060a8006853275386ec4d79e6176514b59a22833a6abe9839f0b95670e86da63a5964437ef63d8abb4d90e1b
-  languageName: node
-  linkType: hard
-
 "@react-native/eslint-config@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/eslint-config@npm:0.85.2"
@@ -7571,13 +7410,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/eslint-plugin@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/eslint-plugin@npm:0.84.1"
-  checksum: 10/6dabbdbc9a42a197fd9194f5eeff2f7a413753fa27fb005187416a1cac016b11186409b8029d92d11603f0b5c67aff075bda542e47737819d71a6b54e35741ee
-  languageName: node
-  linkType: hard
-
 "@react-native/eslint-plugin@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/eslint-plugin@npm:0.85.2"
@@ -7603,13 +7435,6 @@ __metadata:
   version: 0.83.0
   resolution: "@react-native/gradle-plugin@npm:0.83.0"
   checksum: 10/dcd7a47b21629a78a6f079a16a87d85ed78214dd19efafb054e7718624774b07e8c10572d054b9e31ac80c96148127a40da164b44e04e8aa434cfb93ead258fc
-  languageName: node
-  linkType: hard
-
-"@react-native/gradle-plugin@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/gradle-plugin@npm:0.84.1"
-  checksum: 10/9edf358cb865b287eb04c34a218a8fc31740cff01a8d53bc83fe181c6bcbecc6337b3623b4f9f3490fa1d3a309a6e8ba863a900c7e6bdc88d76717af9175c50e
   languageName: node
   linkType: hard
 
@@ -7671,13 +7496,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/js-polyfills@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/js-polyfills@npm:0.84.1"
-  checksum: 10/7074e66d54f302864b580d2bf2c048cdb4c37fc4f6fd9dee0faeb4084d524c2f1e7fa60014a54bdcaaa51d75955fbac6a9274e25b806783eee7edf5bce2fb074
-  languageName: node
-  linkType: hard
-
 "@react-native/js-polyfills@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/js-polyfills@npm:0.85.2"
@@ -7696,20 +7514,6 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: 10/68593adcd7e9655b59242cf42ed6a516f3979f6bcdc5b3f15817c93bc90cb5cd1e76969f058d3c11fc50200a8fc23fdba20196097fbd5473ababe9396585f840
-  languageName: node
-  linkType: hard
-
-"@react-native/metro-babel-transformer@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/metro-babel-transformer@npm:0.84.1"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@react-native/babel-preset": "npm:0.84.1"
-    hermes-parser: "npm:0.32.0"
-    nullthrows: "npm:^1.1.1"
-  peerDependencies:
-    "@babel/core": "*"
-  checksum: 10/0fc5988b37eb0ef083ab354b5c04a722a44009dd08fa40a7574a630e2f47c19ee34b2da7ee0bd9fab9434515ce4d39ef853fc4d7dc7bab575d71e52d12292e89
   languageName: node
   linkType: hard
 
@@ -7736,18 +7540,6 @@ __metadata:
     metro-config: "npm:^0.83.1"
     metro-runtime: "npm:^0.83.1"
   checksum: 10/3ae2a2c55cb988da8a35f5f119b19a476dd85388d4c4970e33fc9af7886d2bba7d894743b997a4cac7389125b87ed1aac436cd0e2426d3ea06bc1cde4838d866
-  languageName: node
-  linkType: hard
-
-"@react-native/metro-config@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/metro-config@npm:0.84.1"
-  dependencies:
-    "@react-native/js-polyfills": "npm:0.84.1"
-    "@react-native/metro-babel-transformer": "npm:0.84.1"
-    metro-config: "npm:^0.83.3"
-    metro-runtime: "npm:^0.83.3"
-  checksum: 10/0637fe16d5e1fa7fcfd729dbfa3842b9ead126c1eb6ebe8ff4bcdc959f92a71bc5e0e9bdeb103a33fb04bb3a53dd3ee219736508acee89963aea6fb9db2901c2
   languageName: node
   linkType: hard
 
@@ -7791,13 +7583,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/normalize-colors@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/normalize-colors@npm:0.84.1"
-  checksum: 10/5c65d26dbfab87d19ae9253cfce4eeb284c6f7663d94e8708a535082da65de8150677cac7953146d691922705fe84ea8abf9205e37096f2d9055bd9e9cca6bf1
-  languageName: node
-  linkType: hard
-
 "@react-native/normalize-colors@npm:0.85.2":
   version: 0.85.2
   resolution: "@react-native/normalize-colors@npm:0.85.2"
@@ -7816,13 +7601,6 @@ __metadata:
   version: 0.81.4
   resolution: "@react-native/typescript-config@npm:0.81.4"
   checksum: 10/21e517036fe5e423d4bb67739168743374c40641dfb2dde080b13bdd68126f280707ebf7d2780df23f5cf7805c759f1db2705473de35f1d3b7761256d2694c7e
-  languageName: node
-  linkType: hard
-
-"@react-native/typescript-config@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/typescript-config@npm:0.84.1"
-  checksum: 10/6616765f8cf7702818ef251168522aeb68fb9baddcfc8235cd00731d0b4158131bf3fb12680b725c851002832c6fa604bee66b059bb15d35362b437b39615fa0
   languageName: node
   linkType: hard
 
@@ -18953,13 +18731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-compiler@npm:250829098.0.9":
-  version: 250829098.0.9
-  resolution: "hermes-compiler@npm:250829098.0.9"
-  checksum: 10/15e1a0565e93f12a01e543d0d6f1a3a4cfb8037c44f89d930abd97c42e37c2b69f230b03e699c97402e6db33b7a9eb2d168c8c4a12966ef3b584e56cc565430a
-  languageName: node
-  linkType: hard
-
 "hermes-estree@npm:0.25.1":
   version: 0.25.1
   resolution: "hermes-estree@npm:0.25.1"
@@ -28617,32 +28388,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:react-native-tvos@0.84.1-0":
-  version: 0.84.1-0
-  resolution: "react-native-tvos@npm:0.84.1-0"
+"react-native@npm:react-native-tvos@0.85.2-0":
+  version: 0.85.2-0
+  resolution: "react-native-tvos@npm:0.85.2-0"
   dependencies:
-    "@jest/create-cache-key-function": "npm:^29.7.0"
-    "@react-native-tvos/virtualized-lists": "npm:0.84.1-0"
-    "@react-native/assets-registry": "npm:0.84.1"
-    "@react-native/codegen": "npm:0.84.1"
-    "@react-native/community-cli-plugin": "npm:0.84.1"
-    "@react-native/gradle-plugin": "npm:0.84.1"
-    "@react-native/js-polyfills": "npm:0.84.1"
-    "@react-native/normalize-colors": "npm:0.84.1"
+    "@react-native-tvos/virtualized-lists": "npm:0.85.2-0"
+    "@react-native/assets-registry": "npm:0.85.2"
+    "@react-native/codegen": "npm:0.85.2"
+    "@react-native/community-cli-plugin": "npm:0.85.2"
+    "@react-native/gradle-plugin": "npm:0.85.2"
+    "@react-native/js-polyfills": "npm:0.85.2"
+    "@react-native/normalize-colors": "npm:0.85.2"
     abort-controller: "npm:^3.0.0"
     anser: "npm:^1.4.9"
     ansi-regex: "npm:^5.0.0"
-    babel-jest: "npm:^29.7.0"
-    babel-plugin-syntax-hermes-parser: "npm:0.32.0"
+    babel-plugin-syntax-hermes-parser: "npm:0.33.3"
     base64-js: "npm:^1.5.1"
     commander: "npm:^12.0.0"
     flow-enums-runtime: "npm:^0.0.6"
-    hermes-compiler: "npm:250829098.0.9"
+    hermes-compiler: "npm:250829098.0.10"
     invariant: "npm:^2.2.4"
-    jest-environment-node: "npm:^29.7.0"
     memoize-one: "npm:^5.0.0"
-    metro-runtime: "npm:^0.83.3"
-    metro-source-map: "npm:^0.83.3"
+    metro-runtime: "npm:^0.84.0"
+    metro-source-map: "npm:^0.84.0"
     nullthrows: "npm:^1.1.1"
     pretty-format: "npm:^29.7.0"
     promise: "npm:^8.3.0"
@@ -28657,14 +28425,17 @@ __metadata:
     ws: "npm:^7.5.10"
     yargs: "npm:^17.6.2"
   peerDependencies:
+    "@react-native/jest-preset": 0.85.2
     "@types/react": ^19.1.1
     react: ^19.2.3
   peerDependenciesMeta:
+    "@react-native/jest-preset":
+      optional: true
     "@types/react":
       optional: true
   bin:
     react-native: cli.js
-  checksum: 10/ed9d89616059b1836000f36243ca87aa9b529e92cebbfefa685ff71c07463a55ae788371daa298c9174909dbbfe79be6d9aa4f30dfec94c63bffc1c1cab016dc
+  checksum: 10/316de2d40dd8167521d8a20c40444124dbbbbb5fa82b7889e9fe86d4f58e9e264868f9e55c9206c73220af6bedf3e19c8b10de2f45e04af2f27fc5b9e5bbf1bf
   languageName: node
   linkType: hard
 
@@ -32093,10 +31864,10 @@ __metadata:
     "@babel/core": "npm:7.28.4"
     "@babel/preset-env": "npm:7.28.3"
     "@babel/runtime": "npm:7.28.4"
-    "@react-native/babel-preset": "npm:0.84.1"
-    "@react-native/eslint-config": "npm:0.84.1"
-    "@react-native/metro-config": "npm:0.84.1"
-    "@react-native/typescript-config": "npm:0.84.1"
+    "@react-native/babel-preset": "npm:0.85.2"
+    "@react-native/eslint-config": "npm:0.85.2"
+    "@react-native/metro-config": "npm:0.85.2"
+    "@react-native/typescript-config": "npm:0.85.2"
     "@types/react": "npm:19.2.2"
     "@types/react-test-renderer": "npm:19.1.0"
     babel-jest: "npm:30.2.0"
@@ -32104,7 +31875,7 @@ __metadata:
     jest: "npm:30.2.0"
     prettier: "npm:3.6.2"
     react: "npm:19.2.3"
-    react-native: "npm:react-native-tvos@0.84.1-0"
+    react-native: "npm:react-native-tvos@0.85.2-0"
     react-native-reanimated: "workspace:*"
     react-native-worklets: "workspace:*"
     react-test-renderer: "npm:19.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6795,20 +6795,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-tvos/virtualized-lists@npm:0.85.2-0":
-  version: 0.85.2-0
-  resolution: "@react-native-tvos/virtualized-lists@npm:0.85.2-0"
+"@react-native-tvos/virtualized-lists@npm:0.85.3-0":
+  version: 0.85.3-0
+  resolution: "@react-native-tvos/virtualized-lists@npm:0.85.3-0"
   dependencies:
     invariant: "npm:^2.2.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
     "@types/react": ^19.2.0
     react: "*"
-    react-native: 0.85.2
+    react-native: 0.85.3
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ce974c9f67aee60b3e4c59c7c26a1a8d11e81e24317c1f7d724b09397746bcd3aec0b79f287e021f026603dff1ac019515dadd76221d9aa6eecdf0f55ce31e9e
+  checksum: 10/6075d390aab2e49a9cf318e3cbbf190841b7d8de59581a56236fcfb568e48f626e56f4fb5b70f6cbd902d264de74b9f0b8f96d060cf1d2413bde9fc6cbcad604
   languageName: node
   linkType: hard
 
@@ -6840,6 +6840,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/assets-registry@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/assets-registry@npm:0.85.3"
+  checksum: 10/614892869515ec035b5e64c4ef310c6bd531bcd623941a40db08255e2b2ba7d988801092b5014a558af2e899388b63d1a818cf42dcb5d014bc87ec72dcc8d336
+  languageName: node
+  linkType: hard
+
 "@react-native/babel-plugin-codegen@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/babel-plugin-codegen@npm:0.81.4"
@@ -6867,6 +6874,16 @@ __metadata:
     "@babel/traverse": "npm:^7.29.0"
     "@react-native/codegen": "npm:0.85.2"
   checksum: 10/d6fe6e0fd54c5eb51c2d0deecebb275cc170518b43beb9baca06d48efe9f3aa348dedbcb3af7fb1d2b6973d7be06ff8b3bf19efe1a16e8a5aeaa84d59295eb95
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-plugin-codegen@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/babel-plugin-codegen@npm:0.85.3"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.0"
+    "@react-native/codegen": "npm:0.85.3"
+  checksum: 10/195a6ba599a61b94e34e6db98dae540289c2aa9a577da5288b908a82e595b80e8859b9684c4b6a3b9d897a70a609bf3ceaf3f37694bec70d9876753c2875f3d4
   languageName: node
   linkType: hard
 
@@ -7023,6 +7040,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-preset@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/babel-preset@npm:0.85.3"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/plugin-proposal-export-default-from": "npm:^7.24.7"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-syntax-export-default-from": "npm:^7.24.7"
+    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
+    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
+    "@babel/plugin-transform-async-generator-functions": "npm:^7.25.4"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.24.7"
+    "@babel/plugin-transform-block-scoping": "npm:^7.25.0"
+    "@babel/plugin-transform-class-properties": "npm:^7.25.4"
+    "@babel/plugin-transform-classes": "npm:^7.25.4"
+    "@babel/plugin-transform-destructuring": "npm:^7.24.8"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.25.2"
+    "@babel/plugin-transform-for-of": "npm:^7.24.7"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.24.8"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.24.7"
+    "@babel/plugin-transform-optional-catch-binding": "npm:^7.24.7"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.24.8"
+    "@babel/plugin-transform-private-methods": "npm:^7.24.7"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.24.7"
+    "@babel/plugin-transform-react-display-name": "npm:^7.24.7"
+    "@babel/plugin-transform-react-jsx": "npm:^7.25.2"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.24.7"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.24.7"
+    "@babel/plugin-transform-regenerator": "npm:^7.24.7"
+    "@babel/plugin-transform-runtime": "npm:^7.24.7"
+    "@babel/plugin-transform-typescript": "npm:^7.25.2"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.24.7"
+    "@react-native/babel-plugin-codegen": "npm:0.85.3"
+    babel-plugin-syntax-hermes-parser: "npm:0.33.3"
+    babel-plugin-transform-flow-enums: "npm:^0.0.2"
+    react-refresh: "npm:^0.14.0"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10/0750392facf3e1e1439accb030d04a9dc3e0242a25b5a3938f31f2a4db1cfbc7e527c11e2673c21d52d993c54e6438044db623dabf1d0a40ded065b748677220
+  languageName: node
+  linkType: hard
+
 "@react-native/codegen@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/codegen@npm:0.81.4"
@@ -7105,6 +7165,23 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: 10/71a6329a133c686f90895a9f6698ea951e6be7c772684f51f4b1bed2e41a6747da1f5a79af451364e3b37c4a32bcaf161d084179061be752e0275c8c0e04fc0a
+  languageName: node
+  linkType: hard
+
+"@react-native/codegen@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/codegen@npm:0.85.3"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/parser": "npm:^7.29.0"
+    hermes-parser: "npm:0.33.3"
+    invariant: "npm:^2.2.4"
+    nullthrows: "npm:^1.1.1"
+    tinyglobby: "npm:^0.2.15"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10/71986731526148205e43d624b4d02348a55da03d05c302cad3a314c7f216bad4703abc8280dfb77c17c787bce1e1c980f1ea516b404a238ae858b1307717a1c9
   languageName: node
   linkType: hard
 
@@ -7200,6 +7277,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/community-cli-plugin@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/community-cli-plugin@npm:0.85.3"
+  dependencies:
+    "@react-native/dev-middleware": "npm:0.85.3"
+    debug: "npm:^4.4.0"
+    invariant: "npm:^2.2.4"
+    metro: "npm:^0.84.3"
+    metro-config: "npm:^0.84.3"
+    metro-core: "npm:^0.84.3"
+    semver: "npm:^7.1.3"
+  peerDependencies:
+    "@react-native-community/cli": "*"
+    "@react-native/metro-config": 0.85.3
+  peerDependenciesMeta:
+    "@react-native-community/cli":
+      optional: true
+    "@react-native/metro-config":
+      optional: true
+  checksum: 10/e2a108d09d323208a7879cda0a622bb4e41d2960302cbea12c46e91cf40a861cc56bb83534354182e9149c2ff5ed8d8609a576da1f77220b4a2e6a859d447f54
+  languageName: node
+  linkType: hard
+
 "@react-native/debugger-frontend@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/debugger-frontend@npm:0.81.4"
@@ -7228,6 +7328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/debugger-frontend@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/debugger-frontend@npm:0.85.3"
+  checksum: 10/c778ae789b23102c74113b08914f213b1da66327b1840bdb2d21600a6916c6d062f53d95bfea7001772a10be279a0038a577b5e4945d1159183658d5b1614668
+  languageName: node
+  linkType: hard
+
 "@react-native/debugger-shell@npm:0.83.0":
   version: 0.83.0
   resolution: "@react-native/debugger-shell@npm:0.83.0"
@@ -7246,6 +7353,17 @@ __metadata:
     debug: "npm:^4.4.0"
     fb-dotslash: "npm:0.5.8"
   checksum: 10/ef4983ef42b9043fd4caae226a20e80b05a792b8359b5dea5f82884b82bb14192efc74a063f85d8615cbb4a269cf7b2aa6070b4c6eb2f8984663e3caa3afc059
+  languageName: node
+  linkType: hard
+
+"@react-native/debugger-shell@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/debugger-shell@npm:0.85.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.4.0"
+    fb-dotslash: "npm:0.5.8"
+  checksum: 10/5c6871ff071a1ad030d6791892d55e7003d67656a7e26bf30ea5a1d23cb71b9c81e55768a754e1fbab19e3ec5ed9b246f9409e84963b0877a61d73f6d193b9e1
   languageName: node
   linkType: hard
 
@@ -7327,6 +7445,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/dev-middleware@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/dev-middleware@npm:0.85.3"
+  dependencies:
+    "@isaacs/ttlcache": "npm:^1.4.1"
+    "@react-native/debugger-frontend": "npm:0.85.3"
+    "@react-native/debugger-shell": "npm:0.85.3"
+    chrome-launcher: "npm:^0.15.2"
+    chromium-edge-launcher: "npm:^0.3.0"
+    connect: "npm:^3.6.5"
+    debug: "npm:^4.4.0"
+    invariant: "npm:^2.2.4"
+    nullthrows: "npm:^1.1.1"
+    open: "npm:^7.0.3"
+    serve-static: "npm:^1.16.2"
+    ws: "npm:^7.5.10"
+  checksum: 10/ff4d698edda3e205dc1de64961628a358f2f2cecbc3c50f4351761fff3eef87608f998ebaa3454b41b1ef6a1bfd5307cd1676fccd5eca348c7b54dac16f2fabc
+  languageName: node
+  linkType: hard
+
 "@react-native/eslint-config@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/eslint-config@npm:0.81.4"
@@ -7396,6 +7534,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/eslint-config@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/eslint-config@npm:0.85.3"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/eslint-parser": "npm:^7.25.1"
+    "@react-native/eslint-plugin": "npm:0.85.3"
+    "@typescript-eslint/eslint-plugin": "npm:^8.36.0"
+    "@typescript-eslint/parser": "npm:^8.36.0"
+    eslint-config-prettier: "npm:^8.5.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-ft-flow: "npm:^2.0.1"
+    eslint-plugin-jest: "npm:^29.0.1"
+    eslint-plugin-react: "npm:^7.37.5"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
+    eslint-plugin-react-native: "npm:^5.0.0"
+  peerDependencies:
+    eslint: ^8.0.0 || ^9.0.0
+    prettier: ">=2"
+  checksum: 10/2df610324f1602c253ea19e7d5790b1592b1eef152665148e10c3377bae47ecf9ee55329ea1e75a441644a2469e4d0815378b229e83d6f3ceb162e1279690513
+  languageName: node
+  linkType: hard
+
 "@react-native/eslint-plugin@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/eslint-plugin@npm:0.81.4"
@@ -7414,6 +7575,13 @@ __metadata:
   version: 0.85.2
   resolution: "@react-native/eslint-plugin@npm:0.85.2"
   checksum: 10/f94a72a28c58c5bd88143eb55bb4948d3ba28dcbdfdd12c27b4ca802ba1c89cd257cd2347ab0f249d311937015b36ae63452a30c9f9c8b0428bcc10c1e830981
+  languageName: node
+  linkType: hard
+
+"@react-native/eslint-plugin@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/eslint-plugin@npm:0.85.3"
+  checksum: 10/275bbb36bbe68a80e2a95194bc303d4a39dd1fe0f812798c9c3378f1fb7ee7857db206a04a7731568197c4a7791e11ef2acd3dc5275930c4154c431c52312520
   languageName: node
   linkType: hard
 
@@ -7442,6 +7610,13 @@ __metadata:
   version: 0.85.2
   resolution: "@react-native/gradle-plugin@npm:0.85.2"
   checksum: 10/3ec15326218eb6d4dba5910bc0bcc09443f581e7a0b30954fa84357bd6cda72863b12343a3a36f027842c374f39ead4d66fda1bb8b81f1cd3f65c5e3bfe8e2c5
+  languageName: node
+  linkType: hard
+
+"@react-native/gradle-plugin@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/gradle-plugin@npm:0.85.3"
+  checksum: 10/c838736286d27a13d90fd14cf81cf2165360da01e43d1f95b0ea4fb5c7716b02153e1b2604a168a39dead6f77a66eaba155ea997b9db46f4887669fbf78f18df
   languageName: node
   linkType: hard
 
@@ -7503,6 +7678,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/js-polyfills@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/js-polyfills@npm:0.85.3"
+  checksum: 10/17eedd2497c128f5c575f3804e2f23c441285e88a64522d740809588d93d11aade5069b3f20edec43715a8aecc3b90e816847e3ff91565bd35a9b692701265a1
+  languageName: node
+  linkType: hard
+
 "@react-native/metro-babel-transformer@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/metro-babel-transformer@npm:0.81.4"
@@ -7531,6 +7713,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/metro-babel-transformer@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/metro-babel-transformer@npm:0.85.3"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@react-native/babel-preset": "npm:0.85.3"
+    hermes-parser: "npm:0.33.3"
+    nullthrows: "npm:^1.1.1"
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 10/114fe0708f01903956ad8684e7bbad717a8ea46f083e09f8eb3a67fada2f09dc0b56da5f7401bd31cf0d3bb8c007f7334396d049b80d3a3895d6e32a99ac32fe
+  languageName: node
+  linkType: hard
+
 "@react-native/metro-config@npm:0.81.4":
   version: 0.81.4
   resolution: "@react-native/metro-config@npm:0.81.4"
@@ -7552,6 +7748,18 @@ __metadata:
     metro-config: "npm:^0.84.0"
     metro-runtime: "npm:^0.84.0"
   checksum: 10/d286fb9ec921acaf76d140039535566e0b092d8a4e4b9b1d7585a6159c3639d304e07c365eed5003c1314a0dc47f6815ed8e651bef506fffe0de3fed12a57fc4
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-config@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/metro-config@npm:0.85.3"
+  dependencies:
+    "@react-native/js-polyfills": "npm:0.85.3"
+    "@react-native/metro-babel-transformer": "npm:0.85.3"
+    metro-config: "npm:^0.84.3"
+    metro-runtime: "npm:^0.84.3"
+  checksum: 10/9a0af6d190df911b5e1b5b346b82e2dffeb6a703c832391e3f7b8bd1ac13751d5a2d7a0ef852cdae8b8474fee07783f49b9daa2a9e8b55c9539bd59f4dd609fc
   languageName: node
   linkType: hard
 
@@ -7590,6 +7798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/normalize-colors@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/normalize-colors@npm:0.85.3"
+  checksum: 10/6ed3f85bf2405c72809ddc4c320910d4afaa399b9eb50ffa0ddd2e5ff478649abaa890517d6b7aeb431dd7d2e1a6412ac4df9da36acc74a8d470ffee44aeaed8
+  languageName: node
+  linkType: hard
+
 "@react-native/normalize-colors@npm:^0.74.1":
   version: 0.74.89
   resolution: "@react-native/normalize-colors@npm:0.74.89"
@@ -7608,6 +7823,13 @@ __metadata:
   version: 0.85.2
   resolution: "@react-native/typescript-config@npm:0.85.2"
   checksum: 10/9459f686acad048eff47e6a144ea2b1c8b5cdfeb98be774826a8604a116f3bd47f23fe8003141d9109a898d41a3adc288335ef173dec4b9438c4a3a7846ea05c
+  languageName: node
+  linkType: hard
+
+"@react-native/typescript-config@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/typescript-config@npm:0.85.3"
+  checksum: 10/0d4295fba2b3abc9136457c9fdf788de26c237bf91e96a48d8434f0a919aea26ddb19f4e008c75d00bc7ca41d6fa1839a73cd67a39d12e5e1a36147e102b45ce
   languageName: node
   linkType: hard
 
@@ -22653,6 +22875,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-babel-transformer@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-babel-transformer@npm:0.84.4"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    flow-enums-runtime: "npm:^0.0.6"
+    hermes-parser: "npm:0.35.0"
+    metro-cache-key: "npm:0.84.4"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/5e3c1b49d88db6e6219f3c47a1fa61dd6cf38def566d9f24a430a8117853009fb0e3f975c7fa5aa20c7af7f142b37ef37b4a22838f0d18324a92002237630fad
+  languageName: node
+  linkType: hard
+
 "metro-cache-key@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-cache-key@npm:0.83.1"
@@ -22686,6 +22921,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
   checksum: 10/8a7a112a16af41fae91bc87359a164ed88c0a3b474861abfda5fcbe9e91afc359e7a126ece005611b1bc5102d1962529a56923ea55da1dec302bc2285663726c
+  languageName: node
+  linkType: hard
+
+"metro-cache-key@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-cache-key@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/381f330ec25ad3823ae843e5c21ed75aa5e34f4c92231aead526f4936f4280e1a73977a8d10fecc2b1ef8f11fc884323a76b650a93c699d6b02c706c17eea7ca
   languageName: node
   linkType: hard
 
@@ -22734,6 +22978,18 @@ __metadata:
     https-proxy-agent: "npm:^7.0.5"
     metro-core: "npm:0.84.3"
   checksum: 10/24d06b49a0bb45257c52227afccb3a6849f784126c8278d07479754b883795330f57cbd13425d817190fe001a33facc835a780ef47aae439ac62f4a19302b71e
+  languageName: node
+  linkType: hard
+
+"metro-cache@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-cache@npm:0.84.4"
+  dependencies:
+    exponential-backoff: "npm:^3.1.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    https-proxy-agent: "npm:^7.0.5"
+    metro-core: "npm:0.84.4"
+  checksum: 10/e59dcc3c691b545ce574383ef22576e8d3e5b8e5e7ea9fbe9e0070d8d36406705c01458c30b4a31ca3b810e43082cd3a1948d389cbb13552f170c336dc651b7e
   languageName: node
   linkType: hard
 
@@ -22801,6 +23057,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-config@npm:0.84.4, metro-config@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-config@npm:0.84.4"
+  dependencies:
+    connect: "npm:^3.6.5"
+    flow-enums-runtime: "npm:^0.0.6"
+    jest-validate: "npm:^29.7.0"
+    metro: "npm:0.84.4"
+    metro-cache: "npm:0.84.4"
+    metro-core: "npm:0.84.4"
+    metro-runtime: "npm:0.84.4"
+    yaml: "npm:^2.6.1"
+  checksum: 10/54c61d4794dcbe5444e65ef3bb28325449f143afd9972e1093d13871472ee9086094c38daf3735fc688448ab13b60e7800623f3cf5685063f7983956a5f55fcd
+  languageName: node
+  linkType: hard
+
 "metro-core@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-core@npm:0.83.1"
@@ -22842,6 +23114,17 @@ __metadata:
     lodash.throttle: "npm:^4.1.1"
     metro-resolver: "npm:0.84.3"
   checksum: 10/ad70ee8bf7ec8b0928ead0d73142e5b8a22365ebe5e2a9bff3501325137dfd0128e2216afb5ff629cddba0823d62c9c0a329dd8b2fcc9fa10a3ae3ddd138d281
+  languageName: node
+  linkType: hard
+
+"metro-core@npm:0.84.4, metro-core@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-core@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    lodash.throttle: "npm:^4.1.1"
+    metro-resolver: "npm:0.84.4"
+  checksum: 10/9ee8513522277c5fe00a8d1ef6b698763b9fd2bd2cdc90786617eef36896d3e1e778a0fd8aadd42027d5ca222a54056e734a51f5adb321195878f06341692713
   languageName: node
   linkType: hard
 
@@ -22913,6 +23196,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-file-map@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-file-map@npm:0.84.4"
+  dependencies:
+    debug: "npm:^4.4.0"
+    fb-watchman: "npm:^2.0.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    graceful-fs: "npm:^4.2.4"
+    invariant: "npm:^2.2.4"
+    jest-worker: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    nullthrows: "npm:^1.1.1"
+    walker: "npm:^1.0.7"
+  checksum: 10/ab4d01e5ab78cc78682603b8eaf68e45ccc00fe5e440e4e69d7e6102f79a13e126da3692ae6f3d4b379a8b05b284498fa18d10b1f9447046068e1aa1b658b2db
+  languageName: node
+  linkType: hard
+
 "metro-minify-terser@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-minify-terser@npm:0.83.1"
@@ -22950,6 +23250,16 @@ __metadata:
     flow-enums-runtime: "npm:^0.0.6"
     terser: "npm:^5.15.0"
   checksum: 10/7372c8570c4fc7d0c5f455f63ae2a5ed1707ab657bc0bb464b861bb15c2148689de3458b487c29d65ca270d0b542d455ad03c435c9187bf449f09a9d4f25ca5d
+  languageName: node
+  linkType: hard
+
+"metro-minify-terser@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-minify-terser@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    terser: "npm:^5.15.0"
+  checksum: 10/e0893b5672a4ad2bc6e2c492f9994a3eae6e633e49f2e5a52738e80260e37bb5143219ce2c337c22dd16cee850e68b99d1ba4bc378d7cc8e9cd60d636aa051b5
   languageName: node
   linkType: hard
 
@@ -23038,6 +23348,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-resolver@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-resolver@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/2234b8820ebebc70ae9688e3f4e4ec031f59bfefe51cd6171f7ce2063d97308663021292dccb2f34d80806d685f7f2583834eb718c8d5465a0385687f14b3996
+  languageName: node
+  linkType: hard
+
 "metro-runtime@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-runtime@npm:0.83.1"
@@ -23075,6 +23394,16 @@ __metadata:
     "@babel/runtime": "npm:^7.25.0"
     flow-enums-runtime: "npm:^0.0.6"
   checksum: 10/ffbf7469e706280e0334495c6ec9a62aa13ed0e6f72a8a7a5a0621eb80d77012db9a6358f1cfef1564e5c9afb7d4effa8a168c2e5092002f473931f1b52992cd
+  languageName: node
+  linkType: hard
+
+"metro-runtime@npm:0.84.4, metro-runtime@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-runtime@npm:0.84.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.0"
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/8c5818fdc67bd8ece9fc16bdcc848e115c76289f41b397efe30e401590dc04e36a4ea5af126682648f3b689ffbee27da20ba27ed261021aa4d222b75a40f353f
   languageName: node
   linkType: hard
 
@@ -23148,6 +23477,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-source-map@npm:0.84.4, metro-source-map@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-source-map@npm:0.84.4"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    metro-symbolicate: "npm:0.84.4"
+    nullthrows: "npm:^1.1.1"
+    ob1: "npm:0.84.4"
+    source-map: "npm:^0.5.6"
+    vlq: "npm:^1.0.0"
+  checksum: 10/675a4df8a85ef411a58cb334932bda6f8bd87a8e031f73ac1dfd76cfe89ebbe994c167fc36b66fc550c09e7bef1cfe405c5693ae4c20198db9753b6a7acae4fd
+  languageName: node
+  linkType: hard
+
 "metro-symbolicate@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-symbolicate@npm:0.83.1"
@@ -23212,6 +23558,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-symbolicate@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-symbolicate@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    metro-source-map: "npm:0.84.4"
+    nullthrows: "npm:^1.1.1"
+    source-map: "npm:^0.5.6"
+    vlq: "npm:^1.0.0"
+  bin:
+    metro-symbolicate: src/index.js
+  checksum: 10/a6aebc3a604aebd1c83dc090249c4f91f2bad25bcdd48c05c5f0cfc56ad223ac2c1ba558123b68ba6c3e97de7515d81b6ba9b048012746395f3eb68a9e90a189
+  languageName: node
+  linkType: hard
+
 "metro-transform-plugins@npm:0.83.1":
   version: 0.83.1
   resolution: "metro-transform-plugins@npm:0.83.1"
@@ -23265,6 +23627,20 @@ __metadata:
     flow-enums-runtime: "npm:^0.0.6"
     nullthrows: "npm:^1.1.1"
   checksum: 10/25086f817e061eff64d616d704bc1648ced485e5eecf9b4139c12df65cd948e06c932bdf98113eb067b44444a1e834867094a39f60a953acc15311432904ae33
+  languageName: node
+  linkType: hard
+
+"metro-transform-plugins@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-transform-plugins@npm:0.84.4"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/ae83306fbb640392205e571ddfb69629ec6d2878d664de85da2150d23458949dba833feef03759d9b15a13c0a50b4191ede41c685d12554c16fb8d56609292d6
   languageName: node
   linkType: hard
 
@@ -23349,6 +23725,27 @@ __metadata:
     metro-transform-plugins: "npm:0.84.3"
     nullthrows: "npm:^1.1.1"
   checksum: 10/b881edc38efc2783811360fc78632cdbb4e67d4940b852dedd7ca384913dc3281461f8af548a79413865330521c5bf3fd111deb83092bf733c8c6deb97a5ed61
+  languageName: node
+  linkType: hard
+
+"metro-transform-worker@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-transform-worker@npm:0.84.4"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    metro: "npm:0.84.4"
+    metro-babel-transformer: "npm:0.84.4"
+    metro-cache: "npm:0.84.4"
+    metro-cache-key: "npm:0.84.4"
+    metro-minify-terser: "npm:0.84.4"
+    metro-source-map: "npm:0.84.4"
+    metro-transform-plugins: "npm:0.84.4"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/bacccf7a3a051a2216490b221c63f16db97f35845232c0bd32edd211f82befa93b319fd6eb00df47595c24b6d7c3ec1851849773ff532de96c76b931709faa2b
   languageName: node
   linkType: hard
 
@@ -23549,6 +23946,55 @@ __metadata:
   bin:
     metro: src/cli.js
   checksum: 10/35d132deb041021f3be247bdf0c25151ec42fab54bfe0f997fd5d15990b9fcf0cd636b60083915c216e2012cd6029b5bca5982327cb06d8fa7c5b716b0e66c33
+  languageName: node
+  linkType: hard
+
+"metro@npm:0.84.4, metro@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro@npm:0.84.4"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    accepts: "npm:^2.0.0"
+    ci-info: "npm:^2.0.0"
+    connect: "npm:^3.6.5"
+    debug: "npm:^4.4.0"
+    error-stack-parser: "npm:^2.0.6"
+    flow-enums-runtime: "npm:^0.0.6"
+    graceful-fs: "npm:^4.2.4"
+    hermes-parser: "npm:0.35.0"
+    image-size: "npm:^1.0.2"
+    invariant: "npm:^2.2.4"
+    jest-worker: "npm:^29.7.0"
+    jsc-safe-url: "npm:^0.2.2"
+    lodash.throttle: "npm:^4.1.1"
+    metro-babel-transformer: "npm:0.84.4"
+    metro-cache: "npm:0.84.4"
+    metro-cache-key: "npm:0.84.4"
+    metro-config: "npm:0.84.4"
+    metro-core: "npm:0.84.4"
+    metro-file-map: "npm:0.84.4"
+    metro-resolver: "npm:0.84.4"
+    metro-runtime: "npm:0.84.4"
+    metro-source-map: "npm:0.84.4"
+    metro-symbolicate: "npm:0.84.4"
+    metro-transform-plugins: "npm:0.84.4"
+    metro-transform-worker: "npm:0.84.4"
+    mime-types: "npm:^3.0.1"
+    nullthrows: "npm:^1.1.1"
+    serialize-error: "npm:^2.1.0"
+    source-map: "npm:^0.5.6"
+    throat: "npm:^5.0.0"
+    ws: "npm:^7.5.10"
+    yargs: "npm:^17.6.2"
+  bin:
+    metro: src/cli.js
+  checksum: 10/22369963a965398add8e79939852b6a8906565d81bcb2a764255526fc8548417aed2976e315ec44cc432e104ea03afc616879449a0a9e4c292cfe0e9f252649d
   languageName: node
   linkType: hard
 
@@ -25219,6 +25665,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
   checksum: 10/7620743b1e94e6c873dbf77338d04c262b5827a69d17bc3625722d58dd129d82125168223843dd459394aebfcd16858e7ad9595e0809c441a3aad15e46dc749c
+  languageName: node
+  linkType: hard
+
+"ob1@npm:0.84.4":
+  version: 0.84.4
+  resolution: "ob1@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/15621cfa2d6bb196c5046031b3f85259735a245d9d7087f41758be3c31589c464e6eef53d94ec3d680fd8286ef08944782b9112f18d790a99421fbc7e311bb32
   languageName: node
   linkType: hard
 
@@ -28388,17 +28843,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:react-native-tvos@0.85.2-0":
-  version: 0.85.2-0
-  resolution: "react-native-tvos@npm:0.85.2-0"
+"react-native@npm:react-native-tvos@0.85.3-0":
+  version: 0.85.3-0
+  resolution: "react-native-tvos@npm:0.85.3-0"
   dependencies:
-    "@react-native-tvos/virtualized-lists": "npm:0.85.2-0"
-    "@react-native/assets-registry": "npm:0.85.2"
-    "@react-native/codegen": "npm:0.85.2"
-    "@react-native/community-cli-plugin": "npm:0.85.2"
-    "@react-native/gradle-plugin": "npm:0.85.2"
-    "@react-native/js-polyfills": "npm:0.85.2"
-    "@react-native/normalize-colors": "npm:0.85.2"
+    "@react-native-tvos/virtualized-lists": "npm:0.85.3-0"
+    "@react-native/assets-registry": "npm:0.85.3"
+    "@react-native/codegen": "npm:0.85.3"
+    "@react-native/community-cli-plugin": "npm:0.85.3"
+    "@react-native/gradle-plugin": "npm:0.85.3"
+    "@react-native/js-polyfills": "npm:0.85.3"
+    "@react-native/normalize-colors": "npm:0.85.3"
     abort-controller: "npm:^3.0.0"
     anser: "npm:^1.4.9"
     ansi-regex: "npm:^5.0.0"
@@ -28409,8 +28864,8 @@ __metadata:
     hermes-compiler: "npm:250829098.0.10"
     invariant: "npm:^2.2.4"
     memoize-one: "npm:^5.0.0"
-    metro-runtime: "npm:^0.84.0"
-    metro-source-map: "npm:^0.84.0"
+    metro-runtime: "npm:^0.84.3"
+    metro-source-map: "npm:^0.84.3"
     nullthrows: "npm:^1.1.1"
     pretty-format: "npm:^29.7.0"
     promise: "npm:^8.3.0"
@@ -28425,7 +28880,7 @@ __metadata:
     ws: "npm:^7.5.10"
     yargs: "npm:^17.6.2"
   peerDependencies:
-    "@react-native/jest-preset": 0.85.2
+    "@react-native/jest-preset": 0.85.3
     "@types/react": ^19.1.1
     react: ^19.2.3
   peerDependenciesMeta:
@@ -28435,7 +28890,7 @@ __metadata:
       optional: true
   bin:
     react-native: cli.js
-  checksum: 10/316de2d40dd8167521d8a20c40444124dbbbbb5fa82b7889e9fe86d4f58e9e264868f9e55c9206c73220af6bedf3e19c8b10de2f45e04af2f27fc5b9e5bbf1bf
+  checksum: 10/c2d96698e1ca4bd6a03e54263826282358cd6318b20aff343743dfc771fd6402e66e5581bfa1ca1ceceb77eae6fcbbcf4446ff23714600d20c82ff8d2efbf6c1
   languageName: node
   linkType: hard
 
@@ -31864,10 +32319,10 @@ __metadata:
     "@babel/core": "npm:7.28.4"
     "@babel/preset-env": "npm:7.28.3"
     "@babel/runtime": "npm:7.28.4"
-    "@react-native/babel-preset": "npm:0.85.2"
-    "@react-native/eslint-config": "npm:0.85.2"
-    "@react-native/metro-config": "npm:0.85.2"
-    "@react-native/typescript-config": "npm:0.85.2"
+    "@react-native/babel-preset": "npm:0.85.3"
+    "@react-native/eslint-config": "npm:0.85.3"
+    "@react-native/metro-config": "npm:0.85.3"
+    "@react-native/typescript-config": "npm:0.85.3"
     "@types/react": "npm:19.2.2"
     "@types/react-test-renderer": "npm:19.1.0"
     babel-jest: "npm:30.2.0"
@@ -31875,7 +32330,7 @@ __metadata:
     jest: "npm:30.2.0"
     prettier: "npm:3.6.2"
     react: "npm:19.2.3"
-    react-native: "npm:react-native-tvos@0.85.2-0"
+    react-native: "npm:react-native-tvos@0.85.3-0"
     react-native-reanimated: "workspace:*"
     react-native-worklets: "workspace:*"
     react-test-renderer: "npm:19.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22862,19 +22862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-babel-transformer@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-babel-transformer@npm:0.84.3"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    flow-enums-runtime: "npm:^0.0.6"
-    hermes-parser: "npm:0.35.0"
-    metro-cache-key: "npm:0.84.3"
-    nullthrows: "npm:^1.1.1"
-  checksum: 10/6682e2c89e46ea81782a05c82e9174ee34090eaf6c1a32e7bb1c2c734b19c6bcfbb0ac6b07b864d75424156ecc23f7db62b5003ddfda6f47449fffca58cfe7a2
-  languageName: node
-  linkType: hard
-
 "metro-babel-transformer@npm:0.84.4":
   version: 0.84.4
   resolution: "metro-babel-transformer@npm:0.84.4"
@@ -22912,15 +22899,6 @@ __metadata:
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
   checksum: 10/8d1f285d6987b4e57b708272c06d30ba12bc74137c7bf8c0fbcfb61ed7855e8cd3fe7a0c4890fa6c50e63719b28bc03c1c2098a33ac8d4817687feed1521133d
-  languageName: node
-  linkType: hard
-
-"metro-cache-key@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-cache-key@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10/8a7a112a16af41fae91bc87359a164ed88c0a3b474861abfda5fcbe9e91afc359e7a126ece005611b1bc5102d1962529a56923ea55da1dec302bc2285663726c
   languageName: node
   linkType: hard
 
@@ -22966,18 +22944,6 @@ __metadata:
     https-proxy-agent: "npm:^7.0.5"
     metro-core: "npm:0.83.6"
   checksum: 10/1e2ea06528a841d478419e780fbd5eca46f1633e7b04dba59f72afa706ad74160da97d665273d6c2365eb73f3b95049b4cd1068a5594e26728941490ac13e9cf
-  languageName: node
-  linkType: hard
-
-"metro-cache@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-cache@npm:0.84.3"
-  dependencies:
-    exponential-backoff: "npm:^3.1.1"
-    flow-enums-runtime: "npm:^0.0.6"
-    https-proxy-agent: "npm:^7.0.5"
-    metro-core: "npm:0.84.3"
-  checksum: 10/24d06b49a0bb45257c52227afccb3a6849f784126c8278d07479754b883795330f57cbd13425d817190fe001a33facc835a780ef47aae439ac62f4a19302b71e
   languageName: node
   linkType: hard
 
@@ -23041,23 +23007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-config@npm:0.84.3, metro-config@npm:^0.84.0":
-  version: 0.84.3
-  resolution: "metro-config@npm:0.84.3"
-  dependencies:
-    connect: "npm:^3.6.5"
-    flow-enums-runtime: "npm:^0.0.6"
-    jest-validate: "npm:^29.7.0"
-    metro: "npm:0.84.3"
-    metro-cache: "npm:0.84.3"
-    metro-core: "npm:0.84.3"
-    metro-runtime: "npm:0.84.3"
-    yaml: "npm:^2.6.1"
-  checksum: 10/4ce849a52ce523e0dd771986f9cc0c41010d264b48b3212b261e4bac378fa27d98d973e2d5805428a889af68c56e996f73b83f761dfee3ee81072495b3e0c021
-  languageName: node
-  linkType: hard
-
-"metro-config@npm:0.84.4, metro-config@npm:^0.84.3":
+"metro-config@npm:0.84.4, metro-config@npm:^0.84.0, metro-config@npm:^0.84.3":
   version: 0.84.4
   resolution: "metro-config@npm:0.84.4"
   dependencies:
@@ -23106,18 +23056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-core@npm:0.84.3, metro-core@npm:^0.84.0":
-  version: 0.84.3
-  resolution: "metro-core@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-    lodash.throttle: "npm:^4.1.1"
-    metro-resolver: "npm:0.84.3"
-  checksum: 10/ad70ee8bf7ec8b0928ead0d73142e5b8a22365ebe5e2a9bff3501325137dfd0128e2216afb5ff629cddba0823d62c9c0a329dd8b2fcc9fa10a3ae3ddd138d281
-  languageName: node
-  linkType: hard
-
-"metro-core@npm:0.84.4, metro-core@npm:^0.84.3":
+"metro-core@npm:0.84.4, metro-core@npm:^0.84.0, metro-core@npm:^0.84.3":
   version: 0.84.4
   resolution: "metro-core@npm:0.84.4"
   dependencies:
@@ -23179,23 +23118,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-file-map@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-file-map@npm:0.84.3"
-  dependencies:
-    debug: "npm:^4.4.0"
-    fb-watchman: "npm:^2.0.0"
-    flow-enums-runtime: "npm:^0.0.6"
-    graceful-fs: "npm:^4.2.4"
-    invariant: "npm:^2.2.4"
-    jest-worker: "npm:^29.7.0"
-    micromatch: "npm:^4.0.4"
-    nullthrows: "npm:^1.1.1"
-    walker: "npm:^1.0.7"
-  checksum: 10/0a0046d2a1c886324ed3f6bd5c882abeafcdbfa910ad01631f2ba4590e145f3265f6005932a6b5769cc78d95093fd97aa21eab838bc278e215c36525ff2bae84
-  languageName: node
-  linkType: hard
-
 "metro-file-map@npm:0.84.4":
   version: 0.84.4
   resolution: "metro-file-map@npm:0.84.4"
@@ -23240,16 +23162,6 @@ __metadata:
     flow-enums-runtime: "npm:^0.0.6"
     terser: "npm:^5.15.0"
   checksum: 10/36773b9127e2e99b70f7d04d03b3f50d3fec2af938088521b36ece4134d9acf23a25c95c90b9c64025d2519eeef7eb93061ff0c9e00ee2bdd25f756c67561138
-  languageName: node
-  linkType: hard
-
-"metro-minify-terser@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-minify-terser@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-    terser: "npm:^5.15.0"
-  checksum: 10/7372c8570c4fc7d0c5f455f63ae2a5ed1707ab657bc0bb464b861bb15c2148689de3458b487c29d65ca270d0b542d455ad03c435c9187bf449f09a9d4f25ca5d
   languageName: node
   linkType: hard
 
@@ -23339,15 +23251,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-resolver@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-resolver@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10/f01275e6c72cbe7c061ba51dac88f862b8cd8d701718f5b9782c0e751418d5821da4d278f54032a6661491f5a32aefb9f4c4f3b79ce2bd7f3e3e89811fc246ff
-  languageName: node
-  linkType: hard
-
 "metro-resolver@npm:0.84.4":
   version: 0.84.4
   resolution: "metro-resolver@npm:0.84.4"
@@ -23387,17 +23290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-runtime@npm:0.84.3, metro-runtime@npm:^0.84.0":
-  version: 0.84.3
-  resolution: "metro-runtime@npm:0.84.3"
-  dependencies:
-    "@babel/runtime": "npm:^7.25.0"
-    flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10/ffbf7469e706280e0334495c6ec9a62aa13ed0e6f72a8a7a5a0621eb80d77012db9a6358f1cfef1564e5c9afb7d4effa8a168c2e5092002f473931f1b52992cd
-  languageName: node
-  linkType: hard
-
-"metro-runtime@npm:0.84.4, metro-runtime@npm:^0.84.3":
+"metro-runtime@npm:0.84.4, metro-runtime@npm:^0.84.0, metro-runtime@npm:^0.84.3":
   version: 0.84.4
   resolution: "metro-runtime@npm:0.84.4"
   dependencies:
@@ -23460,24 +23353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.84.3, metro-source-map@npm:^0.84.0":
-  version: 0.84.3
-  resolution: "metro-source-map@npm:0.84.3"
-  dependencies:
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    flow-enums-runtime: "npm:^0.0.6"
-    invariant: "npm:^2.2.4"
-    metro-symbolicate: "npm:0.84.3"
-    nullthrows: "npm:^1.1.1"
-    ob1: "npm:0.84.3"
-    source-map: "npm:^0.5.6"
-    vlq: "npm:^1.0.0"
-  checksum: 10/b22194d0ed3bdf7cb3c86136143cfd31a2178e6bdc744afcac26a8c25219b77dacaa7e00c17cd52cd0366fcb62d49dffbb6bfcd815ad7e1803c84794871d0e29
-  languageName: node
-  linkType: hard
-
-"metro-source-map@npm:0.84.4, metro-source-map@npm:^0.84.3":
+"metro-source-map@npm:0.84.4, metro-source-map@npm:^0.84.0, metro-source-map@npm:^0.84.3":
   version: 0.84.4
   resolution: "metro-source-map@npm:0.84.4"
   dependencies:
@@ -23542,22 +23418,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-symbolicate@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-symbolicate@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-    invariant: "npm:^2.2.4"
-    metro-source-map: "npm:0.84.3"
-    nullthrows: "npm:^1.1.1"
-    source-map: "npm:^0.5.6"
-    vlq: "npm:^1.0.0"
-  bin:
-    metro-symbolicate: src/index.js
-  checksum: 10/e7781ed3e6fcb772182d079cd5ad0f53367a5a3b4c1f0798549096c980fea72ca39114a537ddaca7e45f0f466b948f454064b27c24894a1e2819be0020889040
-  languageName: node
-  linkType: hard
-
 "metro-symbolicate@npm:0.84.4":
   version: 0.84.4
   resolution: "metro-symbolicate@npm:0.84.4"
@@ -23613,20 +23473,6 @@ __metadata:
     flow-enums-runtime: "npm:^0.0.6"
     nullthrows: "npm:^1.1.1"
   checksum: 10/257f6fffa63e2d436033fb4d0f17e7200b43bad1dcc8da7ff7a5fed6cd00a60a14e5687a6330522773ffbc5c90f81c038e57105ee80313100fbcd6945275a687
-  languageName: node
-  linkType: hard
-
-"metro-transform-plugins@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-transform-plugins@npm:0.84.3"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.29.1"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    flow-enums-runtime: "npm:^0.0.6"
-    nullthrows: "npm:^1.1.1"
-  checksum: 10/25086f817e061eff64d616d704bc1648ced485e5eecf9b4139c12df65cd948e06c932bdf98113eb067b44444a1e834867094a39f60a953acc15311432904ae33
   languageName: node
   linkType: hard
 
@@ -23704,27 +23550,6 @@ __metadata:
     metro-transform-plugins: "npm:0.83.6"
     nullthrows: "npm:^1.1.1"
   checksum: 10/0d8c59fef2a880f060b59fbda0568214bc3290c5e1795a759404e53e97b1ec7b71e55b89a2e25e44337ee49a4e7f0ed1a7c7d788a203ecad48b77fabd8023331
-  languageName: node
-  linkType: hard
-
-"metro-transform-worker@npm:0.84.3":
-  version: 0.84.3
-  resolution: "metro-transform-worker@npm:0.84.3"
-  dependencies:
-    "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.29.1"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    flow-enums-runtime: "npm:^0.0.6"
-    metro: "npm:0.84.3"
-    metro-babel-transformer: "npm:0.84.3"
-    metro-cache: "npm:0.84.3"
-    metro-cache-key: "npm:0.84.3"
-    metro-minify-terser: "npm:0.84.3"
-    metro-source-map: "npm:0.84.3"
-    metro-transform-plugins: "npm:0.84.3"
-    nullthrows: "npm:^1.1.1"
-  checksum: 10/b881edc38efc2783811360fc78632cdbb4e67d4940b852dedd7ca384913dc3281461f8af548a79413865330521c5bf3fd111deb83092bf733c8c6deb97a5ed61
   languageName: node
   linkType: hard
 
@@ -23899,57 +23724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro@npm:0.84.3, metro@npm:^0.84.0":
-  version: 0.84.3
-  resolution: "metro@npm:0.84.3"
-  dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/core": "npm:^7.25.2"
-    "@babel/generator": "npm:^7.29.1"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    accepts: "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
-    ci-info: "npm:^2.0.0"
-    connect: "npm:^3.6.5"
-    debug: "npm:^4.4.0"
-    error-stack-parser: "npm:^2.0.6"
-    flow-enums-runtime: "npm:^0.0.6"
-    graceful-fs: "npm:^4.2.4"
-    hermes-parser: "npm:0.35.0"
-    image-size: "npm:^1.0.2"
-    invariant: "npm:^2.2.4"
-    jest-worker: "npm:^29.7.0"
-    jsc-safe-url: "npm:^0.2.2"
-    lodash.throttle: "npm:^4.1.1"
-    metro-babel-transformer: "npm:0.84.3"
-    metro-cache: "npm:0.84.3"
-    metro-cache-key: "npm:0.84.3"
-    metro-config: "npm:0.84.3"
-    metro-core: "npm:0.84.3"
-    metro-file-map: "npm:0.84.3"
-    metro-resolver: "npm:0.84.3"
-    metro-runtime: "npm:0.84.3"
-    metro-source-map: "npm:0.84.3"
-    metro-symbolicate: "npm:0.84.3"
-    metro-transform-plugins: "npm:0.84.3"
-    metro-transform-worker: "npm:0.84.3"
-    mime-types: "npm:^3.0.1"
-    nullthrows: "npm:^1.1.1"
-    serialize-error: "npm:^2.1.0"
-    source-map: "npm:^0.5.6"
-    throat: "npm:^5.0.0"
-    ws: "npm:^7.5.10"
-    yargs: "npm:^17.6.2"
-  bin:
-    metro: src/cli.js
-  checksum: 10/35d132deb041021f3be247bdf0c25151ec42fab54bfe0f997fd5d15990b9fcf0cd636b60083915c216e2012cd6029b5bca5982327cb06d8fa7c5b716b0e66c33
-  languageName: node
-  linkType: hard
-
-"metro@npm:0.84.4, metro@npm:^0.84.3":
+"metro@npm:0.84.4, metro@npm:^0.84.0, metro@npm:^0.84.3":
   version: 0.84.4
   resolution: "metro@npm:0.84.4"
   dependencies:
@@ -25656,15 +25431,6 @@ __metadata:
   dependencies:
     flow-enums-runtime: "npm:^0.0.6"
   checksum: 10/817cc83247508f6a17641924af5ccd793535e9376442ab8f9e59f7070cfb4830269540cacf79d036cdf087585810ced7dae3ea213c7f2dad73c2f198f1b676f9
-  languageName: node
-  linkType: hard
-
-"ob1@npm:0.84.3":
-  version: 0.84.3
-  resolution: "ob1@npm:0.84.3"
-  dependencies:
-    flow-enums-runtime: "npm:^0.0.6"
-  checksum: 10/7620743b1e94e6c873dbf77338d04c262b5827a69d17bc3625722d58dd129d82125168223843dd459394aebfcd16858e7ad9595e0809c441a3aad15e46dc749c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR bumps RN version in tvos example apps to `0.85.3`.
