### PR TITLE
fix: `animatedProps` should take precedence over inline props

### DIFF
--- a/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
+++ b/packages/react-native-reanimated/__tests__/animatedProps.test.tsx
@@ -4,15 +4,22 @@ import React from 'react';
 import type { TextInputProps } from 'react-native';
 import { Button, TextInput, View } from 'react-native';
 import Animated, {
+  type CSSAnimationProperties,
+  type CSSTransitionProperties,
   useAnimatedProps,
   useSharedValue,
 } from 'react-native-reanimated';
+import { Circle, Svg } from 'react-native-svg';
 
 import type { JestAnimatedStyleHandle } from '../src/hook/commonTypes';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('react-native-svg', () => require('../mock'));
 
 const animationDuration = 100;
 
 const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 interface BaseTextInputComponentProps {
   animatedProps: ComponentProps<typeof AnimatedTextInput>['animatedProps'];
@@ -303,6 +310,192 @@ describe('animatedProps', () => {
 
       removeMocks.forEach((mock) => {
         expect(mock).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Plain object animatedProps', () => {
+    function PlainObjectComponent({
+      animatedProps,
+    }: {
+      animatedProps: Record<string, unknown>;
+    }) {
+      return (
+        <Svg height="100" width="100">
+          <AnimatedCircle
+            testID="circle"
+            cx="50"
+            cy="50"
+            animatedProps={animatedProps}
+          />
+        </Svg>
+      );
+    }
+
+    test('forwards values to the underlying component on initial render', () => {
+      const { getByTestId } = render(
+        <PlainObjectComponent animatedProps={{ r: 20, fill: 'blue' }} />
+      );
+
+      const circle = getByTestId('circle');
+      expect(circle.props.r).toBe(20);
+      expect(circle.props.fill).toBe('blue');
+    });
+
+    test('updates the rendered values when animatedProps change', () => {
+      const { getByTestId, rerender } = render(
+        <PlainObjectComponent animatedProps={{ r: 20, fill: 'blue' }} />
+      );
+
+      rerender(<PlainObjectComponent animatedProps={{ r: 50, fill: 'red' }} />);
+      expect(getByTestId('circle').props.r).toBe(50);
+      expect(getByTestId('circle').props.fill).toBe('red');
+    });
+
+    test('does not forward CSS transition config keys', () => {
+      const transitionConfig: Required<CSSTransitionProperties> = {
+        transitionProperty: 'all',
+        transitionDuration: '500ms',
+        transitionTimingFunction: 'ease-in',
+        transitionDelay: '0ms',
+        transitionBehavior: 'normal',
+        transition: 'all 500ms ease-in 0ms',
+      };
+
+      const { getByTestId } = render(
+        <PlainObjectComponent animatedProps={transitionConfig} />
+      );
+
+      const circle = getByTestId('circle');
+      for (const key of Object.keys(transitionConfig)) {
+        expect(circle.props[key]).toBeUndefined();
+      }
+    });
+
+    test('does not forward CSS animation config keys', () => {
+      const animationConfig: Required<CSSAnimationProperties> = {
+        animationName: 'none',
+        animationDuration: '1s',
+        animationTimingFunction: 'linear',
+        animationDelay: '0ms',
+        animationIterationCount: 1,
+        animationDirection: 'normal',
+        animationFillMode: 'none',
+        animationPlayState: 'running',
+      };
+
+      const { getByTestId } = render(
+        <PlainObjectComponent animatedProps={animationConfig} />
+      );
+
+      const circle = getByTestId('circle');
+      for (const key of Object.keys(animationConfig)) {
+        expect(circle.props[key]).toBeUndefined();
+      }
+    });
+  });
+
+  describe('Precedence over inline props', () => {
+    // animatedProps must win over inline props for the same key, regardless
+    // of JSX attribute order. Order is therefore load-bearing — do not
+    // reorder the JSX attributes in the tests below.
+
+    describe('useAnimatedProps', () => {
+      test('overrides inline value (animatedProps declared first)', () => {
+        function TestComponent() {
+          const animatedProps = useAnimatedProps(() => ({
+            placeholder: 'from-animated-props',
+          }));
+          return (
+            <AnimatedTextInput
+              testID="text"
+              animatedProps={animatedProps}
+              placeholder="from-inline"
+            />
+          );
+        }
+
+        const { getByTestId } = render(<TestComponent />);
+        const textInput = getByTestId('text');
+        expect(textInput.props.placeholder).toBe('from-animated-props');
+      });
+
+      test('overrides inline value (inline declared first)', () => {
+        function TestComponent() {
+          const animatedProps = useAnimatedProps(() => ({
+            placeholder: 'from-animated-props',
+          }));
+          return (
+            <AnimatedTextInput
+              testID="text"
+              placeholder="from-inline"
+              animatedProps={animatedProps}
+            />
+          );
+        }
+
+        const { getByTestId } = render(<TestComponent />);
+        const textInput = getByTestId('text');
+        expect(textInput.props.placeholder).toBe('from-animated-props');
+      });
+    });
+
+    describe('Plain object animatedProps', () => {
+      test('overrides inline value (animatedProps declared first)', () => {
+        const { getByTestId } = render(
+          <Svg height="100" width="100">
+            <AnimatedCircle
+              testID="circle"
+              cx="50"
+              cy="50"
+              animatedProps={{ r: 10, fill: 'blue' }}
+              r={40}
+              fill="red"
+            />
+          </Svg>
+        );
+
+        const circle = getByTestId('circle');
+        expect(circle.props.r).toBe(10);
+        expect(circle.props.fill).toBe('blue');
+      });
+
+      test('overrides inline value (inline declared first)', () => {
+        const { getByTestId } = render(
+          <Svg height="100" width="100">
+            <AnimatedCircle
+              testID="circle"
+              cx="50"
+              cy="50"
+              r={40}
+              fill="red"
+              animatedProps={{ r: 10, fill: 'blue' }}
+            />
+          </Svg>
+        );
+
+        const circle = getByTestId('circle');
+        expect(circle.props.r).toBe(10);
+        expect(circle.props.fill).toBe('blue');
+      });
+
+      test('inline props are kept for keys not present in animatedProps', () => {
+        const { getByTestId } = render(
+          <Svg height="100" width="100">
+            <AnimatedCircle
+              testID="circle"
+              cx="50"
+              cy="50"
+              r={40}
+              fill="red"
+              animatedProps={{ r: 10 }}
+            />
+          </Svg>
+        );
+
+        const circle = getByTestId('circle');
+        expect(circle.props.r).toBe(10);
+        expect(circle.props.fill).toBe('red');
       });
     });
   });

--- a/packages/react-native-reanimated/__tests__/svg.test.tsx
+++ b/packages/react-native-reanimated/__tests__/svg.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Pressable, Text } from 'react-native';
 import Animated, {
-  type CSSAnimationProperties,
-  type CSSTransitionProperties,
   useAnimatedProps,
   useAnimatedStyle,
   useSharedValue,
@@ -119,86 +117,5 @@ describe('Animating wrapper of SVG', () => {
     jest.advanceTimersByTime(600);
 
     expect(wrapper).toHaveAnimatedStyle({ opacity: 1 });
-  });
-});
-
-describe('Plain object animatedProps', () => {
-  function TestComponent({
-    animatedProps,
-  }: {
-    animatedProps: Record<string, unknown>;
-  }) {
-    return (
-      <Svg height="100" width="100">
-        <AnimatedCircle
-          testID="circle"
-          cx="50"
-          cy="50"
-          animatedProps={animatedProps}
-        />
-      </Svg>
-    );
-  }
-
-  test('forwards values to the underlying component on initial render', () => {
-    const { getByTestId } = render(
-      <TestComponent animatedProps={{ r: 20, fill: 'blue' }} />
-    );
-
-    const circle = getByTestId('circle');
-    expect(circle.props.r).toBe(20);
-    expect(circle.props.fill).toBe('blue');
-  });
-
-  test('updates the rendered values when animatedProps change', () => {
-    const { getByTestId, rerender } = render(
-      <TestComponent animatedProps={{ r: 20, fill: 'blue' }} />
-    );
-
-    rerender(<TestComponent animatedProps={{ r: 50, fill: 'red' }} />);
-    expect(getByTestId('circle').props.r).toBe(50);
-    expect(getByTestId('circle').props.fill).toBe('red');
-  });
-
-  test('does not forward CSS transition config keys', () => {
-    const transitionConfig: Required<CSSTransitionProperties> = {
-      transitionProperty: 'all',
-      transitionDuration: '500ms',
-      transitionTimingFunction: 'ease-in',
-      transitionDelay: '0ms',
-      transitionBehavior: 'normal',
-      transition: 'all 500ms ease-in 0ms',
-    };
-
-    const { getByTestId } = render(
-      <TestComponent animatedProps={transitionConfig} />
-    );
-
-    const circle = getByTestId('circle');
-    for (const key of Object.keys(transitionConfig)) {
-      expect(circle.props[key]).toBeUndefined();
-    }
-  });
-
-  test('does not forward CSS animation config keys', () => {
-    const animationConfig: Required<CSSAnimationProperties> = {
-      animationName: 'none',
-      animationDuration: '1s',
-      animationTimingFunction: 'linear',
-      animationDelay: '0ms',
-      animationIterationCount: 1,
-      animationDirection: 'normal',
-      animationFillMode: 'none',
-      animationPlayState: 'running',
-    };
-
-    const { getByTestId } = render(
-      <TestComponent animatedProps={animationConfig} />
-    );
-
-    const circle = getByTestId('circle');
-    for (const key of Object.keys(animationConfig)) {
-      expect(circle.props[key]).toBeUndefined();
-    }
   });
 });

--- a/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx
@@ -59,28 +59,10 @@ export class PropsFilter implements IPropsFilter {
         // it will help other libs to interpret styles correctly
         props[key] = processedStyle;
       } else if (key === 'animatedProps') {
-        const animatedPropsProp = inputProps.animatedProps;
-        const animatedPropsArray = flattenArray<
-          Partial<AnimatedComponentProps<AnimatedProps>>
-        >(animatedPropsProp ?? []);
-
-        animatedPropsArray.forEach((animatedProps) => {
-          if (!animatedProps) {
-            return;
-          }
-          if (animatedProps.viewDescriptors && animatedProps.initial) {
-            const initialValue = animatedProps.initial.value;
-            for (const initialValueKey in initialValue) {
-              props[initialValueKey] = initialValue[initialValueKey];
-            }
-          } else {
-            for (const animatedPropKey in animatedProps) {
-              if (!isCSSStyleProp(animatedPropKey)) {
-                props[animatedPropKey] = animatedProps[animatedPropKey];
-              }
-            }
-          }
-        });
+        // Handled in a second pass after this loop so that animatedProps
+        // values always take precedence over inline props with the same key,
+        // regardless of JSX attribute order.
+        continue;
       } else if (
         has('workletEventHandler', value) &&
         value.workletEventHandler instanceof WorkletEventHandler
@@ -104,6 +86,36 @@ export class PropsFilter implements IPropsFilter {
         props[key] = value;
       }
     }
+
+    // Second pass: apply animatedProps last so it always wins over inline
+    // props that share a key. This makes the precedence deterministic and
+    // independent of the order in which attributes were written in JSX.
+    const animatedPropsProp = inputProps.animatedProps;
+    if (animatedPropsProp) {
+      const animatedPropsArray =
+        flattenArray<Partial<AnimatedComponentProps<AnimatedProps>>>(
+          animatedPropsProp
+        );
+
+      animatedPropsArray.forEach((animatedProps) => {
+        if (!animatedProps) {
+          return;
+        }
+        if (animatedProps.viewDescriptors && animatedProps.initial) {
+          const initialValue = animatedProps.initial.value;
+          for (const initialValueKey in initialValue) {
+            props[initialValueKey] = initialValue[initialValueKey];
+          }
+        } else {
+          for (const animatedPropKey in animatedProps) {
+            if (!isCSSStyleProp(animatedPropKey)) {
+              props[animatedPropKey] = animatedProps[animatedPropKey];
+            }
+          }
+        }
+      });
+    }
+
     return props;
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the inconsistent behavior where `animatedProps` and inline props weren't handles properly and the application of props during initial render dependent on the order in which they are specified. Users will most likely use `animatedProps` to pass transition-related props and would expect these to take precedence over inline props. This PR implements this correction so that `animatedProps` have higher importance and override inline ones.

## Example recordings

Recordings show that the prop that was actually applied in the first render was prop-order-dependent before and after changes the `animatedProps` prop takes precedence.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/73159d40-be05-41b8-a1e4-ddaac76503a0" /> | <video src="https://github.com/user-attachments/assets/6e87ca29-16a1-43e1-afc3-ad393272bd45" /> |

## Test plan

<details>
<summary>Example source code</summary>

```tsx
import React, { useState } from 'react';
import { Button, StyleSheet, Text, View } from 'react-native';
import Animated from 'react-native-reanimated';
import { Circle, Svg } from 'react-native-svg';

const AnimatedCircle = Animated.createAnimatedComponent(Circle);

// Halfway between toggle endpoints (50, 250) — a circle stuck on this value
// sits in the middle of the track, clearly failing to animate.
const INLINE_FALLBACK_CX = 150;

// All three circles should animate from cx=50 to cx=250 in lockstep.
// Section 3 is the precedence regression check: animatedProps must win
// over a conflicting inline `cx` regardless of JSX attribute order.
export default function EmptyExample() {
  const [toggled, setToggled] = useState(false);
  const cx = toggled ? 250 : 50;

  return (
    <View style={styles.container}>
      <Text style={styles.label}>
        All three circles should animate from cx=50 to cx=250 in lockstep.
      </Text>

      <Text style={styles.subLabel}>
        1. cx + transitionDuration both in animatedProps
      </Text>
      <Svg height="60" width="300" style={styles.svg}>
        <AnimatedCircle
          cy="30"
          r="20"
          fill="tomato"
          animatedProps={{
            cx,
            transitionProperty: 'cx',
            transitionDuration: 500,
          }}
        />
      </Svg>

      <Text style={styles.subLabel}>
        2. transitionDuration in animatedProps, cx inline
      </Text>
      <Svg height="60" width="300" style={styles.svg}>
        <AnimatedCircle
          cy="30"
          r="20"
          fill="skyblue"
          cx={cx}
          animatedProps={{
            transitionProperty: 'cx',
            transitionDuration: 500,
          }}
        />
      </Svg>

      <Text style={styles.subLabel}>
        3. cx in both - animatedProps wins regardless of JSX order
      </Text>
      <Svg height="60" width="300" style={styles.svg}>
        {/* JSX order is load-bearing: animatedProps first, inline cx last. */}
        <AnimatedCircle
          cy="30"
          r="20"
          fill="palegreen"
          animatedProps={{
            cx,
            transitionProperty: 'cx',
            transitionDuration: 500,
          }}
          cx={INLINE_FALLBACK_CX}
        />
      </Svg>

      <Button title="Toggle position" onPress={() => setToggled((t) => !t)} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 8,
    paddingHorizontal: 16,
  },
  svg: {
    backgroundColor: '#eee',
  },
  label: {
    fontSize: 14,
    fontWeight: '600',
    textAlign: 'center',
  },
  subLabel: {
    fontSize: 12,
    color: '#444',
  },
});
```
</details>