### PR TITLE
fix: runtime tests in release

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -60,8 +60,9 @@ export default function RuntimeTestsExample() {
         {
           testSuiteName: 'runtimes',
           importTest: () => {
-            require('./tests/runtimes/errorTraces.test');
-            require('./tests/runtimes/loggingFromWorkletRuntime.test');
+            __DEV__ && require('./tests/runtimes/errorTraces.test');
+            __DEV__ &&
+              require('./tests/runtimes/loggingFromWorkletRuntime.test');
             require('./tests/runtimes/createWorkletRuntime.test');
             require('./tests/runtimes/scheduleOnRN.test');
             require('./tests/runtimes/runOnUISync.test');

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/advancedAPI/useFrameCallback.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/advancedAPI/useFrameCallback.test.tsx
@@ -18,23 +18,19 @@ describe('Test *****useFrameCallback*****', () => {
   //   const CancelAfterDelayComponent = ({ timeToStop }: { timeToStop: number }) => {
   //     const width = useSharedValue(0);
   //     const ref = useTestRef(STOP_AFTER_DELAY_REF);
-
   //     const frameCallback = useFrameCallback(({ timeSincePreviousFrame }) => {
   //       if (timeSincePreviousFrame) {
   //         width.value += timeSincePreviousFrame / 8;
   //       }
   //     });
-
   //     const animatedStyle = useAnimatedStyle(() => {
   //       return { width: width.value };
   //     });
-
   //     useEffect(() => {
   //       setTimeout(() => {
   //         frameCallback.setActive(false);
   //       }, timeToStop);
   //     }, [timeToStop, frameCallback]);
-
   //     return (
   //       <View style={styles.container}>
   //         <Animated.View ref={ref} style={[styles.animatedBox, animatedStyle]} />
@@ -44,37 +40,9 @@ describe('Test *****useFrameCallback*****', () => {
   //   test.each([500, 1000])('Run frameCallback for **%p**ms', async timeToStop => {
   //     await render(<CancelAfterDelayComponent timeToStop={timeToStop} />);
   //     const animatedComponent = getTestComponent(STOP_AFTER_DELAY_REF);
-
   //     await wait(timeToStop + 200);
-
   //     const expectedWidth = timeToStop / 8;
   //     expect(await animatedComponent.getAnimatedStyle('width')).toBeWithinRange(expectedWidth - 1, expectedWidth + 2);
   //   });
   // });
-
-  describe('Test _canceling frameCallback_ after predefined time', () => {
-    const InvalidFrameCallback = () => {
-      const imNotAWorklet = () => {
-        console.log('I am not a worklet');
-      };
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const frameCallback = useFrameCallback((_frameInfo) => {
-        imNotAWorklet();
-      });
-
-      return <View />;
-    };
-  });
 });
-
-// const styles = StyleSheet.create({
-//   container: {
-//     flex: 1,
-//     flexDirection: 'column',
-//   },
-//   animatedBox: {
-//     backgroundColor: 'seagreen',
-//     height: 80,
-//     margin: 30,
-//   },
-// });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/advancedAPI/useFrameCallback.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/advancedAPI/useFrameCallback.test.tsx
@@ -64,15 +64,6 @@ describe('Test *****useFrameCallback*****', () => {
 
       return <View />;
     };
-
-    test('frameCallback should be workletized', async () => {
-      await expect(async () => {
-        await render(<InvalidFrameCallback />);
-        await wait(200);
-      }).toThrow(
-        '[Worklets] Tried to synchronously call a non-worklet function `imNotAWorklet` on the UI thread.\nSee https://docs.swmansion.com/react-native-worklets/docs/guides/troubleshooting#tried-to-synchronously-call-a-non-worklet-function-on-the-ui-thread for more details.'
-      );
-    });
   });
 });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/assigningObjects.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/assigningObjects.test.tsx
@@ -73,22 +73,6 @@ describe('Test setting different values as sharedValue', () => {
     }
   );
 
-  test.each([...Presets.stringObjects, ...Presets.dates])(
-    'Object %p causes an error',
-    async (testedValue) => {
-      await expect(async () => {
-        await render(
-          <SharedValueComponent initialValue={testedValue} progress={0} />
-        );
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const _sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
-        await render(<ProgressBar progress={0} />);
-      }).toThrow(
-        '[Worklets] Trying to access property `onFrame` of an object which cannot be sent to the UI runtime.'
-      );
-    }
-  );
-
   describe('Test setting _Error types_ as sharedValue', () => {
     test.each([
       new TypeError('Example TypeError'),

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -524,12 +524,8 @@ describe('Test createSerializable', () => {
         cyclicArray.push(cyclicArray);
 
         await expect(() => {
-          scheduleOnTarget(() => {
-            'worklet';
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _test = cyclicArray[1];
-          });
-        }).toThrow();
+          createSerializable(cyclicArray);
+        }).toThrow('Trying to convert a cyclic object');
       });
 
       test('createSerializableInaccessibleObject', async () => {
@@ -576,7 +572,7 @@ describe('Test createSerializable', () => {
         expect(errorMessage).toInclude(
           'Tried to synchronously call a Remote Function.'
         );
-        expect(errorMessage).toInclude('fooFunction');
+        expect(errorMessage).toInclude(__DEV__ ? 'fooFunction' : 'anonymous');
         expect(errorMessage).toInclude('on the ' + runtimeName + ' Runtime');
       });
 
@@ -605,100 +601,102 @@ describe('Test createSerializable', () => {
   });
 });
 
-describe('createSerializable for unsupported types', () => {
-  test('throws when trying to serialize a Promise', async () => {
-    const promise = Promise.resolve();
-    await expect(() => {
-      createSerializable(promise);
-    }).toThrow('Promises cannot be converted to serializable.');
-  });
-});
-
-describe('Test serializable freezing', () => {
-  const FREEZE_WARNING = 'Tried to modify key';
-
-  test('warns when modifying converted array', async () => {
-    const obj = [1, 2, 3];
-    createSerializable(obj);
-    await expect(() => {
-      obj[0] = 2;
-    }).toThrow(FREEZE_WARNING);
-  });
-
-  test('warns when modifying converted remote function', async () => {
-    const obj = () => {};
-    obj.prop = 1;
-    createSerializable(obj);
-    await expect(() => {
-      obj.prop = 2;
-    }).toThrow(FREEZE_WARNING);
-  });
-
-  test('does not warn when modifying converted host object', async () => {
-    const obj = TurboModuleRegistry.get('Clipboard');
-    if (!obj) {
-      return;
-    }
-    createSerializable(obj);
-    await expect(() => {
-      (obj as any).prop = 2;
-    }).not.toThrow();
-  });
-
-  test('warns when modifying converted plain object', async () => {
-    const obj = { prop: 1 };
-    createSerializable(obj);
-    await expect(() => {
-      obj.prop = 2;
-    }).toThrow(FREEZE_WARNING);
-  });
-
-  test('does not warn when modifying converted RegExp literal', async () => {
-    const obj = /a/;
-    createSerializable(obj);
-    await expect(() => {
-      (obj as any).prop = 2;
-    }).not.toThrow();
-  });
-
-  test('does not warn when modifying converted RegExp instance', async () => {
-    // eslint-disable-next-line prefer-regex-literals
-    const obj = new RegExp('a');
-    createSerializable(obj);
-    await expect(() => {
-      (obj as any).prop = 2;
-    }).not.toThrow();
-  });
-
-  test('does not warn when modifying converted ArrayBuffer', async () => {
-    const obj = new ArrayBuffer(8);
-    createSerializable(obj);
-    await expect(() => {
-      (obj as any).prop = 2;
-    }).not.toThrow();
-  });
-
-  test('does not warn when modifying converted Int32Array', async () => {
-    const obj = new Int32Array(2);
-    createSerializable(obj);
-    await expect(() => {
-      obj[1] = 2;
-    }).not.toThrow();
-  });
-
-  test('handles unconfigurable object without throwing', async () => {
-    const obj = {};
-    Object.defineProperty(obj, 'prop', {
-      value: 1,
-      writable: false,
-      enumerable: true,
-      configurable: false,
+if (__DEV__) {
+  describe('createSerializable for unsupported types', () => {
+    test('throws when trying to serialize a Promise', async () => {
+      const promise = Promise.resolve();
+      await expect(() => {
+        createSerializable(promise);
+      }).toThrow('Promises cannot be converted to serializable.');
     });
-    await expect(() => {
-      createSerializable(obj);
-    }).not.toThrow();
   });
-});
+
+  describe('Test serializable freezing', () => {
+    const FREEZE_WARNING = 'Tried to modify key';
+
+    test('warns when modifying converted array', async () => {
+      const obj = [1, 2, 3];
+      createSerializable(obj);
+      await expect(() => {
+        obj[0] = 2;
+      }).toThrow(FREEZE_WARNING);
+    });
+
+    test('warns when modifying converted remote function', async () => {
+      const obj = () => {};
+      obj.prop = 1;
+      createSerializable(obj);
+      await expect(() => {
+        obj.prop = 2;
+      }).toThrow(FREEZE_WARNING);
+    });
+
+    test('does not warn when modifying converted host object', async () => {
+      const obj = TurboModuleRegistry.get('Clipboard');
+      if (!obj) {
+        return;
+      }
+      createSerializable(obj);
+      await expect(() => {
+        (obj as any).prop = 2;
+      }).not.toThrow();
+    });
+
+    test('warns when modifying converted plain object', async () => {
+      const obj = { prop: 1 };
+      createSerializable(obj);
+      await expect(() => {
+        obj.prop = 2;
+      }).toThrow(FREEZE_WARNING);
+    });
+
+    test('does not warn when modifying converted RegExp literal', async () => {
+      const obj = /a/;
+      createSerializable(obj);
+      await expect(() => {
+        (obj as any).prop = 2;
+      }).not.toThrow();
+    });
+
+    test('does not warn when modifying converted RegExp instance', async () => {
+      // eslint-disable-next-line prefer-regex-literals
+      const obj = new RegExp('a');
+      createSerializable(obj);
+      await expect(() => {
+        (obj as any).prop = 2;
+      }).not.toThrow();
+    });
+
+    test('does not warn when modifying converted ArrayBuffer', async () => {
+      const obj = new ArrayBuffer(8);
+      createSerializable(obj);
+      await expect(() => {
+        (obj as any).prop = 2;
+      }).not.toThrow();
+    });
+
+    test('does not warn when modifying converted Int32Array', async () => {
+      const obj = new Int32Array(2);
+      createSerializable(obj);
+      await expect(() => {
+        obj[1] = 2;
+      }).not.toThrow();
+    });
+
+    test('handles unconfigurable object without throwing', async () => {
+      const obj = {};
+      Object.defineProperty(obj, 'prop', {
+        value: 1,
+        writable: false,
+        enumerable: true,
+        configurable: false,
+      });
+      await expect(() => {
+        createSerializable(obj);
+      }).not.toThrow();
+    });
+  });
+}
 
 declare global {
   var __reanimatedModuleProxy: Record<string, unknown>;

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -496,12 +496,14 @@ describe('Test createSerializableOnUI', () => {
     }).toThrow();
   });
 
-  test('throws when trying to serialize a Promise', async () => {
-    await expect(() =>
-      runOnUISync(() => {
-        'worklet';
-        return Promise.resolve();
-      })
-    ).toThrow('Promises cannot be converted to serializable.');
-  });
+  if (__DEV__) {
+    test('throws when trying to serialize a Promise', async () => {
+      await expect(() =>
+        runOnUISync(() => {
+          'worklet';
+          return Promise.resolve();
+        })
+      ).toThrow('Promises cannot be converted to serializable.');
+    });
+  }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeAsync.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeAsync.test.tsx
@@ -159,7 +159,7 @@ describe('runOnRuntimeAsync', () => {
       await waitForNotification(FAIL_NOTIFICATION);
       expect(reason).toBe('test error');
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling on UI Runtime to a Worker Runtime ', async () => {
       scheduleOnUI(() => {
         'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeAsyncWithId.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeAsyncWithId.test.tsx
@@ -328,7 +328,7 @@ describe('runOnRuntimeAsyncWithId', () => {
         '[Worklets] scheduleOnRuntimeWithId: no worklet runtime found for id 9999'
       );
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling from UI Runtime to UI Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSync.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSync.test.tsx
@@ -79,7 +79,7 @@ describe('runOnRuntimeSync', () => {
       await waitForNotification(PASS_NOTIFICATION);
       expect(value).toBe(42);
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling on UI Runtime to a Worker Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnRuntimeSyncWithId.test.tsx
@@ -120,7 +120,7 @@ describe('runOnRuntimeSyncWithId', () => {
         '[Worklets] runOnRuntimeSyncWithId: no worklet runtime found for id 9999'
       );
     });
-  } else {
+  } else if (__DEV__) {
     test('from UI Runtime to UI Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';
@@ -253,8 +253,8 @@ describe('runOnRuntimeSyncWithId', () => {
         '[Worklets] runOnRuntimeSyncWithId: no worklet runtime found for id 9999'
       );
     });
-  } else {
-    test('from Worker Runtime to UI Runtime', async () => {
+  } else if (__DEV__) {
+    test('throws from Worker Runtime to UI Runtime', async () => {
       scheduleOnRuntime(workletRuntime1, () => {
         'worklet';
         try {
@@ -277,7 +277,7 @@ describe('runOnRuntimeSyncWithId', () => {
       );
     });
 
-    test('from Worker Runtime to self', async () => {
+    test('throws from Worker Runtime to self', async () => {
       scheduleOnRuntime(workletRuntime1, () => {
         'worklet';
         try {
@@ -303,7 +303,7 @@ describe('runOnRuntimeSyncWithId', () => {
       );
     });
 
-    test('from Worker Runtime to other Worker Runtime', async () => {
+    test('throws from Worker Runtime to other Worker Runtime', async () => {
       scheduleOnRuntime(workletRuntime1, () => {
         'worklet';
         try {

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnUIAsync.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnUIAsync.test.tsx
@@ -134,7 +134,7 @@ describe('runOnUIAsync', () => {
       await waitForNotification(FAIL_NOTIFICATION);
       expect(reason).toBe('test error');
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling on UI Runtime to UI Runtime without worklets bundle mode enabled', async () => {
       scheduleOnUI(() => {
         'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnUISync.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/runOnUISync.test.tsx
@@ -78,7 +78,7 @@ describe('runOnUISync', () => {
       await waitForNotification(PASS_NOTIFICATION);
       expect(value).toBe(42);
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling on UI Runtime to UI Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runtimes/scheduleOnUI.test.tsx
@@ -72,7 +72,7 @@ describe('scheduleOnUI', () => {
       await waitForNotification(PASS_NOTIFICATION);
       expect(value).toBe(42);
     });
-  } else {
+  } else if (__DEV__) {
     test('throws when scheduling on UI Runtime to UI Runtime', async () => {
       scheduleOnUI(() => {
         'worklet';


### PR DESCRIPTION
## Summary

Currently runtime tests crash/fail in release because in some of the tests we check if extra debug behavior is triggered, which isn't available in release.

## Test plan

Runtime tests now pass in release.
