### PR TITLE
fix: ruby scripts leaking functions to global scope

### DIFF
--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -2431,7 +2431,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 4f3a0dcbed0181cc62562e805469af3e0915e92e
+  hermes-engine: b9ba3bdab932355003a4fdbafdace38de5d32f16
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: 3163b5e55ecaa9a2c90088fc76f4f4d5ec0fb3d8
   NitroModules: 2d92eeea80a5afdebe7b4fd2443b5bd4d7ba1a44
@@ -2443,7 +2443,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 2affd5cd6bbc2adc7d8994e58c6875078e376ec0
+  React-Core-prebuilt: 4afad692310ce22151e50059a1f69f3e3ee76a44
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2505,7 +2505,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: 82d425a098bb7f62fe936a014c85c0112b8b9217
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: cd8112044e817d8f17b0459e8bd78a78f1d66adb
+  ReactNativeDependencies: bf23d446d8faae94284fcbb899aed45172038cd3
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec

--- a/apps/tvos-example/ios/Podfile.lock
+++ b/apps/tvos-example/ios/Podfile.lock
@@ -2169,7 +2169,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: d530cbf79a7670e8620cacb47d1804e66685f3c5
-  hermes-engine: 7d4a73d9165261d30bfdb715a8879c8192fe8400
+  hermes-engine: 0c1aeb3d8dbaa941429e48333418775dca0a931e
   RCTDeprecation: 40ab3b5cc410e721785f9f7a720f54332b23a83f
   RCTRequired: f43f0af2c182ffd928a63484083f9c6085be0cc3
   RCTSwiftUI: 259305c2d96dd73682562215eba9e1b30486cfe5
@@ -2178,7 +2178,7 @@ SPEC CHECKSUMS:
   React: e8b7bd0882e50d8e4d37f79c8b1ed99b464e8345
   React-callinvoker: d5690d217d7290d423416a8b2c98c20316e301ff
   React-Core: 4b7a3357649ca6d11b50e0d86683cb19677a43c9
-  React-Core-prebuilt: c52bf0a4d54651f8b097d6ad0c807b9785475048
+  React-Core-prebuilt: 2a759c8a20e608548d1811dee6fd251669991b68
   React-CoreModules: 81eefd4e15b21a862e56e5028dbdb693f253f8a4
   React-cxxreact: 3db9d82778f0fc639bca1342cb0c84617a55181c
   React-debug: b2870555dbee7129cf332c7ffaf80e9643a23afb
@@ -2240,7 +2240,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 96408f4be2ec6b31bcae9c3571b58d6bff9f7e4a
   ReactCodegen: 01efb0e862440b4a3e183301c4049638d5e4ac1d
   ReactCommon: 52f9c5c30dda0eb591550d5d1adb265176e1ecc8
-  ReactNativeDependencies: e4afd0921c87d336da03ac8efb01ce9ac1e7a117
+  ReactNativeDependencies: 4dac862dca5a90c6c27da84eea5cd713d16cc547
   RNReanimated: 6156e57bfa725fc262cb271d4e9a7b298de6e998
   RNWorklets: 33acdaa3156cac5f01a1cb90ba9bfd581352f36e
   Yoga: 861ef0ae75949f7330bfa80d9ce24250e963f66c

--- a/packages/react-native-reanimated/RNReanimated.podspec
+++ b/packages/react-native-reanimated/RNReanimated.podspec
@@ -2,11 +2,11 @@ require "json"
 require_relative './scripts/reanimated_utils'
 
 reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
-$config = find_config()
-assert_minimal_react_native_version($config)
+config = ReanimatedUtils.find_config()
+ReanimatedUtils.assert_minimal_react_native_version(config)
 
 boost_compiler_flags = '-Wno-documentation'
