### PR TITLE
fix: build.gradle.kts not falling back to default ABIs

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -121,7 +121,11 @@ val reanimatedPrefabHeadersDir: File = project.file("${layout.buildDirectory.get
 
 fun reactNativeArchitectures(): List<String> {
     val value = project.findProperty("reactNativeArchitectures") as String?
-    return value?.split(",") ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
+    return value?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.ifEmpty { null }
+        ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
 }
 
 if (project == rootProject) {

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -136,7 +136,11 @@ val workletsPrefabHeadersDir: File = project.file("${layout.buildDirectory.get()
 
 fun reactNativeArchitectures(): List<String> {
     val value = project.findProperty("reactNativeArchitectures") as String?
-    return value?.split(",") ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
+    return value?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.ifEmpty { null }
+        ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
 }
 
 if (project == rootProject) {

--- a/packages/react-native-worklets/android/fix-prefab.gradle.kts
+++ b/packages/react-native-worklets/android/fix-prefab.gradle.kts
@@ -1,6 +1,10 @@
 fun reactNativeArchitectures(): List<String> {
     val value = project.findProperty("reactNativeArchitectures") as String?
-    return value?.split(",") ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
+    return value?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.ifEmpty { null }
+        ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
 }
 
 tasks.configureEach {


### PR DESCRIPTION
## Summary

When migrating to Kotlin DSL for `build.gradle` files we introduced a regression where an empty string for React Native Architectures would no longer be considered `falsy` and wouldn't fallback to the default ABI list.

## Test plan

Try passing an empty string as ABIs and see that now that correctly fall backs to the default list.
