### PR TITLE
Remove CMake version requirement

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -195,7 +195,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            this.version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
             path = file("CMakeLists.txt")
         }
     }

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -212,7 +212,6 @@ android {
 
     externalNativeBuild {
         cmake {
-            this.version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
             path = file("CMakeLists.txt")
         }
     }


### PR DESCRIPTION
## Summary

This PR removes the CMake version requirement. This mechanism was originally introduced to match React Native's behavior. However, over time, our version drifted out of sync with the React Native version.

This configuration is unnecessary because we don't use any version-specific CMake features that would require locking it down, and we already specify a minimum CMake version in CMakeLists.txt.

Also, enforcing this specific version can break project setups using Nix, where the environment is intentionally pinned to a specific CMake version for project-related reasons.
