### PR TITLE
refactor: Remove no-op `registerNatives({})` in `JWorkletRuntimeWrapper`

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
@@ -42,7 +42,6 @@ int JWorkletRuntimeWrapper::cxxGetRuntimeId() {
 }
 
 void JWorkletRuntimeWrapper::registerNatives() {
-  javaClassStatic()->registerNatives({});
   registerHybrid(
       {makeNativeMethod("cxxEmitDeviceEvent", JWorkletRuntimeWrapper::cxxEmitDeviceEvent),
        makeNativeMethod("cxxGetRuntimeId", JWorkletRuntimeWrapper::cxxGetRuntimeId)});


### PR DESCRIPTION
## Summary

`JWorkletRuntimeWrapper::registerNatives()` opened with a redundant call:

```cpp
javaClassStatic()->registerNatives({});   // <- removed
registerHybrid({
    makeNativeMethod("cxxEmitDeviceEvent", ...),
    makeNativeMethod("cxxGetRuntimeId", ...),
});
```

**Why it's a no-op:** `javaClassStatic()->registerNatives({})` resolves to `JClass::registerNatives(std::initializer_list<JNINativeMethod>)`, whose entire body (fbjni `CoreClasses-inl.h`) is:

```cpp
auto result = env->RegisterNatives(self(), methods.begin(), static_cast<int>(methods.size()));
FACEBOOK_JNI_THROW_EXCEPTION_IF(result != JNI_OK);
```

With an empty initializer list `methods.size() == 0`, so this is `RegisterNatives(clazz, ptr, 0)` — registering zero native methods, which the JNI spec defines as registering nothing (returns `JNI_OK`). The only effect is a wasted JNI round-trip.

The class's actual native methods (`cxxEmitDeviceEvent`, `cxxGetRuntimeId`) are registered by the `registerHybrid({...})` call immediately below (which routes to `javaClassLocal()->registerNatives(methods)` with the real method list). Removing the empty call has no behavioral effect.

This code is behind `WORKLETS_FETCH_PREVIEW_ENABLED`.

## Test plan

No behavior change — the hybrid's native methods are still registered via `registerHybrid`. Builds and runs identically.