### PR TITLE
fix: disable pull_request_target

### DIFF
--- a/.github/workflows/github-pull-request-description-format.yml
+++ b/.github/workflows/github-pull-request-description-format.yml
@@ -1,6 +1,6 @@
 name: GitHub Pull Request description format
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 

--- a/.github/workflows/github-pull-request-label-format.yml
+++ b/.github/workflows/github-pull-request-label-format.yml
@@ -1,6 +1,6 @@
 name: GitHub Pull Request label format
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary

Disabling `pull_request_target` temporarily until GitHub addresses security risks.

See tanstack attack postmortem ﻿https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
