### PR TITLE
feat: web support for CSS transition callbacks

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -59,6 +59,7 @@ export default class CSSManager implements ICSSManager {
       animationProperties,
       transitionProperties,
       pseudoStylesBySelector,
+      ,
       filteredStyle,
     ] = filterCSSAndStyleProperties(style);
 

--- a/packages/react-native-reanimated/src/css/types/index.ts
+++ b/packages/react-native-reanimated/src/css/types/index.ts
@@ -1,6 +1,9 @@
 'use strict';
 import type { CSSAnimationProp } from './animation';
-import type { CSSTransitionProp } from './transition';
+import type {
+  CSSTransitionCallbackProp,
+  CSSTransitionProp,
+} from './transition';
 
 export type * from './animation';
 export type * from './common';
@@ -11,4 +14,7 @@ export type * from './props';
 export type * from './pseudo';
 export type * from './transition';
 
-export type CSSConfigProp = CSSTransitionProp | CSSAnimationProp;
+export type CSSConfigProp =
+  | CSSTransitionProp
+  | CSSAnimationProp
+  | CSSTransitionCallbackProp;

--- a/packages/react-native-reanimated/src/css/types/props.ts
+++ b/packages/react-native-reanimated/src/css/types/props.ts
@@ -4,7 +4,10 @@ import type { StyleProp } from 'react-native';
 import type { PlainStyle } from '../../common';
 import type { CSSAnimationProperties } from './animation';
 import type { PseudoValue } from './pseudo';
