### PR TITLE
docs: add dynamic topbar banner

### DIFF
--- a/docs/docs-reanimated/docusaurus.config.js
+++ b/docs/docs-reanimated/docusaurus.config.js
@@ -7,6 +7,27 @@ const darkCodeTheme = require('./src/theme/CodeBlock/highlighting-dark.js');
 const webpack = require('webpack');
 const path = require('path');
 
+const {
+  topbarBannerReservationScript,
+} = require('@swmansion/t-rex-ui/topbar-banner');
+// @ts-expect-error -- .ts extension is intentional; not type-checked by tsc here.
+const { TOP_BAR_BANNER } = require('./src/components/topbarBanner.config.ts');
+
+const firstBannerZone = TOP_BAR_BANNER.zones[0];
+const bannerReservationHeadTags = firstBannerZone
+  ? [
+      {
+        tagName: 'script',
+        attributes: { type: 'text/javascript' },
+        innerHTML: topbarBannerReservationScript(
+          firstBannerZone.zoneId,
+          firstBannerZone.contentId,
+          TOP_BAR_BANNER.hiddenPaths
+        ),
+      },
+    ]
+  : [];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'React Native Reanimated',
@@ -22,6 +43,8 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'software-mansion', // Usually your GitHub org/user name.
   projectName: 'react-native-reanimated', // Usually your repo name.
