### PR TITLE
fix: Remove use-after-move in `makeJWorkletRuntimeWrapper`

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
@@ -13,10 +13,10 @@ using namespace facebook::jni;
 
 local_ref<JWorkletRuntimeWrapper::JavaPart> JWorkletRuntimeWrapper::makeJWorkletRuntimeWrapper(
     std::shared_ptr<WorkletRuntime> workletRuntime) {
-  return JWorkletRuntimeWrapper::newObjectCxxArgs(std::move(workletRuntime), workletRuntime->getRuntimeId());
+  return JWorkletRuntimeWrapper::newObjectCxxArgs(std::move(workletRuntime));
 }
 
-JWorkletRuntimeWrapper::JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime, uint64_t runtimeId)
+JWorkletRuntimeWrapper::JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime)
     : workletRuntime_(std::move(workletRuntime)) {}
 
 void JWorkletRuntimeWrapper::cxxEmitDeviceEvent(

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.h
@@ -33,7 +33,7 @@ class JWorkletRuntimeWrapper : public jni::HybridClass<JWorkletRuntimeWrapper> {
  private:
   friend HybridBase;
 
-  JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime, uint64_t runtimeId);
+  explicit JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime);
 
   const std::shared_ptr<WorkletRuntime> workletRuntime_;
 };


### PR DESCRIPTION
## Summary

`JWorkletRuntimeWrapper::makeJWorkletRuntimeWrapper` constructed the hybrid like this:

```cpp
return JWorkletRuntimeWrapper::newObjectCxxArgs(std::move(workletRuntime), workletRuntime->getRuntimeId());
```

`std::move(workletRuntime)` (argument 1) and `workletRuntime->getRuntimeId()` (argument 2) are **indeterminately sequenced** ([expr.call]). If the `shared_ptr` is moved-from before `getRuntimeId()` is evaluated, this dereferences a null pointer. It happens to work today only because clang on arm64 evaluates these arguments right-to-left — i.e. it relies on unspecified behavior.

The `runtimeId` argument was **dead** regardless: the constructor never stored it, and `cxxGetRuntimeId()` already reads `workletRuntime_->getRuntimeId()` directly. Dropping the unused parameter removes the UB and the dead code in one go.

This code path is behind `WORKLETS_FETCH_PREVIEW_ENABLED` (used by `WorkletsModule::getSendRequest`).

## Test plan

Build worklets with `WORKLETS_FETCH_PREVIEW_ENABLED` on Android and exercise a worklet `fetch` request; the runtime wrapper is created and `cxxGetRuntimeId()` returns the correct id as before.