### PR TITLE
fix: initialize mapper registry before native events

### DIFF
--- a/packages/react-native-reanimated/src/initializers.ts
+++ b/packages/react-native-reanimated/src/initializers.ts
@@ -7,6 +7,7 @@ import {
 import { IS_WEB, SHOULD_BE_USE_WEB } from './common';
 import { initSvgCssSupport } from './css/svg';
 import { getStaticFeatureFlag } from './featureFlags';
+import { initializeMapperRegistry } from './mappers';
 import type { IReanimatedModule } from './ReanimatedModule';
 
 export function initializeReanimatedModule(
@@ -29,5 +30,6 @@ if (!SHOULD_BE_USE_WEB) {
   runOnUISync(() => {
     'worklet';
     global._tagToJSPropNamesMapping = {};
+    initializeMapperRegistry();
   });
 }

--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -239,6 +239,20 @@ function createMapperRegistry() {
   };
 }
 
+function getMapperRegistry() {
+  'worklet';
+  let mapperRegistry = global.__mapperRegistry;
+  if (mapperRegistry === undefined) {
+    mapperRegistry = global.__mapperRegistry = createMapperRegistry();
+  }
+  return mapperRegistry;
+}
+
+export function initializeMapperRegistry(): void {
+  'worklet';
+  getMapperRegistry();
+}
+
 let MAPPER_ID = 9999;
 
 export function startMapper(
@@ -249,10 +263,7 @@ export function startMapper(
   const mapperID = (MAPPER_ID += 1);
 
   scheduleOnUI(() => {
-    let mapperRegistry = global.__mapperRegistry;
-    if (mapperRegistry === undefined) {
-      mapperRegistry = global.__mapperRegistry = createMapperRegistry();
-    }
+    const mapperRegistry = getMapperRegistry();
     mapperRegistry.start(mapperID, worklet, inputs, outputs);
   });
 


### PR DESCRIPTION
## Summary

- initialize the Reanimated mapper registry during native runtime initialization
- reuse the same mapper-registry creation path from `startMapper`
- ensures `global.__mapperRun` is available before native event handlers and keyboard events call it

Fixes #9524.

## Test plan

Not run locally. This was validated against the failure mode described in #9524 and a downstream patch in a React Native 0.83 / Reanimated 4.4.0 app.