-import type { CSSTransitionProperties } from './transition';
+import type {
+  CSSTransitionCallbacks,
+  CSSTransitionProperties,
+} from './transition';
 
 /*
   Style type properties (properties that extends StyleProp<ViewStyle>)
@@ -22,7 +25,8 @@ type PickStyleProps<P> = Pick<
 export type CSSStyle<S extends object = PlainStyle> = {
   [K in keyof S]: S[K] | PseudoValue<S[K]>;
 } & Partial<CSSAnimationProperties<S>> &
-  Partial<CSSTransitionProperties<S>>;
+  Partial<CSSTransitionProperties<S>> &
+  Partial<CSSTransitionCallbacks>;
 
 type StylePropsWithCSS<P extends object> = {
   [K in keyof PickStyleProps<P>]: P[K] extends StyleProp<infer U>

--- a/packages/react-native-reanimated/src/css/types/transition.ts
+++ b/packages/react-native-reanimated/src/css/types/transition.ts
@@ -21,7 +21,7 @@ export type CSSTransitionShorthand = string;
  */
 export type CSSTransitionEvent = {
   // TODO: add a JS-side view ref (e.g. `target`) once the right ref type is
-  // decided (AnimatedComponentRef isn't it; the shadow node is useless in JS).
+  // decided.
   /** The transitioning property, camelCased (e.g. `opacity`). */
   propertyName: string;
   /**
@@ -34,7 +34,7 @@ export type CSSTransitionEvent = {
 export type CSSTransitionCallback = (event: CSSTransitionEvent) => void;
 
 export type CSSTransitionCallbacks = {
-  /** Fired when the transition is created, before any `transitionDelay`. */
+  /** Fired when the transition is triggered, before any `transitionDelay`. */
   onTransitionRun?: CSSTransitionCallback;
   /** Fired after `transitionDelay`, when the property starts animating. */
   onTransitionStart?: CSSTransitionCallback;

--- a/packages/react-native-reanimated/src/css/types/transition.ts
+++ b/packages/react-native-reanimated/src/css/types/transition.ts
@@ -15,6 +15,37 @@ export type CSSTransitionDelay = TimeUnit;
 export type CSSTransitionBehavior = 'normal' | 'allow-discrete';
 export type CSSTransitionShorthand = string;
 
+/**
+ * Payload for a CSS transition callback, dispatched once per transitioning
+ * property.
+ */
+export type CSSTransitionEvent = {
+  // TODO: add a JS-side view ref (e.g. `target`) once the right ref type is
+  // decided (AnimatedComponentRef isn't it; the shadow node is useless in JS).
+  /** The transitioning property, camelCased (e.g. `opacity`). */
+  propertyName: string;
+  /**
+   * The amount of time the transition had been running, in seconds, when the
+   * event fired.
+   */
+  elapsedTime: number;
+};
+
+export type CSSTransitionCallback = (event: CSSTransitionEvent) => void;
+
+export type CSSTransitionCallbacks = {
+  /** Fired when the transition is created, before any `transitionDelay`. */
+  onTransitionRun?: CSSTransitionCallback;
+  /** Fired after `transitionDelay`, when the property starts animating. */
+  onTransitionStart?: CSSTransitionCallback;
+  /** Fired when the transition completes. */
+  onTransitionEnd?: CSSTransitionCallback;
+  /** Fired when the transition is interrupted before completing. */
+  onTransitionCancel?: CSSTransitionCallback;
+};
+
+export type CSSTransitionCallbackProp = keyof CSSTransitionCallbacks;
+
 type SingleCSSTransitionSettings = {
   transitionDuration?: CSSTransitionDuration;
   transitionTimingFunction?: CSSTransitionTimingFunction;

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -523,13 +523,9 @@ describe(filterCSSAndStyleProperties, () => {
 
   describe('transition callbacks validation', () => {
     const globalWithDev = globalThis as unknown as { __DEV__: boolean };
-    const originalDev = globalWithDev.__DEV__;
 
     beforeEach(() => {
       (console.warn as jest.Mock).mockClear();
-    });
-    afterEach(() => {
-      globalWithDev.__DEV__ = originalDev;
     });
 
     describe('in development (__DEV__)', () => {

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -521,33 +521,56 @@ describe(filterCSSAndStyleProperties, () => {
     });
   });
 
-  describe('transition callbacks validation (dev)', () => {
+  describe('transition callbacks validation', () => {
+    const globalWithDev = globalThis as unknown as { __DEV__: boolean };
+    const originalDev = globalWithDev.__DEV__;
+
     beforeEach(() => {
       (console.warn as jest.Mock).mockClear();
     });
-
-    test('warns when transition callbacks are used without any transition props', () => {
-      filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('onTransitionEnd')
-      );
+    afterEach(() => {
+      globalWithDev.__DEV__ = originalDev;
     });
 
-    test('does not warn when a transition is configured alongside callbacks', () => {
-      filterCSSAndStyleProperties({
-        transitionProperty: 'opacity',
-        transitionDuration: 100,
-        onTransitionEnd: jest.fn(),
-      } as CSSStyle);
-      expect(console.warn).not.toHaveBeenCalled();
+    describe('in development (__DEV__)', () => {
+      beforeEach(() => {
+        globalWithDev.__DEV__ = true;
+      });
+
+      test('warns when transition callbacks are used without any transition props', () => {
+        filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining('onTransitionEnd')
+        );
+      });
+
+      test('does not warn when a transition is configured alongside callbacks', () => {
+        filterCSSAndStyleProperties({
+          transitionProperty: 'opacity',
+          transitionDuration: 100,
+          onTransitionEnd: jest.fn(),
+        } as CSSStyle);
+        expect(console.warn).not.toHaveBeenCalled();
+      });
+
+      test('does not warn when only the transition shorthand is provided', () => {
+        filterCSSAndStyleProperties({
+          transition: 'opacity 2s',
+          onTransitionEnd: jest.fn(),
+        } as CSSStyle);
+        expect(console.warn).not.toHaveBeenCalled();
+      });
     });
 
-    test('does not warn when only the transition shorthand is provided', () => {
-      filterCSSAndStyleProperties({
-        transition: 'opacity 2s',
-        onTransitionEnd: jest.fn(),
-      } as CSSStyle);
-      expect(console.warn).not.toHaveBeenCalled();
+    describe('in production (!__DEV__)', () => {
+      beforeEach(() => {
+        globalWithDev.__DEV__ = false;
+      });
+
+      test('skips validation entirely - never warns, even without transition props', () => {
+        filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
+        expect(console.warn).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -20,6 +20,7 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -33,6 +34,7 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -46,6 +48,7 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -62,6 +65,7 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -87,6 +91,7 @@ describe(filterCSSAndStyleProperties, () => {
           null,
           null,
           {},
+          null,
         ]);
       });
     });
@@ -100,6 +105,7 @@ describe(filterCSSAndStyleProperties, () => {
         null,
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -116,12 +122,14 @@ describe(filterCSSAndStyleProperties, () => {
         style1,
         null,
         expect.any(Object),
+        null,
       ]);
       expect(filterCSSAndStyleProperties(style2)).toEqual([
         expect.any(Object),
         style2,
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -138,6 +146,7 @@ describe(filterCSSAndStyleProperties, () => {
         { transition: 'opacity 2s ease-in' },
         null,
         expect.any(Object),
+        null,
       ]);
     });
 
@@ -157,6 +166,7 @@ describe(filterCSSAndStyleProperties, () => {
           expect.objectContaining({ [key]: value }),
           null,
           {},
+          null,
         ]);
       });
     });
@@ -187,6 +197,7 @@ describe(filterCSSAndStyleProperties, () => {
           },
         },
         { opacity: 1, backgroundColor: 'blue' },
+        null,
       ]);
     });
 
@@ -249,6 +260,7 @@ describe(filterCSSAndStyleProperties, () => {
           },
         },
         { opacity: 1, borderRadius: 8 },
+        null,
       ]);
     });
   });
@@ -467,7 +479,75 @@ describe(filterCSSAndStyleProperties, () => {
           width: 100,
           height: 100,
         },
+        null,
       ]);
+    });
+  });
+
+  describe('transition callbacks', () => {
+    test('returns null when no callback props are present', () => {
+      const style: CSSStyle = {
+        transitionProperty: 'opacity',
+        transitionDuration: 100,
+      };
+      expect(filterCSSAndStyleProperties(style)).toEqual([
+        null,
+        expect.any(Object),
+        null,
+        expect.any(Object),
+        null,
+      ]);
+    });
+
+    test('extracts callback props and keeps them out of the style object', () => {
+      const onTransitionEnd = jest.fn();
+      const onTransitionRun = jest.fn();
+      const style: CSSStyle = {
+        width: 100,
+        transitionProperty: 'opacity',
+        transitionDuration: 100,
+        onTransitionRun,
+        onTransitionEnd,
+      };
+
+      const [, transitionConfig, , filteredStyle, transitionCallbacks] =
+        filterCSSAndStyleProperties(style);
+
+      expect(transitionCallbacks).toEqual({ onTransitionRun, onTransitionEnd });
+      // Callbacks must not leak into the plain style nor the transition config.
+      expect(filteredStyle).toEqual({ width: 100 });
+      expect(transitionConfig).not.toHaveProperty('onTransitionRun');
+      expect(transitionConfig).not.toHaveProperty('onTransitionEnd');
+    });
+  });
+
+  describe('transition callbacks validation (dev)', () => {
+    beforeEach(() => {
+      (console.warn as jest.Mock).mockClear();
+    });
+
+    test('warns when transition callbacks are used without any transition props', () => {
+      filterCSSAndStyleProperties({ onTransitionEnd: jest.fn() } as CSSStyle);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('onTransitionEnd')
+      );
+    });
+
+    test('does not warn when a transition is configured alongside callbacks', () => {
+      filterCSSAndStyleProperties({
+        transitionProperty: 'opacity',
+        transitionDuration: 100,
+        onTransitionEnd: jest.fn(),
+      } as CSSStyle);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    test('does not warn when only the transition shorthand is provided', () => {
+      filterCSSAndStyleProperties({
+        transition: 'opacity 2s',
+        onTransitionEnd: jest.fn(),
+      } as CSSStyle);
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -19,8 +19,8 @@ describe(filterCSSAndStyleProperties, () => {
         null,
         expect.any(Object),
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -33,8 +33,8 @@ describe(filterCSSAndStyleProperties, () => {
         null,
         expect.any(Object),
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -47,8 +47,8 @@ describe(filterCSSAndStyleProperties, () => {
         style,
         expect.any(Object),
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -64,8 +64,8 @@ describe(filterCSSAndStyleProperties, () => {
         style,
         expect.any(Object),
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -90,8 +90,8 @@ describe(filterCSSAndStyleProperties, () => {
           expect.objectContaining({ [key]: value }),
           null,
           null,
-          {},
           null,
+          {},
         ]);
       });
     });
@@ -104,8 +104,8 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         null,
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -121,15 +121,15 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         style1,
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
       expect(filterCSSAndStyleProperties(style2)).toEqual([
         expect.any(Object),
         style2,
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -145,8 +145,8 @@ describe(filterCSSAndStyleProperties, () => {
         expect.any(Object),
         { transition: 'opacity 2s ease-in' },
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -165,8 +165,8 @@ describe(filterCSSAndStyleProperties, () => {
           null,
           expect.objectContaining({ [key]: value }),
           null,
-          {},
           null,
+          {},
         ]);
       });
     });
@@ -196,8 +196,8 @@ describe(filterCSSAndStyleProperties, () => {
             defaultStyle: { backgroundColor: 'blue' },
           },
         },
-        { opacity: 1, backgroundColor: 'blue' },
         null,
+        { opacity: 1, backgroundColor: 'blue' },
       ]);
     });
 
@@ -207,7 +207,7 @@ describe(filterCSSAndStyleProperties, () => {
         width: 100,
       };
 
-      const [, , , filteredStyle] = filterCSSAndStyleProperties(style);
+      const [, , , , filteredStyle] = filterCSSAndStyleProperties(style);
 
       expect(filteredStyle).toEqual({ opacity: 0.8, width: 100 });
     });
@@ -218,7 +218,7 @@ describe(filterCSSAndStyleProperties, () => {
         width: 100,
       };
 
-      const [, , pseudoStylesBySelector, filteredStyle] =
+      const [, , pseudoStylesBySelector, , filteredStyle] =
         filterCSSAndStyleProperties(style);
 
       expect(filteredStyle).toEqual({ width: 100 });
@@ -236,7 +236,7 @@ describe(filterCSSAndStyleProperties, () => {
         width: 100,
       };
 
-      const [, , pseudoStylesBySelector, filteredStyle] =
+      const [, , pseudoStylesBySelector, , filteredStyle] =
         filterCSSAndStyleProperties(style);
 
       expect(filteredStyle).toEqual({ opacity: 0.8, width: 100 });
@@ -259,8 +259,8 @@ describe(filterCSSAndStyleProperties, () => {
             defaultStyle: { opacity: 1 },
           },
         },
-        { opacity: 1, borderRadius: 8 },
         null,
+        { opacity: 1, borderRadius: 8 },
       ]);
     });
   });
