### PR TITLE
fix: Convert CSS Core Animation `beginTime` to layer-local clock

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -102,7 +102,16 @@ static id idFromPlatformValue(NSString *propertyName, const PlatformValue &value
     }
     anim.toValue = toValue;
     anim.duration = durationSec;
-    anim.beginTime = beginTime;
+    // CABasicAnimation.beginTime is read in the LAYER's local clock, which
+    // diverges from CACurrentMediaTime when any ancestor has a non-default
+    // `speed` / `timeOffset` / `beginTime` (RN Screens manipulates these
+    // during navigation transitions). convertTime: walks the ancestor chain
+    // and returns the absolute time expressed in the layer's local space;
+    // for an untouched hierarchy it returns the input unchanged. Without
+    // this, after a screen pop/push the animation can land in CA's "already
+    // complete" or "never starts" state and snap straight to toValue with no
+    // visible transition.
+    anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
     anim.timingFunction = timing;
     // Persist so presentation holds the animated value before beginTime
     // (kCAFillModeBackwards) and after duration (kCAFillModeForwards),

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -102,15 +102,9 @@ static id idFromPlatformValue(NSString *propertyName, const PlatformValue &value
     }
     anim.toValue = toValue;
     anim.duration = durationSec;
-    // CABasicAnimation.beginTime is read in the LAYER's local clock, which
-    // diverges from CACurrentMediaTime when any ancestor has a non-default
-    // `speed` / `timeOffset` / `beginTime` (RN Screens manipulates these
-    // during navigation transitions). convertTime: walks the ancestor chain
-    // and returns the absolute time expressed in the layer's local space;
-    // for an untouched hierarchy it returns the input unchanged. Without
-    // this, after a screen pop/push the animation can land in CA's "already
-    // complete" or "never starts" state and snap straight to toValue with no
-    // visible transition.
+    // beginTime is in the layer's local clock; convert from absolute time so
+    // ancestor speed/timeOffset (e.g. RN Screens during navigation) doesn't
+    // make the animation appear already complete or never-starting.
     anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
     anim.timingFunction = timing;
     // Persist so presentation holds the animated value before beginTime


### PR DESCRIPTION
## Summary

Fixes delay being wrong after navigating between screens. Look at the hamburger menu button in the **Real World Examples** card - it broke after navigating back and forth.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/5822e4e9-c6e9-4586-afb4-e0ac8f5e92e0" /> | <video src="https://github.com/user-attachments/assets/58f882c3-ac11-4188-8af5-6ec929195c56" /> |
