### PR TITLE
chore: add `MutuallyExclusiveUnion` type helper

### DIFF
--- a/packages/react-native-reanimated/__typetests__/helpersTest.ts
+++ b/packages/react-native-reanimated/__typetests__/helpersTest.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { MutuallyExclusiveUnion } from '../src/common/types/helpers';
+
+type XOrY = MutuallyExclusiveUnion<[{ x: number }, { y: string }]>;
+
+type XYOrPosition = MutuallyExclusiveUnion<
+  [{ x: number; y: number }, { position?: { x: number; y: number } }]
+>;
+
+type AOrBOrC = MutuallyExclusiveUnion<
+  [{ a: number }, { b: number }, { c: number }]
+>;
+
+function MutuallyExclusiveUnionTest() {
+  // Two branches, each with a single required key: either alone is allowed.
+  function singleKeyBranches() {
+    const onlyX: XOrY = { x: 1 };
+    const onlyY: XOrY = { y: 'a' };
+    // @ts-expect-error keys from different branches cannot be combined
+    const both: XOrY = { x: 1, y: 'a' };
+    // @ts-expect-error neither branch's required key is provided
+    const none: XOrY = {};
+  }
+
+  // A fully optional branch makes the empty object a valid member.
+  function optionalBranch() {
+    const empty: XYOrPosition = {};
+    const xy: XYOrPosition = { x: 1, y: 2 };
+    const position: XYOrPosition = { position: { x: 1, y: 2 } };
+    // @ts-expect-error `position` excludes `x` / `y`
+    const mixed: XYOrPosition = { x: 1, y: 2, position: { x: 1, y: 2 } };
+  }
+
+  // Three branches: picking one key excludes the keys from the other two.
+  function threeBranches() {
+    const a: AOrBOrC = { a: 1 };
+    const c: AOrBOrC = { c: 1 };
+    // @ts-expect-error `a` and `c` belong to different branches
+    const ac: AOrBOrC = { a: 1, c: 1 };
+  }
+}

