### PR TITLE
Symbol serializable hotfix

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -167,6 +167,20 @@ describe('Test createSerializable', () => {
         expect(result).toBe(true);
       });
 
+      test('createSerializableSymbol', async () => {
+        const symbolValue: unknown = Symbol('test');
+        scheduleOnTarget(() => {
+          'worklet';
+          const checks = [
+            typeof symbolValue === 'string',
+            symbolValue === 'Symbol(test)',
+          ];
+          scheduleOnRN(callbackPass, checks.every(Boolean));
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
+      });
+
       test('createSerializableHostObject', async () => {
         const hostObjectValue = globalThis.__reanimatedModuleProxy;
         const hostObjectKeys = Object.keys(hostObjectValue);

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -878,6 +878,7 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
     }
 
     if (typeof value === 'symbol') {
+      // TODO: add native support
       return globalThis._createSerializableString(
         String(value)
       ) as FlatSerializableRef<TValue>;

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -163,6 +163,10 @@ export function createSerializable<TValue>(
     return cloneBigInt(value) as SerializableRef<TValue>;
   }
 
+  if (typeof value === 'symbol') {
+    return cloneString(String(value)) as SerializableRef<TValue>;
+  }
+
   if (value === undefined) {
     return cloneUndefined() as SerializableRef<TValue>;
   }
@@ -871,6 +875,12 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
 
     if (typeof value === 'bigint') {
       return globalThis._createSerializableBigInt(value);
+    }
+
+    if (typeof value === 'symbol') {
+      return globalThis._createSerializableString(
+        String(value)
+      ) as FlatSerializableRef<TValue>;
     }
 
     if (value === undefined) {


### PR DESCRIPTION
## Summary
Quick fix that lets symbols get serialized to avoid crashes from react compiler inserting Symbol(react.memo) into stuff

## Test plan
Memory tests
