### PR TITLE
Fix debug worklets without source maps

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
@@ -2,11 +2,7 @@
 
 #include <jsi/jsi.h>
 
-#ifndef NDEBUG
-// Nothing
-#else
 #include <memory>
-#endif // NDEBUG
 #include <string>
 
 namespace worklets {
@@ -64,21 +60,12 @@ class UnpackerLoader {
     }
 
 #ifndef NDEBUG
-    auto evalWithSourceMap = rt.global().getPropertyAsFunction(rt, "evalWithSourceMap");
-    evalWithSourceMap.call(rt, valueUnpacker_.code, valueUnpacker_.location, valueUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, synchronizableUnpacker_.code, synchronizableUnpacker_.location, synchronizableUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt,
-        customSerializableUnpacker_.code,
-        customSerializableUnpacker_.location,
-        customSerializableUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, shareableHostUnpacker_.code, shareableHostUnpacker_.location, shareableHostUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, shareableGuestUnpacker_.code, shareableGuestUnpacker_.location, shareableGuestUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, remoteFunctionUnpacker_.code, remoteFunctionUnpacker_.location, remoteFunctionUnpacker_.sourceMap);
+    installUnpacker(rt, valueUnpacker_);
+    installUnpacker(rt, synchronizableUnpacker_);
+    installUnpacker(rt, customSerializableUnpacker_);
+    installUnpacker(rt, shareableHostUnpacker_);
+    installUnpacker(rt, shareableGuestUnpacker_);
+    installUnpacker(rt, remoteFunctionUnpacker_);
 #else
     rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(valueUnpacker_.code), valueUnpacker_.location);
     rt.evaluateJavaScript(
@@ -96,6 +83,18 @@ class UnpackerLoader {
   }
 
  private:
+#ifndef NDEBUG
+  static void installUnpacker(facebook::jsi::Runtime &rt, const Unpacker &unpacker) {
+    if (unpacker.sourceMap.empty()) {
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(unpacker.code), unpacker.location);
+      return;
+    }
+
+    auto evalWithSourceMap = rt.global().getPropertyAsFunction(rt, "evalWithSourceMap");
+    evalWithSourceMap.call(rt, unpacker.code, unpacker.location, unpacker.sourceMap);
+  }
+#endif // NDEBUG
+
   Unpacker valueUnpacker_;
   Unpacker synchronizableUnpacker_;
   Unpacker customSerializableUnpacker_;

--- a/packages/react-native-worklets/src/memory/valueUnpacker.native.ts
+++ b/packages/react-native-worklets/src/memory/valueUnpacker.native.ts
@@ -23,15 +23,15 @@ export function installValueUnpacker() {
       let workletFun = workletsCache.get(workletHash);
       if (workletFun === undefined) {
         const initData = objectToUnpack.__initData;
-        if (globalThis.evalWithSourceMap) {
+        if (globalThis.evalWithSourceMap && initData?.sourceMap) {
           // if the runtime (hermes only for now) supports loading source maps
           // we want to use the proper filename for the location as it guarantees
           // that debugger understands and loads the source code of the file where
           // the worklet is defined.
           workletFun = globalThis.evalWithSourceMap(
-            '(' + initData!.code + '\n)',
-            initData!.location!,
-            initData!.sourceMap!
+            '(' + initData.code + '\n)',
+            initData.location ?? '',
+            initData.sourceMap
           );
         } else if (globalThis.evalWithSourceUrl) {
           // if the runtime doesn't support loading source maps, in dev mode we


### PR DESCRIPTION
## Summary

Fixes #9600.

Debug Hermes runtimes currently install and unpack worklets with `evalWithSourceMap` whenever that helper exists. Release-transformed OTA/export bundles can contain worklet `__initData.code` without `__initData.sourceMap`, so debug native builds pass an empty source map string into Hermes and crash while parsing it.

This PR makes missing source maps fall back to normal script evaluation instead of calling `evalWithSourceMap` with an empty map.

## Changes

- Skip `evalWithSourceMap` in `valueUnpacker.native.ts` unless `initData.sourceMap` is present.
- Make `UnpackerLoader` use `evaluateJavaScript` for startup unpackers whose source map string is empty.
- Keep source-map evaluation unchanged when a source map is present.

## Validation

- `yarn workspace react-native-worklets lint:js`
- `yarn workspace react-native-worklets type:check:src:native`
- `yarn workspace react-native-worklets format:common --dry-run -Werror`
- `yarn workspace react-native-worklets test --runInBand`

I did not run the full EAS Update dev-client reproduction locally because it requires device builds, but the changed paths match the crash described in the issue.
