### PR TITLE
fix: support legacy `_viewConfig` in animated host lookup for RN < 0.86

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -21,6 +21,8 @@ export function getViewInfo(element: HostInstance): {
 } {
   return {
     reactViewName: (element?.__viewConfig?.uiViewClassName ??
+      // ReactFabricHostComponent (e.g. react-native-macos) exposes `_viewConfig`.
+      element?._viewConfig?.uiViewClassName ??
       element?.__internalInstanceHandle?.type ??
       element?.__internalInstanceHandle?.elementType) as string,
     viewTag: element?.__nativeTag,

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -12,7 +12,9 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    maybeNativeRef.__viewConfig
+    // ReactFabricHostComponent (e.g. react-native-macos) exposes `_viewConfig`;
+    // ReactNativeElement uses `__viewConfig`.
+    (maybeNativeRef.__viewConfig || maybeNativeRef._viewConfig)
   ) {
     return maybeNativeRef;
   }

--- a/packages/react-native-reanimated/src/platform-specific/types.ts
+++ b/packages/react-native-reanimated/src/platform-specific/types.ts
@@ -4,4 +4,6 @@ export type HostInstance = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
   __viewConfig?: Record<string, unknown>;
+  // Legacy ReactFabricHostComponent key (e.g. react-native-macos).
+  _viewConfig?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

[#9589](https://github.com/software-mansion/react-native-reanimated/pull/9589) renamed the native-ref check from `_viewConfig` to `__viewConfig`. Renderers older than RN 0.86 (e.g. react-native-macos 0.81) only expose `_viewConfig`, so the fast path missed and `findHostInstance_DEPRECATED` threw `Argument appears to not be a ReactComponent` for every animated component. This accepts either key (`__viewConfig` first, `_viewConfig` fallback); RN 0.86+ is unaffected.