-example_flag = $config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
+example_flag = config[:is_reanimated_example_app] ? '-DIS_REANIMATED_EXAMPLE_APP' : ''
 reanimated_profiling_flag = ENV['IS_REANIMATED_PROFILING'] ? '-DREANIMATED_PROFILING' : ''
 version_flag = "-DREANIMATED_VERSION=#{reanimated_package_json['version']}"
 ios_min_version = '13.4'
@@ -14,9 +14,9 @@ ios_min_version = '13.4'
 # Directory in which data for further processing for clangd will be stored.
 compilation_metadata_dir = "CompilationDatabase"
 # We want generate the metadata only within the monorepo of Reanimated.
-compilation_metadata_generation_flag = $config[:is_reanimated_example_app] ? "-gen-cdb-fragment-path #{compilation_metadata_dir}" : ''
+compilation_metadata_generation_flag = config[:is_reanimated_example_app] ? "-gen-cdb-fragment-path #{compilation_metadata_dir}" : ''
 
-feature_flags = "-DREANIMATED_FEATURE_FLAGS=\"#{get_static_feature_flags()}\""
+feature_flags = "-DREANIMATED_FEATURE_FLAGS=\"#{ReanimatedUtils.get_static_feature_flags()}\""
 
 Pod::Spec.new do |s|
 
@@ -78,8 +78,8 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/Headers/Public/hermes-engine"',
       '"$(PODS_ROOT)/Headers/Public/RNWorklets"',
       # for static frameworks
-      "\"$(PODS_ROOT)/#{$config[:react_native_common_dir]}\"",
-      "\"$(PODS_ROOT)/#{$config[:react_native_common_dir]}/jsitooling\"",
+      "\"$(PODS_ROOT)/#{config[:react_native_common_dir]}\"",
+      "\"$(PODS_ROOT)/#{config[:react_native_common_dir]}/jsitooling\"",
     ].join(' '),
     "OTHER_CFLAGS" => "$(inherited) #{example_flag} #{version_flag} #{compilation_metadata_generation_flag} #{feature_flags} #{reanimated_profiling_flag}",
   }

--- a/packages/react-native-reanimated/scripts/reanimated_utils.rb
+++ b/packages/react-native-reanimated/scripts/reanimated_utils.rb
@@ -1,90 +1,94 @@
-def try_to_parse_react_native_package_json(node_modules_dir)
-  react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
-  if !File.exist?(react_native_package_json_path)
-    return nil
-  end
-  return JSON.parse(File.read(react_native_package_json_path))
-end
+module ReanimatedUtils
+  module_function
 
-def find_config()
-  result = {
-    :is_reanimated_example_app => nil,
-    :react_native_version => nil,
-    :react_native_node_modules_dir => nil,
-    :react_native_common_dir => nil,
-  }
-
-  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-  react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
-
-  if react_native_json == nil
-    # user configuration, just in case
-    node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-    react_native_json = try_to_parse_react_native_package_json(node_modules_dir)
+  def try_to_parse_react_native_package_json(node_modules_dir)
+    react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
+    if !File.exist?(react_native_package_json_path)
+      return nil
+    end
+    return JSON.parse(File.read(react_native_package_json_path))
   end
 
-  if react_native_json == nil
-    raise '[Reanimated] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
+  def find_config()
+    result = {
+      :is_reanimated_example_app => nil,
+      :react_native_version => nil,
+      :react_native_node_modules_dir => nil,
+      :react_native_common_dir => nil,
+    }
+
+    react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+    react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
+
+    if react_native_json == nil
+      # user configuration, just in case
+      node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
+      react_native_json = try_to_parse_react_native_package_json(node_modules_dir)
+    end
+
+    if react_native_json == nil
+      raise '[Reanimated] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
+    end
+
+    validate_worklets_script = File.expand_path(File.join(__dir__, 'validate-worklets-build.js'))
+    unless system("node \"#{validate_worklets_script}\"")
+      abort("[Reanimated] Failed to validate worklets version")
+    end
+
+
+    result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
+    result[:react_native_version] = react_native_json['version']
+    result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
+
+    pods_root = Pod::Config.instance.project_pods_root
+    react_native_common_dir_absolute = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')
+    react_native_common_dir_relative = Pathname.new(react_native_common_dir_absolute).relative_path_from(pods_root).to_s
+    result[:react_native_common_dir] = react_native_common_dir_relative
+
+    return result
   end
 
