### PR TITLE
chore(Worklets): throw when serializing promises

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -591,9 +591,18 @@ describe('Test createSerializable', () => {
   });
 });
 
-const FREEZE_WARNING = 'Tried to modify key';
+describe('createSerializable for unsupported types', () => {
+  test('throws when trying to serialize a Promise', async () => {
+    const promise = Promise.resolve();
+    await expect(() => {
+      createSerializable(promise);
+    }).toThrow('Promises cannot be converted to serializable.');
+  });
+});
 
 describe('Test serializable freezing', () => {
+  const FREEZE_WARNING = 'Tried to modify key';
+
   test('warns when modifying converted array', async () => {
     const obj = [1, 2, 3];
     createSerializable(obj);

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -494,4 +494,13 @@ describe('Test createSerializableOnUI', () => {
       foo();
     }).toThrow();
   });
+
+  test('throws when trying to serialize a Promise', async () => {
+    await expect(() =>
+      runOnUISync(() => {
+        'worklet';
+        return Promise.resolve();
+      })
+    ).toThrow('Promises cannot be converted to serializable.');
+  });
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/loggingFromWorkletRuntime.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/loggingFromWorkletRuntime.test.tsx
@@ -237,6 +237,7 @@ const testCases: Record<string, TestCase> = {
   },
   promise: {
     expected: '{ _x: 0, _y: 1, _z: undefined, _A: null }',
+    errorsOnNoBundleMode: true,
     factory: () => {
       'worklet';
       return new Promise<void>((r) => {

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -247,6 +247,9 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
+  if (__DEV__ && value instanceof Promise) {
+    throw new Error('[Worklets] Promises cannot be converted to serializable.');
+  }
   return inaccessibleObject(value);
 }
 
@@ -838,6 +841,11 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
             ) as FlatSerializableRef<TValue>;
           }
         }
+      }
+      if (__DEV__ && value instanceof Promise) {
+        throw new Error(
+          '[Worklets] Promises cannot be converted to serializable.'
+        );
       }
       const toAdapt: Record<string, FlatSerializableRef<TValue>> = {};
       for (const [key, element] of Object.entries(value)) {


### PR DESCRIPTION
## Summary

Adding a QoL error when accidentally serializing promises. I fell into this pitfall when working on #9451 with the following code:

```ts
const shareable = createShareable(...);
runOnUISync(() =>  {
  return await shareable.getAsync(); // <- this is asynchronous so the callback returns a promise, it doesn't wait here
});
```

## Test plan

Runtime tests work both in Bundle Mode and Legacy Mode
