### PR TITLE
chore: granular run of lint check CI, per job build cache

### DIFF
--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -72,7 +72,7 @@ jobs:
           WEB: ${{ steps.filter.outputs.web }}
         run: |
           if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
-            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example","apps/next-example","apps/web-example"]'
+            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example","apps/web-example"]'
             web=true
           else
             apps=()

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -50,15 +50,15 @@ jobs:
               - apps/common-app/**
             tvos:
               - apps/tvos-example/**
-            fabric:
-              - apps/fabric-example/**
-            # TODO: fix macos
+            # TODO: fix fabric-example
+            # fabric:
+            #   - apps/fabric-example/**
+            # TODO: fix macos-example
             # macos:
             #   - apps/macos-example/**
             # next-example does not have type:check yet
             # next:
             #   - apps/next-example/**
-
             # web-example uses a hack in tsconfig, it will fail the CI
             # web:
             #   - apps/web-example/**
@@ -69,19 +69,19 @@ jobs:
           SHARED: ${{ steps.filter.outputs.shared }}
           COMMON: ${{ steps.filter.outputs.common-app }}
           TVOS: ${{ steps.filter.outputs.tvos }}
-          FABRIC: ${{ steps.filter.outputs.fabric }}
+          # FABRIC: ${{ steps.filter.outputs.fabric }}
           # MACOS: ${{ steps.filter.outputs.macos }}
-          NEXT: ${{ steps.filter.outputs.next }}
+          # NEXT: ${{ steps.filter.outputs.next }}
           # WEB: ${{ steps.filter.outputs.web }}
         run: |
           if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
-            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example"]'
+            ts_apps='["apps/common-app","apps/tvos-example"]'
             web=true
           else
             apps=()
             [[ "$COMMON" == "true" ]] && apps+=("apps/common-app")
             [[ "$TVOS"   == "true" ]] && apps+=("apps/tvos-example")
-            [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
+            # [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
             # [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
             # [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
             # [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -54,8 +54,9 @@ jobs:
               - apps/fabric-example/**
             macos:
               - apps/macos-example/**
-            next:
-              - apps/next-example/**
+            # next-example does not have type:check yet
+            # next:
+            #   - apps/next-example/**
             web:
               - apps/web-example/**
       - name: Build matrix
@@ -79,7 +80,7 @@ jobs:
             [[ "$TVOS"   == "true" ]] && apps+=("apps/tvos-example")
             [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
             [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
-            [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
+            # [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
             [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")
             if [[ ${#apps[@]} -eq 0 ]]; then
               ts_apps='[]'

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -52,8 +52,9 @@ jobs:
               - apps/tvos-example/**
             fabric:
               - apps/fabric-example/**
-            macos:
-              - apps/macos-example/**
+            # TODO: fix macos
+            # macos:
+            #   - apps/macos-example/**
             # next-example does not have type:check yet
             # next:
             #   - apps/next-example/**
@@ -69,19 +70,19 @@ jobs:
           COMMON: ${{ steps.filter.outputs.common-app }}
           TVOS: ${{ steps.filter.outputs.tvos }}
           FABRIC: ${{ steps.filter.outputs.fabric }}
-          MACOS: ${{ steps.filter.outputs.macos }}
+          # MACOS: ${{ steps.filter.outputs.macos }}
           NEXT: ${{ steps.filter.outputs.next }}
           # WEB: ${{ steps.filter.outputs.web }}
         run: |
           if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
-            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example"]'
+            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example"]'
             web=true
           else
             apps=()
             [[ "$COMMON" == "true" ]] && apps+=("apps/common-app")
             [[ "$TVOS"   == "true" ]] && apps+=("apps/tvos-example")
             [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
-            [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
+            # [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
             # [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
             # [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")
             if [[ ${#apps[@]} -eq 0 ]]; then

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -15,7 +15,7 @@ on:
       - packages/react-native-reanimated/package.json
       - packages/react-native-worklets/src/**
       - packages/react-native-worklets/package.json
-      - "**/tsconfig*.json"
+      - '**/tsconfig*.json'
       - eslint.config.mjs
       - yarn.lock
   workflow_call:
