### PR TITLE
fix: Fix build issues after #9325

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransition.cpp
@@ -42,8 +42,8 @@ void CSSPlatformTransition::runEntry(
       viewTag_, entry.propertyName, fromValue, toValue, rs.duration, rs.startTimestamp, entry.settings.easingConfig});
 
   activeProperties_[entry.propertyName] = ActiveProperty{
-      prev ? std::move(prev->adjustedEnd) : std::move(fromValue),
-      std::move(toValue),
+      prev ? prev->adjustedEnd : fromValue,
+      toValue,
       std::move(rs),
   };
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -70,10 +70,12 @@ struct PlatformDepMethodsHolder {
   MaybeFlushUIUpdatesQueueFunction maybeFlushUIUpdatesQueueFunction;
   PlatformAttachPseudoSelectorFunction attachPseudoSelector;
   PlatformDetachPseudoSelectorFunction detachPseudoSelector;
-  std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
   css::CSSCanRoutePropertyFunction cssCanRouteProperty;
   css::CSSApplyTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
+  // Last so platform initializers that don't supply it (iOS, Android today)
+  // can omit it and rely on value-init (= null shared_ptr).
+  std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -221,7 +221,6 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       maybeFlushUIUpdatesQueueFunction,
       attachPseudoSelectorFunction,
       detachPseudoSelectorFunction,
-      nullptr, // platformAnimationFactory - no Apple implementation yet
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -221,6 +221,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       maybeFlushUIUpdatesQueueFunction,
       attachPseudoSelectorFunction,
       detachPseudoSelectorFunction,
+      nullptr, // platformAnimationFactory - no Apple implementation yet
       cssCanRouteProperty,
       cssApplyTransition,
       cssRemoveTransition,


### PR DESCRIPTION
Two CI regressions landed after #9325 (`CSSPlatformTransition` iOS wiring):

- **iOS build**: positional `PlatformDepMethodsHolder` init was missing the `platformAnimationFactory` field that #9278 introduced. Moved the field to the end of the struct so iOS and Android can both omit it (gets value-initialized to a null `shared_ptr`); the chain that uses it already null-checks.
- **clang-tidy**: `std::move` on `PlatformValue` (a `std::variant` of trivially-copyable alternatives) is a no-op and is flagged by `performance-move-const-arg` under `-warnings-as-errors`. Dropped the redundant moves in `CSSPlatformTransition::runEntry`.