### PR TITLE
fix: 30fps layout animations on iOS release builds

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -322,9 +322,9 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
         if (!surfaceId) {
           return;
         }
+        // The flush set is drained by `executeLayoutAnimationsRequests`, driven
+        // by `runGrandCallback` (backend) or a JS `requestAnimationFrameFinalizer` (non-backend).
         strongThis->layoutAnimationFlushRequests_.insert(*surfaceId);
-
-        strongThis->requestRenderForLayoutAnimations();
       };
 
   EndLayoutAnimationFunction endLayoutAnimation = [weakThis = weak_from_this()](int tag, bool shouldRemove) {
@@ -335,14 +335,6 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
     }
 
     auto surfaceId = strongThis->layoutAnimationsProxy_->endLayoutAnimation(tag, shouldRemove);
-
-    if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
-      // in the backend path this is called from runGrandCallback,
-      // we are guaranteed to have the changes flushed
-    } else {
-      strongThis->requestRenderForLayoutAnimations();
-    }
-
     if (!surfaceId) {
       return;
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -201,20 +201,6 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   void commitUpdates(jsi::Runtime &rt, const UpdatesBatch &updatesBatch);
   void applySynchronousUpdates(UpdatesBatch &updatesBatch, bool allowPartialUpdates);
 
-  /** Use only on the UI thread. */
-  void requestRenderForLayoutAnimations() {
-    if (layoutAnimationRenderRequested_) [[likely]] {
-      return;
-    }
-
-    layoutAnimationRenderRequested_ = true;
-    requestRender_([weakThis = weak_from_this()](double) {
-      if (auto strongThis = weakThis.lock()) {
-        strongThis->layoutAnimationRenderRequested_ = false;
-      }
-    });
-  }
-
 #if REACT_NATIVE_VERSION_MINOR >= 85
   std::shared_ptr<UIManagerAnimationBackend> getAnimationBackend();
   AnimationMutations runGrandCallback(AnimationTimestamp timestamp, GrandCallbackSource source);
@@ -279,8 +265,6 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   std::shared_ptr<ReanimatedMountHook> mountHook_;
   /// Access only on UI thread.
   std::set<SurfaceId> layoutAnimationFlushRequests_;
-  /// Access only on UI thread.
-  bool layoutAnimationRenderRequested_;
 
   const KeyboardEventSubscribeFunction subscribeForKeyboardEventsFunction_;
   const KeyboardEventUnsubscribeFunction unsubscribeFromKeyboardEventsFunction_;

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -52,8 +52,13 @@ function createLayoutAnimationManager(): {
 
   // Flush layout-animation progress once per frame via the frame finalizer
   // (after all `requestAnimationFrame` callbacks), reusing the same
-  // `_maybeFlushUIUpdatesQueue` path as animated-prop updates. The backend
-  // drives its own flush from `runGrandCallback`, so this is non-backend only.
+  // `_maybeFlushUIUpdatesQueue` path as animated-prop updates.
+  // This finalizer runs after the mapper run (which re-queues itself a frame
+  // ahead, so it sits earlier in the finalizer queue). When a mapper-driven
+  // animation is also active, its flush runs first and already commits the
+  // layout-animation updates too, so our `_maybeFlushUIUpdatesQueue` here is a
+  // no-op; when only layout animations run, this is the single flush.
+  // The backend drives its own flush from `runGrandCallback`, so this is non-backend only.
   let flushRequested = false;
   const scheduleFlush = () => {
     if (USE_ANIMATION_BACKEND || flushRequested) {

--- a/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
+++ b/packages/react-native-reanimated/src/layoutReanimation/animationsManager.ts
@@ -11,28 +11,35 @@ import type {
   SharedValue,
 } from '../commonTypes';
 import { LayoutAnimationType } from '../commonTypes';
+import { getStaticFeatureFlag } from '../featureFlags';
 import { makeMutableUI } from '../mutables';
 
 const TAG_OFFSET = 1e9;
 
+const USE_ANIMATION_BACKEND = getStaticFeatureFlag('USE_ANIMATION_BACKEND');
+
 function startObservingProgress(
   tag: number,
-  sharedValue: SharedValue<Record<string, unknown>>
+  sharedValue: SharedValue<Record<string, unknown>>,
+  scheduleFlush: () => void
 ): void {
   'worklet';
   sharedValue.addListener(tag + TAG_OFFSET, () => {
     global._notifyAboutProgress(tag, sharedValue.value);
+    scheduleFlush();
   });
 }
 
 function stopObservingProgress(
   tag: number,
   sharedValue: SharedValue<number>,
+  scheduleFlush: () => void,
   removeView = false
 ): void {
   'worklet';
   sharedValue.removeListener(tag + TAG_OFFSET);
   global._notifyAboutEnd(tag, removeView);
+  scheduleFlush();
 }
 
 function createLayoutAnimationManager(): {
@@ -42,6 +49,22 @@ function createLayoutAnimationManager(): {
   'worklet';
   const currentAnimationForTag = new Map();
   const mutableValuesForTag = new Map();
+
+  // Flush layout-animation progress once per frame via the frame finalizer
+  // (after all `requestAnimationFrame` callbacks), reusing the same
+  // `_maybeFlushUIUpdatesQueue` path as animated-prop updates. The backend
+  // drives its own flush from `runGrandCallback`, so this is non-backend only.
+  let flushRequested = false;
+  const scheduleFlush = () => {
+    if (USE_ANIMATION_BACKEND || flushRequested) {
+      return;
+    }
+    flushRequested = true;
+    globalThis.requestAnimationFrameFinalizer(() => {
+      flushRequested = false;
+      global._maybeFlushUIUpdatesQueue();
+    });
+  };
 
   return {
     start(
@@ -70,7 +93,7 @@ function createLayoutAnimationManager(): {
         value = makeMutableUI(style.initialValues);
         mutableValuesForTag.set(tag, value);
       } else {
-        stopObservingProgress(tag, value);
+        stopObservingProgress(tag, value, scheduleFlush);
         value._value = style.initialValues;
       }
 
@@ -81,14 +104,14 @@ function createLayoutAnimationManager(): {
           currentAnimationForTag.delete(tag);
           mutableValuesForTag.delete(tag);
           const shouldRemoveView = type === LayoutAnimationType.EXITING;
-          stopObservingProgress(tag, value, shouldRemoveView);
+          stopObservingProgress(tag, value, scheduleFlush, shouldRemoveView);
         }
         if (style.callback) {
           style.callback(finished === undefined ? false : finished);
         }
       };
 
-      startObservingProgress(tag, value);
+      startObservingProgress(tag, value, scheduleFlush);
       value.value = animation;
     },
     stop(tag: number) {
@@ -96,7 +119,7 @@ function createLayoutAnimationManager(): {
       if (!value) {
         return;
       }
-      stopObservingProgress(tag, value);
+      stopObservingProgress(tag, value, scheduleFlush);
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes #9591.

Layout animations (`entering` / `exiting` / `layout`) run at 30 FPS on iOS **Release** builds while staying smooth at 60 FPS in Debug. This is a regression from #9431.

On the non-backend path, every `progressLayoutAnimation` scheduled the commit through `requestRenderForLayoutAnimations()`, which posts a render request on `REANodesManager`'s display link, deduped by a single-in-flight flag (`layoutAnimationRenderRequested_`) that the commit clears.

The catch is that progress and the commit run on **two independent `CADisplayLink`s** — progress on the worklets `AnimationFrameQueue`, the commit (`performOperations`) on `REANodesManager` — and the two links are registered at different times, so their firing order within a frame isn't pinned. When the progress link fires first, it checks the flag before the commit has cleared it that frame, the render request is dropped, and the commit only runs every other frame → 30 FPS. Release happens to settle on progress-before-commit; Debug gets the opposite order and stays at 60 FPS. Android isn't affected because both frame sources go through a single `ReactChoreographer` callback queue.

Instead of that gated cross-display-link request, we now flush layout-animation progress the same way animated-prop updates already do: once per frame from the worklet runtime's `requestAnimationFrameFinalizer` (which runs after all `requestAnimationFrame` callbacks), calling `_maybeFlushUIUpdatesQueue`. That's independent of display-link ordering, so the commit lands every frame. This also lets us drop `requestRenderForLayoutAnimations` and the gate flag entirely. The animation-backend path already drives its own flush from `runGrandCallback`, so it's untouched — `progressLayoutAnimation` / `endLayoutAnimation` just record the surface in `layoutAnimationFlushRequests_`.

## Test plan

Run the example below on iOS in **Release** and hold the **Spam** button (it adds / removes / shuffles tiles on an interval, driving continuous `LinearTransition` layout animations). Before: the tiles step every other frame (30 FPS). After: smooth 60 FPS, matching Debug.

<details>
<summary>Example</summary>

```tsx
import React, { useEffect, useRef, useState } from 'react';
import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
import Animated, {
  LinearTransition,
  ZoomIn,
  ZoomOut,
} from 'react-native-reanimated';

const COLORS = [
  '#ef4444', '#f97316', '#f59e0b', '#eab308', '#84cc16', '#22c55e',
  '#10b981', '#14b8a6', '#06b6d4', '#0ea5e9', '#3b82f6', '#6366f1',
  '#8b5cf6', '#a855f7', '#d946ef', '#ec4899',
];

type Tile = { id: string; color: string };

let nextId = 0;
const makeTile = (): Tile => ({
  id: `t-${nextId++}`,
  color: COLORS[Math.floor(Math.random() * COLORS.length)],
});

const initialTiles = () => Array.from({ length: 100 }, makeTile);

export default function StressDemo() {
  const [tiles, setTiles] = useState<Tile[]>(initialTiles);
  const [spam, setSpam] = useState(false);
  const tickRef = useRef(0);

  const add = (n: number) =>
    setTiles((prev) => [...prev, ...Array.from({ length: n }, makeTile)]);
  const remove = (n: number) =>
    setTiles((prev) => prev.slice(0, Math.max(0, prev.length - n)));
  const shuffle = () =>
    setTiles((prev) => [...prev].sort(() => Math.random() - 0.5));
  const reset = () => setTiles(initialTiles());
  useEffect(() => {
    if (!spam) return;
    const id = setInterval(() => {
      const phase = tickRef.current++ % 3;
      if (phase === 0) add(20);
      else if (phase === 1) remove(20);
      else shuffle();
    }, 500);
    return () => clearInterval(id);
  }, [spam]);

  return (
    <View style={styles.container}>
      <View style={styles.toolbar}>
        <Pressable style={styles.button} onPress={() => add(20)}>
          <Text style={styles.buttonText}>+20</Text>
        </Pressable>
        <Pressable style={styles.button} onPress={() => remove(20)}>
          <Text style={styles.buttonText}>-20</Text>
        </Pressable>
        <Pressable style={styles.button} onPress={shuffle}>
          <Text style={styles.buttonText}>Shuffle</Text>
        </Pressable>
        <Pressable
          style={[styles.button, spam && styles.buttonActive]}
          onPress={() => setSpam((s) => !s)}>
          <Text style={styles.buttonText}>{spam ? 'Stop' : 'Spam'}</Text>
        </Pressable>
        <Pressable style={styles.button} onPress={reset}>
          <Text style={styles.buttonText}>Reset</Text>
        </Pressable>
      </View>

      <Text style={styles.count}>
        Tiles: {tiles.length} · ZoomIn / ZoomOut / LinearTransition
      </Text>

      <ScrollView contentContainerStyle={styles.grid}>
        {tiles.map((tile) => (
          <Animated.View
            key={tile.id}
            entering={ZoomIn.duration(250)}
            exiting={ZoomOut.duration(250)}
            layout={LinearTransition.duration(250)}
            style={[styles.tile, { backgroundColor: tile.color }]}
          />
        ))}
      </ScrollView>
    </View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1 },
  toolbar: {
    flexDirection: 'row',
    flexWrap: 'wrap',
    padding: 8,
    gap: 8,
    backgroundColor: '#f3f4f6',
  },
  button: {
    paddingHorizontal: 12,
    paddingVertical: 8,
    backgroundColor: '#1f2937',
    borderRadius: 6,
  },
  buttonActive: { backgroundColor: '#dc2626' },
  buttonText: { color: 'white', fontWeight: '600' },
  count: {
    paddingHorizontal: 12,
    paddingVertical: 4,
    fontWeight: '600',
    color: '#374151',
  },
  grid: {
    flexDirection: 'row',
    flexWrap: 'wrap',
    padding: 8,
    gap: 6,
  },
  tile: {
    width: 50,
    height: 50,
    borderRadius: 6,
  },
});
```

</details>