@@ -104,7 +104,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: "yarn"
+          cache: 'yarn'
       - name: Install monorepo node dependencies
         run: yarn install --immutable
       - name: Build packages
@@ -138,7 +138,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: "yarn"
+          cache: 'yarn'
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
       - name: Install monorepo node dependencies
@@ -168,7 +168,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: "yarn"
+          cache: 'yarn'
       - name: Install monorepo node dependencies
         run: yarn install --immutable
       - name: Download package build outputs

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -57,8 +57,10 @@ jobs:
             # next-example does not have type:check yet
             # next:
             #   - apps/next-example/**
-            web:
-              - apps/web-example/**
+
+            # web-example uses a hack in tsconfig, it will fail the CI
+            # web:
+            #   - apps/web-example/**
       - name: Build matrix
         id: matrix
         env:
@@ -69,10 +71,10 @@ jobs:
           FABRIC: ${{ steps.filter.outputs.fabric }}
           MACOS: ${{ steps.filter.outputs.macos }}
           NEXT: ${{ steps.filter.outputs.next }}
-          WEB: ${{ steps.filter.outputs.web }}
+          # WEB: ${{ steps.filter.outputs.web }}
         run: |
           if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
-            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example","apps/web-example"]'
+            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example"]'
             web=true
           else
             apps=()
@@ -81,7 +83,7 @@ jobs:
             [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
             [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
             # [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
-            [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")
+            # [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")
             if [[ ${#apps[@]} -eq 0 ]]; then
               ts_apps='[]'
             else

--- a/.github/workflows/example-typescript-check-and-lint.yml
+++ b/.github/workflows/example-typescript-check-and-lint.yml
@@ -1,34 +1,134 @@
 name: Example Typescript check and lint
 env:
   YARN_ENABLE_HARDENED_MODE: 0
-  TYPE_CHECK_DIRECTORIES: >-
-    apps/common-app
-    apps/tvos-example
 on:
   pull_request:
-  merge_group:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+    paths:
+      - .github/workflows/example-typescript-check-and-lint.yml
+      - apps/common-app/**
+      - apps/tvos-example/**
+      - apps/web-example/**
+      - apps/fabric-example/**
+      - apps/macos-example/**
+      - apps/next-example/**
+      - packages/react-native-reanimated/src/**
+      - packages/react-native-reanimated/package.json
+      - packages/react-native-worklets/src/**
+      - packages/react-native-worklets/package.json
+      - "**/tsconfig*.json"
+      - eslint.config.mjs
+      - yarn.lock
   workflow_call:
   workflow_dispatch:
 
 jobs:
-  example-typescript-check-and-lint:
+  changes:
     if: github.repository == 'software-mansion/react-native-reanimated'
