### PR TITLE
chore: disabled macos builds in CI pipeline

### DIFF
--- a/.github/workflows/check-ruby-pods-versions.yml
+++ b/.github/workflows/check-ruby-pods-versions.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        working-directory: [fabric-example, macos-example, tvos-example]
+        # TODO: bring back macos-example once they update to RN 0.83
+        working-directory: [fabric-example, tvos-example]
     concurrency:
       group: ruby-pods-version-check-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/example-macos-build-check.yml
+++ b/.github/workflows/example-macos-build-check.yml
@@ -1,52 +1,55 @@
-name: Example macOS build check
-env:
-  YARN_ENABLE_HARDENED_MODE: 0
-on:
-  pull_request:
-    paths:
-      - .github/workflows/example-macos-build-check.yml
-  schedule:
-    - cron: '37 19 * * *'
-  workflow_call:
-  workflow_dispatch:
-
-jobs:
-  example-macos-build-check:
-    if: github.repository == 'software-mansion/react-native-reanimated'
-    runs-on: macos-26
-    env:
-      WORKING_DIRECTORY: apps/macos-example
-      REANIMATED_DIR: packages/react-native-reanimated
-    concurrency:
-      group: macos-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
-        with:
-          ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - name: Install monorepo node dependencies
-        run: yarn install --immutable
-      - name: Build Reanimated package
-        working-directory: ${{ env.REANIMATED_DIR }}
-        run: yarn build
-
-      - name: Install Pods (with caching)
-        uses: ./.github/actions/install-pods
-        with:
-          working-directory: ${{ env.WORKING_DIRECTORY }}
-          pod-directory: macos
-
-      - name: Cache DerivedData
-        uses: ./.github/actions/cache-derived-data
-        with:
-          platform: macos
-          working-directory: ${{ env.WORKING_DIRECTORY }}
-          pod-directory: macos
-
-      - name: Build app
-        working-directory: ${{ env.WORKING_DIRECTORY }}/macos
-        run: xcodebuild -workspace MacOSExample.xcworkspace -configuration Debug -scheme "Debug MacOSExample" -destination "generic/platform=macOS" -quiet
+# disabled: react-native-macos has not been
+# updated for React Native 0.83
+#
+# name: Example macOS build check
+# env:
+#   YARN_ENABLE_HARDENED_MODE: 0
+# on:
+#   pull_request:
+#     paths:
+#       - .github/workflows/example-macos-build-check.yml
+#   schedule:
+#     - cron: '37 19 * * *'
+#   workflow_call:
+#   workflow_dispatch:
+#
+# jobs:
+#   example-macos-build-check:
+#     if: github.repository == 'software-mansion/react-native-reanimated'
+#     runs-on: macos-26
+#     env:
+#       WORKING_DIRECTORY: apps/macos-example
+#       REANIMATED_DIR: packages/react-native-reanimated
+#     concurrency:
+#       group: macos-${{ github.ref }}
+#       cancel-in-progress: true
+#     steps:
+#       - name: Check out Git repository
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+#       - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
+#         with:
+#           ruby-version: '3.3' # Not needed with a `.ruby-version` or `.tool-versions`
+#           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+#
+#       - name: Install monorepo node dependencies
+#         run: yarn install --immutable
+#       - name: Build Reanimated package
+#         working-directory: ${{ env.REANIMATED_DIR }}
+#         run: yarn build
+#
+#       - name: Install Pods (with caching)
+#         uses: ./.github/actions/install-pods
+#         with:
+#           working-directory: ${{ env.WORKING_DIRECTORY }}
+#           pod-directory: macos
+#
+#       - name: Cache DerivedData
+#         uses: ./.github/actions/cache-derived-data
+#         with:
+#           platform: macos
+#           working-directory: ${{ env.WORKING_DIRECTORY }}
+#           pod-directory: macos
+#
+#       - name: Build app
+#         working-directory: ${{ env.WORKING_DIRECTORY }}/macos
+#         run: xcodebuild -workspace MacOSExample.xcworkspace -configuration Debug -scheme "Debug MacOSExample" -destination "generic/platform=macOS" -quiet


### PR DESCRIPTION
## Summary
react-native-macos does not support RN 0.83
its builds fail, and we can't even support yet, so I disabled it

See:
https://www.npmjs.com/package/react-native-macos?activeTab=versions

## Test plan
No macos builds in CI
