### PR TITLE
Remove bridgeless check on iOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -166,12 +166,6 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   return ![_moduleRegistry moduleIsInitialized:[workletsModule class]];
 }
 
-- (void)checkBridgeless
-{
-  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
-  react_native_assert(isBridgeless && "[Reanimated] react-native-reanimated only supports bridgeless mode");
-}
-
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 {
   REAAssertJavaScriptQueue();
@@ -183,7 +177,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
   auto jsCallInvoker = _callInvoker.callInvoker;
 
   react_native_assert(self.bridge != nullptr);
-  [self checkBridgeless];
   react_native_assert(self.bridge.runtime != nullptr);
   jsi::Runtime &rnRuntime = *reinterpret_cast<facebook::jsi::Runtime *>(self.bridge.runtime);
 
@@ -212,7 +205,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
-  [self checkBridgeless];
   REAAssertJavaScriptQueue();
   return std::make_shared<facebook::react::NativeReanimatedModuleSpecJSI>(params);
 }

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -41,12 +41,6 @@ using namespace worklets;
   return workletsModuleProxy_;
 }
 
-- (void)checkBridgeless
-{
-  auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
-  react_native_assert(isBridgeless && "[Worklets] react-native-worklets only supports bridgeless mode");
-}
-
 @synthesize bundleManager = bundleManager_;
 @synthesize callInvoker = callInvoker_;
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
@@ -58,7 +52,6 @@ RCT_EXPORT_MODULE(WorkletsModule);
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule : (BOOL)bundleModeEnabled)
 {
   react_native_assert(self.bridge != nullptr);
-  [self checkBridgeless];
   react_native_assert(self.bridge.runtime != nullptr);
 
   AssertJavaScriptQueue();
@@ -127,7 +120,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toggleSlowAnimationsOnUIRuntime)
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
-  [self checkBridgeless];
   AssertJavaScriptQueue();
   return std::make_shared<facebook::react::NativeWorkletsModuleSpecJSI>(params);
 }


### PR DESCRIPTION
## Summary

Removes the `checkBridgeless` helper and its call sites in `ReanimatedModule.mm` and `WorkletsModule.mm`. The check used `RCTCxxBridge` to assert that the host app was running in bridgeless mode.

Two reasons it can go:

1. Reanimated and Worklets only support the New Architecture, where bridgeless is the only mode, so the assertion is always vacuously true.
2. `RCTCxxBridge` was removed from React Native in facebook/react-native#56837. With that symbol gone, the file no longer compiles against recent nightlies, which breaks the [nightly build](https://github.com/react-native-community/nightly-tests/actions/runs/26084069667/job/76692632497) with:

```
WorkletsModule.mm:46:52: error: use of undeclared identifier 'RCTCxxBridge'
   46 |   auto isBridgeless = ![self.bridge isKindOfClass:[RCTCxxBridge class]];
```

Deleting the check fixes the build and removes a now-meaningless runtime assertion.

## Test plan

- Build `apps/fabric-example` on iOS and verify it compiles and runs.
- Confirm the next nightly build against React Native main is green.