+    runs-on: ubuntu-latest
+    outputs:
+      ts-apps: ${{ steps.matrix.outputs.ts-apps }}
+      web: ${{ steps.matrix.outputs.web }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
+        with:
+          filters: |
+            shared:
+              - .github/workflows/example-typescript-check-and-lint.yml
+              - packages/react-native-reanimated/src/**
+              - packages/react-native-reanimated/package.json
+              - packages/react-native-worklets/src/**
+              - packages/react-native-worklets/package.json
+              - '**/tsconfig*.json'
+              - eslint.config.mjs
+              - yarn.lock
+            common-app:
+              - apps/common-app/**
+            tvos:
+              - apps/tvos-example/**
+            fabric:
+              - apps/fabric-example/**
+            macos:
+              - apps/macos-example/**
+            next:
+              - apps/next-example/**
+            web:
+              - apps/web-example/**
+      - name: Build matrix
+        id: matrix
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          SHARED: ${{ steps.filter.outputs.shared }}
+          COMMON: ${{ steps.filter.outputs.common-app }}
+          TVOS: ${{ steps.filter.outputs.tvos }}
+          FABRIC: ${{ steps.filter.outputs.fabric }}
+          MACOS: ${{ steps.filter.outputs.macos }}
+          NEXT: ${{ steps.filter.outputs.next }}
+          WEB: ${{ steps.filter.outputs.web }}
+        run: |
+          if [[ "$IS_PR" != "true" || "$SHARED" == "true" ]]; then
+            ts_apps='["apps/common-app","apps/tvos-example","apps/fabric-example","apps/macos-example","apps/next-example","apps/web-example"]'
+            web=true
+          else
+            apps=()
+            [[ "$COMMON" == "true" ]] && apps+=("apps/common-app")
+            [[ "$TVOS"   == "true" ]] && apps+=("apps/tvos-example")
+            [[ "$FABRIC" == "true" ]] && apps+=("apps/fabric-example")
+            [[ "$MACOS"  == "true" ]] && apps+=("apps/macos-example")
+            [[ "$NEXT"   == "true" ]] && apps+=("apps/next-example")
+            [[ "$WEB"    == "true" ]] && apps+=("apps/web-example")
+            if [[ ${#apps[@]} -eq 0 ]]; then
+              ts_apps='[]'
+            else
+              ts_apps=$(jq -nc '$ARGS.positional' --args "${apps[@]}")
+            fi
+            web=$([[ "$WEB" == "true" ]] && echo true || echo false)
+          fi
+          echo "ts-apps=$ts_apps" >> "$GITHUB_OUTPUT"
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+
+  build-packages:
+    needs: changes
+    if: needs.changes.outputs.ts-apps != '[]' || needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: typescript-build-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          cache: "yarn"
+      - name: Install monorepo node dependencies
+        run: yarn install --immutable
+      - name: Build packages
+        run: yarn build
+      - name: Upload package build outputs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: packages-build
+          path: |
+            packages/react-native-reanimated/lib
+            packages/react-native-worklets/lib
+            packages/react-native-worklets/plugin/index.js
+            packages/react-native-worklets/plugin/index.js.map
+            packages/react-native-worklets/plugin/index.d.ts
+          retention-days: 1
+          if-no-files-found: error
+
+  example-typescript-check-and-lint:
+    needs: [changes, build-packages]
+    if: needs.changes.outputs.ts-apps != '[]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        working-directory: [
-            apps/common-app,
-            apps/fabric-example,
-            apps/macos-example,
-            # apps/next-example, # next-example doesn't use TypeScript.
-            apps/tvos-example,
-            apps/web-example,
-          ]
+        working-directory: ${{ fromJSON(needs.changes.outputs.ts-apps) }}
     concurrency:
       group: typescript-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
@@ -38,24 +138,44 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: 'yarn'
+          cache: "yarn"
       - name: Clear annotations
         run: .github/workflows/helper/clear-annotations.sh
-
       - name: Install monorepo node dependencies
         run: yarn install --immutable
-      - name: Build packages
-        run: yarn build
-
+      - name: Download package build outputs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: packages-build
+          path: packages
       - name: Check types
         working-directory: ${{ matrix.working-directory }}
-        if: ${{ contains(env.TYPE_CHECK_DIRECTORIES, matrix.working-directory) }}
         run: yarn type:check
       - name: Lint
         working-directory: ${{ matrix.working-directory }}
-        if: ${{ contains(env.TYPE_CHECK_DIRECTORIES, matrix.working-directory) }}
         run: yarn lint
+
+  example-web-build:
+    needs: [changes, build-packages]
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: typescript-web-example-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          cache: "yarn"
+      - name: Install monorepo node dependencies
+        run: yarn install --immutable
+      - name: Download package build outputs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: packages-build
+          path: packages
       - name: Build WebExample
-        working-directory: ${{ matrix.working-directory }}
-        if: ${{ matrix.working-directory == 'apps/web-example' }}
+        working-directory: apps/web-example
         run: yarn build


### PR DESCRIPTION
## Summary
Motivation:
No need to run lint & type check on common app when you fix a typo in docs
No need to lint tvos when you change the color of a button in another app

Also for each job we used to run build
We can build packages once per run, and spawned jobs can reuse it via artifact

## Test plan
The CIs trigger properly when relevant files changed

