### PR TITLE
fix(Worklets): Babel plugin not detecting production environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ playwright/.cache/
 
 # Claude
 .claude
+CLAUDE.md

--- a/packages/react-native-worklets/__tests__/plugin-shared.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-shared.test.ts
@@ -224,6 +224,7 @@ describe.each([
     </script>`.replace(/<\/?script[^>]*>/g, '');
 
     function transformWithEnvName(envName: string): string {
+      capturedFiles.length = 0;
       const transformed = transformSync(sampleInput, {
         filename: MOCK_LOCATION,
         compact: false,
@@ -241,9 +242,10 @@ describe.each([
           ],
         ],
       });
+      assert(transformed);
       return bundleMode
         ? capturedFiles.map((f) => f.content).join('\n')
-        : (transformed?.code ?? '');
+        : (transformed.code ?? '');
     }
 
     test('envName "production" is detected as release', () => {

--- a/packages/react-native-worklets/__tests__/plugin-shared.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-shared.test.ts
@@ -214,4 +214,46 @@ describe.each([
       expect(result.code).toMatchSnapshot();
     });
   });
+
+  describe('state environment flavor detection', () => {
+    const sampleInput = html`<script>
+      function foo() {
+        'worklet';
+        return 1;
+      }
+    </script>`.replace(/<\/?script[^>]*>/g, '');
+
+    function transformWithEnvName(envName: string): string {
+      const transformed = transformSync(sampleInput, {
+        filename: MOCK_LOCATION,
+        compact: false,
+        babelrc: false,
+        configFile: false,
+        envName,
+        plugins: [
+          [
+            plugin,
+            {
+              bundleMode,
+              disableSourceMaps: true,
+              relativeSourceLocation: true,
+            },
+          ],
+        ],
+      });
+      return bundleMode
+        ? capturedFiles.map((f) => f.content).join('\n')
+        : (transformed?.code ?? '');
+    }
+
+    test('envName "production" is detected as release', () => {
+      expect(transformWithEnvName('production')).not.toContain(
+        '__pluginVersion'
+      );
+    });
+
+    test('envName "development" is not detected as release', () => {
+      expect(transformWithEnvName('development')).toContain('__pluginVersion');
+    });
+  });
 });

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -380,10 +380,10 @@ var require_utils = __commonJS({
     exports2.isRelease = isRelease;
     exports2.replaceWithFactoryCall = replaceWithFactoryCall;
     var types_12 = require("@babel/types");
-    function isRelease() {
-      var _a, _b;
+    function isRelease(state) {
+      var _a, _b, _c;
       const pattern = /(prod|release|stag[ei])/i;
-      return !!(((_a = process.env.BABEL_ENV) === null || _a === void 0 ? void 0 : _a.match(pattern)) || ((_b = process.env.NODE_ENV) === null || _b === void 0 ? void 0 : _b.match(pattern)));
+      return !!(((_a = state.file.opts.envName) === null || _a === void 0 ? void 0 : _a.match(pattern)) || ((_b = process.env.BABEL_ENV) === null || _b === void 0 ? void 0 : _b.match(pattern)) || ((_c = process.env.NODE_ENV) === null || _c === void 0 ? void 0 : _c.match(pattern)));
     }
     function replaceWithFactoryCall(toReplace, name, factoryCall) {
       if (!name || !needsDeclaration(toReplace)) {
@@ -839,7 +839,7 @@ var require_workletStringCode = __commonJS({
       const workletFunction = (0, types_12.functionExpression)((0, types_12.identifier)(workletName), expression.params, expression.body, expression.generator, expression.async);
       const code = (0, generator_1.default)(workletFunction).code;
       (0, assert_1.strict)(inputMap, "[Reanimated] `inputMap` is undefined.");
-      const includeSourceMap = !((0, utils_1.isRelease)() || state.opts.disableSourceMaps);
+      const includeSourceMap = !((0, utils_1.isRelease)(state) || state.opts.disableSourceMaps);
       if (includeSourceMap) {
         inputMap.sourcesContent = [];
         for (const sourceFile of inputMap.sources) {
@@ -999,7 +999,7 @@ var require_workletFactory = __commonJS({
       const initDataObjectExpression = (0, types_12.objectExpression)([
         (0, types_12.objectProperty)((0, types_12.identifier)("code"), (0, types_12.stringLiteral)(funString))
       ]);
-      const shouldInjectLocation = !(0, utils_1.isRelease)();
+      const shouldInjectLocation = !(0, utils_1.isRelease)(state);
       if (shouldInjectLocation) {
         let location = state.file.opts.filename;
         if (state.opts.relativeSourceLocation) {
@@ -1031,14 +1031,14 @@ var require_workletFactory = __commonJS({
         (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__closure"), false), (0, types_12.objectExpression)(closureVariables.map((variable) => !state.opts.bundleMode && variable.name.endsWith(types_2.workletClassFactorySuffix) ? (0, types_12.objectProperty)((0, types_12.identifier)(variable.name), (0, types_12.memberExpression)((0, types_12.identifier)(variable.name.slice(0, variable.name.length - types_2.workletClassFactorySuffix.length)), (0, types_12.identifier)(variable.name))) : (0, types_12.objectProperty)((0, types_12.cloneNode)(variable, true), (0, types_12.cloneNode)(variable, true), false, true))))),
         (0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__workletHash"), false), (0, types_12.numericLiteral)(workletHash)))
       ];
-      const shouldInjectVersion = !(0, utils_1.isRelease)();
+      const shouldInjectVersion = !(0, utils_1.isRelease)(state);
       if (shouldInjectVersion) {
         statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__pluginVersion")), (0, types_12.stringLiteral)(shouldMockVersion() ? MOCK_VERSION : REAL_VERSION))));
       }
       if (shouldIncludeInitData) {
         statements.push((0, types_12.expressionStatement)((0, types_12.assignmentExpression)("=", (0, types_12.memberExpression)((0, types_12.identifier)(reactName), (0, types_12.identifier)("__initData"), false), (0, types_12.cloneNode)(initDataId, true))));
       }
-      if (!(0, utils_1.isRelease)() && !state.opts.bundleMode) {
+      if (!(0, utils_1.isRelease)(state) && !state.opts.bundleMode) {
         statements.unshift((0, types_12.variableDeclaration)("const", [
           (0, types_12.variableDeclarator)((0, types_12.identifier)("_e"), (0, types_12.arrayExpression)([
             (0, types_12.newExpression)((0, types_12.memberExpression)((0, types_12.identifier)("global"), (0, types_12.identifier)("Error")), []),
@@ -1823,7 +1823,7 @@ var require_inlineStylesWarning = __commonJS({
       }
     }
     function processInlineStylesWarning(path, state) {
-      if ((0, utils_1.isRelease)()) {
+      if ((0, utils_1.isRelease)(state)) {
         return;
       }
       if (state.opts.disableInlineStylesWarning) {

--- a/packages/react-native-worklets/plugin/src/inlineStylesWarning.ts
+++ b/packages/react-native-worklets/plugin/src/inlineStylesWarning.ts
@@ -103,7 +103,7 @@ export function processInlineStylesWarning(
   path: NodePath<JSXAttribute>,
   state: WorkletsPluginPass
 ) {
-  if (isRelease()) {
+  if (isRelease(state)) {
     return;
   }
   if (state.opts.disableInlineStylesWarning) {

--- a/packages/react-native-worklets/plugin/src/utils.ts
+++ b/packages/react-native-worklets/plugin/src/utils.ts
@@ -8,9 +8,12 @@ import {
   variableDeclarator,
 } from '@babel/types';
 
-export function isRelease() {
+import type { WorkletsPluginPass } from './types';
+
+export function isRelease(state: WorkletsPluginPass) {
   const pattern = /(prod|release|stag[ei])/i;
   return !!(
+    state.file.opts.envName?.match(pattern) ||
     process.env.BABEL_ENV?.match(pattern) ||
     process.env.NODE_ENV?.match(pattern)
   );

--- a/packages/react-native-worklets/plugin/src/workletFactory.ts
+++ b/packages/react-native-worklets/plugin/src/workletFactory.ts
@@ -178,7 +178,7 @@ export function makeWorkletFactory(
   // When testing with jest I noticed that environment variables are set later
   // than some functions are evaluated. E.g. this cannot be above this function
   // because it would always evaluate to true.
-  const shouldInjectLocation = !isRelease();
+  const shouldInjectLocation = !isRelease(state);
   if (shouldInjectLocation) {
     let location = state.file.opts.filename;
     if (state.opts.relativeSourceLocation) {
@@ -275,7 +275,7 @@ export function makeWorkletFactory(
     ),
   ];
 
-  const shouldInjectVersion = !isRelease();
+  const shouldInjectVersion = !isRelease(state);
   if (shouldInjectVersion) {
     statements.push(
       expressionStatement(
@@ -307,7 +307,7 @@ export function makeWorkletFactory(
     );
   }
 
-  if (!isRelease() && !state.opts.bundleMode) {
+  if (!isRelease(state) && !state.opts.bundleMode) {
     statements.unshift(
       variableDeclaration('const', [
         variableDeclarator(

--- a/packages/react-native-worklets/plugin/src/workletStringCode.ts
+++ b/packages/react-native-worklets/plugin/src/workletStringCode.ts
@@ -116,7 +116,7 @@ export function buildWorkletString(
 
   assert(inputMap, '[Reanimated] `inputMap` is undefined.');
 
-  const includeSourceMap = !(isRelease() || state.opts.disableSourceMaps);
+  const includeSourceMap = !(isRelease(state) || state.opts.disableSourceMaps);
 
   if (includeSourceMap) {
     // Clear contents array (should be empty anyways)

--- a/scripts/patches/resolutions.patch
+++ b/scripts/patches/resolutions.patch
@@ -8,7 +8,7 @@ index 035d3de9af..75ced6b69b 100644
      "typescript": "5.9.3"
 +  },
 +  "resolutions": {
-+    "metro@0.84.x": "patch:metro@npm%3A0.84.4#~/.yarn/patches/metro-npm-0.84.4-68d21d57b4.patch",
-+    "metro-runtime@0.84.x": "patch:metro-runtime@npm%3A0.84.4#~/.yarn/patches/metro-runtime-npm-0.84.4-9533293c73.patch"
++    "metro": "patch:metro@npm%3A0.84.4#~/.yarn/patches/metro-npm-0.84.4-68d21d57b4.patch",
++    "metro-runtime": "patch:metro-runtime@npm%3A0.84.4#~/.yarn/patches/metro-runtime-npm-0.84.4-9533293c73.patch"
    }
  }


### PR DESCRIPTION
## Summary

When working on #9607 I noticed that the Worklets Babel plugin doesn't detect if it should be outputting production flavor when the information for that is passed in the state object instead of NODE_ENV. This PR fixes that.

## Test plan

I added new tests for detection of production flavor.
