### PR TITLE
Add support for `placeholderTextColor` in synchronous props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -1,12 +1,21 @@
 import React, { useEffect } from 'react';
-import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+} from 'react-native';
 import Animated, {
   interpolateColor,
+  useAnimatedProps,
   useDerivedValue,
   useSharedValue,
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 export default function SynchronousPropsExample() {
   const sv = useSharedValue(0);
@@ -42,6 +51,10 @@ export default function SynchronousPropsExample() {
     () => [sv.value * 2, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 10, 1],
     [sv]
   );
+
+  const placeholderTextColorAnimatedProps = useAnimatedProps(() => ({
+    placeholderTextColor: interpolateColor(sv.value, [0, 1], ['red', 'blue']),
+  }));
 
   return (
     <ScrollView
@@ -141,6 +154,13 @@ export default function SynchronousPropsExample() {
       <Animated.Image
         style={{ width: 50, height: 50, tintColor: colorSv }}
         source={require('./assets/logo.png')}
+      />
+
+      <Text>placeholderTextColor</Text>
+      <AnimatedTextInput
+        style={{ width: 200, height: 40, borderWidth: 1, padding: 8 }}
+        placeholder="Placeholder text"
+        animatedProps={placeholderTextColorAnimatedProps}
       />
 
       {[

--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -53,7 +53,7 @@ export default function SynchronousPropsExample() {
   );
 
   const placeholderTextColorAnimatedProps = useAnimatedProps(() => ({
-    placeholderTextColor: interpolateColor(sv.value, [0, 1], ['red', 'blue']),
+    placeholderTextColor: colorSv.value,
   }));
 
   return (

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -66,6 +66,7 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       "backgroundColor",
       // "color", // not supported
       "tintColor",
+      "placeholderTextColor",
       "borderRadius",
       "borderTopLeftRadius",
       "borderTopRightRadius",

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -29,6 +29,7 @@ enum Command : std::uint8_t {
   CMD_BACKGROUND_COLOR = 15,
   CMD_COLOR = 16,
   CMD_TINT_COLOR = 17,
+  CMD_PLACEHOLDER_TEXT_COLOR = 18,
 
   CMD_BORDER_RADIUS = 20,
   CMD_BORDER_TOP_LEFT_RADIUS = 21,
@@ -81,6 +82,7 @@ const std::unordered_map<std::string_view, Command> kPropNameToCommand = {
     {"backgroundColor", CMD_BACKGROUND_COLOR},
     {"color", CMD_COLOR},
     {"tintColor", CMD_TINT_COLOR},
+    {"placeholderTextColor", CMD_PLACEHOLDER_TEXT_COLOR},
     {"borderRadius", CMD_BORDER_RADIUS},
     {"borderTopLeftRadius", CMD_BORDER_TOP_LEFT_RADIUS},
     {"borderTopRightRadius", CMD_BORDER_TOP_RIGHT_RADIUS},
@@ -169,6 +171,7 @@ void serializeSynchronousPropsToBuffers(
         case CMD_BACKGROUND_COLOR:
         case CMD_COLOR:
         case CMD_TINT_COLOR:
+        case CMD_PLACEHOLDER_TEXT_COLOR:
         case CMD_BORDER_COLOR:
         case CMD_BORDER_TOP_COLOR:
         case CMD_BORDER_BOTTOM_COLOR:

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -19,6 +19,7 @@ internal object SynchronousPropsBufferParser {
     private const val CMD_BACKGROUND_COLOR = 15
     private const val CMD_COLOR = 16
     private const val CMD_TINT_COLOR = 17
+    private const val CMD_PLACEHOLDER_TEXT_COLOR = 18
 
     private const val CMD_BORDER_RADIUS = 20
     private const val CMD_BORDER_TOP_LEFT_RADIUS = 21
@@ -71,6 +72,7 @@ internal object SynchronousPropsBufferParser {
             CMD_BACKGROUND_COLOR -> "backgroundColor"
             CMD_COLOR -> "color"
             CMD_TINT_COLOR -> "tintColor"
+            CMD_PLACEHOLDER_TEXT_COLOR -> "placeholderTextColor"
             CMD_BORDER_RADIUS -> "borderRadius"
             CMD_BORDER_TOP_LEFT_RADIUS -> "borderTopLeftRadius"
             CMD_BORDER_TOP_RIGHT_RADIUS -> "borderTopRightRadius"
@@ -142,6 +144,7 @@ internal object SynchronousPropsBufferParser {
                 CMD_BACKGROUND_COLOR,
                 CMD_COLOR,
                 CMD_TINT_COLOR,
+                CMD_PLACEHOLDER_TEXT_COLOR,
                 CMD_BORDER_COLOR,
                 CMD_BORDER_TOP_COLOR,
                 CMD_BORDER_BOTTOM_COLOR,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds support for `placeholderTextColor` in synchronous props fast path on both Android and iOS.

https://reactnative.dev/docs/textinput#placeholdertextcolor

## Test plan

Synchronous props are disabled by default in fabric-example, you need to modify the feature flags:

`apps/fabric-example/package.json`

```diff
   "reanimated": {
     "staticFeatureFlags": {
       "RUNTIME_TEST_FLAG": true,
       "DISABLE_COMMIT_PAUSING_MECHANISM": true,
-      "ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS": false,
-      "IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS": false,
+      "ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS": true,
+      "IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS": true,
       "EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS": true,
       "USE_SYNCHRONIZABLE_FOR_MUTABLES": true,
       "USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS": true,
-      "ENABLE_SHARED_ELEMENT_TRANSITIONS": true,
+      "ENABLE_SHARED_ELEMENT_TRANSITIONS": false,
       "FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS": true
     }
   },
```

It's faster to build for single architecture only:

`gradle.properties`

```diff
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+reactNativeArchitectures=arm64-v8a
```