### PR TITLE
refactor(Worklets): add hostRuntimeId to JSIWorkletsModuleProxy

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -10,6 +10,7 @@
 #include <worklets/Tools/JSLogger.h>
 #include <worklets/Tools/WorkletsJSIUtils.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
+#include <worklets/WorkletRuntime/RuntimeData.h>
 
 #ifndef NDEBUG
 #include <algorithm>
@@ -152,12 +153,12 @@ runOnRuntimeSync(jsi::Runtime &rt, const jsi::Value &workletRuntimeValue, const 
 inline jsi::Value createWorkletRuntime(
     jsi::Runtime &originRuntime,
     const std::shared_ptr<RuntimeManager> &runtimeManager,
-    const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
+    const std::shared_ptr<const JSIWorkletsModuleProxy> &sourceProxy,
     const std::string &name,
     std::shared_ptr<SerializableWorklet> &initializer,
     const std::shared_ptr<AsyncQueue> &queue,
     bool enableEventLoop) {
-  const auto workletRuntime = runtimeManager->createWorkletRuntime(jsiWorkletsModuleProxy, name, initializer, queue);
+  const auto workletRuntime = runtimeManager->createWorkletRuntime(sourceProxy, name, initializer, queue);
   return jsi::Object::createFromHostObject(originRuntime, workletRuntime);
 }
 
@@ -221,26 +222,6 @@ inline void registerCustomSerializable(
 }
 
 } // namespace
-
-JSIWorkletsModuleProxy::JSIWorkletsModuleProxy(
-    const bool isDevBundle,
-    const std::shared_ptr<JSScheduler> &jsScheduler,
-    const std::shared_ptr<UIScheduler> &uiScheduler,
-    const std::shared_ptr<MemoryManager> &memoryManager,
-    const std::shared_ptr<RuntimeManager> &runtimeManager,
-    const std::weak_ptr<WorkletRuntime> &uiWorkletRuntime,
-    const std::shared_ptr<RuntimeBindings> &runtimeBindings,
-    const BundleModeConfig &bundleModeConfig,
-    const std::shared_ptr<UnpackerLoader> &unpackerLoader)
-    : isDevBundle_(isDevBundle),
-      bundleModeConfig_(bundleModeConfig),
-      jsScheduler_(jsScheduler),
-      uiScheduler_(uiScheduler),
-      memoryManager_(memoryManager),
-      runtimeManager_(runtimeManager),
-      uiWorkletRuntime_(uiWorkletRuntime),
-      runtimeBindings_(runtimeBindings),
-      unpackerLoader_(unpackerLoader) {}
 
 jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
   auto obj = jsi::Object(rt);
@@ -556,8 +537,7 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
       rt,
       obj,
       "createWorkletRuntime",
