### PR TITLE
fix(Reanimated): mapperRun race condition

### DIFF
--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -76,10 +76,10 @@ export function getViewProp<T>(
 }
 
 function getSensorContainer(): SensorContainer {
-  if (!global.__sensorContainer) {
-    global.__sensorContainer = new SensorContainer();
+  if (!globalThis.__sensorContainer) {
+    globalThis.__sensorContainer = new SensorContainer();
   }
-  return global.__sensorContainer;
+  return globalThis.__sensorContainer;
 }
 
 export function registerEventHandler<TEvent>(
@@ -91,7 +91,18 @@ export function registerEventHandler<TEvent>(
     'worklet';
     eventHandler(event);
     // We call mappers here to make sure view updates can be applied in the same frame after an event.
-    global.__mapperRun();
+    if (globalThis.__mapperRun) {
+      globalThis.__mapperRun();
+    } else {
+      function runMappers() {
+        if (globalThis.__mapperRun) {
+          globalThis.__mapperRun();
+        } else {
+          requestAnimationFrame(runMappers);
+        }
+      }
+      requestAnimationFrame(runMappers);
+    }
   }
   return ReanimatedModule.registerEventHandler(
     createSerializable(handleEvent as WorkletFunction),
@@ -114,7 +125,18 @@ export function subscribeForKeyboardEvents(
     'worklet';
     eventHandler(state, height);
     // We call mappers here to make sure view updates can be applied in the same frame after an event.
-    global.__mapperRun();
+    if (globalThis.__mapperRun) {
+      globalThis.__mapperRun();
+    } else {
+      function runMappers() {
+        if (globalThis.__mapperRun) {
+          globalThis.__mapperRun();
+        } else {
+          requestAnimationFrame(runMappers);
+        }
+      }
+      requestAnimationFrame(runMappers);
+    }
   }
 
   if (__DEV__) {


### PR DESCRIPTION
## Summary

Fixes #9524 

Turns out that an event can fire before `globalThis.__mapperRun` registers in the UI Runtime global scope. Instead of an eager, synchronous initialization for `__mapperRun` I decided it'd be better to keep rescheduling the call to it until it's available - to not lose the potential update and not slow down initialization time.

## Test plan

Reproduction from #9524 no longer crashes

```tsx
import { TextInput, View } from 'react-native';
import { KeyboardProvider } from 'react-native-keyboard-controller';

export default function App() {
  return (
    <KeyboardProvider>
      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
        <TextInput
          placeholder="Crash Test"
          style={{ borderWidth: 1, borderColor: 'black', padding: 10 }}
        />
      </View>
    </KeyboardProvider>
  );
}
```
