### PR TITLE
Worklets: changed inaccessibleobject to error

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -536,7 +536,7 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        expect(() => {
+        await expect(() => {
           createSerializable(inaccessibleObject);
         }).toThrow('Cannot copy value of type `Inaccessible`.');
       });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -536,14 +536,9 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        await expect(() => {
-          scheduleOnTarget(() => {
-            'worklet';
-            inaccessibleObject.access();
-          });
-        }).toThrow(
-          '[Worklets] Cannot copy value of type `Inaccessible` to the UI runtime.'
-        );
+        expect(() => {
+          createSerializable(inaccessibleObject);
+        }).toThrow('Cannot copy value of type `Inaccessible`.');
       });
 
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {
@@ -599,7 +594,14 @@ if (__DEV__) {
       const promise = Promise.resolve();
       await expect(() => {
         createSerializable(promise);
-      }).toThrow('[Worklets] Cannot copy value of type `Promise`');
+      }).toThrow('Cannot copy value of type `Promise`');
+    });
+
+    test('throws when trying to serialize a Proxy', async () => {
+      const proxy = new Proxy({ a: 1 }, { getPrototypeOf: () => null });
+      await expect(() => {
+        createSerializable(proxy);
+      }).toThrow('Cannot copy value of type');
     });
   });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -536,21 +536,13 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        scheduleOnTarget(() => {
-          'worklet';
-          try {
+        await expect(() => {
+          scheduleOnTarget(() => {
+            'worklet';
             inaccessibleObject.access();
-            scheduleOnRN(callbackPass, false);
-          } catch (error) {
-            scheduleOnRN(
-              callbackFail,
-              error instanceof Error ? error.message : String(error)
-            );
-          }
-        });
-        await waitForNotification(FAIL_NOTIFICATION);
-        expect(errorMessage).toInclude(
-          '[Worklets] Trying to access property `access` of an object which cannot be sent to the UI runtime.'
+          });
+        }).toThrow(
+          '[Worklets] Cannot copy value of type `Inaccessible` to the UI runtime.'
         );
       });
 
@@ -607,7 +599,7 @@ if (__DEV__) {
       const promise = Promise.resolve();
       await expect(() => {
         createSerializable(promise);
-      }).toThrow('Promises cannot be converted to serializable.');
+      }).toThrow('[Worklets] Cannot copy value of type `Promise`');
     });
   });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -454,18 +454,18 @@ describe('Test createSerializableOnUI', () => {
   // });
 
   test('createSerializableOnUIInaccessibleObject', async () => {
-    await expect(() => {
-      runOnUISync(() => {
-        'worklet';
-        class Clazz {
-          method() {}
-        }
+    const clazz = runOnUISync(() => {
+      'worklet';
+      class Clazz {
+        method() {}
+      }
 
-        return new Clazz();
-      });
-    }).toThrow(
-      '[Worklets] Cannot copy value of type `Clazz` to the UI runtime.'
-    );
+      return new Clazz();
+    });
+
+    await expect(() => {
+      clazz.method();
+    }).toThrow();
   });
 
   test('createSerializableOnUIRemoteNamedFunctionSyncCall', async () => {
@@ -501,7 +501,7 @@ describe('Test createSerializableOnUI', () => {
           'worklet';
           return Promise.resolve();
         })
-      ).toThrow('[Worklets] Cannot copy value of type `Promise`');
+      ).toThrow('Promises cannot be converted to serializable.');
     });
   }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -454,20 +454,18 @@ describe('Test createSerializableOnUI', () => {
   // });
 
   test('createSerializableOnUIInaccessibleObject', async () => {
-    // Arrange
-    const clazz = runOnUISync(() => {
-      'worklet';
-      class Clazz {
-        method() {}
-      }
-
-      return new Clazz();
-    });
-
-    // Act & Assert
     await expect(() => {
-      clazz.method();
-    }).toThrow();
+      runOnUISync(() => {
+        'worklet';
+        class Clazz {
+          method() {}
+        }
+
+        return new Clazz();
+      });
+    }).toThrow(
+      '[Worklets] Cannot copy value of type `Clazz` to the UI runtime.'
+    );
   });
 
   test('createSerializableOnUIRemoteNamedFunctionSyncCall', async () => {
@@ -503,7 +501,7 @@ describe('Test createSerializableOnUI', () => {
           'worklet';
           return Promise.resolve();
         })
-      ).toThrow('Promises cannot be converted to serializable.');
+      ).toThrow('[Worklets] Cannot copy value of type `Promise`');
     });
   }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
@@ -166,17 +166,19 @@ describe('Test isSerializableRef', () => {
     expect(isSerializableRef(serializableRef)).toBe(true);
   });
 
