### PR TITLE
fix(Worklets): remove unused `hermes/hermes.h` include in `UnpackerLoader.h`

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <hermes/hermes.h>
 #include <jsi/jsi.h>
 
 #ifndef NDEBUG


### PR DESCRIPTION
## Summary

`UnpackerLoader.h` included `<hermes/hermes.h>` but did not use any symbols from it — the file only relies on `facebook::jsi::Runtime` and `facebook::jsi::StringBuffer` from `<jsi/jsi.h>`. The stray include caused a hard build failure on Android in setups where the Hermes prefab header is not on the include path (e.g. Expo prebuild apps consuming Worklets through `expo-modules-core`), since `WorkletRuntime.h` transitively pulls in `UnpackerLoader.h`:

```
react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h:3:10: fatal error: 'hermes/hermes.h' file not found
    3 | #include <hermes/hermes.h>
      |          ^~~~~~~~~~~~~~~~~
```

Removing the unused include fixes the build without affecting behavior — Hermes-specific code (`WorkletHermesRuntime.h`, `HermesProfiling.cpp`) still includes the header where it is actually needed.

Fixes #9446

## Test plan

Reproduction from the issue:

1. `npx create-expo-app@latest` (Expo SDK 55)
2. `npx expo prebuild`
3. `npm i react-native-reanimated@nightly react-native-worklets@nightly` (with this fix included)
4. `npx expo run:android`

Expected: Android build succeeds; before this change it failed with `fatal error: 'hermes/hermes.h' file not found` while compiling `expo-modules-core`.