### PR TITLE
fix: add mutex lock in `LayoutAnimationsManager::transferSharedConfig`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -111,6 +111,7 @@ void LayoutAnimationsManager::transferConfigFromNativeID(const int nativeId, con
 }
 
 void LayoutAnimationsManager::transferSharedConfig(const Tag from, const Tag to) {
+  auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
   sharedTransitions_[to] = sharedTransitions_[from];
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -72,7 +72,8 @@ class LayoutAnimationsManager {
   std::unordered_map<int, std::shared_ptr<Serializable>> exitingAnimations_;
   std::unordered_map<int, std::shared_ptr<Serializable>> layoutAnimations_;
   std::unordered_map<int, bool> shouldAnimateExitingForTag_;
-  mutable std::recursive_mutex animationsMutex_; // Protects `enteringAnimations_`, `exitingAnimations_`,
+  mutable std::recursive_mutex animationsMutex_; // Protects `enteringAnimationsForNativeID_`,
+  // `sharedTransitionsForNativeID_`, `sharedTransitions_`, `enteringAnimations_`, `exitingAnimations_`,
   // `layoutAnimations_` and `shouldAnimateExitingForTag_`.
 };
 


### PR DESCRIPTION
## Summary

`LayoutAnimationsManager::transferSharedConfig` was reading and writing `sharedTransitions_` without acquiring `animationsMutex_`, while every other method touching the map does. This is a data race — the call site (`LayoutAnimationsProxy_Experimental::transferConfigToContainer`) runs on the UI thread during mounting, but `sharedTransitions_` is also mutated from the JS thread via `configureAnimationBatch` and from the UI thread via `transferConfigFromNativeID`, both under the lock.

Also updated the header comment, which only listed 4 of the 7 fields the mutex actually protects.

This is a pure thread-safety fix; behavior is unchanged on the single-threaded path.

## Test plan

Run Shared Element Transitions examples from fabric-example app.
