### PR TITLE
fix(Reanimated): Spring jitter

### DIFF
--- a/packages/react-native-reanimated/src/animation/decay/rigidDecay.ts
+++ b/packages/react-native-reanimated/src/animation/decay/rigidDecay.ts
@@ -11,7 +11,7 @@ export function rigidDecay(
   const { lastTimestamp, startTimestamp, initialVelocity, current, velocity } =
     animation;
 
-  const deltaTime = Math.min(now - lastTimestamp, 64);
+  const deltaTime = Math.min(Math.max(now - lastTimestamp, 0), 64);
   const v =
     velocity *
     Math.exp(

--- a/packages/react-native-reanimated/src/animation/decay/rubberBandDecay.ts
+++ b/packages/react-native-reanimated/src/animation/decay/rubberBandDecay.ts
@@ -12,7 +12,7 @@ export function rubberBandDecay(
   'worklet';
   const { lastTimestamp, startTimestamp, current, velocity } = animation;
 
-  const deltaTime = Math.min(now - lastTimestamp, 64);
+  const deltaTime = Math.min(Math.max(now - lastTimestamp, 0), 64);
   const clampIndex =
     Math.abs(current - config.clamp[0]) < Math.abs(current - config.clamp[1])
       ? 0

--- a/packages/react-native-reanimated/src/animation/spring/spring.ts
+++ b/packages/react-native-reanimated/src/animation/spring/spring.ts
@@ -104,7 +104,7 @@ export const withSpring = ((
       }
       const { lastTimestamp, velocity } = animation;
 
-      const deltaTime = Math.min(now - lastTimestamp, 64);
+      const deltaTime = Math.min(Math.max(now - lastTimestamp, 0), 64);
       animation.lastTimestamp = now;
 
       const t = deltaTime / 1000;
@@ -113,36 +113,22 @@ export const withSpring = ((
 
       const { zeta, omega0, omega1 } = animation;
 
-      let newPosition: number;
-      let newVelocity: number;
-      if (zeta < 1) {
-        ({ position: newPosition, velocity: newVelocity } =
-          underDampedSpringCalculations(animation, {
-            zeta,
-            v0,
-            x0,
-            omega0,
-            omega1,
-            t,
-          }));
-      } else if (zeta > 1) {
-        ({ position: newPosition, velocity: newVelocity } =
-          overDampedSpringCalculations(animation, {
-            zeta,
+      const { position: newPosition, velocity: newVelocity } =
+        zeta < 1
+          ? underDampedSpringCalculations(animation, {
+              zeta,
+              v0,
+              x0,
+              omega0,
+              omega1,
+              t,
+            })
+          : criticallyDampedSpringCalculations(animation, {
             v0,
             x0,
             omega0,
             t,
-          }));
-      } else {
-        ({ position: newPosition, velocity: newVelocity } =
-          criticallyDampedSpringCalculations(animation, {
-            v0,
-            x0,
-            omega0,
-            t,
-          }));
-      }
+          });
 
       animation.current = newPosition;
       animation.velocity = newVelocity;

--- a/packages/react-native-reanimated/src/animation/spring/spring.ts
+++ b/packages/react-native-reanimated/src/animation/spring/spring.ts
@@ -123,11 +123,11 @@ export const withSpring = ((
               t,
             })
           : criticallyDampedSpringCalculations(animation, {
-            v0,
-            x0,
-            omega0,
-            t,
-          });
+              v0,
+              x0,
+              omega0,
+              t,
+            });
 
       animation.current = newPosition;
       animation.velocity = newVelocity;

--- a/packages/react-native-reanimated/src/animation/spring/spring.ts
+++ b/packages/react-native-reanimated/src/animation/spring/spring.ts
@@ -24,7 +24,6 @@ import {
   getEnergy,
   initialCalculations,
   isAnimationTerminatingCalculation,
-  overDampedSpringCalculations,
   safeMergeConfigs,
   scaleZetaToMatchClamps,
   underDampedSpringCalculations,

--- a/packages/react-native-reanimated/src/animation/spring/spring.ts
+++ b/packages/react-native-reanimated/src/animation/spring/spring.ts
@@ -24,6 +24,7 @@ import {
   getEnergy,
   initialCalculations,
   isAnimationTerminatingCalculation,
+  overDampedSpringCalculations,
   safeMergeConfigs,
   scaleZetaToMatchClamps,
   underDampedSpringCalculations,
@@ -112,22 +113,36 @@ export const withSpring = ((
 
       const { zeta, omega0, omega1 } = animation;
 
-      const { position: newPosition, velocity: newVelocity } =
-        zeta < 1
-          ? underDampedSpringCalculations(animation, {
-              zeta,
-              v0,
-              x0,
-              omega0,
-              omega1,
-              t,
-            })
-          : criticallyDampedSpringCalculations(animation, {
-              v0,
-              x0,
-              omega0,
-              t,
-            });
+      let newPosition: number;
+      let newVelocity: number;
+      if (zeta < 1) {
+        ({ position: newPosition, velocity: newVelocity } =
+          underDampedSpringCalculations(animation, {
+            zeta,
+            v0,
+            x0,
+            omega0,
+            omega1,
+            t,
+          }));
+      } else if (zeta > 1) {
+        ({ position: newPosition, velocity: newVelocity } =
+          overDampedSpringCalculations(animation, {
+            zeta,
+            v0,
+            x0,
+            omega0,
+            t,
+          }));
+      } else {
+        ({ position: newPosition, velocity: newVelocity } =
+          criticallyDampedSpringCalculations(animation, {
+            v0,
+            x0,
+            omega0,
+            t,
+          }));
+      }
 
       animation.current = newPosition;
       animation.velocity = newVelocity;
@@ -184,6 +199,16 @@ export const withSpring = ((
             : previousAnimation?.velocity + config.velocity) || 0;
       } else {
         animation.velocity = config.velocity || 0;
+      }
+
+      // Clip velocity that would drive the first frame away from the new target.
+      // Inertia is only preserved when it already points toward toValue.
+      const toValueNum = Number(animation.toValue);
+      if (
+        (toValueNum > value && animation.velocity < 0) ||
+        (toValueNum < value && animation.velocity > 0)
+      ) {
+        animation.velocity = 0;
       }
 
       if (triggeredTwice) {

--- a/packages/react-native-reanimated/src/animation/spring/springUtils.ts
+++ b/packages/react-native-reanimated/src/animation/spring/springUtils.ts
@@ -140,7 +140,7 @@ export function initialCalculations(
      * https://courses.lumenlearning.com/suny-osuniversityphysics/chapter/15-5-damped-oscillations/
      */
     const omega0 = Math.sqrt(stiffness / m);
-    const omega1 = omega0 * Math.sqrt(1 - zeta ** 2);
+    const omega1 = zeta < 1 ? omega0 * Math.sqrt(1 - zeta ** 2) : 0;
 
     return { zeta, omega0, omega1 };
   } else {
@@ -148,7 +148,7 @@ export function initialCalculations(
 
     const zeta = c / (2 * Math.sqrt(k * m)); // damping ratio
     const omega0 = Math.sqrt(k / m); // undamped angular frequency of the oscillator (rad/ms)
-    const omega1 = omega0 * Math.sqrt(1 - zeta ** 2); // exponential decay
+    const omega1 = zeta < 1 ? omega0 * Math.sqrt(1 - zeta ** 2) : 0; // exponential decay
 
     return { zeta, omega0, omega1 };
   }
@@ -302,6 +302,44 @@ export function calculateNewStiffnessToMatchDuration(
     precision,
     maxIterations: 100,
   });
+}
+
+// ts-prune-ignore-next This function is exported to be tested
+export function overDampedSpringCalculations(
+  animation: InnerSpringAnimation,
+  precalculatedValues: {
+    zeta: number;
+    v0: number;
+    x0: number;
+    omega0: number;
+    t: number;
+  }
+): { position: number; velocity: number } {
+  'worklet';
+  const { toValue } = animation;
+  const { zeta, v0, x0, omega0, t } = precalculatedValues;
+
+  // Two distinct real characteristic roots for overdamped (zeta > 1).
+  const omega2 = omega0 * Math.sqrt(zeta ** 2 - 1);
+  const r1 = -zeta * omega0 + omega2; // closer to zero, slower-decaying mode
+  const r2 = -zeta * omega0 - omega2; // further from zero, fast-decaying mode
+
+  // Solve for C1, C2 from initial conditions:
+  //   C1 + C2 = x0        (initial displacement)
+  //   C1*r1 + C2*r2 = v0  (initial displacement velocity)
+  const C1 = (v0 - r2 * x0) / (r1 - r2);
+  const C2 = (r1 * x0 - v0) / (r1 - r2);
+
+  const exp1 = Math.exp(r1 * t);
+  const exp2 = Math.exp(r2 * t);
+
+  const displacement = C1 * exp1 + C2 * exp2;
+  const velocity = C1 * r1 * exp1 + C2 * r2 * exp2;
+
+  return {
+    position: toValue + displacement,
+    velocity,
+  };
 }
 
 export function criticallyDampedSpringCalculations(

--- a/packages/react-native-reanimated/src/animation/spring/springUtils.ts
+++ b/packages/react-native-reanimated/src/animation/spring/springUtils.ts
@@ -304,43 +304,6 @@ export function calculateNewStiffnessToMatchDuration(
   });
 }
 
-export function overDampedSpringCalculations(
-  animation: InnerSpringAnimation,
-  precalculatedValues: {
-    zeta: number;
-    v0: number;
-    x0: number;
-    omega0: number;
-    t: number;
-  }
-): { position: number; velocity: number } {
-  'worklet';
-  const { toValue } = animation;
-  const { zeta, v0, x0, omega0, t } = precalculatedValues;
-
-  // Two distinct real characteristic roots for overdamped (zeta > 1).
-  const omega2 = omega0 * Math.sqrt(zeta ** 2 - 1);
-  const r1 = -zeta * omega0 + omega2; // closer to zero, slower-decaying mode
-  const r2 = -zeta * omega0 - omega2; // further from zero, fast-decaying mode
-
-  // Solve for C1, C2 from initial conditions:
-  //   C1 + C2 = x0        (initial displacement)
-  //   C1*r1 + C2*r2 = v0  (initial displacement velocity)
-  const C1 = (v0 - r2 * x0) / (r1 - r2);
-  const C2 = (r1 * x0 - v0) / (r1 - r2);
-
-  const exp1 = Math.exp(r1 * t);
-  const exp2 = Math.exp(r2 * t);
-
-  const displacement = C1 * exp1 + C2 * exp2;
-  const velocity = C1 * r1 * exp1 + C2 * r2 * exp2;
-
-  return {
-    position: toValue + displacement,
-    velocity,
-  };
-}
-
 export function criticallyDampedSpringCalculations(
   animation: InnerSpringAnimation,
   precalculatedValues: {

--- a/packages/react-native-reanimated/src/animation/spring/springUtils.ts
+++ b/packages/react-native-reanimated/src/animation/spring/springUtils.ts
@@ -304,7 +304,6 @@ export function calculateNewStiffnessToMatchDuration(
   });
 }
 
-// ts-prune-ignore-next This function is exported to be tested
 export function overDampedSpringCalculations(
   animation: InnerSpringAnimation,
   precalculatedValues: {


### PR DESCRIPTION
## Summary

Fixes a visible backward-jump ("jitter") in `withSpring` when used with overdamped configs (e.g. `{ mass: 0.3, damping: 30, stiffness: 400 }`) and rapidly changing targets — typical in gesture-driven `useAnimatedStyle` + pan handlers.

Three minimal, targeted fixes address the root causes without changing how existing springs feel:

1. **Clamp `deltaTime` to be non-negative** in `springOnFrame` (and the same pattern in decay animations that share timestamp inheritance).
2. **Zero inherited velocity on `onStart`** when it points away from the new `toValue`.
3. **Guard `omega1` in `initialCalculations`** so overdamped configs (`ζ ≥ 1`) do not produce `NaN`.

The spring formula dispatch for overdamped springs (`ζ > 1`) is **intentionally unchanged** - still uses `criticallyDampedSpringCalculations` for `ζ ≥ 1`, as upstream does today. A separate overdamped path was explored and reverted to keep this PR minimal and avoid altering animation feel.

## Problem

When a shared value updates on every gesture `onChange`, Reanimated re-runs `useAnimatedStyle` and restarts the spring via `onStart`. Two bugs can make the **first frame after restart** move backward (often 10–40 px):

### 1. Negative `deltaTime` (timestamp ordering)

`onStart` inherits `lastTimestamp` from the previous animation:

```ts
animation.lastTimestamp = previousAnimation?.lastTimestamp || now;
```

On iOS, `CADisplayLink` timestamps can be slightly ahead of gesture event `now`. If `now < lastTimestamp`, then:

```ts
const deltaTime = Math.min(now - lastTimestamp, 64); // negative
```

For overdamped springs, negative `t` makes `e^(r·t)` **grow** (both characteristic roots are negative), so displacement overshoots past `toValue` - a backward jump.

### 2. Wrong-direction inherited velocity

When a spring is interrupted toward a new target, `onStart` keeps the previous velocity even if it points **away** from `toValue`. For small `t`:

```
position(t) ≈ current + velocity × t
```

So the first frame can land on the wrong side of `current` before the spring force corrects it (one-frame glitch, very noticeable at 60 fps).

### 3. `NaN` from `omega1` for overdamped configs (`ζ ≥ 1`)

`initialCalculations` always computed:

```ts
const omega1 = omega0 * Math.sqrt(1 - zeta ** 2);
```

For overdamped springs (`ζ > 1`), `1 - ζ²` is negative, so `omega1` becomes **`NaN`**. That value is stored on the animation object and can propagate through spring state even though `underDampedSpringCalculations` (the only consumer of `omega1`) is not used when `ζ ≥ 1`. `NaN` in animation state contributes to unstable or glitchy frame updates alongside the timestamp and velocity issues above.

## Changes

**Fix 1 — non-negative `deltaTime`**

```ts
const deltaTime = Math.min(Math.max(now - lastTimestamp, 0), 64);
```

At `deltaTime = 0`, spring math is a no-op (`position = current`, velocity unchanged). Normal monotonic timestamps are unaffected.

**Fix 2 — velocity direction guard in `onStart`**

```ts
const toValueNum = Number(animation.toValue);
if (
  (toValueNum > value && animation.velocity < 0) ||
  (toValueNum < value && animation.velocity > 0)
) {
  animation.velocity = 0;
}
```

Same-direction inertia is preserved; only wrong-direction velocity is cleared.

**Fix 3 — safe `omega1` for `ζ ≥ 1` in `initialCalculations`**

Both code paths in `initialCalculations` (duration-based and stiffness/damping-based):

```ts
// Before
const omega1 = omega0 * Math.sqrt(1 - zeta ** 2);

// After
const omega1 = zeta < 1 ? omega0 * Math.sqrt(1 - zeta ** 2) : 0;
```

`omega1` is the damped natural frequency and is only used inside `underDampedSpringCalculations` (`ζ < 1`). For critically damped and overdamped springs the frame loop uses `criticallyDampedSpringCalculations`, which ignores `omega1`. Setting it to `0` when `ζ ≥ 1` matches that usage and avoids storing `NaN` on the animation. Underdamped behavior (`ζ < 1`) is unchanged.

## Out of scope (by design)

- No change to `ζ < 1 ? underDamped : criticallyDamped` dispatch (proper overdamped math is a separate, opt-in change).

## Test plan

<details>
<summary>code</summary>

```js
import React from 'react';
import { View } from 'react-native';
import {Gesture, GestureDetector} from 'react-native-gesture-handler';
import Reanimated, {useAnimatedStyle, useSharedValue, withSpring} from 'react-native-reanimated';

const springConfig = {
  mass: 0.3,
  damping: 30,
  stiffness: 400,
};

export default function Test() {
  const translateX = useSharedValue(0);

  const gesture = Gesture.Pan()
    .onChange((e) => {
      // This is the boundary (referred to below).
      if (e.translationX > 100) {
        translateX.value = e.translationX + 100;
        return;
      }

      translateX.value = e.translationX;
    })
    .onEnd(() => {
      translateX.value = 0;
    });

  const style = useAnimatedStyle(() => {
    return {
      transform: [
        {
          translateX: withSpring(translateX.value, springConfig),
        },
      ],
    };
  });

  return (
    <GestureDetector gesture={gesture}>
      <View style={{flex: 1, backgroundColor: 'red'}}>
        <Reanimated.View style={[{flex: 1, backgroundColor: 'blue'}, style]}></Reanimated.View>
      </View>
    </GestureDetector>
  );
}
```

</details>