### PR TITLE
chore: Simplify CSS transition flow

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
@@ -32,6 +32,13 @@ struct CSSTransitionConfig {
   PropertiesSettingsMap changedPropertiesSettings;
   PropertyValueDiffsMap changedProperties;
   std::vector<std::string> removedProperties;
+
+  bool hasSettingsUpdates() const {
+    return !changedPropertiesSettings.empty() || !removedProperties.empty();
+  }
+  bool hasValueUpdates() const {
+    return !changedProperties.empty();
+  }
 };
 
 CSSTransitionConfig

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/configs/CSSTransitionConfig.h
@@ -39,6 +39,9 @@ struct CSSTransitionConfig {
   bool hasValueUpdates() const {
     return !changedProperties.empty();
   }
+  bool empty() const {
+    return !hasSettingsUpdates() && !hasValueUpdates();
+  }
 };
 
 CSSTransitionConfig

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -13,10 +13,10 @@ CSSLoopTransition::CSSLoopTransition(
     const Tag viewTag,
     const std::string &componentName,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-    CSSTransition::Observer &observer)
+    OnUpdateCallback onUpdate)
     : viewTag_(viewTag),
       componentName_(componentName),
-      observer_(observer),
+      onUpdate_(std::move(onUpdate)),
       styleInterpolator_(TransitionStyleInterpolator(componentName_, viewStylesRepository)),
       progressProvider_(TransitionProgressProvider()) {}
 
@@ -24,13 +24,9 @@ double CSSLoopTransition::getMinDelay(double timestamp) const {
   return progressProvider_.getMinDelay(timestamp);
 }
 