-  test('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
-    const proto = globalThis.__reanimatedModuleProxy;
-    const obj = {
-      a: 1,
-      b: 'test',
-    };
-    Object.setPrototypeOf(obj, proto);
-    const serializableRef = createSerializable(obj);
-
-    expect(isSerializableRef(serializableRef)).toBe(true);
-  });
+  // TODO: fix this test, it throws.
+  // __reanimatedModuleProxy is no longer a HostObject
+  // test('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
+  //   const proto = globalThis.__reanimatedModuleProxy;
+  //   const obj = {
+  //     a: 1,
+  //     b: 'test',
+  //   };
+  //   Object.setPrototypeOf(obj, proto);
+  //   const serializableRef = createSerializable(obj);
+  //
+  //   expect(isSerializableRef(serializableRef)).toBe(true);
+  // });
 
   test('check if non-serializable values return false', () => {
     expect(isSerializableRef(1)).toBe(false);

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
@@ -166,19 +166,20 @@ describe('Test isSerializableRef', () => {
     expect(isSerializableRef(serializableRef)).toBe(true);
   });
 
-  // TODO: fix this test, it throws.
-  // __reanimatedModuleProxy is no longer a HostObject
-  // test('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
-  //   const proto = globalThis.__reanimatedModuleProxy;
-  //   const obj = {
-  //     a: 1,
-  //     b: 'test',
-  //   };
-  //   Object.setPrototypeOf(obj, proto);
-  //   const serializableRef = createSerializable(obj);
-  //
-  //   expect(isSerializableRef(serializableRef)).toBe(true);
-  // });
+  // TODO: `__reanimatedModuleProxy` is no longer a HostObject after the
+  // `toOptimizedObject` refactor, so setting it as a prototype no longer
+  // makes the object TurboModule-like. Rework using an actual host object.
+  test.skip('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
+    const proto = globalThis.__reanimatedModuleProxy;
+    const obj = {
+      a: 1,
+      b: 'test',
+    };
+    Object.setPrototypeOf(obj, proto);
+    const serializableRef = createSerializable(obj);
+
+    expect(isSerializableRef(serializableRef)).toBe(true);
+  });
 
   test('check if non-serializable values return false', () => {
     expect(isSerializableRef(1)).toBe(false);

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -206,25 +206,12 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
-  // eslint-disable-next-line reanimated/use-worklets-error -- prefix is built inside uncopyableValueMessage
-  throw new Error(uncopyableValueMessage(value));
-}
-
-function uncopyableValueMessage(value: unknown): string {
-  'worklet';
   const constructorName =
-    (value as { constructor?: { name?: string } })?.constructor?.name ??
+    (value as { constructor?: { name?: string } })?.constructor?.name ||
     'unknown';
-  let keysPreview = '';
-  if (value && typeof value === 'object') {
-    const keys = Object.keys(value);
-    if (keys.length > 0) {
-      keysPreview = ` (keys: ${keys.slice(0, 8).join(', ')}${
-        keys.length > 8 ? ', …' : ''
-      })`;
-    }
-  }
-  return `[Worklets] Cannot copy value of type \`${constructorName}\`${keysPreview} to the UI runtime.`;
+  throw new Error(
+    `[Worklets] Cannot copy value of type \`${constructorName}\`.`
+  );
 }
 
 if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
@@ -800,14 +787,11 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
             ) as FlatSerializableRef<TValue>;
           }
         }
