### PR TITLE
feat: Adopt AGP v9

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -35,7 +35,7 @@
     "fuse.js": "patch:fuse.js@npm%3A7.1.0#~/.yarn/patches/fuse.js-npm-7.1.0-5dcae892a6.patch",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-native-gesture-handler": "3.0.1",
+    "react-native-gesture-handler": "2.32.0",
     "react-native-mmkv": "4.3.0",
     "react-native-nitro-modules": "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch",
     "react-native-reanimated": "workspace:*",

--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -35,7 +35,7 @@
     "fuse.js": "patch:fuse.js@npm%3A7.1.0#~/.yarn/patches/fuse.js-npm-7.1.0-5dcae892a6.patch",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-native-gesture-handler": "2.30.0",
+    "react-native-gesture-handler": "3.0.1",
     "react-native-mmkv": "4.3.0",
     "react-native-nitro-modules": "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch",
     "react-native-reanimated": "workspace:*",

--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/apps/fabric-example/android/gradle.properties
+++ b/apps/fabric-example/android/gradle.properties
@@ -52,3 +52,8 @@ enableWorkletsProfiling=true
 # https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
+
+# Opt out of built-in kotlin and new DSL behavior that ships with AGP 9.
+# Starting from AGP 10.x these opt outs will be removed.
+android.builtInKotlin=false
+android.newDsl=false

--- a/apps/fabric-example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/fabric-example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/docs-reanimated/package.json
+++ b/docs/docs-reanimated/package.json
@@ -57,7 +57,7 @@
     "react-colorful": "5.6.1",
     "react-dom": "19.1.1",
     "react-native": "0.83.0",
-    "react-native-gesture-handler": "2.28.0",
+    "react-native-gesture-handler": "3.0.1",
     "react-native-reanimated": "4.4.1",
     "react-native-svg": "15.15.4",
     "react-native-web": "0.21.2",

--- a/docs/docs-reanimated/package.json
+++ b/docs/docs-reanimated/package.json
@@ -57,7 +57,7 @@
     "react-colorful": "5.6.1",
     "react-dom": "19.1.1",
     "react-native": "0.83.0",
-    "react-native-gesture-handler": "3.0.1",
+    "react-native-gesture-handler": "2.32.0",
     "react-native-reanimated": "4.4.1",
     "react-native-svg": "15.15.4",
     "react-native-web": "0.21.2",

--- a/docs/docs-worklets/package.json
+++ b/docs/docs-worklets/package.json
@@ -58,7 +58,7 @@
     "react-colorful": "5.6.1",
     "react-dom": "19.1.1",
     "react-native": "0.83.0",
-    "react-native-gesture-handler": "2.28.0",
+    "react-native-gesture-handler": "3.0.1",
     "react-native-reanimated": "4.4.1",
     "react-native-svg": "15.15.4",
     "react-native-web": "0.21.2",

--- a/docs/docs-worklets/package.json
+++ b/docs/docs-worklets/package.json
@@ -58,7 +58,7 @@
     "react-colorful": "5.6.1",
     "react-dom": "19.1.1",
     "react-native": "0.83.0",
-    "react-native-gesture-handler": "3.0.1",
+    "react-native-gesture-handler": "2.32.0",
     "react-native-reanimated": "4.4.1",
     "react-native-svg": "15.15.4",
     "react-native-web": "0.21.2",

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -1,6 +1,9 @@
 import groovy.json.JsonSlurper
+import com.android.Version
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 import javax.inject.Inject
 
@@ -8,7 +11,6 @@ plugins {
     id("com.android.library")
     id("maven-publish")
     id("com.diffplug.spotless") version "8.4.0"
-    id("org.jetbrains.kotlin.android")
 }
 
 fun safeExtGet(prop: String, fallback: Any?): Any? =
