### PR TITLE
Chore: xcode fix for ios builds with old RN

### DIFF
--- a/.github/workflows/reanimated-worklets-compatibility-check.yml
+++ b/.github/workflows/reanimated-worklets-compatibility-check.yml
@@ -147,6 +147,21 @@ jobs:
           reanimated-version: ${{ matrix.reanimatedVersion }}
           worklets-version: ${{ matrix.workletsVersion }}
 
+      # RN >= 0.83 needs Xcode 26.3 because of a bug
+      # See https://github.com/fmtlib/fmt/issues/4740
+      - name: Select Xcode for older React Native
+        if: steps.result-cache.outputs.cache-hit != 'true'
+        env:
+          RN_VERSION: ${{ matrix.reactNativeVersion }}
+        run: |
+          RN_MINOR="$(echo "${RN_VERSION}" | cut -d. -f2)"
+          if [ "${RN_MINOR}" -lt 83 ]; then
+            echo "React Native ${RN_VERSION} < 0.83, pinning Xcode 26.3"
+            echo "DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer" >> "$GITHUB_ENV"
+          else
+            echo "React Native ${RN_VERSION} >= 0.83, using default Xcode"
+          fi
+
       - name: Build app (iOS Debug)
         if: steps.result-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.APP_NAME }}/ios


### PR DESCRIPTION
## Summary

The reanimated-worklets-compatibility-check-ios job started failing with fmt compile errors:

  call to consteval function 'fmt::basic_format_string<...>' is not a constant expression

Root cause: the macos-26 runner's default Xcode moved to 26.4.1, which ships Apple Clang 21. Clang 21 enforces stricter consteval rules that reject fmt's FMT_STRING(...) call sites. The fmt version bundled in React Native < 0.83 hits this; RN >= 0.83 ships a fixed fmt and builds fine. Ref: https://github.com/fmtlib/fmt/issues/4740

Change

In .github/workflows/reanimated-worklets-compatibility-check.yml, add a step to the iOS job that pins Xcode based on the matrix's React Native version:

- RN minor < 83 → pin Xcode 26.3 (Apple Clang 20, predates the bug) via DEVELOPER_DIR.
- RN >= 0.83 → use the runner's default Xcode (26.4.1).

## Test plan
CI uses desired Xcode version