### PR TITLE
perf: Avoid per-event heap allocation in `SensorSetter`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/SensorSetter.h
@@ -2,6 +2,7 @@
 
 #include <fbjni/fbjni.h>
 
+#include <algorithm>
 #include <utility>
 
 namespace reanimated {
@@ -14,9 +15,11 @@ class SensorSetter : public HybridClass<SensorSetter> {
   static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/nativeProxy/SensorSetter;";
 
   void sensorSetter(jni::alias_ref<JArrayFloat> value, int orientationDegrees) {
-    size_t size = value->size();
-    auto elements = value->getRegion(0, size);
-    double array[7];
+    static constexpr size_t kMaxSize = 7;
+    const size_t size = std::min(static_cast<size_t>(value->size()), kMaxSize);
+    jfloat elements[kMaxSize];
+    value->getRegion(0, size, elements);
+    double array[kMaxSize];
     for (size_t i = 0; i < size; i++) {
       array[i] = elements[i];
     }


### PR DESCRIPTION
## Summary

`SensorSetter::sensorSetter` is the Java→C++ callback invoked on **every** sensor sample (up to 60–200 Hz). It called `value->getRegion(0, size)`, which heap-allocates (the two-argument `getRegion` overload returns a `std::unique_ptr<jfloat[]>`, i.e. a `new jfloat[size]`) on each invocation.

This switches to the allocation-free `getRegion(start, length, buf)` overload, reading directly into a fixed stack buffer — eliminating the per-event allocation:

```cpp
static constexpr size_t kMaxSize = 7;
const size_t size = std::min(static_cast<size_t>(value->size()), kMaxSize);
jfloat elements[kMaxSize];
value->getRegion(0, size, elements);
double array[kMaxSize];
for (size_t i = 0; i < size; i++) array[i] = elements[i];
callback_(array, orientationDegrees);
```

**Why this reduces allocation:** the win is heap vs. stack. The two-argument `getRegion(0, size)` overload returns a `std::unique_ptr<jfloat[]>` — a heap `new[]`/`delete[]` (with allocator overhead) once per sensor event. The replacement `jfloat elements[7]` is an automatic stack array: no allocator involved, just a stack-pointer adjustment, essentially free. The extra `jfloat[7]` buffer exists only because `getRegion` yields `jfloat` while the callback wants `double`; adding a stack buffer is free, removing the heap allocation is the gain. Net: one heap allocation per event → zero.

As a side effect, the read is now clamped to the fixed `array[7]` destination, removing the previous unchecked assumption that the incoming Java array never exceeds 7 floats.

Behavior is otherwise unchanged.

## Test plan

Run an example using `useAnimatedSensor` (accelerometer / gyroscope / rotation) on Android and confirm sensor values flow through as before.