### PR TITLE
chore: actually hide android header in FabricExample

### DIFF
--- a/apps/fabric-example/android/app/src/main/res/values/styles.xml
+++ b/apps/fabric-example/android/app/src/main/res/values/styles.xml
@@ -1,5 +1,6 @@
 <resources>
   <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowFullscreen">true</item>
     <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     <item name="android:navigationBarColor">@android:color/transparent</item>
     <item name="android:statusBarColor">@android:color/transparent</item>


### PR DESCRIPTION
## Summary

I always thought the header was hidden but it turns out it was just white as the background

<table>
<th>Before</th><th>After</th>
<tr>
<td>
<img width="540" height="1200" alt="Screenshot_1779278888" src="https://github.com/user-attachments/assets/e0662357-a8ed-4167-a365-1e338e88a9fa" />
</td><td>
<img width="540" height="1200" alt="Screenshot_1779278923" src="https://github.com/user-attachments/assets/316262a6-5432-4612-a844-91e548a81c2f" />
</td>
</tr>
</table>
