### PR TITLE
feat(SET): support transition to modals on iOS

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+# Shared Element Transitions — iOS Modal Support
+
+## Problem
+
+SET's snapshot container is mounted under the RN surface root, which lives inside the presenter VC. On iOS, a modal VC's view is a sibling under `UIWindow`, so it covers the snapshot.
+
+Android works because modal screens don't cross a window boundary.
+
+## Fix
+
+On iOS, reparent the snapshot container `UIView` to the `UIWindow` for the duration of the transition, then put it back before RN removes it.
+
+## Steps
+
+1. **C++** ([SharedTransitions.cpp](packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp)): after the container is mounted, call a new platform method `reparentSharedTransitionContainerToWindow(containerTag)`. At cleanup, call `restoreSharedTransitionContainer(containerTag)` before emitting Remove/Delete.
+
+2. **iOS** ([REANodesManager.mm](packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm)):
+   - Look up the container `UIView` via `componentViewRegistry`.
+   - Reparent to `surfaceRoot.window`, translating frame with `convertRect:toView:`.
+   - Compensate for per-frame frame updates (which arrive in surface-root coords) using a constant `CATransform3D` translation = `surfaceRoot` origin in window coords.
+   - On restore, reverse.
+
+3. **Target frame across modal boundary**: get the modal's final frame via `modalVC.presentationController.frameOfPresentedViewInContainerView` (returns the destination even mid-animation). Add it to the target's in-surface position. Find `modalVC` by walking up `targetView`'s responder chain.
+
+4. **Android**: no-op the new platform methods.
+
+## How C++ and iOS talk
+
+```
+JS
+ │
+ ▼
+ReanimatedModuleProxy (C++)
+ │  owns
+ ▼
+LayoutAnimationsProxy_Experimental (C++)   ◄── SharedTransitions.cpp lives here
+ │  - MountingOverrideDelegate on each surface
+ │  - rewrites ShadowViewMutations (hide source/target, insert container)
+ │
+ │  calls platform methods via function pointers
+ ▼
+PlatformDepMethodsHolder (Obj-C glue)
+ │
+ ▼
+REANodesManager.mm  ──►  surfacePresenter.mountingManager.componentViewRegistry
+                                            │
+                                            ▼
+                                       real UIViews
+```

