### PR TITLE
fix: Fix memory leaks in layout animations

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp
@@ -115,6 +115,12 @@ void LayoutAnimationsManager::transferSharedConfig(const Tag from, const Tag to)
   sharedTransitions_[to] = sharedTransitions_[from];
 }
 
+void LayoutAnimationsManager::clearSharedTransitionConfig(const int tag) {
+  auto lock = std::unique_lock<std::recursive_mutex>(animationsMutex_);
+  sharedTransitions_.erase(tag);
+  sharedTransitionManager_->tagToName_.erase(tag);
+}
+
 std::shared_ptr<SharedTransitionManager> LayoutAnimationsManager::getSharedTransitionManager() {
   return sharedTransitionManager_;
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.h
@@ -59,6 +59,7 @@ class LayoutAnimationsManager {
   void cancelLayoutAnimation(jsi::Runtime &rt, const int tag) const;
   void transferConfigFromNativeID(const int nativeId, const int tag);
   void transferSharedConfig(const Tag from, const Tag to);
+  void clearSharedTransitionConfig(const int tag);
   std::shared_ptr<SharedTransitionManager> getSharedTransitionManager();
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -533,7 +533,6 @@ void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int 
 }
 
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
-  layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
   if (!layoutAnimations_.contains(tag)) {
     return;
   }
@@ -546,6 +545,7 @@ void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) con
 
     auto &uiRuntime = strongThis->uiRuntime_;
     strongThis->layoutAnimationsManager_->cancelLayoutAnimation(uiRuntime, tag);
+    layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
   });
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -290,6 +290,8 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
     sharedContainersToRemove_.push_back(tag);
     tagsToRestore_.push_back(restoreMap_[tag][1]);
     transformForNode_.clear();
+    // Clean the config for the synthetic tag
+    layoutAnimationsManager_->clearSharedTransitionConfig(tag);
   }
   if (!shouldRemove) {
     return surfaceId;
@@ -519,8 +521,7 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
     startExitingAnimation(node);
     lightNodes_[node->current.tag] = node;
   } else {
-    // TODO (future): add proper cleanup
-    //    layoutAnimationsManager_->clearLayoutAnimationConfig(node->tag);
+    maybeCancelAnimation(node->current.tag);
   }
 
   return wantAnimateExit;
@@ -532,6 +533,7 @@ void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int 
 }
 
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
+  layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
   if (!layoutAnimations_.contains(tag)) {
     return;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -166,6 +166,9 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
       if (transitionState_ == TransitionState::CANCELLED) {
         tagsToRestore_.push_back(restoreMap_[tag][BEFORE]);
       }
+      // Progress transitions never call endLayoutAnimation, so we
+      // must clean up the synthetic container config here instead.
+      layoutAnimationsManager_->clearSharedTransitionConfig(tag);
     }
     if (transitionState_ == TransitionState::END) {
       topScreen[surfaceId] = lightNodes_[transitionTag_];
@@ -258,6 +261,18 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
       after.tag = containerTag;
 
       startSharedTransition(containerTag, before, after, surfaceId);
+    }
+
+    // Sweep: clear configs for any deleted views whose shared transition was not used
+    // (no matching element on the destination screen, or partial matches)
+    std::vector<Tag> deletedSharedTags;
+    for (const auto &[tag, _] : sharedTransitionManager_->tagToName_) {
+      if (!lightNodes_.contains(tag)) {
+        deletedSharedTags.push_back(tag);
+      }
+    }
+    for (const auto tag : deletedSharedTags) {
+      layoutAnimationsManager_->clearSharedTransitionConfig(tag);
     }
   } else if (!mutations.empty()) {
     for (auto &[sharedTag, transition] : transitions_) {


### PR DESCRIPTION
## Summary

Layout animation leaks:
- maybeCancelAnimation was missing a call to clearLayoutAnimationConfig, leaving stale entries in layoutAnimations_
- Views popped off the stack without an exiting animation were not cleaned up. Fixed by calling maybeCancelAnimation in startAnimationsRecursively


## Test plan

- Observe the sizes of LayoutAnimationsManager enteringAnimations_ exitingAnimations_ layoutAnimations_  there should be no leak after this change
- Best examples to check for leaks were:
    - LA - basic layout animation