### PR TITLE
refactor: Deduplicate `AndroidUIScheduler` global ref, avoid null-deref after invalidate

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.cpp
@@ -25,7 +25,8 @@ class UISchedulerWrapper : public UIScheduler {
     UIScheduler::scheduleOnUI(job);
     if (!scheduledOnUI_) {
       scheduledOnUI_ = true;
-      androidUiScheduler_->cthis()->scheduleTriggerOnUI();
+      static const auto method = androidUiScheduler_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
+      method(androidUiScheduler_);
     }
   }
 
@@ -36,7 +37,7 @@ class UISchedulerWrapper : public UIScheduler {
 };
 
 AndroidUIScheduler::AndroidUIScheduler(const jni::alias_ref<AndroidUIScheduler::jhybridobject> &jThis)
-    : javaPart_(jni::make_global(jThis)), uiScheduler_(std::make_shared<UISchedulerWrapper>(jni::make_global(jThis))) {}
+    : uiScheduler_(std::make_shared<UISchedulerWrapper>(jni::make_global(jThis))) {}
 
 jni::local_ref<AndroidUIScheduler::jhybriddata> AndroidUIScheduler::initHybrid(
     jni::alias_ref<jhybridobject> jThis) { // NOLINT //(performance-unnecessary-value-param)
@@ -50,13 +51,7 @@ void AndroidUIScheduler::triggerUI() {
   uiScheduler_->triggerUI();
 }
 
-void AndroidUIScheduler::scheduleTriggerOnUI() {
-  static const auto method = javaPart_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
-  method(javaPart_.get());
-}
-
 void AndroidUIScheduler::invalidate() {
-  javaPart_ = nullptr;
   uiScheduler_.reset();
 }
 

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/AndroidUIScheduler.h
@@ -23,8 +23,6 @@ class AndroidUIScheduler : public jni::HybridClass<AndroidUIScheduler> {
     return uiScheduler_;
   }
 
-  void scheduleTriggerOnUI();
-
  private:
   friend HybridBase;
 
@@ -32,7 +30,6 @@ class AndroidUIScheduler : public jni::HybridClass<AndroidUIScheduler> {
 
   void invalidate();
 
-  jni::global_ref<AndroidUIScheduler::javaobject> javaPart_;
   std::shared_ptr<UIScheduler> uiScheduler_;
 
   explicit AndroidUIScheduler(const jni::alias_ref<AndroidUIScheduler::jhybridobject> &jThis);


### PR DESCRIPTION
## Summary

`AndroidUIScheduler` held **two** `global_ref`s to the same Java object — one in the C++ hybrid (`javaPart_`) and one inside `UISchedulerWrapper` (`androidUiScheduler_`) — and the scheduling call path bounced between them:

> wrapper's ref → `cthis()` → C++ `scheduleTriggerOnUI()` → `javaPart_` → Kotlin method

Since the wrapper already holds a ref to the Java object, it can invoke the Kotlin `scheduleTriggerOnUI` method **directly**, which makes both `javaPart_` and the C++ `scheduleTriggerOnUI()` hop redundant. Construction now takes a single `make_global`.

```cpp
// before
: javaPart_(jni::make_global(jThis)),
  uiScheduler_(std::make_shared<UISchedulerWrapper>(jni::make_global(jThis))) {}

// after
: uiScheduler_(std::make_shared<UISchedulerWrapper>(jni::make_global(jThis))) {}
```

```cpp
// in UISchedulerWrapper::scheduleOnUI — before
androidUiScheduler_->cthis()->scheduleTriggerOnUI();
// after
static const auto method = androidUiScheduler_->getClass()->getMethod<void()>("scheduleTriggerOnUI");
method(androidUiScheduler_);
```

## Interaction with #6697 (circular-reference / GC fix) — important

`invalidate()` previously did `javaPart_ = nullptr; uiScheduler_.reset();`. The `javaPart_ = nullptr` was added deliberately in **#6697 (\"fix: Break circular reference in `NativeProxy` and `AndroidUIScheduler`\", @ukaszkosmaty)** and **verified there with heap dumps** — it breaks a C++↔Java reference cycle that the GC otherwise can't collect. This PR must preserve that property, and it does. Mapping the cycles to the same Java object `J`:

- **Cycle A (self-cycle):** `J → HybridData → C++ scheduler → javaPart_ → J`. The hard leak #6697 broke with `javaPart_ = nullptr`. **This PR eliminates it by construction** — there is no `javaPart_` member anymore, so the cycle can never form; there is nothing left to null.
- **Cycle B (via wrapper):** `J → HybridData → C++ scheduler → uiScheduler_ → UISchedulerWrapper → androidUiScheduler_ → J`. #6697 broke this with `uiScheduler_.reset()`, which **this PR keeps** in `invalidate()`.

#6697's heap-dump pass already established that the wrapper's `androidUiScheduler_` ref is released on teardown (when `WorkletsModuleProxy` drops the wrapper) — otherwise Cycle B would have leaked back then. This PR relies on that same, already-verified mechanism while removing the *second* global ref and its cycle entirely, so it is strictly simpler than the heap-dump-verified state, not riskier.

`invalidate()` is now just:

```cpp
void AndroidUIScheduler::invalidate() {
  uiScheduler_.reset();
}
```

## Also fixes a latent null-deref after `invalidate()`

With `javaPart_ = nullptr`, a `scheduleOnUI` still in flight would run `cthis()->scheduleTriggerOnUI()` → `method(javaPart_.get())` — a JNI call on a **null** object. Routing through the wrapper's still-valid ref instead, Kotlin's existing guard handles the race:

```kotlin
synchronized(mActive) { if (mActive.get()) triggerUI() }
```

After `deactivate()` sets `mActive = false`, the scheduled trigger cleanly no-ops instead of dereferencing null.

## Test plan

Verified on an Android emulator (Pixel 10 Pro, API 37, Fabric):
- Clean native compile of `react-native-worklets` for `arm64-v8a`, app installed.
- Ran a looping `withTiming`/`withRepeat` animation: the box animates continuously, confirming the frame loop schedules UI-runtime work through the rewritten `scheduleOnUI` → `scheduleTriggerOnUI` → `triggerUI` path. No `NoSuchMethodError` from the relocated method lookup.
- App restart exercised `invalidate()` (teardown) + re-init with no crash; clean logcat (no JNI/null/abort entries).

**GC note:** the above verifies behavior, not garbage collection. Because this PR touches the cycle-breaking logic from #6697 (which was heap-dump verified), a heap-dump check — reload several times, force GC, confirm `AndroidUIScheduler` / `WorkletsModule` instances don't accumulate — is recommended before merge. The static cycle analysis above indicates the GC property is preserved (Cycle A removed, Cycle B still broken), but it has not yet been re-confirmed with a heap dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)