### PR TITLE
Prefer resolved component ref for host lookup

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/InstanceDiscoveryExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InstanceDiscoveryExample.tsx
@@ -91,7 +91,6 @@ class Node {
   ['getScrollRef()']?: string | Node;
   ['__internalInstanceHandle']?: string | Node;
   ['findHostInstance_DEPRECATED()']?: string | Node;
-  ['_hasAnimatedRef']?: string;
   ['_componentRef']?: string | Node;
   ['stateNode.node']?: string | Node;
   ['shadowNodeWrapper']?: string;
@@ -238,23 +237,18 @@ function comparator(node: Node) {
     }
   }
 
-  if (ref._hasAnimatedRef) {
-    node._hasAnimatedRef = '"YES"';
-    const derivedRef = ref._componentRef;
-    if (derivedRef) {
-      if (foundRefToId.has(derivedRef)) {
-        node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
-      } else {
-        const id = refId++;
-        foundRefToId.set(derivedRef, id);
-        const propName = '_componentRef';
-        const derivedSource = `${source}.${propName}`;
-        const newNode = new Node(id, derivedSource, derivedRef);
-        node[propName] = newNode;
-        nodesToCheck.push(newNode);
-      }
+  const derivedRef = ref._componentRef;
+  if (derivedRef) {
+    if (foundRefToId.has(derivedRef)) {
+      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
-      node['_componentRef'] = '"NO"';
+      const id = refId++;
+      foundRefToId.set(derivedRef, id);
+      const propName = '_componentRef';
+      const derivedSource = `${source}.${propName}`;
+      const newNode = new Node(id, derivedSource, derivedRef);
+      node[propName] = newNode;
+      nodesToCheck.push(newNode);
     }
   }
 }
@@ -268,7 +262,6 @@ const printableProps = [
   'getNativeScrollRef()',
   'getScrollRef()',
   '__internalInstanceHandle',
-  '_hasAnimatedRef',
   '_componentRef',
   'findHostInstance_DEPRECATED()',
   'stateNode.node',

--- a/apps/common-app/src/apps/reanimated/examples/InstanceDiscoveryExample.web.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/InstanceDiscoveryExample.web.tsx
@@ -51,7 +51,6 @@ class Node {
   ['scrollTo()']?: string;
   ['__internalInstanceHandle']?: string | Node;
   ['findHostInstance_DEPRECATED()']?: string | Node;
-  ['_hasAnimatedRef']?: string;
   ['_componentRef']?: string | Node;
   ['stateNode.node']?: string | Node;
   ['_reactInternals']?: string | undefined;
@@ -155,23 +154,18 @@ function comparator(node: Node) {
     }
   }
 
-  if (ref._hasAnimatedRef) {
-    node._hasAnimatedRef = '"YES"';
-    const derivedRef = ref._componentRef;
-    if (derivedRef) {
-      if (foundRefToId.has(derivedRef)) {
-        node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
-      } else {
-        const id = refId++;
-        foundRefToId.set(derivedRef, id);
-        const propName = '_componentRef';
-        const derivedSource = `${source}.${propName}`;
-        const newNode = new Node(id, derivedSource, derivedRef);
-        node[propName] = newNode;
-        nodesToCheck.push(newNode);
-      }
+  const derivedRef = ref._componentRef;
+  if (derivedRef) {
+    if (foundRefToId.has(derivedRef)) {
+      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
-      node['_componentRef'] = '"NO"';
+      const id = refId++;
+      foundRefToId.set(derivedRef, id);
+      const propName = '_componentRef';
+      const derivedSource = `${source}.${propName}`;
+      const newNode = new Node(id, derivedSource, derivedRef);
+      node[propName] = newNode;
+      nodesToCheck.push(newNode);
     }
   }
 }
@@ -193,7 +187,6 @@ const printableProps = [
   'getScrollRef()',
   'scrollTo()',
   '__internalInstanceHandle',
-  '_hasAnimatedRef',
   '_componentRef',
   'stateNode.node',
   '_reactInternals',

--- a/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
+++ b/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable camelcase */
+import type { IAnimatedComponentInternalBase } from '../src/createAnimatedComponent/commonTypes';
+import { findHostInstance } from '../src/platform-specific/findHostInstance';
+
+jest.mock('react-native/Libraries/Renderer/shims/ReactFabric', () => ({
+  findHostInstance_DEPRECATED: jest.fn(),
+}));
+
+const ReactFabric: { findHostInstance_DEPRECATED: jest.Mock } = jest.requireMock(
+  'react-native/Libraries/Renderer/shims/ReactFabric'
+);
+
+describe('findHostInstance', () => {
+  beforeEach(() => {
+    ReactFabric.findHostInstance_DEPRECATED.mockReset();
+  });
+
+  test('uses the resolved component ref when the fast path cannot handle it', () => {
+    const componentRef = { __nativeTag: 42 };
+    const hostInstance = { host: true };
+    const animatedComponent = {
+      _componentRef: componentRef,
+      _hasAnimatedRef: false,
+    } as unknown as IAnimatedComponentInternalBase;
+
+    ReactFabric.findHostInstance_DEPRECATED.mockReturnValue(hostInstance);
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).toHaveBeenCalledWith(
+      componentRef
+    );
+  });
+});

--- a/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
+++ b/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
@@ -6,9 +6,8 @@ jest.mock('react-native/Libraries/Renderer/shims/ReactFabric', () => ({
   findHostInstance_DEPRECATED: jest.fn(),
 }));
 
-const ReactFabric: { findHostInstance_DEPRECATED: jest.Mock } = jest.requireMock(
-  'react-native/Libraries/Renderer/shims/ReactFabric'
-);
+const ReactFabric: { findHostInstance_DEPRECATED: jest.Mock } =
+  jest.requireMock('react-native/Libraries/Renderer/shims/ReactFabric');
 
 describe('findHostInstance', () => {
   beforeEach(() => {
@@ -29,5 +28,20 @@ describe('findHostInstance', () => {
     expect(ReactFabric.findHostInstance_DEPRECATED).toHaveBeenCalledWith(
       componentRef
     );
+  });
+
+  test('uses the fast path for React Native 0.83 host instances', () => {
+    const hostInstance = {
+      __internalInstanceHandle: {},
+      __nativeTag: 42,
+      __viewConfig: { uiViewClassName: 'RCTView' },
+    };
+    const animatedComponent = {
+      _componentRef: hostInstance,
+      _hasAnimatedRef: false,
+    } as unknown as IAnimatedComponentInternalBase;
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -127,7 +127,6 @@ export interface AnimatedComponentRef extends Component {
 export interface IAnimatedComponentInternalBase {
   ChildComponent: AnyComponent;
   _componentRef: AnimatedComponentRef | HTMLElement | null;
-  _hasAnimatedRef: boolean;
   _viewInfo?: ViewInfo;
 
   /**

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -20,7 +20,8 @@ export function getViewInfo(element: HostInstance): {
   viewTag?: number;
 } {
   return {
-    reactViewName: (element?._viewConfig?.uiViewClassName ??
+    reactViewName: (element?.__viewConfig?.uiViewClassName ??
+      element?._viewConfig?.uiViewClassName ??
       element?.__internalInstanceHandle?.type ??
       element?.__internalInstanceHandle?.elementType) as string,
     viewTag: element?.__nativeTag,

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -21,7 +21,6 @@ export function getViewInfo(element: HostInstance): {
 } {
   return {
     reactViewName: (element?.__viewConfig?.uiViewClassName ??
-      element?._viewConfig?.uiViewClassName ??
       element?.__internalInstanceHandle?.type ??
       element?.__internalInstanceHandle?.elementType) as string,
     viewTag: element?.__nativeTag,

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -45,7 +45,6 @@ export default class AnimatedComponent<
   _viewInfo?: ViewInfo;
   _cssStyle: CSSStyle = {}; // RN style object with Reanimated CSS properties
   _componentRef: AnimatedComponentRef | HTMLElement | null = null;
-  _hasAnimatedRef = false;
   // Used only on web
   _componentDOMRef: HTMLElement | null = null;
   _willUnmount: boolean = false;
@@ -139,7 +138,6 @@ export default class AnimatedComponent<
     // Component can specify ref which should be animated when animated version of the component is created.
     // Otherwise, we animate the component itself.
     if (componentRef && componentRef.getAnimatableRef) {
-      this._hasAnimatedRef = true;
       return componentRef.getAnimatableRef();
     }
     // Case for SVG components on Web

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -55,13 +55,10 @@ export function findHostInstance(
   resolveFindHostInstance_DEPRECATED();
   /*
     The Fabric implementation of `findHostInstance_DEPRECATED` requires a React ref as an argument
-    rather than a native ref. If a component implements the `getAnimatableRef` method, it must use 
-    the ref provided by this method. It is the component's responsibility to ensure that this is 
-    a valid React ref.
+    rather than a native ref. Prefer the resolved component ref when available so components can
+    forward their ref to the host view that should be animated.
   */
   return findHostInstance_DEPRECATED(
-    (ref as IAnimatedComponentInternalBase)._hasAnimatedRef
-      ? (ref as IAnimatedComponentInternalBase)._componentRef
-      : ref
+    (ref as IAnimatedComponentInternalBase)._componentRef ?? ref
   );
 }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -12,7 +12,7 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    (maybeNativeRef.__viewConfig ?? maybeNativeRef._viewConfig)
+    maybeNativeRef.__viewConfig
   ) {
     return maybeNativeRef;
   }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -12,7 +12,7 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    maybeNativeRef._viewConfig
+    (maybeNativeRef.__viewConfig ?? maybeNativeRef._viewConfig)
   ) {
     return maybeNativeRef;
   }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -56,7 +56,8 @@ export function findHostInstance(
   /*
     The Fabric implementation of `findHostInstance_DEPRECATED` requires a React ref as an argument
     rather than a native ref. Prefer the resolved component ref when available so components can
-    forward their ref to the host view that should be animated.
+    forward their ref to the host view that should be animated. Components that expose an animatable
+    ref via `getAnimatableRef` already have it resolved into `_componentRef`.
   */
   return findHostInstance_DEPRECATED(
     (ref as IAnimatedComponentInternalBase)._componentRef ?? ref

--- a/packages/react-native-reanimated/src/platform-specific/types.ts
+++ b/packages/react-native-reanimated/src/platform-specific/types.ts
@@ -4,5 +4,4 @@ export type HostInstance = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
   __viewConfig?: Record<string, unknown>;
-  _viewConfig?: Record<string, unknown>;
 };

--- a/packages/react-native-reanimated/src/platform-specific/types.ts
+++ b/packages/react-native-reanimated/src/platform-specific/types.ts
@@ -3,5 +3,6 @@
 export type HostInstance = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
+  __viewConfig?: Record<string, unknown>;
   _viewConfig?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

Fixes #9587.

When `findHostInstance_DEPRECATED` is needed, Reanimated currently falls back to resolving the animated wrapper instance unless the component used `getAnimatableRef`. That can target the outer host view for components that forward their `ref` to an inner host view.

This change prefers the resolved `_componentRef` whenever it is available, preserving the existing fast path while making the deprecated lookup follow the same ref target that `createAnimatedComponent` captured.

## Test plan

```sh
yarn workspace react-native-reanimated test findHostInstance.test.ts --runInBand
yarn eslint packages/react-native-reanimated/src/platform-specific/findHostInstance.ts packages/react-native-reanimated/__tests__/findHostInstance.test.ts
git diff --check
```
