### PR TITLE
fix: Tab bar not switching the active tab content in examples

### DIFF
--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -5,6 +5,7 @@ import {
   Children,
   cloneElement,
   memo,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -12,7 +13,6 @@ import {
 import { Dimensions, StyleSheet, View } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
-  useAnimatedReaction,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -101,13 +101,13 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
   const previousSelectedTabIndex = useSharedValue(0);
   const selectedTabIndex = useSharedValue(0);
 
-  useAnimatedReaction(
-    () => selectedTabName,
-    (name) => {
-      const index = tabNames.indexOf(name);
+  const handleSelectTab = useCallback(
+    (name: string) => {
       previousSelectedTabIndex.value = selectedTabIndex.value;
-      selectedTabIndex.value = index;
-    }
+      selectedTabIndex.value = tabNames.indexOf(name);
+      setSelectedTabName(name);
+    },
+    [tabNames, previousSelectedTabIndex, selectedTabIndex]
   );
 
   useEffect(() => {
@@ -125,7 +125,7 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
         <TabSelector
           selectedTab={selectedTabName}
           tabs={tabNames}
-          onSelectTab={setSelectedTabName}
+          onSelectTab={handleSelectTab}
         />
       </View>
       <View style={flex.fill}>


### PR DESCRIPTION
## Summary

This PR fixes the tab bar used in the example app. Before the fix, it sometimes navigated to the incorrect tab when arrows or tabs were pressed.

## Example recording

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/002c825e-ea73-460a-baad-5c34304772ba" /> | <video src="https://github.com/user-attachments/assets/a5eddcec-4bb1-4d55-878a-2a0a280326e0" /> |

## Test plan

Open a tabbed screen in `web-example` (e.g. Margins) and switch tabs via the cells and left/right arrows - the content follows the selection.