### PR TITLE
fix: Stop CA animations from leaking onto recycled layers

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -104,12 +104,22 @@ static id idFromPlatformValue(NSString *propertyName, const PlatformValue &value
     anim.duration = durationSec;
     anim.beginTime = beginTime;
     anim.timingFunction = timing;
-    // Persist so presentation holds the animated value before beginTime
-    // (kCAFillModeBackwards) and after duration (kCAFillModeForwards),
-    // overriding any concurrent model commits. Cleared in removeTransition.
-    anim.fillMode = kCAFillModeBoth;
-    anim.removedOnCompletion = NO;
+    // Backwards fill paints fromValue during the delay window; the animation
+    // self-removes on completion and the layer reads the model below.
+    anim.fillMode = kCAFillModeBackwards;
+    anim.removedOnCompletion = YES;
+
+    // Commit toValue to the model first (with implicit actions disabled), then
+    // add the animation in the same transaction. The model is correct for the
+    // entire lifetime of the animation; once the animation auto-removes the
+    // layer reads the model and there's no snap. This is what stops stale
+    // animations from outliving their view and bleeding onto layers that RN
+    // has since recycled onto unrelated components.
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [layer setValue:toValue forKeyPath:keyPath];
     [layer addAnimation:anim forKey:keyPath];
+    [CATransaction commit];
   });
 }
 


### PR DESCRIPTION
## Summary

Animations were created with `removedOnCompletion=NO` and `fillMode=kCAFillModeBoth`, so once an opacity transition finished it kept painting its toValue over the model layer forever. When RN later recycled that layer onto a different view, the animation was incorrectly applied to views that shouldn't be animated.

To fix the issue, we switched to `removedOnCompletion=YES` + `fillMode=kCAFillModeBackwards`, and commit `toValue` to the model in the same `setDisableActions` transaction as the `addAnimation` call. The model holds `toValue` throughout the animation's lifetime; once the animation auto-removes, the layer simply reads the model and there's no snap. Stale animations can no longer outlive their duration.

## Example recording

Parts of the app were disappearing on each navigation to the screen in which just a single component was using a Core Animation

https://github.com/user-attachments/assets/672650cd-708d-45a8-a31b-bcbd7377443d

