### PR TITLE
chore: add tests for web CSS transition and animation managers

### DIFF
--- a/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
@@ -5,13 +5,7 @@ import {
   SVG_PATH_WEB_PROPERTIES_CONFIG,
   SVG_POLYGON_WEB_PROPERTIES_CONFIG,
 } from '../../svg/web';
-import type { CSSAnimationKeyframes } from '../../types';
 import { processKeyframeDefinitions } from '../animationParser';
-
-// Helper keeps the loose keyframe-object casts in one place; the real public API
-// is normalized before reaching this function.
-const process = (definitions: object): string =>
-  processKeyframeDefinitions(definitions as CSSAnimationKeyframes);
 
 beforeAll(() => {
   registerWebSvgPropsBuilder('TestStroke', SVG_COMMON_WEB_PROPERTIES_CONFIG);
@@ -53,24 +47,26 @@ describe(processKeyframeDefinitions, () => {
 
 describe('processKeyframeDefinitions (web)', () => {
   test('serializes from/to keyframe selectors and their block styles', () => {
-    expect(process({ from: { opacity: 0 }, to: { opacity: 1 } })).toBe(
-      'from { opacity: 0 } to { opacity: 1 }'
-    );
+    expect(
+      processKeyframeDefinitions({ from: { opacity: 0 }, to: { opacity: 1 } })
+    ).toBe('from { opacity: 0 } to { opacity: 1 }');
   });
 
   test('converts integer selectors to percentages', () => {
-    expect(process({ 0: { opacity: 0 }, 1: { opacity: 1 } })).toBe(
-      '0% { opacity: 0 } 100% { opacity: 1 }'
-    );
+    expect(
+      processKeyframeDefinitions({ 0: { opacity: 0 }, 1: { opacity: 1 } })
+    ).toBe('0% { opacity: 0 } 100% { opacity: 1 }');
   });
 
   test('converts a fractional selector to a percentage', () => {
-    expect(process({ 0.5: { opacity: 0.3 } })).toBe('50% { opacity: 0.3 }');
+    expect(processKeyframeDefinitions({ 0.5: { opacity: 0.3 } })).toBe(
+      '50% { opacity: 0.3 }'
+    );
   });
 
   test('prepends a per-keyframe animationTimingFunction to the block', () => {
     expect(
-      process({
+      processKeyframeDefinitions({
         from: { opacity: 0, animationTimingFunction: 'ease-in' },
         to: { opacity: 1 },
       })

--- a/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
@@ -5,7 +5,13 @@ import {
   SVG_PATH_WEB_PROPERTIES_CONFIG,
   SVG_POLYGON_WEB_PROPERTIES_CONFIG,
 } from '../../svg/web';
+import type { CSSAnimationKeyframes } from '../../types';
 import { processKeyframeDefinitions } from '../animationParser';
+
+// Helper keeps the loose keyframe-object casts in one place; the real public API
+// is normalized before reaching this function.
+const process = (definitions: object): string =>
+  processKeyframeDefinitions(definitions as CSSAnimationKeyframes);
 
 beforeAll(() => {
   registerWebSvgPropsBuilder('TestStroke', SVG_COMMON_WEB_PROPERTIES_CONFIG);
@@ -42,5 +48,34 @@ describe(processKeyframeDefinitions, () => {
     );
     expect(result).toContain('from { d: path("M0,0 L10,10Z") }');
     expect(result).toContain('to { d: path("M0,0 L20,5 Z") }');
+  });
+});
+
+describe('processKeyframeDefinitions (web)', () => {
+  test('serializes from/to keyframe selectors and their block styles', () => {
+    expect(process({ from: { opacity: 0 }, to: { opacity: 1 } })).toBe(
+      'from { opacity: 0 } to { opacity: 1 }'
+    );
+  });
+
+  test('converts integer selectors to percentages', () => {
+    expect(process({ 0: { opacity: 0 }, 1: { opacity: 1 } })).toBe(
+      '0% { opacity: 0 } 100% { opacity: 1 }'
+    );
+  });
+
+  test('converts a fractional selector to a percentage', () => {
+    expect(process({ 0.5: { opacity: 0.3 } })).toBe('50% { opacity: 0.3 }');
+  });
+
+  test('prepends a per-keyframe animationTimingFunction to the block', () => {
+    expect(
+      process({
+        from: { opacity: 0, animationTimingFunction: 'ease-in' },
+        to: { opacity: 1 },
+      })
+    ).toBe(
+      'from { animation-timing-function: ease-in; opacity: 0 } to { opacity: 1 }'
+    );
   });
 });

--- a/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
@@ -1,0 +1,104 @@
+'use strict';
+import {
+  configureWebCSSAnimations,
+  insertCSSAnimation,
+  removeCSSAnimation,
+} from '../domUtils';
+
+// domUtils owns a single shared <style> tag and tracks the @keyframes rules it
+// inserts by index. That state is module-level and persists across tests, so we
+// give every animation a unique name and assert on rules by name / relative
+// order rather than absolute counts. Assertions read the real jsdom CSSOM.
+const STYLE_TAG_ID = 'ReanimatedCSSStyleTag';
+const KEYFRAMES = 'from { opacity: 0 } to { opacity: 1 }';
+
+let nextId = 0;
+const uniqueName = (): string => `anim_${nextId++}`;
+
+const sheetRules = (): CSSKeyframesRule[] => {
+  const sheet = (
+    document.getElementById(STYLE_TAG_ID) as HTMLStyleElement | null
+  )?.sheet;
+  return sheet ? (Array.from(sheet.cssRules) as CSSKeyframesRule[]) : [];
+};
+
+const indexOfRule = (name: string): number =>
+  sheetRules().findIndex((rule) => rule.name === name);
+
+const hasRule = (name: string): boolean => indexOfRule(name) !== -1;
+
+beforeAll(() => {
+  configureWebCSSAnimations();
+});
+
+describe('domUtils (web CSS animations stylesheet)', () => {
+  describe('configureWebCSSAnimations', () => {
+    test('creates a single shared style tag in the document head', () => {
+      // Idempotent: calling it again must not add a second tag.
+      configureWebCSSAnimations();
+
+      expect(document.querySelectorAll(`#${STYLE_TAG_ID}`)).toHaveLength(1);
+    });
+  });
+
+  describe('insertCSSAnimation', () => {
+    test('inserts a real @keyframes rule with the given name and block contents', () => {
+      const name = uniqueName();
+      insertCSSAnimation(name, KEYFRAMES);
+
+      const rule = sheetRules().find((r) => r.name === name);
+      expect(rule).toBeDefined();
+      // The from/to blocks actually made it into the stylesheet.
+      expect(rule!.cssRules).toHaveLength(2);
+      expect(rule!.cssText).toContain('opacity');
+    });
+
+    test('inserts each new animation ahead of the previous one', () => {
+      const first = uniqueName();
+      const second = uniqueName();
+      insertCSSAnimation(first, KEYFRAMES);
+      insertCSSAnimation(second, KEYFRAMES);
+
+      // The newest rule is inserted at the front of the stylesheet.
+      expect(indexOfRule(second)).toBeLessThan(indexOfRule(first));
+    });
+
+    test('ignores a duplicate animation name', () => {
+      const name = uniqueName();
+      insertCSSAnimation(name, KEYFRAMES);
+      insertCSSAnimation(name, KEYFRAMES);
+
+      const matching = sheetRules().filter((r) => r.name === name);
+      expect(matching).toHaveLength(1);
+    });
+  });
+
+  describe('removeCSSAnimation', () => {
+    test('removes the matching @keyframes rule from the stylesheet', () => {
+      const name = uniqueName();
+      insertCSSAnimation(name, KEYFRAMES);
+      expect(hasRule(name)).toBe(true);
+
+      removeCSSAnimation(name);
+
+      expect(hasRule(name)).toBe(false);
+    });
+
+    test('removes only the targeted rule when several are present', () => {
+      const a = uniqueName();
+      const b = uniqueName();
+      const c = uniqueName();
+      insertCSSAnimation(a, KEYFRAMES);
+      insertCSSAnimation(b, KEYFRAMES);
+      insertCSSAnimation(c, KEYFRAMES);
+
+      removeCSSAnimation(b);
+
+      expect(hasRule(b)).toBe(false);
+      expect(hasRule(a)).toBe(true);
+      expect(hasRule(c)).toBe(true);
+      // Surviving rules keep their relative order (newest first).
+      expect(indexOfRule(c)).toBeLessThan(indexOfRule(a));
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
@@ -6,26 +6,30 @@ import {
 } from '../domUtils';
 
 // domUtils owns a single shared <style> tag and tracks the @keyframes rules it
-// inserts by index. That state is module-level and persists across tests, so we
-// give every animation a unique name and assert on rules by name / relative
-// order rather than absolute counts. Assertions read the real jsdom CSSOM.
+// inserts. That state is module-level and persists across tests, so we give
+// every animation a unique name and assert on rules by name. Assertions read the
+// real jsdom CSSOM, checking the parsed keyframe blocks (selectors + property
+// values) rather than the re-serialized cssText, which is jsdom-format-specific.
 const STYLE_TAG_ID = 'ReanimatedCSSStyleTag';
 const KEYFRAMES = 'from { opacity: 0 } to { opacity: 1 }';
 
 let nextId = 0;
 const uniqueName = (): string => `anim_${nextId++}`;
 
-const sheetRules = (): CSSKeyframesRule[] => {
+const allRules = (): CSSKeyframesRule[] => {
   const sheet = (
     document.getElementById(STYLE_TAG_ID) as HTMLStyleElement | null
   )?.sheet;
   return sheet ? (Array.from(sheet.cssRules) as CSSKeyframesRule[]) : [];
 };
 
-const indexOfRule = (name: string): number =>
-  sheetRules().findIndex((rule) => rule.name === name);
+const findRule = (name: string): CSSKeyframesRule | undefined =>
+  allRules().find((rule) => rule.name === name);
 
-const hasRule = (name: string): boolean => indexOfRule(name) !== -1;
+const hasRule = (name: string): boolean => findRule(name) !== undefined;
+
+const blocksOf = (rule: CSSKeyframesRule): CSSKeyframeRule[] =>
+  Array.from(rule.cssRules) as CSSKeyframeRule[];
 
 beforeAll(() => {
   configureWebCSSAnimations();
@@ -44,23 +48,38 @@ describe('domUtils (web CSS animations stylesheet)', () => {
   describe('insertCSSAnimation', () => {
     test('inserts a real @keyframes rule with the given name and block contents', () => {
       const name = uniqueName();
-      insertCSSAnimation(name, KEYFRAMES);
+      insertCSSAnimation(name, 'from { opacity: 0 } to { opacity: 1 }');
 
-      const rule = sheetRules().find((r) => r.name === name);
+      const rule = findRule(name);
       expect(rule).toBeDefined();
-      // The from/to blocks actually made it into the stylesheet.
-      expect(rule!.cssRules).toHaveLength(2);
-      expect(rule!.cssText).toContain('opacity');
+      const blocks = blocksOf(rule!);
+      expect(blocks.map((block) => block.keyText)).toEqual(['from', 'to']);
+      expect(blocks.map((block) => block.style.opacity)).toEqual(['0', '1']);
     });
 
-    test('inserts each new animation ahead of the previous one', () => {
-      const first = uniqueName();
-      const second = uniqueName();
-      insertCSSAnimation(first, KEYFRAMES);
-      insertCSSAnimation(second, KEYFRAMES);
+    test('inserts a multi-step animation with several properties per keyframe', () => {
+      const name = uniqueName();
+      insertCSSAnimation(
+        name,
+        '0% { opacity: 0; transform: translateX(0px) } ' +
+          '50% { opacity: 0.5; width: 20px } ' +
+          '100% { opacity: 1; transform: translateX(100px) }'
+      );
 
-      // The newest rule is inserted at the front of the stylesheet.
-      expect(indexOfRule(second)).toBeLessThan(indexOfRule(first));
+      const blocks = blocksOf(findRule(name)!);
+      expect(blocks.map((block) => block.keyText)).toEqual([
+        '0%',
+        '50%',
+        '100%',
+      ]);
+      expect(blocks.map((block) => block.style.opacity)).toEqual([
+        '0',
+        '0.5',
+        '1',
+      ]);
+      expect(blocks[0].style.transform).toBe('translateX(0px)');
+      expect(blocks[1].style.width).toBe('20px');
+      expect(blocks[2].style.transform).toBe('translateX(100px)');
     });
 
     test('ignores a duplicate animation name', () => {
@@ -68,8 +87,7 @@ describe('domUtils (web CSS animations stylesheet)', () => {
       insertCSSAnimation(name, KEYFRAMES);
       insertCSSAnimation(name, KEYFRAMES);
 
-      const matching = sheetRules().filter((r) => r.name === name);
-      expect(matching).toHaveLength(1);
+      expect(allRules().filter((rule) => rule.name === name)).toHaveLength(1);
     });
   });
 
@@ -97,8 +115,6 @@ describe('domUtils (web CSS animations stylesheet)', () => {
       expect(hasRule(b)).toBe(false);
       expect(hasRule(a)).toBe(true);
       expect(hasRule(c)).toBe(true);
-      // Surviving rules keep their relative order (newest first).
-      expect(indexOfRule(c)).toBeLessThan(indexOfRule(a));
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/domUtils.web.test.ts
@@ -61,9 +61,11 @@ describe('domUtils (web CSS animations stylesheet)', () => {
       const name = uniqueName();
       insertCSSAnimation(
         name,
-        '0% { opacity: 0; transform: translateX(0px) } ' +
-          '50% { opacity: 0.5; width: 20px } ' +
-          '100% { opacity: 1; transform: translateX(100px) }'
+        `
+          0% { opacity: 0; transform: translateX(0px) }
+          50% { opacity: 0.5; width: 20px }
+          100% { opacity: 1; transform: translateX(100px) }
+        `
       );
 
       const blocks = blocksOf(findRule(name)!);

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -5,12 +5,6 @@ import { processKeyframeDefinitions } from '../../animationParser';
 import { insertCSSAnimation, removeCSSAnimation } from '../../domUtils';
 import CSSAnimationsManager from '../CSSAnimationsManager';
 
-// The manager's job is orchestration: hand the processed keyframes to the
-// domUtils stylesheet helpers and write the animation longhands onto the
-// element. We mock that apply boundary (mirroring how the native manager test
-// mocks the `proxy` apply functions) and assert on the calls. The stylesheet
-// mechanics are covered by domUtils.web.test.ts and the keyframe string format
-// by animationParser.test.ts.
 jest.mock('../../domUtils', () => ({
   configureWebCSSAnimations: jest.fn(),
   insertCSSAnimation: jest.fn(),

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -1,0 +1,78 @@
+'use strict';
+import type { ReanimatedHTMLElement } from '../../../../ReanimatedModule/js-reanimated';
+import type { ExistingCSSAnimationProperties } from '../../../types';
+import { insertCSSAnimation, removeCSSAnimation } from '../../domUtils';
+import CSSAnimationsManager from '../CSSAnimationsManager';
+
+// The stylesheet operations touch the global CSSOM, so mock them; the element
+// style application and cleanup run for real against a jsdom element.
+jest.mock('../../domUtils', () => ({
+  configureWebCSSAnimations: jest.fn(),
+  insertCSSAnimation: jest.fn(),
+  removeCSSAnimation: jest.fn(),
+}));
+
+const keyframes = { from: { opacity: 0 }, to: { opacity: 1 } };
+
+const animation = (
+  overrides: Partial<ExistingCSSAnimationProperties> = {}
+): ExistingCSSAnimationProperties =>
+  ({
+    animationName: keyframes,
+    animationDuration: 200,
+    ...overrides,
+  }) as unknown as ExistingCSSAnimationProperties;
+
+describe('CSSAnimationsManager (web)', () => {
+  let element: ReanimatedHTMLElement;
+  let manager: CSSAnimationsManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    element = document.createElement('div') as unknown as ReanimatedHTMLElement;
+    manager = new CSSAnimationsManager(element);
+  });
+
+  describe('update', () => {
+    test('inserts the keyframes and writes the animation longhands to the element', () => {
+      manager.update(
+        animation({
+          animationTimingFunction: 'ease-in-out',
+          animationIterationCount: 2,
+          animationDirection: 'reverse',
+        })
+      );
+
+      expect(insertCSSAnimation).toHaveBeenCalledTimes(1);
+      expect(element.style.animationName.length).toBeGreaterThan(0);
+      expect(element.style.animationDuration).toBe('200ms');
+      expect(element.style.animationTimingFunction).toBe('ease-in-out');
+      expect(element.style.animationIterationCount).toBe('2');
+      expect(element.style.animationDirection).toBe('reverse');
+    });
+
+    test('uses the inserted keyframes name as the animationName', () => {
+      manager.update(animation());
+
+      const insertedName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
+      expect(element.style.animationName).toBe(insertedName);
+    });
+  });
+
+  describe('detach (update with null)', () => {
+    test('clears the element animation and removes the inserted keyframes', () => {
+      manager.update(animation());
+      manager.update(null);
+
+      expect(removeCSSAnimation).toHaveBeenCalled();
+      // removeElementAnimation clears the element's animation longhands.
+      expect(element.style.animationName).toBe('');
+    });
+
+    test('is a no-op when no animation was ever attached', () => {
+      manager.update(null);
+
+      expect(removeCSSAnimation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -136,10 +136,6 @@ describe('CSSAnimationsManager (web)', () => {
       jest.useFakeTimers();
     });
 
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     test('removes the keyframes from the stylesheet after the cleanup timeout', () => {
       manager.update(animation());
       const attachedName = element.style.animationName;

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -1,23 +1,21 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../../ReanimatedModule/js-reanimated';
 import type { ExistingCSSAnimationProperties } from '../../../types';
+import { processKeyframeDefinitions } from '../../animationParser';
+import { insertCSSAnimation, removeCSSAnimation } from '../../domUtils';
 import CSSAnimationsManager from '../CSSAnimationsManager';
 
-// These tests run end to end against the real jsdom CSSOM: the manager inserts
-// real @keyframes rules into the shared <style> tag that domUtils creates, so we
-// assert on the actual stylesheet instead of on mocked stylesheet helpers. That
-// tag is a single app-wide stylesheet, so we assert on rules by their (unique,
-// generated) name rather than on the total rule count.
-const STYLE_TAG_ID = 'ReanimatedCSSStyleTag';
-
-const keyframeNames = (): string[] => {
-  const sheet = (
-    document.getElementById(STYLE_TAG_ID) as HTMLStyleElement | null
-  )?.sheet;
-  return sheet
-    ? Array.from(sheet.cssRules).map((rule) => (rule as CSSKeyframesRule).name)
-    : [];
-};
+// The manager's job is orchestration: hand the processed keyframes to the
+// domUtils stylesheet helpers and write the animation longhands onto the
+// element. We mock that apply boundary (mirroring how the native manager test
+// mocks the `proxy` apply functions) and assert on the calls. The stylesheet
+// mechanics are covered by domUtils.web.test.ts and the keyframe string format
+// by animationParser.test.ts.
+jest.mock('../../domUtils', () => ({
+  configureWebCSSAnimations: jest.fn(),
+  insertCSSAnimation: jest.fn(),
+  removeCSSAnimation: jest.fn(),
+}));
 
 const keyframes = { from: { opacity: 0 }, to: { opacity: 1 } };
 
@@ -35,12 +33,13 @@ describe('CSSAnimationsManager (web)', () => {
   let manager: CSSAnimationsManager;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     element = document.createElement('div') as unknown as ReanimatedHTMLElement;
     manager = new CSSAnimationsManager(element);
   });
 
   describe('update', () => {
-    test('inserts a real @keyframes rule and writes the animation longhands to the element', () => {
+    test('hands the processed keyframes to domUtils and writes the animation longhands to the element', () => {
       manager.update(
         animation({
           animationTimingFunction: 'ease-in-out',
@@ -49,19 +48,21 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      // The generated name is written to the element and exists as an actual
-      // @keyframes rule in the stylesheet.
-      expect(element.style.animationName.length).toBeGreaterThan(0);
-      expect(keyframeNames()).toContain(element.style.animationName);
+      // Boundary: the manager inserts the processed keyframes under the same
+      // name it writes to the element.
+      expect(insertCSSAnimation).toHaveBeenCalledTimes(1);
+      expect(insertCSSAnimation).toHaveBeenCalledWith(
+        element.style.animationName,
+        processKeyframeDefinitions(keyframes)
+      );
+      // Element longhands.
       expect(element.style.animationDuration).toBe('200ms');
       expect(element.style.animationTimingFunction).toBe('ease-in-out');
       expect(element.style.animationIterationCount).toBe('2');
       expect(element.style.animationDirection).toBe('reverse');
     });
 
-    test('inserts a real @keyframes rule for each of multiple comma-separated animations', () => {
-      const before = new Set(keyframeNames());
-
+    test('inserts every one of multiple comma-separated animations', () => {
       manager.update(
         animation({
           animationName: [
@@ -72,24 +73,24 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      const inserted = keyframeNames().filter((name) => !before.has(name));
-      expect(inserted).toHaveLength(2);
-      // Both inserted rules are referenced by the element's animationName.
-      inserted.forEach((name) => {
+      expect(insertCSSAnimation).toHaveBeenCalledTimes(2);
+      const insertedNames = (insertCSSAnimation as jest.Mock).mock.calls.map(
+        (call) => call[0]
+      );
+      insertedNames.forEach((name) => {
         expect(element.style.animationName).toContain(name);
       });
       expect(element.style.animationDuration).toContain('200ms');
       expect(element.style.animationDuration).toContain('300ms');
     });
 
-    test('removes the previous @keyframes rule when switching to a different animation', () => {
+    test('removes the previous animation when switching to a different one', () => {
       manager.update(
         animation({
           animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
         })
       );
       const previousName = element.style.animationName;
-      expect(keyframeNames()).toContain(previousName);
 
       manager.update(
         animation({
@@ -97,39 +98,36 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      expect(keyframeNames()).not.toContain(previousName);
-      expect(keyframeNames()).toContain(element.style.animationName);
+      expect(removeCSSAnimation).toHaveBeenCalledWith(previousName);
     });
   });
 
   describe('detach', () => {
-    test('clears the element animation and removes the @keyframes rule on update(null)', () => {
+    test('removes the keyframes and clears the element animation on update(null)', () => {
       manager.update(animation());
       const attachedName = element.style.animationName;
-      expect(keyframeNames()).toContain(attachedName);
 
       manager.update(null);
 
+      expect(removeCSSAnimation).toHaveBeenCalledWith(attachedName);
+      // removeElementAnimation (not mocked) clears the element longhands.
       expect(element.style.animationName).toBe('');
-      expect(keyframeNames()).not.toContain(attachedName);
     });
 
     test('treats an empty animation name list as a detach', () => {
       manager.update(animation());
       const attachedName = element.style.animationName;
-      expect(attachedName.length).toBeGreaterThan(0);
 
       manager.update(animation({ animationName: [] }));
 
+      expect(removeCSSAnimation).toHaveBeenCalledWith(attachedName);
       expect(element.style.animationName).toBe('');
-      expect(keyframeNames()).not.toContain(attachedName);
     });
 
     test('is a no-op when no animation was ever attached', () => {
-      const before = keyframeNames();
+      manager.update(null);
 
-      expect(() => manager.update(null)).not.toThrow();
-      expect(keyframeNames()).toEqual(before);
+      expect(removeCSSAnimation).not.toHaveBeenCalled();
     });
   });
 
@@ -142,17 +140,16 @@ describe('CSSAnimationsManager (web)', () => {
       jest.useRealTimers();
     });
 
-    test('removes the @keyframes rule from the stylesheet after the cleanup timeout', () => {
+    test('removes the keyframes from the stylesheet after the cleanup timeout', () => {
       manager.update(animation());
       const attachedName = element.style.animationName;
-      expect(keyframeNames()).toContain(attachedName);
 
       manager.unmountCleanup();
-      // Removal is deferred to the end of the event loop, so the rule remains.
-      expect(keyframeNames()).toContain(attachedName);
+      // Removal is deferred to the end of the event loop, so nothing happens yet.
+      expect(removeCSSAnimation).not.toHaveBeenCalled();
 
       jest.runAllTimers();
-      expect(keyframeNames()).not.toContain(attachedName);
+      expect(removeCSSAnimation).toHaveBeenCalledWith(attachedName);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -1,16 +1,23 @@
 'use strict';
 import type { ReanimatedHTMLElement } from '../../../../ReanimatedModule/js-reanimated';
 import type { ExistingCSSAnimationProperties } from '../../../types';
-import { insertCSSAnimation, removeCSSAnimation } from '../../domUtils';
 import CSSAnimationsManager from '../CSSAnimationsManager';
 
-// The stylesheet operations touch the global CSSOM, so mock them; the element
-// style application and cleanup run for real against a jsdom element.
-jest.mock('../../domUtils', () => ({
-  configureWebCSSAnimations: jest.fn(),
-  insertCSSAnimation: jest.fn(),
-  removeCSSAnimation: jest.fn(),
-}));
+// These tests run end to end against the real jsdom CSSOM: the manager inserts
+// real @keyframes rules into the shared <style> tag that domUtils creates, so we
+// assert on the actual stylesheet instead of on mocked stylesheet helpers. That
+// tag is a single app-wide stylesheet, so we assert on rules by their (unique,
+// generated) name rather than on the total rule count.
+const STYLE_TAG_ID = 'ReanimatedCSSStyleTag';
+
+const keyframeNames = (): string[] => {
+  const sheet = (
+    document.getElementById(STYLE_TAG_ID) as HTMLStyleElement | null
+  )?.sheet;
+  return sheet
+    ? Array.from(sheet.cssRules).map((rule) => (rule as CSSKeyframesRule).name)
+    : [];
+};
 
 const keyframes = { from: { opacity: 0 }, to: { opacity: 1 } };
 
@@ -28,13 +35,12 @@ describe('CSSAnimationsManager (web)', () => {
   let manager: CSSAnimationsManager;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     element = document.createElement('div') as unknown as ReanimatedHTMLElement;
     manager = new CSSAnimationsManager(element);
   });
 
   describe('update', () => {
-    test('inserts the keyframes and writes the animation longhands to the element', () => {
+    test('inserts a real @keyframes rule and writes the animation longhands to the element', () => {
       manager.update(
         animation({
           animationTimingFunction: 'ease-in-out',
@@ -43,22 +49,19 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      expect(insertCSSAnimation).toHaveBeenCalledTimes(1);
+      // The generated name is written to the element and exists as an actual
+      // @keyframes rule in the stylesheet.
       expect(element.style.animationName.length).toBeGreaterThan(0);
+      expect(keyframeNames()).toContain(element.style.animationName);
       expect(element.style.animationDuration).toBe('200ms');
       expect(element.style.animationTimingFunction).toBe('ease-in-out');
       expect(element.style.animationIterationCount).toBe('2');
       expect(element.style.animationDirection).toBe('reverse');
     });
 
-    test('uses the inserted keyframes name as the animationName', () => {
-      manager.update(animation());
+    test('inserts a real @keyframes rule for each of multiple comma-separated animations', () => {
+      const before = new Set(keyframeNames());
 
-      const insertedName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
-      expect(element.style.animationName).toBe(insertedName);
-    });
-
-    test('writes multiple comma-separated animations and inserts each keyframes set', () => {
       manager.update(
         animation({
           animationName: [
@@ -69,23 +72,24 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      const insertedNames = (insertCSSAnimation as jest.Mock).mock.calls.map(
-        (call) => call[0]
-      );
-      expect(insertedNames).toHaveLength(2);
-      expect(element.style.animationName).toContain(insertedNames[0]);
-      expect(element.style.animationName).toContain(insertedNames[1]);
+      const inserted = keyframeNames().filter((name) => !before.has(name));
+      expect(inserted).toHaveLength(2);
+      // Both inserted rules are referenced by the element's animationName.
+      inserted.forEach((name) => {
+        expect(element.style.animationName).toContain(name);
+      });
       expect(element.style.animationDuration).toContain('200ms');
       expect(element.style.animationDuration).toContain('300ms');
     });
 
-    test('removes the previous keyframes when switching to a different animation', () => {
+    test('removes the previous @keyframes rule when switching to a different animation', () => {
       manager.update(
         animation({
           animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
         })
       );
-      const previousName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
+      const previousName = element.style.animationName;
+      expect(keyframeNames()).toContain(previousName);
 
       manager.update(
         animation({
@@ -93,34 +97,39 @@ describe('CSSAnimationsManager (web)', () => {
         })
       );
 
-      expect(removeCSSAnimation).toHaveBeenCalledWith(previousName);
+      expect(keyframeNames()).not.toContain(previousName);
+      expect(keyframeNames()).toContain(element.style.animationName);
     });
   });
 
   describe('detach', () => {
-    test('clears the element animation and removes the inserted keyframes on update(null)', () => {
+    test('clears the element animation and removes the @keyframes rule on update(null)', () => {
       manager.update(animation());
+      const attachedName = element.style.animationName;
+      expect(keyframeNames()).toContain(attachedName);
+
       manager.update(null);
 
-      expect(removeCSSAnimation).toHaveBeenCalled();
-      // removeElementAnimation clears the element's animation longhands.
       expect(element.style.animationName).toBe('');
+      expect(keyframeNames()).not.toContain(attachedName);
     });
 
     test('treats an empty animation name list as a detach', () => {
       manager.update(animation());
-      expect(element.style.animationName.length).toBeGreaterThan(0);
+      const attachedName = element.style.animationName;
+      expect(attachedName.length).toBeGreaterThan(0);
 
       manager.update(animation({ animationName: [] }));
 
       expect(element.style.animationName).toBe('');
-      expect(removeCSSAnimation).toHaveBeenCalled();
+      expect(keyframeNames()).not.toContain(attachedName);
     });
 
     test('is a no-op when no animation was ever attached', () => {
-      manager.update(null);
+      const before = keyframeNames();
 
-      expect(removeCSSAnimation).not.toHaveBeenCalled();
+      expect(() => manager.update(null)).not.toThrow();
+      expect(keyframeNames()).toEqual(before);
     });
   });
 
@@ -133,16 +142,17 @@ describe('CSSAnimationsManager (web)', () => {
       jest.useRealTimers();
     });
 
-    test('removes the inserted keyframes from the stylesheet after the cleanup timeout', () => {
+    test('removes the @keyframes rule from the stylesheet after the cleanup timeout', () => {
       manager.update(animation());
-      const insertedName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
+      const attachedName = element.style.animationName;
+      expect(keyframeNames()).toContain(attachedName);
 
       manager.unmountCleanup();
-      // Removal is deferred to the end of the event loop, so nothing is gone yet.
-      expect(removeCSSAnimation).not.toHaveBeenCalled();
+      // Removal is deferred to the end of the event loop, so the rule remains.
+      expect(keyframeNames()).toContain(attachedName);
 
       jest.runAllTimers();
-      expect(removeCSSAnimation).toHaveBeenCalledWith(insertedName);
+      expect(keyframeNames()).not.toContain(attachedName);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -57,10 +57,48 @@ describe('CSSAnimationsManager (web)', () => {
       const insertedName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
       expect(element.style.animationName).toBe(insertedName);
     });
+
+    test('writes multiple comma-separated animations and inserts each keyframes set', () => {
+      manager.update(
+        animation({
+          animationName: [
+            { from: { opacity: 0 }, to: { opacity: 1 } },
+            { from: { opacity: 1 }, to: { opacity: 0 } },
+          ],
+          animationDuration: [200, 300],
+        })
+      );
+
+      const insertedNames = (insertCSSAnimation as jest.Mock).mock.calls.map(
+        (call) => call[0]
+      );
+      expect(insertedNames).toHaveLength(2);
+      expect(element.style.animationName).toContain(insertedNames[0]);
+      expect(element.style.animationName).toContain(insertedNames[1]);
+      expect(element.style.animationDuration).toContain('200ms');
+      expect(element.style.animationDuration).toContain('300ms');
+    });
+
+    test('removes the previous keyframes when switching to a different animation', () => {
+      manager.update(
+        animation({
+          animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
+        })
+      );
+      const previousName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
+
+      manager.update(
+        animation({
+          animationName: { from: { opacity: 1 }, to: { opacity: 0 } },
+        })
+      );
+
+      expect(removeCSSAnimation).toHaveBeenCalledWith(previousName);
+    });
   });
 
-  describe('detach (update with null)', () => {
-    test('clears the element animation and removes the inserted keyframes', () => {
+  describe('detach', () => {
+    test('clears the element animation and removes the inserted keyframes on update(null)', () => {
       manager.update(animation());
       manager.update(null);
 
@@ -69,10 +107,42 @@ describe('CSSAnimationsManager (web)', () => {
       expect(element.style.animationName).toBe('');
     });
 
+    test('treats an empty animation name list as a detach', () => {
+      manager.update(animation());
+      expect(element.style.animationName.length).toBeGreaterThan(0);
+
+      manager.update(animation({ animationName: [] }));
+
+      expect(element.style.animationName).toBe('');
+      expect(removeCSSAnimation).toHaveBeenCalled();
+    });
+
     test('is a no-op when no animation was ever attached', () => {
       manager.update(null);
 
       expect(removeCSSAnimation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unmountCleanup', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('removes the inserted keyframes from the stylesheet after the cleanup timeout', () => {
+      manager.update(animation());
+      const insertedName = (insertCSSAnimation as jest.Mock).mock.calls[0][0];
+
+      manager.unmountCleanup();
+      // Removal is deferred to the end of the event loop, so nothing is gone yet.
+      expect(removeCSSAnimation).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+      expect(removeCSSAnimation).toHaveBeenCalledWith(insertedName);
     });
   });
 });

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSTransitionsManager.web.test.ts
@@ -1,0 +1,74 @@
+'use strict';
+import type { ReanimatedHTMLElement } from '../../../../ReanimatedModule/js-reanimated';
+import type { CSSTransitionProperties } from '../../../types';
+import CSSTransitionsManager from '../CSSTransitionsManager';
+
+const transition = (
+  overrides: Partial<CSSTransitionProperties> = {}
+): CSSTransitionProperties =>
+  ({
+    transitionProperty: 'opacity',
+    transitionDuration: 200,
+    transitionDelay: 100,
+    transitionTimingFunction: 'ease-in-out',
+    ...overrides,
+  }) as CSSTransitionProperties;
+
+describe('CSSTransitionsManager (web)', () => {
+  let element: ReanimatedHTMLElement;
+  let manager: CSSTransitionsManager;
+
+  beforeEach(() => {
+    element = document.createElement('div') as unknown as ReanimatedHTMLElement;
+    manager = new CSSTransitionsManager(element);
+  });
+
+  describe('update', () => {
+    test('writes the transition longhands onto the element style', () => {
+      manager.update(transition());
+
+      expect(element.style.transitionProperty).toBe('opacity');
+      expect(element.style.transitionDuration).toBe('200ms');
+      expect(element.style.transitionDelay).toBe('100ms');
+      expect(element.style.transitionTimingFunction).toBe('ease-in-out');
+    });
+
+    test('kebab-cases camelCased transition properties', () => {
+      manager.update(transition({ transitionProperty: 'backgroundColor' }));
+
+      expect(element.style.transitionProperty).toBe('background-color');
+    });
+
+    test('writes multiple comma-separated properties and durations', () => {
+      manager.update(
+        transition({
+          transitionProperty: ['opacity', 'transform'],
+          transitionDuration: [200, 300],
+        })
+      );
+
+      expect(element.style.transitionProperty).toContain('opacity');
+      expect(element.style.transitionProperty).toContain('transform');
+      expect(element.style.transitionDuration).toContain('200ms');
+      expect(element.style.transitionDuration).toContain('300ms');
+    });
+  });
+
+  describe('detach (update with null)', () => {
+    test('clears the transition longhands after a transition was attached', () => {
+      manager.update(transition());
+      manager.update(null);
+
+      expect(element.style.transitionProperty).toBe('');
+      expect(element.style.transitionDuration).toBe('');
+      expect(element.style.transitionDelay).toBe('');
+      expect(element.style.transitionTimingFunction).toBe('');
+    });
+
+    test('does not touch the element when no transition was ever attached', () => {
+      manager.update(null);
+
+      expect(element.style.cssText).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the web CSS animation/transition path, which had no coverage:

- `web/managers/CSSTransitionsManager`: writes the transition longhands (kebab-cased property, ms durations, timing function, behavior) and clears them on detach.
- `web/managers/CSSAnimationsManager`: hands the processed keyframes to the `domUtils` helpers (mocked, like the native manager test mocks the proxy) and writes the animation longhands; covers multiple animations, switching, detach, and unmount cleanup.
- `web/domUtils`: inserts and removes real `@keyframes` rules against the jsdom CSSOM, checking the parsed block selectors and values.
- `web/animationParser` (`processKeyframeDefinitions`): keyframe object to CSS string, including percentage and per-keyframe timing-function handling.

Test-only, no source changes.

## Test plan

- `jest src/css/web/managers/__tests__ src/css/web/__tests__` (22 tests).