### PR TITLE
release(Worklets): 0.9.1

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2097,7 +2097,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.9.0):
+  - RNWorklets (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2119,10 +2119,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.9.0)
-    - RNWorklets/common (= 0.9.0)
+    - RNWorklets/apple (= 0.9.1)
+    - RNWorklets/common (= 0.9.1)
     - Yoga
-  - RNWorklets/apple (0.9.0):
+  - RNWorklets/apple (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2145,7 +2145,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.9.0):
+  - RNWorklets/common (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2512,7 +2512,7 @@ SPEC CHECKSUMS:
   RNReanimated: 6146a090a34494f27c3d502f498f2a4058f5ccfd
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41
   RNSVG: 04044c3abcf177fd674a1a3d13097efa1adebcbe
-  RNWorklets: 033c38ce2f645d186da51900c8f84cadcb01352c
+  RNWorklets: b8125e088703e97408e082f5b914bee4131a8a7a
   Yoga: 04bb4bfeb02c0000b940c1e6e89e856cd8de5a71
 
 PODFILE CHECKSUM: 5a5e231e2fd86b91c7e0a93852f5aa6de886161f

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -1860,7 +1860,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNWorklets (0.9.0):
+  - RNWorklets (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1882,10 +1882,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.9.0)
-    - RNWorklets/common (= 0.9.0)
+    - RNWorklets/apple (= 0.9.1)
+    - RNWorklets/common (= 0.9.1)
     - Yoga
-  - RNWorklets/apple (0.9.0):
+  - RNWorklets/apple (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1908,7 +1908,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.9.0):
+  - RNWorklets/common (0.9.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2242,7 +2242,7 @@ SPEC CHECKSUMS:
   ReactCommon: 52f9c5c30dda0eb591550d5d1adb265176e1ecc8
   ReactNativeDependencies: b07a5237fb5cae39dc2b5874f8fa4d839e400c94
   RNReanimated: d43550e6327af4f3abe18ccdc49014fe1e1acfe3
-  RNWorklets: 6dc8d984df078b6d7769e973a6f9f4f3ca62021d
+  RNWorklets: 341394f28aa7c8966ca9a341c2bdf1213e2c6bf1
   Yoga: 861ef0ae75949f7330bfa80d9ce24250e963f66c
 
 PODFILE CHECKSUM: 6134d19d5bd4674111735832712fd1901e6c7699

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-worklets",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The React Native multithreading library",
   "keywords": [
     "react-native",
@@ -59,7 +59,7 @@
     "@babel/core": "*",
     "@react-native/metro-config": "*",
     "react": "*",
-    "react-native": "0.81 - 0.85"
+    "react-native": "0.83 - 0.86"
   },
   "dependencies": {
     "@babel/plugin-transform-arrow-functions": "^7.27.1",

--- a/packages/react-native-worklets/src/debug/jsVersion.ts
+++ b/packages/react-native-worklets/src/debug/jsVersion.ts
@@ -5,4 +5,4 @@
  * version used to build the native part of the library in runtime. Remember to
  * keep this in sync with the version declared in `package.json`
  */
-export const jsVersion = '0.9.0';
+export const jsVersion = '0.9.1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -28653,7 +28653,7 @@ __metadata:
     "@babel/core": "*"
     "@react-native/metro-config": "*"
     react: "*"
-    react-native: 0.81 - 0.85
+    react-native: 0.83 - 0.86
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Releasing Worklets 0.9.1, 0.9.0 didn't have peerDependencies for React Native updated.

Build artifact CI: https://github.com/software-mansion/react-native-reanimated/actions/runs/26412815761
