### PR TITLE
fix(Worklets): multiple passes for generated worklet files

### DIFF
--- a/.github/workflows/babel-plugin-static-check.yml
+++ b/.github/workflows/babel-plugin-static-check.yml
@@ -4,8 +4,8 @@ env:
 on:
   pull_request:
     paths:
-      - ".github/workflows/babel-plugin-static-check.yml"
-      - "packages/react-native-worklets/plugin/**"
+      - '.github/workflows/babel-plugin-static-check.yml'
+      - 'packages/react-native-worklets/plugin/**'
   merge_group:
     branches:
       - main
@@ -13,8 +13,8 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/babel-plugin-static-check.yml"
-      - "packages/react-native-worklets/plugin/**"
+      - '.github/workflows/babel-plugin-static-check.yml'
+      - 'packages/react-native-worklets/plugin/**'
   workflow_call:
   workflow_dispatch:
 
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             bundle_output: /dev/null
           - os: windows-latest
-            bundle_output: "NUL"
+            bundle_output: 'NUL'
     runs-on: ${{ matrix.os }}
     concurrency:
       group: babel-plugin-static-check-${{ matrix.os }}-${{ github.ref }}
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: "yarn"
+          cache: 'yarn'
       - name: Clear annotations
         shell: bash
         run: .github/workflows/helper/clear-annotations.sh

--- a/.github/workflows/babel-plugin-static-check.yml
+++ b/.github/workflows/babel-plugin-static-check.yml
@@ -4,8 +4,8 @@ env:
 on:
   pull_request:
     paths:
-      - '.github/workflows/babel-plugin-static-check.yml'
-      - 'packages/react-native-worklets/plugin/**'
+      - ".github/workflows/babel-plugin-static-check.yml"
+      - "packages/react-native-worklets/plugin/**"
   merge_group:
     branches:
       - main
@@ -13,17 +13,25 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/babel-plugin-static-check.yml'
-      - 'packages/react-native-worklets/plugin/**'
+      - ".github/workflows/babel-plugin-static-check.yml"
+      - "packages/react-native-worklets/plugin/**"
   workflow_call:
   workflow_dispatch:
 
 jobs:
   babel-plugin-static-check:
     if: github.repository == 'software-mansion/react-native-reanimated'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            bundle_output: /dev/null
+          - os: windows-latest
+            bundle_output: "NUL"
+    runs-on: ${{ matrix.os }}
     concurrency:
-      group: babel-plugin-static-check-${{ github.ref }}
+      group: babel-plugin-static-check-${{ matrix.os }}-${{ github.ref }}
       cancel-in-progress: true
     env:
       EXAMPLE_DIR: apps/fabric-example
@@ -35,33 +43,40 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          cache: 'yarn'
+          cache: "yarn"
       - name: Clear annotations
+        shell: bash
         run: .github/workflows/helper/clear-annotations.sh
 
       - name: Install monorepo dependencies
         run: yarn install --immutable
       - name: Build Worklets
+        if: matrix.os != 'windows-latest'
         working-directory: ${{ env.WORKLETS_DIR }}
         run: yarn build
 
       - name: Diff
         id: diff
+        if: matrix.os != 'windows-latest'
         run: git update-index --refresh && git diff-index --quiet HEAD --
       - name: Show diff
         if: failure() && steps.diff.outcome == 'failure'
         run: git diff
       - name: Check types
+        if: matrix.os != 'windows-latest'
         working-directory: ${{ env.PLUGIN_DIR }}
         run: yarn type:check
       - name: Lint and format
+        if: matrix.os != 'windows-latest'
         working-directory: ${{ env.PLUGIN_DIR }}
         run: yarn lint
-      - name: Test
+
+      - name: Unit tests
         working-directory: ${{ env.WORKLETS_DIR }}
         run: yarn jest plugin
       - name: Check Example App bundling
+        shell: bash
         working-directory: ${{ env.EXAMPLE_DIR }}
-        run: |
-          yarn workspace react-native-reanimated build
-          yarn react-native bundle --reset-cache --entry-file='App.tsx' --bundle-output='/dev/null' --dev=true --platform='ios'
+        run:
+          yarn react-native bundle --reset-cache --entry-file='App.tsx' --bundle-output='${{ matrix.bundle_output }}'
+          --dev=true --platform=android

--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -370,4 +370,24 @@ describe('babel plugin in bundleMode', () => {
       expect(code).toContain(REQUIRE_PREFIX);
     });
   });
