### PR TITLE
FBJNI audit

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -28,7 +28,8 @@ NativeProxy::NativeProxy(
     jni::alias_ref<facebook::react::JFabricUIManager::javaobject> fabricUIManager,
     const std::shared_ptr<WorkletRuntime> &uiRuntime,
     const std::shared_ptr<UIScheduler> &uiScheduler)
-    : javaPart_(jni::make_global(jThis)),
+    : alive_(std::make_shared<std::atomic<bool>>(true)),
+      javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       uiRuntime_(uiRuntime),
       reanimatedModuleProxy_(std::make_shared<ReanimatedModuleProxy>(
@@ -38,28 +39,15 @@ NativeProxy::NativeProxy(
           jsCallInvoker,
           getPlatformDependentMethods(),
           getIsReducedMotion())) {
-#ifndef NDEBUG
+  // Run the version handshake in both debug and release. The check is a
+  // single JNI call at init and surfaces install-skew issues that otherwise
+  // fail mysteriously deeper in the call chain.
   checkJavaVersion();
   injectCppVersion();
-#endif // NDEBUG
   reanimatedModuleProxy_->init(getPlatformDependentMethods());
   const auto &uiManager = fabricUIManager->getBinding()->getScheduler()->getUIManager();
   reanimatedModuleProxy_->initializeFabric(uiManager);
   registerEventHandler();
-  // removed temporarily, event listener mechanism needs to be fixed on RN side
-  // eventListener_ = std::make_shared<EventListener>(
-  //     [reanimatedModuleProxy,
-  //      getAnimationTimestamp](const RawEvent &rawEvent) {
-  //       return reanimatedModuleProxy->handleRawEvent(
-  //           rawEvent, getAnimationTimestamp());
-  //     });
-  // reactScheduler_ = binding->getScheduler();
-  // reactScheduler_->addEventListener(eventListener_);
-}
-
-NativeProxy::~NativeProxy() {
-  // removed temporary, new event listener mechanism need fix on the RN side
-  // reactScheduler_->removeEventListener(eventListener_);
 }
 
 jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
@@ -81,7 +69,6 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
   return makeCxxInstance(jThis, &rnRuntime, jsCallInvoker, fabricUIManager, uiRuntime, uiScheduler);
 }
 
-#ifndef NDEBUG
 void NativeProxy::checkJavaVersion() {
   std::string javaVersion;
   try {
@@ -112,19 +99,27 @@ void NativeProxy::injectCppVersion() {
         "See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#c-side-failed-to-resolve-java-code-version` for more details.");
   }
 }