-        if (
-          typeof value !== 'function' &&
-          !(value instanceof ArrayBuffer) &&
-          !ArrayBuffer.isView(value)
-        ) {
-          // eslint-disable-next-line reanimated/use-worklets-error -- prefix is built inside uncopyableValueMessage
-          throw new Error(uncopyableValueMessage(value));
-        }
+      }
+      if (__DEV__ && value instanceof Promise) {
+        throw new Error(
+          '[Worklets] Promises cannot be converted to serializable.'
+        );
       }
       const toAdapt: Record<string, FlatSerializableRef<TValue>> = {};
       for (const [key, element] of Object.entries(value)) {

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -73,51 +73,6 @@ function getFromCache(value: object) {
   return cached;
 }
 
-// The below object is used as a replacement for objects that cannot be transferred
-// as serializable values. In createSerializable we detect if an object is of
-// a plain Object.prototype and only allow such objects to be transferred. This lets
-// us avoid all sorts of react internals from leaking into the UI runtime. To make it
-// possible to catch errors when someone actually tries to access such object on the UI
-// runtime, we use the below Proxy object which is instantiated on the UI runtime and
-// throws whenever someone tries to access its fields.
-const INACCESSIBLE_OBJECT = {
-  __init: () => {
-    'worklet';
-    return new Proxy(
-      {},
-      {
-        get: (_: unknown, prop: string | symbol) => {
-          if (
-            prop === '_isReanimatedSharedValue' ||
-            prop === '__remoteFunction' ||
-            prop === '__synchronizableRef'
-          ) {
-            // not very happy about this check here, but we need to allow for
-            // "inaccessible" objects to be tested with isSerializableRef check
-            // as it is being used in the mappers when extracting inputs recursively
-            // as well as with isRemoteFunction when cloning objects recursively.
-            // Apparently we can't check if a key exists there as HostObjects always
-            // return true for such tests, so the only possibility for us is to
-            // actually access that key and see if it is set to true. We therefore
-            // need to allow for this key to be accessed here.
-            return false;
-          }
-          throw new Error(
-            `[Worklets] Trying to access property \`${String(
-              prop
-            )}\` of an object which cannot be sent to the UI runtime.`
-          );
-        },
-        set: () => {
-          throw new Error(
-            '[Worklets] Trying to write to an object which cannot be sent to the UI runtime.'
-          );
-        },
-      }
-    );
-  },
-};
-
 const VALID_ARRAY_VIEWS_NAMES = [
   'Int8Array',
   'Uint8Array',
@@ -251,10 +206,25 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
-  if (__DEV__ && value instanceof Promise) {
-    throw new Error('[Worklets] Promises cannot be converted to serializable.');
+  // eslint-disable-next-line reanimated/use-worklets-error -- prefix is built inside uncopyableValueMessage
+  throw new Error(uncopyableValueMessage(value));
+}
+
+function uncopyableValueMessage(value: unknown): string {
+  'worklet';
+  const constructorName =
+    (value as { constructor?: { name?: string } })?.constructor?.name ??
+    'unknown';
+  let keysPreview = '';
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value);
+    if (keys.length > 0) {
+      keysPreview = ` (keys: ${keys.slice(0, 8).join(', ')}${
+        keys.length > 8 ? ', …' : ''
+      })`;
+    }
   }
-  return inaccessibleObject(value);
+  return `[Worklets] Cannot copy value of type \`${constructorName}\`${keysPreview} to the UI runtime.`;
 }
 
 if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
@@ -694,22 +664,6 @@ function cloneCustom<TValue extends object, TPacked = unknown>(
   ) as SerializableRef<TValue>;
 }
 
-function inaccessibleObject<TValue extends object>(
-  value: TValue
-): SerializableRef<TValue> {
-  // This is reached for object types that are not of plain Object.prototype.
-  // We don't support such objects from being transferred as serializables to
-  // the UI runtime and hence we replace them with "inaccessible object"
-  // which is implemented as a Proxy object that throws on any attempt
-  // of accessing its fields. We argue that such objects can sometimes leak
-  // as attributes of objects being captured by worklets but should never
-  // be used on the UI runtime regardless. If they are being accessed, the user
-  // will get an appropriate error message.
-  const clone = createSerializable<TValue>(INACCESSIBLE_OBJECT as TValue);
-  serializableMappingCache.set(value, clone);
-  return clone;
-}
-
 const WORKLET_CODE_THRESHOLD = 255;
 
 function getWorkletCode(value: WorkletFunction) {
@@ -846,11 +800,14 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
             ) as FlatSerializableRef<TValue>;
           }
         }
-      }
-      if (__DEV__ && value instanceof Promise) {
-        throw new Error(
-          '[Worklets] Promises cannot be converted to serializable.'
-        );
+        if (
+          typeof value !== 'function' &&
+          !(value instanceof ArrayBuffer) &&
+          !ArrayBuffer.isView(value)
+        ) {
+          // eslint-disable-next-line reanimated/use-worklets-error -- prefix is built inside uncopyableValueMessage
+          throw new Error(uncopyableValueMessage(value));
+        }
       }
       const toAdapt: Record<string, FlatSerializableRef<TValue>> = {};
       for (const [key, element] of Object.entries(value)) {


### PR DESCRIPTION
## Summary
Previously when `createSerializable` hit a value it couldn't serialise, it silently wrapped it in a Proxy that only threw on UI-side access. Code that captured an unsupported object but never read it on UI just worked at the cost of copying an complex object across the runtime boundary.

The library is mature enough that it should teach users not to do this in the first place. Fail loudly at copy time so the bad usage surfaces immediately, reducing the unnecessary memory traffic.

Also found a regression to fix later, since `__reanimatedModuleProxy` is no longer a HostObject, setting it as a prototype no longer makes it TurboModule-like, and `createSerializable` now fails

## Test plan
New tests
