### PR TITLE
fix: macos-example RCTEventEmitter error and Xcode 26 build

### DIFF
--- a/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch
+++ b/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch
@@ -1,0 +1,17 @@
+diff --git a/ios/RNCSafeAreaProvider.m b/ios/RNCSafeAreaProvider.m
+index 6f92859b959a01d61c29d89395c2ecad912e6617..7f6b0ebb3bb411470bee5a68f4167a48ff109c32 100644
+--- a/ios/RNCSafeAreaProvider.m
++++ b/ios/RNCSafeAreaProvider.m
+@@ -23,9 +23,11 @@ - (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDis
+   RCTAssertParam(eventDispatcher);
+ 
+   if ((self = [super initWithFrame:CGRectZero])) {
++    // macOS/tvOS use the legacy SafeAreaProvider, which dispatches onInsetsChange
++    // via RCTEventEmitter.receiveEvent (uncallable in bridgeless); keep it unset.
++#if !TARGET_OS_TV && !TARGET_OS_OSX
+     _eventDispatcher = eventDispatcher;
+ 
+-#if !TARGET_OS_TV && !TARGET_OS_OSX
+     [NSNotificationCenter.defaultCenter addObserver:self
+                                            selector:@selector(invalidateSafeAreaInsets)
+                                                name:UIKeyboardDidShowNotification

--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -39,7 +39,7 @@
     "react-native-mmkv": "4.3.0",
     "react-native-nitro-modules": "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch",
     "react-native-reanimated": "workspace:*",
-    "react-native-safe-area-context": "5.7.0",
+    "react-native-safe-area-context": "patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch",
     "react-native-screens": "4.24.0",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "workspace:*",

--- a/apps/macos-example/macos/Podfile
+++ b/apps/macos-example/macos/Podfile
@@ -21,6 +21,23 @@ target 'MacOSExample-macOS' do
 
   post_install do |installer|
     react_native_post_install(installer)
+
+    # Xcode 26 (Apple clang 21) miscompiles fmt 11.0.2's `consteval` path
+    # (fmtlib/fmt#4740, fixed in fmt 11.1+). react-native-macos 0.81 pins 11.0.2,
+    # so widen fmt's "disable consteval on old Apple clang" guard to all Apple
+    # clang. Remove once the bundled fmt is >= 11.1.
+    fmt_base = File.join(__dir__, 'Pods', 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base)
+      source = File.read(fmt_base)
+      needle = '#elif defined(__apple_build_version__) && __apple_build_version__ < 14000029L'
+      if source.include?(needle)
+        File.chmod(0644, fmt_base)
+        File.write(fmt_base, source.sub(needle, '#elif defined(__apple_build_version__)'))
+      elsif !source.include?('#elif defined(__apple_build_version__)')
+        Pod::UI.warn('[macos-example] fmt consteval guard not found in fmt/base.h; ' \
+                     'macOS may fail to build on Xcode 26 (see fmtlib/fmt#4740).')
+      end
+    end
   end
 
   add_compile_metadata_step()

--- a/apps/macos-example/macos/Podfile.lock
+++ b/apps/macos-example/macos/Podfile.lock
@@ -2487,6 +2487,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNReanimated/apple (= 4.5.0-main)
     - RNReanimated/common (= 4.5.0-main)
+    - RNReanimated/view (= 4.5.0-main)
     - RNWorklets
     - SocketRocket
     - Yoga
@@ -2521,6 +2522,36 @@ PODS:
     - SocketRocket
     - Yoga
   - RNReanimated/common (4.5.0-main):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNWorklets
+    - SocketRocket
+    - Yoga
+  - RNReanimated/view (4.5.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -3025,12 +3056,12 @@ SPEC CHECKSUMS:
   ReactCommon: 4702457a560d38a9b96a98a728100cae76820edc
   RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
-  RNReanimated: f74eb3a2bae55e9517eec60b661d74a7b4a1881f
+  RNReanimated: d0570cb3857d58651954d04ac89274e4a5e4cdd7
   RNSVG: 681be694d501c0af971615811d4f2ea9baf58966
   RNWorklets: b3c72e9e460a52cc85ba050b3910702fa1af584a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 4e7825418aa0a50bdaa8dff6d3e5fa8a2994d308
 
-PODFILE CHECKSUM: 039939ed46ccf81ea5381db1bb11adcb20178564
+PODFILE CHECKSUM: 3c88ea1cd4f96bbe2d0954f4ece78df5bc6c2e99
 
 COCOAPODS: 1.15.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -13905,7 +13905,7 @@ __metadata:
     react-native-mmkv: "npm:4.3.0"
     react-native-nitro-modules: "patch:react-native-nitro-modules@npm%3A0.35.2#~/.yarn/patches/react-native-nitro-modules-npm-0.35.2-717188fdb0.patch"
     react-native-reanimated: "workspace:*"
-    react-native-safe-area-context: "npm:5.7.0"
+    react-native-safe-area-context: "patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch"
     react-native-screens: "npm:4.24.0"
     react-native-svg: "npm:15.15.4"
     react-native-worklets: "workspace:*"
@@ -28257,6 +28257,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/9f5d3469c18c90c527c4068560ce4dcc7689e9fc8ddc68b8a5e76c94a6eafdba975ced89a48e08fecfd1303331e8c2498722bc249fcd87b1c5ea64ef3abd1d00
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch":
+  version: 5.7.0
+  resolution: "react-native-safe-area-context@patch:react-native-safe-area-context@npm%3A5.7.0#~/.yarn/patches/react-native-safe-area-context-npm-5.7.0-fcff6bf187.patch::version=5.7.0&hash=53727e"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/9b196df01fbbfb69a0f542a0a0e4b3b977a17c8348e8a8cf8b28dd2714ce8e57669b4a3fbab319e984d6db31f2c9c6ab70df7e67e9079bee43869ac733fd07e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Two fixes so `macos-example` builds and runs on the New Architecture + Xcode 26:
- Patch `react-native-safe-area-context` so it doesn't dispatch `onInsetsChange` through the legacy `RCTEventEmitter.receiveEvent` path on macOS/tvOS (uncallable in bridgeless). iOS/Android use the Fabric component and are unaffected.
- Patch fmt for the Xcode 26 `consteval` build error.
