### PR TITLE
chore: Remove `AnyRecord` type from the example app

### DIFF
--- a/apps/common-app/src/apps/css/components/examples/ConfigWithOverridesBlock.tsx
+++ b/apps/common-app/src/apps/css/components/examples/ConfigWithOverridesBlock.tsx
@@ -2,7 +2,6 @@ import { StyleSheet, View } from 'react-native';
 
 import { getCodeWithOverrides } from '@/apps/css/utils';
 import { colors, radius, spacing } from '@/theme';
-import type { AnyRecord } from '@/types';
 import { typedMemo } from '@/utils';
 
 import { CodeBlock } from '../misc/CodeBlock';
@@ -12,7 +11,7 @@ type ConfigWithOverridesBlockProps<C, O> = {
   overrides?: Array<O>;
 };
 
-function ConfigWithOverridesBlock<C extends AnyRecord, O extends AnyRecord>({
+function ConfigWithOverridesBlock<C extends object, O extends object>({
   overrides,
   sharedConfig,
 }: ConfigWithOverridesBlockProps<C, O>) {

--- a/apps/common-app/src/apps/css/components/examples/ExamplesList.tsx
+++ b/apps/common-app/src/apps/css/components/examples/ExamplesList.tsx
@@ -2,7 +2,7 @@ import type { ComponentType, JSX } from 'react';
 import type { CSSAnimationProperties } from 'react-native-reanimated';
 
 import { stringifyConfig } from '@/apps/css/utils';
-import type { AnyRecord, PlainStyle } from '@/types';
+import type { PlainStyle } from '@/types';
 
 import Scroll from '../layout/Scroll';
 import { Section } from '../layout/Section';
@@ -10,7 +10,7 @@ import type { LabelType } from '../misc/Label';
 import type { ExampleCardProps } from './ExampleCard';
 import ExampleCard from './ExampleCard';
 
-export type ExamplesListProps<P extends AnyRecord, S extends AnyRecord> = Pick<
+export type ExamplesListProps<P extends object, S extends object> = Pick<
   ExampleProps<P, S>,
   'buildAnimation' | 'renderExample'
 > & {
@@ -30,8 +30,8 @@ export type ExamplesListProps<P extends AnyRecord, S extends AnyRecord> = Pick<
 };
 
 export default function ExamplesList<
-  P extends AnyRecord,
-  S extends AnyRecord = PlainStyle,
+  P extends object,
+  S extends object = PlainStyle,
 >({
   buildAnimation,
   CardComponent = ExampleCard,
@@ -66,7 +66,7 @@ export default function ExamplesList<
   );
 }
 
-type ExampleProps<P, S extends AnyRecord> = {
+type ExampleProps<P, S extends object> = {
   CardComponent: ComponentType<ExampleCardProps>;
   denseCode?: boolean;
   buildAnimation: (props: P) => CSSAnimationProperties<S>;
@@ -76,7 +76,7 @@ type ExampleProps<P, S extends AnyRecord> = {
 } & Omit<ExampleCardProps, 'code'> &
   P;
 
-function Example<P extends AnyRecord, S extends AnyRecord>({
+function Example<P extends object, S extends object>({
   buildAnimation,
   CardComponent,
   collapsedExampleHeight,

--- a/apps/common-app/src/apps/css/components/examples/ExamplesScreen.tsx
+++ b/apps/common-app/src/apps/css/components/examples/ExamplesScreen.tsx
@@ -1,16 +1,13 @@
-import type { AnyRecord, PartialBy, PlainStyle } from '@/types';
+import type { PartialBy, PlainStyle } from '@/types';
 
 import { Screen } from '../layout/Screens';
 import TabView from '../layout/TabView';
 import type { ExamplesListProps } from './ExamplesList';
 import ExamplesList from './ExamplesList';
 
-type ExamplesScreenProps<
-  P extends AnyRecord | Array<AnyRecord>,
-  S extends AnyRecord,
-> =
+type ExamplesScreenProps<P extends object | Array<object>, S extends object> =
   P extends Array<infer T>
-    ? T extends AnyRecord
+    ? T extends object
       ? DifferentTypeTabsScreenProps<T, S>
       : never
     :
@@ -18,26 +15,26 @@ type ExamplesScreenProps<
         | ExamplesListProps<P, S>
         | SameTypeTabsScreenProps<P, S>;
 
-type DifferentTypeTabsScreenProps<P extends AnyRecord, S extends AnyRecord> = {
+type DifferentTypeTabsScreenProps<P extends object, S extends object> = {
   tabs: Array<{ name: string } & ExamplesListProps<P, S>>;
 };
 
 type PartialExamplesListProps<
-  P extends AnyRecord,
-  S extends AnyRecord,
+  P extends object,
+  S extends object,
   K extends keyof ExamplesListProps<P, S>,
 > = {
   tabs: Array<{ name: string } & PartialBy<ExamplesListProps<P, S>, K>>;
 } & Pick<ExamplesListProps<P, S>, K>;
 
-type SameTypeTabsScreenProps<P extends AnyRecord, S extends AnyRecord> =
+type SameTypeTabsScreenProps<P extends object, S extends object> =
   | PartialExamplesListProps<P, S, 'buildAnimation' | 'renderExample'>
   | PartialExamplesListProps<P, S, 'buildAnimation'>
   | PartialExamplesListProps<P, S, 'renderExample'>;
 
 export default function ExamplesScreen<
-  P extends AnyRecord | Array<AnyRecord>,
-  S extends AnyRecord = PlainStyle,
+  P extends object | Array<object>,
+  S extends object = PlainStyle,
 >(props: ExamplesScreenProps<P, S>) {
   if ('tabs' in props) {
     const renderTab = (

--- a/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
@@ -29,18 +29,17 @@ import { IS_ANDROID } from '@/utils';
 const filterPaddingAndMarginProps = (
   style: ViewStyle
 ): [ViewStyle, ViewStyle] => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const paddingAndMargin: Record<string, any> = {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rest: Record<string, any> = {};
+  const paddingAndMargin: ViewStyle = {};
+  const rest: ViewStyle = {};
 
   for (const key in style) {
     const k = key as keyof ViewStyle;
-    if (key.startsWith('padding') || key.startsWith('margin')) {
-      paddingAndMargin[key] = style[k];
-    } else {
-      rest[key] = style[k];
-    }
+    Object.assign(
+      key.startsWith('padding') || key.startsWith('margin')
+        ? paddingAndMargin
+        : rest,
+      { [k]: style[k] }
+    );
   }
 
   return [paddingAndMargin, rest];

--- a/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ActionSheetDropdown.tsx
@@ -24,14 +24,15 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { radius, spacing } from '@/theme';
-import type { AnyRecord } from '@/types';
 import { IS_ANDROID } from '@/utils';
 
 const filterPaddingAndMarginProps = (
   style: ViewStyle
 ): [ViewStyle, ViewStyle] => {
-  const paddingAndMargin: AnyRecord = {};
-  const rest: AnyRecord = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const paddingAndMargin: Record<string, any> = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rest: Record<string, any> = {};
 
   for (const key in style) {
     const k = key as keyof ViewStyle;

--- a/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { memo, useMemo, useState } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -33,11 +32,11 @@ import RotatableChevron from './RotatableChevron';
 const convertSelectableConfigToConfig = <T extends object>(
   config: SelectableConfig<T>
 ): T => {
-  const convertedConfig: Record<string, any> = {};
+  const convertedConfig: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(config)) {
     if (key.startsWith('$')) {
-      const options = value as SelectableConfigPropertyOptions<T>;
+      const options = value as SelectableConfigPropertyOptions<unknown>;
       if (!options.disabled) {
         convertedConfig[key.slice(1)] = options.value;
       }
@@ -45,7 +44,7 @@ const convertSelectableConfigToConfig = <T extends object>(
       convertedConfig[key] = value;
     } else {
       convertedConfig[key] = convertSelectableConfigToConfig(
-        value as Record<string, any>
+        value as SelectableConfig<object>
       );
     }
   }
@@ -128,7 +127,7 @@ type BlockProps<T extends object> = {
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
   blockStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: Record<string, any>) => void;
+  onChange: (key: string, config: Record<string, unknown>) => void;
 };
 
 const Block = typedMemo(function Block<T extends object>({
@@ -139,7 +138,7 @@ const Block = typedMemo(function Block<T extends object>({
   onChange,
 }: BlockProps<T>) {
   const stableOnChange = useStableCallback(
-    (key: string, newValue: Record<string, any>) => {
+    (key: string, newValue: Record<string, unknown>) => {
       onChange(objectKey, { ...config, [key]: newValue });
     }
   );
@@ -179,7 +178,7 @@ const Block = typedMemo(function Block<T extends object>({
 
         return (
           <CollapsibleBlock
-            config={value as Record<string, any>}
+            config={value as SelectableConfig<object>}
             formattedKey={formattedKey}
             key={key}
             objectKey={key}
@@ -193,9 +192,9 @@ const Block = typedMemo(function Block<T extends object>({
 
 type CollapsibleBlockProps = {
   formattedKey: string;
-  config: Record<string, any>;
+  config: SelectableConfig<object>;
   objectKey: string;
-  onChange: (key: string, config: Record<string, any>) => void;
+  onChange: (key: string, config: Record<string, unknown>) => void;
 };
 
 const CollapsibleBlock = memo(function CollapsibleBlock({
@@ -244,7 +243,7 @@ type SelectableOptionRowProps<T> = {
   formattedKey: string;
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: Record<string, any>) => void;
+  onChange: (key: string, config: Record<string, unknown>) => void;
 };
 
 const SelectableOptionRow = memo(function SelectableOptionRow<T>({
@@ -335,7 +334,7 @@ type MultipleOptionsOptionSelectorProps<T> = {
   dropdownStyle?: StyleProp<ViewStyle>;
   options: SelectableConfigPropertyOptions<T>;
   objectKey: string;
-  onChange: (key: string, config: Record<string, any>) => void;
+  onChange: (key: string, config: Record<string, unknown>) => void;
 };
 
 const MultipleOptionsOptionSelector = typedMemo(

--- a/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/apps/css/utils';
 import { useStableCallback } from '@/hooks';
 import { colors, flex, radius, sizes, spacing } from '@/theme';
-import type { UnpackArray } from '@/types';
+import type { UnknownRecord, UnpackArray } from '@/types';
 import { deepEqual, typedMemo } from '@/utils';
 
 import Text from '../core/Text';
@@ -32,7 +32,7 @@ import RotatableChevron from './RotatableChevron';
 const convertSelectableConfigToConfig = <T extends object>(
   config: SelectableConfig<T>
 ): T => {
-  const convertedConfig: Record<string, unknown> = {};
+  const convertedConfig: UnknownRecord = {};
 
   for (const [key, value] of Object.entries(config)) {
     if (key.startsWith('$')) {
@@ -127,7 +127,7 @@ type BlockProps<T extends object> = {
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
   blockStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: Record<string, unknown>) => void;
+  onChange: (key: string, config: UnknownRecord) => void;
 };
 
 const Block = typedMemo(function Block<T extends object>({
@@ -138,7 +138,7 @@ const Block = typedMemo(function Block<T extends object>({
   onChange,
 }: BlockProps<T>) {
   const stableOnChange = useStableCallback(
-    (key: string, newValue: Record<string, unknown>) => {
+    (key: string, newValue: UnknownRecord) => {
       onChange(objectKey, { ...config, [key]: newValue });
     }
   );
@@ -194,7 +194,7 @@ type CollapsibleBlockProps = {
   formattedKey: string;
   config: SelectableConfig<object>;
   objectKey: string;
-  onChange: (key: string, config: Record<string, unknown>) => void;
+  onChange: (key: string, config: UnknownRecord) => void;
 };
 
 const CollapsibleBlock = memo(function CollapsibleBlock({
@@ -243,7 +243,7 @@ type SelectableOptionRowProps<T> = {
   formattedKey: string;
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: Record<string, unknown>) => void;
+  onChange: (key: string, config: UnknownRecord) => void;
 };
 
 const SelectableOptionRow = memo(function SelectableOptionRow<T>({
@@ -334,7 +334,7 @@ type MultipleOptionsOptionSelectorProps<T> = {
   dropdownStyle?: StyleProp<ViewStyle>;
   options: SelectableConfigPropertyOptions<T>;
   objectKey: string;
-  onChange: (key: string, config: Record<string, unknown>) => void;
+  onChange: (key: string, config: UnknownRecord) => void;
 };
 
 const MultipleOptionsOptionSelector = typedMemo(

--- a/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
+++ b/apps/common-app/src/apps/css/components/misc/ConfigSelector.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { memo, useMemo, useState } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -20,7 +21,7 @@ import {
 } from '@/apps/css/utils';
 import { useStableCallback } from '@/hooks';
 import { colors, flex, radius, sizes, spacing } from '@/theme';
-import type { AnyRecord, UnpackArray } from '@/types';
+import type { UnpackArray } from '@/types';
 import { deepEqual, typedMemo } from '@/utils';
 
 import Text from '../core/Text';
@@ -29,10 +30,10 @@ import Scroll from '../layout/Scroll';
 import ActionSheetDropdown from './ActionSheetDropdown';
 import RotatableChevron from './RotatableChevron';
 
-const convertSelectableConfigToConfig = <T extends AnyRecord>(
+const convertSelectableConfigToConfig = <T extends object>(
   config: SelectableConfig<T>
 ): T => {
-  const convertedConfig: AnyRecord = {};
+  const convertedConfig: Record<string, any> = {};
 
   for (const [key, value] of Object.entries(config)) {
     if (key.startsWith('$')) {
@@ -44,7 +45,7 @@ const convertSelectableConfigToConfig = <T extends AnyRecord>(
       convertedConfig[key] = value;
     } else {
       convertedConfig[key] = convertSelectableConfigToConfig(
-        value as AnyRecord
+        value as Record<string, any>
       );
     }
   }
@@ -52,7 +53,7 @@ const convertSelectableConfigToConfig = <T extends AnyRecord>(
   return convertedConfig as T;
 };
 
-export function useSelectableConfig<T extends AnyRecord>(
+export function useSelectableConfig<T extends object>(
   config: SelectableConfig<T>
 ): T {
   return useMemo(() => convertSelectableConfigToConfig(config), [config]);
@@ -73,23 +74,23 @@ export type SelectableConfigPropertyOptions<T> = {
   | { maxNumberOfValues: number; options: Array<UnpackArray<T>> }
 );
 
-export type SelectableConfig<C extends AnyRecord> = {
-  [K in keyof C as `$${K & string}`]?: C[K] extends AnyRecord
+export type SelectableConfig<C extends object> = {
+  [K in keyof C as `$${K & string}`]?: C[K] extends object
     ? SelectableConfig<C[K]>
     : SelectableConfigPropertyOptions<C[K]>;
 } & {
   [K in keyof C]: C[K] extends infer U
-    ? U extends AnyRecord
+    ? U extends object
       ? SelectableConfig<U>
       : C[K]
     : never;
 };
 
-type ConfigSelectorProps<T extends AnyRecord> = {
+type ConfigSelectorProps<T extends object> = {
   onChange: (config: T) => void;
 } & Omit<BlockProps<T>, 'objectKey' | 'onChange'>;
 
-function ConfigSelector<T extends AnyRecord>({
+function ConfigSelector<T extends object>({
   onChange,
   ...props
 }: ConfigSelectorProps<T>) {
@@ -122,15 +123,15 @@ function ConfigSelector<T extends AnyRecord>({
   );
 }
 
-type BlockProps<T extends AnyRecord> = {
+type BlockProps<T extends object> = {
   config: SelectableConfig<T>;
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
   blockStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: AnyRecord) => void;
+  onChange: (key: string, config: Record<string, any>) => void;
 };
 
-const Block = typedMemo(function Block<T extends AnyRecord>({
+const Block = typedMemo(function Block<T extends object>({
   blockStyle,
   config,
   dropdownStyle,
@@ -138,7 +139,7 @@ const Block = typedMemo(function Block<T extends AnyRecord>({
   onChange,
 }: BlockProps<T>) {
   const stableOnChange = useStableCallback(
-    (key: string, newValue: AnyRecord) => {
+    (key: string, newValue: Record<string, any>) => {
       onChange(objectKey, { ...config, [key]: newValue });
     }
   );
@@ -162,7 +163,7 @@ const Block = typedMemo(function Block<T extends AnyRecord>({
               formattedKey={formattedKey}
               key={key}
               objectKey={key}
-              options={value}
+              options={value as SelectableConfigPropertyOptions<unknown>}
               onChange={stableOnChange}
             />
           );
@@ -178,7 +179,7 @@ const Block = typedMemo(function Block<T extends AnyRecord>({
 
         return (
           <CollapsibleBlock
-            config={value}
+            config={value as Record<string, any>}
             formattedKey={formattedKey}
             key={key}
             objectKey={key}
@@ -192,9 +193,9 @@ const Block = typedMemo(function Block<T extends AnyRecord>({
 
 type CollapsibleBlockProps = {
   formattedKey: string;
-  config: AnyRecord;
+  config: Record<string, any>;
   objectKey: string;
-  onChange: (key: string, config: AnyRecord) => void;
+  onChange: (key: string, config: Record<string, any>) => void;
 };
 
 const CollapsibleBlock = memo(function CollapsibleBlock({
@@ -243,7 +244,7 @@ type SelectableOptionRowProps<T> = {
   formattedKey: string;
   objectKey: string;
   dropdownStyle?: StyleProp<ViewStyle>;
-  onChange: (key: string, config: AnyRecord) => void;
+  onChange: (key: string, config: Record<string, any>) => void;
 };
 
 const SelectableOptionRow = memo(function SelectableOptionRow<T>({
@@ -334,7 +335,7 @@ type MultipleOptionsOptionSelectorProps<T> = {
   dropdownStyle?: StyleProp<ViewStyle>;
   options: SelectableConfigPropertyOptions<T>;
   objectKey: string;
-  onChange: (key: string, config: AnyRecord) => void;
+  onChange: (key: string, config: Record<string, any>) => void;
 };
 
 const MultipleOptionsOptionSelector = typedMemo(

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/svg/common/FillAndColor.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/svg/common/FillAndColor.tsx
@@ -10,7 +10,6 @@ import type { CircleProps, PolygonProps } from 'react-native-svg';
 import { Circle, Polygon, Svg } from 'react-native-svg';
 
 import { ExamplesScreen } from '@/apps/css/components';
-import type { AnyRecord } from '@/types';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 const AnimatedPolygon = Animated.createAnimatedComponent(Polygon);
@@ -60,7 +59,7 @@ export default function FillAndColorExample() {
     <ExamplesScreen<
       {
         keyframes: CSSAnimationKeyframes<CircleProps>;
-        render: <T extends AnyRecord>(
+        render: <T extends object>(
           animation: CSSAnimationProperties<T>
         ) => JSX.Element;
       },

--- a/apps/common-app/src/apps/css/utils/code.ts
+++ b/apps/common-app/src/apps/css/utils/code.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 export function isValidPropertyName(propertyName: string): boolean {
   const validPropertyNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
   return validPropertyNamePattern.test(propertyName);
@@ -43,9 +39,8 @@ export const formatLeafValue = (
 
 export const MAX_NOT_WRAPPED_LENGTH = 48;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const stringifyConfigObject = <T extends Record<string, any>>(
-  object: T,
+const stringifyConfigObject = <T extends object>(
+  inputObject: T,
   dense = false,
   depth = 0
 ): string => {
@@ -53,36 +48,36 @@ const stringifyConfigObject = <T extends Record<string, any>>(
     throw new Error('Object nesting is too deep');
   }
 
-  if ('cssRules' in object) {
-    object = object.cssRules;
-  }
+  const object: Record<string, unknown> = (
+    'cssRules' in inputObject ? inputObject.cssRules : inputObject
+  ) as Record<string, unknown>;
 
   const formatValue = (
     key: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    value: any,
+    value: unknown,
     currentDepth: number,
     makeDense: boolean
-  ) => {
+  ): string => {
     const nextTab = '  '.repeat(currentDepth);
 
     if (key === 'animationName') {
       return Array.isArray(value) && value.length > 0
         ? `[\n${nextTab}  ${value
-            .map((item) => stringifyConfigObject(item, makeDense, depth + 2))
+            .map((item: object) =>
+              stringifyConfigObject(item, makeDense, depth + 2)
+            )
             .join(`,\n${nextTab}  `)}\n${nextTab}]`
-        : stringifyConfigObject(value, makeDense, currentDepth);
+        : stringifyConfigObject(value as object, makeDense, currentDepth);
     }
 
     return isLeafValue(value)
       ? formatLeafValue(value, nextTab, makeDense)
-      : stringifyConfigObject(value, makeDense, currentDepth);
+      : stringifyConfigObject(value as object, makeDense, currentDepth);
   };
 
   const formatLine = (
     key: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    value: any,
+    value: unknown,
     depth_: number,
     makeDense: boolean
   ) => {
@@ -107,8 +102,7 @@ const stringifyConfigObject = <T extends Record<string, any>>(
     .join(',\n')}\n${currentTab}}`;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const stringifyConfig = <T extends Record<string, any>>(
+export const stringifyConfig = <T extends object>(
   object: 'none' | T,
   dense = false,
   depth = 0
@@ -118,20 +112,16 @@ export const stringifyConfig = <T extends Record<string, any>>(
     : stringifyConfigObject(object, dense, depth);
 };
 
-export const getCodeWithOverrides = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  C extends Record<string, any>,
-  O extends object,
->(
+export const getCodeWithOverrides = <C extends object, O extends object>(
   sharedConfig: C,
   overrides: Array<O> = [],
   excludeKeys: Array<string> = []
 ): string => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const propertyOverrides: Record<string, any> = {};
+  const propertyOverrides: Record<string, Array<unknown>> = {};
   const excludeSet = new Set(excludeKeys);
+  const sharedConfigRecord = sharedConfig as Record<string, unknown>;
 
-  const isQuoted = (value: unknown) =>
+  const isQuoted = (value: unknown): value is string =>
     typeof value === 'string' && value[0] === '"' && value.slice(-1) === '"';
 
   const parseOverrideValue = (value: unknown) => {
@@ -150,10 +140,11 @@ export const getCodeWithOverrides = <
   };
 
   for (const item of overrides) {
+    const itemRecord = item as Record<string, unknown>;
     for (const key in item) {
       if (!excludeSet.has(key)) {
         propertyOverrides[key] ??= [];
-        propertyOverrides[key].push(parseOverride(item[key]));
+        propertyOverrides[key].push(parseOverride(itemRecord[key]));
       }
     }
   }
@@ -167,11 +158,12 @@ export const getCodeWithOverrides = <
       ]),
     ]
       .map((key) => {
-        const value = sharedConfig[key] ?? propertyOverrides[key]?.[0] ?? '';
+        const value =
+          sharedConfigRecord[key] ?? propertyOverrides[key]?.[0] ?? '';
 
         let parsedValue;
         if (key === 'animationName') {
-          parsedValue = stringifyConfig(value, false, 0);
+          parsedValue = stringifyConfig(value as 'none' | object, false, 0);
         } else if (isLeafValue(value)) {
           const formatLine = (makeDense: boolean) =>
             `${key}: ${formatLeafValue(value, '', makeDense)}`;

--- a/apps/common-app/src/apps/css/utils/code.ts
+++ b/apps/common-app/src/apps/css/utils/code.ts
@@ -18,6 +18,13 @@ export const isLeafValue = (value: unknown): boolean =>
   'normalize' in value ||
   'normalizedKeyframes' in value;
 
+const isObjectRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !('normalize' in value) &&
+  !('normalizedKeyframes' in value);
+
 export const formatLeafValue = (
   value: unknown,
   nextTab = '',
@@ -41,8 +48,8 @@ export const formatLeafValue = (
 
 export const MAX_NOT_WRAPPED_LENGTH = 48;
 
-const stringifyConfigObject = <T extends object>(
-  inputObject: T,
+const stringifyConfigObject = (
+  inputObject: UnknownRecord,
   dense = false,
   depth = 0
 ): string => {
@@ -50,9 +57,9 @@ const stringifyConfigObject = <T extends object>(
     throw new Error('Object nesting is too deep');
   }
 
-  const object: UnknownRecord = (
-    'cssRules' in inputObject ? inputObject.cssRules : inputObject
-  ) as UnknownRecord;
+  const object = isObjectRecord(inputObject.cssRules)
+    ? inputObject.cssRules
+    : inputObject;
 
   const formatValue = (
     key: string,
@@ -63,18 +70,23 @@ const stringifyConfigObject = <T extends object>(
     const nextTab = '  '.repeat(currentDepth);
 
     if (key === 'animationName') {
-      return Array.isArray(value) && value.length > 0
-        ? `[\n${nextTab}  ${value
-            .map((item: object) =>
-              stringifyConfigObject(item, makeDense, depth + 2)
-            )
-            .join(`,\n${nextTab}  `)}\n${nextTab}]`
-        : stringifyConfigObject(value as object, makeDense, currentDepth);
+      if (Array.isArray(value) && value.length > 0) {
+        return `[\n${nextTab}  ${value
+          .map((item) =>
+            isObjectRecord(item)
+              ? stringifyConfigObject(item, makeDense, depth + 2)
+              : formatLeafValue(item, nextTab, makeDense)
+          )
+          .join(`,\n${nextTab}  `)}\n${nextTab}]`;
+      }
+      return isObjectRecord(value)
+        ? stringifyConfigObject(value, makeDense, currentDepth)
+        : formatLeafValue(value, nextTab, makeDense);
     }
 
-    return isLeafValue(value)
-      ? formatLeafValue(value, nextTab, makeDense)
-      : stringifyConfigObject(value as object, makeDense, currentDepth);
+    return isObjectRecord(value)
+      ? stringifyConfigObject(value, makeDense, currentDepth)
+      : formatLeafValue(value, nextTab, makeDense);
   };
 
   const formatLine = (
@@ -104,14 +116,17 @@ const stringifyConfigObject = <T extends object>(
     .join(',\n')}\n${currentTab}}`;
 };
 
-export const stringifyConfig = <T extends object>(
-  object: 'none' | T,
+export const stringifyConfig = (
+  object: unknown,
   dense = false,
   depth = 0
 ): string => {
-  return object === 'none'
-    ? 'none'
-    : stringifyConfigObject(object, dense, depth);
+  if (object === 'none') {
+    return 'none';
+  }
+  return isObjectRecord(object)
+    ? stringifyConfigObject(object, dense, depth)
+    : formatLeafValue(object, '  '.repeat(depth), dense);
 };
 
 export const getCodeWithOverrides = <C extends object, O extends object>(
@@ -119,9 +134,14 @@ export const getCodeWithOverrides = <C extends object, O extends object>(
   overrides: Array<O> = [],
   excludeKeys: Array<string> = []
 ): string => {
+  // The generic constraint accepts any object shape from callers; treat it
+  // as an indexable record once at the boundary so the dynamic prop reads
+  // inside don't each need their own cast.
+  const config = sharedConfig as UnknownRecord;
+  const items = overrides as Array<UnknownRecord>;
+
   const propertyOverrides: Record<string, Array<unknown>> = {};
   const excludeSet = new Set(excludeKeys);
-  const sharedConfigRecord = sharedConfig as UnknownRecord;
 
   const isQuoted = (value: unknown): value is string =>
     typeof value === 'string' && value[0] === '"' && value.slice(-1) === '"';
@@ -141,31 +161,24 @@ export const getCodeWithOverrides = <C extends object, O extends object>(
     return parseOverrideValue(value);
   };
 
-  for (const item of overrides) {
-    const itemRecord = item as UnknownRecord;
+  for (const item of items) {
     for (const key in item) {
       if (!excludeSet.has(key)) {
         propertyOverrides[key] ??= [];
-        propertyOverrides[key].push(parseOverride(itemRecord[key]));
+        propertyOverrides[key].push(parseOverride(item[key]));
       }
     }
   }
 
   return (
     '{\n  ' +
-    [
-      ...new Set([
-        ...Object.keys(sharedConfig),
-        ...Object.keys(propertyOverrides),
-      ]),
-    ]
+    [...new Set([...Object.keys(config), ...Object.keys(propertyOverrides)])]
       .map((key) => {
-        const value =
-          sharedConfigRecord[key] ?? propertyOverrides[key]?.[0] ?? '';
+        const value = config[key] ?? propertyOverrides[key]?.[0] ?? '';
 
         let parsedValue;
         if (key === 'animationName') {
-          parsedValue = stringifyConfig(value as 'none' | object, false, 0);
+          parsedValue = stringifyConfig(value, false, 0);
         } else if (isLeafValue(value)) {
           const formatLine = (makeDense: boolean) =>
             `${key}: ${formatLeafValue(value, '', makeDense)}`;

--- a/apps/common-app/src/apps/css/utils/code.ts
+++ b/apps/common-app/src/apps/css/utils/code.ts
@@ -1,3 +1,5 @@
+import type { UnknownRecord } from '@/types';
+
 export function isValidPropertyName(propertyName: string): boolean {
   const validPropertyNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
   return validPropertyNamePattern.test(propertyName);
@@ -48,9 +50,9 @@ const stringifyConfigObject = <T extends object>(
     throw new Error('Object nesting is too deep');
   }
 
-  const object: Record<string, unknown> = (
+  const object: UnknownRecord = (
     'cssRules' in inputObject ? inputObject.cssRules : inputObject
-  ) as Record<string, unknown>;
+  ) as UnknownRecord;
 
   const formatValue = (
     key: string,
@@ -119,7 +121,7 @@ export const getCodeWithOverrides = <C extends object, O extends object>(
 ): string => {
   const propertyOverrides: Record<string, Array<unknown>> = {};
   const excludeSet = new Set(excludeKeys);
-  const sharedConfigRecord = sharedConfig as Record<string, unknown>;
+  const sharedConfigRecord = sharedConfig as UnknownRecord;
 
   const isQuoted = (value: unknown): value is string =>
     typeof value === 'string' && value[0] === '"' && value.slice(-1) === '"';
@@ -140,7 +142,7 @@ export const getCodeWithOverrides = <C extends object, O extends object>(
   };
 
   for (const item of overrides) {
-    const itemRecord = item as Record<string, unknown>;
+    const itemRecord = item as UnknownRecord;
     for (const key in item) {
       if (!excludeSet.has(key)) {
         propertyOverrides[key] ??= [];

--- a/apps/common-app/src/apps/css/utils/code.ts
+++ b/apps/common-app/src/apps/css/utils/code.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import type { AnyRecord } from '@/types';
 
 export function isValidPropertyName(propertyName: string): boolean {
   const validPropertyNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -44,7 +43,8 @@ export const formatLeafValue = (
 
 export const MAX_NOT_WRAPPED_LENGTH = 48;
 
-const stringifyConfigObject = <T extends AnyRecord>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stringifyConfigObject = <T extends Record<string, any>>(
   object: T,
   dense = false,
   depth = 0
@@ -107,7 +107,8 @@ const stringifyConfigObject = <T extends AnyRecord>(
     .join(',\n')}\n${currentTab}}`;
 };
 
-export const stringifyConfig = <T extends AnyRecord>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const stringifyConfig = <T extends Record<string, any>>(
   object: 'none' | T,
   dense = false,
   depth = 0
@@ -117,12 +118,17 @@ export const stringifyConfig = <T extends AnyRecord>(
     : stringifyConfigObject(object, dense, depth);
 };
 
-export const getCodeWithOverrides = <C extends AnyRecord, O extends AnyRecord>(
+export const getCodeWithOverrides = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  C extends Record<string, any>,
+  O extends object,
+>(
   sharedConfig: C,
   overrides: Array<O> = [],
   excludeKeys: Array<string> = []
 ): string => {
-  const propertyOverrides: AnyRecord = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const propertyOverrides: Record<string, any> = {};
   const excludeSet = new Set(excludeKeys);
 
   const isQuoted = (value: unknown) =>

--- a/apps/common-app/src/types/helpers.ts
+++ b/apps/common-app/src/types/helpers.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ImageStyle, TextStyle, ViewStyle } from 'react-native';
 
+export type UnknownRecord = Record<string, unknown>;
+
 export type AnyFunction = (...args: Array<any>) => any;
 
 export type Transforms = ViewStyle['transform'];

--- a/apps/common-app/src/types/helpers.ts
+++ b/apps/common-app/src/types/helpers.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ImageStyle, TextStyle, ViewStyle } from 'react-native';
 
-export type AnyRecord = Record<string, any>;
-
 export type AnyFunction = (...args: Array<any>) => any;
 
 export type Transforms = ViewStyle['transform'];


### PR DESCRIPTION
## Summary

This PR is similar to #9542. This one removes the `AnyRecord` type from the example app.

## Test plan

- `yarn type:check`
- `yarn type:check:strict`
- `yarn lint`