### PR TITLE
feat(Worklets): add native ArrayBuffer serialization support and explicitly deprecate `_createSerializable`

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/loggingFromWorkletRuntime.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/loggingFromWorkletRuntime.test.tsx
@@ -156,11 +156,11 @@ const testCases: Record<string, TestCase> = {
     },
   },
   hostFunction: {
-    bundleMode: '[Function: createSerializable]',
+    bundleMode: '[Function: createSerializableNumber]',
     noBundleMode: '{}',
     factory: () => {
       'worklet';
-      return globalThis.__workletsModuleProxy.createSerializable;
+      return globalThis.__workletsModuleProxy.createSerializableNumber;
     },
   },
   generatorFunction: {
@@ -303,7 +303,9 @@ const testCases: Record<string, TestCase> = {
     factory: () => {
       'worklet';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (globalThis.__workletsModuleProxy as any).createSerializable(42);
+      return (globalThis.__workletsModuleProxy as any).createSerializableNumber(
+        42
+      );
     },
   },
   shareable: {

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -1,4 +1,5 @@
 #include <jsi/jsi.h>
+#include <react/debug/react_native_assert.h>
 #include <worklets/Compat/Holders.h>
 #include <worklets/Compat/StableApi.h>
 #include <worklets/NativeModules/JSIWorkletsModuleProxy.h>
@@ -705,7 +706,13 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
   /* #region deprecated */
 
   jsi_utils::addMethod<2>(
-      rt, obj, "createSerializableLEGACY", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+      rt,
+      obj,
+      "createSerializableLEGACY",
+      [hostRuntimeId = hostRuntimeId_](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+        react_native_assert(
+            hostRuntimeId != RuntimeData::rnRuntimeId &&
+            "createSerializableLEGACY should never be called on the React Native runtime.");
         const auto &value = at<0>(args);
         const auto shouldRetainRemote = jsi::Value::undefined();
         const auto &nativeStateSource = at<1>(args);

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -330,8 +330,8 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
         return makeSerializableArray(rt, at<0>(args).asObject(rt).asArray(rt), at<1>(args));
       });
 
-  jsi_utils::addMethod<2>(
-      rt, obj, "createSerializableArrayBuffer", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+  jsi_utils::addMethod<1>(
+      rt, obj, "createSerializableArrayBuffer", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
         const auto buffer = at<0>(args).getObject(rt).getArrayBuffer(rt);
         return makeSerializableArrayBuffer(rt, buffer);
       });

--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -282,11 +282,6 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
         });
       });
 
-  jsi_utils::addMethod<3>(
-      rt, obj, "createSerializable", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[3]) {
-        return makeSerializableClone(rt, at<0>(args), at<1>(args), at<2>(args));
-      });
-
   jsi_utils::addMethod<1>(
       rt, obj, "createSerializableBigInt", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[1]) {
         return makeSerializableBigInt(rt, at<0>(args).asBigInt(rt));
@@ -332,6 +327,12 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
   jsi_utils::addMethod<2>(
       rt, obj, "createSerializableArray", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
         return makeSerializableArray(rt, at<0>(args).asObject(rt).asArray(rt), at<1>(args));
+      });
+
+  jsi_utils::addMethod<2>(
+      rt, obj, "createSerializableArrayBuffer", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+        const auto buffer = at<0>(args).getObject(rt).getArrayBuffer(rt);
+        return makeSerializableArrayBuffer(rt, buffer);
       });
 
   jsi_utils::addMethod<3>(
@@ -700,6 +701,18 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
         obj.setNativeState(rt, std::move(nativeState));
         return jsi::Value(std::move(obj));
       });