+
+  headTags: bannerReservationHeadTags,
 
   scripts: [
     {

--- a/docs/docs-reanimated/package.json
+++ b/docs/docs-reanimated/package.json
@@ -39,7 +39,7 @@
     "@mui/material": "7.1.0",
     "@react-native/assets-registry": "0.83.0",
     "@shopify/flash-list": "2.1.0",
-    "@swmansion/t-rex-ui": "1.3.2",
+    "@swmansion/t-rex-ui": "1.3.3",
     "@types/react": "19.2.2",
     "@vercel/og": "0.6.2",
     "babel-loader": "9.2.1",

--- a/docs/docs-reanimated/src/components/topbarBanner.config.ts
+++ b/docs/docs-reanimated/src/components/topbarBanner.config.ts
@@ -1,0 +1,29 @@
+import type { BannerZone } from '@swmansion/t-rex-ui';
+
+export const TOP_BAR_BANNER = {
+  rotateIntervalMs: 4000,
+  hiddenPaths: [
+    '/react-native-reanimated/docs',
+    '/react-native-reanimated/cheatsheet',
+    '/react-native-reanimated/examples',
+    '/react-native-reanimated/privacy-policy',
+    '/react-native-reanimated/search',
+  ] as string[],
+  zones: [
+    {
+      zoneId: 'react-native-reanimated-topbar-1',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+    {
+      zoneId: 'react-native-reanimated-topbar-2',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+    {
+      zoneId: 'react-native-reanimated-topbar-3',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+  ] satisfies BannerZone[],
+};

--- a/docs/docs-reanimated/src/theme/Navbar/index.js
+++ b/docs/docs-reanimated/src/theme/Navbar/index.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { Navbar } from '@swmansion/t-rex-ui';
+import { useLocation } from '@docusaurus/router';
+import { Navbar, TopbarBanner, isBannerHidden } from '@swmansion/t-rex-ui';
+import { TOP_BAR_BANNER } from '@site/src/components/topbarBanner.config';
 
 export default function NavbarWrapper(props) {
+  const location = useLocation();
+  const bannerHidden = isBannerHidden(
+    location.pathname,
+    TOP_BAR_BANNER.hiddenPaths
+  );
+
   const titleImages = {
     light: useBaseUrl('/img/title.svg'),
     dark: useBaseUrl('/img/title-dark.svg'),
@@ -13,6 +21,14 @@ export default function NavbarWrapper(props) {
     title: useBaseUrl('/img/title-hero.svg'),
   };
   return (
-    <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    <div style={{ display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+      {!bannerHidden && (
+        <TopbarBanner
+          zones={TOP_BAR_BANNER.zones}
+          rotateIntervalMs={TOP_BAR_BANNER.rotateIntervalMs}
+        />
+      )}
+      <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    </div>
   );
 }

--- a/docs/docs-worklets/docusaurus.config.js
+++ b/docs/docs-worklets/docusaurus.config.js
@@ -7,6 +7,27 @@ const darkCodeTheme = require('./src/theme/CodeBlock/highlighting-dark.js');
 const webpack = require('webpack');
 const path = require('path');
 
+const {
+  topbarBannerReservationScript,
+} = require('@swmansion/t-rex-ui/topbar-banner');
+// @ts-expect-error -- .ts extension is intentional; not type-checked by tsc here.
+const { TOP_BAR_BANNER } = require('./src/components/topbarBanner.config.ts');
+
+const firstBannerZone = TOP_BAR_BANNER.zones[0];
+const bannerReservationHeadTags = firstBannerZone
+  ? [
+      {
+        tagName: 'script',
+        attributes: { type: 'text/javascript' },
+        innerHTML: topbarBannerReservationScript(
+          firstBannerZone.zoneId,
+          firstBannerZone.contentId,
+          TOP_BAR_BANNER.hiddenPaths
+        ),
+      },
+    ]
+  : [];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title:
@@ -22,6 +43,8 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'software-mansion', // Usually your GitHub org/user name.
   projectName: 'react-native-worklets', // Usually your repo name.
+
+  headTags: bannerReservationHeadTags,
 
   scripts: [],
 

--- a/docs/docs-worklets/package.json
+++ b/docs/docs-worklets/package.json
@@ -40,7 +40,7 @@
     "@mui/material": "7.1.0",
     "@react-native/assets-registry": "0.83.0",
     "@shopify/flash-list": "2.1.0",
-    "@swmansion/t-rex-ui": "1.3.2",
+    "@swmansion/t-rex-ui": "1.3.3",
     "@types/react": "19.2.2",
     "@vercel/og": "0.6.2",
     "babel-loader": "9.2.1",

--- a/docs/docs-worklets/src/components/topbarBanner.config.ts
+++ b/docs/docs-worklets/src/components/topbarBanner.config.ts
@@ -1,0 +1,26 @@
+import type { BannerZone } from '@swmansion/t-rex-ui';
+
+export const TOP_BAR_BANNER = {
+  rotateIntervalMs: 4000,
+  hiddenPaths: [
+    '/react-native-worklets/docs',
+    '/react-native-worklets/search',
+  ] as string[],
+  zones: [
+    {
+      zoneId: 'react-native-worklets-topbar-1',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#ff6259',
+    },
+    {
+      zoneId: 'react-native-worklets-topbar-2',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#ff6259',
+    },
+    {
+      zoneId: 'react-native-worklets-topbar-3',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#ff6259',
+    },
+  ] satisfies BannerZone[],
+};

--- a/docs/docs-worklets/src/theme/Navbar/index.js
+++ b/docs/docs-worklets/src/theme/Navbar/index.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { Navbar } from '@swmansion/t-rex-ui';
+import { useLocation } from '@docusaurus/router';
+import { Navbar, TopbarBanner, isBannerHidden } from '@swmansion/t-rex-ui';
+import { TOP_BAR_BANNER } from '@site/src/components/topbarBanner.config';
 
 export default function NavbarWrapper(props) {
+  const location = useLocation();
+  const bannerHidden = isBannerHidden(
+    location.pathname,
+    TOP_BAR_BANNER.hiddenPaths
+  );
+
   const titleImages = {
     light: useBaseUrl('/img/title.svg'),
     dark: useBaseUrl('/img/title-dark.svg'),
@@ -12,6 +20,14 @@ export default function NavbarWrapper(props) {
     logo: useBaseUrl('/img/logo.svg'),
   };
   return (
-    <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    <div style={{ display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+      {!bannerHidden && (
+        <TopbarBanner
+          zones={TOP_BAR_BANNER.zones}
+          rotateIntervalMs={TOP_BAR_BANNER.rotateIntervalMs}
+        />
+      )}
+      <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,9 +8652,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swmansion/t-rex-ui@npm:1.3.2":
-  version: 1.3.2
-  resolution: "@swmansion/t-rex-ui@npm:1.3.2"
+"@swmansion/t-rex-ui@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@swmansion/t-rex-ui@npm:1.3.3"
   dependencies:
     "@docusaurus/core": "npm:3.9.2"
     "@docusaurus/module-type-aliases": "npm:3.9.2"
@@ -8678,7 +8678,7 @@ __metadata:
     react: "*"
     react-dom: "*"
     react-icons: "*"
-  checksum: 10/b967537293a9369f1fd00f8a420b016aa1ce95a70cd6840d96f6ca6366b64059e4e85bdc5629f84be83314ee94bae6a92f952b3204b8f891dd3c9c5504c0838c
+  checksum: 10/8f54dbd22dae69f8b0880ea588867764d443c7ff1cd1e6317922b6650a56fb9655ccfd1532e203714936a9321f339255ae78d78218ac5be262b15ffe822458ac
   languageName: node
   linkType: hard
 
@@ -15630,7 +15630,7 @@ __metadata:
     "@mui/material": "npm:7.1.0"
     "@react-native/assets-registry": "npm:0.83.0"
     "@shopify/flash-list": "npm:2.1.0"
-    "@swmansion/t-rex-ui": "npm:1.3.2"
+    "@swmansion/t-rex-ui": "npm:1.3.3"
     "@types/raf": "npm:3.4.3"
     "@types/react": "npm:19.2.2"
     "@vercel/og": "npm:0.6.2"
@@ -15695,7 +15695,7 @@ __metadata:
     "@mui/material": "npm:7.1.0"
     "@react-native/assets-registry": "npm:0.83.0"
     "@shopify/flash-list": "npm:2.1.0"
-    "@swmansion/t-rex-ui": "npm:1.3.2"
+    "@swmansion/t-rex-ui": "npm:1.3.3"
     "@types/raf": "npm:3.4.3"
     "@types/react": "npm:19.2.2"
     "@vercel/og": "npm:0.6.2"


### PR DESCRIPTION
## Summary

Adds a topbar banner to the landing pages (both reanimated and worklets). Content is served server-side via external service, so banners can be swapped, rotated, or pulled without any repo change or redeploy.
It will be displayed only on main pages. The banners are currently hidden.