### PR TITLE
docs: add dynamic banner serving to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="https://github.com/user-attachments/assets/a516a6ef-fc1e-4d38-a4d8-6d53d6e51a21" alt="React Native Reanimated and React Native Worklets by Software Mansion" width="100%">
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-1\&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-2\&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-3\&n=1)
 
 # Reanimated & Worklets
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <img src="https://github.com/user-attachments/assets/a516a6ef-fc1e-4d38-a4d8-6d53d6e51a21" alt="React Native Reanimated and React Native Worklets by Software Mansion" width="100%">
 
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-3&n=1)
+
 # Reanimated & Worklets
 
 This repository contains two main packages:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="https://github.com/user-attachments/assets/a516a6ef-fc1e-4d38-a4d8-6d53d6e51a21" alt="React Native Reanimated and React Native Worklets by Software Mansion" width="100%">
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-reanimated-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-reanimated-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-reanimated-3&n=1)
 
 # Reanimated & Worklets
 

--- a/packages/react-native-worklets/README.md
+++ b/packages/react-native-worklets/README.md
@@ -1,5 +1,9 @@
 <img src="https://github.com/user-attachments/assets/41b37472-e55a-4c54-9064-31258e03870c" alt="React Native Worklets by Software Mansion" width="100%">
 
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-3&n=1)
+
 ### The React Native multithreading library
 
 React Native Worklets is a library that allows you to run JavaScript code in parallel on multiple threads and runtimes, without writing any native code.

--- a/packages/react-native-worklets/README.md
+++ b/packages/react-native-worklets/README.md
@@ -1,8 +1,8 @@
 <img src="https://github.com/user-attachments/assets/41b37472-e55a-4c54-9064-31258e03870c" alt="React Native Worklets by Software Mansion" width="100%">
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-1\&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-2\&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-3\&n=1)
 
 ### The React Native multithreading library
 

--- a/packages/react-native-worklets/README.md
+++ b/packages/react-native-worklets/README.md
@@ -1,8 +1,8 @@
 <img src="https://github.com/user-attachments/assets/41b37472-e55a-4c54-9064-31258e03870c" alt="React Native Worklets by Software Mansion" width="100%">
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-worklets-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-1?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-1&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-2?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-2&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-worklets-3?n=1)](https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-worklets-3&n=1)
 
 ### The React Native multithreading library
 


### PR DESCRIPTION
Adds dynamic banners to readme. The image and link are served from our delivery server, so we can swap banners without changing the repo. Banners are hidden for now until we turn them on.