### PR TITLE
Add support for `shadowOffset` in synchronous props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -42,6 +42,11 @@ export default function SynchronousPropsExample() {
     [sv]
   );
 
+  const shadowOffsetSv = useDerivedValue(
+    () => ({ width: tenSv.value, height: tenSv.value }),
+    [sv]
+  );
+
   const perspectiveSv = useDerivedValue(
     () => Math.pow(2, sv.value * 3 + 4.5),
     [sv]
@@ -106,6 +111,18 @@ export default function SynchronousPropsExample() {
           height: 50,
           borderWidth: 1,
           zIndex: zIndexSv,
+        }}
+      />
+
+      <Text>shadowOffset (not supported on Android)</Text>
+      <Animated.View
+        style={{
+          width: 50,
+          height: 50,
+          borderWidth: 1,
+          shadowRadius: 2,
+          shadowOpacity: 1,
+          shadowOffset: shadowOffsetSv,
         }}
       />
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -61,6 +61,7 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       "zIndex",
       "shadowColor",
 #if __APPLE__
+      "shadowOffset",
       "shadowOpacity",
       "shadowRadius",
 #endif // __APPLE__


### PR DESCRIPTION
## Summary

This PR adds support for `shadowColor` in synchronous props fast path on iOS only.

https://reactnative.dev/docs/shadow-props#shadowoffset-ios

## Test plan

See https://github.com/software-mansion/react-native-reanimated/pull/9409.
