### PR TITLE
Remove unused `#include` directives to shorten build time

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -4,8 +4,6 @@
 #include <reanimated/Tools/FeatureFlags.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
-#include <react/renderer/core/ComponentDescriptor.h>
-
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -1,6 +1,5 @@
 #include <ReactCommon/CallInvoker.h>
 #include <folly/dynamic.h>
-#include <react/renderer/uimanager/UIManagerBinding.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -1,10 +1,6 @@
-#include <glog/logging.h>
-#include <react/renderer/animations/utils.h>
-#include <react/renderer/core/ConcreteState.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h>
 #include <reanimated/LayoutAnimations/PropsDiffer.h>
-#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
 #include <algorithm>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1,7 +1,5 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
-#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
-#include <react/renderer/animations/utils.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
 #include <memory>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1,5 +1,4 @@
 #include <react/renderer/scheduler/Scheduler.h>
-#include <react/renderer/uimanager/UIManagerBinding.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/Events/UIEventHandler.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/AnimationFrameQueue/AnimationFrameBatchinator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/AnimationFrameQueue/AnimationFrameBatchinator.cpp
@@ -1,6 +1,5 @@
 #include <jsi/jsi.h>
 #include <worklets/AnimationFrameQueue/AnimationFrameBatchinator.h>
-#include <worklets/SharedItems/Serializable.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
 
 #include <atomic>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -2,7 +2,6 @@
 #include <worklets/Compat/Holders.h>
 #include <worklets/Compat/StableApi.h>
 #include <worklets/NativeModules/JSIWorkletsModuleProxy.h>
-#include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/SharedItems/Serializable.h>
 #include <worklets/SharedItems/SerializableFactory.h>
 #include <worklets/SharedItems/Shareable.h>
@@ -10,9 +9,7 @@
 #include <worklets/Tools/FeatureFlags.h>
 #include <worklets/Tools/JSLogger.h>
 #include <worklets/Tools/WorkletsJSIUtils.h>
-#include <worklets/Tools/WorkletsSystraceSection.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
-#include <worklets/WorkletRuntime/UIRuntimeDecorator.h>
 
 #ifndef NDEBUG
 #include <algorithm>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -1,6 +1,4 @@
 #include <jsi/jsi.h>
-#include <react/renderer/uimanager/UIManagerBinding.h>
-#include <react/renderer/uimanager/primitives.h>
 #include <worklets/Compat/Holders.h>
 #include <worklets/Compat/StableApi.h>
 #include <worklets/NativeModules/JSIWorkletsModuleProxy.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react/renderer/uimanager/UIManagerBinding.h>
-#include <react/renderer/uimanager/primitives.h>
 #include <worklets/SharedItems/MemoryManager.h>
 #include <worklets/SharedItems/Serializable.h>
 #include <worklets/SharedItems/UnpackerLoader.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -1,7 +1,5 @@
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/RunLoop/AsyncQueueImpl.h>
-#include <worklets/SharedItems/Serializable.h>
-#include <worklets/Tools/ScriptBuffer.h>
 #include <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
 #include <worklets/WorkletRuntime/UIRuntimeDecorator.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -1,5 +1,3 @@
-#include <react/renderer/uimanager/UIManagerBinding.h>
-#include <react/renderer/uimanager/primitives.h>
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/RunLoop/AsyncQueueImpl.h>
 #include <worklets/SharedItems/Serializable.h>

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.cpp
@@ -1,5 +1,4 @@
 #include <worklets/NativeModules/JSIWorkletsModuleProxy.h>
-#include <worklets/Tools/JSISerializer.h>
 #include <worklets/Tools/JSLogger.h>
 #include <worklets/WorkletRuntime/RuntimeHolder.h>
 #include <worklets/WorkletRuntime/WorkletHermesRuntime.h>

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -1,7 +1,5 @@
-#include <worklets/NativeModules/JSIWorkletsModuleProxy.h>
 #include <worklets/Tools/ScriptBuffer.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
-#include <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
 #include <worklets/android/AnimationFrameCallback.h>
 #include <worklets/android/WorkletsModule.h>


### PR DESCRIPTION
## Summary

We get repeated reports that Reanimated and Worklets take a long time to compile. A `-ftime-trace` profile of a clean `fabric-example` arm64 debug build shows roughly 86% of compile CPU is spent in the frontend (parse + template instantiation), which matches what you'd expect when fat headers are re-parsed across dozens of TUs. Cutting unused includes is the cheapest way to reduce that surface — no API churn, no semantic changes.

This PR removes 19 unused C++ `#include` directives from 13 files in Reanimated and Worklets. Most of the removed headers were heavy React Native renderer headers (`react/renderer/uimanager/UIManagerBinding.h`, `react/renderer/core/ComponentDescriptor.h`, `react/renderer/core/ConcreteState.h`, `reanimated/NativeModules/ReanimatedModuleProxy.h`) that were transitively pulling in `UIManager.h`, `PointerEventsProcessor.h`, `ViewProps.h`, etc. into translation units that don't actually reference any of those symbols. No API or behaviour changes.

## Measurements

Clean `:react-native-worklets:buildCMakeDebug` + `:react-native-reanimated:buildCMakeDebug` for arm64-v8a (NDK 27.1, clang 18, C++20, M-series 12-core, no caches):

Wallclock:
* `main`: 34 s
* this branch: 31 s (-9%)

## What was removed

1. Ran `clang-tidy --checks='-*,misc-include-cleaner'` against every TU in the project's `compile_commands.json` (132 TUs across both libraries). That surfaced 51 candidate findings.
2. For each one, grepped the file for any symbol the header could plausibly provide (including method-chain returns, template specializations, and macro names) before removing.
3. Skipped the false-positive-prone cases:
   - stdlib umbrellas (`<utility>`, `<vector>`, `<memory>`, …) — `misc-include-cleaner` attributes std symbols inconsistently to canonical headers;
   - `<reanimated/Compat/WorkletsApi.h>` — exists only to fire a file-scope `static_assert` version pin;
   - `<fbjni/fbjni.h>` — umbrella header; methods like `facebook::jni::initialize` are reached via its `detail/` subheaders;
   - `<react/fabric/Binding.h>` in `NativeProxy.cpp` — needed for the `getBinding()->getScheduler()` chain to typecheck.

## Test plan

- [ ] `fabric-example` clean Android build (debug, arm64-v8a) — already verified locally
- [ ] `fabric-example` clean iOS build — Common/cpp changes are shared, needs verification
- [ ] Existing CI green
