### PR TITLE
fix(Worklets): autoworkletization for nested worklets

### DIFF
--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -393,14 +393,7 @@ describe('babel plugin in bundleMode', () => {
       expect(code).not.toContain(REQUIRE_PREFIX);
     });
 
-    test('emitted worklet file has scheduling callbacks autoworkletized after a full plugin lifecycle', () => {
-      // Simulates Metro's two-pass lifecycle: the plugin runs on the source
-      // file, then again on each emitted worklet file. By the end of that
-      // lifecycle, scheduling callbacks nested in a worklet body must be
-      // extracted into their own worklet files — regardless of which pass
-      // does the work. Pre-bail-out, pass 2 extracted them; with the
-      // bail-out, pass 2 is a no-op and pass 1 has to pre-process the
-      // emitted file so the result still converges.
+    test('autoworkletization fires before emitting a file', () => {
       const input = html`<script>
         function foo() {
           'worklet';

--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -392,5 +392,36 @@ describe('babel plugin in bundleMode', () => {
       expect(files).toHaveLength(0);
       expect(code).not.toContain(REQUIRE_PREFIX);
     });
+
+    test('emitted worklet file has scheduling callbacks autoworkletized after a full plugin lifecycle', () => {
+      // Simulates Metro's two-pass lifecycle: the plugin runs on the source
+      // file, then again on each emitted worklet file. By the end of that
+      // lifecycle, scheduling callbacks nested in a worklet body must be
+      // extracted into their own worklet files — regardless of which pass
+      // does the work. Pre-bail-out, pass 2 extracted them; with the
+      // bail-out, pass 2 is a no-op and pass 1 has to pre-process the
+      // emitted file so the result still converges.
+      const input = html`<script>
+        function foo() {
+          'worklet';
+          scheduleOnUI(() => {
+            return 1;
+          });
+        }
+      </script>`;
+
+      const { files: firstPass } = runPlugin(input);
+      assert(firstPass.length >= 1);
+      const outerFile = firstPass[firstPass.length - 1];
+
+      const { code: rePassedCode } = runPlugin(
+        outerFile.content,
+        {},
+        {},
+        outerFile.path
+      );
+
+      expect(rePassedCode).toContain(REQUIRE_PREFIX);
+    });
   });
 });

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -415,6 +415,7 @@ var require_globals = __commonJS({
     exports2.initializeGlobals = initializeGlobals;
     exports2.addCustomGlobals = addCustomGlobals;
     var path_1 = __importDefault(require("path"));
+    var autoworkletization_12 = require_autoworkletization();
     var types_12 = require_types();
     var notCapturedIdentifiers = [
       // Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
@@ -538,6 +539,16 @@ var require_globals = __commonJS({
       }
       state.workletNumber = 1;
       state.classesToWorkletize = [];
+      state.autoworkletizationPlugin = {
+        name: "worklets-autoworkletization",
+        visitor: {
+          CallExpression: {
+            enter(nodePath) {
+              (0, autoworkletization_12.processCalleesAutoworkletizableCallbacks)(nodePath, state);
+            }
+          }
+        }
+      };
       if (!state.opts.strictGlobal) {
         initializeGlobals();
         addCustomGlobals(state);
@@ -725,7 +736,7 @@ var require_generate = __commonJS({
       const transformedProg = (_a = (0, core_1.transformFromAstSync)(newProg, void 0, {
         filename: state.file.opts.filename,
         presets: ["@babel/preset-typescript"],
-        plugins: [],
+        plugins: [state.autoworkletizationPlugin],
         ast: false,
         babelrc: false,
         configFile: false,

--- a/packages/react-native-worklets/plugin/src/generate.ts
+++ b/packages/react-native-worklets/plugin/src/generate.ts
@@ -72,7 +72,7 @@ export function generateWorkletFile(
   const transformedProg = transformFromAstSync(newProg, undefined, {
     filename: state.file.opts.filename,
     presets: ['@babel/preset-typescript'],
-    plugins: [],
+    plugins: [state.autoworkletizationPlugin],
     ast: false,
     babelrc: false,
     configFile: false,

--- a/packages/react-native-worklets/plugin/src/globals.ts
+++ b/packages/react-native-worklets/plugin/src/globals.ts
@@ -1,5 +1,8 @@
+import type { NodePath } from '@babel/core';
+import type { CallExpression } from '@babel/types';
 import path from 'path';
 
+import { processCalleesAutoworkletizableCallbacks } from './autoworkletization';
 import { generatedWorkletsDir, type WorkletsPluginPass } from './types';
 
 const notCapturedIdentifiers = [
@@ -142,6 +145,16 @@ export function initializeState(state: WorkletsPluginPass) {
   }
   state.workletNumber = 1;
   state.classesToWorkletize = [];
+  state.autoworkletizationPlugin = {
+    name: 'worklets-autoworkletization',
+    visitor: {
+      CallExpression: {
+        enter(nodePath: NodePath<CallExpression>) {
+          processCalleesAutoworkletizableCallbacks(nodePath, state);
+        },
+      },
+    },
+  };
   if (!state.opts.strictGlobal) {
     initializeGlobals();
     addCustomGlobals(state);

--- a/packages/react-native-worklets/plugin/src/types.ts
+++ b/packages/react-native-worklets/plugin/src/types.ts
@@ -1,4 +1,4 @@
-import type { BabelFile, NodePath } from '@babel/core';
+import type { BabelFile, NodePath, PluginItem } from '@babel/core';
 import type {
   ArrowFunctionExpression,
   FunctionDeclaration,
@@ -26,6 +26,7 @@ export interface WorkletsPluginPass {
   workletNumber: number;
   classesToWorkletize: { node: BabelNode; name: string }[];
   skipFile: boolean;
+  autoworkletizationPlugin: PluginItem;
 }
 
 export type WorkletizableFunction =


### PR DESCRIPTION
## Summary

In #9618 I introduced a regression where autoworkletization wouldn't fire for nested worklets.

We depended on the fact that we'd do another pass of a generated worklet via Metro, and we'd create necessary worklets from that file.

I fixed it by explicitly triggering autoworkletization via a microplugin during the generation step.

This could be superseded by [refactor(Worklets): add worklet directives before react compiler](https://github.com/software-mansion/react-native-reanimated/pull/9206) but unfortunately lack of React Compiler team makes this PR the solution for now.

## Test plan

A new unit test passes, the app works correctly.
