### PR TITLE
fix: re-add LightNode before starting exiting animation

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -516,8 +516,8 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
 
   if (hasExitAnimation) {
     node->state = ANIMATING;
-    startExitingAnimation(node);
     lightNodes_[node->current.tag] = node;
+    startExitingAnimation(node);
   } else {
     layoutAnimationsManager_->clearLayoutAnimationConfig(node->current.tag);
   }


### PR DESCRIPTION
## Summary

Fixes #9615 — the `[LA] Reduced Motion` "always reduce" example crashes on iOS when the box is hidden.

In `startAnimationsRecursively`, the exiting node was re-added to `lightNodes_` *after* `startExitingAnimation`. On iOS, `IOSUIScheduler::scheduleOnUI` runs the job synchronously when already on the main thread, and Fabric mounting runs on the main thread — so `startExitingAnimation` can re-enter `endLayoutAnimation` before control returns. With `ReduceMotion.Always` the exiting animation finishes within the same frame, so the re-entrant `endLayoutAnimation(tag, /*shouldRemove=*/true)` runs while the node is still missing from `lightNodes_` (it was erased by the `Delete` mutation and not yet re-added). `lightNodes_[tag]` then inserts and dereferences a null `shared_ptr`, crashing.

This is iOS-only because Android queues the job instead of running it inline, so the re-add happens first.

The fix re-adds the node to `lightNodes_` *before* calling `startExitingAnimation`, keeping the light tree consistent for the (possibly re-entrant) `endLayoutAnimation` call.

