### PR TITLE
chore: Fade content under the bottom tab bar

### DIFF
--- a/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
+++ b/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
@@ -64,8 +64,9 @@ export default function BottomTabBar({
         {/* @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801 */}
         <Defs>
           <LinearGradient id="bottom-tab-bar" x1="0" x2="0" y1="0" y2="1">
-            <Stop offset="0" stopColor={colors.black} stopOpacity="0" />
-            <Stop offset="1" stopColor={colors.black} stopOpacity="0.2" />
+            <Stop offset="0" stopColor={colors.white} stopOpacity="0" />
+            <Stop offset="0.8" stopColor={colors.white} stopOpacity="1" />
+            <Stop offset="1" stopColor={colors.white} stopOpacity="1" />
           </LinearGradient>
         </Defs>
         <Rect
@@ -97,7 +98,9 @@ export default function BottomTabBar({
 
   return (
     <View style={[styles.wrapper, { height: BOTTOM_BAR_HEIGHT + inset }]}>
-      <View style={StyleSheet.absoluteFill}>{gradient}</View>
+      <View pointerEvents="none" style={styles.gradient}>
+        {gradient}
+      </View>
       <View style={styles.container}>
         <View style={[flex.row, { gap: TABS_GAP }]}>
           <Animated.View
@@ -211,11 +214,19 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.background1,
     borderRadius: spacing.md,
+    boxShadow: '0px 6px 16px -4px rgba(0, 0, 0, 0.2)',
     flexDirection: 'row',
     gap: spacing.xxs,
     marginBottom: spacing.xxs,
     marginHorizontal: spacing.md,
     padding: spacing.xs,
+  },
+  gradient: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: -BOTTOM_BAR_HEIGHT,
   },
   iconOverlay: {
     position: 'absolute',


### PR DESCRIPTION
## Summary

Improve gradient below bottom tab bar in the example app and male the shadow more visible.

## Example recordings

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/c9aae304-0bff-428f-9083-b1602aeddfbe" /> | <video src="https://github.com/user-attachments/assets/3f7373ed-5a5d-462a-814f-2ac6473ded2b" /> |