-  validate_worklets_script = File.expand_path(File.join(__dir__, 'validate-worklets-build.js'))
-  unless system("node \"#{validate_worklets_script}\"")
-    abort("[Reanimated] Failed to validate worklets version")
-  end
-
-
-  result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
-  result[:react_native_version] = react_native_json['version']
-  result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
-
-  pods_root = Pod::Config.instance.project_pods_root
-  react_native_common_dir_absolute = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')
-  react_native_common_dir_relative = Pathname.new(react_native_common_dir_absolute).relative_path_from(pods_root).to_s
-  result[:react_native_common_dir] = react_native_common_dir_relative
-
-  return result
-end
-
-def assert_minimal_react_native_version(config)
-  validate_react_native_version_script = File.expand_path(File.join(__dir__, 'validate-react-native-version.js'))
-  unless system("node \"#{validate_react_native_version_script}\" #{config[:react_native_version]}")
-    raise "[Reanimated] Your installed version of React Native is not compatible with installed version of Reanimated. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/"
-  end
-end
-
-def assert_conflicting_feature_flags(feature_flags)
-  ios_sync_ui_props = feature_flags['IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS'] == 'true'
-  shared_element_transitions = feature_flags['ENABLE_SHARED_ELEMENT_TRANSITIONS'] == 'true'
-
-  if ios_sync_ui_props && shared_element_transitions
-    raise "[Reanimated] The feature flags `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` and `ENABLE_SHARED_ELEMENT_TRANSITIONS` cannot be enabled simultaneously. Please disable one of them in your package.json"
-  end
-end
-
-def get_static_feature_flags()
-  feature_flags = {}
-
-  static_feature_flags_path = File.path('./src/featureFlags/staticFlags.json')
-  if !File.exist?(static_feature_flags_path)
-    raise "[Reanimated] Feature flags file not found at #{static_feature_flags_path}."
-  end
-  static_feature_flags_json = JSON.parse(File.read(static_feature_flags_path))
-  static_feature_flags_json.each do |key, value|
-    feature_flags[key] = value.to_s
-  end
-
-  package_json_path = File.join(Pod::Config.instance.installation_root.to_s, '..', 'package.json')
-  if File.exist?(package_json_path)
-    package_json = JSON.parse(File.read(package_json_path))
-    if package_json['reanimated'] && package_json['reanimated']['staticFeatureFlags']
-      feature_flags_json = package_json['reanimated']['staticFeatureFlags']
-      feature_flags_json.each do |key, value|
-        feature_flags[key] = value.to_s
-      end
+  def assert_minimal_react_native_version(config)
+    validate_react_native_version_script = File.expand_path(File.join(__dir__, 'validate-react-native-version.js'))
+    unless system("node \"#{validate_react_native_version_script}\" #{config[:react_native_version]}")
+      raise "[Reanimated] Your installed version of React Native is not compatible with installed version of Reanimated. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/"
     end
   end
 
-  assert_conflicting_feature_flags(feature_flags)
+  def assert_conflicting_feature_flags(feature_flags)
+    ios_sync_ui_props = feature_flags['IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS'] == 'true'
+    shared_element_transitions = feature_flags['ENABLE_SHARED_ELEMENT_TRANSITIONS'] == 'true'
 
