### PR TITLE
Link Android libc++ explicitly

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 
 target_link_libraries(
   reanimated
+  c++_shared
   log
   ReactAndroid::reactnative
   ReactAndroid::jsi

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories(
 # build shared lib
 set_target_properties(worklets PROPERTIES LINKER_LANGUAGE CXX)
 
-target_link_libraries(worklets android log ReactAndroid::reactnative
+target_link_libraries(worklets c++_shared android log ReactAndroid::reactnative
                       ReactAndroid::jsi fbjni::fbjni)
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 82)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Fixes #9444.

This explicitly links `c++_shared` into both Android native targets so NDK 27 builds include `-lc++_shared` even when CMake leaves `ANDROID_STL` as an unconsumed cache variable.

## Test plan

Ran the fabric example native debug build with the repo-configured NDK 27.1.12297006:

```sh
apps/fabric-example/android/gradlew -p apps/fabric-example/android :react-native-reanimated:externalNativeBuildDebug
```

The build completed successfully for `react-native-worklets` and `react-native-reanimated` across `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`. Generated Ninja files include `-lc++_shared` in both targets while `CMakeCache.txt` still shows `ANDROID_STL:UNINITIALIZED=c++_shared`, matching the issue scenario.

Also ran:

```sh
git diff --check
```
