### PR TITLE
refactor: Encapsulate runtime registration lock with RAII

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/NativeModules/JSIWorkletsModuleProxy.cpp
@@ -212,14 +212,12 @@ inline void registerCustomSerializable(
     const int typeId) {
   const SerializationData data{.determine = determine, .pack = pack, .unpack = unpack, .typeId = typeId};
   // Prevent registering new worklet runtimes while we are updating existing ones to prevent inconsistencies.
-  runtimeManager->pause();
-
-  memoryManager->registerCustomSerializable(data);
-  for (const auto &runtime : runtimeManager->getAllRuntimes()) {
-    memoryManager->loadCustomSerializable(runtime, data);
-  }
-
-  runtimeManager->resume();
+  runtimeManager->withRegistrationPaused([&] {
+    memoryManager->registerCustomSerializable(data);
+    for (const auto &runtime : runtimeManager->getAllRuntimes()) {
+      memoryManager->loadCustomSerializable(runtime, data);
+    }
+  });
 }
 
 } // namespace

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.cpp
@@ -83,12 +83,4 @@ void RuntimeManager::registerRuntime(const uint64_t runtimeId, const std::shared
   weakRuntimes_[runtimeId] = workletRuntime;
 }
 
-void RuntimeManager::pause() {
-  registrationMutex_.lock();
-}
-
-void RuntimeManager::resume() {
-  registrationMutex_.unlock();
-}
-
 } // namespace worklets

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -39,11 +39,9 @@ class RuntimeManager {
 
   std::shared_ptr<WorkletRuntime> createUninitializedUIRuntime(const std::shared_ptr<AsyncQueue> &uiAsyncQueue);
 
-  /** Runs `fn` while registration of new Worklet Runtimes is paused. */
-  template <typename F>
-  void withRegistrationPaused(F &&fn) {
+  void withRegistrationPaused(const std::function<void()> &fn) {
     std::unique_lock<std::mutex> lock(registrationMutex_);
-    std::forward<F>(fn)();
+    fn();
   }
 
  private:

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -39,9 +39,10 @@ class RuntimeManager {
 
   std::shared_ptr<WorkletRuntime> createUninitializedUIRuntime(const std::shared_ptr<AsyncQueue> &uiAsyncQueue);
 
-  void withRegistrationPaused(const std::function<void()> &fn) {
-    std::unique_lock<std::mutex> lock(registrationMutex_);
-    fn();
+  template <class Fn>
+  decltype(auto) withRegistrationPaused(Fn &&fn) {
+    std::unique_lock lock(registrationMutex_);
+    return std::forward<Fn>(fn)();
   }
 
  private:

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/RuntimeManager.h
@@ -9,8 +9,10 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace worklets {
@@ -37,11 +39,12 @@ class RuntimeManager {
 
   std::shared_ptr<WorkletRuntime> createUninitializedUIRuntime(const std::shared_ptr<AsyncQueue> &uiAsyncQueue);
 
-  /** Pauses registration of new Worklet Runtimes. */
-  void pause();
-
-  /** Resumes registration of new Worklet Runtimes. */
-  void resume();
+  /** Runs `fn` while registration of new Worklet Runtimes is paused. */
+  template <typename F>
+  void withRegistrationPaused(F &&fn) {
+    std::unique_lock<std::mutex> lock(registrationMutex_);
+    std::forward<F>(fn)();
+  }
 
  private:
   uint64_t getNextRuntimeId();


### PR DESCRIPTION
## Summary

The `registerCustomSerializable` helper paired manual `runtimeManager->pause()` / `runtimeManager->resume()` calls around a critical section. That pattern is easy to misuse — a missing `resume()`, an early return, or an exception between the two calls would leave the registration mutex permanently locked.

This PR replaces `pause()` / `resume()` with a single `withRegistrationPaused(fn)` template on `RuntimeManager` that holds a `std::unique_lock` over the registration mutex for the duration of the callable. The lock is fully encapsulated inside `RuntimeManager`, so callers can't accidentally drop or skip releasing it, and the critical section is now exception-safe.

## Test plan

- [ ] Build the fabric example app on iOS and Android.
- [ ] Register a custom serializable (e.g. via Reanimated's color / SharedValue paths) and confirm worklet runtimes still load it correctly.