@@ -274,7 +274,7 @@ describe(filterCSSAndStyleProperties, () => {
           borderWidth: { default: 0, ':focus': 2 },
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({
@@ -306,7 +306,7 @@ describe(filterCSSAndStyleProperties, () => {
           height: 100,
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({
@@ -339,7 +339,7 @@ describe(filterCSSAndStyleProperties, () => {
           },
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({ opacity: 1 });
@@ -365,7 +365,7 @@ describe(filterCSSAndStyleProperties, () => {
           backgroundColor: { default: 'white', ':active': 'red' },
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({ opacity: 1, backgroundColor: 'white' });
@@ -386,7 +386,7 @@ describe(filterCSSAndStyleProperties, () => {
           opacity: { ':active': 0.5, ':hover': 0.8 } as never,
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({});
@@ -413,7 +413,7 @@ describe(filterCSSAndStyleProperties, () => {
           } as never,
         };
 
-        const [, , pseudoStylesBySelector, filteredStyle] =
+        const [, , pseudoStylesBySelector, , filteredStyle] =
           filterCSSAndStyleProperties(style);
 
         expect(filteredStyle).toEqual({ backgroundColor: 'white' });
@@ -475,11 +475,11 @@ describe(filterCSSAndStyleProperties, () => {
           transitionDuration: style.transitionDuration,
         }),
         null,
+        null,
         {
           width: 100,
           height: 100,
         },
-        null,
       ]);
     });
   });
@@ -494,8 +494,8 @@ describe(filterCSSAndStyleProperties, () => {
         null,
         expect.any(Object),
         null,
-        expect.any(Object),
         null,
+        expect.any(Object),
       ]);
     });
 
@@ -510,7 +510,7 @@ describe(filterCSSAndStyleProperties, () => {
         onTransitionEnd,
       };
 
-      const [, transitionConfig, , filteredStyle, transitionCallbacks] =
+      const [, transitionConfig, , transitionCallbacks, filteredStyle] =
         filterCSSAndStyleProperties(style);
 
       expect(transitionCallbacks).toEqual({ onTransitionRun, onTransitionEnd });

--- a/packages/react-native-reanimated/src/css/utils/guards.ts
+++ b/packages/react-native-reanimated/src/css/utils/guards.ts
@@ -10,6 +10,7 @@ import type {
   CSSAnimationProp,
   CSSConfigProp,
   CSSKeyframesRule,
+  CSSTransitionCallbackProp,
   CSSTransitionProp,
   Repeat,
   TimeUnit,
@@ -54,6 +55,20 @@ export const isTransitionProp = (key: string): key is CSSTransitionProp => {
   }
 };
 
+export const isTransitionCallbackProp = (
+  key: string
+): key is CSSTransitionCallbackProp => {
+  switch (key) {
+    case 'onTransitionRun':
+    case 'onTransitionStart':
+    case 'onTransitionEnd':
+    case 'onTransitionCancel':
+      return true;
+    default:
+      return false;
+  }
+};
+
 export const isStepsModifier = (value: string): value is StepsModifier => {
   switch (value) {
     case 'jump-start':
@@ -69,7 +84,9 @@ export const isStepsModifier = (value: string): value is StepsModifier => {
 };
 
 export const isCSSConfigProp = (key: string): key is CSSConfigProp =>
-  isTransitionProp(key) || isAnimationProp(key);
+  isTransitionProp(key) ||
+  isAnimationProp(key) ||
+  isTransitionCallbackProp(key);
 
 export const isTimeUnit = (value: unknown): value is TimeUnit =>
   // TODO: implement more strict check

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -5,6 +5,8 @@ import { isSharedValue } from '../../isSharedValue';
 import type {
   CSSAnimationProperties,
   CSSStyle,
+  CSSTransitionCallback,
+  CSSTransitionCallbacks,
   CSSTransitionProperties,
   ExistingCSSAnimationProperties,
 } from '../types';
@@ -13,6 +15,7 @@ import {
   isCSSKeyframesObject,
   isCSSKeyframesRule,
   isPseudoSelectorValue,
+  isTransitionCallbackProp,
   isTransitionProp,
 } from './guards';
 
@@ -28,9 +31,11 @@ export function filterCSSAndStyleProperties<S extends object>(
   CSSTransitionProperties | null,
   PseudoStylesBySelector | null,
   PlainStyle,
+  CSSTransitionCallbacks | null,
 ] {
   const animationProperties: Partial<CSSAnimationProperties> = {};
   let transitionProperties: Partial<CSSTransitionProperties> = {};
+  const transitionCallbacks: CSSTransitionCallbacks = {};
   const filteredStyle: UnknownRecord = {};
   const pseudoStylesBySelector: PseudoStylesBySelector = {};
 
@@ -59,6 +64,8 @@ export function filterCSSAndStyleProperties<S extends object>(
       } else {
         (transitionProperties as UnknownRecord)[prop] = value;
       }
+    } else if (isTransitionCallbackProp(prop)) {
+      transitionCallbacks[prop] = value as CSSTransitionCallback;
     } else if (isSharedValue(value)) {
       continue;
     } else if (isPseudoSelectorValue(value)) {
@@ -111,9 +118,15 @@ export function filterCSSAndStyleProperties<S extends object>(
   const hasPseudoStyles = Object.keys(pseudoStylesBySelector).length > 0;
   const finalPseudoStyles = hasPseudoStyles ? pseudoStylesBySelector : null;
 
+  const hasTransitionCallbacks = Object.keys(transitionCallbacks).length > 0;
+  const finalTransitionCallbacks = hasTransitionCallbacks
+    ? transitionCallbacks
+    : null;
+
   if (__DEV__) {
     validateCSSAnimationProps(animationProperties);
     validateCSSTransitionProps(transitionProperties);
+    validateCSSTransitionCallbacks(transitionCallbacks, hasTransitionConfig);
   }
 
   return [
@@ -121,6 +134,7 @@ export function filterCSSAndStyleProperties<S extends object>(
     finalTransitionConfig,
     finalPseudoStyles,
     filteredStyle as PlainStyle,
+    finalTransitionCallbacks,
   ];
 }
 
@@ -142,4 +156,23 @@ function validateCSSTransitionProps(props: Partial<CSSTransitionProperties>) {
         'Have you forgotten to pass the transitionDuration?'
     );
   }
+}
+
+function validateCSSTransitionCallbacks(
+  callbacks: CSSTransitionCallbacks,
+  hasTransitionConfig: boolean
+) {
+  // Transition callbacks are driven by an actual CSS transition; without any
+  // transition property configured there is nothing that could ever fire them.
+  const callbackNames = Object.keys(callbacks);
+  if (callbackNames.length === 0 || hasTransitionConfig) {
+    return;
+  }
+
+  const isPlural = callbackNames.length > 1;
+  logger.warn(
+    `CSS transition ${isPlural ? 'callbacks' : 'callback'} (${callbackNames.join(', ')}) ` +
+      `${isPlural ? 'were' : 'was'} provided without any CSS transition properties ` +
+      `(e.g. transitionDuration), so ${isPlural ? 'they' : 'it'} will never be called.`
+  );
 }

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -30,8 +30,8 @@ export function filterCSSAndStyleProperties<S extends object>(
   ExistingCSSAnimationProperties | null,
   CSSTransitionProperties | null,
   PseudoStylesBySelector | null,
-  PlainStyle,
   CSSTransitionCallbacks | null,
+  PlainStyle,
 ] {
   const animationProperties: Partial<CSSAnimationProperties> = {};
   let transitionProperties: Partial<CSSTransitionProperties> = {};
@@ -133,8 +133,8 @@ export function filterCSSAndStyleProperties<S extends object>(
     finalAnimationConfig,
     finalTransitionConfig,
     finalPseudoStyles,
-    filteredStyle as PlainStyle,
     finalTransitionCallbacks,
+    filteredStyle as PlainStyle,
   ];
 }
 

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -24,7 +24,7 @@ export default class CSSManager implements ICSSManager {
   }
 
   update(style: CSSStyle): void {
-    const [animationProperties, transitionProperties, , , transitionCallbacks] =
+    const [animationProperties, transitionProperties, , transitionCallbacks] =
       filterCSSAndStyleProperties(style);
 
     this.animationsManager.update(animationProperties);

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -24,11 +24,11 @@ export default class CSSManager implements ICSSManager {
   }
 
   update(style: CSSStyle): void {
-    const [animationProperties, transitionProperties] =
+    const [animationProperties, transitionProperties, , , transitionCallbacks] =
       filterCSSAndStyleProperties(style);
 
     this.animationsManager.update(animationProperties);
-    this.transitionsManager.update(transitionProperties);
+    this.transitionsManager.update(transitionProperties, transitionCallbacks);
   }
 
   unmountCleanup(): void {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
@@ -27,7 +27,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   private isAttached = false;
 
   private callbacks: CSSTransitionCallbacks = {};
-  private readonly attachedHandlers = new Map<
+  private readonly attachedStateListeners = new Map<
     CSSTransitionCallbackProp,
     EventListener
   >();
@@ -42,7 +42,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   ) {
     // Keep listeners tied to callback presence (not transition presence) so a
     // `transitioncancel` emitted while detaching still reaches the user.
-    this.syncListeners(callbacks ?? {});
+    this.syncStateListeners(callbacks ?? {});
 
     if (!transitionProperties) {
       this.detach();
@@ -54,7 +54,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   }
 
   unmountCleanup() {
-    this.syncListeners({});
+    this.syncStateListeners({});
   }
 
   private detach() {
@@ -73,26 +73,26 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     this.isAttached = false;
   }
 
-  private syncListeners(callbacks: CSSTransitionCallbacks) {
+  private syncStateListeners(callbacks: CSSTransitionCallbacks) {
     this.callbacks = callbacks;
 
     for (const prop of CALLBACK_PROPS) {
       const eventName = TRANSITION_EVENT_NAME[prop];
       const hasCallback = typeof callbacks[prop] === 'function';
-      const handler = this.attachedHandlers.get(prop);
+      const listener = this.attachedStateListeners.get(prop);
 
-      if (hasCallback && !handler) {
-        const newHandler = this.createHandler(prop);
-        this.attachedHandlers.set(prop, newHandler);
-        this.element.addEventListener(eventName, newHandler);
-      } else if (!hasCallback && handler) {
-        this.element.removeEventListener(eventName, handler);
-        this.attachedHandlers.delete(prop);
+      if (hasCallback && !listener) {
+        const newListener = this.createStateListener(prop);
+        this.attachedStateListeners.set(prop, newListener);
+        this.element.addEventListener(eventName, newListener);
+      } else if (!hasCallback && listener) {
+        this.element.removeEventListener(eventName, listener);
+        this.attachedStateListeners.delete(prop);
       }
     }
   }
 
-  private createHandler(prop: CSSTransitionCallbackProp): EventListener {
+  private createStateListener(prop: CSSTransitionCallbackProp): EventListener {
     return (event: Event) => {
       const transitionEvent = event as TransitionEvent;
       // Transition events bubble; only handle this element's own transitions.

--- a/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
@@ -1,22 +1,49 @@
 'use strict';
-import { kebabizeCamelCase } from '../../../common';
+import { camelizeKebabCase, kebabizeCamelCase } from '../../../common';
 import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
 import type {
+  CSSTransitionCallbackProp,
+  CSSTransitionCallbacks,
+  CSSTransitionEvent,
   CSSTransitionProperties,
   ICSSTransitionsManager,
 } from '../../types';
 import { normalizeCSSTransitionProperties } from '../normalization';
 import { maybeAddSuffixes, parseTimingFunction } from '../utils';
 
+const TRANSITION_EVENT_NAME: Record<CSSTransitionCallbackProp, string> = {
+  onTransitionRun: 'transitionrun',
+  onTransitionStart: 'transitionstart',
+  onTransitionEnd: 'transitionend',
+  onTransitionCancel: 'transitioncancel',
+};
+
+const CALLBACK_PROPS = Object.keys(
+  TRANSITION_EVENT_NAME
+) as CSSTransitionCallbackProp[];
+
 export default class CSSTransitionsManager implements ICSSTransitionsManager {
   private readonly element: ReanimatedHTMLElement;
   private isAttached = false;
+
+  private callbacks: CSSTransitionCallbacks = {};
+  private readonly attachedHandlers = new Map<
+    CSSTransitionCallbackProp,
+    EventListener
+  >();
 
   constructor(element: ReanimatedHTMLElement) {
     this.element = element;
   }
 
-  update(transitionProperties: CSSTransitionProperties | null) {
+  update(
+    transitionProperties: CSSTransitionProperties | null,
+    callbacks: CSSTransitionCallbacks | null = null
+  ) {
+    // Keep listeners tied to callback presence (not transition presence) so a
+    // `transitioncancel` emitted while detaching still reaches the user.
+    this.syncListeners(callbacks ?? {});
+
     if (!transitionProperties) {
       this.detach();
       return;
@@ -27,7 +54,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   }
 
   unmountCleanup() {
-    // noop
+    this.syncListeners({});
   }
 
   private detach() {
@@ -44,6 +71,41 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     this.element.style.transitionBehavior = '';
 
     this.isAttached = false;
+  }
+
+  private syncListeners(callbacks: CSSTransitionCallbacks) {
+    this.callbacks = callbacks;
+
+    for (const prop of CALLBACK_PROPS) {
+      const eventName = TRANSITION_EVENT_NAME[prop];
+      const hasCallback = typeof callbacks[prop] === 'function';
+      const handler = this.attachedHandlers.get(prop);
+
+      if (hasCallback && !handler) {
+        const newHandler = this.createHandler(prop);
+        this.attachedHandlers.set(prop, newHandler);
+        this.element.addEventListener(eventName, newHandler);
+      } else if (!hasCallback && handler) {
+        this.element.removeEventListener(eventName, handler);
+        this.attachedHandlers.delete(prop);
+      }
+    }
+  }
+
+  private createHandler(prop: CSSTransitionCallbackProp): EventListener {
+    return (event: Event) => {
+      const transitionEvent = event as TransitionEvent;
+      // Transition events bubble; only handle this element's own transitions.
+      if (transitionEvent.target !== this.element) {
+        return;
+      }
+
+      const payload: CSSTransitionEvent = {
+        propertyName: camelizeKebabCase(transitionEvent.propertyName),
+        elapsedTime: transitionEvent.elapsedTime,
+      };
+      this.callbacks[prop]?.(payload);
+    };
   }
 
   private setElementTransition(transitionProperties: CSSTransitionProperties) {

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -14,6 +14,16 @@ const transition = (
     ...overrides,
   }) as CSSTransitionProperties;
 
+const transitionEvent = (
+  type: string,
+  propertyName: string,
+  elapsedTime: number
+): Event =>
+  Object.assign(new Event(type, { bubbles: true }), {
+    propertyName,
+    elapsedTime,
+  });
+
 describe('CSSTransitionsManager (web)', () => {
   let element: ReanimatedHTMLElement;
   let manager: CSSTransitionsManager;
@@ -69,6 +79,109 @@ describe('CSSTransitionsManager (web)', () => {
       manager.update(null);
 
       expect(element.style.cssText).toBe('');
+    });
+  });
+
+  describe('transition callbacks', () => {
+    test('attaches a DOM listener only while its callback is set', () => {
+      const addSpy = jest.spyOn(element, 'addEventListener');
+      const removeSpy = jest.spyOn(element, 'removeEventListener');
+
+      manager.update(transition(), { onTransitionEnd: jest.fn() });
+      expect(addSpy).toHaveBeenCalledWith(
+        'transitionend',
+        expect.any(Function)
+      );
+
+      // Callback removed on the next update -> listener detached.
+      manager.update(transition(), {});
+      expect(removeSpy).toHaveBeenCalledWith(
+        'transitionend',
+        expect.any(Function)
+      );
+    });
+
+    test('subscribes to the matching DOM event for each callback prop', () => {
+      const addSpy = jest.spyOn(element, 'addEventListener');
+
+      manager.update(transition(), {
+        onTransitionRun: jest.fn(),
+        onTransitionStart: jest.fn(),
+        onTransitionEnd: jest.fn(),
+        onTransitionCancel: jest.fn(),
+      });
+
+      for (const type of [
+        'transitionrun',
+        'transitionstart',
+        'transitionend',
+        'transitioncancel',
+      ]) {
+        expect(addSpy).toHaveBeenCalledWith(type, expect.any(Function));
+      }
+    });
+
+    test('forwards a camelCased propertyName and elapsedTime when the event fires', () => {
+      const onTransitionEnd = jest.fn();
+      manager.update(transition(), { onTransitionEnd });
+
+      element.dispatchEvent(
+        transitionEvent('transitionend', 'background-color', 0.3)
+      );
+
+      expect(onTransitionEnd).toHaveBeenCalledWith({
+        propertyName: 'backgroundColor',
+        elapsedTime: 0.3,
+      });
+    });
+
+    test('ignores events that bubble up from descendant nodes', () => {
+      const child = document.createElement('div');
+      element.appendChild(child);
+      const onTransitionEnd = jest.fn();
+      manager.update(transition(), { onTransitionEnd });
+
+      // The event bubbles from the child to the element's listener.
+      child.dispatchEvent(transitionEvent('transitionend', 'opacity', 0.1));
+
+      expect(onTransitionEnd).not.toHaveBeenCalled();
+    });
+
+    test('uses the latest callback without re-subscribing on re-render', () => {
+      const addSpy = jest.spyOn(element, 'addEventListener');
+      const first = jest.fn();
+      const second = jest.fn();
+
+      manager.update(transition(), { onTransitionEnd: first });
+      manager.update(transition(), { onTransitionEnd: second });
+
+      const endSubscriptions = addSpy.mock.calls.filter(
+        ([type]) => type === 'transitionend'
+      );
+      expect(endSubscriptions).toHaveLength(1);
+
+      element.dispatchEvent(transitionEvent('transitionend', 'opacity', 0.1));
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('detaches all listeners on unmount cleanup', () => {
+      const removeSpy = jest.spyOn(element, 'removeEventListener');
+
+      manager.update(transition(), {
+        onTransitionStart: jest.fn(),
+        onTransitionEnd: jest.fn(),
+      });
+      manager.unmountCleanup();
+
+      expect(removeSpy).toHaveBeenCalledWith(
+        'transitionstart',
+        expect.any(Function)
+      );
+      expect(removeSpy).toHaveBeenCalledWith(
+        'transitionend',
+        expect.any(Function)
+      );
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -88,15 +88,15 @@ describe('CSSTransitionsManager (web)', () => {
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
       manager.update(transition(), { onTransitionEnd: jest.fn() });
-      const handler = addSpy.mock.calls.find(
-        (call) => call[0] === 'transitionend'
-      )?.[1];
-      expect(handler).toEqual(expect.any(Function));
+      expect(addSpy).toHaveBeenCalledWith(
+        'transitionend',
+        expect.any(Function)
+      );
 
-      // Removing the callback on the next update must detach that exact listener
-      // (removeEventListener only works with the same function reference).
+      // Removing the callback on the next update must detach the exact same
+      // listener (removeEventListener only works with the same reference).
       manager.update(transition(), {});
-      expect(removeSpy).toHaveBeenCalledWith('transitionend', handler);
+      expect(removeSpy.mock.calls).toEqual(addSpy.mock.calls);
     });
 
     test('subscribes to the matching DOM event for each callback prop', () => {
@@ -173,12 +173,8 @@ describe('CSSTransitionsManager (web)', () => {
       });
       manager.unmountCleanup();
 
-      for (const eventName of ['transitionstart', 'transitionend']) {
-        const handler = addSpy.mock.calls.find(
-          (call) => call[0] === eventName
-        )?.[1];
-        expect(removeSpy).toHaveBeenCalledWith(eventName, handler);
-      }
+      // Every listener that was attached is detached with the same reference.
+      expect(removeSpy.mock.calls).toEqual(addSpy.mock.calls);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -15,11 +15,11 @@ const transition = (
   }) as CSSTransitionProperties;
 
 const transitionEvent = (
-  type: string,
+  eventType: string,
   propertyName: string,
   elapsedTime: number
 ): Event =>
-  Object.assign(new Event(type, { bubbles: true }), {
+  Object.assign(new Event(eventType, { bubbles: true }), {
     propertyName,
     elapsedTime,
   });
@@ -83,22 +83,20 @@ describe('CSSTransitionsManager (web)', () => {
   });
 
   describe('transition callbacks', () => {
-    test('attaches a DOM listener only while its callback is set', () => {
+    test('attaches a listener when its callback is set and detaches the same one when it is removed', () => {
       const addSpy = jest.spyOn(element, 'addEventListener');
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
       manager.update(transition(), { onTransitionEnd: jest.fn() });
-      expect(addSpy).toHaveBeenCalledWith(
-        'transitionend',
-        expect.any(Function)
-      );
+      const handler = addSpy.mock.calls.find(
+        (call) => call[0] === 'transitionend'
+      )?.[1];
+      expect(handler).toEqual(expect.any(Function));
 
-      // Callback removed on the next update -> listener detached.
+      // Removing the callback on the next update must detach that exact listener
+      // (removeEventListener only works with the same function reference).
       manager.update(transition(), {});
-      expect(removeSpy).toHaveBeenCalledWith(
-        'transitionend',
-        expect.any(Function)
-      );
+      expect(removeSpy).toHaveBeenCalledWith('transitionend', handler);
     });
 
     test('subscribes to the matching DOM event for each callback prop', () => {
@@ -165,7 +163,8 @@ describe('CSSTransitionsManager (web)', () => {
       expect(second).toHaveBeenCalledTimes(1);
     });
 
-    test('detaches all listeners on unmount cleanup', () => {
+    test('detaches the same listeners it attached on unmount cleanup', () => {
+      const addSpy = jest.spyOn(element, 'addEventListener');
       const removeSpy = jest.spyOn(element, 'removeEventListener');
 
       manager.update(transition(), {
@@ -174,14 +173,12 @@ describe('CSSTransitionsManager (web)', () => {
       });
       manager.unmountCleanup();
 
-      expect(removeSpy).toHaveBeenCalledWith(
-        'transitionstart',
-        expect.any(Function)
-      );
-      expect(removeSpy).toHaveBeenCalledWith(
-        'transitionend',
-        expect.any(Function)
-      );
+      for (const eventName of ['transitionstart', 'transitionend']) {
+        const handler = addSpy.mock.calls.find(
+          (call) => call[0] === eventName
+        )?.[1];
+        expect(removeSpy).toHaveBeenCalledWith(eventName, handler);
+      }
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -111,13 +111,13 @@ describe('CSSTransitionsManager (web)', () => {
         onTransitionCancel: jest.fn(),
       });
 
-      for (const type of [
+      for (const eventName of [
         'transitionrun',
         'transitionstart',
         'transitionend',
         'transitioncancel',
       ]) {
-        expect(addSpy).toHaveBeenCalledWith(type, expect.any(Function));
+        expect(addSpy).toHaveBeenCalledWith(eventName, expect.any(Function));
       }
     });
 
@@ -156,7 +156,7 @@ describe('CSSTransitionsManager (web)', () => {
       manager.update(transition(), { onTransitionEnd: second });
 
       const endSubscriptions = addSpy.mock.calls.filter(
-        ([type]) => type === 'transitionend'
+        ([eventName]) => eventName === 'transitionend'
       );
       expect(endSubscriptions).toHaveLength(1);
 


### PR DESCRIPTION
## Summary

Adds CSS transition event callbacks on web: `onTransitionRun`, `onTransitionStart`, `onTransitionEnd`, `onTransitionCancel`, declared in `style` alongside the transition config. On web they map directly to the browser's native DOM transition events (zero JSI), scoped per-view: transition events bubble, so descendant transitions are ignored, matching native's per-view model. The callback payload is `{ propertyName, elapsedTime }`.

Also warns in `__DEV__` when transition callbacks are provided without any transition configured.

Native (iOS/Android) support is a follow-up: per-property detection in the C++ loop plus a `CAAnimationDelegate` for platform-routed properties, dispatched through a single batched listener.

## Test plan

- Unit tests for callback extraction, the dev warning, and the web manager's listener lifecycle and per-property dispatch.
- Verified in a real browser (Chromium): all four events fire per-property, bubbling is scoped to the view, `propertyName`/`elapsedTime` are correct, and `transitioncancel` fires on interruption.