### PR TITLE
fix(Reanimated): re-run mappers dirtied during a mapper run

### DIFF
--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -103,13 +103,13 @@ function createMapperRegistry() {
         updateMappersOrder();
       }
       if (isAnyMapperDirty) {
+        isAnyMapperDirty = false;
         for (const mapper of sortedMappers) {
           if (mapper.dirty) {
             mapper.dirty = false;
             mapper.worklet();
           }
         }
-        isAnyMapperDirty = false;
       }
     } finally {
       processingMappers = false;


### PR DESCRIPTION
## Summary

Fixes #9642.

### Incorrect behavior

A `useDerivedValue` stopped re-evaluating after the shared value it reads was updated inside a `useAnimatedReaction` — its result lagged exactly one update behind. Worked in 4.3.1; regressed between nightly `20260401` and `20260516`. Introduced by #9270.

On native, mappers run once per frame. A shared-value listener marks its mapper `dirty` and sets a single `isAnyMapperDirty` gate; `mapperRun` only iterates `sortedMappers` when that gate is set. #9270 cleared the gate **after** the loop:

```js
if (isAnyMapperDirty) {
  for (const mapper of sortedMappers) {
    if (mapper.dirty) {
      mapper.dirty = false;
      mapper.worklet();
    }
  }
  isAnyMapperDirty = false;
}
```

When a mapper writes a shared value **during** the loop (the reaction updating a value read by an earlier-sorted derived value), the listener correctly re-sets `mapper.dirty = true` and `isAnyMapperDirty = true`. But the dependent mapper was already passed this frame, and `isAnyMapperDirty = false` then forced the gate back to `false`. The mapper stayed `dirty` yet was gated out on every following frame — until an unrelated update flipped the gate again, at which point it finally ran but read the *previous* update's value.

### Fix

Reset `isAnyMapperDirty` **before** the loop, so a re-set raised during the run survives and the dependent mapper is picked up on the next frame.

```js
if (isAnyMapperDirty) {
  isAnyMapperDirty = false;
  for (const mapper of sortedMappers) {
    if (mapper.dirty) {
      mapper.dirty = false;
      mapper.worklet();
    }
  }
}
```

This restores the pre-#9270 (4.3.1) semantics: a mapper dirtied during a run re-runs on the next frame with the fresh value.

### Test plan

Repro from #9642 (https://github.com/exploIF/reanimated-ordering-issues): tap **Trigger** repeatedly — Actual now matches Expected on every press instead of trailing by one.