### PR TITLE
Fix: Remove deprecated project.projectDir usage in android-hook.gradle.kts

### DIFF
--- a/scripts/llvm-tools/android-hook.gradle.kts
+++ b/scripts/llvm-tools/android-hook.gradle.kts
@@ -4,8 +4,8 @@ project.tasks.configureEach {
     if (!javaClass.name.startsWith("com.android.build.gradle.tasks.ExternalNativeBuildJsonTask")) {
         return@configureEach
     }
-    val pkgDir: File = project.projectDir.parentFile
-    val cxxRoot = File(project.projectDir, ".cxx")
+    val pkgDir: File = project.layout.projectDirectory.asFile.parentFile
+    val cxxRoot = File(project.layout.projectDirectory.asFile, ".cxx")
     doLast {
         val repoRoot = pkgDir.parentFile.parentFile
         val publishScript = File(repoRoot, "scripts/llvm-tools/emit.js")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

I was seeing `react-native-worklets/android/build.gradle.kts:281:36: 'getter for buildDir: File!' is deprecated. Deprecated in Java` while running react-native-worklets 0.9.1 
[This PR will fix it](https://github.com/software-mansion/react-native-reanimated/pull/9497) so it isn't run during configuration - I still think its a good idea to  replace deprecated project.projectDir calls with project.layout.projectDirectory.asFile to use the modern Gradle API. This addresses deprecation warnings and ensures compatibility with newer Gradle versions.

## Test plan

Build System Verification

  - [ ] Clean builds succeed: Run ./gradlew clean followed by ./gradlew build in both debug
  and release configurations
  - [ ] Prefab headers generation works: Verify that the prefab headers are correctly
  generated at the new path by checking that build/prefab-headers/worklets/ contains the
  expected header files after build
  - [ ] Native compilation succeeds: Ensure CMake builds complete without errors and the
  worklets library is properly linked
  - [ ] Integration with example app: Test that the example app in the repo builds and runs
  correctly with the changes

  Cross-Platform Testing

  - [ ] Different Gradle versions: Test with minimum supported Gradle version and latest
  stable version
  - [ ] Different AGP versions: Verify compatibility with Android Gradle Plugin versions the
  project supports
  - [ ] CI/CD pipeline: Ensure all automated build checks pass

  Backwards Compatibility

  - [ ] Existing projects: Verify that existing React Native projects using worklets
  continue to build without issues
  - [ ] Custom build configurations: Test with projects that have custom buildDir
  configurations

  Validation Steps

  # Verify the prefab headers are generated correctly
  ./gradlew :react-native-worklets:prepareWorkletsHeadersForPrefabs
  ls -la packages/react-native-worklets/android/build/prefab-headers/worklets/

  # Check that the path is correctly used in CMake
  ./gradlew :react-native-worklets:externalNativeBuildDebug --info | grep "prefab-headers"

  This test plan covers the key areas that could be affected by changing from the deprecated
  buildDir to layout.buildDirectory.get().asFile, ensuring the build system continues to
  work correctly across different environments.
