### PR TITLE
Decouple CSS includes

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/FieldValidator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/FieldValidator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
+#include <functional>
+#include <string>
+
+namespace reanimated::css {
+
+struct FieldValidator {
+  std::string fieldName;
+  std::function<bool(const folly::dynamic &)> validateDynamic;
+  std::function<bool(facebook::jsi::Runtime &, const facebook::jsi::Value &)> validateJSI;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <folly/dynamic.h>
-#include <jsi/jsi.h>
+#include <array>
+#include <cstdint>
+#include <functional>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 namespace reanimated::css {
-
-using namespace facebook;
 
 using PropertyPath = std::vector<std::string>;
 using TransitionProperties = std::unordered_set<std::string>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/definitions.h
@@ -16,10 +16,4 @@ using TransitionProperties = std::unordered_set<std::string>;
 using EasingFunction = std::function<double(double)>;
 using ColorChannels = std::array<uint8_t, 4>;
 
-struct FieldValidator {
-  std::string fieldName;
-  std::function<bool(const folly::dynamic &)> validateDynamic;
-  std::function<bool(jsi::Runtime &, const jsi::Value &)> validateJSI;
-};
-
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <reanimated/CSS/common/definitions.h>
-
 #include <folly/dynamic.h>
+
 #include <memory>
 #include <string>
 #include <utility>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix2D.h
@@ -5,9 +5,13 @@
 #include <reanimated/CSS/common/transforms/vectors.h>
 
 #include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
 #include <utility>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 static constexpr size_t MATRIX_2D_DIMENSION = 3; // 3x3 matrix
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix3D.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix3D.h
@@ -12,6 +12,8 @@
 
 namespace reanimated::css {
 
+using namespace facebook;
+
 static constexpr size_t MATRIX_3D_DIMENSION = 4; // 4x4 matrix
 
 class TransformMatrix3D : public TransformMatrixBase<TransformMatrix3D, MATRIX_3D_DIMENSION> {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix3D.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/transforms/TransformMatrix3D.h
@@ -6,6 +6,8 @@
 #include <reanimated/CSS/common/transforms/vectors.h>
 
 #include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
 #include <utility>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSAngle.cpp
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSColor.h
@@ -3,9 +3,14 @@
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSValue.h>
 
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
 #include <string>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 // Base class with common color value functionality
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSDiscreteArray.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/CSS/common/values/CSSDiscreteArray.h>
 
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSLength.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/common/values/CSSLength.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 
 #include <string>
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValue.h
@@ -1,15 +1,26 @@
 #pragma once
 
-#include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
 
+// Forward-declared to keep <react/renderer/core/ShadowNode.h> out of this header.
+namespace facebook::react {
+class ShadowNode;
+} // namespace facebook::react
+
 namespace reanimated::css {
 
+// Forward-declared to keep ViewStylesRepository.h (and its heavy transitive includes) out of this header.
+class ViewStylesRepository;
+
 using namespace facebook;
+using namespace facebook::react;
 
 enum class RelativeTo : std::uint8_t {
   Parent,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBoxShadow.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBoxShadow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <reanimated/CSS/common/FieldValidator.h>
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSBoolean.h>
 #include <reanimated/CSS/common/values/CSSColor.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBoxShadow.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSBoxShadow.h
@@ -1,18 +1,21 @@
 #pragma once
 
 #include <reanimated/CSS/common/FieldValidator.h>
-#include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSBoolean.h>
 #include <reanimated/CSS/common/values/CSSColor.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
 
-#include <folly/json.h>
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
 #include <functional>
 #include <optional>
 #include <string>
 #include <vector>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 struct CSSBoxShadow : public CSSSimpleValue<CSSBoxShadow> {
   CSSDouble offsetX;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSDropShadow.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSDropShadow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <reanimated/CSS/common/FieldValidator.h>
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSBoolean.h>
 #include <reanimated/CSS/common/values/CSSColor.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSDropShadow.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/complex/CSSDropShadow.h
@@ -1,16 +1,20 @@
 #pragma once
 
 #include <reanimated/CSS/common/FieldValidator.h>
-#include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/common/values/CSSBoolean.h>
 #include <reanimated/CSS/common/values/CSSColor.h>
 #include <reanimated/CSS/common/values/CSSNumber.h>
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
 
 #include <functional>
 #include <string>
 #include <vector>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 struct CSSDropShadow : public CSSSimpleValue<CSSDropShadow> {
   CSSDouble offsetX;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/easing/cubicBezier.h
@@ -2,7 +2,11 @@
 
 #include <reanimated/CSS/common/definitions.h>
 
+#include <jsi/jsi.h>
+
 namespace reanimated::css {
+
+using namespace facebook;
 
 double sampleCurveX(double t, double x1, double x2);
 double sampleCurveY(double t, double y1, double y2);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/PropertyInterpolator.h
@@ -5,6 +5,9 @@
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/CSS/progress/KeyframeProgressProvider.h>
 
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -12,6 +15,8 @@
 #include <vector>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 class PropertyInterpolator {
  public:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <reanimated/CSS/InterpolatorRegistry.h>
-#include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/interpolation/groups/RecordPropertiesInterpolator.h>
 #include <reanimated/CSS/progress/TransitionProgressProvider.h>
+
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
 
 #include <memory>
 #include <string>
@@ -12,6 +14,8 @@
 #include <vector>
 
 namespace reanimated::css {
+
+using namespace facebook;
 
 class TransitionStyleInterpolator {
  public:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -4,6 +4,8 @@
 #include <reanimated/CSS/registries/StaticPropsRegistry.h>
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 
+#include <folly/dynamic.h>
+#include <jsi/jsi.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/dom/DOM.h>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGPath.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGPath.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <optional>
 #include <regex>
+#include <sstream>
 #include <string>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStops.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <optional>
 #include <regex>
+#include <sstream>
 #include <string>
 
 namespace reanimated::css {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
 
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary

This PR extracts `FieldValidator` struct definition to a separate header file in order to avoid including `jsi/jsi.h` header file in `definitions.h` to shorten build time.

## Test plan
