### PR TITLE
Chore: added/patched setup node step in 2 actions

### DIFF
--- a/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
+++ b/.github/workflows/react-native-nightly-reanimated-build-check-nightly.yml
@@ -25,6 +25,10 @@ jobs:
       group: ${{ matrix.platform }}-react-native-nightly-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Setup Yarn
         # Sometimes `npx @react-native-community/cli init` fails at random.
         # Pre-installing it with Yarn seems to improve stability.

--- a/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
+++ b/.github/workflows/use-frameworks-reanimated-build-check-nightly.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          node-version: '22'
           registry-url: https://registry.npmjs.org/
       - name: Setup Yarn
         # Sometimes `npx @react-native-community/cli init` fails at random.


### PR DESCRIPTION
## Summary

Those actions fail with some weird error,
Most likely cause is their misconfiguration / lack of setup node step

## Test plan

Those actions now pass / fail in a valid way

