### PR TITLE
[Draft] fix: fix memory leak in Shared Element Transitions

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -62,6 +62,17 @@ void LayoutAnimationsManager::clearLayoutAnimationConfig(const int tag) {
   exitingAnimations_.erase(tag);
   layoutAnimations_.erase(tag);
   shouldAnimateExitingForTag_.erase(tag);
+  sharedTransitions_.erase(tag);
+  sharedTransitionManager_->tagToName_.erase(tag);
+}
+
+void LayoutAnimationsManager::clearSharedTransitionConfig(const int tag) {
+  sharedTransitionManager_->tagToName_.erase(tag);
+}
+
+void LayoutAnimationsManager::eraseSharedTransition(const int tag) {
+  auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
+  sharedTransitions_.erase(tag);
 }
 
 void LayoutAnimationsManager::startLayoutAnimation(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -56,6 +56,8 @@ class LayoutAnimationsManager {
   bool hasLayoutAnimation(const int tag, const LayoutAnimationType type);
   void startLayoutAnimation(jsi::Runtime &rt, const int tag, const LayoutAnimationType type, const jsi::Object &values);
   void clearLayoutAnimationConfig(const int tag);
+  void clearSharedTransitionConfig(const int tag);
+  void eraseSharedTransition(const int tag);
   void cancelLayoutAnimation(jsi::Runtime &rt, const int tag) const;
   void transferConfigFromNativeID(const int nativeId, const int tag);
   void transferSharedConfig(const Tag from, const Tag to);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -97,6 +97,11 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
 
   cleanupAnimations(filteredMutations, propsParserContext, surfaceId);
 
+  for (const auto tag : sharedTransitionTagsToErase_) {
+    layoutAnimationsManager_->eraseSharedTransition(tag);
+  }
+  sharedTransitionTagsToErase_.clear();
+
   transitionMap_.clear();
   transitions_.clear();
 
@@ -185,7 +190,13 @@ void LayoutAnimationsProxy_Experimental::updateLightTree(
         break;
       }
       case ShadowViewMutation::Delete: {
-        lightNodes_.erase(mutation.oldChildShadowView.tag);
+        const auto deletedTag = mutation.oldChildShadowView.tag;
+        lightNodes_.erase(deletedTag);
+        layoutAnimationsManager_->clearSharedTransitionConfig(deletedTag);
+        if (layoutAnimationsManager_->hasLayoutAnimation(
+                deletedTag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION)) {
+          sharedTransitionTagsToErase_.push_back(deletedTag);
+        }
         break;
       }
       case ShadowViewMutation::Insert: {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -58,6 +58,7 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   mutable std::unordered_map<Tag, std::shared_ptr<LightNode>> lightNodes_;
   mutable std::vector<std::shared_ptr<LightNode>> containersToInsert_;
   mutable std::unordered_map<Tag, react::Transform> transformForNode_;
+  mutable std::vector<Tag> sharedTransitionTagsToErase_;
 
   mutable ForceScreenSnapshotFunction forceScreenSnapshot_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -391,6 +391,9 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
         root->children.erase(root->children.begin() + i);
       }
     }
+    lightNodes_.erase(tag);
+    restoreMap_.erase(tag);
+    layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
   }
   sharedContainersToRemove_.clear();
 }


### PR DESCRIPTION
## Summary

sharedTransitions_ and tagToName_ were never cleaned up  - leaking memory

Note: *Fix was created by claude 4.7*. I still have to check if this code makes sense.

### Repro

Apply the following patch to observe the leaking objects:

```diff
diff --git a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
index 713022b4c7..7a43fadade 100644
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -1,5 +1,9 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -39,6 +43,20 @@ void LayoutAnimationsManager::configureAnimationBatch(const std::vector<LayoutAn
       getConfigsForType(type)[tag] = config;
     }
   }
+  // TEMPORARY: diagnostic to measure the shared-transition map footprint.
+  // Remove before merging.
+#ifdef __ANDROID__
+  __android_log_print(
+      ANDROID_LOG_INFO,
+      "reanimated-SET",
+      "[SET-SIZES] sharedTransitions=%zu tagToName=%zu containerTags=%zu "
+      "sharedTransitionsForNativeID=%zu nativeIDToName=%zu",
+      sharedTransitions_.size(),
+      sharedTransitionManager_->tagToName_.size(),
+      sharedTransitionManager_->containerTags_.size(),
+      sharedTransitionsForNativeID_.size(),
+      sharedTransitionManager_->nativeIDToName_.size());
+#endif
 }
 
 void LayoutAnimationsManager::setShouldAnimateExiting(const int tag, const bool value) {
```

1. Open any `[SET]` examples, trigger animations, go back etc.
2. Observe logs `[SET-SIZES] sharedTransitions=204 tagToName=204` is always increasing


## Test plan

TBD
