### PR TITLE
Preallocate and reuse synchronous props buffers on Android

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -220,7 +220,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
   // for vector growth allocations.
   if (StaticFeatureFlags::getFlag("ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS")) {
     synchronousPropsIntBuffer_.reserve(1024);
-    synchronousPropsDoubleBuffer_.reserve(512);
+    synchronousPropsDoubleBuffer_.reserve(1024);
   }
 #endif // ANDROID
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -212,6 +212,15 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
   updatesRegistryManager_->addRegistry(cssTransitionsRegistry_);
   updatesRegistryManager_->addRegistry(animatedPropsRegistry_);
   updatesRegistryManager_->addRegistry(cssAnimationsRegistry_);
+
+#ifdef ANDROID
+  // Pre-allocate the synchronous props buffers so the first frame doesn't pay
+  // for vector growth allocations.
+  if (StaticFeatureFlags::getFlag("ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS")) {
+    synchronousPropsIntBuffer_.reserve(1024);
+    synchronousPropsDoubleBuffer_.reserve(512);
+  }
+#endif // ANDROID
 }
 
 void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMethodsHolder) {
@@ -780,12 +789,9 @@ void ReanimatedModuleProxy::applySynchronousUpdates(UpdatesBatch &updatesBatch, 
 
 #ifdef ANDROID
   if (!synchronousUpdatesBatch.empty()) {
-    std::vector<int> intBuffer;
-    std::vector<double> doubleBuffer;
-    intBuffer.reserve(1024);
-    doubleBuffer.reserve(1024);
-    serializeSynchronousPropsToBuffers(synchronousUpdatesBatch, intBuffer, doubleBuffer);
-    synchronouslyUpdateUIPropsFunction_(intBuffer, doubleBuffer);
+    serializeSynchronousPropsToBuffers(
+        synchronousUpdatesBatch, synchronousPropsIntBuffer_, synchronousPropsDoubleBuffer_);
+    synchronouslyUpdateUIPropsFunction_(synchronousPropsIntBuffer_, synchronousPropsDoubleBuffer_);
   }
 #endif // ANDROID
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -204,14 +204,16 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
-  auto lock = updatesRegistryManager_->lock();
-  // Add registries in order of their priority (from the lowest to the
-  // highest)
-  // CSS transitions should be overriden by animated style animations;
-  // animated style animations should be overriden by CSS animations.
-  updatesRegistryManager_->addRegistry(cssTransitionsRegistry_);
-  updatesRegistryManager_->addRegistry(animatedPropsRegistry_);
-  updatesRegistryManager_->addRegistry(cssAnimationsRegistry_);
+  {
+    auto lock = updatesRegistryManager_->lock();
+    // Add registries in order of their priority (from the lowest to the
+    // highest)
+    // CSS transitions should be overriden by animated style animations;
+    // animated style animations should be overriden by CSS animations.
+    updatesRegistryManager_->addRegistry(cssTransitionsRegistry_);
+    updatesRegistryManager_->addRegistry(animatedPropsRegistry_);
+    updatesRegistryManager_->addRegistry(cssAnimationsRegistry_);
+  }
 
 #ifdef ANDROID
   // Pre-allocate the synchronous props buffers so the first frame doesn't pay

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -202,6 +202,13 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
   const PreserveMountedTagsFunction filterUnmountedTagsFunction_;
 
+#ifdef ANDROID
+  // Reused across `applySynchronousUpdates` calls to avoid per-frame heap
+  // allocations. Access only on the UI thread.
+  std::vector<int> synchronousPropsIntBuffer_;
+  std::vector<double> synchronousPropsDoubleBuffer_;
+#endif // ANDROID
+
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/SynchronousPropsBufferSerializer.cpp
@@ -159,6 +159,9 @@ void serializeSynchronousPropsToBuffers(
     const UpdatesBatch &synchronousUpdatesBatch,
     std::vector<int> &intBuffer,
     std::vector<double> &doubleBuffer) {
+  intBuffer.clear();
+  doubleBuffer.clear();
+
   const auto pushInt = [&](int value) {
     intBuffer.push_back(value);
   };


### PR DESCRIPTION
## Summary

Currently, we're allocating a new `intBuffer` and `doubleBuffer` on each animation frame on Android when synchronous props feature flag is enabled. We're also calling `.reserve(1024)` each time which results in 12 kB allocations on each animation frame.

This PR re-uses `intBuffer` and `doubleBuffer` as well as preallocates them in `ReanimatedModuleProxy` constructor.

## Test plan
