### PR TITLE
fix(Worklets): always expecting sourceMaps in unpackers

### DIFF
--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
@@ -2,11 +2,7 @@
 
 #include <jsi/jsi.h>
 
-#ifndef NDEBUG
-// Nothing
-#else
 #include <memory>
-#endif // NDEBUG
 #include <string>
 
 namespace worklets {
@@ -29,30 +25,24 @@ struct ShareableUnpackers {
 class UnpackerLoader {
  public:
   void loadUnpackers(const ShareableUnpackers &unpackers) {
-    valueUnpacker_ = {
-        "(" + unpackers.valueUnpacker.code + ")();",
-        unpackers.valueUnpacker.location,
-        unpackers.valueUnpacker.sourceMap};
-    synchronizableUnpacker_ = {
-        "(" + unpackers.synchronizableUnpacker.code + ")();",
-        unpackers.synchronizableUnpacker.location,
-        unpackers.synchronizableUnpacker.sourceMap};
-    customSerializableUnpacker_ = {
-        "(" + unpackers.customSerializableUnpacker.code + ")();",
-        unpackers.customSerializableUnpacker.location,
-        unpackers.customSerializableUnpacker.sourceMap};
-    shareableHostUnpacker_ = {
-        "(" + unpackers.shareableHostUnpacker.code + ")();",
-        unpackers.shareableHostUnpacker.location,
-        unpackers.shareableHostUnpacker.sourceMap};
-    shareableGuestUnpacker_ = {
-        "(" + unpackers.shareableGuestUnpacker.code + ")();",
-        unpackers.shareableGuestUnpacker.location,
-        unpackers.shareableGuestUnpacker.sourceMap};
-    remoteFunctionUnpacker_ = {
-        "(" + unpackers.remoteFunctionUnpacker.code + ")();",
-        unpackers.remoteFunctionUnpacker.location,
-        unpackers.remoteFunctionUnpacker.sourceMap};
+    valueUnpacker_ = {"(" + unpackers.valueUnpacker.code + ")();",
+                      unpackers.valueUnpacker.location,
+                      unpackers.valueUnpacker.sourceMap};
+    synchronizableUnpacker_ = {"(" + unpackers.synchronizableUnpacker.code + ")();",
+                               unpackers.synchronizableUnpacker.location,
+                               unpackers.synchronizableUnpacker.sourceMap};
+    customSerializableUnpacker_ = {"(" + unpackers.customSerializableUnpacker.code + ")();",
+                                   unpackers.customSerializableUnpacker.location,
+                                   unpackers.customSerializableUnpacker.sourceMap};
+    shareableHostUnpacker_ = {"(" + unpackers.shareableHostUnpacker.code + ")();",
+                              unpackers.shareableHostUnpacker.location,
+                              unpackers.shareableHostUnpacker.sourceMap};
+    shareableGuestUnpacker_ = {"(" + unpackers.shareableGuestUnpacker.code + ")();",
+                               unpackers.shareableGuestUnpacker.location,
+                               unpackers.shareableGuestUnpacker.sourceMap};
+    remoteFunctionUnpacker_ = {"(" + unpackers.remoteFunctionUnpacker.code + ")();",
+                               unpackers.remoteFunctionUnpacker.location,
+                               unpackers.remoteFunctionUnpacker.sourceMap};
   }
 
   void installUnpackers(facebook::jsi::Runtime &rt) const {
@@ -63,36 +53,42 @@ class UnpackerLoader {
           "[Worklets] UnpackerLoader tried to install unpackers but the code for unpackers was not loaded.");
     }
 
+    const auto useSourceMaps =
 #ifndef NDEBUG
-    auto evalWithSourceMap = rt.global().getPropertyAsFunction(rt, "evalWithSourceMap");
-    evalWithSourceMap.call(rt, valueUnpacker_.code, valueUnpacker_.location, valueUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, synchronizableUnpacker_.code, synchronizableUnpacker_.location, synchronizableUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt,
-        customSerializableUnpacker_.code,
-        customSerializableUnpacker_.location,
-        customSerializableUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, shareableHostUnpacker_.code, shareableHostUnpacker_.location, shareableHostUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, shareableGuestUnpacker_.code, shareableGuestUnpacker_.location, shareableGuestUnpacker_.sourceMap);
-    evalWithSourceMap.call(
-        rt, remoteFunctionUnpacker_.code, remoteFunctionUnpacker_.location, remoteFunctionUnpacker_.sourceMap);
+        !valueUnpacker_.sourceMap.empty();
 #else
-    rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(valueUnpacker_.code), valueUnpacker_.location);
-    rt.evaluateJavaScript(
-        std::make_shared<facebook::jsi::StringBuffer>(synchronizableUnpacker_.code), synchronizableUnpacker_.location);
-    rt.evaluateJavaScript(
-        std::make_shared<facebook::jsi::StringBuffer>(customSerializableUnpacker_.code),
-        customSerializableUnpacker_.location);
-    rt.evaluateJavaScript(
-        std::make_shared<facebook::jsi::StringBuffer>(shareableHostUnpacker_.code), shareableHostUnpacker_.location);
-    rt.evaluateJavaScript(
-        std::make_shared<facebook::jsi::StringBuffer>(shareableGuestUnpacker_.code), shareableGuestUnpacker_.location);
-    rt.evaluateJavaScript(
-        std::make_shared<facebook::jsi::StringBuffer>(remoteFunctionUnpacker_.code), remoteFunctionUnpacker_.location);
+        false;
 #endif // NDEBUG
+
+    if (useSourceMaps) {
+      const auto evalWithSourceMap = rt.global().getPropertyAsFunction(rt, "evalWithSourceMap");
+      evalWithSourceMap.call(rt, valueUnpacker_.code, valueUnpacker_.location, valueUnpacker_.sourceMap);
+      evalWithSourceMap.call(
+          rt, synchronizableUnpacker_.code, synchronizableUnpacker_.location, synchronizableUnpacker_.sourceMap);
+      evalWithSourceMap.call(rt,
+                             customSerializableUnpacker_.code,
+                             customSerializableUnpacker_.location,
+                             customSerializableUnpacker_.sourceMap);
+      evalWithSourceMap.call(
+          rt, shareableHostUnpacker_.code, shareableHostUnpacker_.location, shareableHostUnpacker_.sourceMap);
+      evalWithSourceMap.call(
+          rt, shareableGuestUnpacker_.code, shareableGuestUnpacker_.location, shareableGuestUnpacker_.sourceMap);
+      evalWithSourceMap.call(
+          rt, remoteFunctionUnpacker_.code, remoteFunctionUnpacker_.location, remoteFunctionUnpacker_.sourceMap);
+    } else {
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(valueUnpacker_.code),
+                            valueUnpacker_.location);
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(synchronizableUnpacker_.code),
+                            synchronizableUnpacker_.location);
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(customSerializableUnpacker_.code),
+                            customSerializableUnpacker_.location);
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(shareableHostUnpacker_.code),
+                            shareableHostUnpacker_.location);
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(shareableGuestUnpacker_.code),
+                            shareableGuestUnpacker_.location);
+      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(remoteFunctionUnpacker_.code),
+                            remoteFunctionUnpacker_.location);
+    }
   }
 
  private:

