### PR TITLE
fix: Return real static feature flag values on web

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -21,6 +21,7 @@ import type {
   CSSTransitionConfig,
   NormalizedCSSAnimationKeyframesConfig,
 } from '../../css/native';
+import { DefaultStaticFeatureFlags } from '../../featureFlags/staticFeatureFlags';
 import { assertWorkletsVersion } from '../../platform-specific/workletsVersion';
 import type { IReanimatedModule } from '../reanimatedModuleProxy';
 import type { WebSensor } from './WebSensor';
@@ -258,9 +259,16 @@ class JSReanimated implements IReanimatedModule {
     );
   }
 
-  getStaticFeatureFlag(): boolean {
-    // mock implementation
-    return false;
+  getStaticFeatureFlag(name: string): boolean {
+    // Tests run against this module too; keep every flag off there to preserve
+    // existing snapshots. The real web runtime reads the shared defaults that
+    // mirror `staticFlags.json`.
+    if (IS_JEST) {
+      return false;
+    }
+    return (
+      (DefaultStaticFeatureFlags as Record<string, boolean>)[name] ?? false
+    );
   }
 
   setDynamicFeatureFlag(): void {

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -260,12 +260,6 @@ class JSReanimated implements IReanimatedModule {
   }
 
   getStaticFeatureFlag(name: string): boolean {
-    // Under Jest this module substitutes for the native one but doesn't
-    // implement native-only methods such as `getSettledUpdates`. Some flags
-    // (e.g. `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`) route code into those
-    // methods, so keep every flag off in tests to stay on the JS-compatible
-    // paths. The real web runtime reads the shared defaults that mirror
-    // `staticFlags.json`.
     if (IS_JEST) {
       return false;
     }

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -260,9 +260,12 @@ class JSReanimated implements IReanimatedModule {
   }
 
   getStaticFeatureFlag(name: string): boolean {
-    // Tests run against this module too; keep every flag off there to preserve
-    // existing snapshots. The real web runtime reads the shared defaults that
-    // mirror `staticFlags.json`.
+    // Under Jest this module substitutes for the native one but doesn't
+    // implement native-only methods such as `getSettledUpdates`. Some flags
+    // (e.g. `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`) route code into those
+    // methods, so keep every flag off in tests to stay on the JS-compatible
+    // paths. The real web runtime reads the shared defaults that mirror
+    // `staticFlags.json`.
     if (IS_JEST) {
       return false;
     }

--- a/packages/react-native-reanimated/src/featureFlags/__tests__/staticFeatureFlags.test.ts
+++ b/packages/react-native-reanimated/src/featureFlags/__tests__/staticFeatureFlags.test.ts
@@ -3,9 +3,6 @@ import { DefaultStaticFeatureFlags } from '../staticFeatureFlags';
 import staticFlagsJson from '../staticFlags.json';
 
 describe('DefaultStaticFeatureFlags', () => {
-  // The const mirrors staticFlags.json (the native source of truth) and is the
-  // value source on web, where the native module can't be read. The type only
-  // guards the key set, so this asserts the values stay in sync too.
   it('matches staticFlags.json', () => {
     expect(DefaultStaticFeatureFlags).toStrictEqual(staticFlagsJson);
   });

--- a/packages/react-native-reanimated/src/featureFlags/__tests__/staticFeatureFlags.test.ts
+++ b/packages/react-native-reanimated/src/featureFlags/__tests__/staticFeatureFlags.test.ts
@@ -1,0 +1,12 @@
+'use strict';
+import { DefaultStaticFeatureFlags } from '../staticFeatureFlags';
+import staticFlagsJson from '../staticFlags.json';
+
+describe('DefaultStaticFeatureFlags', () => {
+  // The const mirrors staticFlags.json (the native source of truth) and is the
+  // value source on web, where the native module can't be read. The type only
+  // guards the key set, so this asserts the values stay in sync too.
+  it('matches staticFlags.json', () => {
+    expect(DefaultStaticFeatureFlags).toStrictEqual(staticFlagsJson);
+  });
+});

--- a/packages/react-native-reanimated/src/featureFlags/index.ts
+++ b/packages/react-native-reanimated/src/featureFlags/index.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { logger } from '../common';
 import { ReanimatedModule } from '../ReanimatedModule';
-import type StaticFeatureFlagsJSON from './staticFlags.json';
+import type { StaticFeatureFlagsSchema } from './staticFeatureFlags';
 
 type DynamicFlagsType = {
   EXAMPLE_DYNAMIC_FLAG: boolean;
@@ -64,30 +64,6 @@ export function setDynamicFeatureFlag(
 export function getDynamicFeatureFlag(name: DynamicFlagName): boolean {
   return DynamicFlags.getFlag(name);
 }
-
-/**
- * This constant is needed for typechecking and preserving static typechecks in
- * generated .d.ts files. Without it, the static flags resolve to an object
- * without specific keys.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DefaultStaticFeatureFlags = {
-  RUNTIME_TEST_FLAG: false,
-  DISABLE_COMMIT_PAUSING_MECHANISM: false,
-  ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS: false,
-  IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS: false,
-  EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS: true,
-  IOS_CSS_CORE_ANIMATION: false,
-  USE_SYNCHRONIZABLE_FOR_MUTABLES: true,
-  USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS: true,
-  ENABLE_SHARED_ELEMENT_TRANSITIONS: false,
-  FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS: true,
-  USE_ANIMATION_BACKEND: false,
-} as const satisfies typeof StaticFeatureFlagsJSON;
-
-type StaticFeatureFlagsSchema = {
-  -readonly [K in keyof typeof DefaultStaticFeatureFlags]: boolean;
-};
 
 const staticFeatureFlags: Partial<StaticFeatureFlagsSchema> = {};
 

--- a/packages/react-native-reanimated/src/featureFlags/staticFeatureFlags.ts
+++ b/packages/react-native-reanimated/src/featureFlags/staticFeatureFlags.ts
@@ -1,0 +1,29 @@
+'use strict';
+import type StaticFeatureFlagsJSON from './staticFlags.json';
+
+/**
+ * Default static feature flag values. Mirrors `staticFlags.json` (the native
+ * source of truth) and is the value source on web, where the native module
+ * backing `getStaticFeatureFlag` isn't available.
+ *
+ * Kept in its own module so it can be read from `JSReanimated` without
+ * importing `featureFlags/index`, which would create a require cycle through
+ * `ReanimatedModule`.
+ */
+export const DefaultStaticFeatureFlags = {
+  RUNTIME_TEST_FLAG: false,
+  DISABLE_COMMIT_PAUSING_MECHANISM: false,
+  ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS: false,
+  IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS: false,
+  EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS: true,
+  IOS_CSS_CORE_ANIMATION: false,
+  USE_SYNCHRONIZABLE_FOR_MUTABLES: true,
+  USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS: true,
+  ENABLE_SHARED_ELEMENT_TRANSITIONS: false,
+  FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS: true,
+  USE_ANIMATION_BACKEND: false,
+} as const satisfies typeof StaticFeatureFlagsJSON;
+
+export type StaticFeatureFlagsSchema = {
+  -readonly [K in keyof typeof DefaultStaticFeatureFlags]: boolean;
+};

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -13,7 +13,7 @@ import {
   UIRuntimeId,
 } from 'react-native-worklets';
 
-import { IS_JEST, logger, SHOULD_BE_USE_WEB } from './common';
+import { IS_JEST, IS_WEB, logger, SHOULD_BE_USE_WEB } from './common';
 import type { Mutable } from './commonTypes';
 import { getStaticFeatureFlag } from './featureFlags';
 import { isFirstReactRender, isReactRendering } from './reactUtils';
@@ -183,9 +183,10 @@ function mutableHostDecorator<TValue>(
   return mutable;
 }
 
-const USE_SYNCHRONIZABLE_FOR_MUTABLES = getStaticFeatureFlag(
-  'USE_SYNCHRONIZABLE_FOR_MUTABLES'
-);
+// Synchronizable mutables rely on native machinery that web doesn't have, so
+// keep them off on web (the flag now resolves to its real default there).
+const USE_SYNCHRONIZABLE_FOR_MUTABLES =
+  getStaticFeatureFlag('USE_SYNCHRONIZABLE_FOR_MUTABLES') && !IS_WEB;
 
 function mutableGuestDecorator<TValue>(
   initial: TValue,

--- a/packages/react-native-reanimated/src/mutables.ts
+++ b/packages/react-native-reanimated/src/mutables.ts
@@ -13,7 +13,7 @@ import {
   UIRuntimeId,
 } from 'react-native-worklets';
 
-import { IS_JEST, IS_WEB, logger, SHOULD_BE_USE_WEB } from './common';
+import { IS_JEST, logger, SHOULD_BE_USE_WEB } from './common';
 import type { Mutable } from './commonTypes';
 import { getStaticFeatureFlag } from './featureFlags';
 import { isFirstReactRender, isReactRendering } from './reactUtils';
@@ -183,10 +183,9 @@ function mutableHostDecorator<TValue>(
   return mutable;
 }
 
-// Synchronizable mutables rely on native machinery that web doesn't have, so
-// keep them off on web (the flag now resolves to its real default there).
-const USE_SYNCHRONIZABLE_FOR_MUTABLES =
-  getStaticFeatureFlag('USE_SYNCHRONIZABLE_FOR_MUTABLES') && !IS_WEB;
+const USE_SYNCHRONIZABLE_FOR_MUTABLES = getStaticFeatureFlag(
+  'USE_SYNCHRONIZABLE_FOR_MUTABLES'
+);
 
 function mutableGuestDecorator<TValue>(
   initial: TValue,


### PR DESCRIPTION
`JSReanimated.getStaticFeatureFlag` was a stub returning `false` for every flag, so web ran with all static flags off. It now reads the shared `DefaultStaticFeatureFlags` (extracted to its own module to avoid a require cycle, and a JSON value import the web tree-shake check rejects).

The stub still returns `false` under Jest, because Jest runs against `JSReanimated`, which lacks native-only methods (e.g. `getSettledUpdates`) that some flag-on paths call.

A test asserts `DefaultStaticFeatureFlags` deep-equals `staticFlags.json`, since the type guards only the keys and value types, not the values, and the const is now web's runtime source.

Net effect on web: `EXPERIMENTAL_CSS_ANIMATIONS_FOR_SVG_COMPONENTS` resolves to its real default, which the web SVG CSS animation work depends on.