### PR TITLE
cherry-pick(worklets-0.9-stable): declare @babel/types as a dependency (#9511)

### DIFF
--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -71,6 +71,7 @@
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/plugin-transform-unicode-regex": "^7.27.1",
     "@babel/preset-typescript": "^7.28.5",
+    "@babel/types": "^7.27.1",
     "convert-source-map": "^2.0.0",
     "semver": "^7.7.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -28631,6 +28631,7 @@ __metadata:
     "@babel/plugin-transform-template-literals": "npm:^7.27.1"
     "@babel/plugin-transform-unicode-regex": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.28.5"
+    "@babel/types": "npm:^7.27.1"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native/eslint-config": "npm:0.83.0"
     "@react-native/jest-preset": "patch:@react-native/jest-preset@npm%3A0.85.2#~/.yarn/patches/@react-native-jest-preset-npm-0.85.2-d3275e8971.patch"


### PR DESCRIPTION
Cherry-picking #9511 