### PR TITLE
feat(ReJest): record native updates from platform mutations on new arch

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/AnimationUpdatesRecorder.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/AnimationUpdatesRecorder.ts
@@ -35,6 +35,12 @@ export class AnimationUpdatesRecorder {
         recordLayoutAnimationUpdates(tag, value);
         originalNotifyAboutProgress(tag, value);
       };
+
+      // Start recording the mutations Reanimated sends to the platform. This is
+      // the source of truth for native values on the new architecture. No-op
+      // when the `RUNTIME_TEST_FLAG` static feature flag is disabled.
+      global._clearRecordedNativeMutations?.();
+      global._startRecordingNativeMutations?.();
     });
     return updatesContainer;
   }
@@ -50,6 +56,7 @@ export class AnimationUpdatesRecorder {
         global._notifyAboutProgress = global.originalNotifyAboutProgress;
         global.originalNotifyAboutProgress = undefined;
       }
+      global._stopRecordingNativeMutations?.();
     });
   }
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/UpdatesContainer.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/TestRunner/UpdatesContainer.ts
@@ -1,13 +1,20 @@
 import { makeMutable } from 'react-native-reanimated';
 
 import type { TestComponent } from '../TestComponent';
-import type { Operation, OperationUpdate } from '../types';
-import { isValidPropName } from '../types';
+import type {
+  Operation,
+  OperationUpdate,
+  RecordedNativeMutation,
+} from '../types';
 import { SyncUIRunner } from '../utils/SyncUIRunner';
 import { convertDecimalColor } from '../utils/util';
 
 export type SingleViewSnapshot = Array<OperationUpdate>;
 type MultiViewSnapshot = Record<number, SingleViewSnapshot>;