+
+  /* #region deprecated */
+
+  jsi_utils::addMethod<2>(
+      rt, obj, "createSerializableLEGACY", [](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
+        const auto &value = at<0>(args);
+        const auto shouldRetainRemote = jsi::Value::undefined();
+        const auto &nativeStateSource = at<1>(args);
+        return makeSerializableClone(rt, value, shouldRetainRemote, nativeStateSource);
+      });
+
+  /* #endregion deprecated */
 
   return obj;
 }

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.cpp
@@ -89,6 +89,11 @@ jsi::Value makeSerializableArray(jsi::Runtime &rt, const jsi::Array &array, cons
   return SerializableJSRef::newNativeStateObject(rt, serializable);
 }
 
+jsi::Value makeSerializableArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer) {
+  auto serializable = std::make_shared<SerializableArrayBuffer>(rt, arrayBuffer);
+  return SerializableJSRef::newNativeStateObject(rt, serializable);
+}
+
 jsi::Value makeSerializableMap(jsi::Runtime &rt, const jsi::Array &keys, const jsi::Array &values) {
   auto serializable = std::make_shared<SerializableMap>(rt, keys, values);
   return SerializableJSRef::newNativeStateObject(rt, serializable);

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/SerializableFactory.h
@@ -37,6 +37,8 @@ jsi::Value makeSerializableHostObject(jsi::Runtime &rt, const std::shared_ptr<js
 
 jsi::Value makeSerializableArray(jsi::Runtime &rt, const jsi::Array &array, const jsi::Value &shouldRetainRemote);
 
+jsi::Value makeSerializableArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer);
+
 jsi::Value makeSerializableMap(jsi::Runtime &rt, const jsi::Array &keys, const jsi::Array &values);
 
 jsi::Value makeSerializableSet(jsi::Runtime &rt, const jsi::Array &values);

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntimeDecorator.cpp
@@ -131,12 +131,6 @@ void WorkletRuntimeDecorator::decorate(
     return jsi::Value::undefined();
   });
 
-  jsi_utils::installJsiFunction(
-      rt, "_createSerializable", [](jsi::Runtime &rt, const jsi::Value &value, const jsi::Value &nativeStateSource) {
-        auto shouldRetainRemote = jsi::Value::undefined();
-        return makeSerializableClone(rt, value, shouldRetainRemote, nativeStateSource);
-      });
-
   jsi_utils::installJsiFunction(rt, "_createSerializableHostObject", [](jsi::Runtime &rt, const jsi::Value &value) {
     return makeSerializableHostObject(rt, value.asObject(rt).asHostObject(rt));
   });

--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
@@ -65,18 +65,6 @@ See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting
       this.#workletsModuleProxy.createSerializableBoolean(false);
   }
 
-  createSerializable<TValue>(
-    value: TValue,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ) {
-    return this.#workletsModuleProxy.createSerializable(
-      value,
-      shouldPersistRemote,
-      nativeStateSource
-    );
-  }
-
   createSerializableImport<TValue>(
     from: string,
     to: string
@@ -142,6 +130,10 @@ See https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting
       array,
       shouldRetainRemote
     );
