### PR TITLE
fix(Reanimated): JNI abort during NativeProxy teardown on Android

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -158,6 +158,10 @@ void NativeProxy::registerNatives() {
 }
 
 void NativeProxy::requestRender(std::function<void(double)> onRender) {
+  // Module might be already destroyed.
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = getJniMethod<void(AnimationFrameCallback::javaobject)>("requestRender");
   method(javaPart_.get(), AnimationFrameCallback::newObjectCxxArgs(std::move(onRender)).get());
 }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -187,6 +187,11 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
     return {};
   }
 
+  // Module might be already destroyed.
+  if (!javaPart_) {
+    return {};
+  }
+
   static const auto method = getJniMethod<jboolean(jni::alias_ref<jni::JArrayInt>)>("preserveMountedTags");
   auto jArrayInt = jni::JArrayInt::newArray(tags.size());
   jArrayInt->setRegion(0, tags.size(), tags.data());
@@ -202,6 +207,10 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
 void NativeProxy::synchronouslyUpdateUIProps(
     const std::vector<int> &intBuffer,
     const std::vector<double> &doubleBuffer) {
+  // Module might be already destroyed.
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = getJniMethod<void(jni::alias_ref<jni::JArrayInt>, jni::alias_ref<jni::JArrayDouble>)>(
       "synchronouslyUpdateUIProps");
   auto jArrayInt = jni::JArrayInt::newArray(intBuffer.size());
@@ -333,10 +342,15 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 void NativeProxy::invalidateCpp() {
   uiRuntime_.reset();
   // cleanup all animated sensors here, since the next line resets
-  // the pointer and it will be too late after it
+  // the pointer and it will be too late after it. cleanupSensors() itself
+  // calls back into Java via unregisterSensor, so javaPart_ must still be valid.
   reanimatedModuleProxy_->cleanupSensors();
-  reanimatedModuleProxy_.reset();
+  // Release the Java side before destroying the C++ proxy so that any in-flight
+  // callback from the UI thread (e.g. a Choreographer-driven CSS frame holding
+  // a locked weak_from_this) short-circuits in the javaPart_ null guards
+  // instead of trying to call into Java while teardown is mid-flight.
   javaPart_ = nullptr;
+  reanimatedModuleProxy_.reset();
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -158,7 +158,6 @@ void NativeProxy::registerNatives() {
 }
 
 void NativeProxy::requestRender(std::function<void(double)> onRender) {
-  // Module might be already destroyed.
   if (!javaPart_) {
     return;
   }
@@ -187,7 +186,6 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
     return {};
   }
 
-  // Module might be already destroyed.
   if (!javaPart_) {
     return {};
   }
@@ -207,7 +205,6 @@ std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(std::vect
 void NativeProxy::synchronouslyUpdateUIProps(
     const std::vector<int> &intBuffer,
     const std::vector<double> &doubleBuffer) {
-  // Module might be already destroyed.
   if (!javaPart_) {
     return;
   }
@@ -342,13 +339,8 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 void NativeProxy::invalidateCpp() {
   uiRuntime_.reset();
   // cleanup all animated sensors here, since the next line resets
-  // the pointer and it will be too late after it. cleanupSensors() itself
-  // calls back into Java via unregisterSensor, so javaPart_ must still be valid.
+  // the pointer and it will be too late after it
   reanimatedModuleProxy_->cleanupSensors();
-  // Release the Java side before destroying the C++ proxy so that any in-flight
-  // callback from the UI thread (e.g. a Choreographer-driven CSS frame holding
-  // a locked weak_from_this) short-circuits in the javaPart_ null guards
-  // instead of trying to call into Java while teardown is mid-flight.
   javaPart_ = nullptr;
   reanimatedModuleProxy_.reset();
 }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
@@ -73,14 +73,21 @@ class NodesManager(
     }
 
     fun invalidate() {
+        // Stop new work before tearing the native side down — invalidate() can run off
+        // the UI thread, racing an in-flight Choreographer frame against the C++ teardown.
+        mFabricUIManager.eventDispatcher.removeListener(this)
+        mEventQueue.clear()
+        UiThreadUtil.runOnUiThread {
+            stopUpdatingOnAnimationFrame()
+            mFrameCallbacks.clear()
+        }
+
         mNativeProxy?.let {
             it.invalidate()
             mNativeProxy = null
         }
 
         mDrawPassDetector.invalidate()
-
-        mFabricUIManager.eventDispatcher.removeListener(this)
     }
 
     fun onHostPause() {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
@@ -73,8 +73,6 @@ class NodesManager(
     }
 
     fun invalidate() {
-        // Stop new work before tearing the native side down — invalidate() can run off
-        // the UI thread, racing an in-flight Choreographer frame against the C++ teardown.
         mFabricUIManager.eventDispatcher.removeListener(this)
         mEventQueue.clear()
         UiThreadUtil.runOnUiThread {


### PR DESCRIPTION
## Summary

On Android, a JNI call from C++ into Java could abort the runtime when the Reanimated native side was being torn down (e.g. activity restart, bridge reload). The original crash signature was a CSS animation frame firing after `NativeProxy::invalidateCpp()` had released `javaPart_`: the Choreographer queue still held an `AnimationFrameCallback` from before teardown, and when it fired, the C++ closure re-entered `NativeProxy::requestRender` and called `CallVoidMethod` on a now-null `jni::global_ref`.

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 29706 >>> pl.tomekzaw.odjazdowykrk <<<

backtrace:
  #00  pc 0x00000000000938b8  /apex/com.android.runtime/lib64/bionic/libc.so (abort+164)
  #01  pc 0x00000000008a0c74  /apex/com.android.art/lib64/libart.so (art::Runtime::Abort(char const*)+476)
  #02  pc 0x0000000000016188  /apex/com.android.art/lib64/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_0::__invoke(char const*)+80)
  #03  pc 0x0000000000015730  /apex/com.android.art/lib64/libbase.so (android::base::LogMessage::~LogMessage()+544)
  #04  pc 0x00000000004e7114  /apex/com.android.art/lib64/libart.so (art::JavaVMExt::JniAbort(char const*, char const*)+804)
  #05  pc 0x00000000001400e0  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (_JNIEnv::CallVoidMethod(_jobject*, _jmethodID*, ...)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #06  pc 0x000000000013bad4  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (reanimated::NativeProxy::requestRender(std::__ndk1::function<void (double)>)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #07  pc 0x0000000000141184  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (std::__ndk1::__function::__func<std::__ndk1::function<void (std::__ndk1::function<void (double)>)> reanimated::NativeProxy::bindThis<void, std::__ndk1::function<void (double)>>(void (reanimated::NativeProxy::*)(std::__ndk1::function<void (double)>))::'lambda'(std::__ndk1::function<void (double)>&&), std::__ndk1::allocator<std::__ndk1::function<void (std::__ndk1::function<void (double)>)> reanimated::NativeProxy::bindThis<void, std::__ndk1::function<void (double)>>(void (reanimated::NativeProxy::*)(std::__ndk1::function<void (double)>))::'lambda'(std::__ndk1::function<void (double)>&&)>, void (std::__ndk1::function<void (double)>)>::operator()(std::__ndk1::function<void (double)>&&)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #08  pc 0x00000000001248e4  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (reanimated::ReanimatedModuleProxy::cssLoopCallback(double)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #09  pc 0x0000000000130280  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (std::__ndk1::__function::__func<reanimated::ReanimatedModuleProxy::cssLoopCallback(double)::$_0, std::__ndk1::allocator<reanimated::ReanimatedModuleProxy::cssLoopCallback(double)::$_0>, void (double)>::operator()(double&&)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #10  pc 0x0000000000142530  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/split_config.arm64_v8a.apk!libreanimated.so (facebook::jni::detail::MethodWrapper<void (reanimated::AnimationFrameCallback::*)(double), &reanimated::AnimationFrameCallback::onAnimationFrame(double), reanimated::AnimationFrameCallback, void, double>::call(_JNIEnv*, _jobject*, double)+32063488) (BuildId: 766edc407104030918b72bc71adca00f01c34cbd)
  #11  pc 0x0000000000db80b0  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+112)
  #12  pc 0x00000000002735ec  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/oat/arm64/base.odex (com.swmansion.reanimated.NodesManager.onAnimationFrame+908)
  #13  pc 0x000000000045e438  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/oat/arm64/base.odex (com.swmansion.reanimated.NodesManager$1.doFrameGuarded+72)
  #14  pc 0x000000000024e390  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/oat/arm64/base.odex (com.facebook.react.uimanager.N.doFrame+48)
  #15  pc 0x000000000025dc58  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/oat/arm64/base.odex (com.facebook.react.modules.core.b.g+280)
  #16  pc 0x000000000031d204  /data/app/~~Sl4_zoXk8m9k9DWfARxHnw==/pl.tomekzaw.odjazdowykrk--OxEa8PUR_L0wo_qlo7BkQ==/oat/arm64/base.odex (Y2.h.doFrame+68)
  #17  pc 0x0000000000a88d48  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.Choreographer.doCallbacks+1048)
  #18  pc 0x0000000000a89a88  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.Choreographer.doFrame+2216)
  #19  pc 0x0000000000b0f5a8  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.view.Choreographer$FrameDisplayEventReceiver.run+88)
  #20  pc 0x00000000009445a4  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Handler.dispatchMessage+68)
  #21  pc 0x0000000000947f04  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loopOnce+980)
  #22  pc 0x0000000000947a94  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.os.Looper.loop+916)
  #23  pc 0x00000000006def34  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.app.ActivityThread.main+2036)
  #24  pc 0x000000000032d460  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #25  pc 0x00000000003273d0  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<(art::PointerSize)8>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jobject*, _jobject*, unsigned long)+544)
  #26  pc 0x00000000005c6f80  /apex/com.android.art/lib64/libart.so (art::Method_invoke(_JNIEnv*, _jobject*, _jobject*, _jobjectArray*) (.__uniq.165753521025965369065708152063621506277)+32)
  #27  pc 0x0000000000db9174  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+116)
  #28  pc 0x0000000000c74f04  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run+116)
  #29  pc 0x0000000000c7f1f4  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (com.android.internal.os.ZygoteInit.main+3396)
  #30  pc 0x000000000032d460  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #31  pc 0x000000000032bfc8  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+800)
  #32  pc 0x000000000064a488  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV(_JNIEnv*, _jclass*, _jmethodID*, std::__va_list)+156)
  #33  pc 0x00000000000e1ab4  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+104)
  #34  pc 0x00000000000edf68  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+852)
  #35  pc 0x0000000000010550  /system/bin/app_process64 (main+1276)
  #36  pc 0x000000000008c400  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+104)
```

The same shape is reachable from other C++-to-Java paths invoked on the UI thread during teardown, so this PR closes the gap from a few angles.

### Add a `javaPart_` null guard to `NativeProxy::requestRender`

**What:** `NativeProxy::requestRender` now early-returns if `javaPart_` has already been released, matching the pattern already used by `NativeProxy::maybeFlushUIUpdatesQueue`.

**Why:** This is the change that actually closes the crash. The `weak_from_this()` checks inside `cssLoopCallback`/`OperationsLoop::onRender` do not help, because in the crashing scenario the C++ proxy is still alive — it is the one running the method on the stack thanks to a locked `weak_ptr` — but the Java target reference has already been released by `invalidateCpp()`. Without this guard, the call into Java aborts the runtime via `JniAbort`. With it, the in-flight Choreographer frame bails out cleanly.

### Stop new work in `NodesManager.invalidate()` before tearing down

**What:** `mFabricUIManager.eventDispatcher.removeListener(this)` is moved to the top of `invalidate()` and is followed by `mEventQueue.clear()` (`ConcurrentLinkedQueue`, safe from any thread) and a `UiThreadUtil.runOnUiThread` block that calls `stopUpdatingOnAnimationFrame()` and `mFrameCallbacks.clear()`. Then the native side is invalidated as before.

**Why:** `ReanimatedModule.invalidate()` (the RN `NativeModule` lifecycle hook) is not guaranteed to run on the UI thread, while CSS frames fire on the UI thread. The C++ guard above is sufficient on its own to prevent the crash, but pairing it with this cleanup shrinks the race window: by the time native teardown starts, no new events are dispatched into the queue, the event queue is drained, and a UI-thread runnable is queued to remove the Reanimated `Choreographer` callback so no further frames will be scheduled. `mFrameCallbacks` is a plain `ArrayList` only touched on the UI thread, so its `clear()` has to be bounced there — the rest can run on the calling thread.

### Reorder `NativeProxy::invalidateCpp` so `javaPart_` is nulled earlier

**What:** `javaPart_ = nullptr` is moved up between `reanimatedModuleProxy_->cleanupSensors()` and `reanimatedModuleProxy_.reset()`, instead of after both.

**Why:** `cleanupSensors()` itself calls back into Java via `unregisterSensor`, so it must still see a valid `javaPart_`. But once sensors are unregistered, there is no reason to keep `javaPart_` alive while we destroy the rest of the C++ proxy. Nulling immediately after `cleanupSensors()` means the `javaPart_` null guards become effective during the (potentially deferred, if a UI-thread `weak_from_this` lock is still holding a strong ref) destruction of `ReanimatedModuleProxy` and its `OperationsLoop`, instead of relying on implicit `shared_ptr` lifetime ordering for safety.

### Add the same null guard to `preserveMountedTags` and `synchronouslyUpdateUIProps`

**What:** Both methods get the same one-line `javaPart_` null guard as `requestRender`.

**Why:** Both are reachable from Fabric's synchronous mount commit path on the UI thread. They have the exact same crash shape as `requestRender` if they fire against a torn-down `NativeProxy` — there is nothing CSS-specific about the abort, it is just the first path observed in the wild. Guarding these alongside `requestRender` closes the symmetric race in the synchronous-props and mounted-tags paths without waiting for a separate report.

## Test plan

- [ ] On Android, drive a CSS animation on a screen that gets unmounted / backgrounded repeatedly; verify the app no longer aborts.
- [ ] Verify no regression in normal CSS animation playback and teardown.
- [ ] Smoke-test iOS — no functional change there, just confirm the build is unaffected.
