### PR TITLE
Add support for `outlineColor`, `outlineOffset` and `outlineWidth` in synchronous props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -253,6 +253,40 @@ export default function SynchronousPropsExample() {
         </React.Fragment>
       ))}
 
+      <Text>outlineColor</Text>
+      <Animated.View
+        style={{
+          width: 50,
+          height: 50,
+          borderWidth: 1,
+          outlineWidth: 2,
+          outlineColor: colorSv,
+        }}
+      />
+
+      <Text>outlineOffset</Text>
+      <Animated.View
+        style={{
+          width: 50,
+          height: 50,
+          borderWidth: 1,
+          outlineWidth: 2,
+          outlineColor: 'gray',
+          outlineOffset: tenSv,
+        }}
+      />
+
+      <Text>outlineWidth</Text>
+      <Animated.View
+        style={{
+          width: 50,
+          height: 50,
+          borderWidth: 1,
+          outlineColor: 'gray',
+          outlineWidth: tenSv,
+        }}
+      />
+
       {(['translateX', 'translateY'] as const).map((prop) => (
         <React.Fragment key={prop}>
           <Text>{prop} [px]</Text>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -94,6 +94,9 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       "borderRightColor",
       "borderStartColor",
       "borderEndColor",
+      "outlineColor",
+      "outlineOffset",
+      "outlineWidth",
       "transform",
   };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -54,6 +54,10 @@ enum Command : std::uint8_t {
   CMD_BORDER_START_COLOR = 45,
   CMD_BORDER_END_COLOR = 46,
 
+  CMD_OUTLINE_COLOR = 50,
+  CMD_OUTLINE_OFFSET = 51,
+  CMD_OUTLINE_WIDTH = 52,
+
   CMD_TRANSFORM_TRANSLATE_X = 100,
   CMD_TRANSFORM_TRANSLATE_Y = 101,
   CMD_TRANSFORM_SCALE = 102,
@@ -105,6 +109,9 @@ const std::unordered_map<std::string_view, Command> kPropNameToCommand = {
     {"borderRightColor", CMD_BORDER_RIGHT_COLOR},
     {"borderStartColor", CMD_BORDER_START_COLOR},
     {"borderEndColor", CMD_BORDER_END_COLOR},
+    {"outlineColor", CMD_OUTLINE_COLOR},
+    {"outlineOffset", CMD_OUTLINE_OFFSET},
+    {"outlineWidth", CMD_OUTLINE_WIDTH},
     {"transform", CMD_START_OF_TRANSFORM}, // TODO: use CMD_TRANSFORM?
 };
 
@@ -166,6 +173,8 @@ void serializeSynchronousPropsToBuffers(
         case CMD_Z_INDEX:
         case CMD_SHADOW_OPACITY:
         case CMD_SHADOW_RADIUS:
+        case CMD_OUTLINE_OFFSET:
+        case CMD_OUTLINE_WIDTH:
           pushInt(command);
           pushDouble(value.asDouble());
           break;
@@ -182,6 +191,7 @@ void serializeSynchronousPropsToBuffers(
         case CMD_BORDER_RIGHT_COLOR:
         case CMD_BORDER_START_COLOR:
         case CMD_BORDER_END_COLOR:
+        case CMD_OUTLINE_COLOR:
           pushInt(command);
           pushInt(value.asInt());
           break;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -44,6 +44,10 @@ internal object SynchronousPropsBufferParser {
     private const val CMD_BORDER_START_COLOR = 45
     private const val CMD_BORDER_END_COLOR = 46
 
+    private const val CMD_OUTLINE_COLOR = 50
+    private const val CMD_OUTLINE_OFFSET = 51
+    private const val CMD_OUTLINE_WIDTH = 52
+
     private const val CMD_TRANSFORM_TRANSLATE_X = 100
     private const val CMD_TRANSFORM_TRANSLATE_Y = 101
     private const val CMD_TRANSFORM_SCALE = 102
@@ -95,6 +99,9 @@ internal object SynchronousPropsBufferParser {
             CMD_BORDER_RIGHT_COLOR -> "borderRightColor"
             CMD_BORDER_START_COLOR -> "borderStartColor"
             CMD_BORDER_END_COLOR -> "borderEndColor"
+            CMD_OUTLINE_COLOR -> "outlineColor"
+            CMD_OUTLINE_OFFSET -> "outlineOffset"
+            CMD_OUTLINE_WIDTH -> "outlineWidth"
             else -> throw RuntimeException("Unknown command: $command")
         }
 
@@ -138,6 +145,8 @@ internal object SynchronousPropsBufferParser {
                 CMD_Z_INDEX,
                 CMD_SHADOW_OPACITY,
                 CMD_SHADOW_RADIUS,
+                CMD_OUTLINE_OFFSET,
+                CMD_OUTLINE_WIDTH,
                 -> {
                     val name = commandToString(command)
                     props.putDouble(name, doubleIterator.nextDouble())
@@ -155,6 +164,7 @@ internal object SynchronousPropsBufferParser {
                 CMD_BORDER_RIGHT_COLOR,
                 CMD_BORDER_START_COLOR,
                 CMD_BORDER_END_COLOR,
+                CMD_OUTLINE_COLOR,
                 -> {
                     val name = commandToString(command)
                     props.putInt(name, intIterator.nextInt())


### PR DESCRIPTION
## Summary

This PR adds support for `outlineColor`, `outlineOffset` and `outlineWidth` in synchronous props fast path on both Android and iOS.

* https://reactnative.dev/docs/view-style-props#outlinecolor
* https://reactnative.dev/docs/view-style-props#outlineoffset
* https://reactnative.dev/docs/view-style-props#outlinewidth

## Test plan

See https://github.com/software-mansion/react-native-reanimated/pull/9409.