--- a/packages/react-native-reanimated/src/animation/spring/springConfigs.ts
+++ b/packages/react-native-reanimated/src/animation/spring/springConfigs.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import type { MutuallyExclusiveUnion, Simplify } from '../../common';
 import type { ReduceMotion } from '../../commonTypes';
 
 export const Reanimated3DefaultSpringConfig = {
@@ -74,25 +75,21 @@ export const SnappySpringConfigWithDuration = {
  *   {@link ReduceMotion}.
  * @see https://docs.swmansion.com/react-native-reanimated/docs/animations/withSpring/#config-
  */
-export type SpringConfig = {
-  mass?: number;
-  overshootClamping?: boolean;
-  energyThreshold?: number;
-  velocity?: number;
-  reduceMotion?: ReduceMotion;
-} & (
-  | {
-      stiffness?: number;
-      damping?: number;
-      duration?: never;
-      dampingRatio?: never;
-      clamp?: never;
-    }
-  | {
-      stiffness?: never;
-      damping?: never;
-      duration?: number;
-      dampingRatio?: number;
-      clamp?: { min?: number; max?: number };
-    }
-);
+export type SpringConfig = Simplify<
+  {
+    mass?: number;
+    overshootClamping?: boolean;
+    energyThreshold?: number;
+    velocity?: number;
+    reduceMotion?: ReduceMotion;
+  } & MutuallyExclusiveUnion<
+    [
+      { stiffness?: number; damping?: number },
+      {
+        duration?: number;
+        dampingRatio?: number;
+        clamp?: { min?: number; max?: number };
+      },
+    ]
+  >
+>;

--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -7,7 +7,11 @@ import type {
 import { ColorProperties, processColorInitially } from '../../../Colors';
 import type { StyleProps } from '../../../commonTypes';
 import { IS_ANDROID, IS_IOS } from '../../constants';
-import { type ValueProcessorContext, ValueProcessorTarget } from '../../types';
+import {
+  type MutuallyExclusiveUnion,
+  type ValueProcessorContext,
+  ValueProcessorTarget,
+} from '../../types';
 import { isRecord } from '../../utils';
 
 /**
@@ -22,9 +26,9 @@ export function PlatformColor(...names: string[]): OpaqueColorValue {
       { resource_paths: names }) as unknown as OpaqueColorValue;
 }
 
-type PlatformColorObject =
-  | { semantic: Array<string>; resource_paths?: never }
-  | { semantic?: never; resource_paths?: Array<string> };
+type PlatformColorObject = MutuallyExclusiveUnion<
+  [{ semantic: Array<string> }, { resource_paths?: Array<string> }]
+>;
 
 function isPlatformColorObject(value: unknown): value is PlatformColorObject {
   'worklet';

--- a/packages/react-native-reanimated/src/common/types/helpers.ts
+++ b/packages/react-native-reanimated/src/common/types/helpers.ts
@@ -34,3 +34,30 @@ export type ConvertValuesToArrays<T> = {
 export type ConvertValuesToArraysWithUndefined<T> = {
   [K in keyof T]-?: ConvertValueToArray<T[K]>;
 };
+
+type AllKeys<U> = U extends unknown ? keyof U : never;
+
+/**
+ * Turns a tuple of object shapes into a union whose members are mutually
+ * exclusive: choosing one member forbids every key that belongs only to the
+ * others (each such key becomes `?: never`). Use it instead of hand-writing the
+ * `?: never` fields.
+ *
+ * @example
+ *   `MutuallyExclusiveUnion<[{ x: number }, { y: number }]>` resolves to
+ *   `{ x: number; y?: never } | { y: number; x?: never }`.
+ */
+export type MutuallyExclusiveUnion<
+  T extends ReadonlyArray<unknown>,
+  Processed extends ReadonlyArray<unknown> = [],
+> = T extends readonly [infer First, ...infer Rest]
+  ? Simplify<
+      | (First & {
+          [K in Exclude<
+            AllKeys<[...Processed, ...Rest][number]>,
+            keyof First
+          >]?: never;
+        })
+      | MutuallyExclusiveUnion<Rest, readonly [...Processed, First]>
+    >
+  : never;

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -11,7 +11,7 @@ import type {
 } from 'react-native';
 import type { SerializableRef, WorkletFunction } from 'react-native-worklets';
 
-import type { Maybe } from './common';
+import type { Maybe, MutuallyExclusiveUnion } from './common';
 import type { CSSStyle } from './css';
 import type { EasingFunctionFactory } from './Easing';
 import type { AnimatedStyleHandle } from './hook/commonTypes';
@@ -42,19 +42,16 @@ export interface KeyframeProps extends StyleProps {
   easing?: EasingFunction | EasingFunctionFactory;
 }
 
-type FirstFrame =
-  | {
-      0: KeyframeProps & { easing?: never };
-      from?: never;
-    }
-  | {
-      0?: never;
-      from: KeyframeProps & { easing?: never };
-    };
+// `easing` describes the transition into a keyframe, so the first frame can't have it.
+type FirstKeyframe = KeyframeProps & { easing?: never };
 
-type LastFrame =
-  | { 100?: KeyframeProps; to?: never }
-  | { 100?: never; to: KeyframeProps };
+type FirstFrame = MutuallyExclusiveUnion<
+  [{ 0: FirstKeyframe }, { from: FirstKeyframe }]
+>;
+
+type LastFrame = MutuallyExclusiveUnion<
+  [{ 100?: KeyframeProps }, { to: KeyframeProps }]
+>;
 
 export type ValidKeyframeProps = FirstFrame &
   LastFrame &


### PR DESCRIPTION
## Summary

- Add a reusable `MutuallyExclusiveUnion<[...]>` type helper in `common/types/helpers.ts` that builds a union whose members are mutually exclusive — each *other* branch's keys become `?: never`.
- Replace the hand-written `?: never` unions with it: `FirstFrame` / `LastFrame`, `PlatformColorObject`, and `SpringConfig`.
- Add typetests (`__typetests__/helpersTest.ts`).

## Test plan

- `yarn type:check`
- `yarn lint`