### PR TITLE
fix: Add missing locks

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSAnimationsRegistry.cpp
@@ -106,10 +106,12 @@ void CSSAnimationsRegistry::flushUpdates(UpdatesBatchAnimatedProps &updatesBatch
 CSSAnimationsRegistry::AnimationObserver::AnimationObserver(CSSAnimationsRegistry &owner) : owner_(owner) {}
 
 void CSSAnimationsRegistry::AnimationObserver::onAnimationUpdate(const Tag viewTag) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   owner_.updatedTags_.insert(viewTag);
 }
 
 void CSSAnimationsRegistry::AnimationObserver::onAnimationNeedsRevert(const Tag viewTag) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   owner_.pendingRevertTags_.insert(viewTag);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSKeyframesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSKeyframesRegistry.cpp
@@ -1,4 +1,7 @@
 #include <reanimated/CSS/registries/CSSKeyframesRegistry.h>
+#include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
+
+#include <react/debug/react_native_assert.h>
 
 #include <string>
 #include <utility>
@@ -8,6 +11,7 @@ namespace reanimated::css {
 std::optional<std::reference_wrapper<const CSSKeyframesConfig>> CSSKeyframesRegistry::get(
     const std::string &animationName,
     const std::string &compoundComponentName) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   const auto registryIt = registry_.find(animationName);
   if (registryIt == registry_.end()) {
     return std::nullopt;
@@ -26,10 +30,12 @@ void CSSKeyframesRegistry::set(
     const std::string &animationName,
     const std::string &compoundComponentName,
     CSSKeyframesConfig &&config) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   registry_[animationName][compoundComponentName] = std::move(config);
 }
 
 void CSSKeyframesRegistry::remove(const std::string &animationName, const std::string &compoundComponentName) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   registry_[animationName].erase(compoundComponentName);
   if (registry_[animationName].empty()) {
     registry_.erase(animationName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -118,6 +118,7 @@ void CSSTransitionsRegistry::flushUpdates(UpdatesBatchAnimatedProps &updatesBatc
 CSSTransitionsRegistry::TransitionObserver::TransitionObserver(CSSTransitionsRegistry &owner) : owner_(owner) {}
 
 void CSSTransitionsRegistry::TransitionObserver::onTransitionUpdate(const Tag viewTag) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   owner_.updatedTags_.insert(viewTag);
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
@@ -1,16 +1,21 @@
 #include <reanimated/CSS/registries/StaticPropsRegistry.h>
+#include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
+
+#include <react/debug/react_native_assert.h>
 
 namespace reanimated::css {
 
 void StaticPropsRegistry::set(jsi::Runtime &rt, const Tag viewTag, const jsi::Value &props) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   if (props.isNull() || props.isUndefined()) {
-    remove(viewTag);
+    registry_.erase(viewTag);
   } else {
     registry_[viewTag] = dynamicFromValue(rt, props);
   }
 }
 
 folly::dynamic StaticPropsRegistry::get(const Tag viewTag) const {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   auto it = registry_.find(viewTag);
   if (it == registry_.end()) {
     return nullptr;
@@ -19,10 +24,12 @@ folly::dynamic StaticPropsRegistry::get(const Tag viewTag) const {
 }
 
 void StaticPropsRegistry::remove(const Tag viewTag) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   registry_.erase(viewTag);
 }
 
 bool StaticPropsRegistry::isEmpty() const {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   return registry_.empty();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.cpp
@@ -1,6 +1,9 @@
 #include <cxxreact/ReactNativeVersion.h>
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
+#include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/Tools/FeatureFlags.h>
+
+#include <react/debug/react_native_assert.h>
 
 #include <memory>
 #include <utility>
@@ -14,9 +17,9 @@ static inline std::shared_ptr<const ShadowNode> shadowNodeFromValue(
 }
 
 void AnimatedPropsRegistry::update(jsi::Runtime &rt, const jsi::Value &operations, const double timestamp) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   auto operationsArray = operations.asObject(rt).asArray(rt);
 
-  std::lock_guard<std::mutex> lock{mutex_};
   for (size_t i = 0, length = operationsArray.size(rt); i < length; ++i) {
     auto item = operationsArray.getValueAtIndex(rt, i).asObject(rt);
     auto shadowNodeWrapper = item.getProperty(rt, "shadowNodeWrapper");
@@ -42,7 +45,7 @@ jsi::Value AnimatedPropsRegistry::getUpdatesOlderThanTimestamp(
     jsi::Runtime &rt,
     const double timestamp,
     const double cleanupTimestamp) {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   removeUpdatesOlderThanTimestamp(cleanupTimestamp);
 
   std::vector<std::pair<Tag, std::reference_wrapper<const folly::dynamic>>> updates;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/AnimatedPropsRegistry.h
@@ -19,7 +19,7 @@ class AnimatedPropsRegistry : public UpdatesRegistry {
   jsi::Value getUpdatesOlderThanTimestamp(jsi::Runtime &rt, double timestamp, double cleanupTimestamp);
 
  private:
-  std::unordered_map<Tag, double> timestampMap_; // viewTag -> timestamp, protected by `mutex_`
+  std::unordered_map<Tag, double> timestampMap_;
 
   void removeUpdatesOlderThanTimestamp(double timestamp);
   void removeTag(Tag tag) override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.cpp
@@ -47,7 +47,6 @@ void OperationsLoop::remove(const std::shared_ptr<LoopOperation> &operation) {
 }
 
 void OperationsLoop::update() {
-  auto lock = updatesRegistryManager_->lock();
   auto [operations, timestamp] = beginFrame();
   applyScheduledOperations(std::move(operations), timestamp);
   activateDelayedOperations(timestamp);
@@ -146,6 +145,7 @@ void OperationsLoop::activateDelayedOperations(double timestamp) {
 }
 
 void OperationsLoop::updateActiveOperations(double timestamp) {
+  auto lock = updatesRegistryManager_->lock();
   std::erase_if(activeOps_, [&](auto &op) { return !op->update(timestamp, *this); });
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/Fabric/updates/OperationsLoop.h>
+#include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 
 #include <utility>
 
@@ -7,8 +8,12 @@ namespace reanimated {
 OperationsLoop::OperationsLoop(
     const std::shared_ptr<worklets::UIScheduler> &uiScheduler,
     const RequestRenderFunction &requestRender,
-    const GetAnimationTimestampFunction &getTimestamp)
-    : uiScheduler_(uiScheduler), requestRender_(requestRender), getTimestamp_(getTimestamp) {}
+    const GetAnimationTimestampFunction &getTimestamp,
+    const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager)
+    : uiScheduler_(uiScheduler),
+      requestRender_(requestRender),
+      getTimestamp_(getTimestamp),
+      updatesRegistryManager_(updatesRegistryManager) {}
 
 double OperationsLoop::resolveTimestamp() {
   // Fast path: cache hit is lock-free.
@@ -42,6 +47,7 @@ void OperationsLoop::remove(const std::shared_ptr<LoopOperation> &operation) {
 }
 
 void OperationsLoop::update() {
+  auto lock = updatesRegistryManager_->lock();
   auto [operations, timestamp] = beginFrame();
   applyScheduledOperations(std::move(operations), timestamp);
   activateDelayedOperations(timestamp);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/OperationsLoop.h
@@ -17,6 +17,8 @@
 
 namespace reanimated {
 
+class UpdatesRegistryManager;
+
 class OperationsLoop : public std::enable_shared_from_this<OperationsLoop> {
  public:
   class LoopOperation {
@@ -28,7 +30,8 @@ class OperationsLoop : public std::enable_shared_from_this<OperationsLoop> {
   OperationsLoop(
       const std::shared_ptr<worklets::UIScheduler> &uiScheduler,
       const RequestRenderFunction &requestRender,
-      const GetAnimationTimestampFunction &getTimestamp);
+      const GetAnimationTimestampFunction &getTimestamp,
+      const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager);
 
   double resolveTimestamp();
 
@@ -56,6 +59,7 @@ class OperationsLoop : public std::enable_shared_from_this<OperationsLoop> {
   const std::shared_ptr<worklets::UIScheduler> uiScheduler_;
   const RequestRenderFunction requestRender_;
   const GetAnimationTimestampFunction getTimestamp_;
+  const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
 
   mutable std::mutex queueMutex_;
   std::vector<ScheduledOperation> scheduledOperations_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.cpp
@@ -1,6 +1,9 @@
 #include <reanimated/Fabric/updates/UpdatesRegistry.h>
 
 #include <reanimated/Fabric/updates/PropsLayoutFilter.h>
+#include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
+
+#include <react/debug/react_native_assert.h>
 
 #include <jsi/jsi.h>
 #include <memory>
@@ -12,18 +15,27 @@
 namespace reanimated {
 
 bool UpdatesRegistry::isEmpty() const {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   return updatesRegistry_.empty();
 }
 
 folly::dynamic UpdatesRegistry::get(const Tag tag) const {
-  std::lock_guard<std::mutex> lock{mutex_};
-
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   auto it = updatesRegistry_.find(tag);
   if (it == updatesRegistry_.cend()) {
     return nullptr;
   }
   return it->second.second;
+}
+
+void UpdatesRegistry::remove(const Tag tag) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  removeTag(tag);
+}
+
+void UpdatesRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  flush(updatesBatch);
 }
 
 void UpdatesRegistry::flush(UpdatesBatch &updatesBatch) {
@@ -39,6 +51,11 @@ void UpdatesRegistry::flush(UpdatesBatch &updatesBatch) {
 }
 
 #if REACT_NATIVE_VERSION_MINOR >= 85
+void UpdatesRegistry::flushUpdates(UpdatesBatchAnimatedProps &updatesBatch) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  flush(updatesBatch);
+}
+
 void UpdatesRegistry::flush(UpdatesBatchAnimatedProps &updatesBatch) {
   auto copiedUpdatesBatch = std::move(updatesBatchAnimatedProps_);
   updatesBatchAnimatedProps_.clear();
@@ -49,7 +66,7 @@ void UpdatesRegistry::flush(UpdatesBatchAnimatedProps &updatesBatch) {
 }
 
 void UpdatesRegistry::flushNonLayoutUpdates(jsi::Runtime &rt, AnimationMutations &mutations) {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
 
   UpdatesBatchAnimatedProps remaining;
 
@@ -107,7 +124,7 @@ void UpdatesRegistry::flushNonLayoutUpdates(jsi::Runtime &rt, AnimationMutations
 }
 
 bool UpdatesRegistry::hasPendingAnimatedPropsUpdates() const {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   return !updatesBatchAnimatedProps_.empty();
 }
 
@@ -146,7 +163,7 @@ void UpdatesRegistry::addJSIPropsToAnimatedPropsBatch(
 #endif
 
 UpdatesBatch UpdatesRegistry::getPendingUpdates() {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   flushUpdatesToRegistry(updatesBatch_);
 
   UpdatesBatch updatesBatch;
@@ -158,7 +175,7 @@ UpdatesBatch UpdatesRegistry::getPendingUpdates() {
 }
 
 void UpdatesRegistry::collectProps(PropsMap &propsMap) {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
 
   auto copiedRegistry = updatesRegistry_;
   for (const auto &[tag, pair] : copiedRegistry) {
@@ -220,12 +237,12 @@ void UpdatesRegistry::flushUpdatesToRegistry(const UpdatesBatch &updatesBatch) {
 #ifdef ANDROID
 
 bool UpdatesRegistry::hasPropsToRevert() const {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   return !propsToRevertMap_.empty();
 }
 
 void UpdatesRegistry::collectPropsToRevert(PropsToRevertMap &propsToRevertMap) {
-  std::lock_guard<std::mutex> lock{mutex_};
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
 
   for (const auto &[tag, pair] : propsToRevertMap_) {
     const auto &[shadowNodeFamily, props] = pair;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistry.h
@@ -12,7 +12,6 @@
 #endif
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -46,34 +45,26 @@ struct PropsToRevert {
 using PropsToRevertMap = std::unordered_map<Tag, PropsToRevert>;
 #endif
 
+// All public methods require `UpdatesRegistryManager::lock()` to be held.
 class UpdatesRegistry {
  public:
   virtual ~UpdatesRegistry() {}
 
   virtual bool isEmpty() const;
   folly::dynamic get(Tag tag) const;
-  void remove(Tag tag) {
-    std::lock_guard<std::mutex> lock{mutex_};
-    removeTag(tag);
-  }
+  void remove(Tag tag);
 
 #ifdef ANDROID
   bool hasPropsToRevert() const;
   void collectPropsToRevert(PropsToRevertMap &propsToRevertMap);
 #endif
 
-  // Drains pending style updates as folly::dynamic (acquires mutex_).
-  void flushUpdates(UpdatesBatch &updatesBatch) {
-    std::lock_guard<std::mutex> lock{mutex_};
-    flush(updatesBatch);
-  }
+  // Drains pending style updates as folly::dynamic.
+  void flushUpdates(UpdatesBatch &updatesBatch);
 
 #if REACT_NATIVE_VERSION_MINOR >= 85
-  // Drains pending typed animated props (acquires mutex_).
-  void flushUpdates(UpdatesBatchAnimatedProps &updatesBatch) {
-    std::lock_guard<std::mutex> lock{mutex_};
-    flush(updatesBatch);
-  }
+  // Drains pending typed animated props.
+  void flushUpdates(UpdatesBatchAnimatedProps &updatesBatch);
 
   // Get only non-layout updates (for android event handling) in the animation backend path.
   void flushNonLayoutUpdates(jsi::Runtime &rt, facebook::react::AnimationMutations &mutations);
@@ -93,7 +84,6 @@ class UpdatesRegistry {
   UpdatesBatch getPendingUpdates();
 
  protected:
-  mutable std::mutex mutex_;
   RegistryMap updatesRegistry_;
 
   /// Assumes the caller already locked the registry.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
@@ -1,6 +1,8 @@
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
+#include <react/debug/react_native_assert.h>
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -64,14 +66,17 @@ bool UpdatesRegistryManager::shouldCommitAfterPause() {
 }
 
 void UpdatesRegistryManager::markNodeAsRemovable(const std::shared_ptr<const ShadowNode> &shadowNode) {
+  react_native_assert(isLockedByCurrentThread());
   removableShadowNodes_[shadowNode->getTag()] = shadowNode->getFamilyShared();
 }
 
 void UpdatesRegistryManager::unmarkNodeAsRemovable(Tag viewTag) {
+  react_native_assert(isLockedByCurrentThread());
   removableShadowNodes_.erase(viewTag);
 }
 
 void UpdatesRegistryManager::handleNodeRemovals(const RootShadowNode &rootShadowNode) {
+  react_native_assert(isLockedByCurrentThread());
   RemovableShadowNodes remainingShadowNodes;
 
   for (const auto &[tag, shadowNodeFamily] : removableShadowNodes_) {
@@ -93,6 +98,7 @@ void UpdatesRegistryManager::handleNodeRemovals(const RootShadowNode &rootShadow
 }
 
 PropsMap UpdatesRegistryManager::collectProps() {
+  react_native_assert(isLockedByCurrentThread());
   PropsMap propsMap;
   for (auto &registry : registries_) {
     registry->collectProps(propsMap);
@@ -103,6 +109,7 @@ PropsMap UpdatesRegistryManager::collectProps() {
 #ifdef ANDROID
 
 bool UpdatesRegistryManager::hasPropsToRevert() {
+  react_native_assert(isLockedByCurrentThread());
   for (auto &registry : registries_) {
     if (registry->hasPropsToRevert()) {
       return true;
@@ -127,6 +134,7 @@ void UpdatesRegistryManager::addToPropsMap(
 }
 
 void UpdatesRegistryManager::collectPropsToRevertBySurface(std::unordered_map<SurfaceId, PropsMap> &propsMapBySurface) {
+  react_native_assert(isLockedByCurrentThread());
   for (const auto &registry : registries_) {
     registry->collectPropsToRevert(propsToRevertMap_);
   }
@@ -162,6 +170,7 @@ void UpdatesRegistryManager::collectPropsToRevertBySurface(std::unordered_map<Su
 }
 
 void UpdatesRegistryManager::clearPropsToRevert(const SurfaceId surfaceId) {
+  react_native_assert(isLockedByCurrentThread());
   for (auto it = propsToRevertMap_.begin(); it != propsToRevertMap_.end();) {
     if (it->second.shadowNodeFamily->getSurfaceId() == surfaceId) {
       it = propsToRevertMap_.erase(it);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -203,13 +203,14 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #ifdef __APPLE__
       forceScreenSnapshot_(platformDepMethodsHolder.forceScreenSnapshotFunction),
 #endif
+      staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
+      updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
       operationsLoop_(std::make_shared<OperationsLoop>(
           uiScheduler,
           platformDepMethodsHolder.requestRender,
-          platformDepMethodsHolder.getAnimationTimestamp)),
+          platformDepMethodsHolder.getAnimationTimestamp,
+          updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
-      staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
-      updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(operationsLoop_, cssAnimationKeyframesRegistry_)),
@@ -279,6 +280,7 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
     }
 
     const auto timestamp = strongThis->getAnimationTimestamp_();
+    auto lock = strongThis->updatesRegistryManager_->lock();
     strongThis->animatedPropsRegistry_->update(rt, operations, timestamp);
   };
 
@@ -532,6 +534,7 @@ void ReanimatedModuleProxy::cleanupSensors() {
 }
 
 void ReanimatedModuleProxy::setViewStyle(jsi::Runtime &rt, const jsi::Value &viewTag, const jsi::Value &viewStyle) {
+  auto lock = updatesRegistryManager_->lock();
   staticPropsRegistry_->set(rt, viewTag.asNumber(), viewStyle);
 }
 
@@ -552,16 +555,19 @@ void ReanimatedModuleProxy::registerCSSKeyframes(
     const jsi::Value &compoundComponentName,
     const jsi::Value &keyframesConfig) {
   const auto compoundComponentNameStr = compoundComponentName.asString(rt).utf8(rt);
+  auto parsedConfig =
+      parseCSSAnimationKeyframesConfig(rt, keyframesConfig, compoundComponentNameStr, viewStylesRepository_);
+
+  auto lock = updatesRegistryManager_->lock();
   cssAnimationKeyframesRegistry_->set(
-      animationName.asString(rt).utf8(rt),
-      compoundComponentNameStr,
-      parseCSSAnimationKeyframesConfig(rt, keyframesConfig, compoundComponentNameStr, viewStylesRepository_));
+      animationName.asString(rt).utf8(rt), compoundComponentNameStr, std::move(parsedConfig));
 }
 
 void ReanimatedModuleProxy::unregisterCSSKeyframes(
     jsi::Runtime &rt,
     const jsi::Value &animationName,
     const jsi::Value &compoundComponentName) {
+  auto lock = updatesRegistryManager_->lock();
   cssAnimationKeyframesRegistry_->remove(
       animationName.asString(rt).utf8(rt), compoundComponentName.asString(rt).utf8(rt));
 }
@@ -646,6 +652,7 @@ jsi::Value ReanimatedModuleProxy::getSettledUpdates(jsi::Runtime &rt) {
   // TODO(future): flush updates from CSS animations and CSS transitions registries
   // TODO(future): find a better way to obtain timestamp for removing updates
   // TODO(future): move removing old updates to separate method
+  auto lock = updatesRegistryManager_->lock();
   return animatedPropsRegistry_->getUpdatesOlderThanTimestamp(
       rt, currentTimestamp - 1000 /* 1 second */, currentTimestamp - 2000 /* 2 seconds */);
 }
@@ -808,7 +815,11 @@ void ReanimatedModuleProxy::performOperations() {
 void ReanimatedModuleProxy::performNonLayoutOperations() {
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performNonLayoutOperations");
 
-  UpdatesBatch updatesBatch = animatedPropsRegistry_->getPendingUpdates();
+  UpdatesBatch updatesBatch;
+  {
+    auto lock = updatesRegistryManager_->lock();
+    updatesBatch = animatedPropsRegistry_->getPendingUpdates();
+  }
   applySynchronousUpdates(updatesBatch, true);
 }
 
@@ -1032,24 +1043,28 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
 
   std::unordered_map<SurfaceId, PropsMap> propsMapBySurface;
 
+  // Release the lock before shadowTree.commit - it re-enters via ReanimatedCommitHook.
+  {
+    auto lock = updatesRegistryManager_->lock();
 #ifdef ANDROID
-  updatesRegistryManager_->collectPropsToRevertBySurface(propsMapBySurface);
+    updatesRegistryManager_->collectPropsToRevertBySurface(propsMapBySurface);
 #endif
 
-  if (shouldFlushRegistry_) {
-    shouldFlushRegistry_ = false;
-    const auto propsMap = updatesRegistryManager_->collectProps();
-    for (auto const &[family, props] : propsMap) {
-      const auto surfaceId = family->getSurfaceId();
-      auto &propsVector = propsMapBySurface[surfaceId][family];
-      for (const auto &prop : props) {
-        propsVector.emplace_back(prop);
+    if (shouldFlushRegistry_) {
+      shouldFlushRegistry_ = false;
+      const auto propsMap = updatesRegistryManager_->collectProps();
+      for (auto const &[family, props] : propsMap) {
+        const auto surfaceId = family->getSurfaceId();
+        auto &propsVector = propsMapBySurface[surfaceId][family];
+        for (const auto &prop : props) {
+          propsVector.emplace_back(prop);
+        }
       }
-    }
-  } else {
-    for (auto const &[shadowNodeFamily, props] : updatesBatch) {
-      SurfaceId surfaceId = shadowNodeFamily->getSurfaceId();
-      propsMapBySurface[surfaceId][shadowNodeFamily].emplace_back(props);
+    } else {
+      for (auto const &[shadowNodeFamily, props] : updatesBatch) {
+        SurfaceId surfaceId = shadowNodeFamily->getSurfaceId();
+        propsMapBySurface[surfaceId][shadowNodeFamily].emplace_back(props);
+      }
     }
   }
 
@@ -1077,6 +1092,7 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
 
 #ifdef ANDROID
       if (status == ShadowTree::CommitStatus::Succeeded) {
+        auto lock = updatesRegistryManager_->lock();
         updatesRegistryManager_->clearPropsToRevert(surfaceId);
       }
 #else
@@ -1253,6 +1269,7 @@ std::function<std::string()> ReanimatedModuleProxy::createRegistriesLeakCheck() 
 
     std::string result = "";
 
+    auto lock = strongThis->updatesRegistryManager_->lock();
     result += "AnimatedPropsRegistry: " + format(strongThis->animatedPropsRegistry_->isEmpty());
     result += "\nCSSAnimationsRegistry: " + format(strongThis->cssAnimationsRegistry_->isEmpty());
     result += "\nCSSTransitionsRegistry: " + format(strongThis->cssTransitionsRegistry_->isEmpty());

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -205,23 +205,21 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #endif
       staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
-      operationsLoop_(
-          std::make_shared<OperationsLoop>(
-              uiScheduler,
-              platformDepMethodsHolder.requestRender,
-              platformDepMethodsHolder.getAnimationTimestamp,
-              updatesRegistryManager_)),
+      operationsLoop_(std::make_shared<OperationsLoop>(
+          uiScheduler,
+          platformDepMethodsHolder.requestRender,
+          platformDepMethodsHolder.getAnimationTimestamp,
+          updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(operationsLoop_, cssAnimationKeyframesRegistry_)),
       cssTransitionsRegistry_(std::make_shared<CSSTransitionsRegistry>(viewStylesRepository_, operationsLoop_)),
-      pseudoStylesRegistry_(
-          std::make_shared<PseudoStylesRegistry>(
-              platformDepMethodsHolder.attachPseudoSelector,
-              platformDepMethodsHolder.detachPseudoSelector,
-              cssTransitionsRegistry_,
-              updatesRegistryManager_)),
+      pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
+          platformDepMethodsHolder.attachPseudoSelector,
+          platformDepMethodsHolder.detachPseudoSelector,
+          cssTransitionsRegistry_,
+          updatesRegistryManager_)),
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID
       filterUnmountedTagsFunction_(platformDepMethodsHolder.filterUnmountedTagsFunction),

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -226,16 +226,14 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
-  {
-    auto lock = updatesRegistryManager_->lock();
-    // Add registries in order of their priority (from the lowest to the
-    // highest)
-    // CSS transitions should be overriden by animated style animations;
-    // animated style animations should be overriden by CSS animations.
-    updatesRegistryManager_->addRegistry(cssTransitionsRegistry_);
-    updatesRegistryManager_->addRegistry(animatedPropsRegistry_);
-    updatesRegistryManager_->addRegistry(cssAnimationsRegistry_);
-  }
+  // No lock needed at construction - no other thread holds a reference yet.
+  // Add registries in order of their priority (from the lowest to the
+  // highest). CSS transitions should be overriden by animated style
+  // animations; animated style animations should be overriden by CSS
+  // animations.
+  updatesRegistryManager_->addRegistry(cssTransitionsRegistry_);
+  updatesRegistryManager_->addRegistry(animatedPropsRegistry_);
+  updatesRegistryManager_->addRegistry(cssAnimationsRegistry_);
 
 #ifdef ANDROID
   // Pre-allocate the synchronous props buffers so the first frame doesn't pay
@@ -539,8 +537,8 @@ void ReanimatedModuleProxy::setViewStyle(jsi::Runtime &rt, const jsi::Value &vie
 }
 
 void ReanimatedModuleProxy::markNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper) {
-  auto lock = updatesRegistryManager_->lock();
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
+  auto lock = updatesRegistryManager_->lock();
   updatesRegistryManager_->markNodeAsRemovable(shadowNode);
 }
 
@@ -578,10 +576,11 @@ void ReanimatedModuleProxy::applyCSSAnimations(
     const jsi::Value &compoundComponentName,
     const jsi::Value &animationUpdates) {
   auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
+  const auto compoundComponentNameStr = compoundComponentName.asString(rt).utf8(rt);
   const auto updates = parseCSSAnimationUpdates(rt, animationUpdates);
 
   auto lock = updatesRegistryManager_->lock();
-  cssAnimationsRegistry_->apply(shadowNode, compoundComponentName.asString(rt).utf8(rt), updates);
+  cssAnimationsRegistry_->apply(shadowNode, compoundComponentNameStr, updates);
 }
 
 void ReanimatedModuleProxy::unregisterCSSAnimations(const jsi::Value &viewTag) {
@@ -828,9 +827,9 @@ AnimationMutations ReanimatedModuleProxy::collectNonLayoutAnimationUpdates() {
   ReanimatedSystraceSection s("ReanimatedModuleProxy::collectNonLayoutAnimationUpdates");
 
   AnimationMutations mutations;
+  jsi::Runtime &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
   {
     auto lock = updatesRegistryManager_->lock();
-    jsi::Runtime &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
     animatedPropsRegistry_->flushNonLayoutUpdates(uiRuntime, mutations);
   }
   return mutations;
@@ -1042,29 +1041,34 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
   const auto &shadowTreeRegistry = uiManager_->getShadowTreeRegistry();
 
   std::unordered_map<SurfaceId, PropsMap> propsMapBySurface;
+  PropsMap collectedProps;
+  bool flushRegistry;
 
-  // Release the lock before shadowTree.commit - it re-enters via ReanimatedCommitHook.
+  // Snapshot under the lock; shape propsMapBySurface afterwards. Lock must
+  // be released before shadowTree.commit below - it re-enters via
+  // ReanimatedCommitHook.
   {
     auto lock = updatesRegistryManager_->lock();
 #ifdef ANDROID
     updatesRegistryManager_->collectPropsToRevertBySurface(propsMapBySurface);
 #endif
-
-    if (shouldFlushRegistry_) {
+    flushRegistry = shouldFlushRegistry_;
+    if (flushRegistry) {
       shouldFlushRegistry_ = false;
-      const auto propsMap = updatesRegistryManager_->collectProps();
-      for (auto const &[family, props] : propsMap) {
-        const auto surfaceId = family->getSurfaceId();
-        auto &propsVector = propsMapBySurface[surfaceId][family];
-        for (const auto &prop : props) {
-          propsVector.emplace_back(prop);
-        }
+      collectedProps = updatesRegistryManager_->collectProps();
+    }
+  }
+
+  if (flushRegistry) {
+    for (auto const &[family, props] : collectedProps) {
+      auto &propsVector = propsMapBySurface[family->getSurfaceId()][family];
+      for (const auto &prop : props) {
+        propsVector.emplace_back(prop);
       }
-    } else {
-      for (auto const &[shadowNodeFamily, props] : updatesBatch) {
-        SurfaceId surfaceId = shadowNodeFamily->getSurfaceId();
-        propsMapBySurface[surfaceId][shadowNodeFamily].emplace_back(props);
-      }
+    }
+  } else {
+    for (auto const &[shadowNodeFamily, props] : updatesBatch) {
+      propsMapBySurface[shadowNodeFamily->getSurfaceId()][shadowNodeFamily].emplace_back(props);
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -226,7 +226,6 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #endif // ANDROID
       subscribeForKeyboardEventsFunction_(platformDepMethodsHolder.subscribeForKeyboardEvents),
       unsubscribeFromKeyboardEventsFunction_(platformDepMethodsHolder.unsubscribeFromKeyboardEvents) {
-  // No lock needed at construction - no other thread holds a reference yet.
   // Add registries in order of their priority (from the lowest to the
   // highest). CSS transitions should be overriden by animated style
   // animations; animated style animations should be overriden by CSS
@@ -1044,9 +1043,7 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
   PropsMap collectedProps;
   bool flushRegistry;
 
-  // Snapshot under the lock; shape propsMapBySurface afterwards. Lock must
-  // be released before shadowTree.commit below - it re-enters via
-  // ReanimatedCommitHook.
+  // Release the lock before shadowTree.commit - it re-enters via ReanimatedCommitHook.
   {
     auto lock = updatesRegistryManager_->lock();
 #ifdef ANDROID

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -205,21 +205,23 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
 #endif
       staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
-      operationsLoop_(std::make_shared<OperationsLoop>(
-          uiScheduler,
-          platformDepMethodsHolder.requestRender,
-          platformDepMethodsHolder.getAnimationTimestamp,
-          updatesRegistryManager_)),
+      operationsLoop_(
+          std::make_shared<OperationsLoop>(
+              uiScheduler,
+              platformDepMethodsHolder.requestRender,
+              platformDepMethodsHolder.getAnimationTimestamp,
+              updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(operationsLoop_, cssAnimationKeyframesRegistry_)),
       cssTransitionsRegistry_(std::make_shared<CSSTransitionsRegistry>(viewStylesRepository_, operationsLoop_)),
-      pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
-          platformDepMethodsHolder.attachPseudoSelector,
-          platformDepMethodsHolder.detachPseudoSelector,
-          cssTransitionsRegistry_,
-          updatesRegistryManager_)),
+      pseudoStylesRegistry_(
+          std::make_shared<PseudoStylesRegistry>(
+              platformDepMethodsHolder.attachPseudoSelector,
+              platformDepMethodsHolder.detachPseudoSelector,
+              cssTransitionsRegistry_,
+              updatesRegistryManager_)),
       synchronouslyUpdateUIPropsFunction_(platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
 #ifdef ANDROID
       filterUnmountedTagsFunction_(platformDepMethodsHolder.filterUnmountedTagsFunction),
@@ -783,14 +785,10 @@ void ReanimatedModuleProxy::performOperations() {
       // Update CSS animations and flush updates
       cssAnimationsRegistry_->flushUpdates(updatesBatch);
     }
+  }
 
-    if constexpr (shouldUseSynchronousUpdatesInPerformOperations()) {
-      applySynchronousUpdates(updatesBatch, false);
-    }
-
-    if ((updatesBatch.size() > 0) && updatesRegistryManager_->shouldReanimatedSkipCommit()) {
-      updatesRegistryManager_->pleaseCommitAfterPause();
-    }
+  if constexpr (shouldUseSynchronousUpdatesInPerformOperations()) {
+    applySynchronousUpdates(updatesBatch, false);
   }
 
   if (updatesRegistryManager_->shouldReanimatedSkipCommit()) {
@@ -799,6 +797,9 @@ void ReanimatedModuleProxy::performOperations() {
     // In this case, we should skip the commit here and let React Native do
     // it. The commit will include the current values from the updates manager
     // which will be applied in ReanimatedCommitHook.
+    if (!updatesBatch.empty()) {
+      updatesRegistryManager_->pleaseCommitAfterPause();
+    }
     return;
   }
 
@@ -1049,9 +1050,8 @@ void ReanimatedModuleProxy::commitUpdates(jsi::Runtime &rt, const UpdatesBatch &
 #ifdef ANDROID
     updatesRegistryManager_->collectPropsToRevertBySurface(propsMapBySurface);
 #endif
-    flushRegistry = shouldFlushRegistry_;
+    flushRegistry = shouldFlushRegistry_.exchange(false);
     if (flushRegistry) {
-      shouldFlushRegistry_ = false;
       collectedProps = updatesRegistryManager_->collectProps();
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -253,10 +253,10 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshot_;
 #endif
-  const std::shared_ptr<OperationsLoop> operationsLoop_;
-  const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
+  const std::shared_ptr<OperationsLoop> operationsLoop_;
+  const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -227,7 +227,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 #endif
 
   const bool isReducedMotion_;
-  bool shouldFlushRegistry_ = false;
+  std::atomic<bool> shouldFlushRegistry_{false};
   std::shared_ptr<worklets::WorkletRuntime> uiRuntime_;
   std::shared_ptr<worklets::UIScheduler> uiScheduler_;
   std::shared_ptr<CallInvoker> jsInvoker_;


### PR DESCRIPTION
Remove the per-base mutex_ from UpdatesRegistry and complete PR #9489's migration to a single boundary lock owned by UpdatesRegistryManager.

- Drop UpdatesRegistry::mutex_ and per-method std::lock_guard's; every public method now asserts UpdatesRegistryManager::isLockedByCurrentThread().
- Same for AnimatedPropsRegistry::{update, getUpdatesOlderThanTimestamp}.
- Add manager-lock assertions to StaticPropsRegistry, CSSKeyframesRegistry, the three CSS observer callbacks, and the UpdatesRegistryManager methods that touch shared state.
- Acquire the manager lock at the previously-missed JSI boundaries: setViewStyle, registerCSSKeyframes, unregisterCSSKeyframes, the updateProps lambda, getSettledUpdates, performNonLayoutOperations, and the diagnostic registries-leak-check.
- Pass UpdatesRegistryManager into OperationsLoop and lock at the top of OperationsLoop::update() so the platform RAF tick runs under the same boundary as the JS / commit threads.
- Restructure commitUpdates: snapshot revert/pending props under the lock, release before shadowTree.commit (which re-enters via ReanimatedCommitHook), re-lock briefly for clearPropsToRevert on Android.

Fixes a navigation-time EXC_BAD_ACCESS in StaticPropsRegistry::get caused by setViewStyle mutating registry_ on the JS thread while the commit-hook thread read it via ViewStylesRepository::getStyleProp.
