### PR TITLE
perf(CSS): Move interpolator factory definitions out-of-line to cut clean-build wallclock by ~9%

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.cpp
@@ -14,6 +14,9 @@
 #include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
 #include <reanimated/Compat/WorkletsApi.h>
 
+#include <folly/json.h>
+
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/common/values/CSSValueVariant.h
@@ -2,9 +2,8 @@
 
 #include <reanimated/CSS/common/values/CSSValue.h>
 
-#include <folly/json.h>
+#include <folly/dynamic.h>
 
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.cpp
@@ -1,11 +1,96 @@
 #include <reanimated/CSS/interpolation/InterpolatorFactory.h>
 #include <reanimated/CSS/interpolation/filters/FilterStyleInterpolator.h>
 
+#include <reanimated/CSS/common/values/CSSAngle.h>
+#include <reanimated/CSS/common/values/CSSBoolean.h>
+#include <reanimated/CSS/common/values/CSSColor.h>
+#include <reanimated/CSS/common/values/CSSDiscreteArray.h>
+#include <reanimated/CSS/common/values/CSSKeyword.h>
+#include <reanimated/CSS/common/values/CSSLength.h>
+#include <reanimated/CSS/common/values/CSSNumber.h>
+#include <reanimated/CSS/common/values/complex/CSSBoxShadow.h>
+#include <reanimated/CSS/svg/values/CSSLengthArray.h>
+#include <reanimated/CSS/svg/values/SVGBrush.h>
+#include <reanimated/CSS/svg/values/SVGPath.h>
+#include <reanimated/CSS/svg/values/SVGStops.h>
+#include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace reanimated::css {
+
+// SimpleValueInterpolatorFactory<AllowedTypes...>
+
+template <typename... AllowedTypes>
+SimpleValueInterpolatorFactory<AllowedTypes...>::SimpleValueInterpolatorFactory(
+    CSSValueVariant<AllowedTypes...> defaultValue)
+    : PropertyInterpolatorFactory(), defaultValue_(std::move(defaultValue)) {}
+
+template <typename... AllowedTypes>
+bool SimpleValueInterpolatorFactory<AllowedTypes...>::isDiscreteProperty() const {
+  // The property is considered discrete if all of the allowed types are discrete.
+  return (Discrete<AllowedTypes> && ...);
+}
+
+template <typename... AllowedTypes>
+const CSSValue &SimpleValueInterpolatorFactory<AllowedTypes...>::getDefaultValue() const {
+  return defaultValue_;
+}
+
+template <typename... AllowedTypes>
+std::shared_ptr<PropertyInterpolator> SimpleValueInterpolatorFactory<AllowedTypes...>::create(
+    const PropertyPath &propertyPath,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return std::make_shared<SimpleValueInterpolator<AllowedTypes...>>(propertyPath, defaultValue_, viewStylesRepository);
+}
+
+// ResolvableValueInterpolatorFactory<AllowedTypes...>
+
+template <typename... AllowedTypes>
+ResolvableValueInterpolatorFactory<AllowedTypes...>::ResolvableValueInterpolatorFactory(
+    CSSValueVariant<AllowedTypes...> defaultValue,
+    ResolvableValueInterpolatorConfig config)
+    : PropertyInterpolatorFactory(), defaultValue_(std::move(defaultValue)), config_(std::move(config)) {}
+
+template <typename... AllowedTypes>
+const CSSValue &ResolvableValueInterpolatorFactory<AllowedTypes...>::getDefaultValue() const {
+  return defaultValue_;
+}
+
+template <typename... AllowedTypes>
+std::shared_ptr<PropertyInterpolator> ResolvableValueInterpolatorFactory<AllowedTypes...>::create(
+    const PropertyPath &propertyPath,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const {
+  return std::make_shared<ResolvableValueInterpolator<AllowedTypes...>>(
+      propertyPath, defaultValue_, viewStylesRepository, config_);
+}
+
+// Explicit instantiations — must match the type packs `value<...>()` is called
+// with in InterpolatorRegistry.cpp. Resolvable packs (CSSLength-derived) use
+// ResolvableValueInterpolatorFactory; the rest use SimpleValueInterpolatorFactory.
+
+template class SimpleValueInterpolatorFactory<CSSAngle>;
+template class SimpleValueInterpolatorFactory<CSSBoolean>;
+template class SimpleValueInterpolatorFactory<CSSBoxShadow>;
+template class SimpleValueInterpolatorFactory<CSSColor>;
+template class SimpleValueInterpolatorFactory<CSSDiscreteArray<CSSKeyword>>;
+template class SimpleValueInterpolatorFactory<CSSDisplay>;
+template class SimpleValueInterpolatorFactory<CSSDouble>;
+template class SimpleValueInterpolatorFactory<CSSDouble, CSSKeyword>;
+template class SimpleValueInterpolatorFactory<CSSIndex>;
+template class SimpleValueInterpolatorFactory<CSSInteger>;
+template class SimpleValueInterpolatorFactory<CSSKeyword>;
+template class SimpleValueInterpolatorFactory<SVGBrush>;
+template class SimpleValueInterpolatorFactory<SVGPath>;
+template class SimpleValueInterpolatorFactory<SVGStops>;
+
+template class ResolvableValueInterpolatorFactory<CSSLength>;
+template class ResolvableValueInterpolatorFactory<CSSLength, CSSKeyword>;
+template class ResolvableValueInterpolatorFactory<CSSLengthArray>;
+template class ResolvableValueInterpolatorFactory<SVGStrokeDashArray, CSSKeyword>;
 
 class RecordInterpolatorFactory : public PropertyInterpolatorFactory {
  public:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h
@@ -20,30 +20,21 @@
 
 namespace reanimated::css {
 
-// Template class implementations
+// Member bodies are defined out-of-line in InterpolatorFactory.cpp and the
+// factory class templates are explicit-instantiated there for every concrete
+// `AllowedTypes...` pack used in the registry. This keeps the heavy codegen
+// (vtable, create(), etc.) confined to a single TU instead of being duplicated
+// in every TU that names `value<...>(default)`.
 template <typename... AllowedTypes>
 class SimpleValueInterpolatorFactory : public PropertyInterpolatorFactory {
  public:
-  template <typename TValue>
-  explicit SimpleValueInterpolatorFactory(const TValue &defaultValue)
-      : PropertyInterpolatorFactory(), defaultValue_(defaultValue) {}
+  explicit SimpleValueInterpolatorFactory(CSSValueVariant<AllowedTypes...> defaultValue);
 
-  bool isDiscreteProperty() const override {
-    // The property is considered discrete if all of the allowed types are
-    // discrete
-    return (Discrete<AllowedTypes> && ...);
-  }
-
-  const CSSValue &getDefaultValue() const override {
-    return defaultValue_;
-  }
-
+  bool isDiscreteProperty() const override;
+  const CSSValue &getDefaultValue() const override;
   std::shared_ptr<PropertyInterpolator> create(
       const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const override {
-    return std::make_shared<SimpleValueInterpolator<AllowedTypes...>>(
-        propertyPath, defaultValue_, viewStylesRepository);
-  }
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const override;
 
  private:
   const CSSValueVariant<AllowedTypes...> defaultValue_;
@@ -52,20 +43,14 @@ class SimpleValueInterpolatorFactory : public PropertyInterpolatorFactory {
 template <typename... AllowedTypes>
 class ResolvableValueInterpolatorFactory : public PropertyInterpolatorFactory {
  public:
-  template <typename TValue>
-  explicit ResolvableValueInterpolatorFactory(const TValue &defaultValue, ResolvableValueInterpolatorConfig config)
-      : PropertyInterpolatorFactory(), defaultValue_(defaultValue), config_(std::move(config)) {}
+  ResolvableValueInterpolatorFactory(
+      CSSValueVariant<AllowedTypes...> defaultValue,
+      ResolvableValueInterpolatorConfig config);
 
-  const CSSValue &getDefaultValue() const override {
-    return defaultValue_;
-  }
-
+  const CSSValue &getDefaultValue() const override;
   std::shared_ptr<PropertyInterpolator> create(
       const PropertyPath &propertyPath,
-      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const override {
-    return std::make_shared<ResolvableValueInterpolator<AllowedTypes...>>(
-        propertyPath, defaultValue_, viewStylesRepository, config_);
-  }
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) const override;
 
  private:
   const CSSValueVariant<AllowedTypes...> defaultValue_;


### PR DESCRIPTION
## What

Move the member bodies of `SimpleValueInterpolatorFactory<AllowedTypes...>` and `ResolvableValueInterpolatorFactory<AllowedTypes...>` out of `InterpolatorFactory.h` into `InterpolatorFactory.cpp`, and add explicit `template class` instantiations there for each `AllowedTypes...` pack the registry actually uses (14 for the simple variant, 4 for the resolvable one).

The factories' templated single-arg constructor is replaced by a non-templated one that takes a fully-constructed `CSSValueVariant<AllowedTypes...>` by value. Callers in [InterpolatorFactory.h](packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/InterpolatorFactory.h) (`value<...>(default)` and `value<...>(default, config)`) already construct the variant via `createCSSValue<...>` before passing it in, so this is a no-op at the call sites.

No behaviour change, no API change for the registry — `value<CSSDouble>(0)` etc. still compiles the same.

## Why

`-ftime-trace` profiling showed `InterpolatorRegistry.cpp` as the single heaviest TU in a clean Reanimated build at **~9.5 s wallclock**, with **~4.3 s of that in the backend** — codegen of ~50 distinct `SimpleValueInterpolatorFactory<T...>` / `ResolvableValueInterpolatorFactory<T...>` instantiations, all defined inline in `InterpolatorFactory.h`. Every `value<T...>(default)` call in the registry was emitting the full vtable, constructor body, and `create() { return make_shared<…ValueInterpolator<T...>>(…); }` inline.

With member bodies out-of-line + explicit instantiations, that codegen happens once in `InterpolatorFactory.cpp` instead of once per use in `InterpolatorRegistry.cpp`. Net codegen work across the two TUs is roughly the same, but the registry TU shrinks and the work parallelises with other TUs on multicore builds.

## Numbers (clean arm64 debug, NDK 27.1, M-series 12-core, no caches)

Wallclock for `:react-native-worklets:buildCMakeDebug` + `:react-native-reanimated:buildCMakeDebug`, 5× clean build each:


| | best | median | mean | worst |
|---|---:|---:|---:|---:|
| baseline | 30 s | 33 s | 32.6 s | 36 s |
| this branch | **28 s** | **30 s** | **30.0 s** | **33 s** |
| delta | **−2 s** | **−3 s** | **−2.6 s** | **−3 s** |

The distributions don't overlap at the median — every after-run was at or below the baseline median. ~9 % wallclock reduction.

Expected to be larger on CI (fewer cores → less parallelism upside in the old setup → bigger win from moving work out of the single-threaded `InterpolatorRegistry.cpp` critical path).

## Notes for review

- The factory class templates still live in `InterpolatorFactory.h` (the registry needs the type to construct factories via `make_shared`), but only their declarations. Anyone naming `SimpleValueInterpolatorFactory<NewTypePack>` outside the 14 already-instantiated packs will hit a linker error — add the explicit instantiation in `InterpolatorFactory.cpp`. The current 18 packs (14 simple + 4 resolvable) match 1:1 the explicit instantiations of `SimpleValueInterpolator<…>` in [SimpleValueInterpolator.cpp](packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/SimpleValueInterpolator.cpp) and `ResolvableValueInterpolator<…>` in [ResolvableValueInterpolator.cpp](packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/values/ResolvableValueInterpolator.cpp), so no surprise.
- `createCSSValue<...>` and `value<...>` themselves stay in the header — they're parametric on the default-value type (via `auto`), which makes them awkward to explicit-instantiate exhaustively. Worth revisiting if we want another round of compile-time wins later.
- The previous commit on this branch (`refactor: Update includes in CSSValueVariant files for clarity`) is just hygiene — measured to be in the noise band on its own. Optional to keep in the PR or split out.

## Test plan

- [x] `fabric-example` clean Android build (debug, arm64-v8a) — green
- [ ] `fabric-example` clean iOS build — Common/cpp changes are shared, needs CI
- [ ] Existing CI green
