### PR TITLE
fix: correct react-native env globals access for eslint

### DIFF
--- a/apps/common-app/eslint.config.mjs
+++ b/apps/common-app/eslint.config.mjs
@@ -37,7 +37,7 @@ export default config(
       globals: {
         React: true,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        ...reactNative.environments['react-native']['react-native'],
+        ...reactNative.environments['react-native'].globals,
         ...globals.node,
       },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,7 +141,7 @@ const config = tsEslint.config(
     languageOptions: {
       globals: {
         React: true,
-        ...reactNative.environments['react-native']['react-native'],
+        ...reactNative.environments['react-native'].globals,
         ...jest.environments.globals.globals,
         ...globals.node,
       },


### PR DESCRIPTION
## Summary

Turns out we always used it wrong - but didn't detect it since ESLint leaves checking global envs checking to typescript for .ts files.

## Test plan

CI
