### PR TITLE
Replace `std::stof` with `std::stod` in synchronous props logic

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -228,7 +228,7 @@ void serializeSynchronousPropsToBuffers(
               throw std::runtime_error("[Reanimated] Border radius string must be a percentage");
             }
             pushInt(CMD_UNIT_PERCENT);
-            pushDouble(std::stof(valueStr.substr(0, valueStr.size() - 1)));
+            pushDouble(std::stod(valueStr.substr(0, valueStr.size() - 1)));
           } else {
             throw std::runtime_error("[Reanimated] Border radius value must be either a number or a string");
           }
@@ -265,7 +265,7 @@ void serializeSynchronousPropsToBuffers(
                     throw std::runtime_error("[Reanimated] String translate must be a percentage");
                   }
                   pushInt(CMD_UNIT_PERCENT);
-                  pushDouble(std::stof(transformValueStr.substr(0, transformValueStr.size() - 1)));
+                  pushDouble(std::stod(transformValueStr.substr(0, transformValueStr.size() - 1)));
                 } else {
                   throw std::runtime_error("[Reanimated] Translate value must be either a number or a string");
                 }
@@ -286,7 +286,7 @@ void serializeSynchronousPropsToBuffers(
                 } else {
                   throw std::runtime_error("[Reanimated] Unsupported rotation unit: " + transformValueStr);
                 }
-                pushDouble(std::stof(transformValueStr.substr(0, transformValueStr.size() - 3)));
+                pushDouble(std::stod(transformValueStr.substr(0, transformValueStr.size() - 3)));
                 break;
               }
               case CMD_TRANSFORM_MATRIX: {


### PR DESCRIPTION
## Summary

This PR replaces `std::stof` (float) with `std::stod` (double) in synchronous props logic

## Test plan
