### PR TITLE
fix: Resolve unused HERMES_V1_ENABLED CMake warning

### DIFF
--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -23,6 +23,10 @@ string(APPEND CMAKE_CXX_FLAGS " -DWORKLETS_VERSION=${WORKLETS_VERSION}\
 # Only define manually for older versions to avoid macro redefinition error.
 if(ReactAndroid_VERSION_MINOR LESS 84)
   string(APPEND CMAKE_CXX_FLAGS " -DHERMES_V1_ENABLED=${HERMES_V1_ENABLED}")
+else()
+  # Reference the value so CMake records it as used, otherwise it warns:
+  # "Manually-specified variables were not used by the project: HERMES_V1_ENABLED"
+  set(HERMES_V1_ENABLED "${HERMES_V1_ENABLED}")
 endif()
 
 string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fstack-protector-all")


### PR DESCRIPTION
## Summary

Gradle always forwards `-DHERMES_V1_ENABLED` to the Worklets native build, but for React Native >= 84 the `HERMES_V1_ENABLED` macro is defined centrally by `react-native-flags.cmake`, so our manual define is skipped to avoid a macro redefinition. On React Native versions whose `react-native-flags.cmake` doesn't read the variable, nothing consumes it and CMake warns:

```
  > Task :react-native-worklets:configureCMakeDebug[arm64-v8a]
  C/C++: CMake Warning:
  C/C++:   Manually-specified variables were not used by the project:
  C/C++:     HERMES_V1_ENABLED
```

This references the value in the `else` branch so CMake records it as used, without redefining the macro.

## Test plan

- Build the Android example app and confirm the `Manually-specified variables were not used by the project: HERMES_V1_ENABLED` warning no longer appears.
- Verify the `HERMES_V1_ENABLED` macro is still applied as before (e.g. `HERMES_V1_ENABLED=1` present in the Worklets `compile_commands.json` on RN >= 84).