### PR TITLE
fix: window -> globalThis in nextjs

### DIFF
--- a/apps/next-example/pages/_app.js
+++ b/apps/next-example/pages/_app.js
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 export default function App({ Component, pageProps }) {
   useEffect(() => {
-    window.__NEXT_HYDRATED__ = true;
+    globalThis.__NEXT_HYDRATED__ = true;
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

While running `yarn lint` I keep getting:  `6:5  error  'window' is not defined  no-undef`. This PR should fix it.
