### PR TITLE
chore: Remove `AnyRecord` type from the library

### DIFF
--- a/packages/react-native-reanimated/src/common/style/types.ts
+++ b/packages/react-native-reanimated/src/common/style/types.ts
@@ -1,12 +1,12 @@
 'use strict';
-import type { AnyRecord, ConfigPropertyAlias, ValueProcessor } from '../types';
+import type { ConfigPropertyAlias, ValueProcessor } from '../types';
 
-type PropertyValueConfigBase<P extends AnyRecord> =
+type PropertyValueConfigBase<P extends object> =
   | boolean // true - included, false - excluded
   | ConfigPropertyAlias<P>; // alias for another property
 
 type PropsBuilderPropertyConfig<
-  P extends AnyRecord,
+  P extends object,
   K extends keyof P = keyof P,
 > =
   | PropertyValueConfigBase<P>
@@ -18,6 +18,6 @@ type PropsBuilderPropertyConfig<
       process: ValueProcessor<Required<P>[K], any>; // for custom value processing
     };
 
-export type PropsBuilderConfig<P extends AnyRecord = AnyRecord> = {
+export type PropsBuilderConfig<P extends object> = {
   [K in keyof Required<P>]: PropsBuilderPropertyConfig<P, K>;
 };

--- a/packages/react-native-reanimated/src/common/types/config.ts
+++ b/packages/react-native-reanimated/src/common/types/config.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { AnyRecord, NonMutable } from './helpers';
+import type { NonMutable } from './helpers';
 
 export enum ValueProcessorTarget {
   CSS = 'css',
@@ -16,6 +16,6 @@ export type ValueProcessor<V = unknown, R = V> = (
   context?: ValueProcessorContext
 ) => R | Record<string, R>;
 
-export type ConfigPropertyAlias<P extends AnyRecord> = {
+export type ConfigPropertyAlias<P extends object> = {
   as: keyof P;
 };

--- a/packages/react-native-reanimated/src/common/types/helpers.ts
+++ b/packages/react-native-reanimated/src/common/types/helpers.ts
@@ -11,8 +11,6 @@ export type Maybe<T> = T | null | undefined;
  */
 export type NonMutable<T> = T extends object ? Readonly<T> : T;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyRecord = Record<string, any>;
 export type UnknownRecord = Record<string, unknown>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-native-reanimated/src/common/utils/conversions.ts
+++ b/packages/react-native-reanimated/src/common/utils/conversions.ts
@@ -1,11 +1,11 @@
 'use strict';
-import type { AnyRecord, ConvertValuesToArrays } from '../types';
+import type { ConvertValuesToArrays } from '../types';
 
 export function convertPropertyToArray<T>(value: T | undefined): T[] {
   return value !== undefined ? (Array.isArray(value) ? value : [value]) : [];
 }
 
-export function convertPropertiesToArrays<T extends AnyRecord>(config: T) {
+export function convertPropertiesToArrays<T extends object>(config: T) {
   return Object.fromEntries(
     Object.entries(config).map(([key, value]) => [
       key,

--- a/packages/react-native-reanimated/src/common/utils/guards.ts
+++ b/packages/react-native-reanimated/src/common/utils/guards.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { AnyRecord, ConfigPropertyAlias, UnknownRecord } from '../types';
+import type { ConfigPropertyAlias, UnknownRecord } from '../types';
 
 export const isDefined = <T>(value: T): value is NonNullable<T> =>
   value !== undefined && value !== null;
@@ -38,7 +38,7 @@ export const isRecord = <T extends UnknownRecord = UnknownRecord>(
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
-export const isConfigPropertyAlias = <P extends AnyRecord>(
+export const isConfigPropertyAlias = <P extends object>(
   value: unknown
 ): value is ConfigPropertyAlias<P> =>
   !!value &&

--- a/packages/react-native-reanimated/src/common/web/style/types.ts
+++ b/packages/react-native-reanimated/src/common/web/style/types.ts
@@ -1,40 +1,39 @@
 'use strict';
-import type { AnyRecord, Maybe, NonMutable, UnknownRecord } from '../..';
+import type { Maybe, NonMutable, UnknownRecord } from '../..';
 
 export type ValueProcessor<V = unknown> = (
   value: NonMutable<V>
 ) => Maybe<string> | Record<string, string>;
 
-type ProcessedProps<P extends AnyRecord> = {
+type ProcessedProps<P extends object> = {
   [K in keyof P]: string;
 };
 
-export type RuleBuildHandler<
-  P extends AnyRecord,
-  R = Record<string, string>,
-> = (props: ProcessedProps<P>) => R;
+export type RuleBuildHandler<P extends object, R = Record<string, string>> = (
+  props: ProcessedProps<P>
+) => R;
 
-type BuilderBase<P extends AnyRecord, R = Record<string, string>> = {
+type BuilderBase<P extends object, R = Record<string, string>> = {
   add(property: keyof P, value: P[keyof P]): void;
   build(): R;
 };
 
 export type RuleBuilder<
-  P extends AnyRecord,
+  P extends object,
   R = Record<string, string>,
 > = BuilderBase<P, R>;
 
-type PropertyAlias<P extends AnyRecord> = {
+type PropertyAlias<P extends object> = {
   as: keyof P;
 };
 
-type PropertyValueConfigBase<P extends AnyRecord> =
+type PropertyValueConfigBase<P extends object> =
   | boolean // true - included, false - excluded
   | string // suffix
   | PropertyAlias<P>; // alias for another property
 
 type PropsBuilderPropertyConfig<
-  P extends AnyRecord,
+  P extends object,
   K extends keyof P = keyof P,
 > =
   | PropertyValueConfigBase<P>
@@ -45,20 +44,17 @@ type PropsBuilderPropertyConfig<
       name?: string; // for custom property name
     };
 
-type RuleBuilderPropertyConfig<
-  P extends AnyRecord,
-  K extends keyof P = keyof P,
-> =
+type RuleBuilderPropertyConfig<P extends object, K extends keyof P = keyof P> =
   | PropertyValueConfigBase<P>
   | {
       process?: ValueProcessor<NonNullable<P[K]>>; // for custom value processing
       name?: string; // for custom property name
     };
 
-export type PropsBuilderConfig<P extends AnyRecord> = {
+export type PropsBuilderConfig<P extends object> = {
   [K in keyof P]: PropsBuilderPropertyConfig<P, K>;
 };
 
-export type RuleBuilderConfig<P extends AnyRecord> = {
+export type RuleBuilderConfig<P extends object> = {
   [K in keyof P]: RuleBuilderPropertyConfig<P, K>;
 };

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -11,7 +11,7 @@ import type {
 } from 'react-native';
 import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 
-import type { AnyRecord, Maybe } from './common';
+import type { Maybe } from './common';
 import type { CSSAnimationProperties, CSSTransitionProperties } from './css';
 import type { EasingFunctionFactory } from './Easing';
 import type { AnimatedStyleHandle, DefaultStyle } from './hook/commonTypes';
@@ -507,7 +507,8 @@ export type InternalHostInstance = Partial<
     >;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getScrollableNode: () => any;
-    __internalInstanceHandle: AnyRecord;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    __internalInstanceHandle: Record<string, any>;
   }
 >;
 

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -507,8 +507,7 @@ export type InternalHostInstance = Partial<
     >;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getScrollableNode: () => any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    __internalInstanceHandle: Record<string, any>;
+    __internalInstanceHandle: Record<string, unknown>;
   }
 >;
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -8,7 +8,6 @@ import type {
 } from 'react';
 import type { FlatList, FlatListProps } from 'react-native';
 
-import type { AnyRecord } from '../common';
 import type { InstanceOrElement } from '../commonTypes';
 import type { AnimatedProps } from '../helperTypes';
 import type { AnimatedRef } from '../hook';
@@ -28,7 +27,7 @@ type AnimatedComponentRef<TInstance> =
   | AnimatedRef;
 
 export type AnimatedComponentType<
-  Props extends AnyRecord = object,
+  Props extends object = object,
   Instance = unknown,
 > = (
   props: Omit<AnimatedProps<Props>, 'ref'> & {

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -32,8 +32,7 @@ export type AnimatedComponentProps = UnknownRecord & {
 // private/protected ones when possible (when changes from this repo are merged
 // to the main one)
 export default class AnimatedComponent<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  P extends Record<string, any> = AnimatedComponentProps,
+  P extends UnknownRecord = AnimatedComponentProps,
   S extends object = UnknownRecord,
 >
   extends Component<P, S>
@@ -110,7 +109,13 @@ export default class AnimatedComponent<
   }
 
   _setComponentRef = (ref: Component | HTMLElement) => {
-    const forwardedRef = this.props.forwardedRef;
+    // `forwardedRef` is injected dynamically by the createAnimatedComponent
+    // wrapper and isn't declared on every subclass' props, so we read it
+    // through a narrow cast rather than via the generic constraint.
+    const forwardedRef = this.props.forwardedRef as
+      | ((ref: Component | HTMLElement) => void)
+      | { current: Component | HTMLElement | null }
+      | undefined;
     // Forward to user ref prop (if one has been specified)
     if (typeof forwardedRef === 'function') {
       // Handle function-based refs. String-based refs are handled as functions.
@@ -152,7 +157,8 @@ export default class AnimatedComponent<
   };
 
   _updateStyles(props: P) {
-    this._cssStyle = StyleSheet.flatten(props.style) ?? {};
+    this._cssStyle =
+      StyleSheet.flatten(props.style as StyleProp<CSSStyle>) ?? {};
   }
 
   componentDidMount() {
@@ -219,7 +225,9 @@ export default class AnimatedComponent<
       <ChildComponent
         {...(props ?? this.props)}
         {...platformProps}
-        style={filterNonCSSStyleProps(props?.style ?? this.props.style)}
+        style={filterNonCSSStyleProps(
+          (props?.style ?? this.props.style) as StyleProp<CSSStyle>
+        )}
         // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
         // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
         ref={this._setComponentRef as (ref: Component) => void}

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -110,7 +110,8 @@ export default class AnimatedComponent<
 
   _setComponentRef = (ref: Component | HTMLElement) => {
     // `forwardedRef` is injected dynamically by the createAnimatedComponent
-    // wrapper and isn't declared on every subclass' props, so we read it
+    // wrapper and isn't declared on `AnimatedComponentProps` (it can be any
+    // ref shape — function, RefObject, or `AnimatedRef`), so we read it
     // through a narrow cast rather than via the generic constraint.
     const forwardedRef = this.props.forwardedRef as
       | ((ref: Component | HTMLElement) => void)
@@ -157,6 +158,11 @@ export default class AnimatedComponent<
   };
 
   _updateStyles(props: P) {
+    // `props.style` is `unknown` because `P` is generic and subclasses pass
+    // incompatible prop shapes (the legacy `AnimatedComponent` uses
+    // `NestedArray<StyleProps>` here, with an `overflow: 'scroll'` value not
+    // present in `PlainStyle`). Cast to `StyleProp<CSSStyle>` — the widest
+    // shape `flatten` consumes — at the call site.
     this._cssStyle =
       StyleSheet.flatten(props.style as StyleProp<CSSStyle>) ?? {};
   }

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -4,7 +4,7 @@ import { Component } from 'react';
 import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 
-import type { AnyComponent, AnyRecord, PlainStyle } from '../../common';
+import type { AnyComponent, PlainStyle } from '../../common';
 import { IS_JEST, SHOULD_BE_USE_WEB } from '../../common';
 import type {
   InternalHostInstance,
@@ -32,8 +32,9 @@ export type AnimatedComponentProps = Record<string, unknown> & {
 // private/protected ones when possible (when changes from this repo are merged
 // to the main one)
 export default class AnimatedComponent<
-  P extends AnyRecord = AnimatedComponentProps,
-  S extends AnyRecord = Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  P extends Record<string, any> = AnimatedComponentProps,
+  S extends object = Record<string, unknown>,
 >
   extends Component<P, S>
   implements IAnimatedComponentInternalBase

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -109,10 +109,6 @@ export default class AnimatedComponent<
   }
 
   _setComponentRef = (ref: Component | HTMLElement) => {
-    // `forwardedRef` is injected dynamically by the createAnimatedComponent
-    // wrapper and isn't declared on `AnimatedComponentProps` (it can be any
-    // ref shape — function, RefObject, or `AnimatedRef`), so we read it
-    // through a narrow cast rather than via the generic constraint.
     const forwardedRef = this.props.forwardedRef as
       | ((ref: Component | HTMLElement) => void)
       | { current: Component | HTMLElement | null }
@@ -158,11 +154,6 @@ export default class AnimatedComponent<
   };
 
   _updateStyles(props: P) {
-    // `props.style` is `unknown` because `P` is generic and subclasses pass
-    // incompatible prop shapes (the legacy `AnimatedComponent` uses
-    // `NestedArray<StyleProps>` here, with an `overflow: 'scroll'` value not
-    // present in `PlainStyle`). Cast to `StyleProp<CSSStyle>` — the widest
-    // shape `flatten` consumes — at the call site.
     this._cssStyle =
       StyleSheet.flatten(props.style as StyleProp<CSSStyle>) ?? {};
   }

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -4,7 +4,7 @@ import { Component } from 'react';
 import type { StyleProp } from 'react-native';
 import { Platform, StyleSheet } from 'react-native';
 
-import type { AnyComponent, PlainStyle } from '../../common';
+import type { AnyComponent, PlainStyle, UnknownRecord } from '../../common';
 import { IS_JEST, SHOULD_BE_USE_WEB } from '../../common';
 import type {
   InternalHostInstance,
@@ -23,7 +23,7 @@ import { CSSManager } from '../platform';
 import type { CSSStyle } from '../types';
 import { filterNonCSSStyleProps } from './utils';
 
-export type AnimatedComponentProps = Record<string, unknown> & {
+export type AnimatedComponentProps = UnknownRecord & {
   ref?: Ref<Component>;
   style?: StyleProp<PlainStyle>;
 };
@@ -34,7 +34,7 @@ export type AnimatedComponentProps = Record<string, unknown> & {
 export default class AnimatedComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   P extends Record<string, any> = AnimatedComponentProps,
-  S extends object = Record<string, unknown>,
+  S extends object = UnknownRecord,
 >
   extends Component<P, S>
   implements IAnimatedComponentInternalBase

--- a/packages/react-native-reanimated/src/css/component/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/createAnimatedComponent.tsx
@@ -3,7 +3,6 @@ import type { ComponentRef, ComponentType, ReactNode, Ref } from 'react';
 import type React from 'react';
 import type { FlatList, FlatListProps } from 'react-native';
 
-import type { AnyRecord } from '../../common';
 import type { InitialComponentProps } from '../../createAnimatedComponent/commonTypes';
 import type { AnimatedProps } from '../../helperTypes';
 import type { AnimatedRef } from '../../hook';
@@ -12,7 +11,7 @@ import type { AnimatedComponentProps } from './AnimatedComponent';
 import AnimatedComponentImpl from './AnimatedComponent';
 
 type AnimatedComponentType<
-  Props extends AnyRecord = object,
+  Props extends object = object,
   Instance = unknown,
 > = (
   props: Omit<CSSProps<Props>, 'ref'> & {

--- a/packages/react-native-reanimated/src/css/component/utils.ts
+++ b/packages/react-native-reanimated/src/css/component/utils.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { StyleProp } from 'react-native';
 
-import type { AnyRecord } from '../../common';
+import type { UnknownRecord } from '../../common';
 import type { CSSStyle } from '../types';
 import { isCSSStyleProp } from '../utils/guards';
 
@@ -19,7 +19,7 @@ function filterNonCSSStylePropsRecursive(
   }
 
   if (typeof props === 'object') {
-    return Object.entries(props).reduce<AnyRecord>((acc, [key, value]) => {
+    return Object.entries(props).reduce<UnknownRecord>((acc, [key, value]) => {
       if (!isCSSStyleProp(key)) {
         acc[key] = value;
       }

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
@@ -109,8 +109,7 @@ export function processKeyframes(
 function processProps(
   offset: number,
   props: object,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  keyframeProps: Record<string, any>,
+  keyframeProps: UnknownRecord,
   separatelyInterpolatedNestedProperties: ReadonlySet<string>
 ) {
   Object.entries(props).forEach(([property, value]) => {
@@ -129,7 +128,7 @@ function processProps(
       processProps(
         offset,
         value,
-        keyframeProps[property],
+        keyframeProps[property] as UnknownRecord,
         separatelyInterpolatedNestedProperties
       );
       return;
@@ -138,7 +137,9 @@ function processProps(
     if (!keyframeProps[property]) {
       keyframeProps[property] = [];
     }
-    keyframeProps[property].push({ offset, value });
+    (keyframeProps[property] as Array<{ offset: number; value: unknown }>).push(
+      { offset, value }
+    );
   });
 }
 

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
@@ -106,15 +106,17 @@ export function processKeyframes(
     }, []);
 }
 
+type KeyframeLeafEntries = Array<{ offset: number; value: unknown }>;
+
 function processProps(
   offset: number,
   props: object,
   keyframeProps: UnknownRecord,
   separatelyInterpolatedNestedProperties: ReadonlySet<string>
 ) {
-  Object.entries(props).forEach(([property, value]) => {
+  for (const [property, value] of Object.entries(props)) {
     if (!isDefined(value)) {
-      return;
+      continue;
     }
 
     if (
@@ -122,25 +124,21 @@ function processProps(
       typeof value === 'object' &&
       separatelyInterpolatedNestedProperties.has(property)
     ) {
-      if (!keyframeProps[property]) {
-        keyframeProps[property] = Array.isArray(value) ? [] : {};
-      }
+      const subBuilder = (keyframeProps[property] ??= Array.isArray(value)
+        ? []
+        : {}) as UnknownRecord;
       processProps(
         offset,
         value,
-        keyframeProps[property] as UnknownRecord,
+        subBuilder,
         separatelyInterpolatedNestedProperties
       );
-      return;
+      continue;
     }
 
-    if (!keyframeProps[property]) {
-      keyframeProps[property] = [];
-    }
-    (keyframeProps[property] as Array<{ offset: number; value: unknown }>).push(
-      { offset, value }
-    );
-  });
+    const entries = (keyframeProps[property] ??= []) as KeyframeLeafEntries;
+    entries.push({ offset, value });
+  }
 }
 
 export function normalizeAnimationKeyframes(

--- a/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/animation/keyframes.ts
@@ -1,9 +1,5 @@
 'use strict';
-import type {
-  AnyRecord,
-  NativePropsBuilder,
-  UnknownRecord,
-} from '../../../../common';
+import type { NativePropsBuilder, UnknownRecord } from '../../../../common';
 import {
   getPropsBuilder,
   getSeparatelyInterpolatedNestedProperties,
@@ -113,7 +109,8 @@ export function processKeyframes(
 function processProps(
   offset: number,
   props: object,
-  keyframeProps: AnyRecord,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  keyframeProps: Record<string, any>,
   separatelyInterpolatedNestedProperties: ReadonlySet<string>
 ) {
   Object.entries(props).forEach(([property, value]) => {

--- a/packages/react-native-reanimated/src/css/native/normalization/transition/config.ts
+++ b/packages/react-native-reanimated/src/css/native/normalization/transition/config.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { AnyRecord } from '../../../../common';
+import type { UnknownRecord } from '../../../../common';
 import { convertPropertyToArray } from '../../../../common';
 import type {
   CSSTransitionProperties,
@@ -30,7 +30,7 @@ export const ERROR_MESSAGES = {
 function getExpandedConfigProperties(
   config: CSSTransitionProperties
 ): ExpandedCSSTransitionConfigProperties {
-  const result: AnyRecord = config.transition
+  const result: UnknownRecord = config.transition
     ? parseTransitionShorthand(config.transition)
     : createEmptyTransitionConfig();
 

--- a/packages/react-native-reanimated/src/css/types/props.ts
+++ b/packages/react-native-reanimated/src/css/types/props.ts
@@ -1,7 +1,7 @@
 'use strict';
 import type { StyleProp } from 'react-native';
 
-import type { AnyRecord, PlainStyle } from '../../common';
+import type { PlainStyle } from '../../common';
 import type { CSSAnimationProperties } from './animation';
 import type { CSSTransitionProperties } from './transition';
 
@@ -18,7 +18,7 @@ type PickStyleProps<P> = Pick<
   }[keyof P]
 >;
 
-export type CSSStyle<S extends AnyRecord = PlainStyle> = S &
+export type CSSStyle<S extends object = PlainStyle> = S &
   Partial<CSSAnimationProperties<S>> &
   Partial<CSSTransitionProperties<S>>;
 

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -29,9 +29,7 @@ export function filterCSSAndStyleProperties<S extends object>(
   // The CSS / transition / animation buckets are strongly typed but at this
   // point we are dynamically splitting an opaque style object by prop name;
   // values are validated downstream by the normalizers.
-  for (const [prop, value] of Object.entries(style) as Array<
-    [string, unknown]
-  >) {
+  for (const [prop, value] of Object.entries(style)) {
     if (value === undefined) {
       // If the user explicitly sets a property to undefined (e.g. when they want
       // to remove CSS transition or animation), we treat the property as if it was not

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { PlainStyle } from '../../common';
+import type { PlainStyle, UnknownRecord } from '../../common';
 import { logger } from '../../common';
 import { isSharedValue } from '../../isSharedValue';
 import type {
@@ -24,15 +24,14 @@ export function filterCSSAndStyleProperties<S extends object>(
 ] {
   const animationProperties: Partial<CSSAnimationProperties> = {};
   let transitionProperties: Partial<CSSTransitionProperties> = {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const filteredStyle: Record<string, any> = {};
+  const filteredStyle: UnknownRecord = {};
 
   // The CSS / transition / animation buckets are strongly typed but at this
   // point we are dynamically splitting an opaque style object by prop name;
   // values are validated downstream by the normalizers.
-  for (const [prop, rawValue] of Object.entries(style)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const value = rawValue as any;
+  for (const [prop, value] of Object.entries(style) as Array<
+    [string, unknown]
+  >) {
     if (value === undefined) {
       // If the user explicitly sets a property to undefined (e.g. when they want
       // to remove CSS transition or animation), we treat the property as if it was not
@@ -42,15 +41,17 @@ export function filterCSSAndStyleProperties<S extends object>(
 
     if (isAnimationProp(prop)) {
       // TODO - add support for animation shorthand
-      animationProperties[prop] = value;
+      (animationProperties as UnknownRecord)[prop] = value;
     } else if (isTransitionProp(prop)) {
       // If there is a shorthand `transition` property, all properties specified
       // before are ignored and only these specified later are taken into account
       // and override ones from the shorthand
       if (prop === 'transition') {
-        transitionProperties = { transition: value };
+        transitionProperties = {
+          transition: value as CSSTransitionProperties['transition'],
+        };
       } else {
-        transitionProperties[prop] = value;
+        (transitionProperties as UnknownRecord)[prop] = value;
       }
     } else if (!isSharedValue(value)) {
       filteredStyle[prop] = value;
@@ -86,7 +87,11 @@ export function filterCSSAndStyleProperties<S extends object>(
     validateCSSTransitionProps(transitionProperties);
   }
 
-  return [finalAnimationConfig, finalTransitionConfig, filteredStyle];
+  return [
+    finalAnimationConfig,
+    finalTransitionConfig,
+    filteredStyle as PlainStyle,
+  ];
 }
 
 function validateCSSAnimationProps(props: Partial<CSSAnimationProperties>) {

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -1,5 +1,5 @@
 'use strict';
-import type { AnyRecord, PlainStyle } from '../../common';
+import type { PlainStyle } from '../../common';
 import { logger } from '../../common';
 import { isSharedValue } from '../../isSharedValue';
 import type {
@@ -15,7 +15,7 @@ import {
   isTransitionProp,
 } from './guards';
 
-export function filterCSSAndStyleProperties<S extends AnyRecord>(
+export function filterCSSAndStyleProperties<S extends object>(
   style: CSSStyle<S>
 ): [
   ExistingCSSAnimationProperties | null,
@@ -24,9 +24,15 @@ export function filterCSSAndStyleProperties<S extends AnyRecord>(
 ] {
   const animationProperties: Partial<CSSAnimationProperties> = {};
   let transitionProperties: Partial<CSSTransitionProperties> = {};
-  const filteredStyle: AnyRecord = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const filteredStyle: Record<string, any> = {};
 
-  for (const [prop, value] of Object.entries(style)) {
+  // The CSS / transition / animation buckets are strongly typed but at this
+  // point we are dynamically splitting an opaque style object by prop name;
+  // values are validated downstream by the normalizers.
+  for (const [prop, rawValue] of Object.entries(style)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const value = rawValue as any;
     if (value === undefined) {
       // If the user explicitly sets a property to undefined (e.g. when they want
       // to remove CSS transition or animation), we treat the property as if it was not

--- a/packages/react-native-reanimated/src/css/web/normalization/transition.ts
+++ b/packages/react-native-reanimated/src/css/web/normalization/transition.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { type AnyRecord, convertPropertyToArray } from '../../../common';
+import { convertPropertyToArray, type UnknownRecord } from '../../../common';
 import type { CSSTransitionProp, CSSTransitionProperties } from '../../types';
 import { parseSingleTransitionShorthand, splitByComma } from '../../utils';
 
@@ -41,7 +41,7 @@ export function parseTransitionShorthand(value: string) {
 export function normalizeCSSTransitionProperties(
   config: CSSTransitionProperties
 ): ExpandedCSSTransitionConfigProperties {
-  const result: AnyRecord = config.transition
+  const result: UnknownRecord = config.transition
     ? parseTransitionShorthand(config.transition)
     : createEmptyTransitionConfig();
 

--- a/packages/react-native-reanimated/src/fabricUtils.ts
+++ b/packages/react-native-reanimated/src/fabricUtils.ts
@@ -24,5 +24,5 @@ export function getShadowNodeWrapperFromRef(
     }
   }
 
-  return resolvedInstance!.stateNode.node as ShadowNodeWrapper;
+  return (resolvedInstance!.stateNode as { node: ShadowNodeWrapper }).node;
 }


### PR DESCRIPTION
## Summary

Replaces `AnyRecord` usages with `object` (constraints) or `UnknownRecord` (value positions), drops the `AnyRecord` default on `PropsBuilderConfig`, and deletes the alias from `common/types/helpers.ts`. Three spots that genuinely depend on `any`-typed dynamic property access (`AnimatedComponent`'s `P`, the recursive `processProps` helper, and `__internalInstanceHandle`) keep an inline `Record<string, any>` with an explanatory eslint-disable.

## Test plan

`yarn type:check` (native + web + app + tests), `yarn type:check:strict`, and lint pass.