--- a/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
@@ -77,7 +77,7 @@ function Card({
 function Screen1({ navigation }: NativeStackScreenProps<ParamList, 'Screen1'>) {
   return (
     <Animated.ScrollView style={styles.flexOne}>
-      {[...Array(6)].map((_, i) => (
+      {[...Array(3)].map((_, i) => (
         <Card
           key={i}
           navigation={navigation}
@@ -172,7 +172,7 @@ export default function ModalsExample() {
   return (
     <Stack.Navigator
       screenOptions={{
-        presentation: 'transparentModal',
+        presentation: 'modal',
         headerShown: false,
         animation: 'fade',
       }}>

--- a/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/SharedElementTransitions/Modals.tsx
@@ -43,17 +43,20 @@ function Card({
     <Pressable
       onPress={() => {
         goNext?.();
-      }}>
+      }}
+    >
       <Animated.View
         style={
           isOpen
             ? { height: 500, marginTop: 50, backgroundColor: 'green' }
             : { height: 120, marginTop: 20, backgroundColor: 'green' }
         }
-        sharedTransitionTag={transitionTag + '1'}>
+        sharedTransitionTag={transitionTag + '1'}
+      >
         <Animated.Text
           sharedTransitionTag={transitionTag + '2'}
-          style={[styles.fullWidth, { height: 20 }]}>
+          style={[styles.fullWidth, { height: 20 }]}
+        >
           {title}
         </Animated.Text>
         <Animated.Image
@@ -63,7 +66,8 @@ function Card({
         />
         <Animated.Text
           sharedTransitionTag={transitionTag + '4'}
-          style={[styles.fullWidth, { height: isOpen ? 100 : 0 }]}>
+          style={[styles.fullWidth, { height: isOpen ? 100 : 0 }]}
+        >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas aliquid,
           earum non, dignissimos fugit rerum exercitationem ab consequatur,
           error animi veritatis delectus. Nostrum sapiente distinctio possimus
@@ -83,7 +87,7 @@ function Screen1({ navigation }: NativeStackScreenProps<ParamList, 'Screen1'>) {
           navigation={navigation}
           title={'Title' + i}
           transitionTag={'sharedTag' + i}
-          nextScreen="Screen2"
+          nextScreen='Screen2'
           goNext={() =>
             navigation.navigate('Screen2', {
               title: 'Title' + i,
@@ -160,7 +164,7 @@ function Screen2({
           title={title}
           transitionTag={sharedTransitionTag}
           isOpen={true}
-          nextScreen="Screen1"
+          nextScreen='Screen1'
           goNext={goNext}
         />
       </Animated.View>
@@ -174,10 +178,11 @@ export default function ModalsExample() {
       screenOptions={{
         presentation: 'modal',
         headerShown: false,
-        animation: 'fade',
-      }}>
-      <Stack.Screen name="Screen1" component={Screen1} />
-      <Stack.Screen name="Screen2" component={Screen2} />
+        animation: 'default',
+      }}
+    >
+      <Stack.Screen name='Screen1' component={Screen1} />
+      <Stack.Screen name='Screen2' component={Screen2} />
     </Stack.Navigator>
   );
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -100,8 +100,8 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   insertContainers(filteredMutations, rootChildCount, surfaceId);
 
 #ifdef __APPLE__
-  if (!containerTagsToReparent_.empty() && reparentSharedTransitionContainersToWindow_) {
-    reparentSharedTransitionContainersToWindow_(containerTagsToReparent_);
+  if (!containerTagsToReparent_.empty() && queueSharedTransitionContainersForReparenting_) {
+    queueSharedTransitionContainersForReparenting_(containerTagsToReparent_);
     containerTagsToReparent_.clear();
   }
 #endif

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -104,6 +104,10 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
     queueSharedTransitionContainersForReparenting_(containerTagsToReparent_);
     containerTagsToReparent_.clear();
   }
+  if (!containerTagsToRestore_.empty() && queueSharedTransitionContainersForRestoring_) {
+    queueSharedTransitionContainersForRestoring_(containerTagsToRestore_);
+    containerTagsToRestore_.clear();
+  }
 #endif
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -1,3 +1,4 @@
+#include <glog/logging.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h>
 #include <reanimated/LayoutAnimations/PropsDiffer.h>
@@ -257,7 +258,12 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::progressLayoutAnima
   auto newProps = getComponentDescriptorForShadowView(layoutAnimation.finalView)
                       .cloneProps(propsParserContext, layoutAnimation.finalView.props, std::move(*rawProps));
   auto &updateMap = surfaceManager.getUpdateMap(layoutAnimation.finalView.surfaceId);
-  updateMap.insert_or_assign(tag, UpdateValues{newProps, Frame(uiRuntime_, newStyle)});
+  auto frame = Frame(uiRuntime_, newStyle);
+  if (sharedTransitionManager_->tagToName_.contains(tag)) {
+    LOG(INFO) << "@@ progressLayoutAnimation (TIME DRIVEN) containerTag=" << tag << " x=" << frame.x.value_or(0)
+              << " y=" << frame.y.value_or(0) << " w=" << frame.width.value_or(0) << " h=" << frame.height.value_or(0);
+  }
+  updateMap.insert_or_assign(tag, UpdateValues{newProps, frame});
 
   return layoutAnimation.finalView.surfaceId;
 }
@@ -832,6 +838,11 @@ void LayoutAnimationsProxy_Experimental::startSharedTransition(
     propsDiff.setProperty(uiRuntime, "windowWidth", window.width);
     propsDiff.setProperty(uiRuntime, "windowHeight", window.height);
 
+    LOG(INFO) << "@@@ startSharedTransition (TIME DRIVEN) containerTag=" << tag << " surfaceId=" << surfaceId
+              << " before=(" << before.layoutMetrics.frame.origin.x << "," << before.layoutMetrics.frame.origin.y << ","
+              << before.layoutMetrics.frame.size.width << "x" << before.layoutMetrics.frame.size.height << ")"
+              << " after=(" << after.layoutMetrics.frame.origin.x << "," << after.layoutMetrics.frame.origin.y << ","
+              << after.layoutMetrics.frame.size.width << "x" << after.layoutMetrics.frame.size.height << ")";
     strongThis->layoutAnimationsManager_->startLayoutAnimation(
         uiRuntime, tag, LayoutAnimationType::SHARED_ELEMENT_TRANSITION, propsDiff);
   });

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -99,6 +99,13 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
 
   insertContainers(filteredMutations, rootChildCount, surfaceId);
 
+#ifdef __APPLE__
+  if (!containerTagsToReparent_.empty() && reparentSharedTransitionContainersToWindow_) {
+    reparentSharedTransitionContainersToWindow_(containerTagsToReparent_);
+    containerTagsToReparent_.clear();
+  }
+#endif
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -62,7 +62,9 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   mutable ForceScreenSnapshotFunction forceScreenSnapshot_;
 #ifdef __APPLE__
   mutable QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparenting_;
+  mutable QueueSharedTransitionContainersForRestoringFunction queueSharedTransitionContainersForRestoring_;
   mutable std::vector<Tag> containerTagsToReparent_;
+  mutable std::vector<Tag> containerTagsToRestore_;
 #endif
 
   LayoutAnimationsProxy_Experimental(
@@ -136,6 +138,10 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   void setQueueSharedTransitionContainersForReparentingFunction(
       QueueSharedTransitionContainersForReparentingFunction reparent) {
     queueSharedTransitionContainersForReparenting_ = std::move(reparent);
+  }
+  void setQueueSharedTransitionContainersForRestoringFunction(
+      QueueSharedTransitionContainersForRestoringFunction restore) {
+    queueSharedTransitionContainersForRestoring_ = std::move(restore);
   }
 #endif
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -60,6 +60,10 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   mutable std::unordered_map<Tag, react::Transform> transformForNode_;
 
   mutable ForceScreenSnapshotFunction forceScreenSnapshot_;
+#ifdef __APPLE__
+  mutable ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindow_;
+  mutable std::vector<Tag> containerTagsToReparent_;
+#endif
 
   LayoutAnimationsProxy_Experimental(
       const std::shared_ptr<LayoutAnimationsManager> &layoutAnimationsManager,
@@ -128,6 +132,10 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
 #ifdef __APPLE__
   void setForceScreenSnapshotFunction(ForceScreenSnapshotFunction forceScreenSnapshot) {
     forceScreenSnapshot_ = std::move(forceScreenSnapshot);
+  }
+  void setReparentSharedTransitionContainersToWindowFunction(
+      ReparentSharedTransitionContainersToWindowFunction reparent) {
+    reparentSharedTransitionContainersToWindow_ = std::move(reparent);
   }
 #endif
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -61,7 +61,7 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
 
   mutable ForceScreenSnapshotFunction forceScreenSnapshot_;
 #ifdef __APPLE__
-  mutable ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindow_;
+  mutable QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparenting_;
   mutable std::vector<Tag> containerTagsToReparent_;
 #endif
 
@@ -133,9 +133,9 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
   void setForceScreenSnapshotFunction(ForceScreenSnapshotFunction forceScreenSnapshot) {
     forceScreenSnapshot_ = std::move(forceScreenSnapshot);
   }
-  void setReparentSharedTransitionContainersToWindowFunction(
-      ReparentSharedTransitionContainersToWindowFunction reparent) {
-    reparentSharedTransitionContainersToWindow_ = std::move(reparent);
+  void setQueueSharedTransitionContainersForReparentingFunction(
+      QueueSharedTransitionContainersForReparentingFunction reparent) {
+    queueSharedTransitionContainersForReparenting_ = std::move(reparent);
   }
 #endif
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -72,7 +72,11 @@ void LayoutAnimationsProxy_Experimental::findSharedElementsOnScreen(
     parentTag[indexNum] = parent->current.tag;
 
     if (parentTag[BEFORE] && parentTag[AFTER]) {
-      LOG(INFO) << "@@@ found a potential transition: sharedTag=" << sharedTag;
+      const auto &beforeOrigin = snapshot[BEFORE].layoutMetrics.frame.origin;
+      const auto &afterOrigin = snapshot[AFTER].layoutMetrics.frame.origin;
+      LOG(INFO) << "@@@ found a potential transition: sharedTag=" << sharedTag << " before.abs=(" << beforeOrigin.x
+                << "," << beforeOrigin.y << ")"
+                << " after.abs=(" << afterOrigin.x << "," << afterOrigin.y << ")";
       transitions_.emplace_back(sharedTag, transition);
     } else if (parentTag[AFTER]) {
       // TODO (future): this is adding unnecessary views to the list
@@ -427,6 +431,13 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
 
 std::vector<react::Point> LayoutAnimationsProxy_Experimental::getAbsolutePositionsForRootPathView(
     const std::shared_ptr<LightNode> &node) const {
+  bool hasModalAncestor = false;
+  for (auto scan = node; scan; scan = scan->parent.lock()) {
+    if (scan->current.componentName && !strcmp(scan->current.componentName, "RNSModalScreen")) {
+      hasModalAncestor = true;
+      break;
+    }
+  }
   std::vector<react::Point> viewsAbsolutePositions;
   auto currentNode = node;
   while (currentNode) {
@@ -438,13 +449,21 @@ std::vector<react::Point> LayoutAnimationsProxy_Experimental::getAbsolutePositio
       auto data = state->getData();
       viewPosition -= data.contentOffset;
     }
-    if (!strcmp(componentName, "RNSScreen") && currentNode->children.size() >= 2) {
+    if (!hasModalAncestor && !strcmp(componentName, "RNSScreen") && currentNode->children.size() >= 2) {
       const auto &parent = currentNode->parent.lock();
       react_native_assert(parent && "Parent node is nullptr");
 
       const float headerHeight =
           parent->current.layoutMetrics.frame.size.height - currentNode->current.layoutMetrics.frame.size.height;
       viewPosition.y += headerHeight;
+    }
+    if (!strcmp(componentName, "RNSModalScreen")) {
+      auto rootIt = lightNodes_.find(currentNode->current.surfaceId);
+      if (rootIt != lightNodes_.end() && rootIt->second) {
+        const float surfaceHeight = rootIt->second->current.layoutMetrics.frame.size.height;
+        const float modalHeight = currentNode->current.layoutMetrics.frame.size.height;
+        viewPosition.y += surfaceHeight - modalHeight;
+      }
     }
     viewPosition += currentNode->current.layoutMetrics.frame.origin;
     viewsAbsolutePositions.emplace_back(viewPosition);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -237,6 +237,9 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     sharedTransitionManager_->containerTags_[sharedTag] = containerTag;
     LOG(INFO) << "@@@ created a new helper container: containerTag=" << containerTag << " sharedTag=" << sharedTag
               << " parent=surfaceId(" << surfaceId << ")";
+#ifdef __APPLE__
+    containerTagsToReparent_.push_back(containerTag);
+#endif
   } else {
     LOG(INFO) << "@@@ reusing container: containerTag=" << containerTag << " sharedTag=" << sharedTag;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -10,6 +10,7 @@
 #endif // !ANDROID
 
 #include <folly/dynamic.h>
+#include <glog/logging.h>
 
 #include <ranges>
 
@@ -71,6 +72,7 @@ void LayoutAnimationsProxy_Experimental::findSharedElementsOnScreen(
     parentTag[indexNum] = parent->current.tag;
 
     if (parentTag[BEFORE] && parentTag[AFTER]) {
+      LOG(INFO) << "@@@ found a potential transition: sharedTag=" << sharedTag;
       transitions_.emplace_back(sharedTag, transition);
     } else if (parentTag[AFTER]) {
       // TODO (future): this is adding unnecessary views to the list
@@ -100,6 +102,7 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
     auto root = lightNodes_[surfaceId];
     auto beforeTopScreen = topScreen[surfaceId];
     auto afterTopScreen = lightNodes_[transitionTag_];
+    LOG(INFO) << "@@@ transition started: surfaceId=" << surfaceId;
     if (beforeTopScreen && afterTopScreen && beforeTopScreen != afterTopScreen) {
       findSharedElementsOnScreen(beforeTopScreen, BEFORE, propsParserContext);
       findSharedElementsOnScreen(afterTopScreen, AFTER, propsParserContext);
@@ -124,6 +127,8 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
       }
     }
   } else if (transitionState_ == TransitionState::ACTIVE) {
+    LOG(INFO) << "@@@ transition active progress=" << transitionProgress_
+              << " activeTransitions=" << activeTransitions_.size();
     for (auto tag : activeTransitions_) {
       auto layoutAnimation = layoutAnimations_[tag];
       auto &updateMap = surfaceManager.getUpdateMap(layoutAnimation.finalView.surfaceId);
@@ -153,6 +158,8 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
                           .cloneProps(propsParserContext, layoutAnimation.finalView.props, std::move(rawProps));
 #endif
 
+      LOG(INFO) << "@@@ progress update (GESTURE DRIVEN) containerTag=" << tag << " progress=" << transitionProgress_
+                << " frame=(" << x << "," << y << "," << width << "x" << height << ")";
       updateMap.insert_or_assign(tag, UpdateValues{newProps, {x, y, width, height}});
     }
   }
@@ -160,6 +167,7 @@ void LayoutAnimationsProxy_Experimental::handleProgressTransition(
   if (transitionState_ == TransitionState::START) {
     transitionState_ = TransitionState::ACTIVE;
   } else if (transitionState_ == TransitionState::END || transitionState_ == TransitionState::CANCELLED) {
+    LOG(INFO) << "@@@ transition ended or was cancelled";
     for (auto tag : activeTransitions_) {
       sharedContainersToRemove_.push_back(tag);
       tagsToRestore_.push_back(restoreMap_[tag][AFTER]);
@@ -227,6 +235,10 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     lightNodes_[containerTag] = std::move(node);
 
     sharedTransitionManager_->containerTags_[sharedTag] = containerTag;
+    LOG(INFO) << "@@@ created a new helper container: containerTag=" << containerTag << " sharedTag=" << sharedTag
+              << " parent=surfaceId(" << surfaceId << ")";
+  } else {
+    LOG(INFO) << "@@@ reusing container: containerTag=" << containerTag << " sharedTag=" << sharedTag;
   }
   return containerTag;
 }
@@ -245,6 +257,9 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
   }
 
   if (beforeTopScreen != afterTopScreen) {
+    LOG(INFO) << "@@@ starting shared transition (screens changed) surfaceId=" << surfaceId
+              << " old screen tag=" << (beforeTopScreen ? beforeTopScreen->current.tag : -1)
+              << " new screen tag=" << (afterTopScreen ? afterTopScreen->current.tag : -1);
     for (auto &[sharedTag, transition] : transitions_) {
       auto &[before, after] = transition.snapshot;
       const auto &transform = transition.transform;
@@ -285,6 +300,8 @@ void LayoutAnimationsProxy_Experimental::hideTransitioningViews(
     int indexNum = static_cast<int>(index);
     const auto &shadowView = transition.snapshot[indexNum];
     const auto &parentTag = transition.parentTag[indexNum];
+    LOG(INFO) << "@@@ hideTransitioningViews: " << (index == BEFORE ? "old_screen" : "new_screen")
+              << " sharedTag=" << sharedTag << " tag=" << shadowView.tag << " parent=" << parentTag;
     auto m = ShadowViewMutation::UpdateMutation(
         shadowView, cloneViewWithoutOpacity(shadowView, propsParserContext), parentTag);
     filteredMutations.push_back(m);
@@ -354,6 +371,8 @@ void LayoutAnimationsProxy_Experimental::insertContainers(
   filteredMutations.reserve(containersToInsert_.size() * 2);
   auto root = lightNodes_[surfaceId];
   for (auto &node : containersToInsert_) {
+    LOG(INFO) << "@@@ insert helper containers to the root: containerTag=" << node->current.tag << " parent=surfaceId("
+              << surfaceId << ") index=" << rootChildCount;
     filteredMutations.push_back(ShadowViewMutation::CreateMutation(node->current));
     filteredMutations.push_back(ShadowViewMutation::InsertMutation(surfaceId, node->current, rootChildCount++));
   }
@@ -370,6 +389,7 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
     ReanimatedSystraceSection s("Restore tag");
     auto &node = lightNodes_[tag];
     if (node) {
+      LOG(INFO) << "@@@ cleanupSharedTransitions: restoring opacity for tag=" << tag;
       auto view = node->current;
       const auto &parent = node->parent.lock();
       react_native_assert(parent && "Parent node is nullptr");
@@ -383,6 +403,7 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
 
   ReanimatedSystraceSection s2("remove shared containers");
   for (auto &tag : sharedContainersToRemove_) {
+    LOG(INFO) << "@@@ cleanupSharedTransitions: removing container tag=" << tag;
     auto root = lightNodes_[surfaceId];
     for (int i = 0; i < root->children.size(); i++) {
       auto &child = root->children[i];

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -407,6 +407,9 @@ void LayoutAnimationsProxy_Experimental::cleanupSharedTransitions(
   ReanimatedSystraceSection s2("remove shared containers");
   for (auto &tag : sharedContainersToRemove_) {
     LOG(INFO) << "@@@ cleanupSharedTransitions: removing container tag=" << tag;
+#ifdef __APPLE__
+    containerTagsToRestore_.push_back(tag);
+#endif
     auto root = lightNodes_[surfaceId];
     for (int i = 0; i < root->children.size(); i++) {
       auto &child = root->children[i];

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -204,6 +204,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       forceScreenSnapshot_(platformDepMethodsHolder.forceScreenSnapshotFunction),
       queueSharedTransitionContainersForReparenting_(
           platformDepMethodsHolder.queueSharedTransitionContainersForReparentingFunction),
+      queueSharedTransitionContainersForRestoring_(
+          platformDepMethodsHolder.queueSharedTransitionContainersForRestoringFunction),
 #endif
       staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
@@ -1240,6 +1242,8 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
       layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
       layoutAnimationsProxyExperimental->setQueueSharedTransitionContainersForReparentingFunction(
           queueSharedTransitionContainersForReparenting_);
+      layoutAnimationsProxyExperimental->setQueueSharedTransitionContainersForRestoringFunction(
+          queueSharedTransitionContainersForRestoring_);
 #endif
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
     } else {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -202,6 +202,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       getAnimationTimestamp_(platformDepMethodsHolder.getAnimationTimestamp),
 #ifdef __APPLE__
       forceScreenSnapshot_(platformDepMethodsHolder.forceScreenSnapshotFunction),
+      reparentSharedTransitionContainersToWindow_(
+          platformDepMethodsHolder.reparentSharedTransitionContainersToWindowFunction),
 #endif
       staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
@@ -1236,6 +1238,8 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
       );
 #ifdef __APPLE__
       layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
+      layoutAnimationsProxyExperimental->setReparentSharedTransitionContainersToWindowFunction(
+          reparentSharedTransitionContainersToWindow_);
 #endif
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
     } else {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -202,8 +202,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       getAnimationTimestamp_(platformDepMethodsHolder.getAnimationTimestamp),
 #ifdef __APPLE__
       forceScreenSnapshot_(platformDepMethodsHolder.forceScreenSnapshotFunction),
-      reparentSharedTransitionContainersToWindow_(
-          platformDepMethodsHolder.reparentSharedTransitionContainersToWindowFunction),
+      queueSharedTransitionContainersForReparenting_(
+          platformDepMethodsHolder.queueSharedTransitionContainersForReparentingFunction),
 #endif
       staticPropsRegistry_(std::make_shared<StaticPropsRegistry>()),
       updatesRegistryManager_(std::make_shared<UpdatesRegistryManager>(staticPropsRegistry_)),
@@ -1238,8 +1238,8 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
       );
 #ifdef __APPLE__
       layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
-      layoutAnimationsProxyExperimental->setReparentSharedTransitionContainersToWindowFunction(
-          reparentSharedTransitionContainersToWindow_);
+      layoutAnimationsProxyExperimental->setQueueSharedTransitionContainersForReparentingFunction(
+          queueSharedTransitionContainersForReparenting_);
 #endif
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
     } else {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -253,6 +253,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshot_;
   QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparenting_;
+  QueueSharedTransitionContainersForRestoringFunction queueSharedTransitionContainersForRestoring_;
 #endif
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -252,7 +252,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshot_;
-  ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindow_;
+  QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparenting_;
 #endif
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -252,6 +252,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshot_;
+  ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindow_;
 #endif
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -49,6 +49,8 @@ using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 
 using ForceScreenSnapshotFunction = std::function<void(Tag tag)>;
 
+using ReparentSharedTransitionContainersToWindowFunction = std::function<void(const std::vector<Tag> &containerTags)>;
+
 using PlatformAttachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector, std::function<void(bool)>)>;
 using PlatformDetachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector)>;
 
@@ -59,6 +61,7 @@ struct PlatformDepMethodsHolder {
 #endif // ANDROID
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;
+  ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindowFunction;
 #endif
   SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction;
   GetAnimationTimestampFunction getAnimationTimestamp;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -50,6 +50,7 @@ using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 using ForceScreenSnapshotFunction = std::function<void(Tag tag)>;
 
 using QueueSharedTransitionContainersForReparentingFunction = std::function<void(const std::vector<Tag> &containerTags)>;
+using QueueSharedTransitionContainersForRestoringFunction = std::function<void(const std::vector<Tag> &containerTags)>;
 
 using PlatformAttachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector, std::function<void(bool)>)>;
 using PlatformDetachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector)>;
@@ -62,6 +63,7 @@ struct PlatformDepMethodsHolder {
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;
   QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparentingFunction;
+  QueueSharedTransitionContainersForRestoringFunction queueSharedTransitionContainersForRestoringFunction;
 #endif
   SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction;
   GetAnimationTimestampFunction getAnimationTimestamp;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -49,7 +49,7 @@ using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 
 using ForceScreenSnapshotFunction = std::function<void(Tag tag)>;
 
-using ReparentSharedTransitionContainersToWindowFunction = std::function<void(const std::vector<Tag> &containerTags)>;
+using QueueSharedTransitionContainersForReparentingFunction = std::function<void(const std::vector<Tag> &containerTags)>;
 
 using PlatformAttachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector, std::function<void(bool)>)>;
 using PlatformDetachPseudoSelectorFunction = std::function<void(Tag, PseudoSelector)>;
@@ -61,7 +61,7 @@ struct PlatformDepMethodsHolder {
 #endif // ANDROID
 #ifdef __APPLE__
   ForceScreenSnapshotFunction forceScreenSnapshotFunction;
-  ReparentSharedTransitionContainersToWindowFunction reparentSharedTransitionContainersToWindowFunction;
+  QueueSharedTransitionContainersForReparentingFunction queueSharedTransitionContainersForReparentingFunction;
 #endif
   SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction;
   GetAnimationTimestampFunction getAnimationTimestamp;

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -22,5 +22,6 @@ typedef void (^REAPerformOperations)();
 - (void)registerPerformOperations:(REAPerformOperations)performOperations;
 - (void)maybeFlushUIUpdatesQueue;
 - (void)queueSharedTransitionContainersForReparenting:(NSArray<NSNumber *> *)containerTags;
+- (void)queueSharedTransitionContainersForRestoring:(NSArray<NSNumber *> *)containerTags;
 
 @end

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -10,7 +10,7 @@ typedef void (^REAPerformOperations)();
 
 @interface REANodesManager : NSObject
 
-@property (weak) RCTSurfacePresenter *surfacePresenter;
+@property (nonatomic, weak) RCTSurfacePresenter *surfacePresenter;
 
 - (nonnull instancetype)init;
 - (void)invalidate;
@@ -21,6 +21,6 @@ typedef void (^REAPerformOperations)();
 - (void)synchronouslyUpdateUIProps:(ReactTag)viewTag props:(const folly::dynamic &)props;
 - (void)registerPerformOperations:(REAPerformOperations)performOperations;
 - (void)maybeFlushUIUpdatesQueue;
-- (void)reparentSharedTransitionContainersToWindow:(NSArray<NSNumber *> *)containerTags;
+- (void)queueSharedTransitionContainersForReparenting:(NSArray<NSNumber *> *)containerTags;
 
 @end

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.h
@@ -21,5 +21,6 @@ typedef void (^REAPerformOperations)();
 - (void)synchronouslyUpdateUIProps:(ReactTag)viewTag props:(const folly::dynamic &)props;
 - (void)registerPerformOperations:(REAPerformOperations)performOperations;
 - (void)maybeFlushUIUpdatesQueue;
+- (void)reparentSharedTransitionContainersToWindow:(NSArray<NSNumber *> *)containerTags;
 
 @end

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -24,6 +24,7 @@ using namespace facebook::react;
   NSMutableArray<NSNumber *> *_pendingReparentContainerTags;
   NSMutableArray<NSNumber *> *_pendingRestoreContainerTags;
   NSMutableDictionary<NSNumber *, UIView *> *_surfaceRootByContainerTag;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_subviewIndexByContainerTag;
   UIView *_debugRedRectangle;
   UIWindow *_overlayWindow;
 }
@@ -66,6 +67,7 @@ using namespace facebook::react;
     _pendingReparentContainerTags = [NSMutableArray new];
     _pendingRestoreContainerTags = [NSMutableArray new];
     _surfaceRootByContainerTag = [NSMutableDictionary new];
+    _subviewIndexByContainerTag = [NSMutableDictionary new];
     _eventHandler = ^(id<RCTEvent> event) {
       // no-op
     };
@@ -207,35 +209,61 @@ using namespace facebook::react;
   }
   NSLog(@"@@@ willMountComponentsWithRootTag:%ld pending restore tags=%@", (long)rootTag, _pendingRestoreContainerTags);
 
-  // Real restore disabled while debugging. Just remove the debug red rectangle
-  // to confirm the cleanup path fires.
-  if (_debugRedRectangle != nil) {
-    [_debugRedRectangle removeFromSuperview];
-    _debugRedRectangle = nil;
-    NSLog(@"@@@ debug: removed red rectangle");
+  RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
+
+  // Restore order must produce the exact surface-root.subviews ordering RN
+  // expects when it processes the Remove mutations: each container must occupy
+  // the index it had when we reparented it out. To achieve that, sort by the
+  // stashed original index ascending and use insertSubview:atIndex: so each
+  // insertion lands at its true target slot (earlier inserts at lower indices
+  // don't shift later ones up).
+  NSArray<NSNumber *> *sortedTags = [_pendingRestoreContainerTags
+      sortedArrayUsingComparator:^NSComparisonResult(NSNumber *a, NSNumber *b) {
+        NSNumber *ia = _subviewIndexByContainerTag[a];
+        NSNumber *ib = _subviewIndexByContainerTag[b];
+        NSUInteger va = ia != nil ? ia.unsignedIntegerValue : NSUIntegerMax;
+        NSUInteger vb = ib != nil ? ib.unsignedIntegerValue : NSUIntegerMax;
+        if (va < vb) return NSOrderedAscending;
+        if (va > vb) return NSOrderedDescending;
+        return NSOrderedSame;
+      }];
+
+  for (NSNumber *tag in sortedTags) {
+    UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
+    UIView *surfaceRoot = _surfaceRootByContainerTag[tag];
+    NSNumber *originalIndex = _subviewIndexByContainerTag[tag];
+    [_surfaceRootByContainerTag removeObjectForKey:tag];
+    [_subviewIndexByContainerTag removeObjectForKey:tag];
+
+    if (container == nil || surfaceRoot == nil) {
+      NSLog(@"@@@ restore: tag=%@ container=%@ surfaceRoot=%@, skipping", tag, container, surfaceRoot);
+      continue;
+    }
+
+    container.layer.transform = CATransform3DIdentity;
+    container.userInteractionEnabled = YES;
+    NSUInteger insertIndex = originalIndex != nil ? originalIndex.unsignedIntegerValue : surfaceRoot.subviews.count;
+    if (insertIndex > surfaceRoot.subviews.count) {
+      insertIndex = surfaceRoot.subviews.count;
+    }
+    [surfaceRoot insertSubview:container atIndex:insertIndex];
+    NSLog(@"@@@ restore: tag=%@ moved back to surface root at index=%lu", tag, (unsigned long)insertIndex);
   }
 
-  // RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
-  //
-  // for (NSNumber *tag in _pendingRestoreContainerTags) {
-  //   UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
-  //   UIView *surfaceRoot = _surfaceRootByContainerTag[tag];
-  //   [_surfaceRootByContainerTag removeObjectForKey:tag];
-  //
-  //   if (container == nil || surfaceRoot == nil) {
-  //     NSLog(@"@@@ restore: tag=%@ container=%@ surfaceRoot=%@, skipping", tag, container, surfaceRoot);
-  //     continue;
-  //   }
-  //
-  //   // Reverse the compensating transform and move back so RN's Remove/Delete
-  //   // mutations (about to be processed) find the view under the surface root.
-  //   container.layer.transform = CATransform3DIdentity;
-  //   container.userInteractionEnabled = YES;
-  //   [surfaceRoot addSubview:container];
-  //   NSLog(@"@@@ restore: tag=%@ moved back to surface root", tag);
-  // }
-
   [_pendingRestoreContainerTags removeAllObjects];
+}
+
+- (UIWindow *)overlayWindowForScene:(UIWindowScene *)scene
+{
+  if (_overlayWindow == nil && scene != nil) {
+    _overlayWindow = [[UIWindow alloc] initWithWindowScene:scene];
+    _overlayWindow.windowLevel = UIWindowLevelAlert + 1;
+    _overlayWindow.backgroundColor = [UIColor clearColor];
+    _overlayWindow.userInteractionEnabled = NO;
+    _overlayWindow.rootViewController = [UIViewController new];
+    _overlayWindow.hidden = NO;
+  }
+  return _overlayWindow;
 }
 
 - (void)didMountComponentsWithRootTag:(NSInteger)rootTag
@@ -245,63 +273,71 @@ using namespace facebook::react;
   }
   NSLog(@"@@@ didMountComponentsWithRootTag:%ld pending reparent tags=%@", (long)rootTag, _pendingReparentContainerTags);
 
-  // Real reparent disabled while debugging. Drop a red rectangle on the window
-  // so we can visually confirm something gets layered above the modal.
-  UIWindowScene *targetScene = nil;
-  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
-    if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
-      targetScene = (UIWindowScene *)scene;
-      break;
-    }
-  }
-  if (targetScene == nil) {
-    NSLog(@"@@@ debug: no foreground active window scene");
-    [_pendingReparentContainerTags removeAllObjects];
-    return;
-  }
-  if (_overlayWindow == nil) {
-    _overlayWindow = [[UIWindow alloc] initWithWindowScene:targetScene];
-    _overlayWindow.windowLevel = UIWindowLevelAlert + 1;
-    _overlayWindow.backgroundColor = [UIColor clearColor];
-    _overlayWindow.userInteractionEnabled = NO;
-    _overlayWindow.rootViewController = [UIViewController new];
-    _overlayWindow.hidden = NO;
-    NSLog(@"@@@ debug: created overlay window level=%.1f frame=%@", _overlayWindow.windowLevel, NSStringFromCGRect(_overlayWindow.frame));
-  }
-  if (_debugRedRectangle == nil) {
-    _debugRedRectangle = [[UIView alloc] initWithFrame:CGRectMake(40, 100, 120, 120)];
-    _debugRedRectangle.backgroundColor = [UIColor redColor];
-    _debugRedRectangle.userInteractionEnabled = NO;
-  }
-  [_overlayWindow addSubview:_debugRedRectangle];
-  NSLog(@"@@@ debug: added red rectangle to overlay window subviews=%@", _overlayWindow.subviews);
+  RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
 
-  // RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
-  //
-  // for (NSNumber *tag in _pendingReparentContainerTags) {
-  //   UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
-  //   if (container == nil) {
-  //     NSLog(@"@@@ reparent: container tag=%@ not found in registry, skipping", tag);
-  //     continue;
-  //   }
-  //   UIView *surfaceRoot = container.superview;
-  //   UIWindow *windowForContainer = surfaceRoot.window;
-  //   if (surfaceRoot == nil || windowForContainer == nil) {
-  //     NSLog(@"@@@ reparent: container tag=%@ has no window (superview=%@, window=%@), skipping", tag, surfaceRoot, windowForContainer);
-  //     continue;
-  //   }
-  //
-  //   CGPoint surfaceOriginInWindow = [surfaceRoot convertPoint:CGPointZero toView:windowForContainer];
-  //   NSLog(
-  //       @"@@@ reparent: tag=%@ moving to window; surfaceOriginInWindow=(%.1f,%.1f)",
-  //       tag,
-  //       surfaceOriginInWindow.x,
-  //       surfaceOriginInWindow.y);
-  //   _surfaceRootByContainerTag[tag] = surfaceRoot;
-  //   [windowForContainer addSubview:container];
-  //   container.layer.transform = CATransform3DMakeTranslation(surfaceOriginInWindow.x, surfaceOriginInWindow.y, 0);
-  //   container.userInteractionEnabled = NO;
-  // }
+  // First pass: capture the original subview index for each container BEFORE
+  // any reparenting, because removing a view from its superview compacts the
+  // remaining indices and we'd record wrong values for later iterations.
+  NSMutableDictionary<NSNumber *, UIView *> *containerByTag = [NSMutableDictionary new];
+  for (NSNumber *tag in _pendingReparentContainerTags) {
+    UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
+    if (container == nil) {
+      NSLog(@"@@@ reparent: container tag=%@ not found in registry, skipping", tag);
+      continue;
+    }
+    UIView *surfaceRoot = container.superview;
+    if (surfaceRoot == nil) {
+      NSLog(@"@@@ reparent: container tag=%@ has no superview, skipping", tag);
+      continue;
+    }
+    NSUInteger originalIndex = [surfaceRoot.subviews indexOfObject:container];
+    _surfaceRootByContainerTag[tag] = surfaceRoot;
+    _subviewIndexByContainerTag[tag] = @(originalIndex);
+    containerByTag[tag] = container;
+    NSLog(@"@@@ reparent: tag=%@ captured originalIndex=%lu", tag, (unsigned long)originalIndex);
+  }
+
+  // Second pass: actually reparent.
+  for (NSNumber *tag in _pendingReparentContainerTags) {
+    UIView *container = containerByTag[tag];
+    UIView *surfaceRoot = _surfaceRootByContainerTag[tag];
+    if (container == nil || surfaceRoot == nil) {
+      continue;
+    }
+    UIWindow *surfaceWindow = surfaceRoot.window;
+    if (surfaceWindow == nil) {
+      NSLog(@"@@@ reparent: container tag=%@ surface has no window, skipping", tag);
+      continue;
+    }
+    UIWindow *overlay = [self overlayWindowForScene:surfaceWindow.windowScene];
+    if (overlay == nil) {
+      NSLog(@"@@@ reparent: container tag=%@ no overlay window, skipping", tag);
+      continue;
+    }
+
+    CGPoint surfaceOriginInOverlay = [surfaceRoot convertPoint:CGPointZero toView:overlay];
+    CGPoint surfaceOriginInItsWindow = [surfaceRoot convertPoint:CGPointZero toView:surfaceWindow];
+    CGRect surfaceFrameInScreen = [surfaceRoot.window convertRect:surfaceRoot.bounds fromView:surfaceRoot];
+    NSLog(
+        @"@@@ reparent: tag=%@ surfaceOriginInOverlay=(%.1f,%.1f) surfaceOriginInItsWindow=(%.1f,%.1f) surfaceFrameInScreen=%@ surfaceWindow=%@ overlay=%@",
+        tag,
+        surfaceOriginInOverlay.x,
+        surfaceOriginInOverlay.y,
+        surfaceOriginInItsWindow.x,
+        surfaceOriginInItsWindow.y,
+        NSStringFromCGRect(surfaceFrameInScreen),
+        surfaceWindow,
+        overlay);
+    NSLog(
+        @"@@@ reparent: tag=%@ container.frame=%@ in surfaceRoot.bounds=%@",
+        tag,
+        NSStringFromCGRect(container.frame),
+        NSStringFromCGRect(surfaceRoot.bounds));
+    [overlay addSubview:container];
+    container.layer.transform = CATransform3DMakeTranslation(surfaceOriginInOverlay.x, surfaceOriginInOverlay.y, 0);
+    container.userInteractionEnabled = NO;
+    NSLog(@"@@@ reparent: tag=%@ post-reparent container.frame=%@", tag, NSStringFromCGRect(container.frame));
+  }
 
   [_pendingReparentContainerTags removeAllObjects];
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -22,6 +22,7 @@ using namespace facebook::react;
   REAEventHandler _eventHandler;
   REAPerformOperations _performOperations;
   NSMutableArray<NSNumber *> *_pendingReparentContainerTags;
+  NSMutableArray<NSNumber *> *_pendingRestoreContainerTags;
 }
 
 - (READisplayLink *)getDisplayLink
@@ -60,6 +61,7 @@ using namespace facebook::react;
   if ((self = [super init])) {
     _onAnimationCallbacks = [NSMutableArray new];
     _pendingReparentContainerTags = [NSMutableArray new];
+    _pendingRestoreContainerTags = [NSMutableArray new];
     _eventHandler = ^(id<RCTEvent> event) {
       // no-op
     };
@@ -183,7 +185,26 @@ using namespace facebook::react;
   NSLog(@"@@@ queued reparent for tags: %@ (pending=%lu)", containerTags, (unsigned long)_pendingReparentContainerTags.count);
 }
 
+- (void)queueSharedTransitionContainersForRestoring:(NSArray<NSNumber *> *)containerTags
+{
+  // Called from C++ at the end of pullTransaction. The Remove/Delete mutations
+  // for these tags are in the same transaction that's about to be mounted, so we
+  // must restore the original parent BEFORE the mount runs (in willMount).
+  [_pendingRestoreContainerTags addObjectsFromArray:containerTags];
+  NSLog(@"@@@ queued restore for tags: %@ (pending=%lu)", containerTags, (unsigned long)_pendingRestoreContainerTags.count);
+}
+
 #pragma mark - RCTSurfacePresenterObserver
+
+- (void)willMountComponentsWithRootTag:(NSInteger)rootTag
+{
+  if (_pendingRestoreContainerTags.count == 0) {
+    return;
+  }
+  NSLog(@"@@@ willMountComponentsWithRootTag:%ld pending restore tags=%@", (long)rootTag, _pendingRestoreContainerTags);
+  // TODO: look up each tag in componentViewRegistry and reparent back to surface root.
+  [_pendingRestoreContainerTags removeAllObjects];
+}
 
 - (void)didMountComponentsWithRootTag:(NSInteger)rootTag
 {

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -7,15 +7,21 @@
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTComponentViewRegistry.h>
 #import <React/RCTMountingManager.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterStub.h>
 #import <React/RCTUtils.h>
 
 using namespace facebook::react;
+
+@interface REANodesManager () <RCTSurfacePresenterObserver>
+@end
 
 @implementation REANodesManager {
   READisplayLink *_displayLink;
   NSMutableArray<REAOnAnimationCallback> *_onAnimationCallbacks;
   REAEventHandler _eventHandler;
   REAPerformOperations _performOperations;
+  NSMutableArray<NSNumber *> *_pendingReparentContainerTags;
 }
 
 - (READisplayLink *)getDisplayLink
@@ -53,6 +59,7 @@ using namespace facebook::react;
 
   if ((self = [super init])) {
     _onAnimationCallbacks = [NSMutableArray new];
+    _pendingReparentContainerTags = [NSMutableArray new];
     _eventHandler = ^(id<RCTEvent> event) {
       // no-op
     };
@@ -158,9 +165,34 @@ using namespace facebook::react;
   }
 }
 
-- (void)reparentSharedTransitionContainersToWindow:(NSArray<NSNumber *> *)containerTags
+- (void)setSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter
 {
-  NSLog(@"@@@ reparentSharedTransitionContainersToWindow: %@", containerTags);
+  if (_surfacePresenter == surfacePresenter) {
+    return;
+  }
+  [_surfacePresenter removeObserver:self];
+  _surfacePresenter = surfacePresenter;
+  [_surfacePresenter addObserver:self];
+}
+
+- (void)queueSharedTransitionContainersForReparenting:(NSArray<NSNumber *> *)containerTags
+{
+  // Called from C++ at the end of pullTransaction. The UIViews don't exist yet —
+  // queue tags and process them once the mounting transaction has been applied.
+  [_pendingReparentContainerTags addObjectsFromArray:containerTags];
+  NSLog(@"@@@ queued reparent for tags: %@ (pending=%lu)", containerTags, (unsigned long)_pendingReparentContainerTags.count);
+}
+
+#pragma mark - RCTSurfacePresenterObserver
+
+- (void)didMountComponentsWithRootTag:(NSInteger)rootTag
+{
+  if (_pendingReparentContainerTags.count == 0) {
+    return;
+  }
+  NSLog(@"@@@ didMountComponentsWithRootTag:%ld pending reparent tags=%@", (long)rootTag, _pendingReparentContainerTags);
+  // TODO: look up each tag in componentViewRegistry and reparent to window.
+  [_pendingReparentContainerTags removeAllObjects];
 }
 
 - (void)synchronouslyUpdateUIProps:(ReactTag)viewTag props:(const folly::dynamic &)props

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -158,6 +158,11 @@ using namespace facebook::react;
   }
 }
 
+- (void)reparentSharedTransitionContainersToWindow:(NSArray<NSNumber *> *)containerTags
+{
+  NSLog(@"@@@ reparentSharedTransitionContainersToWindow: %@", containerTags);
+}
+
 - (void)synchronouslyUpdateUIProps:(ReactTag)viewTag props:(const folly::dynamic &)props
 {
   RCTAssertMainQueue();

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -23,6 +23,9 @@ using namespace facebook::react;
   REAPerformOperations _performOperations;
   NSMutableArray<NSNumber *> *_pendingReparentContainerTags;
   NSMutableArray<NSNumber *> *_pendingRestoreContainerTags;
+  NSMutableDictionary<NSNumber *, UIView *> *_surfaceRootByContainerTag;
+  UIView *_debugRedRectangle;
+  UIWindow *_overlayWindow;
 }
 
 - (READisplayLink *)getDisplayLink
@@ -62,6 +65,7 @@ using namespace facebook::react;
     _onAnimationCallbacks = [NSMutableArray new];
     _pendingReparentContainerTags = [NSMutableArray new];
     _pendingRestoreContainerTags = [NSMutableArray new];
+    _surfaceRootByContainerTag = [NSMutableDictionary new];
     _eventHandler = ^(id<RCTEvent> event) {
       // no-op
     };
@@ -202,7 +206,35 @@ using namespace facebook::react;
     return;
   }
   NSLog(@"@@@ willMountComponentsWithRootTag:%ld pending restore tags=%@", (long)rootTag, _pendingRestoreContainerTags);
-  // TODO: look up each tag in componentViewRegistry and reparent back to surface root.
+
+  // Real restore disabled while debugging. Just remove the debug red rectangle
+  // to confirm the cleanup path fires.
+  if (_debugRedRectangle != nil) {
+    [_debugRedRectangle removeFromSuperview];
+    _debugRedRectangle = nil;
+    NSLog(@"@@@ debug: removed red rectangle");
+  }
+
+  // RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
+  //
+  // for (NSNumber *tag in _pendingRestoreContainerTags) {
+  //   UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
+  //   UIView *surfaceRoot = _surfaceRootByContainerTag[tag];
+  //   [_surfaceRootByContainerTag removeObjectForKey:tag];
+  //
+  //   if (container == nil || surfaceRoot == nil) {
+  //     NSLog(@"@@@ restore: tag=%@ container=%@ surfaceRoot=%@, skipping", tag, container, surfaceRoot);
+  //     continue;
+  //   }
+  //
+  //   // Reverse the compensating transform and move back so RN's Remove/Delete
+  //   // mutations (about to be processed) find the view under the surface root.
+  //   container.layer.transform = CATransform3DIdentity;
+  //   container.userInteractionEnabled = YES;
+  //   [surfaceRoot addSubview:container];
+  //   NSLog(@"@@@ restore: tag=%@ moved back to surface root", tag);
+  // }
+
   [_pendingRestoreContainerTags removeAllObjects];
 }
 
@@ -212,7 +244,65 @@ using namespace facebook::react;
     return;
   }
   NSLog(@"@@@ didMountComponentsWithRootTag:%ld pending reparent tags=%@", (long)rootTag, _pendingReparentContainerTags);
-  // TODO: look up each tag in componentViewRegistry and reparent to window.
+
+  // Real reparent disabled while debugging. Drop a red rectangle on the window
+  // so we can visually confirm something gets layered above the modal.
+  UIWindowScene *targetScene = nil;
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+      targetScene = (UIWindowScene *)scene;
+      break;
+    }
+  }
+  if (targetScene == nil) {
+    NSLog(@"@@@ debug: no foreground active window scene");
+    [_pendingReparentContainerTags removeAllObjects];
+    return;
+  }
+  if (_overlayWindow == nil) {
+    _overlayWindow = [[UIWindow alloc] initWithWindowScene:targetScene];
+    _overlayWindow.windowLevel = UIWindowLevelAlert + 1;
+    _overlayWindow.backgroundColor = [UIColor clearColor];
+    _overlayWindow.userInteractionEnabled = NO;
+    _overlayWindow.rootViewController = [UIViewController new];
+    _overlayWindow.hidden = NO;
+    NSLog(@"@@@ debug: created overlay window level=%.1f frame=%@", _overlayWindow.windowLevel, NSStringFromCGRect(_overlayWindow.frame));
+  }
+  if (_debugRedRectangle == nil) {
+    _debugRedRectangle = [[UIView alloc] initWithFrame:CGRectMake(40, 100, 120, 120)];
+    _debugRedRectangle.backgroundColor = [UIColor redColor];
+    _debugRedRectangle.userInteractionEnabled = NO;
+  }
+  [_overlayWindow addSubview:_debugRedRectangle];
+  NSLog(@"@@@ debug: added red rectangle to overlay window subviews=%@", _overlayWindow.subviews);
+
+  // RCTComponentViewRegistry *componentViewRegistry = _surfacePresenter.mountingManager.componentViewRegistry;
+  //
+  // for (NSNumber *tag in _pendingReparentContainerTags) {
+  //   UIView *container = [componentViewRegistry findComponentViewWithTag:static_cast<Tag>(tag.integerValue)];
+  //   if (container == nil) {
+  //     NSLog(@"@@@ reparent: container tag=%@ not found in registry, skipping", tag);
+  //     continue;
+  //   }
+  //   UIView *surfaceRoot = container.superview;
+  //   UIWindow *windowForContainer = surfaceRoot.window;
+  //   if (surfaceRoot == nil || windowForContainer == nil) {
+  //     NSLog(@"@@@ reparent: container tag=%@ has no window (superview=%@, window=%@), skipping", tag, surfaceRoot, windowForContainer);
+  //     continue;
+  //   }
+  //
+  //   CGPoint surfaceOriginInWindow = [surfaceRoot convertPoint:CGPointZero toView:windowForContainer];
+  //   NSLog(
+  //       @"@@@ reparent: tag=%@ moving to window; surfaceOriginInWindow=(%.1f,%.1f)",
+  //       tag,
+  //       surfaceOriginInWindow.x,
+  //       surfaceOriginInWindow.y);
+  //   _surfaceRootByContainerTag[tag] = surfaceRoot;
+  //   [windowForContainer addSubview:container];
+  //   container.layer.transform = CATransform3DMakeTranslation(surfaceOriginInWindow.x, surfaceOriginInWindow.y, 0);
+  //   container.userInteractionEnabled = NO;
+  // }
+
   [_pendingReparentContainerTags removeAllObjects];
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -141,7 +141,7 @@ css::CSSRemoveTransitionFunction makeCSSRemoveTransition(REACSSPlatformTransitio
   };
 }
 
-ReparentSharedTransitionContainersToWindowFunction makeReparentSharedTransitionContainersToWindowFunction(
+QueueSharedTransitionContainersForReparentingFunction makeQueueSharedTransitionContainersForReparentingFunction(
     REANodesManager *nodesManager)
 {
   return [nodesManager](const std::vector<Tag> &containerTags) {
@@ -149,7 +149,7 @@ ReparentSharedTransitionContainersToWindowFunction makeReparentSharedTransitionC
     for (auto tag : containerTags) {
       [tags addObject:@(tag)];
     }
-    [nodesManager reparentSharedTransitionContainersToWindow:tags];
+    [nodesManager queueSharedTransitionContainersForReparenting:tags];
   };
 }
 
@@ -189,8 +189,8 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
 
   auto forceScreenSnapshotFunction = makeForceScreenSnapshotFunction(nodesManager);
 
-  auto reparentSharedTransitionContainersToWindowFunction =
-      makeReparentSharedTransitionContainersToWindowFunction(nodesManager);
+  auto queueSharedTransitionContainersForReparentingFunction =
+      makeQueueSharedTransitionContainersForReparentingFunction(nodesManager);
 
   auto synchronouslyUpdateUIPropsFunction = makeSynchronouslyUpdateUIPropsFunction(nodesManager);
 
@@ -226,7 +226,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
       forceScreenSnapshotFunction,
-      reparentSharedTransitionContainersToWindowFunction,
+      queueSharedTransitionContainersForReparentingFunction,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -141,6 +141,18 @@ css::CSSRemoveTransitionFunction makeCSSRemoveTransition(REACSSPlatformTransitio
   };
 }
 
+ReparentSharedTransitionContainersToWindowFunction makeReparentSharedTransitionContainersToWindowFunction(
+    REANodesManager *nodesManager)
+{
+  return [nodesManager](const std::vector<Tag> &containerTags) {
+    NSMutableArray<NSNumber *> *tags = [NSMutableArray arrayWithCapacity:containerTags.size()];
+    for (auto tag : containerTags) {
+      [tags addObject:@(tag)];
+    }
+    [nodesManager reparentSharedTransitionContainersToWindow:tags];
+  };
+}
+
 ForceScreenSnapshotFunction makeForceScreenSnapshotFunction(REANodesManager *nodesManager)
 {
   auto forceScreenSnapshot = [=](Tag tag) {
@@ -177,6 +189,9 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
 
   auto forceScreenSnapshotFunction = makeForceScreenSnapshotFunction(nodesManager);
 
+  auto reparentSharedTransitionContainersToWindowFunction =
+      makeReparentSharedTransitionContainersToWindowFunction(nodesManager);
+
   auto synchronouslyUpdateUIPropsFunction = makeSynchronouslyUpdateUIPropsFunction(nodesManager);
 
   auto getAnimationTimestamp = makeGetAnimationTimestamp();
@@ -211,6 +226,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
       forceScreenSnapshotFunction,
+      reparentSharedTransitionContainersToWindowFunction,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -153,6 +153,18 @@ QueueSharedTransitionContainersForReparentingFunction makeQueueSharedTransitionC
   };
 }
 
+QueueSharedTransitionContainersForRestoringFunction makeQueueSharedTransitionContainersForRestoringFunction(
+    REANodesManager *nodesManager)
+{
+  return [nodesManager](const std::vector<Tag> &containerTags) {
+    NSMutableArray<NSNumber *> *tags = [NSMutableArray arrayWithCapacity:containerTags.size()];
+    for (auto tag : containerTags) {
+      [tags addObject:@(tag)];
+    }
+    [nodesManager queueSharedTransitionContainersForRestoring:tags];
+  };
+}
+
 ForceScreenSnapshotFunction makeForceScreenSnapshotFunction(REANodesManager *nodesManager)
 {
   auto forceScreenSnapshot = [=](Tag tag) {
@@ -192,6 +204,9 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   auto queueSharedTransitionContainersForReparentingFunction =
       makeQueueSharedTransitionContainersForReparentingFunction(nodesManager);
 
+  auto queueSharedTransitionContainersForRestoringFunction =
+      makeQueueSharedTransitionContainersForRestoringFunction(nodesManager);
+
   auto synchronouslyUpdateUIPropsFunction = makeSynchronouslyUpdateUIPropsFunction(nodesManager);
 
   auto getAnimationTimestamp = makeGetAnimationTimestamp();
@@ -227,6 +242,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       requestRender,
       forceScreenSnapshotFunction,
       queueSharedTransitionContainersForReparentingFunction,
+      queueSharedTransitionContainersForRestoringFunction,
       synchronouslyUpdateUIPropsFunction,
       getAnimationTimestamp,
       registerSensorFunction,


### PR DESCRIPTION
## Summary

Currently, SETs don't work for transition to modals, because on iOS modals are displayed above the React Surface. This MR fixes this problem by reparenting the container view above the React Surface.

- [ ] fix flickering

## Test plan

Check Modals example on iOS.

# Attachments

https://github.com/user-attachments/assets/b1786636-b4af-4811-842f-ff84657eab9f


