### PR TITLE
fix(Worklets): eager imports issue

### DIFF
--- a/packages/react-native-worklets/README.md
+++ b/packages/react-native-worklets/README.md
@@ -7,9 +7,7 @@ React Native Worklets is a library that allows you to run JavaScript code in par
 ## Nightly CI state
 
 [![NPM Worklets publish \[Nightly\]](https://github.com/software-mansion/react-native-reanimated/actions/workflows/npm-worklets-publish.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/npm-worklets-publish.yml)
-[![Lint clang-tidy \[Nightly\]](https://github.com/software-mansion/react-native-reanimated/actions/workflows/lint-clang-tidy-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/lint-clang-tidy-nightly.yml)
 [![Expo DevClient build check](https://github.com/software-mansion/react-native-reanimated/actions/workflows/expo-devclient-build-check-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/expo-devclient-build-check-nightly.yml)
-[![Worklets Bundle Mode build check \[Nightly\]](https://github.com/software-mansion/react-native-reanimated/actions/workflows/worklets-bundle-mode-build-check-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/worklets-bundle-mode-build-check-nightly.yml)
 [![URL validation](https://github.com/software-mansion/react-native-reanimated/actions/workflows/url-validation-nightly.yml/badge.svg)](https://github.com/software-mansion/react-native-reanimated/actions/workflows/url-validation-nightly.yml)
 
 ## Documentation

--- a/packages/react-native-worklets/src/memory/shareableGuestUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/shareableGuestUnpacker.native.ts
@@ -1,13 +1,14 @@
+/* eslint-disable n/no-missing-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 'use strict';
 
-import {
-  runOnRuntimeAsyncWithId as BundleRunOnRuntimeAsyncFromId,
-  runOnRuntimeSyncWithId as BundleRunOnRuntimeSyncFromId,
-  scheduleOnRuntimeWithId as BundleScheduleOnRuntimeFromId,
+import type {
+  runOnRuntimeAsyncWithId as BundleRunOnRuntimeAsyncWithId,
+  runOnRuntimeSyncWithId as BundleRunOnRuntimeSyncWithId,
+  scheduleOnRuntimeWithId as BundleScheduleOnRuntimeWithId,
 } from '../runtimes';
 import type { WorkletFunction } from '../types';
-import { createSerializable } from './serializable';
-import { serializableMappingCache } from './serializableMappingCache';
 import type {
   SerializableRef,
   Shareable,
@@ -19,26 +20,27 @@ import type {
 export function installShareableGuestUnpacker() {
   'worklet';
   'no-worklet-closure';
-  let runOnRuntimeSyncFromId: typeof BundleRunOnRuntimeSyncFromId;
-  let runOnRuntimeAsyncFromId: typeof BundleRunOnRuntimeAsyncFromId;
+  let runOnRuntimeSyncFromId: typeof BundleRunOnRuntimeSyncWithId;
+  let runOnRuntimeAsyncFromId: typeof BundleRunOnRuntimeAsyncWithId;
   let memoize: (
     unpacked: Shareable<unknown>,
     serialized: SerializableRef<unknown>
   ) => void;
 
-  let scheduleOnRuntimeFromId: typeof BundleScheduleOnRuntimeFromId;
+  let scheduleOnRuntimeFromId: typeof BundleScheduleOnRuntimeWithId;
   let serializer: (value: unknown) => SerializableRef<unknown>;
 
   if (
     globalThis.__RUNTIME_KIND === 1 ||
     globalThis._WORKLETS_BUNDLE_MODE_ENABLED
   ) {
-    serializer = createSerializable;
+    serializer = require('./serializable').createSerializable;
+    const { serializableMappingCache } = require('./serializableMappingCache');
     memoize = serializableMappingCache.set.bind(serializableMappingCache);
 
-    runOnRuntimeSyncFromId = BundleRunOnRuntimeSyncFromId;
-    runOnRuntimeAsyncFromId = BundleRunOnRuntimeAsyncFromId;
-    scheduleOnRuntimeFromId = BundleScheduleOnRuntimeFromId;
+    runOnRuntimeSyncFromId = require('../runtimes').runOnRuntimeSyncWithId;
+    runOnRuntimeAsyncFromId = require('../runtimes').runOnRuntimeAsyncWithId;
+    scheduleOnRuntimeFromId = require('../runtimes').scheduleOnRuntimeWithId;
   } else {
     // Serializer can't be inlined here because it might be yet undefined
     // when the unpacker is installed.
@@ -59,7 +61,7 @@ export function installShareableGuestUnpacker() {
         return globalThis.__serializer(worklet(...args));
       });
       return proxy.runOnRuntimeSyncWithId(hostId, serializedWorklet);
-    }) as typeof BundleRunOnRuntimeSyncFromId;
+    }) as typeof BundleRunOnRuntimeSyncWithId;
 
     scheduleOnRuntimeFromId = ((
       hostId: number,
@@ -74,13 +76,13 @@ export function installShareableGuestUnpacker() {
           return globalThis.__serializer(worklet(...args));
         })
       );
-    }) as typeof BundleScheduleOnRuntimeFromId;
+    }) as typeof BundleScheduleOnRuntimeWithId;
 
     runOnRuntimeAsyncFromId = (() => {
       throw new Error(
         '[Worklets] `Shareable.getAsync` can only be called on the RN Runtime.'
       );
-    }) as typeof BundleRunOnRuntimeAsyncFromId;
+    }) as typeof BundleRunOnRuntimeAsyncWithId;
   }
 
   function shareableGuestUnpacker<TValue>(

--- a/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/synchronizableUnpacker.native.ts
@@ -1,6 +1,8 @@
+/* eslint-disable n/no-missing-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 'use strict';
 
-import { createSerializable } from './serializable';
 import { type Synchronizable, type SynchronizableRef } from './types';
 
 export function installSynchronizableUnpacker() {
@@ -9,7 +11,7 @@ export function installSynchronizableUnpacker() {
   // TODO: Add cache for synchronizables.
   const serializer =
     globalThis.__RUNTIME_KIND === 1 || globalThis._WORKLETS_BUNDLE_MODE_ENABLED
-      ? createSerializable
+      ? require('./serializable').createSerializable
       : (value: unknown) => globalThis.__serializer(value);
 
   function synchronizableUnpacker<TValue>(


### PR DESCRIPTION
## Summary

Requires #9486 to not break in Bundle Mode.

Fixes https://github.com/software-mansion/react-native-reanimated/issues/9445 where disabled `inlineRequires` result in in an import path that breaks ours assumptions about side-effect order triggering.

Keep in mind that the workaround is somehow fragile and might break in the future if we make edits in similar files.

## Test plan

Add 

```js
config.transformer.getTransformOptions = async () => ({
  transform: {
    inlineRequires: false,
  },
});
```

to metro.config.js in FabricExample and see that now it works correctly.