+
+  describe('bail-out on already-generated worklet files', () => {
+    test('does not re-process a file inside the .worklets directory', () => {
+      const generatedFilename = path.join(
+        path.dirname(require.resolve('react-native-worklets/package.json')),
+        '.worklets',
+        '12345.js'
+      );
+      const input = html`<script>
+        function foo() {
+          'worklet';
+          var x = 1;
+        }
+      </script>`;
+
+      const { code, files } = runPlugin(input, {}, {}, generatedFilename);
+      expect(files).toHaveLength(0);
+      expect(code).not.toContain(REQUIRE_PREFIX);
+    });
+  });
 });

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -405,11 +405,17 @@ var require_utils = __commonJS({
 var require_globals = __commonJS({
   "lib/globals.js"(exports2) {
     "use strict";
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.globals = exports2.defaultGlobals = void 0;
     exports2.initializeState = initializeState;
+    exports2.isGeneratedWorkletFile = isGeneratedWorkletFile;
     exports2.initializeGlobals = initializeGlobals;
     exports2.addCustomGlobals = addCustomGlobals;
+    var path_1 = __importDefault(require("path"));
+    var types_12 = require_types();
     var notCapturedIdentifiers = [
       // Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
       // Note that objects' properties don't need to be listed since we always only capture the whole object,
@@ -526,12 +532,23 @@ var require_globals = __commonJS({
       "_WORKLET"
     ];
     function initializeState(state) {
+      state.skipFile = isGeneratedWorkletFile(state.file.opts.filename);
+      if (state.skipFile) {
+        return;
+      }
       state.workletNumber = 1;
       state.classesToWorkletize = [];
       if (!state.opts.strictGlobal) {
         initializeGlobals();
         addCustomGlobals(state);
       }
+    }
+    function isGeneratedWorkletFile(filename) {
+      if (!filename) {
+        return false;
+      }
+      const generatedWorkletsDirPath = path_1.default.join("react-native-worklets", types_12.generatedWorkletsDir);
+      return filename.includes(generatedWorkletsDirPath);
     }
     exports2.defaultGlobals = new Set(notCapturedIdentifiers);
     function initializeGlobals() {
@@ -1884,7 +1901,10 @@ var types_1 = require_types();
 var webOptimization_1 = require_webOptimization();
 var workletSubstitution_1 = require_workletSubstitution();
 module.exports = function WorkletsBabelPlugin() {
-  function runWithTaggedExceptions(fun) {
+  function runWithTaggedExceptions(state, fun) {
+    if (state.skipFile) {
+      return;
+    }
     try {
       fun();
     } catch (e) {
@@ -1897,14 +1917,14 @@ module.exports = function WorkletsBabelPlugin() {
   return {
     name: "worklets",
     pre() {
-      runWithTaggedExceptions(() => {
+      runWithTaggedExceptions(this, () => {
         (0, globals_1.initializeState)(this);
       });
     },
     visitor: {
       CallExpression: {
         enter(path, state) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             (0, autoworkletization_1.processCalleesAutoworkletizableCallbacks)(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               (0, webOptimization_1.substituteWebCallExpression)(path);
@@ -1914,19 +1934,19 @@ module.exports = function WorkletsBabelPlugin() {
       },
       [types_1.WorkletizableFunction]: {
         enter(path, state) {
-          runWithTaggedExceptions(() => (0, workletSubstitution_1.processIfWithWorkletDirective)(path, state) || (0, autoworkletization_1.processIfAutoworkletizableCallback)(path, state));
+          runWithTaggedExceptions(state, () => (0, workletSubstitution_1.processIfWithWorkletDirective)(path, state) || (0, autoworkletization_1.processIfAutoworkletizableCallback)(path, state));
         }
       },
       ObjectExpression: {
         enter(path, state) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             (0, contextObject_1.processIfWorkletContextObject)(path, state);
           });
         }
       },
       ClassDeclaration: {
         enter(path, state) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             if (state.opts.disableWorkletClasses) {
               return;
             }
@@ -1936,21 +1956,21 @@ module.exports = function WorkletsBabelPlugin() {
       },
       Program: {
         enter(path, state) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             (0, file_1.processIfWorkletFile)(path, state);
           });
         }
       },
       ExpressionStatement: {
         enter(path, state) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             (0, bundleMode_1.toggleBundleMode)(path, state);
           });
         }
       },
       JSXAttribute: {
         enter(path, state) {
-          runWithTaggedExceptions(() => (0, inlineStylesWarning_1.processInlineStylesWarning)(path, state));
+          runWithTaggedExceptions(state, () => (0, inlineStylesWarning_1.processInlineStylesWarning)(path, state));
         }
       }
     }

--- a/packages/react-native-worklets/plugin/src/globals.ts
+++ b/packages/react-native-worklets/plugin/src/globals.ts
@@ -1,4 +1,6 @@
-import type { WorkletsPluginPass } from './types';
+import path from 'path';
+
+import { generatedWorkletsDir, type WorkletsPluginPass } from './types';
 
 const notCapturedIdentifiers = [
   // Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
@@ -134,12 +136,29 @@ const notCapturedIdentifiers = [
 ];
 
 export function initializeState(state: WorkletsPluginPass) {
+  state.skipFile = isGeneratedWorkletFile(state.file.opts.filename);
+  if (state.skipFile) {
+    return;
+  }
   state.workletNumber = 1;
   state.classesToWorkletize = [];
   if (!state.opts.strictGlobal) {
     initializeGlobals();
     addCustomGlobals(state);
   }
+}
+
+export function isGeneratedWorkletFile(
+  filename: string | undefined | null
+): boolean {
+  if (!filename) {
+    return false;
+  }
+  const generatedWorkletsDirPath = path.join(
+    'react-native-worklets',
+    generatedWorkletsDir
+  );
+  return filename.includes(generatedWorkletsDirPath);
 }
 
 export const defaultGlobals = new Set(notCapturedIdentifiers);

--- a/packages/react-native-worklets/plugin/src/plugin.ts
+++ b/packages/react-native-worklets/plugin/src/plugin.ts
@@ -24,7 +24,10 @@ import { substituteWebCallExpression } from './webOptimization';
 import { processIfWithWorkletDirective } from './workletSubstitution';
 
 module.exports = function WorkletsBabelPlugin(): PluginItem {
-  function runWithTaggedExceptions(fun: () => void) {
+  function runWithTaggedExceptions(state: WorkletsPluginPass, fun: () => void) {
+    if (state.skipFile) {
+      return;
+    }
     try {
       fun();
     } catch (e) {
@@ -39,14 +42,14 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
     name: 'worklets',
 
     pre(this: WorkletsPluginPass) {
-      runWithTaggedExceptions(() => {
+      runWithTaggedExceptions(this, () => {
         initializeState(this);
       });
     },
     visitor: {
       CallExpression: {
         enter(path: NodePath<CallExpression>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             processCalleesAutoworkletizableCallbacks(path, state);
             if (state.opts.substituteWebPlatformChecks) {
               substituteWebCallExpression(path);
@@ -60,6 +63,7 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
           state: WorkletsPluginPass
         ) {
           runWithTaggedExceptions(
+            state,
             () =>
               processIfWithWorkletDirective(path, state) ||
               processIfAutoworkletizableCallback(path, state)
@@ -68,14 +72,14 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
       },
       ObjectExpression: {
         enter(path: NodePath<ObjectExpression>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             processIfWorkletContextObject(path, state);
           });
         },
       },
       ClassDeclaration: {
         enter(path: NodePath<ClassDeclaration>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             if (state.opts.disableWorkletClasses) {
               return;
             }
@@ -85,21 +89,21 @@ module.exports = function WorkletsBabelPlugin(): PluginItem {
       },
       Program: {
         enter(path: NodePath<Program>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             processIfWorkletFile(path, state);
           });
         },
       },
       ExpressionStatement: {
         enter(path: NodePath<ExpressionStatement>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() => {
+          runWithTaggedExceptions(state, () => {
             toggleBundleMode(path, state);
           });
         },
       },
       JSXAttribute: {
         enter(path: NodePath<JSXAttribute>, state: WorkletsPluginPass) {
-          runWithTaggedExceptions(() =>
+          runWithTaggedExceptions(state, () =>
             processInlineStylesWarning(path, state)
           );
         },

--- a/packages/react-native-worklets/plugin/src/types.ts
+++ b/packages/react-native-worklets/plugin/src/types.ts
@@ -25,6 +25,7 @@ export interface WorkletsPluginPass {
   filename: string | undefined;
   workletNumber: number;
   classesToWorkletize: { node: BabelNode; name: string }[];
+  skipFile: boolean;
 }
 
 export type WorkletizableFunction =


### PR DESCRIPTION
## Summary

Fixes #9214.

In some cases in Bundle Mode Worklets Babel plugin would perform additional transforms on an already generated file, leading to undefined behavior. This PR makes it so we bail-out on generated files.

## Test plan

I added new tests.
