### PR TITLE
fix: prevent exiting views from getting stuck under heavy load on Android

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
@@ -1,0 +1,365 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  getStaticFeatureFlag,
+  ZoomIn,
+  ZoomOut,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+const SPIKE_COUNT = 60;
+const SPIKE_INTERVAL_MS = 700;
+const ITEM_LOOP_INTERVAL_MS = 40;
+const ITEM_VISIBLE_MS = 100;
+const ITEM_COUNT = 12;
+
+const COLORS = [
+  '#FF6B6B',
+  '#FFD93D',
+  '#6BCB77',
+  '#4D96FF',
+  '#C77DFF',
+  '#FF9F45',
+  '#00C9A7',
+  '#F72585',
+  '#4CC9F0',
+  '#7209B7',
+];
+
+function SpikeNode({ index, onDone }: { index: number; onDone: () => void }) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withRepeat(
+      withTiming(1, { duration: 200 + (index % 8) * 50 }),
+      -1,
+      true
+    );
+
+    const timeout = setTimeout(onDone, 32);
+    return () => clearTimeout(timeout);
+  }, [index, onDone, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: 0.15 + progress.value * 0.1,
+    transform: [{ scale: 0.95 + progress.value * 0.1 }],
+  }));
+
+  return <Animated.View style={[styles.stressNode, animatedStyle]} />;
+}
+
+export default function ExitingTagReuseStressExample() {
+  const sharedElementTransitionsEnabled = getStaticFeatureFlag(
+    'ENABLE_SHARED_ELEMENT_TRANSITIONS'
+  );
+  const [visibleIds, setVisibleIds] = useState<Set<number>>(() => new Set());
+  const [spikeIds, setSpikeIds] = useState<number[]>([]);
+  const [running, setRunning] = useState(true);
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const cursorRef = useRef(0);
+  const spikeCounterRef = useRef(0);
+  const itemIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const spikeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null
+  );
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const mountNext = useCallback(() => {
+    const id = cursorRef.current;
+    cursorRef.current = (cursorRef.current + 1) % ITEM_COUNT;
+
+    setVisibleIds((prev) => new Set(prev).add(id));
+
+    const timeout = setTimeout(() => {
+      setVisibleIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      timeoutsRef.current = timeoutsRef.current.filter((t) => t !== timeout);
+    }, ITEM_VISIBLE_MS);
+
+    timeoutsRef.current.push(timeout);
+  }, []);
+
+  const fireSpike = useCallback(() => {
+    const ids = Array.from(
+      { length: SPIKE_COUNT },
+      () => spikeCounterRef.current++
+    );
+    setSpikeIds((prev) => [...prev, ...ids]);
+    setCountdown(SPIKE_INTERVAL_MS / 1000);
+  }, []);
+
+  const removeSpikeId = useCallback((id: number) => {
+    setSpikeIds((prev) => prev.filter((value) => value !== id));
+  }, []);
+
+  useEffect(() => {
+    if (!running) {
+      if (itemIntervalRef.current) {
+        clearInterval(itemIntervalRef.current);
+        itemIntervalRef.current = null;
+      }
+
+      setVisibleIds(new Set());
+      return;
+    }
+
+    itemIntervalRef.current = setInterval(mountNext, ITEM_LOOP_INTERVAL_MS);
+
+    return () => {
+      if (itemIntervalRef.current) {
+        clearInterval(itemIntervalRef.current);
+        itemIntervalRef.current = null;
+      }
+    };
+  }, [mountNext, running]);
+
+  useEffect(() => {
+    if (!running) {
+      if (spikeIntervalRef.current) {
+        clearInterval(spikeIntervalRef.current);
+        spikeIntervalRef.current = null;
+      }
+
+      if (countdownIntervalRef.current) {
+        clearInterval(countdownIntervalRef.current);
+        countdownIntervalRef.current = null;
+      }
+
+      setCountdown(null);
+      setSpikeIds([]);
+      return;
+    }
+
+    setCountdown(SPIKE_INTERVAL_MS / 1000);
+    spikeIntervalRef.current = setInterval(fireSpike, SPIKE_INTERVAL_MS);
+    countdownIntervalRef.current = setInterval(() => {
+      setCountdown((value) =>
+        value !== null && value > 1 ? value - 1 : SPIKE_INTERVAL_MS / 1000
+      );
+    }, 1000);
+
+    return () => {
+      if (spikeIntervalRef.current) {
+        clearInterval(spikeIntervalRef.current);
+        spikeIntervalRef.current = null;
+      }
+
+      if (countdownIntervalRef.current) {
+        clearInterval(countdownIntervalRef.current);
+        countdownIntervalRef.current = null;
+      }
+    };
+  }, [fireSpike, running]);
+
+  useEffect(() => {
+    return () => {
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  return (
+    <View style={styles.root}>
+      <View pointerEvents="none" style={styles.stressContainer}>
+        {spikeIds.map((id) => (
+          <SpikeNode index={id} key={id} onDone={() => removeSpikeId(id)} />
+        ))}
+      </View>
+
+      <View style={styles.header}>
+        <Text style={styles.title}>Exiting Tag Reuse Stress Test</Text>
+        <Text style={styles.hint}>
+          Reuses the same tags under heavy entering/exiting churn to catch stale
+          cleanup bugs.
+        </Text>
+        <Text style={styles.debugLine}>
+          JS flag ENABLE_SHARED_ELEMENT_TRANSITIONS ={' '}
+          {String(sharedElementTransitionsEnabled)}
+        </Text>
+      </View>
+
+      <View style={styles.controls}>
+        <Pressable
+          disabled={running}
+          onPress={() => setRunning(true)}
+          style={[
+            styles.button,
+            styles.startButton,
+            running && styles.disabled,
+          ]}>
+          <Text style={styles.buttonText}>Start</Text>
+        </Pressable>
+        <Pressable
+          disabled={!running}
+          onPress={() => setRunning(false)}
+          style={[
+            styles.button,
+            styles.stopButton,
+            !running && styles.disabled,
+          ]}>
+          <Text style={styles.buttonText}>Stop</Text>
+        </Pressable>
+      </View>
+
+      <Text style={styles.spikeLabel}>
+        {countdown === null ? 'Stopped' : `Next spike in ${countdown}s`}
+      </Text>
+
+      <ScrollView contentContainerStyle={styles.grid}>
+        {Array.from({ length: ITEM_COUNT }, (_, index) => {
+          const isVisible = visibleIds.has(index);
+
+          return (
+            <View key={index} style={styles.slot}>
+              <View style={styles.slotPlaceholder}>
+                <Text style={styles.slotIndex}>{index}</Text>
+              </View>
+              {isVisible && (
+                <Animated.View
+                  entering={ZoomIn}
+                  exiting={ZoomOut}
+                  style={[
+                    styles.itemFill,
+                    { backgroundColor: COLORS[index % COLORS.length] },
+                  ]}>
+                  <Text style={styles.itemText}>{index}</Text>
+                </Animated.View>
+              )}
+            </View>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#000',
+    paddingTop: 60,
+  },
+  stressContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    overflow: 'hidden',
+  },
+  stressNode: {
+    width: 4,
+    height: 4,
+    backgroundColor: '#fff',
+  },
+  header: {
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  hint: {
+    color: '#ff9f45',
+    fontSize: 12,
+  },
+  debugLine: {
+    color: '#8fd3ff',
+    fontSize: 12,
+    marginTop: 6,
+  },
+  controls: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  button: {
+    height: 52,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  startButton: {
+    backgroundColor: '#6BCB77',
+  },
+  stopButton: {
+    backgroundColor: '#FF6B6B',
+  },
+  disabled: {
+    opacity: 0.35,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  spikeLabel: {
+    color: '#ffd93d',
+    fontSize: 13,
+    fontWeight: '600',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingBottom: 40,
+  },
+  slot: {
+    width: 64,
+    height: 64,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  slotPlaceholder: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#333',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 0,
+  },
+  slotIndex: {
+    color: '#444',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  itemFill: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  itemText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
@@ -58,14 +58,10 @@ export default function ExitingTagReuseStressExample() {
   const [visibleIds, setVisibleIds] = useState<Set<number>>(() => new Set());
   const [spikeIds, setSpikeIds] = useState<number[]>([]);
   const [running, setRunning] = useState(true);
-  const [countdown, setCountdown] = useState<number | null>(null);
   const cursorRef = useRef(0);
   const spikeCounterRef = useRef(0);
   const itemIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const spikeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
-    null
-  );
   const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const mountNext = useCallback(() => {
@@ -92,7 +88,6 @@ export default function ExitingTagReuseStressExample() {
       () => spikeCounterRef.current++
     );
     setSpikeIds((prev) => [...prev, ...ids]);
-    setCountdown(SPIKE_INTERVAL_MS / 1000);
   }, []);
 
   const removeSpikeId = useCallback((id: number) => {
@@ -127,33 +122,16 @@ export default function ExitingTagReuseStressExample() {
         spikeIntervalRef.current = null;
       }
 
-      if (countdownIntervalRef.current) {
-        clearInterval(countdownIntervalRef.current);
-        countdownIntervalRef.current = null;
-      }
-
-      setCountdown(null);
       setSpikeIds([]);
       return;
     }
 
-    setCountdown(SPIKE_INTERVAL_MS / 1000);
     spikeIntervalRef.current = setInterval(fireSpike, SPIKE_INTERVAL_MS);
-    countdownIntervalRef.current = setInterval(() => {
-      setCountdown((value) =>
-        value !== null && value > 1 ? value - 1 : SPIKE_INTERVAL_MS / 1000
-      );
-    }, 1000);
 
     return () => {
       if (spikeIntervalRef.current) {
         clearInterval(spikeIntervalRef.current);
         spikeIntervalRef.current = null;
-      }
-
-      if (countdownIntervalRef.current) {
-        clearInterval(countdownIntervalRef.current);
-        countdownIntervalRef.current = null;
       }
     };
   }, [fireSpike, running]);
@@ -209,7 +187,7 @@ export default function ExitingTagReuseStressExample() {
       </View>
 
       <Text style={styles.spikeLabel}>
-        {countdown === null ? 'Stopped' : `Next spike in ${countdown}s`}
+        {running ? `Running - spike every ${SPIKE_INTERVAL_MS}ms` : 'Stopped'}
       </Text>
 
       <ScrollView contentContainerStyle={styles.grid}>

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -171,6 +171,11 @@ const DurationZeroExample: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/DurationZero').default as React.FC
   );
+const ExitingTagReuseStressExample: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/ExitingTagReuseStressExample')
+      .default as React.FC
+  );
 const DynamicColorIOSExample: React.FC = () =>
   React.createElement(require('./DynamicColorIOSExample').default as React.FC);
 const EmojiWaterfallExample: React.FC = () =>
@@ -1198,6 +1203,10 @@ export const EXAMPLES: Record<string, Example> = {
   DurationZeroExample: {
     title: '[LA] Duration zero',
     screen: DurationZeroExample,
+  },
+  ExitingTagReuseStressExample: {
+    title: '[LA] Exiting tag reuse stress',
+    screen: ExitingTagReuseStressExample,
   },
   DefaultAnimationsOverrides: {
     title: '[LA] Default layout animations overrides',

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -37,8 +37,12 @@ const facebook::react::ShadowNode *findInShadowTreeByTag(const facebook::react::
 
 void LayoutAnimationsProxyCommon::restoreOpacityInCaseOfFlakyEnteringAnimation(SurfaceId surfaceId) const {
   std::vector<std::pair<double, Tag>> opacityToRestore;
-  for (const auto tag : finishedAnimationTags_) {
-    const auto &opacity = layoutAnimations_[tag].opacity;
+  for (const auto tag : maybeSettledAnimationTags_) {
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    const auto &opacity = layoutAnimationIt->second.opacity;
     if (opacity.has_value()) {
       opacityToRestore.emplace_back(std::pair<double, Tag>{opacity.value(), tag});
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace reanimated {
@@ -22,6 +23,10 @@ struct LayoutAnimation {
   bool isViewAlreadyMounted = false;
   int count = 1;
   LayoutAnimation &operator=(const LayoutAnimation &other) = default;
+
+  bool isSettled() const {
+    return count == 0;
+  }
 };
 
 class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDelegate {
@@ -60,7 +65,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   virtual void startSurface(const SurfaceId surfaceId);
 
  protected:
-  mutable std::vector<Tag> finishedAnimationTags_;
+  mutable std::unordered_set<Tag> maybeSettledAnimationTags_;
   mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
   std::shared_ptr<const ContextContainer> contextContainer_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -535,11 +535,11 @@ void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) con
   if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  const auto wasSettled = layoutAnimationIt->second.isSettled();
-  layoutAnimations_.erase(layoutAnimationIt);
-  if (wasSettled) {
+  if (layoutAnimationIt->second.isSettled()) {
+    // Already settled - cleanupAnimations will erase it together with its updateMap entry.
     return;
   }
+  layoutAnimations_.erase(layoutAnimationIt);
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -330,9 +330,8 @@ void LayoutAnimationsProxy_Experimental::handleRemovals(
       // reparentings.
 
       auto current = node->current;
-      const auto layoutAnimationIt = layoutAnimations_.find(node->current.tag);
-      if (layoutAnimationIt != layoutAnimations_.end() && !layoutAnimationIt->second.isSettled()) {
-        current = layoutAnimationIt->second.currentView;
+      if (layoutAnimations_.contains(node->current.tag)) {
+        current = layoutAnimations_.at(node->current.tag).currentView;
       }
       filteredMutations.push_back(
           ShadowViewMutation::InsertMutation(parent->current.tag, current, static_cast<int>(parent->children.size())));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -276,11 +276,10 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
   // one after the other, so we need to keep count of how many
   // were actually triggered, so that we don't cleanup necessary
   // structures too early
-  if (layoutAnimation.count > 1) {
-    layoutAnimation.count--;
+  if (--layoutAnimation.count > 0) {
     return {};
   }
-  finishedAnimationTags_.push_back(tag);
+  maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
   if (sharedTransitionManager_->tagToName_.contains(tag)) {
@@ -331,8 +330,9 @@ void LayoutAnimationsProxy_Experimental::handleRemovals(
       // reparentings.
 
       auto current = node->current;
-      if (layoutAnimations_.contains(node->current.tag)) {
-        current = layoutAnimations_.at(node->current.tag).currentView;
+      const auto layoutAnimationIt = layoutAnimations_.find(node->current.tag);
+      if (layoutAnimationIt != layoutAnimations_.end() && !layoutAnimationIt->second.isSettled()) {
+        current = layoutAnimationIt->second.currentView;
       }
       filteredMutations.push_back(
           ShadowViewMutation::InsertMutation(parent->current.tag, current, static_cast<int>(parent->children.size())));
@@ -397,7 +397,7 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(SurfaceId surfaceI
 
     const auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end()) {
+    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
       continue;
     }
 
@@ -532,10 +532,15 @@ void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int 
 }
 
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
-  if (!layoutAnimations_.contains(tag)) {
+  const auto layoutAnimationIt = layoutAnimations_.find(tag);
+  if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  layoutAnimations_.erase(tag);
+  const auto wasSettled = layoutAnimationIt->second.isSettled();
+  layoutAnimations_.erase(layoutAnimationIt);
+  if (wasSettled) {
+    return;
+  }
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {
@@ -625,12 +630,17 @@ void LayoutAnimationsProxy_Experimental::cleanupAnimations(
 #ifdef ANDROID
   restoreOpacityInCaseOfFlakyEnteringAnimation(surfaceId);
 #endif // ANDROID
-  for (const auto tag : finishedAnimationTags_) {
-    auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
-    layoutAnimations_.erase(tag);
+  auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+  for (const auto tag : maybeSettledAnimationTags_) {
+    // Skip tags re-animated since they settled (count back above 0).
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    layoutAnimations_.erase(layoutAnimationIt);
     updateMap.erase(tag);
   }
-  finishedAnimationTags_.clear();
+  maybeSettledAnimationTags_.clear();
 }
 
 // MARK: Start Animation

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -53,6 +53,8 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
     updateMap.erase(tag);
   }
   maybeSettledAnimationTags_.clear();
+  // Past this point no animation can be settled - we hold the mutex for the whole
+  // transaction, so no end callback can run until we return.
 
   parseRemoveMutations(movedViews, mutations, roots);
 
@@ -299,7 +301,7 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
 
         if (movedViews.contains(tag)) {
           auto layoutAnimationIt = layoutAnimations_.find(tag);
-          if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
+          if (layoutAnimationIt == layoutAnimations_.end()) {
             if (oldShadowViewsForReparentings.contains(tag)) {
               filteredMutations.push_back(ShadowViewMutation::InsertMutation(
                   mutationParent, oldShadowViewsForReparentings[tag], mutation.index));
@@ -336,11 +338,8 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
 
       case ShadowViewMutation::Type::Update: {
         auto shouldAnimate = hasLayoutChanged(mutation);
-        const auto layoutAnimationIt = layoutAnimations_.find(tag);
-        const auto hasOngoingAnimation =
-            layoutAnimationIt != layoutAnimations_.end() && !layoutAnimationIt->second.isSettled();
         if (!layoutAnimationsManager_->hasLayoutAnimation(tag, LayoutAnimationType::LAYOUT) ||
-            (!shouldAnimate && !hasOngoingAnimation)) {
+            (!shouldAnimate && !layoutAnimations_.contains(tag))) {
           // We should cancel any ongoing animation here to ensure that the
           // proper final state is reached for this view However, due to how
           // RNSScreens handle adding headers (a second commit is triggered to

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
 #include <memory>
@@ -42,12 +43,16 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 #ifdef ANDROID
   restoreOpacityInCaseOfFlakyEnteringAnimation(surfaceId);
 #endif // ANDROID
-  for (const auto tag : finishedAnimationTags_) {
-    auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
-    layoutAnimations_.erase(tag);
+  auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+  for (const auto tag : maybeSettledAnimationTags_) {
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    layoutAnimations_.erase(layoutAnimationIt);
     updateMap.erase(tag);
   }
-  finishedAnimationTags_.clear();
+  maybeSettledAnimationTags_.clear();
 
   parseRemoveMutations(movedViews, mutations, roots);
 
@@ -109,11 +114,10 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   // one after the other, so we need to keep count of how many
   // were actually triggered, so that we don't cleanup necessary
   // structures too early
-  if (layoutAnimation.count > 1) {
-    layoutAnimation.count--;
+  if (--layoutAnimation.count > 0) {
     return {};
   }
-  finishedAnimationTags_.push_back(tag);
+  maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
   if (!shouldRemove || !nodeForTag_.contains(tag)) {
@@ -121,6 +125,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   }
 
   auto node = nodeForTag_[tag];
+  react_native_assert(node->isMutationNode() && "exiting tag must map to a MutationNode");
   auto mutationNode = std::static_pointer_cast<MutationNode>(node);
   mutationNode->state = ExitingState_Legacy::DEAD;
   auto &[deadNodes] = surfaceContext_[surfaceId];
@@ -294,7 +299,7 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
 
         if (movedViews.contains(tag)) {
           auto layoutAnimationIt = layoutAnimations_.find(tag);
-          if (layoutAnimationIt == layoutAnimations_.end()) {
+          if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
             if (oldShadowViewsForReparentings.contains(tag)) {
               filteredMutations.push_back(ShadowViewMutation::InsertMutation(
                   mutationParent, oldShadowViewsForReparentings[tag], mutation.index));
@@ -331,8 +336,11 @@ void LayoutAnimationsProxy_Legacy::handleUpdatesAndEnterings(
 
       case ShadowViewMutation::Type::Update: {
         auto shouldAnimate = hasLayoutChanged(mutation);
+        const auto layoutAnimationIt = layoutAnimations_.find(tag);
+        const auto hasOngoingAnimation =
+            layoutAnimationIt != layoutAnimations_.end() && !layoutAnimationIt->second.isSettled();
         if (!layoutAnimationsManager_->hasLayoutAnimation(tag, LayoutAnimationType::LAYOUT) ||
-            (!shouldAnimate && !layoutAnimations_.contains(tag))) {
+            (!shouldAnimate && !hasOngoingAnimation)) {
           // We should cancel any ongoing animation here to ensure that the
           // proper final state is reached for this view However, due to how
           // RNSScreens handle adding headers (a second commit is triggered to
@@ -406,7 +414,7 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
 
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end()) {
+    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
       continue;
     }
 
@@ -757,10 +765,15 @@ void LayoutAnimationsProxy_Legacy::updateOngoingAnimationTarget(const int tag, c
 }
 
 void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
-  if (!layoutAnimations_.contains(tag)) {
+  const auto layoutAnimationIt = layoutAnimations_.find(tag);
+  if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  layoutAnimations_.erase(tag);
+  const auto wasSettled = layoutAnimationIt->second.isSettled();
+  layoutAnimations_.erase(layoutAnimationIt);
+  if (wasSettled) {
+    return;
+  }
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -768,11 +768,7 @@ void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
   if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  const auto wasSettled = layoutAnimationIt->second.isSettled();
   layoutAnimations_.erase(layoutAnimationIt);
-  if (wasSettled) {
-    return;
-  }
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -210,7 +210,11 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     ShadowViewMutationList &filteredMutations,
     SurfaceId surfaceId) const {
   auto containerTag = sharedTransitionManager_->containerTags_[sharedTag];
-  auto shouldCreateContainer = (containerTag == -1 || !layoutAnimations_.contains(containerTag));
+  auto shouldCreateContainer = true;
+  if (containerTag != -1) {
+    const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
+    shouldCreateContainer = layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled();
+  }
 
   if (shouldCreateContainer) {
     containerTag = containerTag_;
@@ -264,11 +268,12 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
       auto &[_, after] = transition.snapshot;
 
       auto containerTag = sharedTransitionManager_->containerTags_[sharedTag];
-      if (!layoutAnimations_.contains(containerTag)) {
+      const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
+      if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
         continue;
       }
       after.tag = containerTag;
-      const auto &la = layoutAnimations_[containerTag];
+      const auto &la = layoutAnimationIt->second;
       if (la.finalView.layoutMetrics != after.layoutMetrics) {
         overrideTransform(after, transition.transform[AFTER], propsParserContext);
         startSharedTransition(containerTag, la.currentView, after, surfaceId);


### PR DESCRIPTION
## Summary

Fixes #9170.

On Android an exiting `Animated.View` could stay stuck on screen after it was unmounted, under heavy/spiky UI-thread load.

When a layout animation finishes, its entry in `layoutAnimations_` isn't erased right away — the tag is queued and the entry is erased during the next `pullTransaction` (so the final frame can still be flushed). That deferred erase races with tag reuse because the steps run on two different threads: `endLayoutAnimation` and the `scheduleOnUI`'d `createLayoutAnimation` run on the UI thread, while `pullTransaction` (and the cleanup at the top of it) runs on the mounting thread — which on Android is usually the JS thread, during React commits. The recursive mutex serializes each critical section but doesn't order them, and the re-create isn't done inside `pullTransaction`, so under load:

1. `[UI thread]` `endLayoutAnimation(T)` — animation ends, `T` is queued for cleanup.
2. `[UI thread]` `startExitingAnimation`'s scheduled job runs `createLayoutAnimation(T)` — `layoutAnimations_[T]` is re-created for the reused tag.
3. `[JS thread]` `pullTransaction` runs the cleanup, which erases the queued tags → wipes the freshly re-created `layoutAnimations_[T]`.
4. `[UI thread]` `endLayoutAnimation(T, shouldRemove=true)` — `layoutAnimations_` no longer contains `T`, so it returns early, the node is never marked `DEAD`, and the view stays on screen forever.

On iOS `pullTransaction` always runs on the UI thread, so it's all one thread. `scheduleOnUI` called from `pullTransaction` runs `createLayoutAnimation` inline, after the cleanup, within the same `pullTransaction` — so step 2 can't slip in before step 3, and the window never opens.

Ideally, once pull model / branching is made default we can remove the threading weridness around this.

The fix makes `count` (the number of in-flight animations for a view) the source of truth for whether an entry has settled: `endLayoutAnimation` decrements it to 0, and the cleanup re-checks it before erasing, so a tag that was re-animated in the meantime is back at `count >= 1` (the start paths do `count + 1`) and is left alone. Read sites that can run before the cleanup in a transaction now also check that the entry isn't settled; sites that run after it don't need to — the cleanup holds the mutex for the whole transaction, so no settled entry can exist there.

## Test plan

Added an `[LA] Exiting tag reuse stress` example: a fixed grid that mounts/unmounts views in the same slots with `ZoomIn`/`ZoomOut`, plus periodic spikes of short-lived views to load the UI thread.

1. Run on Android (Fabric), with `ENABLE_SHARED_ELEMENT_TRANSITIONS` both off (Legacy proxy) and on (Experimental proxy).
2. Open the example (it starts automatically), let it run through a few spikes, tap **Stop**.
3. Before: views remain stuck on screen after Stop. After: the grid clears completely.
