### PR TITLE
fix(Worklets): unused lambda capture in release Android build

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -730,6 +730,7 @@ jsi::Object JSIWorkletsModuleProxy::toOptimizedObject(jsi::Runtime &rt) const {
         react_native_assert(
             hostRuntimeId != RuntimeData::rnRuntimeId &&
             "createSerializableLEGACY should never be called on the React Native runtime.");
+        (void)hostRuntimeId;
         const auto &value = at<0>(args);
         const auto shouldRetainRemote = jsi::Value::undefined();
         const auto &nativeStateSource = at<1>(args);


### PR DESCRIPTION
## Summary

`react_native_assert` expands to `((void)0)` in release builds, so the `hostRuntimeId` init-capture in `createSerializableLEGACY` ends up unused and trips `-Werror=unused-lambda-capture`. Reference the variable via `(void)hostRuntimeId;` so the assert stays active in debug while the release build compiles cleanly.

```
/Users/tomekzaw/Private/OdjazdowyKrk/node_modules/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp:729:8: error: lambda capture 'hostRuntimeId' is not used [-Werror,-Wunused-lambda-capture]
    729 |       [hostRuntimeId = hostRuntimeId_](jsi::Runtime &rt, const jsi::Value &, const jsi::Value(&args)[2]) {
        |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
```

## Test plan

- [x] Build react-native-worklets on Android in release mode
