### PR TITLE
Revert "perf: Convert events to `jsi::Value` without a JSON round-trip in `handleEvent`"

### DIFF
--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -1,6 +1,4 @@
-#include <jsi/JSIDynamic.h>
 #include <react/fabric/Binding.h>
-#include <react/jni/WritableNativeMap.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/RuntimeDecorators/RNRuntimeDecorator.h>
 #include <reanimated/Tools/FeatureFlags.h>
@@ -272,19 +270,30 @@ void NativeProxy::handleEvent(
     // Ignore events with null payload.
     return;
   }
-
-  if (!event->isInstanceOf(react::WritableNativeMap::javaClassStatic())) {
+  // TODO: convert event directly to jsi::Value without JSON serialization
+  std::string eventAsString;
+  try {
+    eventAsString = event->toString();
+  } catch (...) {
+    // Events from other libraries may contain NaN or INF values which
+    // cannot be represented in JSON. See
+    // https://github.com/software-mansion/react-native-reanimated/issues/1776
+    // for details.
     return;
   }
-
-  auto nativeMap = jni::static_ref_cast<react::WritableNativeMap::javaobject>(jni::static_ref_cast<jobject>(event));
-  auto eventPayload = nativeMap->cthis()->consume();
-  if (eventPayload.isNull()) {
+  std::string eventJSON = eventAsString;
+  if (eventJSON == "null") {
     return;
   }
 
   auto &uiRuntime = getJSIRuntimeFromWorkletRuntime(uiRuntime_);
-  jsi::Value payload = jsi::valueFromDynamic(uiRuntime, eventPayload);
+  jsi::Value payload;
+  try {
+    payload = jsi::Value::createFromJsonUtf8(uiRuntime, reinterpret_cast<uint8_t *>(&eventJSON[0]), eventJSON.size());
+  } catch (std::exception &) {
+    // Ignore events with malformed JSON payload.
+    return;
+  }
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     reanimatedModuleProxy_->handleEventAndFlush(


### PR DESCRIPTION
Reverts software-mansion/react-native-reanimated#9581

#9581 made `handleEvent` consume the incoming event payload map via `NativeMap::consume()`, which moves out its `folly::dynamic` and marks the map consumed. That map is owned by the React Native event and is also dispatched to JS, and some events return a cached instance from `getEventData()`, so consuming it in Reanimated corrupts the downstream dispatch and throws `ObjectAlreadyConsumedException: Map already consumed` on Android. Reverting to be safe for the 4.5.0 release; a fixed version that keeps the optimization is in #9686.

Confirmed crashes:

MapLibre `MapChangeEvent`:

```
com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchUniqueEvent(Native Method)
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchUnique(EventEmitterWrapper.kt:71)
	at com.facebook.react.fabric.FabricUIManager.receiveEvent(FabricUIManager.java:1149)
	at com.facebook.react.fabric.events.FabricEventEmitter.receiveEvent(FabricEventEmitter.kt:28)
	at com.facebook.react.uimanager.events.Event.dispatchModern(Event.kt:192)
	at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:51)
	at org.maplibre.reactnative.components.mapview.MLRNMapView.handleMapChangedEvent(MLRNMapView.kt:1513)
	at org.maplibre.reactnative.components.mapview.MLRNMapView.onWillStartRenderingMap(MLRNMapView.kt:731)
```

Expo view events (`KEventEmitterWrapper.UIEvent`, for example expo-image):

```
com.facebook.react.bridge.ObjectAlreadyConsumedException: Map already consumed
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatchEvent(Native Method)
	at com.facebook.react.fabric.events.EventEmitterWrapper.dispatch(EventEmitterWrapper.kt:47)
	at com.facebook.react.fabric.FabricUIManager.receiveEvent(FabricUIManager.java:1151)
	at com.facebook.react.fabric.events.FabricEventEmitter.receiveEvent(FabricEventEmitter.kt:28)
	at com.facebook.react.uimanager.events.Event.dispatchModern(Event.kt:192)
	at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:51)
	at expo.modules.kotlin.events.KEventEmitterWrapper.emit(KModuleEventEmitterWrapper.kt:109)
	at expo.modules.kotlin.viewevent.ViewEvent.invoke(ViewEvent.kt:47)
	at expo.modules.image.events.GlideRequestListener$onResourceReady$1.invokeSuspend(GlideRequestListener.kt:61)
```
