### PR TITLE
feat: web CSS animation support for SVG Circle

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -260,6 +260,9 @@ class JSReanimated implements IReanimatedModule {
   }
 
   getStaticFeatureFlag(name: string): boolean {
+    // In Jest, JSReanimated replaces the native module but lacks native-only
+    // methods (e.g. getSettledUpdates) that some flags hit, so they stay off
+    // in tests. On web, return the real staticFlags.json values.
     if (IS_JEST) {
       return false;
     }

--- a/packages/react-native-reanimated/src/common/web/style/index.ts
+++ b/packages/react-native-reanimated/src/common/web/style/index.ts
@@ -2,6 +2,10 @@
 export * from './builders';
 export * from './config';
 export * from './processors';
-export { webPropsBuilder } from './propsBuilder';
+export {
+  createWebPropsBuilder,
+  type WebPropsBuilder,
+  webPropsBuilder,
+} from './propsBuilder';
 export * from './ruleBuilder';
 export type * from './types';

--- a/packages/react-native-reanimated/src/common/web/style/propsBuilder.ts
+++ b/packages/react-native-reanimated/src/common/web/style/propsBuilder.ts
@@ -15,9 +15,13 @@ import type { PropsBuilderConfig, RuleBuilder } from './types';
 type WebPropsBuilderConfig<P extends UnknownRecord = UnknownRecord> =
   PropsBuilderConfig<P>;
 
+export type WebPropsBuilder<P extends UnknownRecord = UnknownRecord> = {
+  build(props: Partial<P>): string | null;
+};
+
 export function createWebPropsBuilder<TProps extends UnknownRecord>(
   config: WebPropsBuilderConfig<TProps>
-) {
+): WebPropsBuilder<TProps> {
   const usedRuleBuilders = new Set<RuleBuilder<TProps>>();
 
   const propsBuilder = createPropsBuilder({

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -174,7 +174,10 @@ export default class AnimatedComponent<
     if (!IS_JEST) {
       this._CSSManager ??= new CSSManager(
         this._getViewInfo(),
-        this.ChildComponent.displayName
+        // `react-native-svg`'s web classes don't set `static displayName`
+        // (only the native side does), so fall back to the class `name` which
+        // matches the React `displayName` pattern used elsewhere.
+        this.ChildComponent.displayName ?? this.ChildComponent.name
       );
       this._CSSManager?.update(this._cssStyle);
     }

--- a/packages/react-native-reanimated/src/css/svg/init.web.ts
+++ b/packages/react-native-reanimated/src/css/svg/init.web.ts
@@ -1,5 +1,9 @@
 'use strict';
+import {
+  registerWebSvgPropsBuilder,
+  SVG_CIRCLE_WEB_PROPERTIES_CONFIG,
+} from './web';
 
 export function initSvgCssSupport() {
-  // TODO: Add web support for SVG components
+  registerWebSvgPropsBuilder('Circle', SVG_CIRCLE_WEB_PROPERTIES_CONFIG);
 }

--- a/packages/react-native-reanimated/src/css/svg/web/configs/circle.ts
+++ b/packages/react-native-reanimated/src/css/svg/web/configs/circle.ts
@@ -1,0 +1,15 @@
+'use strict';
+// TODO: Fix me
+// @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
+import type { CircleProps } from 'react-native-svg';
+
+import type { SvgStyleBuilderConfig } from './common';
+import { SVG_COMMON_WEB_PROPERTIES_CONFIG } from './common';
+
+export const SVG_CIRCLE_WEB_PROPERTIES_CONFIG: SvgStyleBuilderConfig<CircleProps> =
+  {
+    ...SVG_COMMON_WEB_PROPERTIES_CONFIG,
+    cx: 'px',
+    cy: 'px',
+    r: 'px',
+  };

--- a/packages/react-native-reanimated/src/css/svg/web/configs/common.ts
+++ b/packages/react-native-reanimated/src/css/svg/web/configs/common.ts
@@ -1,0 +1,68 @@
+'use strict';
+import type { GestureResponderHandlers } from 'react-native';
+import type {
+  AccessibilityProps,
+  ColorProps,
+  DefinitionProps,
+  FillProps,
+  NativeProps,
+  ResponderProps,
+  StrokeProps,
+  TouchableProps,
+  TransformProps,
+} from 'react-native-svg';
+
+import { processColor, type PropsBuilderConfig } from '../../../../common/web';
+
+const colorAttributes = { process: processColor };
+
+const colorProps: PropsBuilderConfig<ColorProps> = {
+  color: colorAttributes,
+};
+
+const fillProps: PropsBuilderConfig<FillProps> = {
+  fill: colorAttributes,
+  fillOpacity: true,
+  fillRule: true,
+};
+
+const strokeProps: PropsBuilderConfig<StrokeProps> = {
+  stroke: colorAttributes,
+  strokeWidth: 'px',
+  strokeOpacity: true,
+  strokeDasharray: 'px',
+  strokeDashoffset: 'px',
+  strokeLinecap: true,
+  strokeLinejoin: true,
+  strokeMiterlimit: true,
+};
+
+const transformProps: PropsBuilderConfig<TransformProps> = {
+  transform: true,
+};
+
+const responderProps: PropsBuilderConfig<
+  Omit<ResponderProps, keyof GestureResponderHandlers>
+> = {
+  pointerEvents: true,
+};
+
+type NonAnimatablePropNames =
+  | keyof GestureResponderHandlers
+  | keyof TouchableProps
+  | keyof DefinitionProps
+  | keyof NativeProps
+  | keyof AccessibilityProps;
+
+export type SvgStyleBuilderConfig<T> = PropsBuilderConfig<
+  Omit<T, NonAnimatablePropNames>
+>;
+
+export const SVG_COMMON_WEB_PROPERTIES_CONFIG = {
+  ...colorProps,
+  ...fillProps,
+  ...strokeProps,
+  ...transformProps,
+  ...responderProps,
+  opacity: true,
+} as const;

--- a/packages/react-native-reanimated/src/css/svg/web/index.ts
+++ b/packages/react-native-reanimated/src/css/svg/web/index.ts
@@ -1,0 +1,4 @@
+'use strict';
+export * from './configs/circle';
+export * from './configs/common';
+export * from './registry';

--- a/packages/react-native-reanimated/src/css/svg/web/registry.ts
+++ b/packages/react-native-reanimated/src/css/svg/web/registry.ts
@@ -1,0 +1,52 @@
+'use strict';
+import type { UnknownRecord } from '../../../common';
+import {
+  createWebPropsBuilder,
+  type PropsBuilderConfig,
+  type WebPropsBuilder,
+} from '../../../common/web';
+
+const PROPS_BUILDERS = new Map<string, WebPropsBuilder>();
+const PATTERN_PROPS_BUILDERS: Array<{
+  matcher: RegExp | ((name: string) => boolean);
+  builder: WebPropsBuilder;
+}> = [];
+
+function findBuilder(componentName: string): WebPropsBuilder | null {
+  const exact = PROPS_BUILDERS.get(componentName);
+  if (exact) {
+    return exact;
+  }
+
+  // Pattern matches in registration order
+  for (const { matcher, builder } of PATTERN_PROPS_BUILDERS) {
+    const matches =
+      matcher instanceof RegExp
+        ? matcher.test(componentName)
+        : matcher(componentName);
+    if (matches) {
+      return builder;
+    }
+  }
+
+  return null;
+}
+
+export function getWebSvgPropsBuilder(
+  componentName: string
+): WebPropsBuilder | null {
+  return findBuilder(componentName);
+}
+
+export function registerWebSvgPropsBuilder<P extends UnknownRecord>(
+  componentName: string | RegExp | ((name: string) => boolean),
+  config: PropsBuilderConfig<P>
+): void {
+  const builder = createWebPropsBuilder(config);
+
+  if (typeof componentName === 'string') {
+    PROPS_BUILDERS.set(componentName, builder);
+  } else {
+    PATTERN_PROPS_BUILDERS.push({ matcher: componentName, builder });
+  }
+}

--- a/packages/react-native-reanimated/src/css/web/animationParser.ts
+++ b/packages/react-native-reanimated/src/css/web/animationParser.ts
@@ -1,21 +1,27 @@
 'use strict';
 import type { PlainStyle } from '../../common';
 import { hasSuffix } from '../../common';
-import { webPropsBuilder } from '../../common/web';
+import { type WebPropsBuilder, webPropsBuilder } from '../../common/web';
+import { getWebSvgPropsBuilder } from '../svg/web';
 import type {
   CSSAnimationKeyframeBlock,
   CSSAnimationKeyframes,
 } from '../types';
 import { parseTimingFunction } from './utils';
 
-export function processKeyframeDefinitions(definitions: CSSAnimationKeyframes) {
+export function processKeyframeDefinitions(
+  definitions: CSSAnimationKeyframes,
+  componentName = ''
+) {
+  const propsBuilder = getWebSvgPropsBuilder(componentName) ?? webPropsBuilder;
+
   return Object.entries(definitions)
     .reduce<string[]>((acc, [timestamp, rules]) => {
       const step = hasSuffix(timestamp)
         ? timestamp
         : `${parseFloat(timestamp) * 100}%`;
 
-      const processedBlock = processKeyframeBlock(rules);
+      const processedBlock = processKeyframeBlock(rules, propsBuilder);
 
       if (!processedBlock) {
         return acc;
@@ -28,11 +34,11 @@ export function processKeyframeDefinitions(definitions: CSSAnimationKeyframes) {
     .join(' ');
 }
 
-function processKeyframeBlock({
-  animationTimingFunction,
-  ...rules
-}: CSSAnimationKeyframeBlock<PlainStyle>): string | null {
-  const style = webPropsBuilder.build(rules);
+function processKeyframeBlock(
+  { animationTimingFunction, ...rules }: CSSAnimationKeyframeBlock<PlainStyle>,
+  propsBuilder: WebPropsBuilder
+): string | null {
+  const style = propsBuilder.build(rules);
 
   if (!style) {
     return null;

--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -40,15 +40,17 @@ type ProcessedSettings = ConvertValuesToArrays<CSSAnimationSettings>;
 
 export default class CSSAnimationsManager implements ICSSAnimationsManager {
   private readonly element: ReanimatedHTMLElement;
+  private readonly componentName: string;
 
   // Keys are processed keyframes
   private attachedAnimations: Record<string, ProcessedAnimation> = {};
   private unmountCleanupCalled = false;
 
-  constructor(element: ReanimatedHTMLElement) {
+  constructor(element: ReanimatedHTMLElement, componentName = '') {
     configureWebCSSAnimations();
 
     this.element = element;
+    this.componentName = componentName;
   }
 
   update(animationProperties: ExistingCSSAnimationProperties | null) {
@@ -81,7 +83,10 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
       } else {
         // If keyframes was defined as an object, the additional processing is needed
         const keyframes = definition as CSSAnimationKeyframes;
-        const processedKeyframes = processKeyframeDefinitions(keyframes);
+        const processedKeyframes = processKeyframeDefinitions(
+          keyframes,
+          this.componentName
+        );
 
         // If the animation with the same keyframes was already attached, we can reuse it
         // Otherwise, we need to create a new CSSKeyframesRule object

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -13,10 +13,13 @@ export default class CSSManager implements ICSSManager {
   private readonly animationsManager: CSSAnimationsManager;
   private readonly transitionsManager: CSSTransitionsManager;
 
-  constructor(viewInfo: ViewInfo, _componentDisplayName = '') {
+  constructor(viewInfo: ViewInfo, componentDisplayName = '') {
     this.element = viewInfo.DOMElement as ReanimatedHTMLElement;
 
-    this.animationsManager = new CSSAnimationsManager(this.element);
+    this.animationsManager = new CSSAnimationsManager(
+      this.element,
+      componentDisplayName
+    );
     this.transitionsManager = new CSSTransitionsManager(this.element);
   }
 


### PR DESCRIPTION
## Summary

Adds CSS animation support for `react-native-svg`'s `<Circle>` on web. Before this, SVG-specific props (`cx`, `cy`, `r`, `fill`, `stroke*`) were silently dropped because the web props builder only knew about RN standard style props.

This PR introduces a per-component web SVG props builder registry that mirrors the native one, with `Circle` registered first (rest will be added in the next PR).

## Example recording

https://github.com/user-attachments/assets/4524b947-1ba5-4c4f-84d0-ff81a5a4d099


## Test plan

Verified in `apps/web-example` (Circle radius/position/opacity all animate) plus tsc, lint and the full jest suite.

Follow-up #9549 registers the remaining components.