### PR TITLE
fix: Make `.d.ts` declarations resolvable under `moduleResolution: 'nodenext'`

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -34,7 +34,7 @@
     "type:check:strict": "yarn type:check:strict:src && yarn type:check:strict:app",
     "type:check:strict:src": "yarn tsc --noEmit --customConditions react-native-strict-api",
     "type:check:strict:app": "yarn workspace common-app type:check:strict",
-    "build": "yarn workspace react-native-worklets build && yarn set-version && bob build",
+    "build": "yarn workspace react-native-worklets build && yarn set-version && bob build && echo '{\"type\":\"module\"}' > lib/typescript/package.json",
     "prepack": "yarn build",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "tree-shake:check:web": "yarn is-tree-shakable --resolution web",

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -9,7 +9,7 @@
     "worklets"
   ],
   "scripts": {
-    "build": "yarn workspace babel-plugin-worklets build && yarn set-version && bob build",
+    "build": "yarn workspace babel-plugin-worklets build && yarn set-version && bob build && echo '{\"type\":\"module\"}' > lib/typescript/package.json",
     "circular-dependency-check": "yarn madge --extensions js,jsx --circular lib",
     "find-unused-code:js": "knip",
     "format": "yarn format:js && yarn format:plugin && yarn format:common && yarn format:android && yarn format:apple",


### PR DESCRIPTION
## Summary

Fixes #9447

Under `nodenext`, TypeScript picks per-file module format from the nearest `package.json`'s `"type"`. Reanimated's package has no `"type"`, so the declarations are interpreted as CommonJS — which makes the `import * as Animated from './Animated'; export default Animated;` pattern in `lib/typescript/index.d.ts` expose the whole module type rather than the inner namespace. Consumers under `nodenext` see:

    Property 'View' does not exist on type
      'typeof import(".../react-native-reanimated/lib/typescript/index")'

This emits a one-line `{"type":"module"}` package.json into `lib/typescript/` (and the worklets equivalent) at the end of `bob build`. Scope is limited to the declarations folder: runtime output under `lib/module/` stays in the parent's scope and is untouched. No source edits, no new dependencies, no change to bob targets.

Supersedes #9454: `ts-add-js-extension` adds a runtime dependency for an import-rewrite that does not actually resolve the underlying CJS-vs-ESM interpretation issue (verified empirically - the same `Property 'View' does not exist` error reproduces with that PR's changes applied).

## Test Plan

Verified against the repro from #9447 - `tsc --noEmit` passes under `nodenext`, `node16`, `bundler`, and `node10`.