### PR TITLE
perf: Convert events to `jsi::Value` without a JSON round-trip in `handleEvent`

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -1,4 +1,6 @@
+#include <jsi/JSIDynamic.h>
 #include <react/fabric/Binding.h>
+#include <react/jni/WritableNativeMap.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #include <reanimated/Tools/FeatureFlags.h>
@@ -270,30 +272,19 @@ void NativeProxy::handleEvent(
     // Ignore events with null payload.
     return;
   }
-  // TODO: convert event directly to jsi::Value without JSON serialization
-  std::string eventAsString;
-  try {
-    eventAsString = event->toString();
-  } catch (...) {
-    // Events from other libraries may contain NaN or INF values which
-    // cannot be represented in JSON. See
-    // https://github.com/software-mansion/react-native-reanimated/issues/1776
-    // for details.
+
+  if (!event->isInstanceOf(react::WritableNativeMap::javaClassStatic())) {
     return;
   }
-  std::string eventJSON = eventAsString;
-  if (eventJSON == "null") {
+
+  auto nativeMap = jni::static_ref_cast<react::WritableNativeMap::javaobject>(jni::static_ref_cast<jobject>(event));
+  auto eventPayload = nativeMap->cthis()->consume();
+  if (eventPayload.isNull()) {
     return;
   }
 
   auto &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
-  jsi::Value payload;
-  try {
-    payload = jsi::Value::createFromJsonUtf8(uiRuntime, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
-  } catch (std::exception &) {
-    // Ignore events with malformed JSON payload.
-    return;
-  }
+  jsi::Value payload = jsi::valueFromDynamic(uiRuntime, eventPayload);
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     reanimatedModuleProxy_->handleEventAndFlush(


### PR DESCRIPTION
## Summary

`NativeProxy::handleEvent` (the worklet event path for gesture/scroll events) serialized **every** event payload to a JSON string and immediately re-parsed it:

```
folly::dynamic (already in NativeMap.map_)
  → NativeMap::toString()              // folly::toJson — serialize to a JSON std::string
  → std::string copy                   // eventJSON = eventAsString
  → jsi::Value::createFromJsonUtf8()    // re-parse that string back into a jsi::Value
```

The payload is a `WritableNativeMap` whose data is *already* a `folly::dynamic`, so the serialize + re-parse (and the extra string copy) are pure overhead on a hot path. This reads the dynamic directly via `NativeMap::consume()` and converts with `jsi::valueFromDynamic` — one conversion, no JSON. It mirrors the pattern already used in `JWorkletRuntimeWrapper::cxxEmitDeviceEvent`.

## Behavior change — fixes #1776

The old `try/catch` existed because `folly::toJson` **rejects NaN/INF**, so events carrying non-finite numbers threw during serialization and were silently dropped. The dynamic path has no such restriction, so those events are now delivered with JS `NaN`/`Infinity` instead of being swallowed. This is the intended fix for #1776.

## Safety

- **Ownership / `consume()` is destructive:** safe because Reanimated owns the map exclusively here — it's either freshly produced by `Event.getEventData()` and dispatched only to our handler (`NodesManager.handleEvent` → `event.dispatchModern`), or an explicit `WritableMap.copy()` held by `CopiedEvent`.
- **Type guard:** `WritableMap` is a Java interface unrelated by C++ inheritance to the `WritableNativeMap` hybrid, so the ref is reinterpreted through the common `jobject` base, guarded by an `isInstanceOf` check. Non-native maps (e.g. `JavaOnlyMap`) are skipped — they were already dropped by the old path (their `toString()` isn't valid JSON), so there's no regression.

## Test plan

Verified on an Android emulator (Pixel 10 Pro, API 37, new architecture / Fabric):
- Built `react-native-reanimated` natively (clean CMake compile for `arm64-v8a`).
- Drove a `useAnimatedScrollHandler` screen: the scroll-driven animation tracks `event.contentOffset.y` correctly, confirming event payloads reach the worklet with correct numeric values.
- Stress-scrolled (many rapid events → many `consume()` calls): no crash, no `JNI`/`ClassCastException`/native-abort entries in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)