+
+// Safety net so a failing UI worklet can never hang the whole test run by
+// preventing `runOnUIBlocking`'s unlock callback from firing.
+const RUN_ON_UI_TIMEOUT_MS = 8000;
 
 type JsUpdate = {
   tag: number;
@@ -16,44 +23,12 @@ type JsUpdate = {
 };
 type NativeUpdate = {
   tag: number;
-  shadowNodeWrapper?: unknown;
   snapshot: Record<string, unknown>;
   jsUpdateIndex: number;
 };
 
 export function createUpdatesContainer() {
   const jsUpdates = makeMutable<Array<JsUpdate>>([]);
-  const nativeSnapshots = makeMutable<Array<NativeUpdate>>([]);
-
-  function _updateNativeSnapshot(
-    updateInfos: JsUpdate[],
-    jsUpdateIndex: number
-  ): void {
-    'worklet';
-    nativeSnapshots.modify((values) => {
-      'worklet';
-      for (const updateInfo of updateInfos) {
-        const snapshot: OperationUpdate = {};
-        const updatedProps = Object.keys(updateInfo.update);
-        const propsToUpdate = updatedProps.filter((propName) =>
-          isValidPropName(propName)
-        );
-        for (const prop of propsToUpdate) {
-          snapshot[prop] = global._obtainProp(
-            updateInfo?.shadowNodeWrapper,
-            prop
-          );
-        }
-        values.push({
-          tag: updateInfo.tag,
-          shadowNodeWrapper: updateInfo.shadowNodeWrapper,
-          snapshot,
-          jsUpdateIndex,
-        });
-      }
-      return values;
-    });
-  }
 
   function _updateJsSnapshot(newUpdates: JsUpdate[]): void {
     'worklet';
@@ -69,23 +44,26 @@ export function createUpdatesContainer() {
     operations: Operation[]
   ): Array<Required<JsUpdate>> {
     'worklet';
-    const jsUpdates: Array<Required<JsUpdate>> = [];
+    const extractedUpdates: Array<Required<JsUpdate>> = [];
     for (const operation of operations) {
       const { updates } = operation;
-      jsUpdates.push({
+      extractedUpdates.push({
         tag: operation.tag ?? -1,
         shadowNodeWrapper: operation.shadowNodeWrapper,
         update: updates,
       });
     }
-    return jsUpdates;
+    return extractedUpdates;
   }
 
   function pushAnimationUpdates(operations: Operation[]) {
     'worklet';
-    const newUpdates = _extractJSUpdatesUpdatesFromOperation(operations);
-    _updateNativeSnapshot(newUpdates, jsUpdates.value.length - 1);
-    _updateJsSnapshot(newUpdates);
+    // Only the JS-computed values are captured here. The native values are
+    // recorded in C++ (`NativeMutationsRegistry`) from the mutations actually
+    // sent to the platform and retrieved later via `getNativeSnapshots`. We must
+    // NOT read native props per frame: on the new architecture that read
+    // (`getNewestCloneOfShadowNode`) deadlocks against the in-flight commits.
+    _updateJsSnapshot(_extractJSUpdatesUpdatesFromOperation(operations));
   }
 
   function pushLayoutAnimationUpdates(
@@ -100,7 +78,6 @@ export function createUpdatesContainer() {
         updatesCopy.backgroundColor
       );
     }
-    _updateNativeSnapshot([{ tag, update }], jsUpdates.value.length - 1);
     jsUpdates.modify((updates) => {
       updates.push({
         tag,
@@ -173,31 +150,31 @@ export function createUpdatesContainer() {
     component?: TestComponent,
     propsNames: string[] = []
   ): Promise<SingleViewSnapshot> {
-    const nativeSnapshotsCount = nativeSnapshots.value.length;
-    const jsUpdatesCount = jsUpdates.value.length;
-    if (jsUpdatesCount === nativeSnapshotsCount) {
-      await new SyncUIRunner().runOnUIBlocking(() => {
-        'worklet';
-        const lastSnapshot = nativeSnapshots.value[nativeSnapshotsCount - 1];
-        if (lastSnapshot) {
-          _updateNativeSnapshot(
-            [
-              {
-                tag: lastSnapshot.tag,
-                shadowNodeWrapper: lastSnapshot.shadowNodeWrapper,
-                update: lastSnapshot.snapshot,
-              },
-            ],
-            jsUpdatesCount - 1
-          );
-        }
-      });
-    }
-    const sortedUpdates = _sortUpdatesByViewTag(
-      nativeSnapshots.value,
-      propsNames
-    );
+    // Reconstruct the native snapshots from the mutations recorded in C++ (the
+    // values actually sent to the platform), in order. Each recorded mutation is
+    // one native frame; the matcher's `+ Number(native)` offset accounts for the
+    // one-frame lag between a JS update and its committed native value.
+    const recorded = await getRecordedNativeMutations();
+    const nativeUpdates: NativeUpdate[] = recorded
+      .filter((mutation) => mutation.snapshot !== undefined)
+      .map((mutation) => ({
+        tag: mutation.tag,
+        snapshot: mutation.snapshot as Record<string, unknown>,
+        jsUpdateIndex: mutation.index,
+      }));
+    const sortedUpdates = _sortUpdatesByViewTag(nativeUpdates, propsNames);
     return _getComponentFromSortedUpdates(sortedUpdates, component);
+  }
+
+  async function getRecordedNativeMutations(): Promise<
+    RecordedNativeMutation[]
+  > {
+    const recorded = makeMutable<RecordedNativeMutation[]>([]);
+    await new SyncUIRunner().runOnUIBlocking(() => {
+      'worklet';
+      recorded.value = global._getRecordedNativeMutations?.() ?? [];
+    }, RUN_ON_UI_TIMEOUT_MS);
+    return recorded.value;
   }
 
   return {
@@ -205,5 +182,6 @@ export function createUpdatesContainer() {
     pushLayoutAnimationUpdates,
     getUpdates,
     getNativeSnapshots,
+    getRecordedNativeMutations,
   };
 }

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/types.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/ReJest/types.ts
@@ -152,6 +152,24 @@ export type Mismatch = {
 export type DefaultValue = 'not_ok' | 'ok';
 export type ValueWrapper<T> = { value: T | DefaultValue };
 
+/**
+ * A single native update recorded by the `NativeMutationsRegistry` (C++) - the
+ * value that was actually sent to the platform mounting layer. Either a
+ * `snapshot` of the view's props (from a `ShadowViewMutation`) or a Core
+ * Animation `descriptor` (for props routed straight to the `CALayer`).
+ */
+export type RecordedNativeMutation = {
+  tag: number;
+  index: number;
+  snapshot?: Record<string, string>;
+  descriptor?: {
+    property: string;
+    from: number;
+    to: number;
+    duration: number;
+  };
+};
+
 declare global {
   var mockedAnimationTimestamp: number | undefined;
   var framesCount: number | undefined;
@@ -175,6 +193,18 @@ declare global {
     value: Record<string, unknown>
   ) => void;
   var _obtainProp: (shadowNodeWrapper: unknown, propName: string) => string;
+  // ReJest native-mutation recording (installed only when the
+  // `RUNTIME_TEST_FLAG` static feature flag is enabled). See
+  // `NativeMutationsRegistry` on the native side.
+  var _startRecordingNativeMutations: (() => void) | undefined;
+  var _stopRecordingNativeMutations: (() => void) | undefined;
+  var _clearRecordedNativeMutations: (() => void) | undefined;
+  var _getRecordedNativeMutations: (() => RecordedNativeMutation[]) | undefined;
+  // Reads the latest value of `propName` actually sent to the platform for the
+  // given view. Mirrors `_obtainProp` but reflects the recorded mutation stream.
+  var _obtainLatestRecordedProp:
+    | ((shadowNodeWrapper: unknown, propName: string) => string)
+    | undefined;
   var __flushAnimationFrame: (frameTimestamp: number) => void;
   var LayoutAnimationsManager: {
     start: LayoutAnimationStartFunction;

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -46,6 +46,12 @@ export default function RuntimeTestsExample() {
           },
         },
         {
+          testSuiteName: 'native updates',
+          importTest: () => {
+            require('./tests/nativeUpdates/nativeMutationsRecording.test');
+          },
+        },
+        {
           testSuiteName: 'memory',
           importTest: () => {
             require('./tests/memory/createSerializable.test');

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/nativeUpdates/nativeMutationsRecording.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/nativeUpdates/nativeMutationsRecording.test.tsx
@@ -1,0 +1,122 @@
+import type React from 'react';
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import Animated, {
+  css,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import {
+  describe,
+  expect,
+  getTestComponent,
+  recordAnimationUpdates,
+  render,
+  test,
+  useTestRef,
+  wait,
+} from '../../ReJest/RuntimeTestsApi';
+import type { RecordedNativeMutation } from '../../ReJest/types';
+
+/**
+ * Verifies the new-architecture native-update interception.
+ *
+ * On the new architecture the value sent to a native view is no longer readable
+ * synchronously from the shadow node - it is applied through Fabric commits /
+ * mutations, and a synchronous `getNewestCloneOfShadowNode` read deadlocks
+ * against the in-flight commits. Instead, the `NativeMutationsRegistry` (C++)
+ * records the `ShadowViewMutation`s that Reanimated sends to the platform (from
+ * the same `pullTransaction` funnel the layout-animations delegate owns), and
+ * ReJest reads them back via `getRecordedNativeMutations` /
+ * `getNativeSnapshots`.
+ *
+ * Recording is gated behind the `RUNTIME_TEST_FLAG` static feature flag, which
+ * is enabled in this app.
+ *
+ * NOTE: layout animations and shared element transitions flow through the very
+ * same recording call site (the experimental proxy's `filteredMutations`), so
+ * they are covered by the same mechanism exercised here.
+ */
+
+const OPACITY_REF = 'OpacityBox';
+
+function nativeValuesForTag(
+  recorded: RecordedNativeMutation[],
+  tag: number,
+  prop: string
+): number[] {
+  return recorded
+    .filter(
+      (mutation) =>
+        mutation.tag === tag && mutation.snapshot?.[prop] !== undefined
+    )
+    .map((mutation) => Number(mutation.snapshot![prop]));
+}
+
+describe('Native mutations recording (new architecture)', () => {
+  const OpacityComponent = ({ duration }: { duration: number }) => {
+    const opacity = useSharedValue(1);
+    const ref = useTestRef(OPACITY_REF);
+    const style = useAnimatedStyle(() => ({ opacity: opacity.value }));
+    useEffect(() => {
+      opacity.value = withTiming(0, { duration });
+    }, [opacity, duration]);
+    return (
+      <View style={styles.container}>
+        <Animated.View ref={ref} style={[styles.box, style]} />
+      </View>
+    );
+  };
+
+  async function recordRendered(component: React.JSX.Element, waitMs = 600) {
+    const updatesContainer = await recordAnimationUpdates();
+    await render(component);
+    await wait(waitMs);
+    return updatesContainer;
+  }
+
+  test('records the native opacity mutations sent to the platform', async () => {
+    const updatesContainer = await recordRendered(
+      <OpacityComponent duration={300} />
+    );
+    const recorded = await updatesContainer.getRecordedNativeMutations();
+    const tag = getTestComponent(OPACITY_REF).getTag();
+    const opacities = nativeValuesForTag(recorded, tag, 'opacity');
+
+    // A real recording: several native opacity values that start opaque and
+    // settle at zero - the values actually mounted on the platform.
+    expect(opacities.length).toBeWithinRange(2, 100000);
+    expect(opacities[0]).toBeWithinRange(0.9, 1);
+    expect(opacities[opacities.length - 1]).toBeWithinRange(0, 0.1);
+  });
+
+  test('native snapshots track the JS-computed values of an animation', async () => {
+    const updatesContainer = await recordRendered(
+      <OpacityComponent duration={300} />
+    );
+    const component = getTestComponent(OPACITY_REF);
+    const updates = updatesContainer.getUpdates(component, ['opacity']);
+    const nativeUpdates = await updatesContainer.getNativeSnapshots(component, [
+      'opacity',
+    ]);
+    // The native channel (reconstructed from the recorded mutations) tracks the
+    // JS channel (the values the worklet computed). This is the cross-check the
+    // framework lost on the new architecture.
+    expect(updates).toMatchNativeSnapshots(nativeUpdates);
+  });
+});
+
+const styles = css.create({
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  box: {
+    width: 80,
+    height: 80,
+    margin: 30,
+    backgroundColor: 'tomato',
+  },
+});

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -2,16 +2,19 @@
 #include <reanimated/Tools/FeatureFlags.h>
 
 #include <utility>
+#include <variant>
 
 namespace reanimated::css {
 
 CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
     CSSCanRoutePropertyFunction canRoute,
     CSSApplyTransitionFunction applyTransition,
-    CSSRemoveTransitionFunction removeTransition)
+    CSSRemoveTransitionFunction removeTransition,
+    CSSRecordTransitionDescriptorFunction recordDescriptor)
     : canRoute_(std::move(canRoute)),
       applyTransition_(std::move(applyTransition)),
-      removeTransition_(std::move(removeTransition)) {}
+      removeTransition_(std::move(removeTransition)),
+      recordDescriptor_(std::move(recordDescriptor)) {}
 
 bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
   if constexpr (!StaticFeatureFlags::getFlag("IOS_CSS_CORE_ANIMATION")) {
@@ -21,6 +24,16 @@ bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const
 }
 
 void CSSPlatformTransitionProxy::run(const CSSPlatformTransitionPropertyConfig &config) const {
+  // Testing-only (ReJest): record the descriptor handed to Core Animation. These
+  // transitions run on the platform's CALayer and emit no per-frame mutation, so
+  // this is the only point where the animation's from/to/duration is observable.
+  if (recordDescriptor_) {
+    const auto *fromValue = std::get_if<double>(&config.fromValue);
+    const auto *toValue = std::get_if<double>(&config.toValue);
+    if (fromValue != nullptr && toValue != nullptr) {
+      recordDescriptor_(config.viewTag, config.propertyName, *fromValue, *toValue, config.durationMs);
+    }
+  }
   if (applyTransition_) {
     applyTransition_(config);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -46,6 +46,10 @@ struct CSSPlatformTransitionConfig {
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
 using CSSApplyTransitionFunction = std::function<void(const CSSPlatformTransitionPropertyConfig &config)>;
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
+// Testing-only (ReJest). Records the descriptor of a transition routed to the
+// platform (Core Animation) before it is handed off. Null in normal builds.
+using CSSRecordTransitionDescriptorFunction = std::function<
+    void(Tag viewTag, const std::string &propertyName, double fromValue, double toValue, double durationMs)>;
 
 struct CSSTransitionRouting {
   TransitionProperties loop;
@@ -63,7 +67,8 @@ class CSSPlatformTransitionProxy {
   CSSPlatformTransitionProxy(
       CSSCanRoutePropertyFunction canRoute,
       CSSApplyTransitionFunction applyTransition,
-      CSSRemoveTransitionFunction removeTransition);
+      CSSRemoveTransitionFunction removeTransition,
+      CSSRecordTransitionDescriptorFunction recordDescriptor = nullptr);
 
   void run(const CSSPlatformTransitionPropertyConfig &config) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
@@ -80,6 +85,7 @@ class CSSPlatformTransitionProxy {
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;
+  CSSRecordTransitionDescriptorFunction recordDescriptor_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/NativeMutationsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/NativeMutationsRegistry.cpp
@@ -1,0 +1,133 @@
+#include <reanimated/Fabric/updates/NativeMutationsRegistry.h>
+#include <reanimated/NativeModules/PropValueProcessor.h>
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace reanimated {
+
+// The props ReJest is able to snapshot. Mirrors `isValidPropName` on the JS
+// side and the set supported by `PropValueProcessor`.
+static constexpr std::array<std::string_view, 8> kRecordableProps =
+    {"opacity", "zIndex", "width", "height", "top", "left", "backgroundColor", "boxShadow"};
+
+void NativeMutationsRegistry::start() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  recording_.store(true);
+  index_ = 0;
+  mutationLog_.clear();
+  descriptorLog_.clear();
+  latestViewForTag_.clear();
+}
+
+void NativeMutationsRegistry::stop() {
+  recording_.store(false);
+}
+
+void NativeMutationsRegistry::clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  index_ = 0;
+  mutationLog_.clear();
+  descriptorLog_.clear();
+  latestViewForTag_.clear();
+}
+
+bool NativeMutationsRegistry::isRecording() const {
+  return recording_.load();
+}
+
+void NativeMutationsRegistry::record(const ShadowViewMutationList &mutations) {
+  if (!recording_.load()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto currentIndex = index_++;
+  for (const auto &mutation : mutations) {
+    if (mutation.type != ShadowViewMutation::Update && mutation.type != ShadowViewMutation::Insert) {
+      continue;
+    }
+    const auto &view = mutation.newChildShadowView;
+    if (view.tag <= 0 || !view.props) {
+      continue;
+    }
+    mutationLog_.push_back({view.tag, currentIndex, view});
+    latestViewForTag_[view.tag] = view;
+  }
+}
+
+void NativeMutationsRegistry::recordCoreAnimationDescriptor(
+    Tag tag,
+    const std::string &propName,
+    double fromValue,
+    double toValue,
+    double durationMs) {
+  if (!recording_.load()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  descriptorLog_.push_back({tag, index_++, propName, fromValue, toValue, durationMs});
+}
+
+std::string NativeMutationsRegistry::obtainLatestProp(jsi::Runtime &rt, Tag tag, const std::string &propName) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto it = latestViewForTag_.find(tag);
+  if (it == latestViewForTag_.end()) {
+    return "";
+  }
+  try {
+    return PropValueProcessor::processPropValue(propName, it->second, rt);
+  } catch (...) {
+    // The prop is not present on this view (e.g. a backgroundColor that was
+    // never set). Treat it as "no recorded value" and let the caller fall back.
+    return "";
+  }
+}
+
+jsi::Value NativeMutationsRegistry::getRecordedMutations(jsi::Runtime &rt) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  const auto total = mutationLog_.size() + descriptorLog_.size();
+  jsi::Array result(rt, total);
+  size_t resultIndex = 0;
+
+  for (const auto &entry : mutationLog_) {
+    jsi::Object item(rt);
+    item.setProperty(rt, "tag", jsi::Value(static_cast<int>(entry.tag)));
+    item.setProperty(rt, "index", jsi::Value(static_cast<double>(entry.index)));
+
+    jsi::Object snapshot(rt);
+    for (const auto &propName : kRecordableProps) {
+      const std::string prop{propName};
+      try {
+        const auto value = PropValueProcessor::processPropValue(prop, entry.view, rt);
+        snapshot.setProperty(rt, prop.c_str(), jsi::String::createFromUtf8(rt, value));
+      } catch (...) {
+        // Prop absent on this view - skip it.
+      }
+    }
+    item.setProperty(rt, "snapshot", std::move(snapshot));
+    result.setValueAtIndex(rt, resultIndex++, std::move(item));
+  }
+
+  for (const auto &entry : descriptorLog_) {
+    jsi::Object item(rt);
+    item.setProperty(rt, "tag", jsi::Value(static_cast<int>(entry.tag)));
+    item.setProperty(rt, "index", jsi::Value(static_cast<double>(entry.index)));
+
+    jsi::Object descriptor(rt);
+    descriptor.setProperty(rt, "property", jsi::String::createFromUtf8(rt, entry.propName));
+    descriptor.setProperty(rt, "from", jsi::Value(entry.fromValue));
+    descriptor.setProperty(rt, "to", jsi::Value(entry.toValue));
+    descriptor.setProperty(rt, "duration", jsi::Value(entry.durationMs));
+    item.setProperty(rt, "descriptor", std::move(descriptor));
+    result.setValueAtIndex(rt, resultIndex++, std::move(item));
+  }
+
+  return result;
+}
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/NativeMutationsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/NativeMutationsRegistry.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/mounting/ShadowView.h>
+#include <react/renderer/mounting/ShadowViewMutation.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace reanimated {
+
+using namespace facebook;
+using namespace react;
+
+/**
+ * Records the prop updates Reanimated sends to the platform mounting layer.
+ *
+ * This is a testing-only utility used by the ReJest runtime testing framework
+ * to capture the *native* values of an animation (as opposed to the values
+ * computed in JS). On the new architecture, animated props reach the platform
+ * as `ShadowViewMutation`s pulled through the layout-animations
+ * `MountingOverrideDelegate` (`pullTransaction`). This registry listens to that
+ * same stream, so it observes exactly what is mounted - regardless of whether
+ * the value came from an animated style, a layout animation, a shared element
+ * transition or a CSS animation.
+ *
+ * iOS Core Animation routes some properties (e.g. opacity transitions) straight
+ * to the `CALayer` and therefore emits no per-frame mutation. For those, the
+ * animation *descriptor* (from/to/duration) is recorded separately via
+ * `recordCoreAnimationDescriptor`.
+ *
+ * All recording is gated behind the `RUNTIME_TEST_FLAG` static feature flag at
+ * the call sites, so this class is never exercised in production builds.
+ *
+ * Thread-safety: `record` runs on the mounting thread (`pullTransaction`),
+ * while the read methods run on the UI runtime thread. The registry owns an
+ * independent mutex and must never call back into the proxy / registry manager
+ * to avoid lock-ordering issues with the commit-pause mutex.
+ */
+class NativeMutationsRegistry {
+ public:
+  // Recording lifecycle (called from the UI runtime thread).
+  void start();
+  void stop();
+  void clear();
+  bool isRecording() const;
+
+  // Called from `pullTransaction` (mounting thread). No `jsi::Runtime` access.
+  void record(const ShadowViewMutationList &mutations);
+
+  // Called from the iOS Core Animation hook (any thread). No `jsi::Runtime`.
+  void recordCoreAnimationDescriptor(
+      Tag tag,
+      const std::string &propName,
+      double fromValue,
+      double toValue,
+      double durationMs);
+
+  // Returns the most recently recorded value of `propName` for `tag`, or an
+  // empty string when nothing was recorded for that tag yet. Mirrors the string
+  // contract of `obtainProp`. Reads from the props/layout actually sent to the
+  // platform.
+  std::string obtainLatestProp(jsi::Runtime &rt, Tag tag, const std::string &propName) const;
+
+  // Full dump of everything recorded during the current session, as an array of
+  // `{ tag, index, snapshot? , descriptor? }` objects. `snapshot` holds the
+  // recorded values of the ReJest-valid props; `descriptor` holds a recorded
+  // Core Animation descriptor.
+  jsi::Value getRecordedMutations(jsi::Runtime &rt) const;
+
+ private:
+  struct MutationEntry {
+    Tag tag;
+    uint64_t index;
+    ShadowView view;
+  };
+
+  struct DescriptorEntry {
+    Tag tag;
+    uint64_t index;
+    std::string propName;
+    double fromValue;
+    double toValue;
+    double durationMs;
+  };
+
+  mutable std::mutex mutex_;
+  std::atomic<bool> recording_{false};
+  uint64_t index_{0};
+
+  std::vector<MutationEntry> mutationLog_;
+  std::vector<DescriptorEntry> descriptorLog_;
+  std::unordered_map<Tag, ShadowView> latestViewForTag_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -5,6 +5,7 @@
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <reanimated/Compat/WorkletsApi.h>
+#include <reanimated/Fabric/updates/NativeMutationsRegistry.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
@@ -59,7 +60,15 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   virtual std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) = 0;
   virtual void startSurface(const SurfaceId surfaceId);
 
+  // Testing-only (ReJest). Set when the `RUNTIME_TEST_FLAG` static feature flag
+  // is enabled so `pullTransaction` can record the mutations sent to the
+  // platform. Null in production builds.
+  void setNativeMutationsRegistry(const std::shared_ptr<NativeMutationsRegistry> &nativeMutationsRegistry) {
+    nativeMutationsRegistry_ = nativeMutationsRegistry;
+  }
+
  protected:
+  std::shared_ptr<NativeMutationsRegistry> nativeMutationsRegistry_;
   mutable std::vector<Tag> finishedAnimationTags_;
   mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -1,6 +1,7 @@
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h>
 #include <reanimated/LayoutAnimations/PropsDiffer.h>
+#include <reanimated/Tools/FeatureFlags.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
 #include <algorithm>
@@ -97,6 +98,12 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Experimental::pullTrans
   transitions_.clear();
 
   insertContainers(filteredMutations, rootChildCount, surfaceId);
+
+  if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+    if (nativeMutationsRegistry_) {
+      nativeMutationsRegistry_->record(filteredMutations);
+    }
+  }
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
 
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <reanimated/Tools/FeatureFlags.h>
 
 #include <memory>
 #include <ranges>
@@ -58,6 +59,12 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   handleUpdatesAndEnterings(filteredMutations, movedViews, mutations, propsParserContext, surfaceId);
 
   addOngoingAnimations(surfaceId, filteredMutations);
+
+  if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+    if (nativeMutationsRegistry_) {
+      nativeMutationsRegistry_->record(filteredMutations);
+    }
+  }
 
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/PropValueProcessor.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/PropValueProcessor.cpp
@@ -39,11 +39,30 @@ std::string PropValueProcessor::processPropValue(
       std::string("Getting property `" + propName + "` with function `getViewProp` is not supported"));
 }
 
+std::string
+PropValueProcessor::processPropValue(const std::string &propName, const ShadowView &shadowView, jsi::Runtime &rt) {
+  if (isLayoutProp(propName)) {
+    return processLayoutPropFromFrame(propName, shadowView.layoutMetrics.frame);
+  } else if (isStyleProp(propName)) {
+    auto viewProps = std::static_pointer_cast<const ViewProps>(shadowView.props);
+    if (!viewProps) {
+      throw std::runtime_error("ShadowView has no props for style property: " + propName);
+    }
+    return processStyleProp(propName, viewProps, rt);
+  }
+
+  throw std::runtime_error(std::string("Getting property `" + propName + "` from a ShadowView is not supported"));
+}
+
 std::string PropValueProcessor::processLayoutProp(
     const std::string &propName,
     const LayoutableShadowNode *layoutableShadowNode) {
-  const auto &frame = layoutableShadowNode->layoutMetrics_.frame;
+  return processLayoutPropFromFrame(propName, layoutableShadowNode->layoutMetrics_.frame);
+}
 
+std::string PropValueProcessor::processLayoutPropFromFrame(
+    const std::string &propName,
+    const facebook::react::Rect &frame) {
   if (propName == "width") {
     return std::to_string(frame.size.width);
   } else if (propName == "height") {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/PropValueProcessor.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/PropValueProcessor.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/mounting/ShadowView.h>
 
 #include <memory>
 #include <string>
@@ -21,8 +23,17 @@ class PropValueProcessor {
   static std::string
   processPropValue(const std::string &propName, const std::shared_ptr<const ShadowNode> &shadowNode, jsi::Runtime &rt);
 
+  // Overload that reads a prop value directly from a `ShadowView` (the snapshot
+  // carried by a `ShadowViewMutation`). Used by `NativeMutationsRegistry` to
+  // read the value that is actually being sent to the platform. Style props are
+  // read from `shadowView.props` and layout props from
+  // `shadowView.layoutMetrics.frame`.
+  static std::string processPropValue(const std::string &propName, const ShadowView &shadowView, jsi::Runtime &rt);
+
  private:
   static std::string processLayoutProp(const std::string &propName, const LayoutableShadowNode *layoutableShadowNode);
+
+  static std::string processLayoutPropFromFrame(const std::string &propName, const facebook::react::Rect &frame);
 
   static std::string
   processStyleProp(const std::string &propName, const std::shared_ptr<const ViewProps> &viewProps, jsi::Runtime &rt);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -45,6 +45,21 @@ static inline std::shared_ptr<const ShadowNode> shadowNodeFromValue(
   return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(rt, shadowNodeWrapper);
 }
 
+// Testing-only (ReJest). Returns a recorder that captures Core Animation
+// transition descriptors (from/to/duration) routed to the iOS `CALayer`, which
+// otherwise emit no per-frame mutations. Null (and compiled out) unless the
+// `RUNTIME_TEST_FLAG` static feature flag is enabled.
+static css::CSSRecordTransitionDescriptorFunction makeCoreAnimationDescriptorRecorder(
+    const std::shared_ptr<NativeMutationsRegistry> &registry) {
+  if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+    return [registry](Tag tag, const std::string &propName, double from, double to, double durationMs) {
+      registry->recordCoreAnimationDescriptor(tag, propName, from, to, durationMs);
+    };
+  } else {
+    return nullptr;
+  }
+}
+
 namespace {
 
 #if REACT_NATIVE_VERSION_MINOR >= 85
@@ -211,6 +226,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           platformDepMethodsHolder.getAnimationTimestamp,
           updatesRegistryManager_)),
       animatedPropsRegistry_(std::make_shared<AnimatedPropsRegistry>()),
+      nativeMutationsRegistry_(std::make_shared<NativeMutationsRegistry>()),
       viewStylesRepository_(std::make_shared<ViewStylesRepository>(staticPropsRegistry_, animatedPropsRegistry_)),
       cssAnimationKeyframesRegistry_(std::make_shared<CSSKeyframesRegistry>()),
       cssAnimationsRegistry_(std::make_shared<CSSAnimationsRegistry>(
@@ -223,7 +239,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           std::make_shared<CSSPlatformTransitionProxy>(
               platformDepMethodsHolder.cssCanRouteProperty,
               platformDepMethodsHolder.cssApplyTransition,
-              platformDepMethodsHolder.cssRemoveTransition))),
+              platformDepMethodsHolder.cssRemoveTransition,
+              makeCoreAnimationDescriptorRecorder(nativeMutationsRegistry_)))),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,
           platformDepMethodsHolder.detachPseudoSelector,
@@ -374,6 +391,66 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
     };
   }
 
+  // ReJest native-mutation recording globals. Built only under the
+  // `RUNTIME_TEST_FLAG` static feature flag; the empty struct is harmless
+  // otherwise (the install in `UIRuntimeDecorator` is also compiled out).
+  NativeMutationsRecorderFunctions nativeMutationsRecorderFunctions;
+  if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+    nativeMutationsRecorderFunctions.startRecording = [weakThis = weak_from_this()]() {
+      if (auto strongThis = weakThis.lock()) {
+        strongThis->nativeMutationsRegistry_->start();
+      }
+    };
+    nativeMutationsRecorderFunctions.stopRecording = [weakThis = weak_from_this()]() {
+      if (auto strongThis = weakThis.lock()) {
+        strongThis->nativeMutationsRegistry_->stop();
+      }
+    };
+    nativeMutationsRecorderFunctions.clearRecording = [weakThis = weak_from_this()]() {
+      if (auto strongThis = weakThis.lock()) {
+        strongThis->nativeMutationsRegistry_->clear();
+      }
+    };
+    nativeMutationsRecorderFunctions.getRecordedMutations = [weakThis =
+                                                                 weak_from_this()](jsi::Runtime &rt) -> jsi::Value {
+      auto strongThis = weakThis.lock();
+      if (!strongThis) {
+        return jsi::Array(rt, 0);
+      }
+      // Must never throw - this runs inside a UI worklet whose exception would
+      // prevent the test's unlock callback from firing and hang the run.
+      try {
+        return strongThis->nativeMutationsRegistry_->getRecordedMutations(rt);
+      } catch (...) {
+        return jsi::Array(rt, 0);
+      }
+    };
+    nativeMutationsRecorderFunctions.obtainLatestRecordedProp =
+        [weakThis = weak_from_this()](
+            jsi::Runtime &rt, const jsi::Value &shadowNodeWrapper, const jsi::Value &propName) -> jsi::Value {
+      auto strongThis = weakThis.lock();
+      if (!strongThis) {
+        return jsi::String::createFromUtf8(rt, "");
+      }
+      // Must never throw - see note above. `shadowNodeFromValue` throws for an
+      // invalid/undefined wrapper, and the fallback may throw for an
+      // unsupported prop; swallow both and return an empty string.
+      try {
+        const auto propNameStr = propName.asString(rt).utf8(rt);
+        const auto shadowNode = shadowNodeFromValue(rt, shadowNodeWrapper);
+        auto result = strongThis->nativeMutationsRegistry_->obtainLatestProp(rt, shadowNode->getTag(), propNameStr);
+        if (result.empty()) {
+          // No mutation recorded for this tag yet (e.g. the first frame or a
+          // Core-Animation-routed prop). Fall back to reading the shadow node.
+          result = strongThis->obtainPropFromShadowNode(rt, propNameStr, shadowNode);
+        }
+        return jsi::String::createFromUtf8(rt, result);
+      } catch (...) {
+        return jsi::String::createFromUtf8(rt, "");
+      }
+    };
+  }
+
   jsi::Runtime &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
   UIRuntimeDecorator::decorate(
       uiRuntime,
@@ -386,7 +463,8 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
       progressLayoutAnimation,
       endLayoutAnimation,
       platformDepMethodsHolder.maybeFlushUIUpdatesQueueFunction,
-      requestAnimationFrame);
+      requestAnimationFrame,
+      nativeMutationsRecorderFunctions);
 }
 
 ReanimatedModuleProxy::~ReanimatedModuleProxy() {
@@ -1232,6 +1310,9 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
 #ifdef __APPLE__
       layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
 #endif
+      if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+        layoutAnimationsProxyExperimental->setNativeMutationsRegistry(nativeMutationsRegistry_);
+      }
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
     } else {
       auto layoutAnimationsProxyLegacy = std::make_shared<LayoutAnimationsProxy_Legacy>(
@@ -1249,6 +1330,9 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
       );
       // TODO (future): support in experimental
       uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
+      if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+        layoutAnimationsProxyLegacy->setNativeMutationsRegistry(nativeMutationsRegistry_);
+      }
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);
     }
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -20,6 +20,7 @@
 #include <reanimated/Fabric/ReanimatedMountHook.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
+#include <reanimated/Fabric/updates/NativeMutationsRegistry.h>
 #include <reanimated/Fabric/updates/OperationsLoop.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
@@ -243,6 +244,11 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::shared_ptr<OperationsLoop> operationsLoop_;
   const std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
+  // Testing-only (ReJest). Records the mutations / Core Animation descriptors
+  // sent to the platform when the `RUNTIME_TEST_FLAG` static feature flag is
+  // enabled. Declared before the CSS registries so it can be wired into the
+  // CSS transition proxy at construction.
+  const std::shared_ptr<NativeMutationsRegistry> nativeMutationsRegistry_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
   const std::shared_ptr<CSSKeyframesRegistry> cssAnimationKeyframesRegistry_;
   const std::shared_ptr<CSSAnimationsRegistry> cssAnimationsRegistry_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/RuntimeDecorators/UIRuntimeDecorator.h>
+#include <reanimated/Tools/FeatureFlags.h>
 #include <reanimated/Tools/ReaJSIUtils.h>
 
 namespace reanimated {
@@ -14,7 +15,8 @@ void UIRuntimeDecorator::decorate(
     const ProgressLayoutAnimationFunction &progressLayoutAnimation,
     const EndLayoutAnimationFunction &endLayoutAnimation,
     const MaybeFlushUIUpdatesQueueFunction &maybeFlushUIUpdatesQueue,
-    const std::optional<worklets::RequestAnimationFrameHostFunction> &requestAnimationFrame) {
+    const std::optional<worklets::RequestAnimationFrameHostFunction> &requestAnimationFrame,
+    const NativeMutationsRecorderFunctions &nativeMutationsRecorderFunctions) {
 
   jsi_utils::installJsiFunction(uiRuntime, "_updateProps", updateProps);
   jsi_utils::installJsiFunction(uiRuntime, "_dispatchCommand", dispatchCommand);
@@ -27,6 +29,20 @@ void UIRuntimeDecorator::decorate(
   jsi_utils::installJsiFunction(uiRuntime, "_maybeFlushUIUpdatesQueue", maybeFlushUIUpdatesQueue);
   if (requestAnimationFrame.has_value()) {
     worklets::installRequestAnimationFrame(uiRuntime, *requestAnimationFrame);
+  }
+
+  // ReJest native-mutation recording. Compiled out entirely in normal builds.
+  if constexpr (StaticFeatureFlags::getFlag("RUNTIME_TEST_FLAG")) {
+    jsi_utils::installJsiFunction(
+        uiRuntime, "_startRecordingNativeMutations", nativeMutationsRecorderFunctions.startRecording);
+    jsi_utils::installJsiFunction(
+        uiRuntime, "_stopRecordingNativeMutations", nativeMutationsRecorderFunctions.stopRecording);
+    jsi_utils::installJsiFunction(
+        uiRuntime, "_clearRecordedNativeMutations", nativeMutationsRecorderFunctions.clearRecording);
+    jsi_utils::installJsiFunction(
+        uiRuntime, "_getRecordedNativeMutations", nativeMutationsRecorderFunctions.getRecordedMutations);
+    jsi_utils::installJsiFunction(
+        uiRuntime, "_obtainLatestRecordedProp", nativeMutationsRecorderFunctions.obtainLatestRecordedProp);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/RuntimeDecorators/UIRuntimeDecorator.h
@@ -5,11 +5,23 @@
 #include <reanimated/Tools/PlatformDepMethodsHolder.h>
 #include <worklets/Compat/StableApi.h>
 
+#include <functional>
 #include <optional>
 
 using namespace facebook;
 
 namespace reanimated {
+
+// Testing-only (ReJest). Bundle of UI-runtime globals that expose the
+// `NativeMutationsRegistry` to JS. Only installed when the `RUNTIME_TEST_FLAG`
+// static feature flag is enabled.
+struct NativeMutationsRecorderFunctions {
+  std::function<void()> startRecording;
+  std::function<void()> stopRecording;
+  std::function<void()> clearRecording;
+  std::function<jsi::Value(jsi::Runtime &)> getRecordedMutations;
+  std::function<jsi::Value(jsi::Runtime &, const jsi::Value &, const jsi::Value &)> obtainLatestRecordedProp;
+};
 
 class UIRuntimeDecorator {
  public:
@@ -24,7 +36,8 @@ class UIRuntimeDecorator {
       const ProgressLayoutAnimationFunction &progressLayoutAnimation,
       const EndLayoutAnimationFunction &endLayoutAnimation,
       const MaybeFlushUIUpdatesQueueFunction &maybeFlushUIUpdatesQueue,
-      const std::optional<worklets::RequestAnimationFrameHostFunction> &requestAnimationFrame);
+      const std::optional<worklets::RequestAnimationFrameHostFunction> &requestAnimationFrame,
+      const NativeMutationsRecorderFunctions &nativeMutationsRecorderFunctions);
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/src/updateProps/updateProps.ts
+++ b/packages/react-native-reanimated/src/updateProps/updateProps.ts
@@ -105,6 +105,7 @@ function updateJSProps(operations: JSPropsOperation[]) {
 }
 
 type NativePropsOperation = {
+  tag: number;
   shadowNodeWrapper: ShadowNodeWrapper;
   updates: StyleProps;
 };
@@ -142,6 +143,10 @@ function createUpdatePropsManager() {
 
         if (nativePropUpdates) {
           nativeOperations.push({
+            // `tag` lets the ReJest testing framework group recorded updates by
+            // view. The native side ignores it (it derives the tag from the
+            // shadow node wrapper).
+            tag: viewTag,
             shadowNodeWrapper,
             updates: nativePropUpdates,
           });


### PR DESCRIPTION
## Summary

ReJest's recording of **native** animation updates broke on the new
architecture. It read native prop values synchronously from the shadow node
(`_obtainProp` → `getNewestCloneOfShadowNode`), which on the new arch
**deadlocks against in-flight Fabric commits** and returns stale values once
animations are applied via commits / the animation backend / Core Animation.
This is why several `toMatchNativeSnapshots` / `getNativeSnapshots` tests were
disabled with `// TODO: ... it hangs` and `// tag is not passed to _updateProps`.

This PR records native updates **the way the user suggested** — by listening to
the `ShadowViewMutation`s Reanimated sends to the platform, reusing the same
`pullTransaction` funnel the layout-animation delegate already owns — and feeds
them into the ReJest matchers.

## How it works

**JS channel** (values the worklet computes) is still captured via the existing
`_updateProps` / `_notifyAboutProgress` interception.

**Native channel** (values sent to the platform) is now captured in C++:

- New `NativeMutationsRegistry` (`Common/cpp/reanimated/Fabric/updates/`) — a
  thread-safe recorder of the `ShadowViewMutation`s sent to the platform, plus
  Core Animation transition descriptors (`from`/`to`/`duration`) routed to the
  iOS `CALayer` (which emit no per-frame mutation).
- `record(filteredMutations)` is called at the end of **both**
  `LayoutAnimationsProxy_Experimental::pullTransaction` and `_Legacy::pullTransaction`,
  so it captures animated styles, layout animations and shared element
  transitions through one chokepoint. CSS routed to Core Animation is captured
  at the `CSSPlatformTransitionProxy::run` boundary.
- Exposed to the UI runtime via new globals (`_startRecordingNativeMutations`,
  `_stopRecordingNativeMutations`, `_clearRecordedNativeMutations`,
  `_getRecordedNativeMutations`, `_obtainLatestRecordedProp`).
- `UpdatesContainer.getNativeSnapshots` now **reconstructs native snapshots from
  the recorded mutation stream** instead of reading the shadow node per frame —
  which is what removes the deadlock — while preserving the existing matcher /
  frame-lag contract.

**All native code is gated behind the existing `RUNTIME_TEST_FLAG` static feature
flag** (`if constexpr` + a runtime atomic), so it is compiled out / a no-op in
production builds.

Also fixes a latent bug: `_updateProps` operations were missing their `tag`, so
ReJest could not group recorded updates per component (the `// tag is not passed`
TODOs).

## Verification

Built and run on the iOS simulator (`fabric-example`, new arch, experimental
proxy + `IOS_CSS_CORE_ANIMATION`). The new `native updates` suite passes:

```
Native mutations recording (new architecture)
 ✔ records the native opacity mutations sent to the platform   (20 mutations, opacity 1 → 0)
 ✔ native snapshots track the JS-computed values of an animation
🧮 Tests summary: 2 passed, 0 failed, 0 skipped
✅ All tests passed!
```

The C++ recorder captured the real per-frame native opacity values (1 → 0) and
`toMatchNativeSnapshots` confirmed they match the JS-computed values — the
cross-check the framework lost on the new arch.

## Still draft — follow-ups

- **Layout animations & shared element transitions**: covered by the same
  recording call site (the experimental proxy's `filteredMutations`); dedicated
  tests are blocked by a *pre-existing* harness hang on entering/exiting
  animations (the `entering and exiting` / `layout transitions` suites are
  already disabled).
- **CSS animations (iOS)**: in this config they don't surface as shadow
  mutations (`totalRecorded == 0`) and the CSS-animation component's unmount
  hangs the harness — needs investigation of the iOS CSS apply path.
- **CSS + Core Animation descriptor**: the recording hook is wired at
  `CSSPlatformTransitionProxy::run`; the iOS opacity transition did not surface a
  descriptor in this run — needs a closer look at the routing.
- `_obtainLatestRecordedProp` is installed but currently unused by the JS side
  (kept as a usable API); could be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)