### PR TITLE
Re-land perf: Convert events to `jsi::Value` without a JSON round-trip in `handleEvent`

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Events/UIEventHandlerRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Events/UIEventHandlerRegistry.cpp
@@ -87,8 +87,12 @@ void UIEventHandlerRegistry::processEvent(
 
 bool UIEventHandlerRegistry::isAnyHandlerWaitingForEvent(const std::string &eventName, const int emitterReactTag) {
   const std::lock_guard<std::mutex> lock(instanceMutex);
+  const auto withoutTagIt = eventMappingsWithoutTag.find(eventName);
+  if (withoutTagIt != eventMappingsWithoutTag.end() && !withoutTagIt->second.empty()) {
+    return true;
+  }
   const auto eventHash = std::make_pair(emitterReactTag, eventName);
-  auto it = eventMappingsWithTag.find(eventHash);
+  const auto it = eventMappingsWithTag.find(eventHash);
   return it != eventMappingsWithTag.end() && !it->second.empty();
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -288,8 +288,8 @@ void NativeProxy::handleEvent(
   // a cached getEventData() map.
   static const auto copyMethod =
       react::WritableMap::javaClassStatic()->getMethod<react::WritableMap::javaobject()>("copy");
-  auto nativeMap = jni::static_ref_cast<react::WritableNativeMap::javaobject>(
-      jni::static_ref_cast<jobject>(copyMethod(event)));
+  auto nativeMap =
+      jni::static_ref_cast<react::WritableNativeMap::javaobject>(jni::static_ref_cast<jobject>(copyMethod(event)));
   auto eventPayload = nativeMap->cthis()->consume();
   if (eventPayload.isNull()) {
     return;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -273,11 +273,23 @@ void NativeProxy::handleEvent(
     return;
   }
 
+  auto eventNameStr = eventName->toString();
+  if (!reanimatedModuleProxy_->isAnyHandlerWaitingForEvent(eventNameStr, emitterReactTag)) {
+    return;
+  }
+
   if (!event->isInstanceOf(react::WritableNativeMap::javaClassStatic())) {
     return;
   }
 
-  auto nativeMap = jni::static_ref_cast<react::WritableNativeMap::javaobject>(jni::static_ref_cast<jobject>(event));
+  // Consume a copy of the payload so the original map stays intact for the downstream
+  // dispatch to JS. The map is owned by the RN event and reused across dispatch targets,
+  // so consuming it directly throws ObjectAlreadyConsumedException for events that return
+  // a cached getEventData() map.
+  static const auto copyMethod =
+      react::WritableMap::javaClassStatic()->getMethod<react::WritableMap::javaobject()>("copy");
+  auto nativeMap = jni::static_ref_cast<react::WritableNativeMap::javaobject>(
+      jni::static_ref_cast<jobject>(copyMethod(event)));
   auto eventPayload = nativeMap->cthis()->consume();
   if (eventPayload.isNull()) {
     return;
@@ -288,12 +300,12 @@ void NativeProxy::handleEvent(
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     reanimatedModuleProxy_->handleEventAndFlush(
-        eventName->toString(),
+        eventNameStr,
         emitterReactTag,
         payload,
         isInDrawPass ? GrandCallbackSource::EventInAndroidDraw : GrandCallbackSource::Event);
   } else {
-    reanimatedModuleProxy_->handleEvent(eventName->toString(), emitterReactTag, payload, getAnimationTimestamp());
+    reanimatedModuleProxy_->handleEvent(eventNameStr, emitterReactTag, payload, getAnimationTimestamp());
   }
 }
 


### PR DESCRIPTION
## Summary

On Android, `handleEvent` consumes the event payload map via `NativeMap::consume()`, which was introduced in #9581. `consume()` moves out the underlying `folly::dynamic` and marks the map consumed. That map is owned by the React Native event and is reused: it is also dispatched to JS, and some events return a cached instance from `getEventData()`. Consuming it in Reanimated corrupts the downstream dispatch and throws `ObjectAlreadyConsumedException: Map already consumed`.

Reanimated observes events as an `EventDispatcherListener`, so its listener runs before the real dispatch to JS. Events whose `getEventData()` returns a fresh map on every call (such as React Native's `ScrollEvent`) are unaffected, which is why this was not caught earlier. Events that return a cached map crash. Two confirmed in the wild:

- MapLibre `MapChangeEvent`, which returns a stored `eventData`:

```
com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchUniqueEvent(Native Method)
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchUnique(EventEmitterWrapper.kt:71)
	at com.facebook.react.fabric.FabricUIManager.receiveEvent(FabricUIManager.java:1149)
	at com.facebook.react.fabric.events.FabricEventEmitter.receiveEvent(FabricEventEmitter.kt:28)
	at com.facebook.react.uimanager.events.Event.dispatchModern(Event.kt:192)
	at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:51)
	at org.maplibre.reactnative.components.mapview.MLRNMapView.handleMapChangedEvent(MLRNMapView.kt:1513)
	at org.maplibre.reactnative.components.mapview.MLRNMapView.onWillStartRenderingMap(MLRNMapView.kt:731)
```

- Expo `KEventEmitterWrapper.UIEvent`, which returns a stored `eventBody` and is the base class for every expo-modules-core view event (for example expo-image):

```
com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchEvent(Native Method)
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatch(EventEmitterWrapper.kt:47)
	at com.facebook.react.fabric.FabricUIManager.receiveEvent(FabricUIManager.java:1151)
	at com.facebook.react.fabric.events.FabricEventEmitter.receiveEvent(FabricEventEmitter.kt:28)
	at com.facebook.react.uimanager.events.Event.dispatchModern(Event.kt:192)
	at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:51)
	at expo.modules.kotlin.events.KEventEmitterWrapper.emit(KModuleEventEmitterWrapper.kt:109)
	at expo.modules.kotlin.viewevent.ViewEvent.invoke(ViewEvent.kt:47)
	at expo.modules.image.events.GlideRequestListener$onResourceReady$1.invokeSuspend(GlideRequestListener.kt:61)
```

This PR changes `handleEvent` to:

1. Return early when no worklet handler is subscribed to the event. `handleEvent` previously consumed and converted every event's payload before checking subscription (the check lives in `processEvent`), so unrelated events were destroyed as collateral. This fixes those crashes and also avoids converting payloads that nothing is listening to.
2. Consume a copy of the map when a handler is subscribed, leaving the original intact for the dispatch to JS.

## Alternatives considered

- Revert #9581 to the JSON path (`toString()` followed by `createFromJsonUtf8`). Non-destructive and correct, but loses the conversion speedup from #9581 and reintroduces the dropping of events carrying NaN or INF values (#1776).
- Copy the map at the event source, for example MapLibre `MapChangeEvent.getEventData().copy()`. Fixes MapLibre but is per-library whack-a-mole: expo-image still crashed through the same path, and the same applies to any other library that returns a cached map.
- Copy the map on the Kotlin side, by passing `params.copy()` from `EventHandler`. General, but copies on every event Reanimated observes, including the scroll and gesture hot path.
- Copy the map on the C++ side unconditionally. Same redundant copy on the hot path.

The chosen approach copies only when a handler is actually subscribed, so the common case (no handler) does no work, and the copy is paid only for events that are being animated.

## Test plan

On Android with the new architecture, render a component that dispatches an event whose `getEventData()` returns a cached map while Reanimated is installed, for example a MapLibre `MapView` (`onWillStartRenderingMap`) or an expo-image `Image` (`onLoad`). Before this change the app crashes with the trace above as soon as the event fires; after it, the event is delivered normally. `useAnimatedScrollHandler` continues to receive scroll events, which use the fresh-map path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
