### PR TITLE
Add file extensions to generated .d.ts files

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -34,7 +34,7 @@
     "type:check:strict": "yarn type:check:strict:src && yarn type:check:strict:app",
     "type:check:strict:src": "yarn tsc --noEmit --customConditions react-native-strict-api",
     "type:check:strict:app": "yarn workspace common-app type:check:strict",
-    "build": "yarn workspace react-native-worklets build && yarn set-version && bob build",
+    "build": "yarn workspace react-native-worklets build && yarn set-version && bob build && ts-add-js-extension --dir=lib/typescript --showprogress=false",
     "prepack": "yarn build",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "tree-shake:check:web": "yarn is-tree-shakable --resolution web",
@@ -138,6 +138,7 @@
     "react-native-web": "0.21.1",
     "react-native-worklets": "workspace:*",
     "react-test-renderer": "19.2.3",
+    "ts-add-js-extension": "1.6.6",
     "typescript": "5.9.3"
   },
   "react-native-builder-bob": {

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -9,7 +9,7 @@
     "worklets"
   ],
   "scripts": {
-    "build": "yarn workspace babel-plugin-worklets build && yarn set-version && bob build",
+    "build": "yarn workspace babel-plugin-worklets build && yarn set-version && bob build && ts-add-js-extension --dir=lib/typescript --showprogress=false",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "find-unused-code:js": "knip",
     "format": "yarn format:js && yarn format:plugin && yarn format:common && yarn format:android && yarn format:apple",
@@ -93,6 +93,7 @@
     "react": "19.2.3",
     "react-native": "0.85.2",
     "react-native-builder-bob": "0.40.13",
+    "ts-add-js-extension": "1.6.6",
     "typescript": "5.9.3"
   },
   "main": "./lib/module/index",


### PR DESCRIPTION
## Summary
Adds missing file extensions to `.d.ts` files so that `react-native-reanimated` can be used with `moduleResolution: 'nodenext'`

fixes #9447 

## Test plan

Run build and see that output `.d.ts` files have file extensions for imports and exports