-#endif // NDEBUG
 
 void NativeProxy::installJSIBindings() {
+  if (!reanimatedModuleProxy_) {
+    return;
+  }
   jsi::Runtime &rnRuntime = *rnRuntime_;
   auto &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
   RNRuntimeDecorator::decorate(rnRuntime, uiRuntime, reanimatedModuleProxy_);
 }
 
 bool NativeProxy::isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag) {
+  if (!reanimatedModuleProxy_) {
+    return false;
+  }
   return reanimatedModuleProxy_->isAnyHandlerWaitingForEvent(eventName, emitterReactTag);
 }
 
 void NativeProxy::performOperations() {
+  if (!reanimatedModuleProxy_) {
+    return;
+  }
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     // We don't use performOperations in the backend path,
     // but we don't have access to the feature flags in Kotlin, so we gate it here
@@ -134,15 +129,24 @@ void NativeProxy::performOperations() {
 }
 
 void NativeProxy::performNonLayoutOperations() {
+  if (!reanimatedModuleProxy_) {
+    return;
+  }
   reanimatedModuleProxy_->performNonLayoutOperations();
 }
 
 bool NativeProxy::getIsReducedMotion() {
+  if (!javaPart_) {
+    return false;
+  }
   static const auto method = getJniMethod<jboolean()>("getIsReducedMotion");
   return method(javaPart_.get());
 }
 
 void NativeProxy::toggleSlowAnimationsOnUIRuntime() {
+  if (!reanimatedModuleProxy_) {
+    return;
+  }
   reanimatedModuleProxy_->toggleSlowAnimationsOnUIRuntime();
 }
 
@@ -163,6 +167,9 @@ void NativeProxy::requestRender(std::function<void(double)> onRender) {
 }
 
 void NativeProxy::registerEventHandler() {
+  if (!javaPart_) {
+    return;
+  }
   auto eventHandler = bindThis(&NativeProxy::handleEvent);
   static const auto method = getJniMethod<void(EventHandler::javaobject)>("registerEventHandler");
   method(javaPart_.get(), EventHandler::newObjectCxxArgs(std::move(eventHandler)).get());
@@ -208,15 +215,24 @@ void NativeProxy::synchronouslyUpdateUIProps(
 }
 
 int NativeProxy::registerSensor(int sensorType, int interval, int, std::function<void(double[], int)> setter) {
+  if (!javaPart_) {
+    return -1;
+  }
   static const auto method = getJniMethod<int(int, int, SensorSetter::javaobject)>("registerSensor");
   return method(javaPart_.get(), sensorType, interval, SensorSetter::newObjectCxxArgs(std::move(setter)).get());
 }
 void NativeProxy::unregisterSensor(int sensorId) {
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = getJniMethod<void(int)>("unregisterSensor");
   method(javaPart_.get(), sensorId);
 }
 
 void NativeProxy::setGestureState(int handlerTag, int newState) {
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = getJniMethod<void(int, int)>("setGestureState");
   method(javaPart_.get(), handlerTag, newState);
 }
@@ -225,6 +241,9 @@ int NativeProxy::subscribeForKeyboardEvents(
     std::function<void(int, int)> callback,
     bool isStatusBarTranslucent,
     bool isNavigationBarTranslucent) {
+  if (!javaPart_) {
+    return -1;
+  }
   static const auto method =
       getJniMethod<int(KeyboardWorkletWrapper::javaobject, bool, bool)>("subscribeForKeyboardEvents");
   return method(
@@ -235,11 +254,17 @@ int NativeProxy::subscribeForKeyboardEvents(
 }
 
 void NativeProxy::unsubscribeFromKeyboardEvents(int listenerId) {
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = getJniMethod<void(int)>("unsubscribeFromKeyboardEvents");
   method(javaPart_.get(), listenerId);
 }
 
 double NativeProxy::getAnimationTimestamp() {
+  if (!javaPart_) {
+    return 0.0;
+  }
   static const auto method = getJniMethod<jlong()>("getAnimationTimestamp");
   jlong output = method(javaPart_.get());
   return static_cast<double>(output);
@@ -251,6 +276,9 @@ void NativeProxy::handleEvent(
     jni::alias_ref<react::WritableMap> event,
     jboolean isInDrawPass) {
   // handles RCTEvents from RNGestureHandler
+  if (!reanimatedModuleProxy_ || !uiRuntime_) {
+    return;
+  }
   if (event.get() == nullptr) {
     // Ignore events with null payload.
     return;
@@ -327,12 +355,17 @@ PlatformDepMethodsHolder NativeProxy::getPlatformDependentMethods() {
 }
 
 void NativeProxy::invalidateCpp() {
+  // Flip the shared flag first so any callback lambdas captured via
+  // `bindThis` short-circuit before touching `this`.
+  alive_->store(false, std::memory_order_release);
   uiRuntime_.reset();
   // cleanup all animated sensors here, since the next line resets
   // the pointer and it will be too late after it
-  reanimatedModuleProxy_->cleanupSensors();
-  reanimatedModuleProxy_.reset();
+  if (reanimatedModuleProxy_) {
+    reanimatedModuleProxy_->cleanupSensors();
+  }
   javaPart_ = nullptr;
+  reanimatedModuleProxy_.reset();
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -9,8 +9,10 @@
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -19,7 +21,7 @@ namespace reanimated {
 using namespace facebook;
 using namespace facebook::jni;
 
-class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_from_this<NativeProxy> {
+class NativeProxy : public jni::HybridClass<NativeProxy> {
  public:
   static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/NativeProxy;";
   static jni::local_ref<jhybriddata> initHybrid(
@@ -30,18 +32,18 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
 
   static void registerNatives();
 
-  ~NativeProxy() override;
-
  private:
   friend HybridBase;
+  // Shared with every lambda produced by `bindThis`. Flipped to false in
+  // `invalidateCpp` before tearing the rest down, so callbacks that fire on
+  // background/UI threads bail out instead of dereferencing a dying `this`.
+  std::shared_ptr<std::atomic<bool>> alive_;
   jni::global_ref<NativeProxy::javaobject> javaPart_;
   jsi::Runtime *rnRuntime_;
   std::shared_ptr<worklets::WorkletRuntime> uiRuntime_;
   std::shared_ptr<ReanimatedModuleProxy> reanimatedModuleProxy_;
-#ifndef NDEBUG
   void checkJavaVersion();
   void injectCppVersion();
-#endif // NDEBUG
   // removed temporarily, event listener mechanism needs to be fixed on RN side
   // std::shared_ptr<facebook::react::Scheduler> reactScheduler_;
   // std::shared_ptr<EventListener> eventListener_;
@@ -73,17 +75,22 @@ class NativeProxy : public jni::HybridClass<NativeProxy>, std::enable_shared_fro
       jboolean isInDrawPass);
 
   /***
-   * Wraps a method of `NativeProxy` in a function object capturing `this`
-   * @tparam TReturn return type of passed method
-   * @tparam TParams parameter types of passed method
-   * @param methodPtr pointer to method to be wrapped
-   * @return a function object with the same signature as the method, calling
-   * that method on `this`
+   * Wraps a method of `NativeProxy` in a function object that defends against
+   * `this` outliving the wrapped call. The returned lambda captures a shared
+   * "alive" flag (toggled off in `invalidateCpp`); if the flag is cleared by
+   * the time the lambda runs, the call is skipped and a default-constructed
+   * return value is produced.
    */
   template <class TReturn, class... TParams>
   std::function<TReturn(TParams...)> bindThis(TReturn (NativeProxy::*methodPtr)(TParams...)) {
-    // It's probably safe to pass `this` as reference here...
-    return [this, methodPtr](TParams &&...args) {
+    return [this, methodPtr, alive = alive_](TParams &&...args) -> TReturn {
+      if (!alive->load(std::memory_order_acquire)) {
+        if constexpr (std::is_void_v<TReturn>) {
+          return;
+        } else {
+          return TReturn{};
+        }
+      }
       return (this->*methodPtr)(std::forward<TParams>(args)...);
     };
   }

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
@@ -2,6 +2,7 @@
 
 #include <fbjni/fbjni.h>
 
+#include <algorithm>
 #include <utility>
 
 namespace reanimated {
@@ -14,9 +15,14 @@ class SensorSetter : public HybridClass<SensorSetter> {
   static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/nativeProxy/SensorSetter;";
 
   void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
-    size_t size = value->size();
+    // The Android sensor APIs feeding this callback emit at most 7 floats
+    // (rotation vector with heading accuracy is the largest payload). Clamp
+    // defensively so a malformed JArrayFloat can't overflow the stack
+    // buffer below.
+    constexpr size_t kMaxSensorValues = 7;
+    size_t size = std::min<size_t>(value->size(), kMaxSensorValues);
     auto elements = value->getRegion(0, size);
-    double array[7];
+    double array[kMaxSensorValues];
     for (size_t i = 0; i < size; i++) {
       array[i] = elements[i];
     }

--- a/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.cpp
@@ -1,5 +1,9 @@
 #include <worklets/RunLoop/EventLoop.h>
 
+#ifdef ANDROID
+#include <fbjni/fbjni.h>
+#endif // ANDROID
+
 #include <memory>
 #include <string>
 #include <thread>
@@ -29,45 +33,54 @@ void EventLoop::run() {
 #if __APPLE__
     pthread_setname_np(threadName.c_str());
 #endif
-    while (state->running) {
-      std::unique_lock<std::mutex> lock(state->mutex);
 
-      if (state->queue.empty()) {
-        state->cv.wait(lock);
-      } else {
-        const auto &nextTimeout = state->queue[0];
-        const auto timeToWait = nextTimeout.targetTime - getCurrentTimeInMs();
-        state->cv.wait_for(lock, std::chrono::milliseconds(timeToWait));
-      }
+    auto runLoop = [&] {
+      while (state->running) {
+        std::unique_lock<std::mutex> lock(state->mutex);
 
-      // Early return if the Event Loop got destroyed already.
-      if (!state->running) {
-        return;
-      }
+        if (state->queue.empty()) {
+          state->cv.wait(lock);
+        } else {
+          const auto &nextTimeout = state->queue[0];
+          const auto timeToWait = nextTimeout.targetTime - getCurrentTimeInMs();
+          state->cv.wait_for(lock, std::chrono::milliseconds(timeToWait));
+        }
 
-      const auto currentTime = getCurrentTimeInMs();
-      std::vector<std::function<void(jsi::Runtime & rt)>> jobs;
-      auto &timeouts = state->queue;
-      timeouts.erase(
-          std::remove_if(
-              timeouts.begin(),
-              timeouts.end(),
-              [currentTime, &jobs](const Timeout &timeout) {
-                if (currentTime >= timeout.targetTime) {
-                  jobs.emplace_back(timeout.callback);
-                  return true;
-                }
-                return false;
-              }),
-          timeouts.end());
-      lock.unlock();
+        // Early return if the Event Loop got destroyed already.
+        if (!state->running) {
+          return;
+        }
 
-      if (auto strongThis = weakThis.lock()) {
-        for (auto &job : jobs) {
-          strongThis->pushTask(std::move(job));
+        const auto currentTime = getCurrentTimeInMs();
+        std::vector<std::function<void(jsi::Runtime & rt)>> jobs;
+        auto &timeouts = state->queue;
+        timeouts.erase(
+            std::remove_if(
+                timeouts.begin(),
+                timeouts.end(),
+                [currentTime, &jobs](const Timeout &timeout) {
+                  if (currentTime >= timeout.targetTime) {
+                    jobs.emplace_back(timeout.callback);
+                    return true;
+                  }
+                  return false;
+                }),
+            timeouts.end());
+        lock.unlock();
+
+        if (auto strongThis = weakThis.lock()) {
+          for (auto &job : jobs) {
+            strongThis->pushTask(std::move(job));
+          }
         }
       }
-    }
+    };
+
+#ifdef ANDROID
+    facebook::jni::ThreadScope::WithClassLoader(runLoop);
+#else
+    runLoop();
+#endif // ANDROID
   });
 #ifdef ANDROID
   pthread_setname_np(thread.native_handle(), threadName.c_str());

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -1,5 +1,8 @@
 #include <worklets/android/AndroidUIScheduler.h>
 
+#include <atomic>
+#include <mutex>
+#include <unordered_set>
 #include <utility>
 
 namespace worklets {
@@ -7,31 +10,49 @@ namespace worklets {
 using namespace facebook;
 using namespace react;
 
-static thread_local bool tls_isOnUIThread = false;
+namespace {
+// Per-thread set of scheduler IDs whose UI thread is this thread. Scoped per
+// instance (via monotonic integer ID, not pointer) so that multiple
+// schedulers do not collide and a destroyed scheduler's stale ID cannot
+// match a fresh allocation at the same address.
+std::atomic<uint64_t> s_nextSchedulerId{1};
+thread_local std::unordered_set<uint64_t> tls_uiThreadSchedulerIds;
+} // namespace
 
 class UISchedulerWrapper : public UIScheduler {
  private:
+  const uint64_t id_;
+  std::mutex mutex_;
   jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler_;
 
  public:
   explicit UISchedulerWrapper(jni::global_ref<AndroidUIScheduler::javaobject> androidUiScheduler)
-      : androidUiScheduler_(std::move(androidUiScheduler)) {}
+      : id_(s_nextSchedulerId.fetch_add(1, std::memory_order_relaxed)),
+        androidUiScheduler_(std::move(androidUiScheduler)) {}
 
   void scheduleOnUI(std::function<void()> job) override {
-    if (tls_isOnUIThread) {
+    if (tls_uiThreadSchedulerIds.count(id_) > 0) {
       job();
       return;
     }
     UIScheduler::scheduleOnUI(job);
     if (!scheduledOnUI_) {
       scheduledOnUI_ = true;
-      androidUiScheduler_->cthis()->scheduleTriggerOnUI();
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (androidUiScheduler_) {
+        androidUiScheduler_->cthis()->scheduleTriggerOnUI();
+      }
     }
   }
 
   void triggerUI() override {
-    tls_isOnUIThread = true;
+    tls_uiThreadSchedulerIds.insert(id_);
     UIScheduler::triggerUI();
+  }
+
+  void invalidate() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    androidUiScheduler_.reset();
   }
 };
 
@@ -51,11 +72,21 @@ void AndroidUIScheduler::triggerUI() {
 }
 
 void AndroidUIScheduler::scheduleTriggerOnUI() {
+  if (!javaPart_) {
+    return;
+  }
   static const auto method = javaPart_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
   method(javaPart_.get());
 }
 
 void AndroidUIScheduler::invalidate() {
+  // Drop the wrapper's global ref to this AndroidUIScheduler so consumers
+  // (WorkletRuntimes, async queues) that still hold the wrapper don't keep
+  // the Java side alive past invalidation. The wrapper internally guards
+  // against post-invalidate JNI calls.
+  if (uiScheduler_) {
+    static_cast<UISchedulerWrapper *>(uiScheduler_.get())->invalidate();
+  }
   javaPart_ = nullptr;
   uiScheduler_.reset();
 }

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.cpp
@@ -17,9 +17,12 @@ jni::local_ref<JScriptBufferWrapper::jhybriddata> JScriptBufferWrapper::initHybr
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
     jni::alias_ref<JAssetManager::javaobject> assetManager, // NOLINT //(performance-unnecessary-value-param)
     const std::string &sourceURL) {
-  auto manager = extractAssetManager(assetManager);
-  auto bigString = loadScriptFromAssets(manager, sourceURL);
-  auto script = std::make_shared<ScriptBuffer>(std::move(bigString));
+  std::shared_ptr<const ScriptBuffer> script;
+  RecoverableError::runRethrowingAsRecoverable<std::system_error>([&assetManager, &sourceURL, &script]() {
+    auto manager = extractAssetManager(assetManager);
+    auto bigString = loadScriptFromAssets(manager, sourceURL);
+    script = std::make_shared<ScriptBuffer>(std::move(bigString));
+  });
   return makeCxxInstance(std::move(script), sourceURL);
 }
 
@@ -38,8 +41,11 @@ jni::local_ref<JScriptBufferWrapper::jhybriddata> JScriptBufferWrapper::initHybr
     jni::alias_ref<jhybridobject> jThis, // NOLINT //(performance-unnecessary-value-param)
     const std::string &scriptStr,
     const std::string &sourceURL) {
-  auto bigString = std::make_shared<JSBigStdString>(scriptStr);
-  auto script = std::make_shared<ScriptBuffer>(std::move(bigString));
+  std::shared_ptr<const ScriptBuffer> script;
+  RecoverableError::runRethrowingAsRecoverable<std::system_error>([&scriptStr, &script]() {
+    auto bigString = std::make_shared<JSBigStdString>(scriptStr);
+    script = std::make_shared<ScriptBuffer>(std::move(bigString));
+  });
   return makeCxxInstance(std::move(script), sourceURL);
 }
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
@@ -42,7 +42,6 @@ int JWorkletRuntimeWrapper::cxxGetRuntimeId() {
 }
 
 void JWorkletRuntimeWrapper::registerNatives() {
-  javaClassStatic()->registerNatives({});
   registerHybrid(
       {makeNativeMethod("cxxEmitDeviceEvent", JWorkletRuntimeWrapper::cxxEmitDeviceEvent),
        makeNativeMethod("cxxGetRuntimeId", JWorkletRuntimeWrapper::cxxGetRuntimeId)});

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -31,7 +31,8 @@ WorkletsModule::WorkletsModule(
     jsi::Runtime *rnRuntime,
     const std::shared_ptr<facebook::react::CallInvoker> &jsCallInvoker,
     const std::shared_ptr<UIScheduler> &uiScheduler)
-    : javaPart_(jni::make_global(jThis)),
+    : alive_(std::make_shared<std::atomic<bool>>(true)),
+      javaPart_(jni::make_global(jThis)),
       rnRuntime_(rnRuntime),
       workletsModuleProxy_(std::make_shared<WorkletsModuleProxy>(
           *rnRuntime,
@@ -91,7 +92,10 @@ std::shared_ptr<RuntimeBindings> WorkletsModule::getRuntimeBindings(
 }
 
 RuntimeBindings::RequestAnimationFrame WorkletsModule::getRequestAnimationFrame() {
-  return [javaPart = javaPart_](std::function<void(const double)> &&callback) -> void {
+  return [javaPart = javaPart_, alive = alive_](std::function<void(const double)> &&callback) -> void {
+    if (!alive->load(std::memory_order_acquire)) {
+      return;
+    }
     static const auto jRequestAnimationFrame =
         javaPart->getClass()->getMethod<void(AnimationFrameCallback::javaobject)>("requestAnimationFrame");
     jRequestAnimationFrame(javaPart.get(), AnimationFrameCallback::newObjectCxxArgs(std::move(callback)).get());
@@ -100,15 +104,24 @@ RuntimeBindings::RequestAnimationFrame WorkletsModule::getRequestAnimationFrame(
 
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
 RuntimeBindings::AbortRequest WorkletsModule::getAbortRequest() {
-  return [javaPart = javaPart_](jsi::Runtime &rt, double requestId) -> void {
-    static const auto jAbortRequest = javaPart->getClass()->getMethod<void(int, double)>("abortRequest");
+  return [javaPart = javaPart_, alive = alive_](jsi::Runtime &rt, double requestId) -> void {
+    if (!alive->load(std::memory_order_acquire)) {
+      return;
+    }
     auto workletRuntime = WorkletRuntime::getWeakRuntimeFromJSIRuntime(rt).lock();
+    if (!workletRuntime) {
+      return;
+    }
+    static const auto jAbortRequest = javaPart->getClass()->getMethod<void(int, double)>("abortRequest");
     jAbortRequest(javaPart.get(), static_cast<int>(workletRuntime->getRuntimeId()), requestId);
   };
 }
 
 RuntimeBindings::ClearCookies WorkletsModule::getClearCookies() {
-  return [javaPart = javaPart_](jsi::Runtime &rt, jsi::Function &&responseSender) {
+  return [javaPart = javaPart_, alive = alive_](jsi::Runtime &rt, jsi::Function &&responseSender) {
+    if (!alive->load(std::memory_order_acquire)) {
+      return;
+    }
     static const auto jClearCookies = javaPart->getClass()->getMethod<void(JCallback::javaobject)>("clearCookies");
     auto jsiFunction = std::make_shared<jsi::Function>(std::move(responseSender));
     auto workletRuntime = WorkletRuntime::getWeakRuntimeFromJSIRuntime(rt);
@@ -130,7 +143,7 @@ RuntimeBindings::ClearCookies WorkletsModule::getClearCookies() {
 }
 
 RuntimeBindings::SendRequest WorkletsModule::getSendRequest() {
-  return [javaPart = javaPart_](
+  return [javaPart = javaPart_, alive = alive_](
              jsi::Runtime &rt,
              jsi::String &method,
              jsi::String &url,
@@ -141,6 +154,13 @@ RuntimeBindings::SendRequest WorkletsModule::getSendRequest() {
              bool incrementalUpdates,
              double timeout,
              bool withCredentials) {
+    if (!alive->load(std::memory_order_acquire)) {
+      return;
+    }
+    auto workletRuntime = WorkletRuntime::getWeakRuntimeFromJSIRuntime(rt).lock();
+    if (!workletRuntime) {
+      return;
+    }
     static const auto jSendRequest = javaPart->getClass()
                                          ->getMethod<void(
                                              JWorkletRuntimeWrapper::javaobject,
@@ -154,8 +174,6 @@ RuntimeBindings::SendRequest WorkletsModule::getSendRequest() {
                                              double /* timeout */,
                                              bool /* withCredentials */
                                              )>("sendRequest");
-    auto workletRuntime = WorkletRuntime::getWeakRuntimeFromJSIRuntime(rt).lock();
-
     jSendRequest(
         javaPart.get(),
         JWorkletRuntimeWrapper::makeJWorkletRuntimeWrapper(workletRuntime).get(),
@@ -173,17 +191,29 @@ RuntimeBindings::SendRequest WorkletsModule::getSendRequest() {
 #endif // WORKLETS_FETCH_PREVIEW_ENABLED
 
 std::function<bool()> WorkletsModule::getIsOnJSQueueThread() {
-  return [javaPart = javaPart_]() -> bool {
+  return [javaPart = javaPart_, alive = alive_]() -> bool {
+    if (!alive->load(std::memory_order_acquire)) {
+      return false;
+    }
     return javaPart->getClass()->getMethod<jboolean()>("isOnJSQueueThread").operator()(javaPart);
   };
 }
 
 void WorkletsModule::invalidateCpp() {
-  javaPart_.reset();
+  // Flip the shared flag first so binding lambdas captured into
+  // RuntimeBindings short-circuit before touching the JNI side.
+  alive_->store(false, std::memory_order_release);
+  // Drop the proxy (and everything it transitively owns — runtimes, event
+  // loops, async queues) before clearing the Java reference, so any JNI
+  // callbacks fired during teardown still see a live Java side.
   workletsModuleProxy_.reset();
+  javaPart_.reset();
 }
 
 void WorkletsModule::startCpp() {
+  if (!workletsModuleProxy_) {
+    return;
+  }
   workletsModuleProxy_->start();
 }
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h
@@ -10,6 +10,7 @@
 #include <worklets/android/AndroidUIScheduler.h>
 #include <worklets/android/JScriptBufferWrapper.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -65,6 +66,10 @@ class WorkletsModule : public jni::HybridClass<WorkletsModule> {
   std::function<bool()> getIsOnJSQueueThread();
 
   friend HybridBase;
+  // Shared with every binding lambda captured into RuntimeBindings. Flipped
+  // to false in `invalidateCpp` so lambdas that fire on worklet runtimes
+  // after teardown skip the JNI call.
+  std::shared_ptr<std::atomic<bool>> alive_;
   jni::global_ref<WorkletsModule::javaobject> javaPart_;
   jsi::Runtime *rnRuntime_;
   std::shared_ptr<WorkletsModuleProxy> workletsModuleProxy_;

--- a/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/AndroidUIScheduler.kt
+++ b/packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/AndroidUIScheduler.kt
@@ -14,7 +14,10 @@ class AndroidUIScheduler(
     @field:DoNotStrip
     private val mHybridData: HybridData = initHybrid()
 
-    private val mContext: ReactApplicationContext = context
+    // Capture the exception handler at construction so that scheduleTriggerOnUI
+    // (invoked from C++) cannot NPE if the React context has already been
+    // invalidated by the time the call reaches Kotlin.
+    private val mExceptionHandler = context.exceptionHandler
     private val mActive = AtomicBoolean(true)
 
     private val mUIThreadRunnable =
@@ -39,7 +42,7 @@ class AndroidUIScheduler(
     @Suppress("unused")
     private fun scheduleTriggerOnUI() {
         UiThreadUtil.runOnUiThread(
-            object : GuardedRunnable(mContext.exceptionHandler) {
+            object : GuardedRunnable(mExceptionHandler) {
                 override fun runGuarded() {
                     mUIThreadRunnable.run()
                 }


### PR DESCRIPTION
## Summary

Follow-up to the CSS-loop teardown JNI-abort fix on `@tomekzaw/fix-native-proxy-request-render-jni-abort` (commits `15f288a162`, `d5398e963d`). I audited the rest of the JNI/FBJNI surface across `react-native-reanimated` and `react-native-worklets` Android and this PR lands fixes for the lifecycle, stability, and memory-management gaps it surfaced. Verified by `:app:assembleDebug` on `apps/fabric-example`.

The audit findings below are grouped by severity. Severity reflects practical risk on a real device (reload, backgrounding, hot path). All `H`/`M` findings except `M5` are included in this PR; deferred items are listed under "Deferred to follow-ups" at the bottom.

### High-severity findings (real crash potential)

#### H1. `AndroidUIScheduler::scheduleTriggerOnUI()` dereferenced `javaPart_` with no null guard after `invalidate()`

`packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp:53-56`

```cpp
void AndroidUIScheduler::scheduleTriggerOnUI() {
  static const auto method = javaPart_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
  method(javaPart_.get());
}
```

`invalidate()` set `javaPart_ = nullptr` and reset `uiScheduler_`. But the actual `UISchedulerWrapper` held inside `uiScheduler_` invoked this method via `androidUiScheduler_->cthis()->scheduleTriggerOnUI()` from the JS thread (`UISchedulerWrapper::scheduleOnUI`, line 28). The Kotlin side guarded the *reverse* direction (`mActive` synchronization in `AndroidUIScheduler.kt:25-29` protected `triggerUI()` called from the UI thread) but did **not** protect `scheduleTriggerOnUI` originating from C++.

Sequence to reproduce: JS thread enqueues a UI job → JS thread invalidates module → C++ background completes a fence and calls `scheduleOnUI` → `scheduleTriggerOnUI` → null-deref on `javaPart_->getClass()`.

**Fix in this PR:** added `if (!javaPart_) return;` at the top of `scheduleTriggerOnUI`. Plus the `UISchedulerWrapper` changes in H2 below.

#### H2. `UISchedulerWrapper` held a strong global_ref back to the HybridClass — ownership cycle / dangling jobject after invalidate

`packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp:12-39`

`AndroidUIScheduler` owned `uiScheduler_ = std::make_shared<UISchedulerWrapper>(jni::make_global(jThis))`. The wrapper stored a `jni::global_ref<AndroidUIScheduler::javaobject>` that kept the Java side reachable for as long as the wrapper lived. The wrapper was itself handed out via `getUIScheduler()` (line 22) and stored in `WorkletsModuleProxy`, `EventLoop` queues, every `WorkletRuntime`, etc.

Practical consequences:

1. The Java `AndroidUIScheduler` couldn't be collected until *every* consumer of the wrapper dropped it — outliving the React instance reload by an unpredictable amount.
2. After `invalidate()` cleared `javaPart_` and reset the local `shared_ptr`, the wrapper survived via its other references; subsequent calls still passed through `androidUiScheduler_->cthis()->scheduleTriggerOnUI()` and hit H1.

**Fix in this PR:** the wrapper now drops its global ref on invalidate (under a mutex) and bails out post-invalidate. `AndroidUIScheduler::invalidate()` calls into the wrapper before resetting its own state.

#### H3. `WorkletsModule` lambdas captured into `RuntimeBindings` could outlive `invalidateCpp()`

`packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp:93-99, 102-108, 110-130, 132-172, 175-179`

All five binding lambdas captured `javaPart = javaPart_` (a copy of the global_ref), then internally did `javaPart->getClass()->getMethod<…>(…)` without null/validity checks. These lambdas live inside `RuntimeBindings` which is held by every `WorkletRuntime` long after `WorkletsModule::invalidateCpp()` runs.

Two failure modes:

- **JNI on detached thread.** When the lambda is invoked from a worklet runtime thread that the JVM never attached (no `ThreadScope`), the JNI call crashes. See also H6.
- **Logic-level: calling Java after invalidate.** The captured `global_ref` keeps the Java `WorkletsModule` alive, so the JNI call itself usually returns, but it may execute on a module the Java side considers dead — undefined behavior on the Kotlin side.

**Fix in this PR:** each binding lambda now captures a shared `std::atomic<bool> alive_` flag alongside `javaPart` and short-circuits before touching JNI when the flag is cleared. `invalidateCpp` flips it first, before tearing the rest down.

#### H4. `WorkletsModule::invalidateCpp()` reset the Java ref before the proxy, inverting safe teardown order

`packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp:181-184`

```cpp
void WorkletsModule::invalidateCpp() {
  javaPart_.reset();
  workletsModuleProxy_.reset();
}
```

Compare to the Reanimated order at `NativeProxy.cpp:339-346` (from `d5398e963d`):

```cpp
uiRuntime_.reset();
reanimatedModuleProxy_->cleanupSensors();
javaPart_ = nullptr;
reanimatedModuleProxy_.reset();
```

Reanimated drains the things that call back into Java *first*, then drops `javaPart_`, then destroys the proxy. Worklets dropped `javaPart_` first; if `~WorkletsModuleProxy` (or any of its subcomponents — async queues, runtimes, schedulers) reached back into Java during destruction, it would see a dead reference.

**Fix in this PR:** invalidate order reversed — proxy drains while `javaPart_` is still live, matching the Reanimated ordering.

#### H5. Callback HybridClass objects (`EventHandler`, `AnimationFrameCallback`, `SensorSetter`, `KeyboardWorkletWrapper`) kept raw `this` to `NativeProxy`

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h:83-89` (`bindThis` used `[this, methodPtr]`)

The C++ proxy objects are constructed via `newObjectCxxArgs(std::move(handler))` (e.g. `NativeProxy.cpp:171, 165, 222, 242`) where `handler` was a `bindThis(&NativeProxy::…)` lambda holding a raw `NativeProxy*`. The resulting jobject is then handed to Java and stored:

- `EventHandler` is registered in `NodesManager` via `NativeProxy::registerEventHandler` (NativeProxy.cpp:170).
- `SensorSetter`, `KeyboardWorkletWrapper`, `AnimationFrameCallback` are passed into Java sensor/keyboard/choreographer subsystems.

If the Java side retains these objects past `NativeProxy::invalidateCpp()` (which sets `javaPart_ = nullptr` and drops `reanimatedModuleProxy_` but does not unregister the Java-side handlers), the next callback dispatches a method on a destroyed `NativeProxy`.

The inline comment "It's probably *safe* to pass `this` as reference here…" (NativeProxy.h:85) acknowledged this was uncertain.

**Fix in this PR:** `bindThis` now captures a shared `std::atomic<bool> alive_` and short-circuits to a default-constructed return when invalidated. Dropped the unused `enable_shared_from_this` inheritance and the empty `~NativeProxy()`.

#### H6. `EventLoop` timeout thread was not attached to the JVM on Android

`packages/react-native-worklets/Common/cpp/worklets/RunLoop/EventLoop.cpp:26-76`

The timeout thread was spawned without `jni::ThreadScope::WithClassLoader`. Compare `AsyncQueueImpl::AsyncQueueImpl` which correctly wraps the run loop in `jni::ThreadScope::WithClassLoader` (AsyncQueueImpl.cpp:37).

If `queue_` is the UI queue (`AsyncQueueUI`), `pushTask` → `queue_->push` → `uiScheduler_->scheduleOnUI` → `androidUiScheduler_->cthis()->scheduleTriggerOnUI()` → JNI call from an unattached thread → crash. Even if `queue_` is `AsyncQueueImpl` (which itself queues to an attached thread), any custom code that runs inline before the queue hop is on the unattached thread.

**Fix in this PR:** the timeout thread body now runs inside `facebook::jni::ThreadScope::WithClassLoader(runLoop)` under `#ifdef ANDROID`, matching `AsyncQueueImpl`.

#### H7. `NativeProxy::registerEventHandler` and several siblings were missing the null-guard pattern added in `d5398e963d`

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp`

Commit `d5398e963d` added `if (!javaPart_) return;` to `requestRender`, `maybeFlushUIUpdatesQueue`, `preserveMountedTags`, `synchronouslyUpdateUIProps`. `registerEventHandler`, `getIsReducedMotion` (line 140), `getAnimationTimestamp` (252), `setGestureState` (229), `registerSensor` (220), `unregisterSensor` (224), `subscribeForKeyboardEvents` (234), `unsubscribeFromKeyboardEvents` (247) all lacked the guard. Some are clearly only called during init, but `getAnimationTimestamp` (called from event handling — line 300) and the sensor/keyboard methods (called from worklet-runtime callbacks) are reachable post-invalidate.

**Fix in this PR:** null guard added to all of them, with appropriate default returns (false / 0.0 / −1) for the non-void cases.

#### H8. `NativeProxy::handleEvent` re-entered `getAnimationTimestamp` → JNI without a guard

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp:300`

In the non-`USE_ANIMATION_BACKEND` path, `handleEvent` called `getAnimationTimestamp()`, which is itself a JNI call into `javaPart_` without a null check. If an event arrived between `javaPart_ = nullptr` and the proxy actually being destroyed, this would crash. The handler is reachable via the EventHandler lambda (H5), so this is the same race surface.

**Fix in this PR:** `handleEvent` bails at the top if `reanimatedModuleProxy_` or `uiRuntime_` is gone; `getAnimationTimestamp` is also guarded (per H7).

### Medium-severity findings

#### M1. Inconsistent / duplicated method-ID caching strategy

Every method in `NativeProxy.cpp` repeats `static const auto method = getJniMethod<…>("name");`. This works, but it forces the lookup to happen on the first hot path call and means tearing down or rebuilding the cache requires touching every call site. Worklets used an even worse variant: `static const auto` *inside lambdas* (`WorkletsModule.cpp:95, 104, 112, 144, 177`), where the cache is captured into runtime bindings.

**Status in this PR:** the deeper "cache at construction" rework is left for a follow-up (see C2). H3's `alive_` flag in the captured lambdas closes the use-after-invalidate hole without changing the caching strategy.

#### M2. `static thread_local bool tls_isOnUIThread` leaked across thread reuse and was process-global

`packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp:10, 21, 33`

Process-wide, never reset. With a second `AndroidUIScheduler` instance, or any thread that happens to call `triggerUI` once and later does unrelated work, the flag would misroute `scheduleOnUI` calls into direct invocation on the wrong thread.

**Fix in this PR:** per-scheduler via a monotonic integer ID and a `thread_local std::unordered_set<uint64_t>`. IDs are integers (not pointers) so a destroyed scheduler's stale ID cannot match a fresh allocation at the same address.

#### M3. `bindThis` ignored `enable_shared_from_this`

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h:22, 83-89`

`NativeProxy` inherited (privately) from `std::enable_shared_from_this<NativeProxy>` but `bindThis` returned a raw-`this`-capturing lambda. The base class was dead weight.

**Fix in this PR:** dropped the inheritance and rebuilt `bindThis` around the shared `alive_` atomic flag (see H5).

#### M4. `WorkletsModule::getWorkletsModuleProxy()` returns a `shared_ptr` to internal state

`packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.h:35-37`

Hands out a strong reference to the proxy. Any caller that retains the returned `shared_ptr` extends the proxy's lifetime past `invalidateCpp()` and effectively leaks it, since the HybridData can't unload while `workletsModuleProxy_` is held externally.

**Status in this PR:** not addressed — changing this signature touches every call site of `getWorkletsModuleProxy()`. Tracked as a follow-up.

#### M5. `EventHandler::receiveEvent` (and the other callbacks) have no top-level exception handling

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/EventHandler.h:19-26` (also `AnimationFrameCallback.h:16-18`, `SensorSetter.h:16-24`, `KeyboardWorkletWrapper.h:16-18`)

FBJNI's `makeNativeMethod` wrapper *does* translate C++ exceptions to Java exceptions, so the JVM does not abort. However, the captured `handler_` calls back into `NativeProxy`/`ReanimatedModuleProxy` which can throw `jsi::JSError` carrying stack info — these become opaque `RuntimeException`s on the Java side, often crashing the app with no developer-readable trace. JSI errors should be caught and surfaced via the existing JS error pipeline, not the JVM unwind path.

**Status in this PR:** not addressed — naive try-catches would swallow signal. Doing this right requires integrating with the JS error pipeline; tracked as a follow-up.

#### M6. `SensorSetter::sensorSetter` wrote to a fixed-size stack buffer with caller-provided size

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h:16-24`

```cpp
void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
  size_t size = value->size();
  auto elements = value->getRegion(0, size);
  double array[7];                       // ← fixed 7
  for (size_t i = 0; i < size; i++) {
    array[i] = elements[i];              // ← writes `size` elements
  }
  callback_(array, orientationDegrees);
}
```

If `value->size()` ever exceeded 7, this was a stack-buffer overflow. The Java side controls `size`, but it was not statically enforced. Sensor payloads are 3, 4, or 7 floats depending on sensor type, so 7 is the max, but the safety relied on an unwritten contract.

**Fix in this PR:** clamped to `std::min<size_t>(value->size(), 7)` so a malformed `JArrayFloat` cannot overflow the stack buffer.

#### M7. `injectCppVersion` / `checkJavaVersion` only ran under `#ifndef NDEBUG`

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp:41-44, 85-114`

In release builds, a mismatched Java/C++ pair would fail mysteriously deeper in the call chain. The check is cheap (a single JNI call at init) and saves hours of debugging.

**Fix in this PR:** version handshake runs in release too. The Kotlin side's `checkCppVersion` remains gated on `BuildConfig.DEBUG`, but the C++ side now both compares the Java version and writes the C++ version back (`setCppVersion` exists in release because `cppVersion`'s setter is auto-generated with `@set:DoNotStrip`).

#### M8. `installJSIBindings`, `performOperations`, `performNonLayoutOperations`, `toggleSlowAnimationsOnUIRuntime`, `isAnyHandlerWaitingForEvent` didn't null-check the C++ proxy

`packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp:117-147`

After `invalidateCpp()` drops `reanimatedModuleProxy_`, any inbound JNI call into these methods would crash on null deref.

**Fix in this PR:** `if (!reanimatedModuleProxy_) return …;` at the top of each.

#### M9. `JScriptBufferWrapper::initHybridFromAssets` was missing the `RecoverableError` wrapping that `initHybridFromFile` used

`packages/react-native-worklets/android/src/main/cpp/worklets/android/JScriptBufferWrapper.cpp:16-44`

`initHybridFromFile` wrapped `JSBigFileString::fromPath` in `RecoverableError::runRethrowingAsRecoverable<std::system_error>` so I/O errors surface as a recoverable exception (which React handles). `initHybridFromAssets` and `initHybridFromString` did not.

**Fix in this PR:** applied the same wrapping consistently across all three init variants.

#### M10. Pointer / refcount provenance of `jWorkletRuntimeWrapper` is unclear

`packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp:14-20, 22-38`

`makeJWorkletRuntimeWrapper` is invoked from inside `getSendRequest`'s lambda (`WorkletsModule.cpp:161`) every time a request is sent. Each call creates a new HybridClass instance. The wrapper holds a `shared_ptr<WorkletRuntime>` — fine — but `cxxEmitDeviceEvent` schedules into that runtime asynchronously. If the JWorkletRuntimeWrapper is GC'd before the scheduled job runs, the captured `workletRuntime_` in the C++ part stays alive (via the schedule's lambda), but the `params` came from a `ReadableNativeArray` that may have JNI lifetime tied to the now-collected wrapper. Worth verifying `consume()` (line 25) produces a fully-detached `folly::dynamic`.

**Status in this PR:** not addressed — wanted code-level confirmation before changing anything. Tracked as a follow-up.

#### M11. `JWorkletRuntimeWrapper::registerNatives` had a dead no-op `registerNatives({})` call

`packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp:44-49`

**Fix in this PR:** removed.

#### M12. `WorkletsModule.cpp:157` dereferenced `workletRuntime` without checking the `.lock()` result

```cpp
auto workletRuntime = WorkletRuntime::getWeakRuntimeFromJSIRuntime(rt).lock();
…
JWorkletRuntimeWrapper::makeJWorkletRuntimeWrapper(workletRuntime).get(),
```

`workletRuntime` may be null if the runtime was already destroyed (e.g. reload while a request is in flight). `makeJWorkletRuntimeWrapper(nullptr)` calls `workletRuntime->getRuntimeId()` → null deref. Same pattern at `WorkletsModule.cpp:105-106` (`getAbortRequest`).

**Fix in this PR:** `if (!workletRuntime) return;` before using, in both `abortRequest` and `sendRequest`.

#### M13. `mContext.exceptionHandler` access in `AndroidUIScheduler.kt:42` was unguarded

`packages/react-native-worklets/android/src/main/java/com/swmansion/worklets/AndroidUIScheduler.kt:40-48`

`scheduleTriggerOnUI` is invoked from C++; `mContext` is a strong `ReactApplicationContext`. If the context was invalidated between the call entering JNI-back and reaching the runnable, `mContext.exceptionHandler` could NPE inside the `GuardedRunnable` constructor.

**Fix in this PR:** capture `mExceptionHandler` at construction and reuse the captured handler.

### Low-severity findings (correctness/quality, not crash-paths)

- **L1.** PCH headers pull in heavy includes that most callers don't need (`ReanimatedPCH.h` includes Fabric / Yoga / RuntimeExecutor). **Not addressed** — compile-time-only, needs measurement.
- **L2.** Three `initHybrid*` variants for `JScriptBufferWrapper`. **Not addressed** — style preference.
- **L3.** `bindThis` comment "It's probably safe…" should not be in production code. **Addressed** — comment replaced, lifetime is now actually safe.
- **L4.** `~NativeProxy` was empty but kept for an obsolete commented-out block. **Addressed** — destructor removed.
- **L5.** `NativeProxy` constructor calls `getPlatformDependentMethods()` twice. **Not addressed** — needs `ReanimatedModuleProxy::init` contract change.
- **L6.** `tls_isOnUIThread` needs an explanatory comment. **Addressed** as part of M2.
- **L7.** `getJniMethod` template could move to a shared utilities header. **Not addressed** — bigger refactor with low value.

### Cross-cutting observations

#### C1. Two packages, two teardown idioms

Reanimated's `invalidateCpp()` drains in a specific order; Worklets' was two unconditional resets. Bringing them onto a single `Invalidatable` mixin (debug-asserts that everything reachable through it has been invalidated before destructor runs) would let the same teardown ordering rules apply everywhere, and would catch H4-class bugs as soon as a new field is added. **Not in this PR** — tracked as a follow-up.

#### C2. The JNI surface is implicit — there is no single place to list "what Java methods does C++ call"

Right now you'd have to grep `getMethod<` across both packages. A `JavaContract` header that names every method-ID, validates them once in `JNI_OnLoad`, and exposes typed accessors would surface name typos at startup instead of on first invocation, and would consolidate H1/H7/H8-style guards. **Not in this PR** — substantial refactor; subsumes M1.

#### C3. iOS doesn't have most of these problems because there is no equivalent invalidate step

`apple/reanimated/apple/native/NativeProxy.mm` and `apple/worklets/apple/WorkletsModule.mm` rely on ARC and `dealloc`. The fixes in this PR are Android-specific. No symmetric iOS work is needed.

#### C4. Recent commits addressed the symptom, not the root cause

The CSS-loop teardown JNI-abort fix (`15f288a162`) and the "tighten teardown ordering and extend null guards" commit (`d5398e963d`) are exactly the kind of patch this audit predicted more of. The systemic fixes are:

1. Centralize Java-method invocation through a single null-checked accessor — partially addressed via per-method guards (H7, H8, M8); the centralization is part of C2 follow-up.
2. Replace raw-`this` captures with a shared `alive` flag — done in H5 / M3.
3. Replace strong global_refs in long-lived wrappers with refs that can be dropped on invalidate — done for `UISchedulerWrapper` in H1 / H2.
4. Always wrap detached Android threads with `ThreadScope::WithClassLoader` — done in H6, audits future code.

### Deferred to follow-ups

- **M4** — change `getWorkletsModuleProxy` return type to `weak_ptr` (touches every call site).
- **M5** — exception handling integrated with the JS error pipeline.
- **M10** — confirm `WritableNativeArray::cthis()->consume()` produces a fully-detached `folly::dynamic`.
- **L1, L2, L5, L7** — compile-time / style cleanups.
- **C1** — `Invalidatable` mixin.
- **C2** — single typed `JavaContract` header replacing scattered `getMethod<…>` lookups (subsumes M1).

## Test plan

- [x] `:app:assembleDebug` on `apps/fabric-example` (41s, clean).
- [ ] iOS build sanity check: `yarn build && yarn ios` on `apps/fabric-example`. Only one shared-tree file changed (`EventLoop.cpp`) and the new code is fully behind `#ifdef ANDROID`, so iOS should be unaffected — but worth confirming.
- [ ] Reload stress test: dev-menu reload 50× on `apps/fabric-example` with CSS animations + sensors active, watching `adb logcat -b crash | grep -E 'JNI|FATAL|SIGSEGV'`. Pre-fix this reproduces; post-fix it should be quiet.
- [ ] Background / re-foreground the app rapidly during an animation; assert no `SIGSEGV` in `adb logcat -b crash`.
- [ ] Run the Worklets test app's keyboard + sensor + fetch-preview suite to exercise H3 / M12.
- [ ] Run with HWASan (`-fsanitize=hwaddress`) on an arm64 device to catch any remaining stale-pointer reads (H5).