-  return feature_flags.map { |key, value| "[#{key}:#{value}]" }.join('')
+    if ios_sync_ui_props && shared_element_transitions
+      raise "[Reanimated] The feature flags `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS` and `ENABLE_SHARED_ELEMENT_TRANSITIONS` cannot be enabled simultaneously. Please disable one of them in your package.json"
+    end
+  end
+
+  def get_static_feature_flags()
+    feature_flags = {}
+
+    static_feature_flags_path = File.path('./src/featureFlags/staticFlags.json')
+    if !File.exist?(static_feature_flags_path)
+      raise "[Reanimated] Feature flags file not found at #{static_feature_flags_path}."
+    end
+    static_feature_flags_json = JSON.parse(File.read(static_feature_flags_path))
+    static_feature_flags_json.each do |key, value|
+      feature_flags[key] = value.to_s
+    end
+
+    package_json_path = File.join(Pod::Config.instance.installation_root.to_s, '..', 'package.json')
+    if File.exist?(package_json_path)
+      package_json = JSON.parse(File.read(package_json_path))
+      if package_json['reanimated'] && package_json['reanimated']['staticFeatureFlags']
+        feature_flags_json = package_json['reanimated']['staticFeatureFlags']
+        feature_flags_json.each do |key, value|
+          feature_flags[key] = value.to_s
+        end
+      end
+    end
+
+    assert_conflicting_feature_flags(feature_flags)
+
+    return feature_flags.map { |key, value| "[#{key}:#{value}]" }.join('')
+  end
 end

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -2,21 +2,21 @@ require "json"
 require_relative './scripts/worklets_utils'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-$worklets_config = worklets_find_config()
-worklets_assert_minimal_react_native_version($worklets_config)
+worklets_config = WorkletsUtils.find_config()
+WorkletsUtils.assert_minimal_react_native_version(worklets_config)
 
 ios_min_version = '13.4'
 
 # Directory in which data for further processing for clangd will be stored.
 compilation_metadata_dir = "CompilationDatabase"
 # We want generate the metadata only within the monorepo of Reanimated.
-compilation_metadata_generation_flag = $worklets_config[:is_reanimated_example_app] ? "-gen-cdb-fragment-path #{compilation_metadata_dir}" : ''
+compilation_metadata_generation_flag = worklets_config[:is_reanimated_example_app] ? "-gen-cdb-fragment-path #{compilation_metadata_dir}" : ''
 
 
-feature_flags = $worklets_config[:feature_flags_flag]
+feature_flags = worklets_config[:feature_flags_flag]
 version_flag = "-DWORKLETS_VERSION=#{package['version']}"
 worklets_profiling_flag = ENV['IS_WORKLETS_PROFILING'] ? '-DWORKLETS_PROFILING' : ''
-fetch_preview_flag = $worklets_config[:fetch_preview_flag]
+fetch_preview_flag = worklets_config[:fetch_preview_flag]
 hermes_v1_flag = ENV['RCT_HERMES_V1_ENABLED'] == '1' ? '-DHERMES_V1_ENABLED' : ''
 
 # React Native doesn't expose these flags, but not having them
@@ -86,8 +86,8 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/Headers/Public/React-hermes"',
       '"$(PODS_ROOT)/Headers/Public/hermes-engine"',
       # for static frameworks
-      "\"$(PODS_ROOT)/#{$worklets_config[:react_native_common_dir]}\"",
-      "\"$(PODS_ROOT)/#{$worklets_config[:react_native_common_dir]}/jsitooling\"",
+      "\"$(PODS_ROOT)/#{worklets_config[:react_native_common_dir]}\"",
+      "\"$(PODS_ROOT)/#{worklets_config[:react_native_common_dir]}/jsitooling\"",
     ].join(' '),
   }
   

--- a/packages/react-native-worklets/scripts/worklets_utils.rb
+++ b/packages/react-native-worklets/scripts/worklets_utils.rb
@@ -1,90 +1,94 @@
-def worklets_try_to_parse_react_native_package_json(node_modules_dir)
-  react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
-  if !File.exist?(react_native_package_json_path)
-    return nil
-  end
-  return JSON.parse(File.read(react_native_package_json_path))
-end
+module WorkletsUtils
+  module_function
 
