### PR TITLE
fix: use optional chaining on Platform.OS to prevent crash in Bundle Mode

### DIFF
--- a/packages/react-native-reanimated/src/common/constants/platform.ts
+++ b/packages/react-native-reanimated/src/common/constants/platform.ts
@@ -10,12 +10,12 @@ function isWindowAvailable() {
 }
 
 export const IS_ANDROID: boolean = /* @__PURE__ */ (() =>
-  Platform.OS === 'android')();
-export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform.OS === 'ios')();
-export const IS_WEB: boolean = Platform.OS === 'web';
+  Platform?.OS === 'android')();
+export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform?.OS === 'ios')();
+export const IS_WEB: boolean = Platform?.OS === 'web';
 export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;
 /** @knipIgnore */
-export const IS_WINDOWS: boolean = Platform.OS === 'windows';
+export const IS_WINDOWS: boolean = Platform?.OS === 'windows';
 
 export const IS_WINDOW_AVAILABLE: boolean = isWindowAvailable();
 


### PR DESCRIPTION
## Summary

Fixes #9433

When `react-native-worklets` Bundle Mode is enabled, worklet modules are evaluated in a separate JS runtime where `react-native`'s `Platform` module is `undefined`. Reanimated's `platform.ts` accesses `Platform.OS` at module scope, causing a crash at startup:

```
TypeError: Cannot read property 'OS' of undefined
```

This happens because Bundle Mode extracts worklet code into standalone modules that get loaded in the worklets runtime. When those modules transitively import from `react-native-reanimated`, `platform.ts` is evaluated — but `Platform` doesn't exist in that context.

## Fix

Use optional chaining (`Platform?.OS`) so that when `Platform` is `undefined`, all comparisons safely evaluate to `false`. This is correct behavior since these constants (`IS_ANDROID`, `IS_IOS`, `IS_WEB`, `IS_WINDOWS`) gate UI-thread-only features that don't apply on the worklet thread.

## Changes

- `packages/react-native-reanimated/src/common/constants/platform.ts` — `Platform.OS` → `Platform?.OS` (4 occurrences)

## Reproduction

1. Set up Bundle Mode per [worklets docs](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup)
2. Any reanimated usage crashes on startup with the TypeError above

## Test plan

- [x] Verified fix in a production Expo SDK 56 app (RN 0.85.3, Reanimated 4.4.0, Worklets 0.9.1) with Bundle Mode enabled
- [x] All platform constants correctly resolve to `false` on worklet thread (no UI-thread features are gated incorrectly)
- [x] App runs normally on both iOS device and simulator with the fix applied