### PR TITLE
fix: clang-tidy violations across native sources

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGPath.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGPath.cpp
@@ -238,8 +238,8 @@ SubPath SVGPath::interpolateSubPaths(const SubPath &from, const SubPath &to, dou
 
   for (size_t i = 0; i < shorterSize; ++i) {
     size_t currentGroupSize = baseGroupSize + (i < remainder ? 1 : 0);
-    std::vector<Cubic> x =
-        from.C.size() <= to.C.size() ? splitCubic(from.C[i], currentGroupSize) : splitCubic(to.C[i], currentGroupSize);
+    const auto count = static_cast<int>(currentGroupSize);
+    std::vector<Cubic> x = from.C.size() <= to.C.size() ? splitCubic(from.C[i], count) : splitCubic(to.C[i], count);
     prolongatedShorter.insert(prolongatedShorter.end(), x.begin(), x.end());
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -839,7 +839,7 @@ void Node::applyMutationToIndices(const ShadowViewMutation &mutation) {
 
 // Should only be called on unflattened parents
 void Node::removeChildFromUnflattenedTree(const std::shared_ptr<MutationNode> &child) {
-  for (int i = unflattenedChildren.size() - 1; i >= 0; i--) {
+  for (size_t i = unflattenedChildren.size(); i-- > 0;) {
     if (unflattenedChildren[i]->tag == child->tag) {
       unflattenedChildren.erase(unflattenedChildren.begin() + i);
       break;
@@ -847,7 +847,7 @@ void Node::removeChildFromUnflattenedTree(const std::shared_ptr<MutationNode> &c
   }
 
   auto &flattenedChildren = child->parent->children;
-  for (int i = flattenedChildren.size() - 1; i >= 0; i--) {
+  for (size_t i = flattenedChildren.size(); i-- > 0;) {
     if (flattenedChildren[i]->tag == child->tag) {
       flattenedChildren.erase(flattenedChildren.begin() + i);
       return;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/RNRuntimeDecorator.cpp
@@ -39,7 +39,7 @@ void RNRuntimeDecorator::decorate(
 void RNRuntimeDecorator::installDebugBindings(
     jsi::Runtime &rnRuntime,
     const std::shared_ptr<ReanimatedModuleProxy> &reanimatedModuleProxy) {
-#if TARGET_OS_X
+#if defined(TARGET_OS_X) && TARGET_OS_X
   jsi_utils::installJsiFunction(
       rnRuntime, "__getTagFromShadowNodeWrapper", [](jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper) {
         auto node = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(rt, shadowNodeWrapper);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReaJSIUtils.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/ReaJSIUtils.h
@@ -155,7 +155,7 @@ struct takes_runtime<jsi::Runtime &, Rest...> {
 template <typename Ret, typename... Args>
 void installJsiFunction(jsi::Runtime &rt, std::string_view name, const std::function<Ret(Args...)> &function) {
   auto clb = createHostFunction(function);
-  auto argsCount = sizeof...(Args) - takes_runtime<Args...>::value;
+  auto argsCount = static_cast<unsigned int>(sizeof...(Args) - takes_runtime<Args...>::value);
   jsi::Value jsiFunction =
       jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name.data()), argsCount, clb);
   rt.global().setProperty(rt, name.data(), jsiFunction);

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/EventHandler.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/EventHandler.h
@@ -17,9 +17,9 @@ class EventHandler : public HybridClass<EventHandler> {
   static auto constexpr kJavaDescriptor = "Lcom/swmansion/reanimated/nativeProxy/EventHandler;";
 
   void receiveEvent(
-      jni::alias_ref<JString> eventKey,
+      jni::alias_ref<JString> eventKey, // NOLINT(performance-unnecessary-value-param)
       jint emitterReactTag,
-      jni::alias_ref<react::WritableMap> event,
+      jni::alias_ref<react::WritableMap> event, // NOLINT(performance-unnecessary-value-param)
       jboolean isInDrawPass) {
     ReanimatedSystraceSection s("EventHandler::receiveEvent");
     handler_(eventKey, emitterReactTag, event, isInDrawPass);

--- a/packages/react-native-reanimated/apple/reanimated/apple/REASlowAnimations.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REASlowAnimations.mm
@@ -14,7 +14,7 @@ CGFloat getUIAnimationDragCoefficient(void)
 #if TARGET_IPHONE_SIMULATOR
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    UIAnimationDragCoefficient = (float (*)(void))dlsym(RTLD_DEFAULT, "UIAnimationDragCoefficient");
+    UIAnimationDragCoefficient = reinterpret_cast<float (*)(void)>(dlsym(RTLD_DEFAULT, "UIAnimationDragCoefficient"));
   });
 #endif
   return UIAnimationDragCoefficient ? UIAnimationDragCoefficient() : 1.f;

--- a/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/keyboardObserver/REAKeyboardEventObserver.mm
@@ -9,7 +9,7 @@
 #import <reanimated/apple/REAUIView.h>
 #import <reanimated/apple/keyboardObserver/REAKeyboardEventObserver.h>
 
-typedef NS_ENUM(NSUInteger, KeyboardState) {
+typedef NS_ENUM(NSUInteger, KeyboardState) { // NOLINT(performance-enum-size,cppcoreguidelines-use-enum-class)
   UNKNOWN = 0,
   OPENING = 1,
   OPEN = 2,
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 - (void)runListeners:(float)keyboardHeight
 {
   for (NSString *key in _listeners.allKeys) {
-    ((KeyboardEventListenerBlock)_listeners[key])(_state, keyboardHeight);
+    ((KeyboardEventListenerBlock)_listeners[key])(static_cast<int>(_state), keyboardHeight);
   }
 }
 
@@ -424,6 +424,7 @@ typedef NS_ENUM(NSUInteger, KeyboardState) {
 - (REAUIView *_Nullable)getKeyboardView
 {
   if (!_keyboardView) {
+    // NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
     auto window = [self findView:[UIApplication sharedApplication].windows
                        condition:[self withPrefix:@[ @"<UITextEffectsWindow" ]]];
     auto container = [self findView:window.subviews

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -38,7 +38,7 @@ SetGestureStateFunction makeSetGestureStateFunction(RCTModuleRegistry *moduleReg
 
 RequestRenderFunction makeRequestRender(REANodesManager *nodesManager)
 {
-  auto requestRender = [nodesManager](std::function<void(double)> onRender) {
+  auto requestRender = [nodesManager](const std::function<void(double)> &onRender) {
     [nodesManager postOnAnimation:^(READisplayLink *displayLink) {
 #if !TARGET_OS_OSX
       auto targetTimestamp = displayLink.targetTimestamp;
@@ -80,8 +80,10 @@ MaybeFlushUIUpdatesQueueFunction makeMaybeFlushUIUpdatesQueueFunction(REANodesMa
 
 RegisterSensorFunction makeRegisterSensorFunction(ReanimatedSensorContainer *reanimatedSensorContainer)
 {
-  auto registerSensorFunction =
-      [=](int sensorType, int interval, int iosReferenceFrame, std::function<void(double[], int)> setter) -> int {
+  auto registerSensorFunction = [=](int sensorType,
+                                    int interval,
+                                    int iosReferenceFrame,
+                                    const std::function<void(double[], int)> &setter) -> int {
     return [reanimatedSensorContainer
            registerSensor:(ReanimatedSensorType)sensorType
                  interval:interval
@@ -102,7 +104,7 @@ UnregisterSensorFunction makeUnregisterSensorFunction(ReanimatedSensorContainer 
 KeyboardEventSubscribeFunction makeSubscribeForKeyboardEventsFunction(REAKeyboardEventObserver *keyboardObserver)
 {
   auto subscribeForKeyboardEventsFunction =
-      [=](std::function<void(int keyboardState, int height)> keyboardEventDataUpdater,
+      [=](const std::function<void(int keyboardState, int height)> &keyboardEventDataUpdater,
           bool isStatusBarTranslucent,
           bool isNavigationBarTranslucent) {
         // ignore isStatusBarTranslucent and isNavigationBarTranslucent - those are Android only
@@ -149,7 +151,7 @@ ForceScreenSnapshotFunction makeForceScreenSnapshotFunction(REANodesManager *nod
     REAUIView<RCTComponentViewProtocol> *maybeRNSScreenView = [componentViewRegistry findComponentViewWithTag:tag];
     SEL setSnapshotAfterUpdatesSelector = @selector(setSnapshotAfterUpdates:);
     if ([maybeRNSScreenView respondsToSelector:setSnapshotAfterUpdatesSelector]) {
-      [(id<RNScreenViewOptionalProtocol>)maybeRNSScreenView setSnapshotAfterUpdates:YES];
+      [static_cast<id<RNScreenViewOptionalProtocol>>(maybeRNSScreenView) setSnapshotAfterUpdates:YES];
     }
   };
   return forceScreenSnapshot;

--- a/packages/react-native-reanimated/apple/reanimated/apple/sensor/ReanimatedSensor.m
+++ b/packages/react-native-reanimated/apple/reanimated/apple/sensor/ReanimatedSensor.m
@@ -195,10 +195,11 @@
 - (int)getInterfaceOrientation
 {
   UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
-  if (@available(iOS 13.0, *)) {
-    orientation = UIApplication.sharedApplication.windows.firstObject.windowScene.interfaceOrientation;
-  } else {
-    orientation = UIApplication.sharedApplication.statusBarOrientation;
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if ([scene isKindOfClass:[UIWindowScene class]]) {
+      orientation = ((UIWindowScene *)scene).interfaceOrientation;
+      break;
+    }
   }
   switch (orientation) {
     case UIInterfaceOrientationLandscapeLeft:

--- a/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
+++ b/packages/react-native-worklets/Common/cpp/worklets/WorkletRuntime/WorkletRuntime.h
@@ -31,7 +31,6 @@ concept ImplicitlySerializableCallable = std::is_assignable_v<const jsi::Functio
 
 template <typename TCallable>
 concept RuntimeCallable = requires(TCallable &&callable, jsi::Runtime &rt) {
-  // NOLINTNEXTLINE(readability/braces) cpplint doesn't understand concepts
   { callable(rt) };
 } || ImplicitlySerializableCallable<TCallable>;
 


### PR DESCRIPTION
## Summary

Extracted from
- #9497

to reduce the noise of the LLVM integration feature.

## Test plan

The CI will fail due to change of tooling - but the upstream PR should pass.
