### PR TITLE
fix: clang-tidy version mismatch w/ pch

### DIFF
--- a/scripts/clang-tidy-lint.sh
+++ b/scripts/clang-tidy-lint.sh
@@ -15,4 +15,7 @@ if [ ! -f "compile_commands.json" ]; then
   )
 fi
 
-run-clang-tidy -quiet -p . -header-filter="^.*/$1/.*\.h$" "$1"
+ndk_bin="$(grep -oE '/[^ "]+/clang\+\+' compile_commands.json | head -1 | xargs dirname)"
+
+run-clang-tidy -quiet -p . -clang-tidy-binary "$ndk_bin/clang-tidy" \
+  -header-filter="^.*/$1/.*\.h$" "$1"


### PR DESCRIPTION
## Summary
We use precompiled headers in android build
This breaks clang-tidy CI when clang version is mismatched between NDK and ubuntu/system clang
This PR makes the clang-tidy script use the NDK clang
## Test plan
CI works
