### PR TITLE
docs: Add `IOS_CSS_CORE_ANIMATION` feature flag to docs

### DIFF
--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -19,7 +19,7 @@ Feature flags are available since Reanimated 4.
 | [`DISABLE_COMMIT_PAUSING_MECHANISM`](#disable_commit_pausing_mechanism)                             | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#android_synchronously_update_ui_props)                   | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#ios_synchronously_update_ui_props)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
-| [`EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`](#experimental_css_animations_for_svg_components) | [static](#static-feature-flags) |  4.1.0   |  –   |                  `false`                  |
+| [`EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`](#experimental_platform_css_animations)                     | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
 | [`USE_SYNCHRONIZABLE_FOR_MUTABLES`](#use_synchronizable_for_mutables)                               | [static](#static-feature-flags) |  4.1.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS`](#use_commit_hook_only_for_react_commits)                 | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
@@ -96,9 +96,9 @@ This feature flag works only on Android and has no effect on iOS. For more detai
 
 When enabled, non-layout styles will be applied using the `[RCTSurfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:props:]` method (which doesn't involve layout recalculation) instead of than `ShadowTree::commit` method (which requires layout recalculation). Limitations and unwanted side effects are the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`. The set of supported styles is the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`, with the addition of `shadowOffset`, `shadowOpacity` and `shadowRadius`, which are iOS-only. For more details, see the original [PR #8367](https://github.com/software-mansion/react-native-reanimated/pull/8367).
 
-### `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`
+### `EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`
 
-When enabled, CSS animations and transitions will also work for a limited set of props of several components from [`react-native-svg`](https://github.com/software-mansion/react-native-svg) library. Currently, `Circle`, `Ellipse`, `Line`, `Path` and `Rect` components are supported.
+When enabled, Reanimated may route CSS animations and transitions to platform-native animation APIs (Core Animation on Apple platforms) instead of running them on the JS-driven animation loop. Platform-routed animations run on the platform's animation thread, which can improve smoothness for supported properties at the cost of a different runtime trade-off model. The set of supported properties is determined by the platform implementation and currently only iOS provides one. This feature flag is experimental and defaults to `false`.
 
 ### `USE_SYNCHRONIZABLE_FOR_MUTABLES`
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -19,12 +19,12 @@ Feature flags are available since Reanimated 4.
 | [`DISABLE_COMMIT_PAUSING_MECHANISM`](#disable_commit_pausing_mechanism)                             | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#android_synchronously_update_ui_props)                   | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#ios_synchronously_update_ui_props)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
-| [`EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`](#experimental_platform_css_animations)                     | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
 | [`USE_SYNCHRONIZABLE_FOR_MUTABLES`](#use_synchronizable_for_mutables)                               | [static](#static-feature-flags) |  4.1.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS`](#use_commit_hook_only_for_react_commits)                 | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
 | [`FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`](#force_react_render_for_settled_animations)           | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_ANIMATION_BACKEND`](#use_animation_backend)                                                   | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
+| [`EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`](#experimental_platform_css_animations)                     | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
 
 :::info
 
@@ -96,10 +96,6 @@ This feature flag works only on Android and has no effect on iOS. For more detai
 
 When enabled, non-layout styles will be applied using the `[RCTSurfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:props:]` method (which doesn't involve layout recalculation) instead of than `ShadowTree::commit` method (which requires layout recalculation). Limitations and unwanted side effects are the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`. The set of supported styles is the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`, with the addition of `shadowOffset`, `shadowOpacity` and `shadowRadius`, which are iOS-only. For more details, see the original [PR #8367](https://github.com/software-mansion/react-native-reanimated/pull/8367).
 
-### `EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`
-
-When enabled, Reanimated may route CSS animations and transitions to platform-native animation APIs (Core Animation on Apple platforms) instead of running them on the JS-driven animation loop. Platform-routed animations run on the platform's animation thread, which can improve smoothness for supported properties at the cost of a different runtime trade-off model. The set of supported properties is determined by the platform implementation and currently only iOS provides one. This feature flag is experimental and defaults to `false`.
-
 ### `USE_SYNCHRONIZABLE_FOR_MUTABLES`
 
 This feature flag is supposed to speedup shared value reads on the RN runtime by reducing the number of calls to `executeOnUIRuntimeSync`. When enabled, mutables (which are the primitives behind shared values) use [Synchronizable](https://docs.swmansion.com/react-native-worklets/docs/memory/synchronizable) state to check if they should sync with the UI Runtime. For more details, see [PR #8080](https://github.com/software-mansion/react-native-reanimated/pull/8080).
@@ -121,6 +117,10 @@ This feature flag enables a mechanism that periodically synchronizes animated st
 When enabled, Reanimated will use the React Native's new Animation Backend for applying animated changes. The backend will now be responsible for keeping animation changes in sync with the current React tree. This is meant to help with long-term stability and unlock new performance optimizations.
 
 This flag is experimental and defaults to `false`. To use it, you must run React Native 0.85.2 or newer with `useSharedAnimatedBackend` feature flag enabled (which is achieved by using React Native's Experimental release level in development).
+
+### `EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`
+
+When enabled, Reanimated may route CSS animations and transitions to platform-native animation APIs (Core Animation on Apple platforms) instead of running them on the JS-driven animation loop. Platform-routed animations run on the platform's animation thread, which can improve smoothness for supported properties at the cost of a different runtime trade-off model. The set of supported properties is determined by the platform implementation and currently only iOS provides one. This feature flag is experimental and defaults to `false`.
 
 ## Static feature flags
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -25,7 +25,7 @@ Feature flags are available since Reanimated 4.
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
 | [`FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`](#force_react_render_for_settled_animations)           | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_ANIMATION_BACKEND`](#use_animation_backend)                                                   | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
-| [`IOS_USE_CORE_ANIMATION_FOR_CSS`](#ios_use_core_animation_for_css)                                 | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
+| [`IOS_CSS_CORE_ANIMATION`](#ios_css_core_animation)                                                 | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
 
 :::info
 
@@ -123,7 +123,7 @@ When enabled, Reanimated will use the React Native's new Animation Backend for a
 
 This flag is experimental and defaults to `false`. To use it, you must run React Native 0.85.2 or newer with `useSharedAnimatedBackend` feature flag enabled (which is achieved by using React Native's Experimental release level in development).
 
-### `IOS_USE_CORE_ANIMATION_FOR_CSS`
+### `IOS_CSS_CORE_ANIMATION`
 
 When enabled, Reanimated may route CSS transitions to platform-native animation APIs instead of running them on the JS-driven animation loop. Currently, only the `opacity` property is routed, and only on iOS, where the platform path uses Core Animation. Support for additional properties, CSS animations (not just transitions), and Android will be added in the future. This feature flag is experimental and defaults to `false`.
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -25,7 +25,7 @@ Feature flags are available since Reanimated 4.
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
 | [`FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`](#force_react_render_for_settled_animations)           | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_ANIMATION_BACKEND`](#use_animation_backend)                                                   | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
-| [`EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`](#experimental_platform_css_animations)                     | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
+| [`IOS_USE_CORE_ANIMATION_FOR_CSS`](#ios_use_core_animation_for_css)                                 | [static](#static-feature-flags) |  4.4.0   |  –   |                  `false`                  |
 
 :::info
 
@@ -123,7 +123,7 @@ When enabled, Reanimated will use the React Native's new Animation Backend for a
 
 This flag is experimental and defaults to `false`. To use it, you must run React Native 0.85.2 or newer with `useSharedAnimatedBackend` feature flag enabled (which is achieved by using React Native's Experimental release level in development).
 
-### `EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`
+### `IOS_USE_CORE_ANIMATION_FOR_CSS`
 
 When enabled, Reanimated may route CSS transitions to platform-native animation APIs instead of running them on the JS-driven animation loop. Currently, only the `opacity` property is routed, and only on iOS, where the platform path uses Core Animation. Support for additional properties, CSS animations (not just transitions), and Android will be added in the future. This feature flag is experimental and defaults to `false`.
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -19,7 +19,7 @@ Feature flags are available since Reanimated 4.
 | [`DISABLE_COMMIT_PAUSING_MECHANISM`](#disable_commit_pausing_mechanism)                             | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#android_synchronously_update_ui_props)                   | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#ios_synchronously_update_ui_props)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
-| [`EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`](#experimental_css_animations_for_svg_components) | [static](#static-feature-flags) |  4.1.0   | 4.4.0  |                  `false`                  |
+| [`EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`](#experimental_css_animations_for_svg_components) | [static](#static-feature-flags) |  4.1.0   |  –   |                  `false`                  |
 | [`USE_SYNCHRONIZABLE_FOR_MUTABLES`](#use_synchronizable_for_mutables)                               | [static](#static-feature-flags) |  4.1.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS`](#use_commit_hook_only_for_react_commits)                 | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
@@ -99,7 +99,7 @@ When enabled, non-layout styles will be applied using the `[RCTSurfacePresenter 
 
 ### `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`
 
-Removed in 4.4.0; the behaviour is now enabled unconditionally. When this flag was available, CSS animations and transitions also worked for a limited set of props on several components from the [`react-native-svg`](https://github.com/software-mansion/react-native-svg) library (`Circle`, `Ellipse`, `Line`, `Path` and `Rect`).
+When enabled, CSS animations and transitions will also work for a limited set of props of several components from [`react-native-svg`](https://github.com/software-mansion/react-native-svg) library. Currently, `Circle`, `Ellipse`, `Line`, `Path` and `Rect` components are supported.
 
 ### `USE_SYNCHRONIZABLE_FOR_MUTABLES`
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -19,6 +19,7 @@ Feature flags are available since Reanimated 4.
 | [`DISABLE_COMMIT_PAUSING_MECHANISM`](#disable_commit_pausing_mechanism)                             | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#android_synchronously_update_ui_props)                   | [static](#static-feature-flags) |  4.0.0   |  –   |                  `false`                  |
 | [`IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`](#ios_synchronously_update_ui_props)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
+| [`EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`](#experimental_css_animations_for_svg_components) | [static](#static-feature-flags) |  4.1.0   | 4.4.0  |                  `false`                  |
 | [`USE_SYNCHRONIZABLE_FOR_MUTABLES`](#use_synchronizable_for_mutables)                               | [static](#static-feature-flags) |  4.1.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS`](#use_commit_hook_only_for_react_commits)                 | [static](#static-feature-flags) |  4.2.0   |  –   | `true` for 4.3.0+ <br/> `false` otherwise |
 | [`ENABLE_SHARED_ELEMENT_TRANSITIONS`](#enable_shared_element_transitions)                           | [static](#static-feature-flags) |  4.2.0   |  –   |                  `false`                  |
@@ -95,6 +96,10 @@ This feature flag works only on Android and has no effect on iOS. For more detai
 ### `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`
 
 When enabled, non-layout styles will be applied using the `[RCTSurfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:props:]` method (which doesn't involve layout recalculation) instead of than `ShadowTree::commit` method (which requires layout recalculation). Limitations and unwanted side effects are the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`. The set of supported styles is the same as for `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`, with the addition of `shadowOffset`, `shadowOpacity` and `shadowRadius`, which are iOS-only. For more details, see the original [PR #8367](https://github.com/software-mansion/react-native-reanimated/pull/8367).
+
+### `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS`
+
+Removed in 4.4.0; the behaviour is now enabled unconditionally. When this flag was available, CSS animations and transitions also worked for a limited set of props on several components from the [`react-native-svg`](https://github.com/software-mansion/react-native-svg) library (`Circle`, `Ellipse`, `Line`, `Path` and `Rect`).
 
 ### `USE_SYNCHRONIZABLE_FOR_MUTABLES`
 

--- a/docs/docs-reanimated/docs/guides/feature-flags.md
+++ b/docs/docs-reanimated/docs/guides/feature-flags.md
@@ -120,7 +120,7 @@ This flag is experimental and defaults to `false`. To use it, you must run React
 
 ### `EXPERIMENTAL_PLATFORM_CSS_ANIMATIONS`
 
-When enabled, Reanimated may route CSS animations and transitions to platform-native animation APIs (Core Animation on Apple platforms) instead of running them on the JS-driven animation loop. Platform-routed animations run on the platform's animation thread, which can improve smoothness for supported properties at the cost of a different runtime trade-off model. The set of supported properties is determined by the platform implementation and currently only iOS provides one. This feature flag is experimental and defaults to `false`.
+When enabled, Reanimated may route CSS transitions to platform-native animation APIs instead of running them on the JS-driven animation loop. Currently, only the `opacity` property is routed, and only on iOS, where the platform path uses Core Animation. Support for additional properties, CSS animations (not just transitions), and Android will be added in the future. This feature flag is experimental and defaults to `false`.
 
 ## Static feature flags
 


### PR DESCRIPTION
Docs follow-up adding `IOS_CSS_CORE_ANIMATION` to the FF table