### PR TITLE
Add support for `shadowColor` in synchronous props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -131,6 +131,19 @@ export default function SynchronousPropsExample() {
         }}
       />
 
+      <Text>shadowColor</Text>
+      <Animated.View
+        style={{
+          width: 50,
+          height: 50,
+          borderWidth: 1,
+          elevation: 2,
+          shadowRadius: 2,
+          shadowOpacity: 1,
+          shadowColor: colorSv,
+        }}
+      />
+
       <Text>backgroundColor</Text>
       <Animated.View
         style={{

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -59,6 +59,7 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       "opacity",
       "elevation",
       "zIndex",
+      "shadowColor",
 #if __APPLE__
       "shadowOpacity",
       "shadowRadius",

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -24,6 +24,7 @@ enum Command : std::uint8_t {
   CMD_OPACITY = 10,
   CMD_ELEVATION = 11,
   CMD_Z_INDEX = 12,
+  CMD_SHADOW_COLOR = 19,
   CMD_SHADOW_OPACITY = 13,
   CMD_SHADOW_RADIUS = 14,
   CMD_BACKGROUND_COLOR = 15,
@@ -77,6 +78,7 @@ const std::unordered_map<std::string_view, Command> kPropNameToCommand = {
     {"opacity", CMD_OPACITY},
     {"elevation", CMD_ELEVATION},
     {"zIndex", CMD_Z_INDEX},
+    {"shadowColor", CMD_SHADOW_COLOR},
     {"shadowOpacity", CMD_SHADOW_OPACITY},
     {"shadowRadius", CMD_SHADOW_RADIUS},
     {"backgroundColor", CMD_BACKGROUND_COLOR},
@@ -168,6 +170,7 @@ void serializeSynchronousPropsToBuffers(
           pushDouble(value.asDouble());
           break;
 
+        case CMD_SHADOW_COLOR:
         case CMD_BACKGROUND_COLOR:
         case CMD_COLOR:
         case CMD_TINT_COLOR:

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.JavaOnlyMap
 import java.util.Arrays
 
 internal object SynchronousPropsBufferParser {
-    // NOTE: Keep in sync with SynchronousPropsBufferSerializer.h
+    // NOTE: Keep in sync with command IDs in SynchronousPropsBufferSerializer.cpp
     private const val CMD_START_OF_VIEW = 1
     private const val CMD_START_OF_TRANSFORM = 2
     private const val CMD_END_OF_TRANSFORM = 3

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -14,6 +14,7 @@ internal object SynchronousPropsBufferParser {
     private const val CMD_OPACITY = 10
     private const val CMD_ELEVATION = 11
     private const val CMD_Z_INDEX = 12
+    private const val CMD_SHADOW_COLOR = 19
     private const val CMD_SHADOW_OPACITY = 13
     private const val CMD_SHADOW_RADIUS = 14
     private const val CMD_BACKGROUND_COLOR = 15
@@ -67,6 +68,7 @@ internal object SynchronousPropsBufferParser {
             CMD_OPACITY -> "opacity"
             CMD_ELEVATION -> "elevation"
             CMD_Z_INDEX -> "zIndex"
+            CMD_SHADOW_COLOR -> "shadowColor"
             CMD_SHADOW_OPACITY -> "shadowOpacity"
             CMD_SHADOW_RADIUS -> "shadowRadius"
             CMD_BACKGROUND_COLOR -> "backgroundColor"
@@ -141,6 +143,7 @@ internal object SynchronousPropsBufferParser {
                     props.putDouble(name, doubleIterator.nextDouble())
                 }
 
+                CMD_SHADOW_COLOR,
                 CMD_BACKGROUND_COLOR,
                 CMD_COLOR,
                 CMD_TINT_COLOR,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.JavaOnlyMap
 import java.util.Arrays
 
 internal object SynchronousPropsBufferParser {
-    // NOTE: Keep in sync with command IDs in SynchronousPropsBufferSerializer.cpp
+    // NOTE: Keep in sync with SynchronousPropsBufferSerializer.cpp
     private const val CMD_START_OF_VIEW = 1
     private const val CMD_START_OF_TRANSFORM = 2
     private const val CMD_END_OF_TRANSFORM = 3


### PR DESCRIPTION
## Summary

This PR adds support for `shadowColor` in synchronous props fast path on both Android and iOS.

> Note that only `shadowColor` works on both Android and iOS, all other `shadow` props only work on iOS.
https://reactnative.dev/docs/shadow-props#shadowcolor

## Test plan

See https://github.com/software-mansion/react-native-reanimated/pull/9409.
