### PR TITLE
chore: Deduplicate `CSSLengthArray` and `SVGStrokeDashArray`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
@@ -1,74 +1,21 @@
 #include <reanimated/CSS/svg/values/CSSLengthArray.h>
 
 #include <algorithm>
-#include <sstream>
+#include <cmath>
+#include <utility>
+#include <vector>
 
 namespace reanimated::css {
-
-CSSLengthArray::CSSLengthArray(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  const auto &array = jsiValue.asObject(rt).asArray(rt);
-  const auto arraySize = array.size(rt);
-  lengths.reserve(arraySize);
-  for (size_t i = 0; i < arraySize; ++i) {
-    lengths.emplace_back(rt, array.getValueAtIndex(rt, i));
-  }
-  ensureLengthsNonempty();
-}
-
-CSSLengthArray::CSSLengthArray(const folly::dynamic &value) {
-  lengths.reserve(value.size());
-  for (const auto &item : value) {
-    lengths.emplace_back(item);
-  }
-  ensureLengthsNonempty();
-}
-
-bool CSSLengthArray::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  if (!jsiValue.isObject() || !jsiValue.asObject(rt).isArray(rt)) {
-    return false;
-  }
-  const auto &array = jsiValue.asObject(rt).asArray(rt);
-  for (size_t i = 0; i < array.size(rt); ++i) {
-    if (!CSSLength::canConstruct(rt, array.getValueAtIndex(rt, i))) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool CSSLengthArray::canConstruct(const folly::dynamic &value) {
-  return value.isArray() &&
-      std::all_of(value.begin(), value.end(), [](const auto &item) { return CSSLength::canConstruct(item); });
-}
-
-folly::dynamic CSSLengthArray::toDynamic() const {
-  folly::dynamic array = folly::dynamic::array;
-  array.reserve(lengths.size());
-  for (const auto &length : lengths) {
-    array.push_back(length.toDynamic());
-  }
-  return array;
-}
-
-std::string CSSLengthArray::toString() const {
-  std::stringstream ss;
-  ss << "[";
-  for (const auto &length : lengths) {
-    ss << length.toString();
-    if (&length != &lengths.back()) {
-      ss << ", ";
-    }
-  }
-  ss << "]";
-  return ss.str();
-}
 
 CSSLengthArray CSSLengthArray::interpolate(
     double progress,
     const CSSLengthArray &to,
     const ResolvableValueInterpolationContext &context) const {
-  const auto &fromLengths = lengths;
-  const auto &toLengths = to.lengths;
+  // An empty list behaves as a single zero so that interpolation between lists
+  // of different sizes (and against the default value) stays in bounds.
+  static const std::vector<CSSLength> fallback{CSSLength(0.0)};
+  const auto &fromLengths = values.empty() ? fallback : values;
+  const auto &toLengths = to.values.empty() ? fallback : to.values;
 
   size_t fromSize = fromLengths.size();
   size_t toSize = toLengths.size();
@@ -89,10 +36,6 @@ CSSLengthArray CSSLengthArray::interpolate(
   return CSSLengthArray(std::move(result));
 }
 
-bool CSSLengthArray::operator==(const CSSLengthArray &other) const {
-  return lengths == other.lengths;
-}
-
 #ifndef NDEBUG
 
 std::ostream &operator<<(std::ostream &os, const CSSLengthArray &value) {
@@ -101,11 +44,5 @@ std::ostream &operator<<(std::ostream &os, const CSSLengthArray &value) {
 }
 
 #endif // NDEBUG
-
-void CSSLengthArray::ensureLengthsNonempty() {
-  if (lengths.empty()) {
-    lengths.emplace_back(0);
-  }
-}
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.cpp
@@ -11,8 +11,7 @@ CSSLengthArray CSSLengthArray::interpolate(
     double progress,
     const CSSLengthArray &to,
     const ResolvableValueInterpolationContext &context) const {
-  // An empty list behaves as a single zero so that interpolation between lists
-  // of different sizes (and against the default value) stays in bounds.
+  // Treat an empty list as a single zero.
   static const std::vector<CSSLength> fallback{CSSLength(0.0)};
   const auto &fromLengths = values.empty() ? fallback : values;
   const auto &toLengths = to.values.empty() ? fallback : to.values;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
@@ -7,12 +7,7 @@
 namespace reanimated::css {
 
 struct CSSLengthArray : public CSSLengthVector<CSSLengthArray> {
-  static constexpr char kOpenBracket = '[';
-  static constexpr char kCloseBracket = ']';
-
-  // The default value is a single zero so that "to"-only animations
-  // interpolate from 0. An explicitly empty list is also accepted and treated
-  // as zero by `interpolate`.
+  // Defaults to a single zero; an empty list is also treated as zero.
   CSSLengthArray() : CSSLengthVector(std::vector<CSSLength>{CSSLength(0.0)}) {}
   using CSSLengthVector::CSSLengthVector;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthArray.h
@@ -1,53 +1,29 @@
 #pragma once
 
-#include <reanimated/CSS/common/values/CSSLength.h>
+#include <reanimated/CSS/svg/values/CSSLengthVector.h>
 
-#include <concepts>
-#include <string>
-#include <utility>
 #include <vector>
 
 namespace reanimated::css {
 
-// TODO:
-// This class can be changed into a template in the future
-// Then it can be also used for interpolating the SVGStops
-struct CSSLengthArray : public CSSResolvableValue<CSSLengthArray> {
+struct CSSLengthArray : public CSSLengthVector<CSSLengthArray> {
+  static constexpr char kOpenBracket = '[';
+  static constexpr char kCloseBracket = ']';
 
-  CSSLengthArray() {
-    ensureLengthsNonempty();
-  }
-  explicit CSSLengthArray(CSSLength singleValue) : lengths{std::move(singleValue)} {
-    ensureLengthsNonempty();
-  }
-  template <typename T>
-    requires(!std::same_as<std::decay_t<T>, CSSLengthArray>) && std::constructible_from<std::vector<CSSLength>, T>
-  explicit CSSLengthArray(T &&value) : lengths{std::forward<T>(value)} {
-    ensureLengthsNonempty();
-  }
-  explicit CSSLengthArray(jsi::Runtime &rt, const jsi::Value &jsiValue);
-  explicit CSSLengthArray(const folly::dynamic &value);
+  // The default value is a single zero so that "to"-only animations
+  // interpolate from 0. An explicitly empty list is also accepted and treated
+  // as zero by `interpolate`.
+  CSSLengthArray() : CSSLengthVector(std::vector<CSSLength>{CSSLength(0.0)}) {}
+  using CSSLengthVector::CSSLengthVector;
 
-  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
-  static bool canConstruct(const folly::dynamic &value);
-
-  folly::dynamic toDynamic() const override;
-  std::string toString() const override;
   CSSLengthArray interpolate(
       double progress,
       const CSSLengthArray &to,
       const ResolvableValueInterpolationContext &context) const override;
 
-  bool operator==(const CSSLengthArray &other) const;
-
 #ifndef NDEBUG
-  friend std::ostream &operator<<(std::ostream &os, const CSSLengthArray &dimension);
+  friend std::ostream &operator<<(std::ostream &os, const CSSLengthArray &value);
 #endif // NDEBUG
-
- private:
-  std::vector<CSSLength> lengths;
-
-  void ensureLengthsNonempty();
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
@@ -1,0 +1,87 @@
+#include <reanimated/CSS/svg/values/CSSLengthArray.h>
+#include <reanimated/CSS/svg/values/CSSLengthVector.h>
+#include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+template <typename Derived>
+CSSLengthVector<Derived>::CSSLengthVector(std::vector<CSSLength> values) : values(std::move(values)) {}
+
+template <typename Derived>
+CSSLengthVector<Derived>::CSSLengthVector(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  const auto array = jsiValue.asObject(rt).asArray(rt);
+  const auto size = array.size(rt);
+  values.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    values.emplace_back(rt, array.getValueAtIndex(rt, i));
+  }
+}
+
+template <typename Derived>
+CSSLengthVector<Derived>::CSSLengthVector(const folly::dynamic &value) {
+  values.reserve(value.size());
+  for (const auto &item : value) {
+    values.emplace_back(item);
+  }
+}
+
+template <typename Derived>
+bool CSSLengthVector<Derived>::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
+  if (!jsiValue.isObject() || !jsiValue.asObject(rt).isArray(rt)) {
+    return false;
+  }
+  const auto array = jsiValue.asObject(rt).asArray(rt);
+  const auto size = array.size(rt);
+  for (size_t i = 0; i < size; ++i) {
+    if (!CSSLength::canConstruct(rt, array.getValueAtIndex(rt, i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename Derived>
+bool CSSLengthVector<Derived>::canConstruct(const folly::dynamic &value) {
+  return value.isArray() &&
+      std::all_of(value.begin(), value.end(), [](const auto &item) { return CSSLength::canConstruct(item); });
+}
+
+template <typename Derived>
+folly::dynamic CSSLengthVector<Derived>::toDynamic() const {
+  folly::dynamic array = folly::dynamic::array;
+  array.reserve(values.size());
+  for (const auto &length : values) {
+    array.push_back(length.toDynamic());
+  }
+  return array;
+}
+
+template <typename Derived>
+std::string CSSLengthVector<Derived>::toString() const {
+  std::stringstream ss;
+  ss << Derived::kOpenBracket;
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << values[i].toString();
+  }
+  ss << Derived::kCloseBracket;
+  return ss.str();
+}
+
+template <typename Derived>
+bool CSSLengthVector<Derived>::operator==(const Derived &other) const {
+  return values == other.values;
+}
+
+template struct CSSLengthVector<CSSLengthArray>;
+template struct CSSLengthVector<SVGStrokeDashArray>;
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
@@ -77,7 +77,7 @@ std::string CSSLengthVector<Derived>::toString() const {
 }
 
 template <typename Derived>
-bool CSSLengthVector<Derived>::operator==(const Derived &other) const {
+bool CSSLengthVector<Derived>::operator==(const CSSLengthVector &other) const {
   return values == other.values;
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.cpp
@@ -65,14 +65,14 @@ folly::dynamic CSSLengthVector<Derived>::toDynamic() const {
 template <typename Derived>
 std::string CSSLengthVector<Derived>::toString() const {
   std::stringstream ss;
-  ss << Derived::kOpenBracket;
+  ss << '[';
   for (size_t i = 0; i < values.size(); ++i) {
     if (i > 0) {
       ss << ", ";
     }
     ss << values[i].toString();
   }
-  ss << Derived::kCloseBracket;
+  ss << ']';
   return ss.str();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
@@ -7,17 +7,6 @@
 
 namespace reanimated::css {
 
-/*
- * Base for CSS values that hold a list of CSSLength values and interpolate
- * them element-wise. Concrete subclasses only implement `interpolate`, which
- * decides how the two lists are paired/resized before interpolating the
- * corresponding elements (e.g. nearest-neighbor resampling for CSSLengthArray,
- * least-common-multiple repetition for SVGStrokeDashArray).
- *
- * Each `Derived` must declare two static members used by `toString`:
- *   static constexpr char kOpenBracket;
- *   static constexpr char kCloseBracket;
- */
 template <typename Derived>
 struct CSSLengthVector : public CSSResolvableValue<Derived> {
   std::vector<CSSLength> values;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
@@ -22,7 +22,7 @@ struct CSSLengthVector : public CSSResolvableValue<Derived> {
   folly::dynamic toDynamic() const override;
   std::string toString() const override;
 
-  bool operator==(const Derived &other) const;
+  bool operator==(const CSSLengthVector &other) const;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/CSSLengthVector.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <reanimated/CSS/common/values/CSSLength.h>
+
+#include <string>
+#include <vector>
+
+namespace reanimated::css {
+
+/*
+ * Base for CSS values that hold a list of CSSLength values and interpolate
+ * them element-wise. Concrete subclasses only implement `interpolate`, which
+ * decides how the two lists are paired/resized before interpolating the
+ * corresponding elements (e.g. nearest-neighbor resampling for CSSLengthArray,
+ * least-common-multiple repetition for SVGStrokeDashArray).
+ *
+ * Each `Derived` must declare two static members used by `toString`:
+ *   static constexpr char kOpenBracket;
+ *   static constexpr char kCloseBracket;
+ */
+template <typename Derived>
+struct CSSLengthVector : public CSSResolvableValue<Derived> {
+  std::vector<CSSLength> values;
+
+  CSSLengthVector() = default;
+  explicit CSSLengthVector(std::vector<CSSLength> values);
+  explicit CSSLengthVector(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  explicit CSSLengthVector(const folly::dynamic &value);
+
+  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
+  static bool canConstruct(const folly::dynamic &value);
+
+  folly::dynamic toDynamic() const override;
+  std::string toString() const override;
+
+  bool operator==(const Derived &other) const;
+};
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -1,68 +1,9 @@
 #include <reanimated/CSS/svg/values/SVGStrokeDashArray.h>
 
-#include <string>
+#include <numeric>
 #include <vector>
 
 namespace reanimated::css {
-
-SVGStrokeDashArray::SVGStrokeDashArray() : values() {}
-
-SVGStrokeDashArray::SVGStrokeDashArray(const std::vector<CSSLength> &values) : values(values) {}
-
-SVGStrokeDashArray::SVGStrokeDashArray(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  const auto &array = jsiValue.asObject(rt).asArray(rt);
-  const auto arraySize = array.size(rt);
-  values.reserve(arraySize);
-  for (size_t i = 0; i < arraySize; ++i) {
-    values.emplace_back(rt, array.getValueAtIndex(rt, i));
-  }
-}
-
-SVGStrokeDashArray::SVGStrokeDashArray(const folly::dynamic &value) {
-  for (const auto &value : value) {
-    values.emplace_back(value);
-  }
-}
-
-bool SVGStrokeDashArray::canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue) {
-  if (!jsiValue.isObject() || !jsiValue.asObject(rt).isArray(rt)) {
-    return false;
-  }
-  const auto &array = jsiValue.asObject(rt).asArray(rt);
-  for (size_t i = 0; i < array.size(rt); ++i) {
-    if (!CSSLength::canConstruct(rt, array.getValueAtIndex(rt, i))) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool SVGStrokeDashArray::canConstruct(const folly::dynamic &value) {
-  return value.isArray() &&
-      std::all_of(value.begin(), value.end(), [](const auto &value) { return CSSLength::canConstruct(value); });
-}
-
-folly::dynamic SVGStrokeDashArray::toDynamic() const {
-  folly::dynamic array = folly::dynamic::array;
-  array.reserve(values.size());
-  for (const auto &value : values) {
-    array.push_back(value.toDynamic());
-  }
-  return array;
-}
-
-std::string SVGStrokeDashArray::toString() const {
-  std::stringstream ss;
-  ss << "{";
-  for (const auto &value : values) {
-    ss << value.toString();
-    if (&value != &values.back()) {
-      ss << ", ";
-    }
-  }
-  ss << "}";
-  return ss.str();
-}
 
 SVGStrokeDashArray SVGStrokeDashArray::interpolate(
     double progress,
@@ -95,10 +36,6 @@ SVGStrokeDashArray SVGStrokeDashArray::interpolate(
   }
 
   return SVGStrokeDashArray(result);
-}
-
-bool SVGStrokeDashArray::operator==(const SVGStrokeDashArray &other) const {
-  return values == other.values;
 }
 
 #ifndef NDEBUG

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
@@ -1,32 +1,19 @@
 #pragma once
 
-#include <reanimated/CSS/common/values/CSSLength.h>
-
-#include <numeric>
-#include <string>
-#include <vector>
+#include <reanimated/CSS/svg/values/CSSLengthVector.h>
 
 namespace reanimated::css {
 
-struct SVGStrokeDashArray : public CSSResolvableValue<SVGStrokeDashArray> {
-  std::vector<CSSLength> values;
+struct SVGStrokeDashArray : public CSSLengthVector<SVGStrokeDashArray> {
+  static constexpr char kOpenBracket = '{';
+  static constexpr char kCloseBracket = '}';
 
-  SVGStrokeDashArray();
-  explicit SVGStrokeDashArray(const std::vector<CSSLength> &values);
-  explicit SVGStrokeDashArray(jsi::Runtime &rt, const jsi::Value &jsiValue);
-  explicit SVGStrokeDashArray(const folly::dynamic &value);
+  using CSSLengthVector::CSSLengthVector;
 
-  static bool canConstruct(jsi::Runtime &rt, const jsi::Value &jsiValue);
-  static bool canConstruct(const folly::dynamic &value);
-
-  folly::dynamic toDynamic() const override;
-  std::string toString() const override;
   SVGStrokeDashArray interpolate(
       double progress,
       const SVGStrokeDashArray &to,
       const ResolvableValueInterpolationContext &context) const override;
-
-  bool operator==(const SVGStrokeDashArray &other) const;
 
 #ifndef NDEBUG
   friend std::ostream &operator<<(std::ostream &os, const SVGStrokeDashArray &strokeDashArray);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
@@ -5,9 +5,6 @@
 namespace reanimated::css {
 
 struct SVGStrokeDashArray : public CSSLengthVector<SVGStrokeDashArray> {
-  static constexpr char kOpenBracket = '{';
-  static constexpr char kCloseBracket = '}';
-
   using CSSLengthVector::CSSLengthVector;
 
   SVGStrokeDashArray interpolate(


### PR DESCRIPTION
## Summary

Deduplicate `CSSLengthArray` and `SVGStrokeDashArray`. Both are a `vector<CSSLength>` and shared identical scaffolding (constructors, JSI/dynamic parsing, `canConstruct`, `toDynamic`, `toString`, equality); only their `interpolate()` differs. The shared parts now live in a `CSSLengthVector` CRTP base, so each type keeps just its own `interpolate()`. No behavior change.
