### PR TITLE
Chore: Pinned actions to commit hash

### DIFF
--- a/.github/actions/android-validation/action.yml
+++ b/.github/actions/android-validation/action.yml
@@ -14,13 +14,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Java 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
       with:
         distribution: 'zulu'
         java-version: 17
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         cache: 'yarn'
 

--- a/.github/actions/cache-derived-data/action.yml
+++ b/.github/actions/cache-derived-data/action.yml
@@ -17,7 +17,7 @@ runs:
   using: 'composite'
   steps:
     - name: Restore DerivedData cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: ~/Library/Developer/Xcode/DerivedData
         key: derived-${{ inputs.platform }}-${{ hashFiles(

--- a/.github/actions/create-rnc-cli-app/action.yml
+++ b/.github/actions/create-rnc-cli-app/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Restore app cache
       id: app-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: ${{ inputs.app-name }}
         key: rnc-cli-app-${{ runner.os }}-${{ steps.cli-version.outputs.version }}-${{ inputs.react-native-version }}
@@ -42,7 +42,7 @@ runs:
 
     - name: Save app cache
       if: steps.app-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: ${{ inputs.app-name }}
         key: rnc-cli-app-${{ runner.os }}-${{ steps.cli-version.outputs.version }}-${{ inputs.react-native-version }}
@@ -56,7 +56,7 @@ runs:
 
     - name: Setup Ruby (iOS)
       if: ${{ runner.os == 'macOS' }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
       with:
         ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/actions/install-pods/action.yml
+++ b/.github/actions/install-pods/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Restore Pods cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ${{ inputs.working-directory }}/${{ inputs.pod-directory }}/Pods

--- a/.github/actions/reanimated-compatibility-check-build/action.yml
+++ b/.github/actions/reanimated-compatibility-check-build/action.yml
@@ -50,7 +50,7 @@ runs:
       run: yarn add "react-native-worklets@https://github.com/software-mansion/react-native-reanimated.git#workspace=react-native-worklets&commit=${{ github.sha }}"
     - name: Setup Ruby (iOS)
       if: ${{ inputs.platform == 'iOS' }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
       with:
         ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/actions/setup-cpp-lint/action.yml
+++ b/.github/actions/setup-cpp-lint/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/android-validation.yml
+++ b/.github/workflows/android-validation.yml
@@ -52,7 +52,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run Android validation
         uses: ./.github/actions/android-validation

--- a/.github/workflows/apple-validation.yml
+++ b/.github/workflows/apple-validation.yml
@@ -52,7 +52,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run Apple validation
         uses: ./.github/actions/apple-validation

--- a/.github/workflows/babel-plugin-static-check.yml
+++ b/.github/workflows/babel-plugin-static-check.yml
@@ -31,9 +31,9 @@ jobs:
       PLUGIN_DIR: packages/react-native-worklets/plugin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
       - name: Clear annotations

--- a/.github/workflows/check-branch-changes.yml
+++ b/.github/workflows/check-branch-changes.yml
@@ -16,7 +16,7 @@ jobs:
       has_changes: ${{ steps.commit_check.outputs.has_changes }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}

--- a/.github/workflows/check-ruby-pods-versions.yml
+++ b/.github/workflows/check-ruby-pods-versions.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/common-validation.yml
+++ b/.github/workflows/common-validation.yml
@@ -48,7 +48,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run Common validation
         uses: ./.github/actions/common-validation

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,7 +22,7 @@ jobs:
       WORKLETS_DOCS_DIR: docs/docs-worklets
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install monorepo node dependencies
         run: yarn install
 

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -21,7 +21,7 @@ jobs:
       WORKLETS_DOCS_DIR: docs/docs-worklets
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install monorepo node dependencies
         run: yarn install
 
@@ -41,7 +41,7 @@ jobs:
         run: yarn prepublish
 
       - name: Publish generated content to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           FOLDER: ${{ env.REANIMATED_DOCS_DIR }}/build
           BRANCH: gh-pages

--- a/.github/workflows/example-android-build-check.yml
+++ b/.github/workflows/example-android-build-check.yml
@@ -45,10 +45,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/example-ios-build-check.yml
+++ b/.github/workflows/example-ios-build-check.yml
@@ -55,8 +55,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/example-macos-build-check.yml
+++ b/.github/workflows/example-macos-build-check.yml
@@ -22,8 +22,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/example-next-build-check-and-test.yml
+++ b/.github/workflows/example-next-build-check-and-test.yml
@@ -24,9 +24,9 @@ jobs:
       WORKING_DIRECTORY: apps/next-example
     steps:
       - name: Checkout Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: yarn
       - name: Install monorepo node dependencies

--- a/.github/workflows/example-tvos-build-check.yml
+++ b/.github/workflows/example-tvos-build-check.yml
@@ -22,8 +22,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -34,9 +34,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
       - name: Clear annotations

--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -27,14 +27,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Check out reanimated repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Java 17
         if: ${{ matrix.platform == 'Android' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'zulu'
           java-version: 17
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         if: ${{ matrix.platform == 'iOS' }}
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`

--- a/.github/workflows/github-close-when-stale-nightly.yml
+++ b/.github/workflows/github-close-when-stale-nightly.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
-          ref: stable
+          ref: b9b49d4de95b48a5a9688f94a7642b49f0e810c7
 
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:

--- a/.github/workflows/github-close-when-stale-nightly.yml
+++ b/.github/workflows/github-close-when-stale-nightly.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/github-issue-platforms-check.yml
+++ b/.github/workflows/github-issue-platforms-check.yml
@@ -12,12 +12,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/github-issue-platforms-check.yml
+++ b/.github/workflows/github-issue-platforms-check.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
-          ref: stable
+          ref: b9b49d4de95b48a5a9688f94a7642b49f0e810c7
 
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:

--- a/.github/workflows/github-issue-repro-check.yml
+++ b/.github/workflows/github-issue-repro-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
-          ref: stable
+          ref: b9b49d4de95b48a5a9688f94a7642b49f0e810c7
 
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:

--- a/.github/workflows/github-issue-repro-check.yml
+++ b/.github/workflows/github-issue-repro-check.yml
@@ -14,12 +14,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/github-issue-template-check.yml
+++ b/.github/workflows/github-issue-template-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
-          ref: stable
+          ref: b9b49d4de95b48a5a9688f94a7642b49f0e810c7
 
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:

--- a/.github/workflows/github-issue-template-check.yml
+++ b/.github/workflows/github-issue-template-check.yml
@@ -14,12 +14,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: 'software-mansion-labs/swmansion-bot'
           ref: stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/github-pull-request-description-format.yml
+++ b/.github/workflows/github-pull-request-description-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update PR Description
-        uses: software-mansion-labs/pr-description@main
+        uses: software-mansion-labs/pr-description@5d5cc919c7628544433cf034cdae4e53cb86a67c
         with:
           content: ''
           regex: "<!-- .* -->\n"

--- a/.github/workflows/github-pull-request-label-format.yml
+++ b/.github/workflows/github-pull-request-label-format.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
         with:
           configuration-path: '.github/labeler.yml'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-clang-tidy.yml
+++ b/.github/workflows/lint-clang-tidy.yml
@@ -28,7 +28,7 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install monorepo node dependencies
         run: yarn install --immutable

--- a/.github/workflows/monorepo-static-checks.yml
+++ b/.github/workflows/monorepo-static-checks.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       # Setup VM
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
 

--- a/.github/workflows/nighly-fail-notification.yml
+++ b/.github/workflows/nighly-fail-notification.yml
@@ -15,10 +15,10 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
 

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
           node-version: 22

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -31,7 +31,7 @@ jobs:
         run: corepack enable && yarn init
       - name: Set up JDK 18
         if: ${{ matrix.platform == 'Android' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'zulu'
           java-version: '18'
@@ -58,7 +58,7 @@ jobs:
       - name: Install Worklets
         working-directory: ${{ env.APP_NAME }}
         run: yarn add "react-native-worklets@https://github.com/software-mansion/react-native-reanimated.git#workspace=react-native-worklets&commit=${{ github.sha }}"
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         if: ${{ matrix.platform == 'iOS' }}
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`

--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -26,7 +26,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
       - name: Setup Yarn

--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       react-native-versions: ${{ steps.set-outputs.outputs.react-native-versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Read compatibility.json
         run: node .github/workflows/helper/read-compatibility.js
       - name: Set outputs
@@ -42,18 +42,18 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up JDK 18
         if: ${{ matrix.platform == 'Android' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
         with:
           distribution: 'zulu'
           java-version: '18'
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: 24
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         if: ${{ matrix.platform == 'iOS' }}
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`

--- a/.github/workflows/reanimated-static-checks.yml
+++ b/.github/workflows/reanimated-static-checks.yml
@@ -21,9 +21,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: yarn
       - name: Run static checks

--- a/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
+++ b/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       react-native-versions-with-nightly: ${{ steps.set-outputs.outputs.react-native-versions-with-nightly }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Read compatibility.json
         run: node .github/workflows/helper/read-compatibility.js
       - name: Set outputs
@@ -38,9 +38,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
       - name: Clear annotations

--- a/.github/workflows/reanimated-worklets-compatibility-check.yml
+++ b/.github/workflows/reanimated-worklets-compatibility-check.yml
@@ -25,10 +25,10 @@ jobs:
       matrix: ${{ steps.set-outputs.outputs.matrix }}
       matrix-size: ${{ steps.set-outputs.outputs.matrix-size }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
 
@@ -54,22 +54,22 @@ jobs:
       CACHE_KEY: ${{ matrix.reactNativeVersion }}-${{ matrix.reanimatedVersion }}-${{ matrix.workletsVersion }}
       BUILD_MARKER_DIR: .compatibility-build-markers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
 
       - name: Set up JDK 18
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: 'zulu'
           java-version: '18'
 
       - name: Restore result cache
         id: result-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.BUILD_MARKER_DIR }}/${{ env.CACHE_KEY }}.success
           key: reanimated-worklets-compat-android-${{ env.CACHE_KEY }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Save result cache
         if: steps.result-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.BUILD_MARKER_DIR }}/${{ env.CACHE_KEY }}.success
           key: reanimated-worklets-compat-android-${{ env.CACHE_KEY }}
@@ -119,16 +119,16 @@ jobs:
       CACHE_KEY: ${{ matrix.reactNativeVersion }}-${{ matrix.reanimatedVersion }}-${{ matrix.workletsVersion }}
       BUILD_MARKER_DIR: .compatibility-build-markers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
 
       - name: Restore result cache
         id: result-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.BUILD_MARKER_DIR }}/${{ env.CACHE_KEY }}.success
           key: reanimated-worklets-compat-ios-${{ env.CACHE_KEY }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Save result cache
         if: steps.result-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.BUILD_MARKER_DIR }}/${{ env.CACHE_KEY }}.success
           key: reanimated-worklets-compat-ios-${{ env.CACHE_KEY }}

--- a/.github/workflows/url-validation-nightly.yml
+++ b/.github/workflows/url-validation-nightly.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'yarn'
           node-version: '22'

--- a/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
+++ b/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
@@ -25,7 +25,7 @@ jobs:
         type: [static, dynamic]
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           registry-url: https://registry.npmjs.org/
       - name: Setup Yarn
@@ -53,7 +53,7 @@ jobs:
       - name: Install Worklets
         working-directory: ${{ env.APP_NAME }}
         run: yarn add "react-native-worklets@https://github.com/software-mansion/react-native-reanimated.git#workspace=react-native-worklets&commit=${{ github.sha }}"
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
         with:
           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/windows-hosted-app-reanimated-build-check-nightly.yml
+++ b/.github/workflows/windows-hosted-app-reanimated-build-check-nightly.yml
@@ -21,7 +21,7 @@ jobs:
       APP_NAME: app
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/worklets-static-checks.yml
+++ b/.github/workflows/worklets-static-checks.yml
@@ -21,9 +21,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: yarn
       - name: Run static checks

--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
 
       - name: Check if all versions are exact
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

When refering to actions, instead of using tags, we now use concrete commits

Why:
If repo gets compromised and bad actor pushes malware and releases it under tag, we pull the infected package
This mitigates that attack vector

Here is what got replaced with what:

| Action@Tag                                       | Pinned SHA                                 | Source                                                                  |
| ------------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------- |
| actions/checkout@v4                              | 34e114876b0b11c390a56381ad16ebd13914f8d5   | https://github.com/actions/checkout/commits/v4                          |
| actions/setup-node@v4                            | 49933ea5288caeca8642d1e84afbd3f7d6820020   | https://github.com/actions/setup-node/commits/v4                        |
| actions/setup-node@v3                            | 3235b876344d2a9aa001b8d1453c930bba69e610   | https://github.com/actions/setup-node/commits/v3                        |
| actions/setup-java@v4                            | c1e323688fd81a25caa38c78aa6df2d33d3e20d9   | https://github.com/actions/setup-java/commits/v4                        |
| actions/setup-java@v3                            | 17f84c3641ba7b8f6deff6309fc4c864478f5d62   | https://github.com/actions/setup-java/commits/v3                        |
| actions/setup-python@v4                          | 7f4fc3e22c37d6ff65e88745f38bd3157c663f7c   | https://github.com/actions/setup-python/commits/v4                      |
| actions/cache@v4 (+ /restore, /save)             | 0057852bfaa89a56745cba8c7296529d2fc39830   | https://github.com/actions/cache/commits/v4                             |
| actions/cache@v3                                 | 6f8efc29b200d32929f49075959781ed54ec270c   | https://github.com/actions/cache/commits/v3                             |
| actions/labeler@v5                               | 8558fd74291d67161a8a78ce36a881fa63b766a9   | https://github.com/actions/labeler/commits/v5                           |
| ruby/setup-ruby@v1                               | 6aaa311d81eba98ae12eaffbcb63296ace0efcde   | https://github.com/ruby/setup-ruby/commits/v1                           |
| software-mansion-labs/pr-description@main        | 5d5cc919c7628544433cf034cdae4e53cb86a67c   | https://github.com/software-mansion-labs/pr-description/commits/main    |
| JamesIves/github-pages-deploy-action@releases/v3 | 132898c54c57c7cc6b80eb3a89968de8fc283505   | https://github.com/JamesIves/github-pages-deploy-action/commits/releases/v3 |
| software-mansion-labs/swmansion-bot@stable     | b9b49d4de95b48a5a9688f94a7642b49f0e810c7   | https://github.com/software-mansion-labs/swmansion-bot/commits/stable |

## Test plan

Actions work

