### PR TITLE
fix: Don't crash on iOS double reload when surface presenter has no scheduler

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/ReanimatedModule.mm
@@ -163,7 +163,18 @@ RCT_EXPORT_MODULE(ReanimatedModule);
 - (BOOL)hasReactNativeFailedReload
 {
   id workletsModule = [_moduleRegistry moduleForName:"WorkletsModule"];
-  return ![_moduleRegistry moduleIsInitialized:[workletsModule class]];
+  if (![_moduleRegistry moduleIsInitialized:[workletsModule class]]) {
+    return YES;
+  }
+
+  // On a double reload React Native can momentarily leave the surface presenter without
+  // a scheduler. This is another manifestation of the same non-fatal reload race, so we
+  // bail on it here instead of asserting on a nil scheduler later in installTurboModule.
+  if ([_surfacePresenter scheduler] == nil) {
+    return YES;
+  }
+
+  return NO;
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installTurboModule)


### PR DESCRIPTION
## Summary

On a double reload (e.g. during an OTA update, when the app is reloaded right after evaluating the bundle) React Native can momentarily leave the surface presenter without a scheduler. `installTurboModule` then hit a `react_native_assert` on the nil scheduler and aborted with `SIGABRT`.

This nil scheduler is just another symptom of the same non-fatal reload race already handled by `hasReactNativeFailedReload`, so we detect it there and bail out with `@NO` instead of asserting.

## Test plan

- Run the fabric-example app on iOS (debug build).
- Trigger a double reload — two fast reloads in a row, or reload immediately after launch (mimicking the OTA-update timing).
- Before: `SIGABRT` at the `scheduler != nil` assert in `ReanimatedModule.mm`. After: the app reloads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)