-def worklets_find_config()
-  result = {
-    :feature_flags_flag => nil,
-    :fetch_preview_flag => nil,
-    :is_reanimated_example_app => nil,
-    :react_native_version => nil,
-    :react_native_node_modules_dir => nil,
-    :react_native_common_dir => nil,
-  }
-
-  react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-  react_native_json = worklets_try_to_parse_react_native_package_json(react_native_node_modules_dir)
-
-  if react_native_json == nil
-    # user configuration, just in case
-    node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-    react_native_json = worklets_try_to_parse_react_native_package_json(node_modules_dir)
+  def try_to_parse_react_native_package_json(node_modules_dir)
+    react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
+    if !File.exist?(react_native_package_json_path)
+      return nil
+    end
+    return JSON.parse(File.read(react_native_package_json_path))
   end
 
-  if react_native_json == nil
-    raise '[Worklets] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
+  def find_config()
+    result = {
+      :feature_flags_flag => nil,
+      :fetch_preview_flag => nil,
+      :is_reanimated_example_app => nil,
+      :react_native_version => nil,
+      :react_native_node_modules_dir => nil,
+      :react_native_common_dir => nil,
+    }
+
+    react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+    react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
+
+    if react_native_json == nil
+      # user configuration, just in case
+      node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
+      react_native_json = try_to_parse_react_native_package_json(node_modules_dir)
+    end
+
+    if react_native_json == nil
+      raise '[Worklets] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
+    end
+
+    result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
+    result[:react_native_version] = react_native_json['version']
+    result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
+
+    pods_root = Pod::Config.instance.project_pods_root
+    react_native_common_dir_absolute = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')
+    react_native_common_dir_relative = Pathname.new(react_native_common_dir_absolute).relative_path_from(pods_root).to_s
+    result[:react_native_common_dir] = react_native_common_dir_relative
+
+    feature_flags = get_static_feature_flags()
+    result[:feature_flags_flag] = get_static_feature_flags_flag(feature_flags)
+    result[:fetch_preview_flag] = get_flag_from_feature_flags(feature_flags, 'FETCH_PREVIEW_ENABLED')
+
+    return result
   end
 
-  result[:is_reanimated_example_app] = ENV["IS_REANIMATED_EXAMPLE_APP"] != nil
-  result[:react_native_version] = react_native_json['version']
-  result[:react_native_node_modules_dir] = File.expand_path(react_native_node_modules_dir)
-
-  pods_root = Pod::Config.instance.project_pods_root
-  react_native_common_dir_absolute = File.join(react_native_node_modules_dir, 'react-native', 'ReactCommon')
-  react_native_common_dir_relative = Pathname.new(react_native_common_dir_absolute).relative_path_from(pods_root).to_s
-  result[:react_native_common_dir] = react_native_common_dir_relative
-
-  feature_flags = worklets_get_static_feature_flags()
-  result[:feature_flags_flag] = worklets_get_static_feature_flags_flag(feature_flags)
-  result[:fetch_preview_flag] = worklets_get_flag_from_feature_flags(feature_flags, 'FETCH_PREVIEW_ENABLED')
-  
-  return result
-end
-
-def worklets_assert_minimal_react_native_version(config)
-  validate_react_native_version_script = File.expand_path(File.join(__dir__, 'validate-react-native-version.js'))
-  unless system("node \"#{validate_react_native_version_script}\" #{config[:react_native_version]}")
-    raise "[Worklets] Your installed version of React Native is not compatible with installed version of Worklets. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-worklets/docs/guides/compatibility/"
-  end
-end
-
-def worklets_get_flag_from_feature_flags(feature_flags, flag_name)
-  if feature_flags[flag_name] == 'true'
-    return "-DWORKLETS_#{flag_name}"
-  else
-    return ''
-  end
-end
-
-def worklets_get_static_feature_flags()
-  feature_flags = {}
-
-  static_feature_flags_path = File.path('./src/featureFlags/staticFlags.json')
-  if !File.exist?(static_feature_flags_path)
-    raise "[Worklets] Feature flags file not found at #{static_feature_flags_path}."
-  end
-  static_feature_flags_json = JSON.parse(File.read(static_feature_flags_path))
-  static_feature_flags_json.each do |key, value|
-    feature_flags[key] = value.to_s
-  end
-
-  package_json_path = File.join(Pod::Config.instance.installation_root.to_s, '..', 'package.json')
-  if File.exist?(package_json_path)
-    package_json = JSON.parse(File.read(package_json_path))
-    if package_json['worklets'] && package_json['worklets']['staticFeatureFlags']
-      feature_flags_json = package_json['worklets']['staticFeatureFlags']
-      feature_flags_json.each do |key, value|
-        feature_flags[key] = value.to_s
-      end
+  def assert_minimal_react_native_version(config)
+    validate_react_native_version_script = File.expand_path(File.join(__dir__, 'validate-react-native-version.js'))
+    unless system("node \"#{validate_react_native_version_script}\" #{config[:react_native_version]}")
+      raise "[Worklets] Your installed version of React Native is not compatible with installed version of Worklets. See the documentation for the list of supported versions: https://docs.swmansion.com/react-native-worklets/docs/guides/compatibility/"
     end
   end
