### PR TITLE
fix(worklets): compile JSX in generated worklet files

### DIFF
--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -2,11 +2,13 @@ import '../plugin/src/jestMatchers';
 
 import type { TransformOptions } from '@babel/core';
 import { transformSync } from '@babel/core';
+import { isFunctionExpression, isVariableDeclaration } from '@babel/types';
 import { strict as assert } from 'assert';
 import { html } from 'code-tag';
 import * as path from 'path';
 
 import { countOccurrences } from '../jest/pluginTestUtils';
+import type { WorkletsPluginPass } from '../plugin/src/types';
 
 type CapturedFile = { path: string; content: string };
 
@@ -22,6 +24,8 @@ jest.mock('fs', () => {
   };
 });
 
+// eslint-disable-next-line import/first
+import { generateWorkletFile } from '../plugin/src/generate';
 // eslint-disable-next-line import/first
 import type { PluginOptions } from '../plugin';
 // eslint-disable-next-line import/first
@@ -198,6 +202,43 @@ describe('babel plugin in bundleMode', () => {
       expect(files).toHaveLength(1);
       expect(code).toMatchSnapshot();
       expect(files[0].content).toMatchSnapshot();
+    });
+
+    test('lowers JSX in written worklet files', () => {
+      const transformed = transformSync(
+        html`<script>
+          const factory = function () {
+            return <ImportedComponent __self={this} />;
+          };
+        </script>`.replace(/<\/?script[^>]*>/g, ''),
+        {
+          ast: true,
+          babelrc: false,
+          code: false,
+          configFile: false,
+          plugins: ['@babel/plugin-syntax-jsx'],
+        }
+      );
+      assert(transformed);
+      assert(transformed.ast);
+
+      const statement = transformed.ast.program.body[0];
+      assert(isVariableDeclaration(statement));
+
+      const factory = statement.declarations[0].init;
+      assert(isFunctionExpression(factory));
+
+      const autoworkletizationPlugin = { visitor: {} };
+      const state = {
+        file: { opts: { filename: MOCK_LOCATION } },
+        autoworkletizationPlugin,
+      } as WorkletsPluginPass;
+
+      generateWorkletFile(new Set(), new Set(), factory, 1, state);
+      const files = capturedFiles;
+      expect(files).toHaveLength(1);
+      expect(files[0].content).toContain('react/jsx-runtime');
+      expect(files[0].content).not.toContain('<ImportedComponent');
     });
 
     test('rebases relative imports against the worklets directory', () => {

--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -70,6 +70,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.27.1",
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/plugin-transform-unicode-regex": "^7.27.1",
+    "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@babel/types": "^7.27.1",
     "convert-source-map": "^2.0.0",

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -733,9 +733,14 @@ var require_generate = __commonJS({
       const relativeImports = Array.from(relativeBindingsToImport).filter((binding) => binding.path.isImportSpecifier() && binding.path.parentPath.isImportDeclaration()).map((binding) => (0, types_12.importDeclaration)([(0, types_12.cloneNode)(binding.path.node, true)], (0, imports_1.createImportPathLiteral)(binding.path.parentPath.node.source.value, state)));
       const imports = [...libraryImports, ...relativeImports];
       const newProg = (0, types_12.program)([...imports, (0, types_12.exportDefaultDeclaration)(factory)]);
+      const reactPreset = require.resolve("@babel/preset-react");
+      const reactPresetOptions = {
+        development: false,
+        runtime: "automatic"
+      };
       const transformedProg = (_a = (0, core_1.transformFromAstSync)(newProg, void 0, {
         filename: state.file.opts.filename,
-        presets: ["@babel/preset-typescript"],
+        presets: ["@babel/preset-typescript", [reactPreset, reactPresetOptions]],
         plugins: [state.autoworkletizationPlugin],
         ast: false,
         babelrc: false,

--- a/packages/react-native-worklets/plugin/src/generate.ts
+++ b/packages/react-native-worklets/plugin/src/generate.ts
@@ -69,9 +69,15 @@ export function generateWorkletFile(
 
   const newProg = program([...imports, exportDefaultDeclaration(factory)]);
 
+  const reactPreset = require.resolve('@babel/preset-react');
+  const reactPresetOptions = {
+    development: false,
+    runtime: 'automatic',
+  };
+
   const transformedProg = transformFromAstSync(newProg, undefined, {
     filename: state.file.opts.filename,
-    presets: ['@babel/preset-typescript'],
+    presets: ['@babel/preset-typescript', [reactPreset, reactPresetOptions]],
     plugins: [state.autoworkletizationPlugin],
     ast: false,
     babelrc: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -28362,6 +28362,7 @@ __metadata:
     "@babel/plugin-transform-shorthand-properties": "npm:^7.27.1"
     "@babel/plugin-transform-template-literals": "npm:^7.27.1"
     "@babel/plugin-transform-unicode-regex": "npm:^7.27.1"
+    "@babel/preset-react": "npm:^7.28.5"
     "@babel/preset-typescript": "npm:^7.28.5"
     "@babel/types": "npm:^7.27.1"
     "@react-native-community/cli": "npm:20.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This fixes and enables JSX usage in worklets:

- https://github.com/software-mansion/react-native-reanimated/issues/9214

**Background:**

Imagine you have

```jsx
// MyComp.tsx
return <ImportedComponent />
```

then metro transforms our app code. In dev, React Native’s Babel preset includes JSX dev handling, which annotates JSX with debug metadata:

```jsx
// MyComp.tsx - transformed
return <ImportedComponent __self={this} />;
```

Now, the worklets plugin captures this and writes it into the generated worklet file.
As we created a new file, Metro later processes that generated `.worklets/<hash>.js` file too.

Here, Babel’s JSX dev transform sees JSX that already has `__self` and throws while trying to apply dev JSX handling again with the error described in #9214!

**What I changed:**

I basically configured the worklets babel plugin that writes the .worklets/<hash>.js` files to use `@babel/preset-react`.

This way:

```jsx
<ImportedComponent __self={this} />
```
would become:
```js
import { jsx as _jsx } from 'react/jsx-runtime';

return _jsx(ImportedComponent, { __self: this });
```

now, when metro processes the file, it would not try to transform the JSX and insert __self, as its already transformed.

I am not sure if this is an actual fix or rather a workaround.

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

Added a test file!
