### PR TITLE
fix: `moduleSuffixes` placement in web tsconfigs

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/native/configs/pattern.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/configs/pattern.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import type { PatternProps } from 'react-native-svg';
-
 // TODO: Fix me
 // @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
+import type { PatternProps } from 'react-native-svg';
+
 import type { SvgStyleBuilderConfig } from './common';
 
 // TODO: Fix me

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -13,7 +13,7 @@ export default class CSSManager implements ICSSManager {
   private readonly animationsManager: CSSAnimationsManager;
   private readonly transitionsManager: CSSTransitionsManager;
 
-  constructor(viewInfo: ViewInfo) {
+  constructor(viewInfo: ViewInfo, _componentDisplayName = '') {
     this.element = viewInfo.DOMElement as ReanimatedHTMLElement;
 
     this.animationsManager = new CSSAnimationsManager(this.element);

--- a/packages/react-native-reanimated/tsconfig.web.json
+++ b/packages/react-native-reanimated/tsconfig.web.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.native.json",
   "compilerOptions": {
-    "paths": {
-      "moduleSuffixes": [".web.test", ".web", ""]
-    }
+    "moduleSuffixes": [".web.test", ".web", ""]
   },
   "exclude": [
     "**/*.native.ts",

--- a/packages/react-native-worklets/tsconfig.web.json
+++ b/packages/react-native-worklets/tsconfig.web.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.native.json",
   "compilerOptions": {
-    "paths": {
-      "moduleSuffixes": [".web", ""]
-    }
+    "moduleSuffixes": [".web", ""]
   },
   "exclude": [
     "**/*.native.ts",


### PR DESCRIPTION
## Summary

This PR fixes an incorrect placement of the `moduleSuffixes` field in web tsconfig files (see: https://www.typescriptlang.org/tsconfig/#moduleSuffixes). It also makes necessary changes to ensure typecheck passes (we need to align types of the CSSManager between platforms).

## Test plan

Minimal repro of the underlying issue:

```sh
mkdir -p /tmp/_msfx/src && cd /tmp/_msfx
echo 'export const VALUE: number = 42;'           > src/foo.ts
echo "export const VALUE: string = 'forty-two';"  > src/foo.web.ts
echo "import { VALUE } from './foo'; const x: number = VALUE; export default x;" > src/consumer.ts
cat > tsconfig.base.json <<'EOT'
{ "compilerOptions": { "noEmit": true, "strict": true, "module": "esnext", "moduleResolution": "bundler", "baseUrl": "." } }
EOT
cat > tsconfig.broken.json <<'EOT'
{ "extends": "./tsconfig.base.json", "compilerOptions": { "paths": { "moduleSuffixes": [".web", ""] } }, "include": ["src"] }
EOT
cat > tsconfig.fixed.json <<'EOT'
{ "extends": "./tsconfig.base.json", "compilerOptions": { "moduleSuffixes": [".web", ""] }, "include": ["src"] }
EOT
npx -y typescript -p tsconfig.broken.json; echo "broken exit $?"
npx -y typescript -p tsconfig.fixed.json;  echo "fixed exit $?"
```

Expected: broken exits 0, fixed exits 2 with `Type 'string' is not assignable to type 'number'`.
