### PR TITLE
Add support for `borderBlockColor`, `borderBlockStartColor` and `borderBlockEndColor` in synchronous props

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SynchronousPropsExample.tsx
@@ -238,6 +238,9 @@ export default function SynchronousPropsExample() {
         'borderRightColor',
         'borderStartColor',
         'borderEndColor',
+        'borderBlockColor',
+        'borderBlockStartColor',
+        'borderBlockEndColor',
       ].map((prop) => (
         <React.Fragment key={prop}>
           <Text>{prop}</Text>

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -94,6 +94,9 @@ std::pair<UpdatesBatch, UpdatesBatch> partitionUpdates(
       "borderRightColor",
       "borderStartColor",
       "borderEndColor",
+      "borderBlockColor",
+      "borderBlockStartColor",
+      "borderBlockEndColor",
       "transform",
   };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -53,6 +53,9 @@ enum Command : std::uint8_t {
   CMD_BORDER_RIGHT_COLOR = 44,
   CMD_BORDER_START_COLOR = 45,
   CMD_BORDER_END_COLOR = 46,
+  CMD_BORDER_BLOCK_COLOR = 47,
+  CMD_BORDER_BLOCK_START_COLOR = 48,
+  CMD_BORDER_BLOCK_END_COLOR = 49,
 
   CMD_TRANSFORM_TRANSLATE_X = 100,
   CMD_TRANSFORM_TRANSLATE_Y = 101,
@@ -105,6 +108,9 @@ const std::unordered_map<std::string_view, Command> kPropNameToCommand = {
     {"borderRightColor", CMD_BORDER_RIGHT_COLOR},
     {"borderStartColor", CMD_BORDER_START_COLOR},
     {"borderEndColor", CMD_BORDER_END_COLOR},
+    {"borderBlockColor", CMD_BORDER_BLOCK_COLOR},
+    {"borderBlockStartColor", CMD_BORDER_BLOCK_START_COLOR},
+    {"borderBlockEndColor", CMD_BORDER_BLOCK_END_COLOR},
     {"transform", CMD_START_OF_TRANSFORM}, // TODO: use CMD_TRANSFORM?
 };
 
@@ -182,6 +188,9 @@ void serializeSynchronousPropsToBuffers(
         case CMD_BORDER_RIGHT_COLOR:
         case CMD_BORDER_START_COLOR:
         case CMD_BORDER_END_COLOR:
+        case CMD_BORDER_BLOCK_COLOR:
+        case CMD_BORDER_BLOCK_START_COLOR:
+        case CMD_BORDER_BLOCK_END_COLOR:
           pushInt(command);
           pushInt(value.asInt());
           break;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/SynchronousPropsBufferParser.kt
@@ -43,6 +43,9 @@ internal object SynchronousPropsBufferParser {
     private const val CMD_BORDER_RIGHT_COLOR = 44
     private const val CMD_BORDER_START_COLOR = 45
     private const val CMD_BORDER_END_COLOR = 46
+    private const val CMD_BORDER_BLOCK_COLOR = 47
+    private const val CMD_BORDER_BLOCK_START_COLOR = 48
+    private const val CMD_BORDER_BLOCK_END_COLOR = 49
 
     private const val CMD_TRANSFORM_TRANSLATE_X = 100
     private const val CMD_TRANSFORM_TRANSLATE_Y = 101
@@ -95,6 +98,9 @@ internal object SynchronousPropsBufferParser {
             CMD_BORDER_RIGHT_COLOR -> "borderRightColor"
             CMD_BORDER_START_COLOR -> "borderStartColor"
             CMD_BORDER_END_COLOR -> "borderEndColor"
+            CMD_BORDER_BLOCK_COLOR -> "borderBlockColor"
+            CMD_BORDER_BLOCK_START_COLOR -> "borderBlockStartColor"
+            CMD_BORDER_BLOCK_END_COLOR -> "borderBlockEndColor"
             else -> throw RuntimeException("Unknown command: $command")
         }
 
@@ -155,6 +161,9 @@ internal object SynchronousPropsBufferParser {
                 CMD_BORDER_RIGHT_COLOR,
                 CMD_BORDER_START_COLOR,
                 CMD_BORDER_END_COLOR,
+                CMD_BORDER_BLOCK_COLOR,
+                CMD_BORDER_BLOCK_START_COLOR,
+                CMD_BORDER_BLOCK_END_COLOR,
                 -> {
                     val name = commandToString(command)
                     props.putInt(name, intIterator.nextInt())


### PR DESCRIPTION
## Summary

This PR adds support for `borderBlockColor`, `borderBlockStartColor` and `borderBlockEndColor` in synchronous props fast path on both Android and iOS.

* https://reactnative.dev/docs/view-style-props#borderblockcolor
* https://reactnative.dev/docs/view-style-props#borderblockstartcolor
* https://reactnative.dev/docs/view-style-props#borderblockendcolor

## Test plan

See https://github.com/software-mansion/react-native-reanimated/pull/9409.