-TransitionProgressState CSSLoopTransition::getState() const {
-  return progressProvider_.getState();
-}
-
 bool CSSLoopTransition::update(const double timestamp, OperationsLoop &loop) {
   progressProvider_.update(timestamp);
-  observer_.onTransitionUpdate(viewTag_);
+  onUpdate_(viewTag_);
 
   if (progressProvider_.getState() == TransitionProgressState::Pending) {
     loop.schedule(shared_from_this(), timestamp + progressProvider_.getMinDelay(timestamp));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.cpp
@@ -97,8 +97,6 @@ void CSSLoopTransition::handleChangedProperties(
       continue;
     }
 
-    properties_.insert(propertyName);
-
     // Update the transition style interpolator
     bool isReversed;
     if (lastUpdateValue.count(propertyName)) {
@@ -131,8 +129,6 @@ void CSSLoopTransition::handleChangedProperties(
       continue;
     }
 
-    properties_.insert(propertyName);
-
     bool isReversed;
     if (lastUpdateValue.count(propertyName)) {
       isReversed = styleInterpolator_.createOrUpdateInterpolator(
@@ -150,15 +146,11 @@ void CSSLoopTransition::handleChangedProperties(
 void CSSLoopTransition::removeProperties(const std::vector<std::string> &propertyNames) {
   styleInterpolator_.removeProperties(propertyNames);
   progressProvider_.removeProperties(propertyNames);
-  for (const auto &propertyName : propertyNames) {
-    properties_.erase(propertyName);
-  }
 }
 
 void CSSLoopTransition::removeProperty(const std::string &propertyName) {
   styleInterpolator_.removeProperty(propertyName);
   progressProvider_.removeProperty(propertyName);
-  properties_.erase(propertyName);
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -51,7 +51,6 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
   const std::string componentName_;
   OnUpdateCallback onUpdate_;
 
-  TransitionProperties properties_;
   TransitionStyleInterpolator styleInterpolator_;
   TransitionProgressProvider progressProvider_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSLoopTransition.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
-#include <reanimated/CSS/core/transition/CSSTransition.h>
 #include <reanimated/CSS/interpolation/styles/TransitionStyleInterpolator.h>
 #include <reanimated/CSS/progress/TransitionProgressProvider.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -16,18 +16,15 @@ namespace reanimated::css {
 
 class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enable_shared_from_this<CSSLoopTransition> {
  public:
+  using OnUpdateCallback = std::function<void(Tag)>;
+
   CSSLoopTransition(
       Tag viewTag,
       const std::string &componentName,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-      CSSTransition::Observer &observer);
-
-  TransitionProperties getProperties() const {
-    return properties_;
-  }
+      OnUpdateCallback onUpdate);
 
   double getMinDelay(double timestamp) const;
-  TransitionProgressState getState() const;
 
   bool update(double timestamp, OperationsLoop &loop) override;
 
@@ -52,7 +49,7 @@ class CSSLoopTransition : public OperationsLoop::LoopOperation, public std::enab
  private:
   const Tag viewTag_;
   const std::string componentName_;
-  CSSTransition::Observer &observer_;
+  OnUpdateCallback onUpdate_;
 
   TransitionProperties properties_;
   TransitionStyleInterpolator styleInterpolator_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -1,6 +1,8 @@
 #include <reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h>
 #include <reanimated/Tools/FeatureFlags.h>
 
+#include <react/debug/react_native_assert.h>
+
 #include <utility>
 
 namespace reanimated::css {
@@ -78,15 +80,9 @@ CSSPlatformTransitionProxy::ProcessedConfig CSSPlatformTransitionProxy::processC
     }
   }
 
-  // Any value diffs without matching settings - forward to whichever side they
-  // were last on. (Practically rare: parser emits settings + values together.)
-  while (!config.changedProperties.empty()) {
-    auto valueNode = config.changedProperties.extract(config.changedProperties.begin());
-    if (!result.routing.platform.contains(valueNode.key())) {
-      result.routing.loop.insert(valueNode.key());
-      result.loop.changedProperties.insert(std::move(valueNode));
-    }
-  }
+  // The parser pairs every value diff with settings, so the drain above must
+  // have consumed all of changedProperties.
+  react_native_assert(config.changedProperties.empty() && "[Reanimated] CSS transition value diff without settings");
 
   // Props JS asked to stop transitioning: look up the owning side in routing
   // and forward the cancel there.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -41,6 +41,10 @@ struct CSSPlatformTransitionConfig {
   PropertiesSettingsMap changedPropertiesSettings;
   std::vector<CSSPlatformTransitionRawEntry> changedProperties;
   std::vector<std::string> removedProperties;
+
+  bool empty() const {
+    return changedPropertiesSettings.empty() && changedProperties.empty() && removedProperties.empty();
+  }
 };
 
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -43,24 +43,19 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
 
   if (!processed.platform.empty()) {
     auto &platformTransition = ensurePlatformTransition();
-    if (!processed.platform.changedPropertiesSettings.empty() || !processed.platform.removedProperties.empty()) {
-      platformTransition.updateSettings(
-          processed.platform.changedPropertiesSettings, processed.platform.removedProperties);
-    }
-    if (!processed.platform.changedProperties.empty() || !processed.platform.removedProperties.empty()) {
-      platformTransition.run(rt, processed.platform, timestamp);
-    }
+    platformTransition.updateSettings(
+        processed.platform.changedPropertiesSettings, processed.platform.removedProperties);
+    platformTransition.run(rt, processed.platform, timestamp);
   }
 
   const auto &loopConfig = processed.loop;
-  if (!loopConfig.hasSettingsUpdates() && !loopConfig.hasValueUpdates()) {
+  if (loopConfig.empty()) {
     return folly::dynamic::object();
   }
 
   auto &loopTransition = ensureLoopTransition();
-  if (loopConfig.hasSettingsUpdates()) {
-    loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
-  }
+  loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
+
   // Settings-only configs reconfigure without running.
   if (!loopConfig.hasValueUpdates()) {
     return folly::dynamic::object();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -11,15 +11,14 @@ namespace reanimated::css {
 CSSTransition::CSSTransition(
     std::shared_ptr<const ShadowNode> shadowNode,
     const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-    Observer &observer,
-    const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy)
+    const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy,
+    const std::shared_ptr<OperationsLoop> &loop,
+    Observer &observer)
     : shadowNode_(std::move(shadowNode)),
-      loopTransition_(std::make_shared<CSSLoopTransition>(
-          shadowNode_->getTag(),
-          shadowNode_->getComponentName(),
-          viewStylesRepository,
-          observer)),
-      platformTransitionProxy_(platformTransitionProxy) {}
+      viewStylesRepository_(viewStylesRepository),
+      platformTransitionProxy_(platformTransitionProxy),
+      loop_(loop),
+      observer_(observer) {}
 
 CSSTransition::~CSSTransition() {
   if (platformTransition_) {
@@ -28,45 +27,58 @@ CSSTransition::~CSSTransition() {
 }
 
 TransitionProperties CSSTransition::getProperties() const {
-  // Loop-side properties are tracked by the loop transition; merge in any
-  // routed-to-platform names so callers see the full set.
-  TransitionProperties result = loopTransition_->getProperties();
+  TransitionProperties result = routing_.loop;
+  result.reserve(routing_.loop.size() + routing_.platform.size());
   result.insert(routing_.platform.begin(), routing_.platform.end());
   return result;
 }
 
-double CSSTransition::getMinDelay(double timestamp) const {
-  return loopTransition_->getMinDelay(timestamp);
-}
+folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates) {
+  const auto timestamp = loop_->resolveTimestamp();
 
-TransitionProgressState CSSTransition::getState() const {
-  return loopTransition_->getState();
-}
+  // CSSTransition owns routing: platform-routed props run immediately on the platform
+  // transition; the loop-routed remainder is applied to the loop transition below.
+  auto processed = platformTransitionProxy_->processConfig(std::move(config), routing_);
+  routing_ = std::move(processed.routing);
 
-void CSSTransition::schedule(OperationsLoop &loop) {
-  const auto timestamp = loop.resolveTimestamp();
-  loop.schedule(loopTransition_, timestamp + loopTransition_->getMinDelay(timestamp));
-}
+  if (!processed.platform.empty()) {
+    auto &platformTransition = ensurePlatformTransition();
+    if (!processed.platform.changedPropertiesSettings.empty() || !processed.platform.removedProperties.empty()) {
+      platformTransition.updateSettings(
+          processed.platform.changedPropertiesSettings, processed.platform.removedProperties);
+    }
+    if (!processed.platform.changedProperties.empty() || !processed.platform.removedProperties.empty()) {
+      platformTransition.run(rt, processed.platform, timestamp);
+    }
+  }
 
-void CSSTransition::unschedule(OperationsLoop &loop) {
-  loop.remove(loopTransition_);
+  const auto &loopConfig = processed.loop;
+  if (!loopConfig.hasSettingsUpdates() && !loopConfig.hasValueUpdates()) {
+    return folly::dynamic::object();
+  }
+
+  auto &loopTransition = ensureLoopTransition();
+  if (loopConfig.hasSettingsUpdates()) {
+    loopTransition.updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
+  }
+  // Settings-only configs reconfigure without running.
+  if (!loopConfig.hasValueUpdates()) {
+    return folly::dynamic::object();
+  }
+
+  auto initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
+  scheduleLoop(timestamp);
+  return initialUpdate;
 }
 
 folly::dynamic CSSTransition::run(
-    jsi::Runtime &rt,
-    const PropertyValueDiffsMap &propertiesDiffs,
-    const folly::dynamic &lastUpdateValue,
-    const double timestamp) {
-  return loopTransition_->run(rt, shadowNode_, propertiesDiffs, lastUpdateValue, timestamp);
-}
+    const PropertyValueDynamicDiffsMap &propertyDiffs,
+    const folly::dynamic &lastUpdates) {
+  const auto timestamp = loop_->resolveTimestamp();
 
-folly::dynamic CSSTransition::run(
-    const PropertyValueDynamicDiffsMap &propertiesDiffs,
-    const folly::dynamic &lastUpdateValue,
-    const double timestamp) {
   PropertyValueDynamicDiffsMap loopDiffs;
   PropertyValueDynamicDiffsMap platformDiffs;
-  for (const auto &[propertyName, propertyDiff] : propertiesDiffs) {
+  for (const auto &[propertyName, propertyDiff] : propertyDiffs) {
     if (routing_.platform.contains(propertyName)) {
       platformDiffs.emplace(propertyName, propertyDiff);
     } else {
@@ -77,34 +89,29 @@ folly::dynamic CSSTransition::run(
   if (!platformDiffs.empty()) {
     ensurePlatformTransition().run(platformDiffs, timestamp);
   }
-
-  return loopTransition_->run(shadowNode_, loopDiffs, lastUpdateValue, timestamp);
-}
-
-void CSSTransition::updateSettings(
-    const PropertiesSettingsMap &changedPropertiesSettings,
-    const std::vector<std::string> &removedProperties) {
-  loopTransition_->updateSettings(changedPropertiesSettings, removedProperties);
-}
-
-CSSTransitionConfig
-CSSTransition::splitForPlatformRouting(jsi::Runtime &rt, CSSTransitionConfig &&config, const double timestamp) {
-  auto processed = platformTransitionProxy_->processConfig(std::move(config), routing_);
-  routing_ = std::move(processed.routing);
-
-  if (!processed.platform.changedPropertiesSettings.empty() || !processed.platform.removedProperties.empty()) {
-    ensurePlatformTransition().updateSettings(
-        processed.platform.changedPropertiesSettings, processed.platform.removedProperties);
-  }
-  if (!processed.platform.changedProperties.empty() || !processed.platform.removedProperties.empty()) {
-    ensurePlatformTransition().run(rt, processed.platform, timestamp);
+  if (loopDiffs.empty() && !loopTransition_) {
+    return folly::dynamic::object();
   }
 
-  return std::move(processed.loop);
+  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
+  scheduleLoop(timestamp);
+  return initialUpdate;
 }
 
-folly::dynamic CSSTransition::computeCurrentStyle() {
+folly::dynamic CSSTransition::computeCurrentLoopStyle() {
+  if (!loopTransition_) {
+    return folly::dynamic::object();
+  }
   return loopTransition_->computeCurrentStyle(shadowNode_);
+}
+
+void CSSTransition::cancel() {
+  if (loopTransition_) {
+    loop_->remove(loopTransition_);
+  }
+  if (platformTransition_) {
+    platformTransition_->cancelAll();
+  }
 }
 
 CSSPlatformTransition &CSSTransition::ensurePlatformTransition() {
@@ -112,6 +119,21 @@ CSSPlatformTransition &CSSTransition::ensurePlatformTransition() {
     platformTransition_ = std::make_unique<CSSPlatformTransition>(shadowNode_->getTag(), platformTransitionProxy_);
   }
   return *platformTransition_;
+}
+
+CSSLoopTransition &CSSTransition::ensureLoopTransition() {
+  if (!loopTransition_) {
+    loopTransition_ = std::make_shared<CSSLoopTransition>(
+        shadowNode_->getTag(),
+        shadowNode_->getComponentName(),
+        viewStylesRepository_,
+        [&observer = observer_](Tag viewTag) { observer.onTransitionUpdate(viewTag); });
+  }
+  return *loopTransition_;
+}
+
+void CSSTransition::scheduleLoop(const double timestamp) {
+  loop_->schedule(loopTransition_, timestamp + loopTransition_->getMinDelay(timestamp));
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
+#include <reanimated/CSS/core/transition/CSSLoopTransition.h>
 #include <reanimated/CSS/core/transition/CSSPlatformTransition.h>
 #include <reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h>
-#include <reanimated/CSS/easing/EasingFunctions.h>
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
-#include <reanimated/CSS/progress/TransitionProgressProvider.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
 
 #include <react/renderer/core/ShadowNode.h>
@@ -18,8 +17,6 @@
 
 namespace reanimated::css {
 
-class CSSLoopTransition;
-
 class CSSTransition {
  public:
   class Observer {
@@ -31,8 +28,9 @@ class CSSTransition {
   CSSTransition(
       std::shared_ptr<const ShadowNode> shadowNode,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
-      Observer &observer,
-      const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy);
+      const std::shared_ptr<CSSPlatformTransitionProxy> &platformTransitionProxy,
+      const std::shared_ptr<OperationsLoop> &loop,
+      Observer &observer);
   ~CSSTransition();
 
   Tag getViewTag() const {
@@ -48,40 +46,29 @@ class CSSTransition {
   }
 
   TransitionProperties getProperties() const;
-  double getMinDelay(double timestamp) const;
-  TransitionProgressState getState() const;
 
-  void schedule(OperationsLoop &loop);
-  void unschedule(OperationsLoop &loop);
+  folly::dynamic computeCurrentLoopStyle();
 
-  folly::dynamic run(
-      jsi::Runtime &rt,
-      const PropertyValueDiffsMap &propertiesDiffs,
-      const folly::dynamic &lastUpdateValue,
-      double timestamp);
-  /** TODO: unify folly::dynamic and jsi::value versions */
-  folly::dynamic
-  run(const PropertyValueDynamicDiffsMap &propertiesDiffs, const folly::dynamic &lastUpdateValue, double timestamp);
-  void updateSettings(
-      const PropertiesSettingsMap &changedPropertiesSettings,
-      const std::vector<std::string> &removedProperties);
-
-  // Splits the incoming config via the platform proxy, applies the platform-side
-  // entries directly, and returns the loop-side config (settings + value diffs)
-  // for the caller to feed into updateSettings / run.
-  CSSTransitionConfig splitForPlatformRouting(jsi::Runtime &rt, CSSTransitionConfig &&config, double timestamp);
-
-  folly::dynamic computeCurrentStyle();
+  /// Applies a config: routes props between the platform and loop sides and runs them.
+  folly::dynamic run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates);
+  /// Runs the loop side directly from already-computed (dynamic) diffs.
+  folly::dynamic run(const PropertyValueDynamicDiffsMap &propertyDiffs, const folly::dynamic &lastUpdates);
+  void cancel();
 
  private:
   const std::shared_ptr<const ShadowNode> shadowNode_;
-  const std::shared_ptr<CSSLoopTransition> loopTransition_;
+  const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<CSSPlatformTransitionProxy> platformTransitionProxy_;
+  const std::shared_ptr<OperationsLoop> loop_;
+  Observer &observer_;
 
   CSSTransitionRouting routing_;
   std::unique_ptr<CSSPlatformTransition> platformTransition_;
+  std::shared_ptr<CSSLoopTransition> loopTransition_;
 
   CSSPlatformTransition &ensurePlatformTransition();
+  CSSLoopTransition &ensureLoopTransition();
+  void scheduleLoop(double timestamp);
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -25,55 +25,18 @@ void CSSTransitionsRegistry::updateConfigOrRun(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     CSSTransitionConfig &&config) {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
-  const auto viewTag = shadowNode->getTag();
-
-  if (!registry_.contains(viewTag)) {
-    auto transition = std::make_shared<CSSTransition>(
-        shadowNode, viewStylesRepository_, transitionObserver_, platformTransitionProxy_);
-    registry_.insert({viewTag, transition});
-  }
-
-  const auto &transition = registry_.at(viewTag);
-
-  // Split via the platform proxy: platform-routed props are handled inside
-  // CSSTransition::splitForPlatformRouting; the returned config carries only
-  // the loop-side settings + value diffs + removals.
-  auto loopConfig = transition->splitForPlatformRouting(rt, std::move(config), loop_->resolveTimestamp());
-
-  if (loopConfig.changedPropertiesSettings.size() || loopConfig.removedProperties.size()) {
-    transition->updateSettings(loopConfig.changedPropertiesSettings, loopConfig.removedProperties);
-  }
-  if (loopConfig.changedProperties.size()) {
-    runTransition(rt, transition, viewTag, loopConfig.changedProperties);
-  }
-}
-
-void CSSTransitionsRegistry::run(
-    jsi::Runtime &rt,
-    const std::shared_ptr<const ShadowNode> &shadowNode,
-    const PropertyValueDiffsMap &propertyDiffs) {
-  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
-  const auto viewTag = shadowNode->getTag();
-  const auto &transition = registry_.at(viewTag);
-
-  runTransition(rt, transition, viewTag, propertyDiffs);
+  const auto &transition = getOrCreateTransition(shadowNode);
+  auto initialUpdate = transition->run(rt, std::move(config), getUpdatesFromRegistry(transition->getViewTag()));
+  recordInitialUpdate(transition, initialUpdate);
 }
 
 void CSSTransitionsRegistry::run(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const PropertyValueDynamicDiffsMap &propertyDiffs) {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
-  const auto viewTag = shadowNode->getTag();
-  const auto &transition = registry_.at(viewTag);
-
-  const auto &lastUpdates = getUpdatesFromRegistry(viewTag);
-  const auto timestamp = loop_->resolveTimestamp();
-
-  auto initialUpdate = transition->run(propertyDiffs, lastUpdates, timestamp);
-
-  transition->schedule(*loop_);
-  updateInUpdatesRegistry(transition, initialUpdate);
-  updatedTags_.insert(viewTag);
+  const auto &transition = getOrCreateTransition(shadowNode);
+  auto initialUpdate = transition->run(propertyDiffs, getUpdatesFromRegistry(transition->getViewTag()));
+  recordInitialUpdate(transition, initialUpdate);
 }
 
 void CSSTransitionsRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
@@ -86,8 +49,7 @@ void CSSTransitionsRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
     }
 
     auto &transition = it->second;
-    const auto updates = transition->computeCurrentStyle();
-
+    const auto updates = transition->computeCurrentLoopStyle();
     if (!updates.empty()) {
       addUpdatesToBatch(transition->getShadowNodeFamily(), updates);
     }
@@ -107,8 +69,7 @@ void CSSTransitionsRegistry::flushUpdates(UpdatesBatchAnimatedProps &updatesBatc
     }
 
     auto &transition = it->second;
-    const auto updates = transition->computeCurrentStyle();
-
+    const auto updates = transition->computeCurrentLoopStyle();
     if (!updates.empty()) {
       addRawPropsToAnimatedPropsBatch(transition->getShadowNodeFamily(), updates);
       // Legacy flushes merge each frame into the updates registry; animated-props flushes do not.
@@ -131,7 +92,7 @@ void CSSTransitionsRegistry::TransitionObserver::onTransitionUpdate(const Tag vi
 void CSSTransitionsRegistry::removeTag(const Tag viewTag) {
   const auto it = registry_.find(viewTag);
   if (it != registry_.end()) {
-    it->second->unschedule(*loop_);
+    it->second->cancel();
   }
   removeFromUpdatesRegistry(viewTag);
   registry_.erase(viewTag);
@@ -162,19 +123,26 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   setInUpdatesRegistry(shadowNode->getFamilyShared(), filteredUpdates);
 }
 
-void CSSTransitionsRegistry::runTransition(
-    jsi::Runtime &rt,
+const std::shared_ptr<CSSTransition> &CSSTransitionsRegistry::getOrCreateTransition(
+    const std::shared_ptr<const ShadowNode> &shadowNode) {
+  const auto viewTag = shadowNode->getTag();
+  if (!registry_.contains(viewTag)) {
+    registry_.emplace(
+        viewTag,
+        std::make_shared<CSSTransition>(
+            shadowNode, viewStylesRepository_, platformTransitionProxy_, loop_, transitionObserver_));
+  }
+  return registry_.at(viewTag);
+}
+
+void CSSTransitionsRegistry::recordInitialUpdate(
     const std::shared_ptr<CSSTransition> &transition,
-    const facebook::react::Tag &viewTag,
-    const PropertyValueDiffsMap &propertyDiffs) {
-  const auto &lastUpdates = getUpdatesFromRegistry(viewTag);
-  const auto timestamp = loop_->resolveTimestamp();
-
-  auto initialUpdate = transition->run(rt, propertyDiffs, lastUpdates, timestamp);
-
-  transition->schedule(*loop_);
+    const folly::dynamic &initialUpdate) {
+  if (initialUpdate.empty()) {
+    return;
+  }
   updateInUpdatesRegistry(transition, initialUpdate);
-  updatedTags_.insert(viewTag);
+  updatedTags_.insert(transition->getViewTag());
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -21,17 +21,11 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
 
   bool needsFlush() const;
 
-  // TO DO: In the future we want to decouple config update and run
+  // TODO: In the future we want to decouple config update and run
   void updateConfigOrRun(
       jsi::Runtime &rt,
       const std::shared_ptr<const ShadowNode> &shadowNode,
       CSSTransitionConfig &&config);
-  /// run Should be called only after someone has already set settings with updateConfigOrRun
-  void run(
-      jsi::Runtime &rt,
-      const std::shared_ptr<const ShadowNode> &shadowNode,
-      const PropertyValueDiffsMap &propertyDiffs);
-  /** TODO: unify folly::dynamic and jsi::value versions */
   void run(const std::shared_ptr<const ShadowNode> &shadowNode, const PropertyValueDynamicDiffsMap &propertyDiffs);
 
   void flushUpdates(UpdatesBatch &updatesBatch);
@@ -62,12 +56,9 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
   std::unordered_set<Tag> updatedTags_;
 
   void removeTag(Tag viewTag) override;
+  const std::shared_ptr<CSSTransition> &getOrCreateTransition(const std::shared_ptr<const ShadowNode> &shadowNode);
   void updateInUpdatesRegistry(const std::shared_ptr<CSSTransition> &transition, const folly::dynamic &updates);
-  void runTransition(
-      jsi::Runtime &rt,
-      const std::shared_ptr<CSSTransition> &transition,
-      const facebook::react::Tag &viewTag,
-      const PropertyValueDiffsMap &propertyDiffs);
+  void recordInitialUpdate(const std::shared_ptr<CSSTransition> &transition, const folly::dynamic &initialUpdate);
 };
 
 } // namespace reanimated::css


### PR DESCRIPTION
## Summary
Cleans up the internal CSS transition flow to make it simpler to follow and easier to extend in upcoming work. No behavior change.

## Test plan
Build on iOS and Android and smoke-test a CSS transition.