--- a/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/SharedItems/UnpackerLoader.h
@@ -25,24 +25,30 @@ struct ShareableUnpackers {
 class UnpackerLoader {
  public:
   void loadUnpackers(const ShareableUnpackers &unpackers) {
-    valueUnpacker_ = {"(" + unpackers.valueUnpacker.code + ")();",
-                      unpackers.valueUnpacker.location,
-                      unpackers.valueUnpacker.sourceMap};
-    synchronizableUnpacker_ = {"(" + unpackers.synchronizableUnpacker.code + ")();",
-                               unpackers.synchronizableUnpacker.location,
-                               unpackers.synchronizableUnpacker.sourceMap};
-    customSerializableUnpacker_ = {"(" + unpackers.customSerializableUnpacker.code + ")();",
-                                   unpackers.customSerializableUnpacker.location,
-                                   unpackers.customSerializableUnpacker.sourceMap};
-    shareableHostUnpacker_ = {"(" + unpackers.shareableHostUnpacker.code + ")();",
-                              unpackers.shareableHostUnpacker.location,
-                              unpackers.shareableHostUnpacker.sourceMap};
-    shareableGuestUnpacker_ = {"(" + unpackers.shareableGuestUnpacker.code + ")();",
-                               unpackers.shareableGuestUnpacker.location,
-                               unpackers.shareableGuestUnpacker.sourceMap};
-    remoteFunctionUnpacker_ = {"(" + unpackers.remoteFunctionUnpacker.code + ")();",
-                               unpackers.remoteFunctionUnpacker.location,
-                               unpackers.remoteFunctionUnpacker.sourceMap};
+    valueUnpacker_ = {
+        "(" + unpackers.valueUnpacker.code + ")();",
+        unpackers.valueUnpacker.location,
+        unpackers.valueUnpacker.sourceMap};
+    synchronizableUnpacker_ = {
+        "(" + unpackers.synchronizableUnpacker.code + ")();",
+        unpackers.synchronizableUnpacker.location,
+        unpackers.synchronizableUnpacker.sourceMap};
+    customSerializableUnpacker_ = {
+        "(" + unpackers.customSerializableUnpacker.code + ")();",
+        unpackers.customSerializableUnpacker.location,
+        unpackers.customSerializableUnpacker.sourceMap};
+    shareableHostUnpacker_ = {
+        "(" + unpackers.shareableHostUnpacker.code + ")();",
+        unpackers.shareableHostUnpacker.location,
+        unpackers.shareableHostUnpacker.sourceMap};
+    shareableGuestUnpacker_ = {
+        "(" + unpackers.shareableGuestUnpacker.code + ")();",
+        unpackers.shareableGuestUnpacker.location,
+        unpackers.shareableGuestUnpacker.sourceMap};
+    remoteFunctionUnpacker_ = {
+        "(" + unpackers.remoteFunctionUnpacker.code + ")();",
+        unpackers.remoteFunctionUnpacker.location,
+        unpackers.remoteFunctionUnpacker.sourceMap};
   }
 
   void installUnpackers(facebook::jsi::Runtime &rt) const {
@@ -65,10 +71,11 @@ class UnpackerLoader {
       evalWithSourceMap.call(rt, valueUnpacker_.code, valueUnpacker_.location, valueUnpacker_.sourceMap);
       evalWithSourceMap.call(
           rt, synchronizableUnpacker_.code, synchronizableUnpacker_.location, synchronizableUnpacker_.sourceMap);
-      evalWithSourceMap.call(rt,
-                             customSerializableUnpacker_.code,
-                             customSerializableUnpacker_.location,
-                             customSerializableUnpacker_.sourceMap);
+      evalWithSourceMap.call(
+          rt,
+          customSerializableUnpacker_.code,
+          customSerializableUnpacker_.location,
+          customSerializableUnpacker_.sourceMap);
       evalWithSourceMap.call(
           rt, shareableHostUnpacker_.code, shareableHostUnpacker_.location, shareableHostUnpacker_.sourceMap);
       evalWithSourceMap.call(
@@ -76,18 +83,22 @@ class UnpackerLoader {
       evalWithSourceMap.call(
           rt, remoteFunctionUnpacker_.code, remoteFunctionUnpacker_.location, remoteFunctionUnpacker_.sourceMap);
     } else {
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(valueUnpacker_.code),
-                            valueUnpacker_.location);
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(synchronizableUnpacker_.code),
-                            synchronizableUnpacker_.location);
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(customSerializableUnpacker_.code),
-                            customSerializableUnpacker_.location);
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(shareableHostUnpacker_.code),
-                            shareableHostUnpacker_.location);
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(shareableGuestUnpacker_.code),
-                            shareableGuestUnpacker_.location);
-      rt.evaluateJavaScript(std::make_shared<facebook::jsi::StringBuffer>(remoteFunctionUnpacker_.code),
-                            remoteFunctionUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(valueUnpacker_.code), valueUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(synchronizableUnpacker_.code),
+          synchronizableUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(customSerializableUnpacker_.code),
+          customSerializableUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(shareableHostUnpacker_.code), shareableHostUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(shareableGuestUnpacker_.code),
+          shareableGuestUnpacker_.location);
+      rt.evaluateJavaScript(
+          std::make_shared<facebook::jsi::StringBuffer>(remoteFunctionUnpacker_.code),
+          remoteFunctionUnpacker_.location);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #9600

Requires #9609

Fixing a bug that happens in configuration of Production Bundle and Debug App where we'd assume that debug-metadata is always available in unpackers. We didn't run into this problem because the Worklets Babel plugin didn't always resolve the bundle flavor correctly and would sometimes emit the debug metadata anyway.

## Test plan

Disable Bundle Mode and load a production bundle into a debug app with the DevTools options inside the app - it no longer crashes.
