### PR TITLE
chore(clang-tidy): only build what we need for clang-tidy

### DIFF
--- a/scripts/clang-tidy-lint.sh
+++ b/scripts/clang-tidy-lint.sh
@@ -11,7 +11,7 @@ if [ ! -f "compile_commands.json" ]; then
   (
     cd ../../apps/fabric-example || exit 1
     yarn
-    cd android && ./gradlew assembleDebug --build-cache -PreactNativeArchitectures=arm64-v8a
+    cd android && ./gradlew :react-native-worklets:assembleDebug :react-native-reanimated:assembleDebug --build-cache -PreactNativeArchitectures=arm64-v8a
   )
 fi
 


### PR DESCRIPTION
## Summary
We don't need to build whole fabric example for clang-tidy for worklets/reanimated
It's slow
So let's stop doing it

## Test plan
CI works