For the record, the crash stack trace was:
```
Thread 1 Queue : com.apple.main-thread (serial)
#0	0x000000010433888c in __pthread_kill ()
#1	0x0000000104e7a338 in pthread_kill ()
#2	0x000000018017b984 in abort ()
#3	0x000000018017ad5c in __assert_rtn ()
#4	0x00000001070f8dcc in reanimated::LayoutAnimationsProxy_Experimental::endLayoutAnimation at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:299
#5	0x0000000107198724 in reanimated::ReanimatedModuleProxy::init(reanimated::PlatformDepMethodsHolder const&)::$_3::operator()(int, bool) const at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp:337
#6	0x00000001071986ac in std::__1::__invoke[abi:dee210106]<reanimated::ReanimatedModuleProxy::init(reanimated::PlatformDepMethodsHolder const&)::$_3&, int, bool> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#7	0x000000010719866c in std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee210106]<reanimated::ReanimatedModuleProxy::init(reanimated::PlatformDepMethodsHolder const&)::$_3&, int, bool> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:342
#8	0x0000000107198638 in std::__1::__invoke_r[abi:dee210106]<void, reanimated::ReanimatedModuleProxy::init(reanimated::PlatformDepMethodsHolder const&)::$_3&, int, bool> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:348
#9	0x00000001071983f4 in std::__1::__function::__func<reanimated::ReanimatedModuleProxy::init(reanimated::PlatformDepMethodsHolder const&)::$_3, void (int, bool)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:174
#10	0x0000000107240d08 in std::__1::__function::__value_func<void (int, bool)>::operator()[abi:dee210106] at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:274
#11	0x0000000107240cb0 in std::__1::function<void (int, bool)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:772
#12	0x0000000107240c28 in std::__1::__invoke[abi:dee210106]<std::__1::function<void (int, bool)>&, int, bool> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#13	0x0000000107240be8 in std::__1::__apply_tuple_impl[abi:dee210106]<std::__1::function<void (int, bool)>&, std::__1::tuple<int, bool>, 0ul, 1ul> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/tuple:1380
#14	0x0000000107240b9c in std::__1::apply[abi:dee210106]<std::__1::function<void (int, bool)>&, std::__1::tuple<int, bool>> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/tuple:1384
#15	0x00000001072401bc in reanimated::jsi_utils::apply<int, bool> at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Private/RNReanimated/reanimated/Tools/ReaJSIUtils.h:115
#16	0x000000010723ffec in std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> reanimated::jsi_utils::createHostFunction<std::__1::function<void (int, bool)>>(std::__1::function<void (int, bool)> const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long) const at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Private/RNReanimated/reanimated/Tools/ReaJSIUtils.h:125
#17	0x000000010723ff58 in std::__1::__invoke[abi:dee210106]<std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> reanimated::jsi_utils::createHostFunction<std::__1::function<void (int, bool)>>(std::__1::function<void (int, bool)> const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#18	0x000000010723ff04 in std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> reanimated::jsi_utils::createHostFunction<std::__1::function<void (int, bool)>>(std::__1::function<void (int, bool)> const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:334
#19	0x000000010723feb8 in std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> reanimated::jsi_utils::createHostFunction<std::__1::function<void (int, bool)>>(std::__1::function<void (int, bool)> const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:348
#20	0x000000010723fc68 in std::__1::__function::__func<std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)> reanimated::jsi_utils::createHostFunction<std::__1::function<void (int, bool)>>(std::__1::function<void (int, bool)> const&)::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long), facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:174
#21	0x0000000107471f3c in std::__1::__function::__value_func<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()[abi:dee210106] at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:274
#22	0x0000000107471ec8 in std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:772
#23	0x00000001074cd0e4 in facebook::jsi::DecoratedHostFunction::operator() at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:36
#24	0x00000001074cd084 in std::__1::__invoke[abi:dee210106]<facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#25	0x00000001074cd030 in std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:334
#26	0x00000001074ccfe4 in std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:348
#27	0x00000001074ccd6c in std::__1::__function::__func<facebook::jsi::DecoratedHostFunction, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:174
#28	0x0000000107471f3c in std::__1::__function::__value_func<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator()[abi:dee210106] at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:274
#29	0x0000000107471ec8 in std::__1::function<facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:772
#30	0x00000001074cd0e4 in facebook::jsi::DecoratedHostFunction::operator() at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:36
#31	0x00000001074cd084 in std::__1::__invoke[abi:dee210106]<facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#32	0x00000001074cd030 in std::__1::__invoke_void_return_wrapper<facebook::jsi::Value, false>::__call[abi:dee210106]<facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:334
#33	0x00000001074ccfe4 in std::__1::__invoke_r[abi:dee210106]<facebook::jsi::Value, facebook::jsi::DecoratedHostFunction&, facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:348
#34	0x00000001074ccd6c in std::__1::__function::__func<facebook::jsi::DecoratedHostFunction, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned long)>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:174
#35	0x0000000105aff9b0 in facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::HFContext::func ()
#36	0x0000000105ce3008 in hermes::vm::Interpreter::handleCallSlowPath ()
#37	0x0000000105ce5198 in hermes::vm::Interpreter::interpretFunction<false, false> ()
#38	0x0000000105dbbd98 in hermes::vm::Runtime::interpretFunctionImpl ()
#39	0x0000000105ccbf50 in hermes::vm::JSFunction::_callImpl ()
#40	0x0000000105ccaa48 in hermes::vm::Callable::executeCall1 ()
#41	0x0000000105dc05f8 in hermes::vm::JSObject::putNamedWithReceiver_RJS ()
#42	0x0000000105cee3d8 in hermes::vm::Interpreter::putByIdSlowPath_RJS ()
#43	0x0000000105ce6068 in hermes::vm::Interpreter::interpretFunction<false, false> ()
#44	0x0000000105dbbd98 in hermes::vm::Runtime::interpretFunctionImpl ()
#45	0x0000000105ccbf50 in hermes::vm::JSFunction::_callImpl ()
#46	0x0000000105af6450 in facebook::hermes::(anonymous namespace)::HermesRuntimeImpl::call ()
#47	0x00000001074cb55c in facebook::jsi::RuntimeDecorator<facebook::jsi::Runtime, facebook::jsi::Runtime>::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:415
#48	0x00000001074c9058 in facebook::jsi::WithRuntimeDecorator<worklets::WorkletsReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:987
#49	0x00000001074cb55c in facebook::jsi::RuntimeDecorator<facebook::jsi::Runtime, facebook::jsi::Runtime>::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:415
#50	0x00000001074d7328 in facebook::jsi::WithRuntimeDecorator<worklets::AroundLock, facebook::jsi::Runtime, facebook::jsi::Runtime>::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:987
#51	0x0000000106e9bb7c in facebook::jsi::Function::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/jsi-inl.h:313
#52	0x0000000106e9bb0c in facebook::jsi::Function::call at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/jsi-inl.h:318
#53	0x00000001070ed158 in facebook::jsi::Function::call<facebook::jsi::Value, facebook::jsi::Value, facebook::jsi::Object const&, facebook::jsi::Value> at /Users/tomekzaw/RNOS/react-native-reanimated/apps/fabric-example/ios/Pods/Headers/Public/React-jsi/jsi/jsi-inl.h:326
#54	0x00000001070ececc in reanimated::LayoutAnimationsManager::startLayoutAnimation at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsManager.cpp:85
#55	0x00000001071165b0 in reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation(std::__1::shared_ptr<reanimated::LightNode> const&) const::$_0::operator()() const at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:751
#56	0x0000000107116348 in std::__1::__invoke[abi:dee210106]<reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation(std::__1::shared_ptr<reanimated::LightNode> const&) const::$_0&> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:87
#57	0x0000000107116324 in std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:dee210106]<reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation(std::__1::shared_ptr<reanimated::LightNode> const&) const::$_0&> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:342
#58	0x0000000107116300 in std::__1::__invoke_r[abi:dee210106]<void, reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation(std::__1::shared_ptr<reanimated::LightNode> const&) const::$_0&> at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__type_traits/invoke.h:348
#59	0x00000001071160a8 in std::__1::__function::__func<reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation(std::__1::shared_ptr<reanimated::LightNode> const&) const::$_0, void ()>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:174
#60	0x0000000106e9ce20 in std::__1::__function::__value_func<void ()>::operator()[abi:dee210106] at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:274
#61	0x0000000106e9cdd8 in std::__1::function<void ()>::operator() at /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.5.sdk/usr/include/c++/v1/__functional/function.h:772
#62	0x0000000107457558 in worklets::IOSUIScheduler::scheduleOnUI at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-worklets/apple/worklets/apple/IOSUIScheduler.mm:11
#63	0x00000001074bf368 in worklets::scheduleOnUI at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-worklets/Common/cpp/worklets/Compat/StableApi.cpp:21
#64	0x00000001070fabf4 in reanimated::LayoutAnimationsProxy_Experimental::startExitingAnimation at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:724
#65	0x00000001070f97f8 in reanimated::LayoutAnimationsProxy_Experimental::startAnimationsRecursively at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:519
#66	0x00000001070f6bbc in reanimated::LayoutAnimationsProxy_Experimental::handleRemovals at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:323
#67	0x00000001070f5128 in reanimated::LayoutAnimationsProxy_Experimental::pullTransaction at /Users/tomekzaw/RNOS/react-native-reanimated/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp:89
#68	0x000000010d3338c0 in facebook::react::MountingCoordinator::pullTransaction ()
#69	0x000000010d354b70 in facebook::react::TelemetryController::pullTransaction ()
#70	0x000000010d563c70 in -[RCTMountingManager performTransaction:] ()
#71	0x000000010d563940 in -[RCTMountingManager initiateTransaction:] ()
#72	0x000000010d56318c in __42-[RCTMountingManager scheduleTransaction:]_block_invoke ()
#73	0x000000010cec2f28 in __RCTExecuteOnMainQueue_block_invoke ()
#74	0x0000000104dd7ee8 in _dispatch_call_block_and_release ()
#75	0x0000000104df1374 in _dispatch_client_callout ()
#76	0x0000000104de6ff0 in _dispatch_main_queue_drain ()
#77	0x0000000104de6b28 in _dispatch_main_queue_callback_4CF ()
#78	0x0000000180422a94 in __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ ()
#79	0x0000000180421c6c in __CFRunLoopRun ()
#80	0x000000018041c904 in _CFRunLoopRunSpecificWithOptions ()
#81	0x00000001933599c0 in GSEventRunModal ()
#82	0x00000001864a54cc in -[UIApplication _run] ()
#83	0x0000000186b9f910 in UIApplicationMain ()
#84	0x000000018564a820 in UIApplicationMain ()
#85	0x0000000106e03388 in static UIApplicationDelegate.main() ()
#86	0x0000000106e032f8 in static AppDelegate.$main() ()
#87	0x0000000106e03c58 in main ()
#88	0x00000001043bf0e4 in start_sim ()
#89	0x00000001041f7e00 in start ()
Enqueued from Thread 10 Queue : com.apple.root.default-qos.overcommit (serial)
#0	0x0000000104ddd0a8 in dispatch_async ()
#1	0x000000010cec2ec0 in RCTExecuteOnMainQueue ()
#2	0x000000010d562fc0 in -[RCTMountingManager scheduleTransaction:] ()
#3	0x000000010d589614 in -[RCTSurfacePresenter schedulerShouldRenderTransactions:] ()
#4	0x000000010d577b7c in SchedulerDelegateProxy::schedulerShouldRenderTransactions ()
#5	0x000000010d3a8e64 in facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0::operator()() const ()
#6	0x000000010d3a8e30 in std::__1::__invoke[abi:de190102]<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0&> ()
#7	0x000000010d3a8de8 in std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:de190102]<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0&> ()
#8	0x000000010d3a8dc4 in std::__1::__function::__alloc_func<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0, std::__1::allocator<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0>, void ()>::operator()[abi:de190102] ()
#9	0x000000010d3a7b94 in std::__1::__function::__func<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0, std::__1::allocator<facebook::react::Scheduler::uiManagerDidFinishTransaction(std::__1::shared_ptr<facebook::react::MountingCoordinator const>, bool)::$_0>, void ()>::operator() ()
#10	0x000000010d72109c in std::__1::__function::__value_func<void ()>::operator()[abi:de190102] ()
#11	0x000000010d721054 in std::__1::function<void ()>::operator() ()
#12	0x000000010d73b66c in facebook::react::RuntimeScheduler_Modern::updateRendering ()
#13	0x000000010d73b010 in facebook::react::RuntimeScheduler_Modern::runEventLoopTick ()
#14	0x000000010d73ac7c in facebook::react::RuntimeScheduler_Modern::runEventLoop ()
#15	0x000000010d744764 in facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0::operator()(facebook::jsi::Runtime&) const ()
#16	0x000000010d744734 in std::__1::__invoke[abi:de190102]<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0&, facebook::jsi::Runtime&> ()
#17	0x000000010d7446e4 in std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:de190102]<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0&, facebook::jsi::Runtime&> ()
#18	0x000000010d7446b8 in std::__1::__function::__alloc_func<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0, std::__1::allocator<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0>, void (facebook::jsi::Runtime&)>::operator()[abi:de190102] ()
#19	0x000000010d743550 in std::__1::__function::__func<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0, std::__1::allocator<facebook::react::RuntimeScheduler_Modern::scheduleEventLoop()::$_0>, void (facebook::jsi::Runtime&)>::operator() ()
#20	0x000000010d7e17a4 in std::__1::__function::__value_func<void (facebook::jsi::Runtime&)>::operator()[abi:de190102] ()
#21	0x000000010d7dfe0c in std::__1::function<void (facebook::jsi::Runtime&)>::operator() ()
#22	0x000000010d7dfa5c in _ZZZN8facebook5react13ReactInstanceC1ENSt3__110unique_ptrINS0_9JSRuntimeENS2_14default_deleteIS4_EEEENS2_10shared_ptrINS0_18MessageQueueThreadEEENS8_INS0_12TimerManagerEEENS2_8functionIFvRNS_3jsi7RuntimeERKNS0_14JsErrorHandler14ProcessedErrorEEEEPNS0_18jsinspector_modern10HostTargetEENK3$_0clINSD_IFvSG_EEEEEDaT_ENKUlvE_clEv ()
#23	0x000000010d7df9ac in _ZNSt3__18__invokeB8de190102IRZZN8facebook5react13ReactInstanceC1ENS_10unique_ptrINS2_9JSRuntimeENS_14default_deleteIS5_EEEENS_10shared_ptrINS2_18MessageQueueThreadEEENS9_INS2_12TimerManagerEEENS_8functionIFvRNS1_3jsi7RuntimeERKNS2_14JsErrorHandler14ProcessedErrorEEEEPNS2_18jsinspector_modern10HostTargetEENK3$_0clINSE_IFvSH_EEEEEDaT_EUlvE_JEEEDTclclsr3stdE7declvalISW_EEspclsr3stdE7declvalIT0_EEEEOSW_DpOSZ_ ()
#24	0x000000010d7df964 in _ZNSt3__128__invoke_void_return_wrapperIvLb1EE6__callB8de190102IJRZZN8facebook5react13ReactInstanceC1ENS_10unique_ptrINS4_9JSRuntimeENS_14default_deleteIS7_EEEENS_10shared_ptrINS4_18MessageQueueThreadEEENSB_INS4_12TimerManagerEEENS_8functionIFvRNS3_3jsi7RuntimeERKNS4_14JsErrorHandler14ProcessedErrorEEEEPNS4_18jsinspector_modern10HostTargetEENK3$_0clINSG_IFvSJ_EEEEEDaT_EUlvE_EEEvDpOT_ ()
#25	0x000000010d7df940 in _ZNSt3__110__function12__alloc_funcIZZN8facebook5react13ReactInstanceC1ENS_10unique_ptrINS3_9JSRuntimeENS_14default_deleteIS6_EEEENS_10shared_ptrINS3_18MessageQueueThreadEEENSA_INS3_12TimerManagerEEENS_8functionIFvRNS2_3jsi7RuntimeERKNS3_14JsErrorHandler14ProcessedErrorEEEEPNS3_18jsinspector_modern10HostTargetEENK3$_0clINSF_IFvSI_EEEEEDaT_EUlvE_NS_9allocatorISY_EEFvvEEclB8de190102Ev ()
#26	0x000000010d7de680 in _ZNSt3__110__function6__funcIZZN8facebook5react13ReactInstanceC1ENS_10unique_ptrINS3_9JSRuntimeENS_14default_deleteIS6_EEEENS_10shared_ptrINS3_18MessageQueueThreadEEENSA_INS3_12TimerManagerEEENS_8functionIFvRNS2_3jsi7RuntimeERKNS3_14JsErrorHandler14ProcessedErrorEEEEPNS3_18jsinspector_modern10HostTargetEENK3$_0clINSF_IFvSI_EEEEEDaT_EUlvE_NS_9allocatorISY_EEFvvEEclEv ()
#27	0x000000010ced09d0 in std::__1::__function::__value_func<void ()>::operator()[abi:de190102] ()
#28	0x000000010cecfd30 in std::__1::function<void ()>::operator() ()
#29	0x000000010cedf8ac in facebook::react::tryAndReturnError ()
#30	0x000000010ced0018 in facebook::react::RCTMessageThread::tryFunc ()
#31	0x000000010ced538c in facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0::operator()() const ()
#32	0x000000010ced5330 in std::__1::__invoke[abi:de190102]<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0&> ()
#33	0x000000010ced52e8 in std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:de190102]<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0&> ()
#34	0x000000010ced52c4 in std::__1::__function::__alloc_func<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0, std::__1::allocator<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0>, void ()>::operator()[abi:de190102] ()
#35	0x000000010ced3f80 in std::__1::__function::__func<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0, std::__1::allocator<facebook::react::RCTMessageThread::runOnQueue(std::__1::function<void ()>&&)::$_0>, void ()>::operator() ()
#36	0x000000010ced09d0 in std::__1::__function::__value_func<void ()>::operator()[abi:de190102] ()
#37	0x000000010cecfd30 in std::__1::function<void ()>::operator() ()
#38	0x000000010cecfd04 in invocation function for block in facebook::react::RCTMessageThread::runAsync(std::__1::function<void ()>) ()
#39	0x0000000180422d28 in __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ ()
#40	0x00000001804224b4 in __CFRunLoopDoBlocks ()
#41	0x0000000180421df8 in __CFRunLoopRun ()
#42	0x000000018041c904 in _CFRunLoopRunSpecificWithOptions ()
#43	0x000000010d8670d8 in +[RCTJSThreadManager runRunLoop] ()
#44	0x0000000181154edc in __NSThread__start__ ()
#45	0x0000000104e7a63c in _pthread_start ()
#46	0x0000000104e75a34 in thread_start ()
```

## Test plan

1. Build the `fabric-example` app on iOS.
2. Open the `[LA] Reduced motion` example.
3. In the `always reduce` section, toggle the box (`show` / `hide`) several times.
4. The box animates instantly and the app no longer crashes.

Verified on the iOS simulator: before the fix, the first `hide` reliably crashes; after the fix, repeated show/hide cycles run without crashing and the box hides correctly.