-      [clone = std::make_shared<JSIWorkletsModuleProxy>(*this)](
-          jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[5]) {
+      [sourceProxy = shared_from_this()](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[5]) {
         const auto name = at<0>(args).asString(rt).utf8(rt);
         auto serializableInitializer = extractSerializableOrThrow<SerializableWorklet>(
             rt, at<1>(args), "[Worklets] Initializer must be a worklet.");
@@ -571,9 +551,10 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
         }
 
         const auto enableEventLoop = at<4>(args).asBool();
+        const auto runtimeManager = sourceProxy->getRuntimeManager();
 
         return createWorkletRuntime(
-            rt, clone->getRuntimeManager(), clone, name, serializableInitializer, asyncQueue, enableEventLoop);
+            rt, runtimeManager, sourceProxy, name, serializableInitializer, asyncQueue, enableEventLoop);
       });
 
   jsi_utils::addMethod<3>(

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.h
@@ -7,6 +7,7 @@
 #include <worklets/Tools/ScriptBuffer.h>
 #include <worklets/WorkletRuntime/BundleModeConfig.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
+#include <worklets/WorkletRuntime/RuntimeData.h>
 #include <worklets/WorkletRuntime/RuntimeManager.h>
 #include <worklets/WorkletRuntime/UIRuntimeDecorator.h>
 
@@ -19,7 +20,7 @@ namespace worklets {
 
 class WorkletRuntime;
 
-class JSIWorkletsModuleProxy {
+class JSIWorkletsModuleProxy : public std::enable_shared_from_this<JSIWorkletsModuleProxy> {
  public:
   explicit JSIWorkletsModuleProxy(
       const bool isDevBundle,
@@ -30,9 +31,37 @@ class JSIWorkletsModuleProxy {
       const std::weak_ptr<WorkletRuntime> &uiWorkletRuntime,
       const std::shared_ptr<RuntimeBindings> &runtimeBindings,
       const BundleModeConfig &bundleModeConfig,
-      const std::shared_ptr<UnpackerLoader> &unpackerLoader);
+      const std::shared_ptr<UnpackerLoader> &unpackerLoader,
+      RuntimeData::RuntimeId hostRuntimeId)
+      : isDevBundle_(isDevBundle),
+        bundleModeConfig_(bundleModeConfig),
+        jsScheduler_(jsScheduler),
+        uiScheduler_(uiScheduler),
+        memoryManager_(memoryManager),
+        runtimeManager_(runtimeManager),
+        uiWorkletRuntime_(uiWorkletRuntime),
+        runtimeBindings_(runtimeBindings),
+        unpackerLoader_(unpackerLoader),
+        hostRuntimeId_(hostRuntimeId) {}
 
-  JSIWorkletsModuleProxy(const JSIWorkletsModuleProxy &other) = default;
+  static std::shared_ptr<JSIWorkletsModuleProxy> createForNewRuntime(
+      const std::shared_ptr<const JSIWorkletsModuleProxy> &sourceProxy,
+      RuntimeData::RuntimeId hostRuntimeId) {
+    return std::make_shared<JSIWorkletsModuleProxy>(
+        sourceProxy->isDevBundle_,
+        sourceProxy->jsScheduler_,
+        sourceProxy->uiScheduler_,
+        sourceProxy->memoryManager_,
+        sourceProxy->runtimeManager_,
+        sourceProxy->uiWorkletRuntime_,
+        sourceProxy->runtimeBindings_,
+        sourceProxy->bundleModeConfig_,
+        sourceProxy->unpackerLoader_,
+        hostRuntimeId);
+  }
+
+  /** No copy constructor to prevent making JSIWorkletsModuleProxy with wrong hostRuntimeId. */
+  JSIWorkletsModuleProxy(const JSIWorkletsModuleProxy &other) = delete;
 
   [[nodiscard]]
   jsi::Object toOptimizedObject(jsi::Runtime &rt) const;
@@ -87,6 +116,7 @@ class JSIWorkletsModuleProxy {
   const std::weak_ptr<WorkletRuntime> uiWorkletRuntime_;
   const std::shared_ptr<RuntimeBindings> runtimeBindings_;
   const std::shared_ptr<UnpackerLoader> unpackerLoader_;
+  const RuntimeData::RuntimeId hostRuntimeId_;
 };
 
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/WorkletsModuleProxy.cpp
@@ -1,7 +1,9 @@
+#include <worklets/NativeModules/JSIWorkletsModuleProxy.h>
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
 #include <worklets/RunLoop/AsyncQueueImpl.h>
 #include <worklets/WorkletRuntime/RNRuntimeWorkletDecorator.h>
 #include <worklets/WorkletRuntime/RuntimeBindings.h>
+#include <worklets/WorkletRuntime/RuntimeData.h>
 #include <worklets/WorkletRuntime/UIRuntimeDecorator.h>
 
 #include <memory>
@@ -27,7 +29,8 @@ void WorkletsModuleProxy::start() {
    * We call additional `init` method here because
    * JSIWorkletsModuleProxy needs a weak_ptr to the UI Runtime.
    */
-  uiWorkletRuntime_->init(std::make_shared<JSIWorkletsModuleProxy>(*rnRuntimeProxy_));
+  const auto uiRuntimeProxy = JSIWorkletsModuleProxy::createForNewRuntime(rnRuntimeProxy_, RuntimeData::uiRuntimeId);
+  uiWorkletRuntime_->init(uiRuntimeProxy);
 
   animationFrameBatchinator_ =
       std::make_shared<AnimationFrameBatchinator>(uiWorkletRuntime_, runtimeBindings_->requestAnimationFrame);
@@ -62,7 +65,8 @@ WorkletsModuleProxy::WorkletsModuleProxy(
           uiWorkletRuntime_,
           runtimeBindings_,
           bundleModeConfig_,
-          unpackerLoader_)) {
+          unpackerLoader_,
+          RuntimeData::rnRuntimeId)) {
   RNRuntimeWorkletDecorator::decorate(rnRuntime, rnRuntimeProxy_->toOptimizedObject(rnRuntime), jsLogger_);
 }
 

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -37,17 +37,18 @@ std::shared_ptr<WorkletRuntime> RuntimeManager::getUIRuntime() {
 }
 
 std::shared_ptr<WorkletRuntime> RuntimeManager::createWorkletRuntime(
-    const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
+    const std::shared_ptr<const JSIWorkletsModuleProxy> &sourceProxy,
     const std::string &name,
     const std::shared_ptr<SerializableWorklet> &initializer,
     const std::shared_ptr<AsyncQueue> &queue,
     bool enableEventLoop) {
   const auto runtimeId = getNextRuntimeId();
 
-  auto workletRuntime =
+  const auto workletRuntime =
       std::make_shared<WorkletRuntime>(runtimeId, RuntimeData::RuntimeKind::Worker, name, queue, enableEventLoop);
+  const auto targetProxy = JSIWorkletsModuleProxy::createForNewRuntime(sourceProxy, runtimeId);
 
-  workletRuntime->init(jsiWorkletsModuleProxy);
+  workletRuntime->init(targetProxy);
 
   if (initializer) {
     workletRuntime->runSync(initializer);

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -29,7 +29,7 @@ class RuntimeManager {
   std::shared_ptr<WorkletRuntime> getUIRuntime();
 
   std::shared_ptr<WorkletRuntime> createWorkletRuntime(
-      const std::shared_ptr<JSIWorkletsModuleProxy> &jsiWorkletsModuleProxy,
+      const std::shared_ptr<const JSIWorkletsModuleProxy> &sourceProxy,
       const std::string &name,
       const std::shared_ptr<SerializableWorklet> &initializer = nullptr,
       const std::shared_ptr<AsyncQueue> &queue = nullptr,


### PR DESCRIPTION
## Summary

I'm adding `hostRuntimeId` property to JSIWorkletsModuleProxy.

JSIWorkletsModuleProxy is already an object bound to a single Worklet Runtime. I'll use the new member in upstream PRs #9272.

## Test plan

App works
