### PR TITLE
fix(createAnimatedComponent): avoid false no-deprecated on bare reference

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -41,19 +41,6 @@ type AnimatableComponent<C extends ComponentType<any>> = C & {
 };
 
 /**
- * @deprecated Please use `Animated.FlatList` component instead of calling
- *   `Animated.createAnimatedComponent(FlatList)` manually.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createAnimatedComponent<T = any>(
-  Component: typeof FlatList<T>,
-  options?: Options<InitialComponentProps>
-): AnimatedComponentType<
-  Readonly<FlatListProps<T>>,
-  ComponentRef<typeof FlatList<T>>
->;
-
-/**
  * Lets you create an Animated version of any React Native component.
  *
  * @param Component - The component you want to make animatable.
@@ -69,9 +56,28 @@ export function createAnimatedComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInstance extends AnimatableComponent<ComponentType<any>>,
 >(
-  Component: TInstance,
+  // `FlatList` is excluded so that calls passing it fall through to the
+  // deprecated overload below (which nudges towards `Animated.FlatList`).
+  // This overload is declared first so that a bare reference to
+  // `createAnimatedComponent` (e.g. `Animated.createAnimatedComponent` passed
+  // as a value) resolves to a non-deprecated signature instead of being
+  // falsely flagged by `@typescript-eslint/no-deprecated`.
+  Component: TInstance extends typeof FlatList<infer _> ? never : TInstance,
   options?: Options<InitialComponentProps>
 ): AnimatedComponentType<Readonly<ComponentProps<TInstance>>, TInstance>;
+
+/**
+ * @deprecated Please use `Animated.FlatList` component instead of calling
+ *   `Animated.createAnimatedComponent(FlatList)` manually.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createAnimatedComponent<T = any>(
+  Component: typeof FlatList<T>,
+  options?: Options<InitialComponentProps>
+): AnimatedComponentType<
+  Readonly<FlatListProps<T>>,
+  ComponentRef<typeof FlatList<T>>
+>;
 
 export function createAnimatedComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

A bare value reference to `createAnimatedComponent` — for example passing `Animated.createAnimatedComponent` as a prop/callback **without calling it** — is statically flagged as deprecated by [`@typescript-eslint/no-deprecated`](https://typescript-eslint.io/rules/no-deprecated/) (and its oxlint port `typescript/no-deprecated`):

```
`createAnimatedComponent` is deprecated. Please use `Animated.FlatList` component
instead of calling `Animated.createAnimatedComponent(FlatList)` manually.
```

This is a false positive — no `FlatList` is involved. The cause is overload ordering:

- `createAnimatedComponent` declares the `@deprecated` `FlatList` overload **first**, followed by the general overload.
- At a **call site**, TypeScript runs overload resolution and reads the *resolved* signature's JSDoc, so `createAnimatedComponent(View)` is correctly seen as non-deprecated.
- At a **value reference** (no call to resolve), TypeScript falls back to the **first declared signature** for the deprecation tag — which is the deprecated `FlatList` overload. So every value reference is flagged, regardless of the contextual type.

This bites any library/app that accepts `Animated.createAnimatedComponent` as a value. It surfaced downstream in [software-mansion-labs/react-native-bottom-sheet#23](https://github.com/software-mansion-labs/react-native-bottom-sheet/issues/23), where the documented pattern is to pass `Animated.createAnimatedComponent` as a prop.

### Fix

Reorder the overloads so the **general (non-deprecated) overload is declared first**, and **exclude `FlatList` from it** (`TInstance extends typeof FlatList<infer _> ? never : TInstance`) so that `createAnimatedComponent(FlatList)` calls still fall through to the deprecated overload.

A naive reorder alone does not work: the general overload's constraint matches `FlatList` too, so it would swallow `FlatList` calls and silently drop the intended deprecation. The `never` exclusion is what keeps the deprecation nudge alive for direct `FlatList` usage.

Result:

| usage | before | after |
|---|---|---|
| `Animated.createAnimatedComponent` (value reference) | ❌ deprecated | ✅ not deprecated |
| `createAnimatedComponent(FlatList)` | ✅ deprecated | ✅ deprecated |
| `createAnimatedComponent(TextInput)` | ✅ not deprecated | ✅ not deprecated |

Runtime behavior and the returned component types are unchanged — only the static signature dispatch order moves.

## Test plan

`createAnimatedComponent(FlatList)` continues to warn and return a `FlatList`-typed animated component; a bare reference no longer warns:

```tsx
import { FlatList, TextInput } from 'react-native';
import Animated, { createAnimatedComponent } from 'react-native-reanimated';

const ref = createAnimatedComponent;             // not deprecated (was falsely flagged)
const flist = createAnimatedComponent(FlatList); // still deprecated (nudges to Animated.FlatList)
const tinp = createAnimatedComponent(TextInput); // not deprecated
```

Verified locally:

- `yarn type:check:src:native` (`tsc --noEmit`) — no new errors.
- The existing `__typetests__` that use `createAnimatedComponent(FlatList)` (`FlatListTest`, `AnimatedComponentTest`, `AnimatedPropsTest`, `useAnimatedScrollHandlerTest`, `useAnimatedRefTest`) pass.
- ESLint passes on the changed file.
- Confirmed via the language service that the `deprecated` quick-info tag (the signal `no-deprecated` consumes) is absent on value references and present on `createAnimatedComponent(FlatList)` calls.

Made with [Claude Code](https://claude.com/product/claude-code).
