### PR TITLE
Add `constexpr` in feature flag check in synchronous props buffer preallocation on Android

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -230,7 +230,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #ifdef ANDROID
   // Pre-allocate the synchronous props buffers so the first frame doesn't pay
   // for vector growth allocations.
-  if (StaticFeatureFlags::getFlag("ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS")) {
+  if constexpr (StaticFeatureFlags::getFlag("ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS")) {
     synchronousPropsIntBuffer_.reserve(1024);
     synchronousPropsDoubleBuffer_.reserve(1024);
   }


### PR DESCRIPTION
## Summary

This PR adds a missing `constexpr` for a conditional that checks whether a Reanimated static feature flag is enabled.

## Test plan