@@ -103,6 +105,16 @@ fun validateConflictingFeatureFlags(featureFlags: HashMap<String, String>) {
 
 if (project != rootProject) {
     apply(plugin = "com.facebook.react")
+}
+
+val AGP_MAJOR_VERSION: Int = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
+val IS_BUILT_IN_KOTLIN_ENABLED: Boolean? =
+  providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: false
+val IS_AGP_8_OR_LOWER: Boolean = AGP_MAJOR_VERSION <= 8
+val SHOULD_ENABLE_AGP_FALLBACK: Boolean = IS_AGP_8_OR_LOWER || (IS_BUILT_IN_KOTLIN_ENABLED == false)
+
+if (SHOULD_ENABLE_AGP_FALLBACK) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 val packageDir: File = project.projectDir.parentFile
@@ -237,8 +249,8 @@ android {
     }
 }
 
-if (project != rootProject) {
-    kotlin {
+if (project != rootProject && SHOULD_ENABLE_AGP_FALLBACK) {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")
         }

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -1,7 +1,6 @@
 import groovy.json.JsonSlurper
 import com.android.Version
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
@@ -107,13 +106,17 @@ if (project != rootProject) {
     apply(plugin = "com.facebook.react")
 }
 
-val AGP_MAJOR_VERSION: Int = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
-val IS_BUILT_IN_KOTLIN_ENABLED: Boolean? =
-  providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: false
-val IS_AGP_8_OR_LOWER: Boolean = AGP_MAJOR_VERSION <= 8
-val SHOULD_ENABLE_AGP_FALLBACK: Boolean = IS_AGP_8_OR_LOWER || (IS_BUILT_IN_KOTLIN_ENABLED == false)
+fun shouldEnableAgpFallback(): Boolean {
+    val agpMajorVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
+    if (agpMajorVersion <= 8) {
+        return true
+    }
 
-if (SHOULD_ENABLE_AGP_FALLBACK) {
+    val isBuiltInKotlinEnabled = providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: true
+    return !isBuiltInKotlinEnabled
+}
+
+if (shouldEnableAgpFallback()) {
     apply(plugin = "org.jetbrains.kotlin.android")
 }
 
@@ -249,7 +252,7 @@ android {
     }
 }
 
-if (project != rootProject && SHOULD_ENABLE_AGP_FALLBACK) {
+if (project != rootProject && shouldEnableAgpFallback()) {
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")

--- a/packages/react-native-reanimated/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-reanimated/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-reanimated/android/settings.gradle.kts
+++ b/packages/react-native-reanimated/android/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id.startsWith("com.android")) {
-                useModule("com.android.tools.build:gradle:8.13.1")
+                useModule("com.android.tools.build:gradle:9.2.1")
             }
             if (requested.id.id == "com.diffplug.spotless") {
                 useModule("com.diffplug.spotless:spotless-plugin-gradle:8.1.0")

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -117,13 +117,17 @@ if (project != rootProject) {
     apply(plugin = "com.facebook.react")
 }
 
-val AGP_MAJOR_VERSION: Int = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
-val IS_BUILT_IN_KOTLIN_ENABLED: Boolean? =
-  providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: false
-val IS_AGP_8_OR_LOWER: Boolean = AGP_MAJOR_VERSION <= 8
-val SHOULD_ENABLE_AGP_FALLBACK: Boolean = IS_AGP_8_OR_LOWER || (IS_BUILT_IN_KOTLIN_ENABLED == false)
+fun shouldEnableAgpFallback(): Boolean {
+    val agpMajorVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
+    if (agpMajorVersion <= 8) {
+        return true
+    }
 
-if (SHOULD_ENABLE_AGP_FALLBACK) {
+    val isBuiltInKotlinEnabled = providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: true
+    return !isBuiltInKotlinEnabled
+}
+
+if (shouldEnableAgpFallback()) {
     apply(plugin = "org.jetbrains.kotlin.android")
 }
 
@@ -293,7 +297,7 @@ android {
     }
 }
 
-if (project != rootProject && SHOULD_ENABLE_AGP_FALLBACK) {
+if (project != rootProject && shouldEnableAgpFallback()) {
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -1,6 +1,8 @@
 import groovy.json.JsonSlurper
+import com.android.Version
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 import javax.inject.Inject
 
@@ -8,7 +10,6 @@ plugins {
     id("com.android.library")
     id("maven-publish")
     id("com.diffplug.spotless") version "8.1.0"
-    id("org.jetbrains.kotlin.android")
 }
 
 fun safeExtGet(prop: String, fallback: Any?): Any? =
@@ -114,6 +115,16 @@ fun isFlagEnabled(featureFlags: Map<String, String>, flagName: String): Boolean 
 
 if (project != rootProject) {
     apply(plugin = "com.facebook.react")
+}
+
+val AGP_MAJOR_VERSION: Int = Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toIntOrNull() ?: Int.MAX_VALUE
+val IS_BUILT_IN_KOTLIN_ENABLED: Boolean? =
+  providers.gradleProperty("android.builtInKotlin").orNull?.toBooleanStrictOrNull() ?: false
+val IS_AGP_8_OR_LOWER: Boolean = AGP_MAJOR_VERSION <= 8
+val SHOULD_ENABLE_AGP_FALLBACK: Boolean = IS_AGP_8_OR_LOWER || (IS_BUILT_IN_KOTLIN_ENABLED == false)
+
+if (SHOULD_ENABLE_AGP_FALLBACK) {
+    apply(plugin = "org.jetbrains.kotlin.android")
 }
 
 val featureFlags = getStaticFeatureFlags()
@@ -267,11 +278,11 @@ android {
 
     sourceSets {
         getByName("main") {
-            java {
+            kotlin {
                 if (FETCH_PREVIEW_ENABLED) {
-                    srcDir("src/networking")
+                    directories.add("src/networking")
                 } else {
-                    srcDir("src/no-networking")
+                    directories.add("src/no-networking")
                 }
             }
         }
@@ -282,8 +293,8 @@ android {
     }
 }
 
-if (project != rootProject) {
-    kotlin {
+if (project != rootProject && SHOULD_ENABLE_AGP_FALLBACK) {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget = JvmTarget.fromTarget("17")
         }

--- a/packages/react-native-worklets/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-worklets/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-worklets/android/settings.gradle.kts
+++ b/packages/react-native-worklets/android/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id.startsWith("com.android")) {
-                useModule("com.android.tools.build:gradle:8.13.1")
+                useModule("com.android.tools.build:gradle:9.2.1")
             }
             if (requested.id.id == "com.diffplug.spotless") {
                 useModule("com.diffplug.spotless:spotless-plugin-gradle:8.1.0")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,6 +3557,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@egjs/hammerjs@npm:^2.0.17":
+  version: 2.0.17
+  resolution: "@egjs/hammerjs@npm:2.0.17"
+  dependencies:
+    "@types/hammerjs": "npm:^2.0.36"
+  checksum: 10/f695129d45edfcfd6c5f2d1d36186da36ffade013991972ce23721a6b7ad7f214ce282abc4023e3f6b63062620852a63e897b523f247804afc7acd188fee9d9d
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.7.1":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -9333,6 +9342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hammerjs@npm:^2.0.36":
+  version: 2.0.46
+  resolution: "@types/hammerjs@npm:2.0.46"
+  checksum: 10/1b6502d668f45ca49fb488c01f7938d3aa75e989d70c64801c8feded7d659ca1a118f745c1b604d220efe344c93231767d5cc68c05e00e069c14539b6143cfd9
+  languageName: node
+  linkType: hard
+
 "@types/hast@npm:^2.0.0":
   version: 2.3.10
   resolution: "@types/hast@npm:2.3.10"
@@ -13885,7 +13901,7 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-native: "npm:0.85.2"
-    react-native-gesture-handler: "npm:3.0.1"
+    react-native-gesture-handler: "npm:2.32.0"
     react-native-mmkv: "npm:4.3.0"
     react-native-nitro-modules: "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch"
     react-native-reanimated: "workspace:*"
@@ -15636,7 +15652,7 @@ __metadata:
     react-colorful: "npm:5.6.1"
     react-dom: "npm:19.1.1"
     react-native: "npm:0.83.0"
-    react-native-gesture-handler: "npm:3.0.1"
+    react-native-gesture-handler: "npm:2.32.0"
     react-native-reanimated: "npm:4.4.1"
     react-native-svg: "npm:15.15.4"
     react-native-web: "npm:0.21.2"
@@ -15701,7 +15717,7 @@ __metadata:
     react-colorful: "npm:5.6.1"
     react-dom: "npm:19.1.1"
     react-native: "npm:0.83.0"
-    react-native-gesture-handler: "npm:3.0.1"
+    react-native-gesture-handler: "npm:2.32.0"
     react-native-reanimated: "npm:4.4.1"
     react-native-svg: "npm:15.15.4"
     react-native-web: "npm:0.21.2"
@@ -19124,7 +19140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -27935,16 +27951,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:3.0.1":
-  version: 3.0.1
-  resolution: "react-native-gesture-handler@npm:3.0.1"
+"react-native-gesture-handler@npm:2.32.0":
+  version: 2.32.0
+  resolution: "react-native-gesture-handler@npm:2.32.0"
   dependencies:
+    "@egjs/hammerjs": "npm:^2.0.17"
     "@types/react-test-renderer": "npm:^19.1.0"
+    hoist-non-react-statics: "npm:^3.3.0"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/ba02645c6c4ead6664fa3c9c8e4d239cf103cfd1c89aa8e88df03bce02472ac9dc190dcc73f53e9d9c74b35d3d961b058b5bf3d342919f138c51fa09e4e8978b
+  checksum: 10/b43d350fd281ed9f75a469873a1eb74ae7cfa3d3e15dc7e57b11c0da5702a107b2824e1a9115386d9812e1179e86ccb952d6617cecbdbb26097d7c186088210f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,15 +3557,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@egjs/hammerjs@npm:^2.0.17":
-  version: 2.0.17
-  resolution: "@egjs/hammerjs@npm:2.0.17"
-  dependencies:
-    "@types/hammerjs": "npm:^2.0.36"
-  checksum: 10/f695129d45edfcfd6c5f2d1d36186da36ffade013991972ce23721a6b7ad7f214ce282abc4023e3f6b63062620852a63e897b523f247804afc7acd188fee9d9d
-  languageName: node
-  linkType: hard
-
 "@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.7.1":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -9342,13 +9333,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hammerjs@npm:^2.0.36":
-  version: 2.0.46
-  resolution: "@types/hammerjs@npm:2.0.46"
-  checksum: 10/1b6502d668f45ca49fb488c01f7938d3aa75e989d70c64801c8feded7d659ca1a118f745c1b604d220efe344c93231767d5cc68c05e00e069c14539b6143cfd9
-  languageName: node
-  linkType: hard
-
 "@types/hast@npm:^2.0.0":
   version: 2.3.10
   resolution: "@types/hast@npm:2.3.10"
@@ -9645,7 +9629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-test-renderer@npm:19.1.0":
+"@types/react-test-renderer@npm:19.1.0, @types/react-test-renderer@npm:^19.1.0":
   version: 19.1.0
   resolution: "@types/react-test-renderer@npm:19.1.0"
   dependencies:
@@ -13901,7 +13885,7 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-native: "npm:0.85.2"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:3.0.1"
     react-native-mmkv: "npm:4.3.0"
     react-native-nitro-modules: "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch"
     react-native-reanimated: "workspace:*"
@@ -15652,7 +15636,7 @@ __metadata:
     react-colorful: "npm:5.6.1"
     react-dom: "npm:19.1.1"
     react-native: "npm:0.83.0"
-    react-native-gesture-handler: "npm:2.28.0"
+    react-native-gesture-handler: "npm:3.0.1"
     react-native-reanimated: "npm:4.4.1"
     react-native-svg: "npm:15.15.4"
     react-native-web: "npm:0.21.2"
@@ -15717,7 +15701,7 @@ __metadata:
     react-colorful: "npm:5.6.1"
     react-dom: "npm:19.1.1"
     react-native: "npm:0.83.0"
-    react-native-gesture-handler: "npm:2.28.0"
+    react-native-gesture-handler: "npm:3.0.1"
     react-native-reanimated: "npm:4.4.1"
     react-native-svg: "npm:15.15.4"
     react-native-web: "npm:0.21.2"
@@ -19140,7 +19124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -27951,31 +27935,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:2.28.0":
-  version: 2.28.0
-  resolution: "react-native-gesture-handler@npm:2.28.0"
+"react-native-gesture-handler@npm:3.0.1":
+  version: 3.0.1
+  resolution: "react-native-gesture-handler@npm:3.0.1"
   dependencies:
-    "@egjs/hammerjs": "npm:^2.0.17"
-    hoist-non-react-statics: "npm:^3.3.0"
+    "@types/react-test-renderer": "npm:^19.1.0"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/856a9cb50b467e5e21cdd50930be68fee20f1c8ea13caa3cabb0bebd1345d0a847cd7b761a39b2d42b986b9d8e82e9419ccaf481b17373233c7ece7fed08dc70
-  languageName: node
-  linkType: hard
-
-"react-native-gesture-handler@npm:2.30.0":
-  version: 2.30.0
-  resolution: "react-native-gesture-handler@npm:2.30.0"
-  dependencies:
-    "@egjs/hammerjs": "npm:^2.0.17"
-    hoist-non-react-statics: "npm:^3.3.0"
-    invariant: "npm:^2.2.4"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10/242b1eb29202bc9fc7bf0271c3da102559adc9f2810441465b6d78c1a8ed8f65bdd91335957c841a4716f796be3e7b87d1d55629d6803ea12e1be832d89c946c
+  checksum: 10/ba02645c6c4ead6664fa3c9c8e4d239cf103cfd1c89aa8e88df03bce02472ac9dc190dcc73f53e9d9c74b35d3d961b058b5bf3d342919f138c51fa09e4e8978b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

This PR is rasied following the second phase of the RFC around AGP v9 adoption:

RFC: https://github.com/react-native-community/discussions-and-proposals/pull/1006

The gist of this PR is to make Reanimated and Worklets AGP v9 compliant with backward compatibility. The main scope of changes is the `react-native-reanimated/android/build.gradle` and `react-native-worklets/android/build.gradle`. The rest of the changes can be considered temporary.

The rest changes include:

- Making Fabric Example App AGP9 compliant
- Upgrade `Gradle` to `v9.4.1`
- Use `proguard-android-optimize` proguard file
- Enable opt outs in the `gradle.properties`

Ideally, we should not enable the opt outs and leverage the AGP 9 built-in kotlin and newDSL. However, if we do not do it, then other libraries which are not yet AGP v9 compliant starts to fail. Hence, we need to keep the opt outs enabled for a while. For the context, react-native starting from 0.87.x will ship with AGP v9 and opt outs enabled by default for the new apps, which is the first phase of AGP v9 adoption.

With the second phase when the libraries starts adoption AGP v9, we can eventually remove the opt outs from Fabric Example.

Note:
- Upgraded `react-native-gesture-handler` as the updates contain a fix for not calling `rootViewTag` as a function invocation

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->

To test this PR, we need to do a few steps:

- Set the `agp` version to `9.2.1` and `kotlin` to `2.2.0` in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
+++ b/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.12.0"
+agp = "9.2.1"
 gson = "2.8.9"

-kotlin = "2.1.20"
+kotlin = "2.2.0"
 assertj = "3.25.1"
```

- Comment out the following functions in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
+++ b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
@@ -1,10 +1,10 @@
      configureBuildTypesForApp(project)
    }

    // Library Only Configuration
-    configureBuildConfigFieldsForLibraries(project)
-    configureNamespaceForLibraries(project)
+    // configureBuildConfigFieldsForLibraries(project)
+    // configureNamespaceForLibraries(project)
    project.pluginManager.withPlugin("com.android.library") {
```

These step is only required because we have RN version on 0.85.2 and `AGP` + `kotlin` bump will be shipped with 0.87.x.

<details>
<summary>Verified on a local RN App with these changes applied</summary>

https://github.com/user-attachments/assets/ff745cff-6484-4445-b47b-42476d47b511




</details>

<details>
<summary>Verified by locally patching mmkv, safe-area, etc and making those AGP v9 compliant and removing the opt outs to test the changes in the PR </summary>



https://github.com/user-attachments/assets/74abe0d5-5d9d-48c4-8348-5851bdfc22ce




</details>


<details>
<summary>Verified these changes work with AGP 8 </summary>


https://github.com/user-attachments/assets/21ee1910-b2eb-40f3-a4ce-bc7ea725d572





</details>

