### PR TITLE
Fix build error against React Native nightly caused by SAM conversion of CustomEventNamesResolver

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
@@ -54,8 +54,9 @@ class NodesManager(
         val uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC)
         assert(uiManager != null)
         mCustomEventNamesResolver =
-            UIManagerModule.CustomEventNamesResolver { eventName ->
-                uiManager!!.resolveCustomDirectEventName(eventName)
+            object : UIManagerModule.CustomEventNamesResolver {
+                override fun resolveCustomEventName(eventName: String): String? =
+                    uiManager!!.resolveCustomDirectEventName(eventName)
             }
         mDrawPassDetector = DrawPassDetector(context)
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt
@@ -55,8 +55,7 @@ class NodesManager(
         assert(uiManager != null)
         mCustomEventNamesResolver =
             object : UIManagerModule.CustomEventNamesResolver {
-                override fun resolveCustomEventName(eventName: String): String? =
-                    uiManager!!.resolveCustomDirectEventName(eventName)
+                override fun resolveCustomEventName(eventName: String): String? = uiManager!!.resolveCustomDirectEventName(eventName)
             }
         mDrawPassDetector = DrawPassDetector(context)
 


### PR DESCRIPTION
## Summary

Fixes the Android build error reported by [nightly-tests](https://react-native-community.github.io/nightly-tests/):

```
> Task :react-native-reanimated:compileDebugKotlin FAILED
e: file:///tmp/RNApp/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt:57:29 Interface 'interface CustomEventNamesResolver : Any' does not have constructors.
e: file:///tmp/RNApp/node_modules/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.kt:57:56 Cannot infer type for this parameter. Specify it explicitly.
```

On React Native nightly, `UIManagerModule` has been converted from Java to Kotlin and `CustomEventNamesResolver` is now a plain Kotlin `interface`, so the SAM constructor syntax `UIManagerModule.CustomEventNamesResolver { ... }` no longer compiles. This PR replaces it with an explicit anonymous object, which compiles both against the old Java interface and the new Kotlin one.

## Test plan

- Run `./gradlew :react-native-reanimated:compileDebugKotlin` in `apps/fabric-example/android` — builds successfully against the currently pinned React Native version.
- Build an app against React Native nightly — the `compileDebugKotlin` task no longer fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)