### PR TITLE
fix: runtime tests wrongly mocking console on UI Runtime

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/matchers/rawMatchers.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/matchers/rawMatchers.ts
@@ -252,6 +252,10 @@ async function mockConsole(): Promise<
   console.warn = mockedConsoleFunction;
   await syncUIRunner.runOnUIBlocking(() => {
     'worklet';
+    (globalThis as Record<string, unknown>).__originalConsoleError =
+      console.error;
+    (globalThis as Record<string, unknown>).__originalConsoleWarn =
+      console.warn;
     console.error = mockedConsoleFunction;
     console.warn = mockedConsoleFunction;
   });
@@ -261,8 +265,12 @@ async function mockConsole(): Promise<
     console.warn = originalWarning;
     await syncUIRunner.runOnUIBlocking(() => {
       'worklet';
-      console.error = originalError;
-      console.warn = originalWarning;
+      console.error = (globalThis as Record<string, unknown>)
+        .__originalConsoleError as typeof console.error;
+      console.warn = (globalThis as Record<string, unknown>)
+        .__originalConsoleWarn as typeof console.warn;
+      delete (globalThis as Record<string, unknown>).__originalConsoleError;
+      delete (globalThis as Record<string, unknown>).__originalConsoleWarn;
     });
   };
 


### PR DESCRIPTION
## Summary

`console.log` on UI runtime was wrongfully replaced with a remote function from RN Runtime.

This code could probably be fully removed but I didn't want to dive into it too deeply at this point.

## Test plan

Running `memory` and `runtimes` test suites within one test run doesn't crash both in Bundle Mode and Legacy Mode.
