### PR TITLE
fix: CSS `animatedProps` in SVG not passed in initial render

### DIFF
--- a/packages/react-native-reanimated/__tests__/svg.test.tsx
+++ b/packages/react-native-reanimated/__tests__/svg.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Pressable, Text } from 'react-native';
 import Animated, {
+  type CSSAnimationProperties,
+  type CSSTransitionProperties,
   useAnimatedProps,
   useAnimatedStyle,
   useSharedValue,
@@ -117,5 +119,86 @@ describe('Animating wrapper of SVG', () => {
     jest.advanceTimersByTime(600);
 
     expect(wrapper).toHaveAnimatedStyle({ opacity: 1 });
+  });
+});
+
+describe('Plain object animatedProps', () => {
+  function TestComponent({
+    animatedProps,
+  }: {
+    animatedProps: Record<string, unknown>;
+  }) {
+    return (
+      <Svg height="100" width="100">
+        <AnimatedCircle
+          testID="circle"
+          cx="50"
+          cy="50"
+          animatedProps={animatedProps}
+        />
+      </Svg>
+    );
+  }
+
+  test('forwards values to the underlying component on initial render', () => {
+    const { getByTestId } = render(
+      <TestComponent animatedProps={{ r: 20, fill: 'blue' }} />
+    );
+
+    const circle = getByTestId('circle');
+    expect(circle.props.r).toBe(20);
+    expect(circle.props.fill).toBe('blue');
+  });
+
+  test('updates the rendered values when animatedProps change', () => {
+    const { getByTestId, rerender } = render(
+      <TestComponent animatedProps={{ r: 20, fill: 'blue' }} />
+    );
+
+    rerender(<TestComponent animatedProps={{ r: 50, fill: 'red' }} />);
+    expect(getByTestId('circle').props.r).toBe(50);
+    expect(getByTestId('circle').props.fill).toBe('red');
+  });
+
+  test('does not forward CSS transition config keys', () => {
+    const transitionConfig: Required<CSSTransitionProperties> = {
+      transitionProperty: 'all',
+      transitionDuration: '500ms',
+      transitionTimingFunction: 'ease-in',
+      transitionDelay: '0ms',
+      transitionBehavior: 'normal',
+      transition: 'all 500ms ease-in 0ms',
+    };
+
+    const { getByTestId } = render(
+      <TestComponent animatedProps={transitionConfig} />
+    );
+
+    const circle = getByTestId('circle');
+    for (const key of Object.keys(transitionConfig)) {
+      expect(circle.props[key]).toBeUndefined();
+    }
+  });
+
+  test('does not forward CSS animation config keys', () => {
+    const animationConfig: Required<CSSAnimationProperties> = {
+      animationName: 'none',
+      animationDuration: '1s',
+      animationTimingFunction: 'linear',
+      animationDelay: '0ms',
+      animationIterationCount: 1,
+      animationDirection: 'normal',
+      animationFillMode: 'none',
+      animationPlayState: 'running',
+    };
+
+    const { getByTestId } = render(
+      <TestComponent animatedProps={animationConfig} />
+    );
+
+    const circle = getByTestId('circle');
+    for (const key of Object.keys(animationConfig)) {
+      expect(circle.props[key]).toBeUndefined();
+    }
   });
 });

--- a/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
@@ -2,6 +2,7 @@
 
 import { initialUpdaterRun } from '../animation';
 import type { StyleProps } from '../commonTypes';
+import { isCSSStyleProp } from '../css/utils';
 import type { AnimatedStyleHandle } from '../hook/commonTypes';
 import { isSharedValue } from '../isSharedValue';
 import { WorkletEventHandler } from '../WorkletEventHandler';
@@ -64,13 +65,20 @@ export class PropsFilter implements IPropsFilter {
         >(animatedPropsProp ?? []);
 
         animatedPropsArray.forEach((animatedProps) => {
-          if (animatedProps?.viewDescriptors && animatedProps.initial) {
-            Object.keys(animatedProps.initial.value).forEach(
-              (initialValueKey) => {
-                props[initialValueKey] =
-                  animatedProps.initial?.value[initialValueKey];
+          if (!animatedProps) {
+            return;
+          }
+          if (animatedProps.viewDescriptors && animatedProps.initial) {
+            const initialValue = animatedProps.initial.value;
+            for (const initialValueKey in initialValue) {
+              props[initialValueKey] = initialValue[initialValueKey];
+            }
+          } else {
+            for (const animatedPropKey in animatedProps) {
+              if (!isCSSStyleProp(animatedPropKey)) {
+                props[animatedPropKey] = animatedProps[animatedPropKey];
               }
-            );
+            }
           }
         });
       } else if (


### PR DESCRIPTION
## Summary

Fix CSS SVG missing props on the first render issue. The previous behavior was counter-intuitive as we had to pass inline props (as we normally do on SVGs, like `<Circle r={50} />`) to ensure the prop is applied and also use `animatedProps` to trigger transitions. We ended up having to write duplicate props like this to ensure that transitions work properly and SVG components aren't missing any prop on initial render `<Circle r={50} animatedProps={{ r: 50, transitionDuration: 500 }} />`, which was cumbersome. This PR fixes the issue by spreading non-css props (all props except css-transition and css-animation specific ones) onto the underlying component so that we no longer have to specify props like `r={50}` separately inline and just e.g. `<Circle animatedProps={{ r: 50, transitionDuration: 500 }} />` works.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/d8e3b835-002a-43ed-976f-d1e32d9d1254" /> | <video src="https://github.com/user-attachments/assets/b4544bb4-ff95-407c-aa85-f870192fa553" /> |

## Test plan

Copy the following example to the example app and compare how it worked before and how it works now.

<details>
<summary>Example source code</summary>

```tsx
import React, { useState } from 'react';
import { Button, StyleSheet, Text, View } from 'react-native';
import Animated from 'react-native-reanimated';
import { Circle, Svg } from 'react-native-svg';

const AnimatedCircle = Animated.createAnimatedComponent(Circle);

export default function EmptyExample() {
  const [toggled, setToggled] = useState(false);
  const cx = toggled ? 250 : 50;
  const fill = toggled ? 'skyblue' : 'tomato';

  return (
    <View style={styles.container}>
      <Text style={styles.label}>Expected initial cx: 50 (left side)</Text>
      <Svg height="120" width="300" style={styles.svg}>
        <AnimatedCircle
          cy="60"
          r="25"
          animatedProps={{
            cx,
            fill,
            transitionDuration: 500,
          }}
        />
      </Svg>
      <Button title="Toggle position" onPress={() => setToggled((t) => !t)} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 12,
  },
  svg: {
    backgroundColor: '#eee',
  },
  label: {
    fontSize: 14,
  },
});
```
</details>