### PR TITLE
fix: Dedupe native keyframes registration across same-content rules

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
+  hermes-engine: 2804a328bd7257cab440238977f66e78e500b9aa
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 3f3b29d3397ee033fc3082bd43d8287ceae3b4d9
+  React-Core-prebuilt: 49e61824dcac929adcea10bf6db4fcdf2f58114a
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: 8866d6164a71eae10eb7477a6f7a30589a1b6194
+  ReactNativeDependencies: 69d31adaa8131d2a14381236d5fd738e371a0f98
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 2804a328bd7257cab440238977f66e78e500b9aa
+  hermes-engine: 1a19285028fb614d915822559faf4e12c1da33dd
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 49e61824dcac929adcea10bf6db4fcdf2f58114a
+  React-Core-prebuilt: 3f3b29d3397ee033fc3082bd43d8287ceae3b4d9
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: 69d31adaa8131d2a14381236d5fd738e371a0f98
+  ReactNativeDependencies: 8866d6164a71eae10eb7477a6f7a30589a1b6194
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/packages/react-native-reanimated/src/css/native/keyframes/CSSKeyframesRegistry.ts
+++ b/packages/react-native-reanimated/src/css/native/keyframes/CSSKeyframesRegistry.ts
@@ -15,7 +15,7 @@ type KeyframesEntry = {
  * last view that uses them.
  */
 class CSSKeyframesRegistry {
-  private readonly cssTextToNameMap_: Map<string, string> = new Map();
+  private readonly cssTextToNames_: Map<string, Set<string>> = new Map();
   private readonly nameToKeyframes_: Map<string, KeyframesEntry> = new Map();
 
   get(nameOrCssText: string) {
@@ -24,7 +24,10 @@ class CSSKeyframesRegistry {
       return result.keyframesRule;
     }
 
-    const animationName = this.cssTextToNameMap_.get(nameOrCssText);
+    const animationName = this.cssTextToNames_
+      .get(nameOrCssText)
+      ?.values()
+      .next().value;
     if (animationName) {
       return this.nameToKeyframes_.get(animationName)?.keyframesRule;
     }
@@ -61,8 +64,14 @@ class CSSKeyframesRegistry {
 
     // Store the keyframes to name mapping in order to reuse the same
     // animation name when possible (when the same inline keyframes object
-    // is used)
-    this.cssTextToNameMap_.set(keyframesRule.cssText, keyframesRule.name);
+    // is used). Multiple separately-constructed `CSSKeyframesRuleImpl`
+    // instances may share the same `cssText` but have different names, so
+    // every name with this content must be tracked to keep content-based
+    // lookup working until the last same-content rule is removed.
+    if (!this.cssTextToNames_.has(keyframesRule.cssText)) {
+      this.cssTextToNames_.set(keyframesRule.cssText, new Set());
+    }
+    this.cssTextToNames_.get(keyframesRule.cssText)?.add(keyframesRule.name);
 
     // Register animation keyframes only if they are not already registered
     // (when they are added for the first time)
@@ -95,13 +104,21 @@ class CSSKeyframesRegistry {
 
     if (Object.keys(keyframesEntry.usedBy).length === 0) {
       this.nameToKeyframes_.delete(animationName);
-      this.cssTextToNameMap_.delete(keyframesEntry.keyframesRule.cssText);
+      const namesForCssText = this.cssTextToNames_.get(
+        keyframesEntry.keyframesRule.cssText
+      );
+      if (namesForCssText) {
+        namesForCssText.delete(animationName);
+        if (namesForCssText.size === 0) {
+          this.cssTextToNames_.delete(keyframesEntry.keyframesRule.cssText);
+        }
+      }
     }
   }
 
   clear() {
     this.nameToKeyframes_.clear();
-    this.cssTextToNameMap_.clear();
+    this.cssTextToNames_.clear();
   }
 }
 

--- a/packages/react-native-reanimated/src/css/native/keyframes/__tests__/CSSKeyframesRegistry.test.ts
+++ b/packages/react-native-reanimated/src/css/native/keyframes/__tests__/CSSKeyframesRegistry.test.ts
@@ -193,4 +193,117 @@ describe('CSSKeyframesRegistry', () => {
       expect(unregisterCSSKeyframes).toHaveBeenCalledTimes(1); // Finally, the animation is removed
     });
   });
+
+  describe('get', () => {
+    test('returns the rule when looked up by its name', () => {
+      cssKeyframesRegistry.add(
+        keyframesRule1,
+        viewTag1,
+        COMPOUND_COMPONENT_NAME
+      );
+
+      expect(cssKeyframesRegistry.get(keyframesRule1.name)).toBe(
+        keyframesRule1
+      );
+    });
+
+    test('returns the rule when looked up by its cssText', () => {
+      cssKeyframesRegistry.add(
+        keyframesRule1,
+        viewTag1,
+        COMPOUND_COMPONENT_NAME
+      );
+
+      expect(cssKeyframesRegistry.get(keyframesRule1.cssText)).toBe(
+        keyframesRule1
+      );
+    });
+
+    test('returns undefined when neither name nor cssText match a registered rule', () => {
+      cssKeyframesRegistry.add(
+        keyframesRule1,
+        viewTag1,
+        COMPOUND_COMPONENT_NAME
+      );
+
+      expect(
+        cssKeyframesRegistry.get('not-a-registered-animation-name')
+      ).toBeUndefined();
+      expect(
+        cssKeyframesRegistry.get('{"to":{"opacity":0.99}}')
+      ).toBeUndefined();
+    });
+
+    test.each([
+      {
+        which: 'first-added',
+        removed: keyframesRule1,
+        removedViewTag: viewTag1,
+        survivor: keyframesRule2,
+      },
+      {
+        which: 'second-added',
+        removed: keyframesRule2,
+        removedViewTag: viewTag2,
+        survivor: keyframesRule1,
+      },
+    ])(
+      'finds a survivor by content lookup after the $which rule is removed',
+      ({ removed, removedViewTag, survivor }) => {
+        // Two separately-constructed rules share the same cssText but have
+        // different names — both must remain reachable by content lookup
+        // until the last one is removed.
+        expect(keyframesRule1.cssText).toBe(keyframesRule2.cssText);
+        expect(keyframesRule1.name).not.toBe(keyframesRule2.name);
+
+        cssKeyframesRegistry.add(
+          keyframesRule1,
+          viewTag1,
+          COMPOUND_COMPONENT_NAME
+        );
+        cssKeyframesRegistry.add(
+          keyframesRule2,
+          viewTag2,
+          COMPOUND_COMPONENT_NAME
+        );
+
+        cssKeyframesRegistry.remove(
+          removed.name,
+          removedViewTag,
+          COMPOUND_COMPONENT_NAME
+        );
+
+        expect(cssKeyframesRegistry.get(keyframesRule1.cssText)).toBe(survivor);
+      }
+    );
+
+    test('returns undefined from content lookup only after every same-content rule is removed', () => {
+      cssKeyframesRegistry.add(
+        keyframesRule1,
+        viewTag1,
+        COMPOUND_COMPONENT_NAME
+      );
+      cssKeyframesRegistry.add(
+        keyframesRule2,
+        viewTag2,
+        COMPOUND_COMPONENT_NAME
+      );
+
+      cssKeyframesRegistry.remove(
+        keyframesRule1.name,
+        viewTag1,
+        COMPOUND_COMPONENT_NAME
+      );
+      expect(cssKeyframesRegistry.get(keyframesRule1.cssText)).toBe(
+        keyframesRule2
+      );
+
+      cssKeyframesRegistry.remove(
+        keyframesRule2.name,
+        viewTag2,
+        COMPOUND_COMPONENT_NAME
+      );
+      expect(cssKeyframesRegistry.get(keyframesRule1.cssText)).toBeUndefined();
+    });
+  });
 });

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
@@ -198,21 +198,18 @@ describe('CSSAnimationsManager', () => {
           2,
           COMPOUND_COMPONENT_NAME
         );
-        const manager3 = new CSSAnimationsManager(
-          shadowNodeWrapper,
-          3,
-          COMPOUND_COMPONENT_NAME
-        );
 
         manager1.update({ animationName: rule1 });
         manager2.update({ animationName: rule2 });
+        expect(registerCSSKeyframes).toHaveBeenCalledTimes(2);
+
         manager1.unmountCleanup();
+        // Re-attach manager1 with matching inline keyframes - should reuse
+        // rule2 instead of constructing and registering a third rule.
+        manager1.update({ animationName: keyframes });
 
-        jest.clearAllMocks();
-        manager3.update({ animationName: keyframes });
-
-        expect(registerCSSKeyframes).not.toHaveBeenCalled();
-        expect(applyCSSAnimations).toHaveBeenCalledWith(
+        expect(registerCSSKeyframes).toHaveBeenCalledTimes(2);
+        expect(applyCSSAnimations).toHaveBeenLastCalledWith(
           shadowNodeWrapper,
           COMPOUND_COMPONENT_NAME,
           expect.objectContaining({ animationNames: [rule2.name] })

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSAnimationsManager.test.ts
@@ -4,7 +4,7 @@ import type { ShadowNodeWrapper } from '../../../../commonTypes';
 import { ANIMATION_NAME_PREFIX } from '../../../constants';
 import { CSSKeyframesRuleBase } from '../../../models';
 import type { CSSAnimationProperties } from '../../../types';
-import { cssKeyframesRegistry } from '../../keyframes';
+import { cssKeyframesRegistry, CSSKeyframesRuleImpl } from '../../keyframes';
 import { normalizeSingleCSSAnimationSettings } from '../../normalization';
 import {
   applyCSSAnimations,
@@ -178,6 +178,45 @@ describe('CSSAnimationsManager', () => {
         expect(keyframesRule2).toBeDefined();
 
         expect(keyframesRule2).toBe(keyframesRule1);
+      });
+
+      test('reuses a surviving same-content rule when a sibling unmounts', () => {
+        // Two pre-constructed rules share cssText but have different names.
+        // After one unmounts, inline keyframes of the same content must reuse
+        // the survivor instead of registering a duplicate.
+        const keyframes = { from: { opacity: 0 }, to: { opacity: 1 } };
+        const rule1 = new CSSKeyframesRuleImpl(keyframes);
+        const rule2 = new CSSKeyframesRuleImpl(keyframes);
+
+        const manager1 = new CSSAnimationsManager(
+          shadowNodeWrapper,
+          1,
+          COMPOUND_COMPONENT_NAME
+        );
+        const manager2 = new CSSAnimationsManager(
+          shadowNodeWrapper,
+          2,
+          COMPOUND_COMPONENT_NAME
+        );
+        const manager3 = new CSSAnimationsManager(
+          shadowNodeWrapper,
+          3,
+          COMPOUND_COMPONENT_NAME
+        );
+
+        manager1.update({ animationName: rule1 });
+        manager2.update({ animationName: rule2 });
+        manager1.unmountCleanup();
+
+        jest.clearAllMocks();
+        manager3.update({ animationName: keyframes });
+
+        expect(registerCSSKeyframes).not.toHaveBeenCalled();
+        expect(applyCSSAnimations).toHaveBeenCalledWith(
+          shadowNodeWrapper,
+          COMPOUND_COMPONENT_NAME,
+          expect.objectContaining({ animationNames: [rule2.name] })
+        );
       });
 
       test('detaches an existing animation if the new config is empty', () => {


### PR DESCRIPTION
## Summary

`CSSKeyframesRegistry`'s `cssText - name` map dropped the content-to-name mapping when one keyframes rule was removed by content. We stored a single name per `cssText`, but multiple rules with the same content can coexist in the registry under different names (each `css.keyframes()` call constructs a fresh `CSSKeyframesRuleImpl`; only inline-keyframes lookups go through `cssKeyframesRegistry.get(cssText)` and reuse the existing instance). Removing the rule the map pointed to wiped the entry, leaving same-content siblings unreachable by content lookup and causing duplicate native registrations on subsequent inline lookups.

Replaced `Map<string, string>` with `Map<string, Set<string>>` so every name registered under a given `cssText` is tracked; the entry is removed only when the last same-content name is gone.