### PR TITLE
Sync settled props when app resumes

### DIFF
--- a/packages/react-native-reanimated/__tests__/PropsRegistryGarbageCollector.test.ts
+++ b/packages/react-native-reanimated/__tests__/PropsRegistryGarbageCollector.test.ts
@@ -1,0 +1,70 @@
+'use strict';
+
+import { AppState } from 'react-native';
+
+import { PropsRegistryGarbageCollector } from '../src/PropsRegistryGarbageCollector';
+import { ReanimatedModule } from '../src/ReanimatedModule';
+
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn(),
+  },
+}));
+
+jest.mock('../src/ReanimatedModule', () => ({
+  ReanimatedModule: {
+    getSettledUpdates: jest.fn(),
+  },
+}));
+
+describe('PropsRegistryGarbageCollector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    PropsRegistryGarbageCollector.viewsMap.clear();
+    PropsRegistryGarbageCollector.viewsCount = 0;
+    PropsRegistryGarbageCollector.unregisterInterval();
+  });
+
+  afterEach(() => {
+    PropsRegistryGarbageCollector.viewsMap.clear();
+    PropsRegistryGarbageCollector.viewsCount = 0;
+    PropsRegistryGarbageCollector.unregisterInterval();
+  });
+
+  it('syncs settled props immediately when app becomes active', () => {
+    const removeMock = jest.fn();
+    let onAppStateChange: ((state: string) => void) | undefined;
+    const addEventListenerSpy = jest.spyOn(AppState, 'addEventListener');
+
+    addEventListenerSpy.mockImplementation(
+      (_eventType: string, listener: (state: string) => void) => {
+        onAppStateChange = listener;
+        return { remove: removeMock };
+      }
+    );
+
+    (ReanimatedModule.getSettledUpdates as jest.Mock).mockReturnValue([
+      {
+        viewTag: 101,
+        styleProps: { opacity: 1 },
+      },
+    ]);
+    const component = {
+      _syncStylePropsBackToReact: jest.fn(),
+    };
+
+    PropsRegistryGarbageCollector.registerView(101, component);
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function));
+
+    onAppStateChange?.('active');
+
+    expect(ReanimatedModule.getSettledUpdates as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(component._syncStylePropsBackToReact).toHaveBeenCalledWith({
+      opacity: 1,
+    });
+
+    PropsRegistryGarbageCollector.unregisterInterval();
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
+++ b/packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts
@@ -1,6 +1,12 @@
 'use strict';
 
 import {
+  AppState,
+  type AppStateStatus,
+  type NativeEventSubscription,
+} from 'react-native';
+
+import {
   unprocessColor,
   unprocessColorsInProps,
 } from './common/style/processors/colors';
@@ -14,6 +20,7 @@ export const PropsRegistryGarbageCollector = {
   viewsCount: 0,
   viewsMap: new Map<number, IAnimatedComponentInternal>(),
   intervalId: null as NodeJS.Timeout | null,
+  appStateSubscription: null as NativeEventSubscription | null,
 
   registerView(viewTag: number, component: IAnimatedComponentInternal) {
     if (this.viewsMap.has(viewTag)) {
@@ -56,12 +63,26 @@ export const PropsRegistryGarbageCollector = {
       this.syncPropsBackToReact.bind(this),
       FLUSH_INTERVAL_MS
     );
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      this.handleAppStateChange.bind(this)
+    );
   },
 
   unregisterInterval() {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
+    }
+    this.appStateSubscription?.remove();
+    this.appStateSubscription = null;
+  },
+
+  handleAppStateChange(nextAppState: AppStateStatus) {
+    if (nextAppState === 'active') {
+      // Sync immediately on resume so React state catches up before the next
+      // polling tick can reapply an outdated settled snapshot.
+      this.syncPropsBackToReact();
     }
   },
 };


### PR DESCRIPTION
## Summary

Fixes #9574.

`FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` syncs completed animated props back into React on a polling interval. On Android, a press-driven `Linking.openURL` can pause the app before the next polling tick, leaving React state behind the final native animated value until the app resumes.

This registers an `AppState` listener while the settled-props collector is active and triggers an immediate sync when the app becomes `active`, so React catches up as soon as the app returns instead of waiting for the next interval tick.

## Test plan

Added a Jest regression test for the app-resume sync:

```sh
yarn workspace react-native-reanimated test PropsRegistryGarbageCollector.test.ts --runInBand
yarn eslint packages/react-native-reanimated/src/PropsRegistryGarbageCollector.ts packages/react-native-reanimated/__tests__/PropsRegistryGarbageCollector.test.ts
```

I also smoke-tested the linked Android repro on an API 35 emulator:

```sh
git clone https://github.com/lujjjh/reanimated-settled-props-repro
pnpm install
pnpm exec expo prebuild --platform android --clean
pnpm android
```

I ran the press-driven flow from #9574 repeatedly on the published `4.4.0` package and on this branch wired through `file:../react-native-reanimated/packages/react-native-reanimated`. The issue did not reproduce in this emulator run, but the patched build compiled, installed, launched, and kept the modal open through 8 browser-return loops with the same modal bounds after returning.