### PR TITLE
fix(Worklets): repair NDEBUG-only build error in SerializableRemoteFunction

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/Serializable.h
@@ -262,8 +262,9 @@ class SerializableRemoteFunction : public Serializable,
  public:
   SerializableRemoteFunction(
       jsi::Runtime &rt,
-      jsi::Function &&function,
+      jsi::Function &&function
 #ifndef NDEBUG
+      ,
       const std::string &name
 #endif
       )

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
@@ -62,15 +62,17 @@ jsi::Value makeSerializableHostFunction(
 
 jsi::Value makeSerializableRemoteFunction(
     jsi::Runtime &rt,
-    jsi::Function function,
+    jsi::Function function
 #ifndef NDEBUG
+    ,
     const std::string &name
 #endif
 ) {
   auto serializable = std::make_shared<SerializableRemoteFunction>(
       rt,
-      std::move(function),
+      std::move(function)
 #ifndef NDEBUG
+          ,
       name
 #endif
   );

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.h
@@ -51,8 +51,9 @@ jsi::Value makeSerializableHostFunction(
 
 jsi::Value makeSerializableRemoteFunction(
     jsi::Runtime &rt,
-    jsi::Function function,
+    jsi::Function function
 #ifndef NDEBUG
+    ,
     const std::string &name
 #endif
 );


### PR DESCRIPTION
## Summary

In Release builds (where `NDEBUG` is defined), the `#ifndef NDEBUG` blocks in `SerializableRemoteFunction`'s constructor and in `makeSerializableRemoteFunction` elide the `name` parameter but leave a dangling comma before it — producing `function, )`, which is a syntax error. Debug builds compile because the block keeps the parameter and the comma is legal.

The fix moves the comma inside the `#ifndef NDEBUG` blocks so the last always-present argument has no trailing comma in either configuration. This matches the pattern already used correctly at [`JSIWorkletsModuleProxy.cpp:368-376`](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp#L368-L376).

Regression introduced in #9386.

## Test plan

- [ ] Debug build still compiles (`yarn ios` in `apps/fabric-example`)
- [ ] Release build now compiles (`yarn ios --mode Release` in `apps/fabric-example`) — previously failed with `Expected parameter declarator` at `Serializable.h:269`
