### PR TITLE
perf: Cache `isOnJSQueueThread` JNI method lookup

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/WorkletsModule.cpp
@@ -174,7 +174,8 @@ RuntimeBindings::SendRequest WorkletsModule::getSendRequest() {
 
 std::function<bool()> WorkletsModule::getIsOnJSQueueThread() {
   return [javaPart = javaPart_]() -> bool {
-    return javaPart->getClass()->getMethod<jboolean()>("isOnJSQueueThread").operator()(javaPart);
+    static const auto jIsOnJSQueueThread = javaPart->getClass()->getMethod<jboolean()>("isOnJSQueueThread");
+    return jIsOnJSQueueThread(javaPart);
   };
 }
 


### PR DESCRIPTION
## Summary

The lambda returned by `WorkletsModule::getIsOnJSQueueThread()` re-resolved the `isOnJSQueueThread` method ID on **every** invocation — a string-keyed `getClass()->getMethod<...>()` lookup into class metadata, which is genuinely expensive when done per-call. Since this predicate can be called frequently, the cost adds up.

This caches the descriptor with `static const auto`, so the lookup happens once and is reused — matching the pattern already used by every other binding lambda in this same file (`requestAnimationFrame`, `abortRequest`, `clearCookies`, `sendRequest`).

```cpp
return [javaPart = javaPart_]() -> bool {
  static const auto jIsOnJSQueueThread = javaPart->getClass()->getMethod<jboolean()>("isOnJSQueueThread");
  return jIsOnJSQueueThread(javaPart);
};
```

Behavior is unchanged.

## Test plan

Build and run any example on Android; JS-queue-thread checks behave as before.