### PR TITLE
chore: Simplify `AnimatedStyle` types

### DIFF
--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -455,10 +455,6 @@ type MaybeSharedValueRecursive<Value> = Value extends readonly (infer Item)[]
           }
     : MaybeSharedValue<Value>;
 
-type AnimatedCSSPropKeys =
-  | keyof CSSAnimationProperties
-  | keyof CSSTransitionProperties;
-
 type ReanimatedCSSProps = Partial<
   CSSAnimationProperties & CSSTransitionProperties
 >;
@@ -471,7 +467,7 @@ type ReanimatedCSSProps = Partial<
 type WithReanimatedCSS<Style> =
   | (Style & ReanimatedCSSProps)
   | (Style extends object
-      ? Omit<Style, AnimatedCSSPropKeys> & ReanimatedCSSProps
+      ? Omit<Style, keyof ReanimatedCSSProps> & ReanimatedCSSProps
       : never);
 
 // Ideally we want AnimatedStyle to not be generic, but there are


### PR DESCRIPTION
A follow-up PR after #9394 with the unnecessary `AnimatedCSSPropKeys` alias removal