### PR TITLE
fix: Require `onStart` in `valueSetter` animation detection

### DIFF
--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -17,7 +17,8 @@ export function valueSetter<Value>(
     (value !== null &&
       typeof value === 'object' &&
       // TODO TYPESCRIPT fix this after fixing AnimationObject type
-      (value as unknown as AnimationObject).onFrame !== undefined)
+      (value as unknown as AnimationObject).onFrame !== undefined &&
+      (value as unknown as AnimationObject).onStart !== undefined)
   ) {
     const animation: AnimationObject<Value> =
       typeof value === 'function'


### PR DESCRIPTION
## Summary

`valueSetter` decides whether a value is an `AnimationObject` by checking a single property — `onFrame !== undefined`. Any non-null object that happens to have an `onFrame`-shaped property is then treated as an animation, and `animation.onStart(...)` is called unconditionally. When `onStart` is missing the call throws `TypeError: undefined is not a function`, surfacing in production traces as:

```
TypeError: undefined is not a function
    at initializeAnimation (valueSetter.ts:42)
    at valueSetter (valueSetter.ts:46)
    at set value (mutables.ts:60)
    ...
```

This PR tightens the check to require **both** `onFrame` and `onStart` to be defined before entering the animation branch. Real animation objects (`withTiming`, `withSpring`, `withDelay`, etc.) all define both, so behavior is unchanged for them — but plain objects that coincidentally expose an `onFrame` property now fall through to a regular `mutable._value = value` write instead of crashing.

Closes #8974

## Test plan

Drop the snippet below into `EmptyExample.tsx` and tap the button. On `main` it crashes with `TypeError: undefined is not a function` inside `initializeAnimation`. With this patch the button is a no-op (the value is stored normally).

```tsx
import React from 'react';
import { Button, StyleSheet, View } from 'react-native';
import { scheduleOnUI } from 'react-native-worklets';
import { useSharedValue } from 'react-native-reanimated';

export default function EmptyExample() {
  const sv = useSharedValue<unknown>(null);

  const crashViaHostObjectLikeProxy = () => {
    scheduleOnUI(() => {
      'worklet';
      // Mimics a permissive JSI HostObject: `onFrame` resolves to a non-undefined
      // value but `onStart` is undefined — exactly the shape that makes
      // valueSetter misclassify the value as an AnimationObject.
      const fakeHostObject = new Proxy(
        {},
        {
          get: (_target, prop) =>
            prop === 'onFrame' ? () => true : undefined,
        }
      );
      sv.value = fakeHostObject;
    });
  };

  return (
    <View style={styles.container}>
      <Button
        title="Crash via host-object-like Proxy"
        onPress={crashViaHostObjectLikeProxy}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 16,
  },
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)