-  return feature_flags
-end
 
-def worklets_get_static_feature_flags_flag(feature_flags)
-  return "-DWORKLETS_FEATURE_FLAGS=\"#{feature_flags.map { |key, value| "[#{key}:#{value}]" }.join('')}\""
+  def get_flag_from_feature_flags(feature_flags, flag_name)
+    if feature_flags[flag_name] == 'true'
+      return "-DWORKLETS_#{flag_name}"
+    else
+      return ''
+    end
+  end
+
+  def get_static_feature_flags()
+    feature_flags = {}
+
+    static_feature_flags_path = File.path('./src/featureFlags/staticFlags.json')
+    if !File.exist?(static_feature_flags_path)
+      raise "[Worklets] Feature flags file not found at #{static_feature_flags_path}."
+    end
+    static_feature_flags_json = JSON.parse(File.read(static_feature_flags_path))
+    static_feature_flags_json.each do |key, value|
+      feature_flags[key] = value.to_s
+    end
+
+    package_json_path = File.join(Pod::Config.instance.installation_root.to_s, '..', 'package.json')
+    if File.exist?(package_json_path)
+      package_json = JSON.parse(File.read(package_json_path))
+      if package_json['worklets'] && package_json['worklets']['staticFeatureFlags']
+        feature_flags_json = package_json['worklets']['staticFeatureFlags']
+        feature_flags_json.each do |key, value|
+          feature_flags[key] = value.to_s
+        end
+      end
+    end
+    return feature_flags
+  end
+
+  def get_static_feature_flags_flag(feature_flags)
+    return "-DWORKLETS_FEATURE_FLAGS=\"#{feature_flags.map { |key, value| "[#{key}:#{value}]" }.join('')}\""
+  end
 end


### PR DESCRIPTION
## Summary

I fixed Ruby-level leaks in the worklets and reanimated podspecs so they no longer shadowed methods and variables in other podspecs evaluated during the same pod install run.

The utils files defined top-level defs, which became private methods on Object, and $config / $worklets_config were unnecessary globals. I wrapped the helpers in WorkletsUtils / ReanimatedUtils modules and dropped both configs to locals.

i.e. it fixes a conflict with RNGH which used global scope functions as well: https://github.com/software-mansion/react-native-reanimated/actions/runs/26872525645/job/79251191313?pr=9592

## Test plan

`yarn build-apps`
