### PR TITLE
docs: Sort worklets compatibility table versions numerically

### DIFF
--- a/docs/docs-reanimated/src/components/Compatibility/index.tsx
+++ b/docs/docs-reanimated/src/components/Compatibility/index.tsx
@@ -85,7 +85,9 @@ const extractVersions = (
   data: [string, CompatibilityEntry][],
   getVersions: (entry: CompatibilityEntry) => string[]
 ): string[] =>
-  Array.from(new Set(data.flatMap(([, entry]) => getVersions(entry)))).sort();
+  Array.from(new Set(data.flatMap(([, entry]) => getVersions(entry)))).sort(
+    (a, b) => a.localeCompare(b, undefined, { numeric: true })
+  );
 
 const createCompatibilityItems = (
   filteredData: [string, CompatibilityEntry][],


### PR DESCRIPTION
## Summary

The `react-native-worklets` compatibility table sorted version strings alphabetically, so `0.10.x` was placed before `0.4.x`. Sort the columns with numeric collation so versions order correctly.

Fixes #9567

## Examples

### Before

<img width="1034" height="599" alt="image" src="https://github.com/user-attachments/assets/f1622070-de29-483b-ba34-df0601b37128" />

### After

<img width="884" height="513" alt="Screenshot 2026-05-30 at 19 23 17" src="https://github.com/user-attachments/assets/c05c1b0d-41eb-42e9-85e9-84eb8772a09f" />

## Test plan

Open the compatibility page and confirm the worklets table columns read `0.4.x` through `0.10.x`, then `nightly`.