+  }
+
+  createSerializableArrayBuffer(arrayBuffer: ArrayBuffer) {
+    return this.#workletsModuleProxy.createSerializableArrayBuffer(arrayBuffer);
   }
 
   createSerializableMap<TKey, TValue>(

--- a/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
@@ -200,14 +200,11 @@ export interface WorkletsModuleProxy {
 
   getUISchedulerHolder(): object;
 
-  /* #region deprecated */
-
+  /** @deprecated Don't use unless you have to. */
   createSerializableLEGACY<TValue>(
     value: TValue,
     nativeStateSource?: object
   ): SerializableRef<TValue>;
-
-  /* #endregion deprecated */
 }
 
 type InternalMethods = 'loadUnpackers' | 'createSerializableLEGACY';

--- a/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/workletsModuleProxy.ts
@@ -30,12 +30,6 @@ export interface WorkletsModuleProxy {
     remoteFunctionUnpackerSourceMap: string
   ): void;
 
-  createSerializable<TValue>(
-    value: TValue,
-    shouldPersistRemote: boolean,
-    nativeStateSource?: object
-  ): SerializableRef<TValue>;
-
   createSerializableImport<TValue>(
     source: string,
     imported: string
@@ -73,6 +67,10 @@ export interface WorkletsModuleProxy {
     array: unknown[],
     shouldRetainRemote?: boolean
   ): SerializableRef<unknown[]>;
+
+  createSerializableArrayBuffer(
+    arrayBuffer: ArrayBuffer
+  ): SerializableRef<ArrayBuffer>;
 
   createSerializableMap<TKey, TValue>(
     keys: TKey[],
@@ -201,9 +199,18 @@ export interface WorkletsModuleProxy {
   getUIRuntimeHolder(): object;
 
   getUISchedulerHolder(): object;
+
+  /* #region deprecated */
+
+  createSerializableLEGACY<TValue>(
+    value: TValue,
+    nativeStateSource?: object
+  ): SerializableRef<TValue>;
+
+  /* #endregion deprecated */
 }
 
-type InternalMethods = 'loadUnpackers';
+type InternalMethods = 'loadUnpackers' | 'createSerializableLEGACY';
 
 type TurboModulePublic = {
   toggleSlowAnimationsOnUIRuntime(): boolean;

--- a/packages/react-native-worklets/src/initializers/initializers.native.ts
+++ b/packages/react-native-worklets/src/initializers/initializers.native.ts
@@ -11,10 +11,7 @@ import { getStaticFeatureFlag } from '../featureFlags/featureFlags';
 import { bundleValueUnpacker } from '../memory/bundleUnpacker';
 import { installCustomSerializableUnpacker } from '../memory/customSerializableUnpacker';
 import { installRemoteFunctionUnpacker } from '../memory/remoteFunctionUnpacker';
-import {
-  createSerializable,
-  makeShareableCloneOnUIRecursive,
-} from '../memory/serializable';
+import { makeShareableCloneOnUIRecursive } from '../memory/serializable';
 import { installShareableGuestUnpacker } from '../memory/shareableGuestUnpacker';
 import { installShareableHostUnpacker } from '../memory/shareableHostUnpacker';
 import { installSynchronizableUnpacker } from '../memory/synchronizableUnpacker';
@@ -121,15 +118,7 @@ export function setupConsoleForwarding(boundCapturableConsole: typeof console) {
 
 export function setupSerializer() {
   'worklet';
-  if (
-    !globalThis._WORKLETS_BUNDLE_MODE_ENABLED &&
-    globalThis.__RUNTIME_KIND === 1
-  ) {
-    globalThis.__serializer =
-      createSerializable as typeof globalThis.__serializer;
-  } else {
-    globalThis.__serializer = makeShareableCloneOnUIRecursive;
-  }
+  globalThis.__serializer = makeShareableCloneOnUIRecursive;
 }
 
 let initialized = false;
@@ -177,7 +166,6 @@ function initializeRNRuntime() {
     }
   }
 
-  setupSerializer();
   registerReportFatalRemoteError();
 }
 

--- a/packages/react-native-worklets/src/initializers/initializers.native.ts
+++ b/packages/react-native-worklets/src/initializers/initializers.native.ts
@@ -11,7 +11,10 @@ import { getStaticFeatureFlag } from '../featureFlags/featureFlags';
 import { bundleValueUnpacker } from '../memory/bundleUnpacker';
 import { installCustomSerializableUnpacker } from '../memory/customSerializableUnpacker';
 import { installRemoteFunctionUnpacker } from '../memory/remoteFunctionUnpacker';
-import { makeShareableCloneOnUIRecursive } from '../memory/serializable';
+import {
+  createSerializable,
+  makeShareableCloneOnUIRecursive,
+} from '../memory/serializable';
 import { installShareableGuestUnpacker } from '../memory/shareableGuestUnpacker';
 import { installShareableHostUnpacker } from '../memory/shareableHostUnpacker';
 import { installSynchronizableUnpacker } from '../memory/synchronizableUnpacker';
@@ -118,7 +121,15 @@ export function setupConsoleForwarding(boundCapturableConsole: typeof console) {
 
 export function setupSerializer() {
   'worklet';
-  globalThis.__serializer = makeShareableCloneOnUIRecursive;
+  if (
+    !globalThis._WORKLETS_BUNDLE_MODE_ENABLED &&
+    globalThis.__RUNTIME_KIND === 1
+  ) {
+    globalThis.__serializer =
+      createSerializable as typeof globalThis.__serializer;
+  } else {
+    globalThis.__serializer = makeShareableCloneOnUIRecursive;
+  }
 }
 
 let initialized = false;
@@ -166,6 +177,7 @@ function initializeRNRuntime() {
     }
   }
 
+  setupSerializer();
   registerReportFatalRemoteError();
 }
 

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -56,11 +56,12 @@ function isPlainJSObject(object: object): object is Record<string, unknown> {
 
 /**
  * RN has introduced a new representation of TurboModules as a JS object whose
- * prototype is the host object More details:
+ * prototype is the host object. More details:
  * https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp#L182
  */
 function isTurboModuleLike(object: object): object is Record<string, unknown> {
-  return isHostObject(Object.getPrototypeOf(object));
+  const proto = Object.getPrototypeOf(object);
+  return proto !== null && isHostObject(proto);
 }
 
 function getFromCache(value: object) {

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -54,6 +54,11 @@ function isPlainJSObject(object: object): object is Record<string, unknown> {
   return Object.getPrototypeOf(object) === Object.prototype;
 }
 
+/**
+ * RN has introduced a new representation of TurboModules as a JS object whose
+ * prototype is the host object More details:
+ * https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp#L182
+ */
 function isTurboModuleLike(object: object): object is Record<string, unknown> {
   return isHostObject(Object.getPrototypeOf(object));
 }
@@ -139,7 +144,6 @@ export function createSerializable<TValue>(
 ): SerializableRef<TValue> {
   detectCyclicObject(value, depth);
 
-  const isObject = typeof value === 'object';
   const isFunction = typeof value === 'function';
 
   if (typeof value === 'string') {
@@ -166,13 +170,6 @@ export function createSerializable<TValue>(
     return cloneNull() as SerializableRef<TValue>;
   }
 
-  if ((!isObject && !isFunction) || value === null) {
-    // TODO: most likely dead code
-    throw new Error(
-      `[Worklets] Trying to serialize an unsupported value type (${typeof value}).`
-    );
-  }
-
   const cached = getFromCache(value);
   if (cached !== undefined) {
     return cached as SerializableRef<TValue>;
@@ -183,20 +180,22 @@ export function createSerializable<TValue>(
   }
   if (isFunction) {
     if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
-      if ((value as WorkletImport).__bundleData) {
-        return cloneImport(value as WorkletImport) as SerializableRef<TValue>;
+      if ((value as unknown as WorkletImport).__bundleData) {
+        return cloneImport(
+          value as unknown as WorkletImport
+        ) as SerializableRef<TValue>;
       }
     }
-    if ((value as RemoteFunction).__remoteFunction) {
+    if ((value as unknown as RemoteFunction).__remoteFunction) {
       // Remote functions are already serialized.
-      return value;
+      return value as unknown as SerializableRef<TValue>;
     }
     if (!isWorkletFunction(value)) {
-      return cloneNonWorkletFunction(value) as SerializableRef<TValue>;
+      return cloneNonWorkletFunction(
+        value as () => unknown
+      ) as SerializableRef<TValue>;
     }
   }
-  // RN has introduced a new representation of TurboModules as a JS object whose prototype is the host object
-  // More details: https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp#L182
   if (isTurboModuleLike(value)) {
     return cloneTurboModuleLike(value, shouldPersistRemote, depth);
   }

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -167,7 +167,10 @@ export function createSerializable<TValue>(
   }
 
   if ((!isObject && !isFunction) || value === null) {
-    return clonePrimitive(value, shouldPersistRemote);
+    // TODO: most likely dead code
+    throw new Error(
+      `[Worklets] Trying to serialize an unsupported value type (${typeof value}).`
+    );
   }
 
   const cached = getFromCache(value);
@@ -232,7 +235,7 @@ export function createSerializable<TValue>(
     return cloneError(value) as SerializableRef<TValue>;
   }
   if (value instanceof ArrayBuffer) {
-    return cloneArrayBuffer(value, shouldPersistRemote);
+    return cloneArrayBuffer(value) as SerializableRef<TValue>;
   }
   if (ArrayBuffer.isView(value)) {
     // typed array (e.g. Int32Array, Uint8ClampedArray) or DataView
@@ -350,13 +353,6 @@ function detectCyclicObject(value: unknown, depth: number) {
   } else {
     processedObjectAtThresholdDepth = undefined;
   }
-}
-
-function clonePrimitive<T>(
-  value: T,
-  shouldPersistRemote: boolean
-): SerializableRef<T> {
-  return WorkletsModule.createSerializable(value, shouldPersistRemote);
 }
 
 function cloneString(value: string): SerializableRef<string> {
@@ -628,16 +624,11 @@ function cloneError(value: Error): SerializableRef<Error> {
   return clone;
 }
 
-function cloneArrayBuffer<T extends ArrayBuffer>(
-  value: T,
-  shouldPersistRemote: boolean
-): SerializableRef<T> {
-  const clone = WorkletsModule.createSerializable(
-    value,
-    shouldPersistRemote,
-    value
-  );
-  serializableMappingCache.set(value, clone);
+function cloneArrayBuffer(
+  arrayBuffer: ArrayBuffer
+): SerializableRef<ArrayBuffer> {
+  const clone = WorkletsModule.createSerializableArrayBuffer(arrayBuffer);
+  serializableMappingCache.set(arrayBuffer, clone);
   serializableMappingCache.set(clone);
 
   return clone;
@@ -852,7 +843,7 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
       for (const [key, element] of Object.entries(value)) {
         toAdapt[key] = cloneRecursive(element);
       }
-      return globalThis._createSerializable(
+      return globalThis.__workletsModuleProxy.createSerializableLEGACY(
         toAdapt,
         value
       ) as FlatSerializableRef<TValue>;
@@ -882,7 +873,10 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
       return globalThis._createSerializableNull();
     }
 
-    return globalThis._createSerializable(value, undefined);
+    return globalThis.__workletsModuleProxy.createSerializableLEGACY(
+      value,
+      undefined
+    ) as FlatSerializableRef<TValue>;
   }
   return cloneRecursive(value);
 }

--- a/packages/react-native-worklets/src/privateGlobals.d.ts
+++ b/packages/react-native-worklets/src/privateGlobals.d.ts
@@ -34,10 +34,6 @@ declare global {
   var _WORKLETS_BUNDLE_MODE_ENABLED: boolean | undefined;
   var _WORKLETS_VERSION_CPP: string | undefined;
   var _WORKLETS_VERSION_JS: string | undefined;
-  var _createSerializable: <T>(
-    value: T,
-    nativeStateSource?: object
-  ) => FlatSerializableRef<T>;
   var _createSerializableString: (value: string) => FlatSerializableRef<string>;
   var _createSerializableNumber: (value: number) => FlatSerializableRef<number>;
   var _createSerializableBoolean: (


### PR DESCRIPTION
## Summary

Extracted from #9451

I wanted to implemented full native support for `ArrayBuffer` just like for Errors #9452 but I noticed our previous workaround used `_createSerializable` (through WorkletsModule) which shouldn't be a thing. 

I'm also explicitly moving `_createSerializable` from global to `workletsModuleProxy.createSerializableLEGACY`. We want to remove this function fully in the near future

## Test plan

Runtime tests pass.