### PR TITLE
feat: Prioritize pseudoselectors over renders old

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -100,6 +100,10 @@ const routes = {
         name: ':active',
         Component: pseudoSelectors.Active,
       },
+      PseudoActiveBlocksRender: {
+        name: ':active blocks render transition',
+        Component: pseudoSelectors.ActiveBlocksRender,
+      },
       PseudoActiveDeepest: {
         name: ':active-deepest',
         Component: pseudoSelectors.ActiveDeepest,

--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -124,17 +124,22 @@ const routes = {
         name: 'Per-state transition configs',
         Component: pseudoSelectors.PerStateTransitionConfig,
       },
-      PseudoPlanets: {
-        name: 'Planets',
-        Component: pseudoSelectors.Planets,
-      },
       PseudoArbitraryWebSelectors: {
         name: 'Arbitrary web selectors',
         Component: pseudoSelectors.ArbitraryWebSelectors,
       },
-      PseudoShowcase: {
+      Showcase: {
         name: 'Showcase',
-        Component: pseudoSelectors.Showcase,
+        routes: {
+          PseudoPlanets: {
+            name: 'Planets',
+            Component: pseudoSelectors.Planets,
+          },
+          PseudoForm: {
+            name: 'Form',
+            Component: pseudoSelectors.Form,
+          },
+        },
       },
     },
   },

--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -124,6 +124,10 @@ const routes = {
         name: 'Per-state transition configs',
         Component: pseudoSelectors.PerStateTransitionConfig,
       },
+      PseudoPlanets: {
+        name: 'Planets',
+        Component: pseudoSelectors.Planets,
+      },
       PseudoArbitraryWebSelectors: {
         name: 'Arbitrary web selectors',
         Component: pseudoSelectors.ArbitraryWebSelectors,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveBlocksRender.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveBlocksRender.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+import {
+  Screen,
+  Scroll,
+  Section,
+  VerticalExampleCard,
+} from '@/apps/css/components';
+import { colors, radius, sizes, spacing } from '@/theme';
+
+export default function ActiveBlocksRender() {
+  const [phase, setPhase] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPhase((prev) => (prev + 1) % 2);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const renderColor = phase === 0 ? colors.danger : colors.primaryLight;
+
+  return (
+    <Screen>
+      <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>
+        <Section
+          description="backgroundColor is driven by two sources at once: a render-driven transition that toggles red <-> light blue every 1000ms via the 'default' value, and a ':active' selector that sets dark navy. Press and hold the box: while ':active' is active, the incoming render transitions on backgroundColor should be blocked and the box should hold dark navy (no red/blue flicker). Release and the looping render transition resumes."
+          title="Selector blocks render transition">
+          <VerticalExampleCard
+            title="backgroundColor: render loop vs :active"
+            code={`const renderColor = phase === 0 ? colors.danger : colors.primaryLight;
+
+<Animated.View
+  style={{
+    backgroundColor: {
+      default: renderColor,
+      ':active': colors.primaryDark,
+    },
+    transitionDuration: '900ms',
+    transitionTimingFunction: 'linear',
+  }}
+  onStartShouldSetResponder={() => true}
+/>`}
+            collapsedCode={`backgroundColor: {
+  default: renderColor,
+  ':active': colors.primaryDark,
+},`}>
+            <Animated.View
+              style={[
+                styles.box,
+                {
+                  backgroundColor: {
+                    ':active': colors.primaryDark,
+                    default: renderColor,
+                  },
+                  transitionDuration: '900ms',
+                  transitionTimingFunction: 'linear',
+                },
+              ]}
+              onStartShouldSetResponder={() => true}
+            />
+          </VerticalExampleCard>
+        </Section>
+      </Scroll>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: {
+    borderRadius: radius.md,
+    height: sizes.md,
+    width: sizes.md,
+  },
+  content: {
+    gap: spacing.xs,
+  },
+});

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Form.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Form.tsx
@@ -139,7 +139,7 @@ function Card({
   );
 }
 
-export default function Showcase() {
+export default function Form() {
   return (
     <Screen>
       <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
@@ -1,0 +1,163 @@
+import { StyleSheet, Text } from 'react-native';
+import Animated, { css } from 'react-native-reanimated';
+
+import {
+  Screen,
+  Scroll,
+  Section,
+  VerticalExampleCard,
+} from '@/apps/css/components';
+import { colors, spacing } from '@/theme';
+
+// Elliptical orbit kept tight so the planets stay on screen; wider than tall
+// fakes the "tilted into the screen" look.
+const ORBIT_RX = 90;
+const ORBIT_RY = 40;
+const ORBIT_DURATION = '12s';
+// Smoothness of the path the planet's frame is moved along.
+const ORBIT_STEPS = 36;
+
+const PLANETS = [
+  { color: colors.danger, name: 'Mars', size: 44 },
+  { color: colors.primary, name: 'Venus', size: 60 },
+  { color: colors.primaryDark, name: 'Jupiter', size: 78 },
+];
+
+const MAX_PLANET_SIZE = Math.max(...PLANETS.map((planet) => planet.size));
+const PLANE_WIDTH = 2 * ORBIT_RX + MAX_PLANET_SIZE;
+const PLANE_HEIGHT = 2 * ORBIT_RY + MAX_PLANET_SIZE;
+const CENTER_X = PLANE_WIDTH / 2;
+const CENTER_Y = PLANE_HEIGHT / 2;
+
+// The orbit is driven by animating left/top (layout) rather than a transform.
+// On iOS the touch hit-area follows animated layout but NOT an animated
+// transform, so this keeps the orbiting planets tappable (:active) there.
+function makeOrbit(offsetDeg: number, size: number) {
+  const frames: Record<string, { left: number; top: number }> = {};
+  for (let step = 0; step <= ORBIT_STEPS; step++) {
+    const percent = ((step / ORBIT_STEPS) * 100).toFixed(4);
+    const angle = ((offsetDeg + (360 * step) / ORBIT_STEPS) * Math.PI) / 180;
+    frames[`${percent}%`] = {
+      left: CENTER_X + ORBIT_RX * Math.cos(angle) - size / 2,
+      top: CENTER_Y + ORBIT_RY * Math.sin(angle) - size / 2,
+    };
+  }
+  return css.keyframes(frames);
+}
+
+const ORBITS = PLANETS.map((planet, index) =>
+  makeOrbit((360 / PLANETS.length) * index, planet.size)
+);
+
+export default function Planets() {
+  return (
+    <Screen>
+      <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>
+        <Section
+          description="Three differently sized planets orbit the screen center on a tilted (elliptical) path. Each planet's name is hidden until you press it, which activates its ':active' pseudo-selector; hovering (pointer) enlarges it with a colored glow."
+          title="Planets">
+          <VerticalExampleCard
+            title="Press a planet to reveal its name"
+            code={`<Animated.View
+  style={{
+    // 0.02 not 0: iOS skips alpha<0.01 views in hit-testing
+    opacity: { default: 0.02, ':active': 1 },
+    transitionDuration: '200ms',
+  }}
+  onStartShouldSetResponder={() => true}>
+  <Text>{name}</Text>
+</Animated.View>`}
+            collapsedCode={`opacity: {
+  default: 0.02,
+  ':active': 1,
+},`}>
+            <Animated.View style={styles.stage}>
+              <Animated.View style={styles.orbitPlane}>
+                {PLANETS.map((planet, index) => (
+                  <Animated.View
+                    key={planet.name}
+                    style={[
+                      styles.orbiter,
+                      {
+                        animationDuration: ORBIT_DURATION,
+                        animationIterationCount: 'infinite',
+                        animationName: ORBITS[index],
+                        animationTimingFunction: 'linear',
+                      },
+                      {
+                        backgroundColor: planet.color,
+                        borderRadius: planet.size / 2,
+                        height: planet.size,
+                        width: planet.size,
+                        // Glow matches the planet color; grows on hover.
+                        elevation: { ':hover': 12, default: 0 },
+                        shadowColor: planet.color,
+                        shadowOpacity: { ':hover': 0.9, default: 0 },
+                        shadowRadius: { ':hover': 18, default: 0 },
+                        // Enlarge 10% on hover (pointer only).
+                        transform: {
+                          ':hover': [{ scale: 1.1 }],
+                          default: [{ scale: 1 }],
+                        },
+                        transitionDuration: '200ms',
+                      },
+                    ]}>
+                    <Animated.View
+                      style={[
+                        styles.nameWrapper,
+                        {
+                          // Default is a hair above 0 (not 0) on purpose: UIKit
+                          // hit-testing skips views with alpha < 0.01, so a true
+                          // opacity-0 target isn't pressable on iOS (it is on
+                          // Android). 0.02 is invisible but still hit-tested.
+                          opacity: { ':active': 1, default: 0.02 },
+                          transitionDuration: '200ms',
+                        },
+                      ]}
+                      onStartShouldSetResponder={() => true}>
+                      <Text style={styles.name}>{planet.name}</Text>
+                    </Animated.View>
+                  </Animated.View>
+                ))}
+              </Animated.View>
+            </Animated.View>
+          </VerticalExampleCard>
+        </Section>
+      </Scroll>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    gap: spacing.xs,
+  },
+  name: {
+    color: colors.white,
+    fontSize: 12,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  nameWrapper: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  orbitPlane: {
+    height: PLANE_HEIGHT,
+    width: PLANE_WIDTH,
+  },
+  orbiter: {
+    position: 'absolute',
+    shadowOffset: { height: 0, width: 0 },
+  },
+  stage: {
+    alignItems: 'center',
+    height: PLANE_HEIGHT + spacing.xl,
+    justifyContent: 'center',
+  },
+});

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
@@ -9,12 +9,9 @@ import {
 } from '@/apps/css/components';
 import { colors, spacing } from '@/theme';
 
-// Elliptical orbit kept tight so the planets stay on screen; wider than tall
-// fakes the "tilted into the screen" look.
 const ORBIT_RX = 90;
 const ORBIT_RY = 40;
 const ORBIT_DURATION = '12s';
-// Smoothness of the path the planet's frame is moved along.
 const ORBIT_STEPS = 36;
 
 const PLANETS = [
@@ -29,9 +26,6 @@ const PLANE_HEIGHT = 2 * ORBIT_RY + MAX_PLANET_SIZE;
 const CENTER_X = PLANE_WIDTH / 2;
 const CENTER_Y = PLANE_HEIGHT / 2;
 
-// The orbit is driven by animating left/top (layout) rather than a transform.
-// On iOS the touch hit-area follows animated layout but NOT an animated
-// transform, so this keeps the orbiting planets tappable (:active) there.
 function makeOrbit(offsetDeg: number, size: number) {
   const frames: Record<string, { left: number; top: number }> = {};
   for (let step = 0; step <= ORBIT_STEPS; step++) {
@@ -54,7 +48,7 @@ export default function Planets() {
     <Screen>
       <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>
         <Section
-          description="Three differently sized planets orbit the screen center on a tilted (elliptical) path. Each planet's name is hidden until you press it, which activates its ':active' pseudo-selector; hovering (pointer) enlarges it with a colored glow."
+          description="Three differently sized planets orbit the screen center on a tilted (elliptical) path. Each planet's name is hidden until you press it, which activates its ':active' pseudo-selector; hovering enlarges it with a colored glow."
           title="Planets">
           <VerticalExampleCard
             title="Press a planet to reveal its name"
@@ -89,12 +83,10 @@ export default function Planets() {
                         borderRadius: planet.size / 2,
                         height: planet.size,
                         width: planet.size,
-                        // Glow matches the planet color; grows on hover.
                         elevation: { ':hover': 12, default: 0 },
                         shadowColor: planet.color,
                         shadowOpacity: { ':hover': 0.9, default: 0 },
                         shadowRadius: { ':hover': 18, default: 0 },
-                        // Enlarge 10% on hover (pointer only).
                         transform: {
                           ':hover': [{ scale: 1.1 }],
                           default: [{ scale: 1 }],
@@ -106,10 +98,6 @@ export default function Planets() {
                       style={[
                         styles.nameWrapper,
                         {
-                          // Default is a hair above 0 (not 0) on purpose: UIKit
-                          // hit-testing skips views with alpha < 0.01, so a true
-                          // opacity-0 target isn't pressable on iOS (it is on
-                          // Android). 0.02 is invisible but still hit-tested.
                           opacity: { ':active': 1, default: 0.02 },
                           transitionDuration: '200ms',
                         },

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
@@ -1,4 +1,5 @@
 import Active from './Active';
+import ActiveBlocksRender from './ActiveBlocksRender';
 import ActiveDeepest from './ActiveDeepest';
 import ArbitraryWebSelectors from './ArbitraryWebSelectors';
 import Focus from './Focus';
@@ -10,6 +11,7 @@ import Showcase from './Showcase';
 
 export default {
   Active,
+  ActiveBlocksRender,
   ActiveDeepest,
   ArbitraryWebSelectors,
   Focus,

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
@@ -4,11 +4,11 @@ import ActiveDeepest from './ActiveDeepest';
 import ArbitraryWebSelectors from './ArbitraryWebSelectors';
 import Focus from './Focus';
 import FocusWithin from './FocusWithin';
+import Form from './Form';
 import Hover from './Hover';
 import HoverWithLoop from './HoverWithLoop';
 import PerStateTransitionConfig from './PerStateTransitionConfig';
 import Planets from './Planets';
-import Showcase from './Showcase';
 
 export default {
   Active,
@@ -17,9 +17,9 @@ export default {
   ArbitraryWebSelectors,
   Focus,
   FocusWithin,
+  Form,
   Hover,
   HoverWithLoop,
   PerStateTransitionConfig,
   Planets,
-  Showcase,
 };

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
@@ -7,6 +7,7 @@ import FocusWithin from './FocusWithin';
 import Hover from './Hover';
 import HoverWithLoop from './HoverWithLoop';
 import PerStateTransitionConfig from './PerStateTransitionConfig';
+import Planets from './Planets';
 import Showcase from './Showcase';
 
 export default {
@@ -19,5 +20,6 @@ export default {
   Hover,
   HoverWithLoop,
   PerStateTransitionConfig,
+  Planets,
   Showcase,
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -36,6 +36,12 @@ TransitionProperties CSSTransition::getProperties() const {
 folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
+  for (const auto &propertyName : pseudoLockedProperties_) {
+    config.changedPropertiesSettings.erase(propertyName);
+    config.changedProperties.erase(propertyName);
+    std::erase(config.removedProperties, propertyName);
+  }
+
   // CSSTransition owns routing: platform-routed props run immediately on the platform
   // transition; the loop-routed remainder is applied to the loop transition below.
   auto processed = platformTransitionProxy_->processConfig(std::move(config), routing_);
@@ -98,6 +104,10 @@ folly::dynamic CSSTransition::computeCurrentLoopStyle() {
     return folly::dynamic::object();
   }
   return loopTransition_->computeCurrentStyle(shadowNode_);
+}
+
+void CSSTransition::setPseudoLockedProperties(TransitionProperties properties) {
+  pseudoLockedProperties_ = std::move(properties);
 }
 
 void CSSTransition::cancel() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -55,6 +55,8 @@ class CSSTransition {
   folly::dynamic run(const PropertyValueDynamicDiffsMap &propertyDiffs, const folly::dynamic &lastUpdates);
   void cancel();
 
+  void setPseudoLockedProperties(TransitionProperties properties);
+
  private:
   const std::shared_ptr<const ShadowNode> shadowNode_;
   const std::shared_ptr<ViewStylesRepository> viewStylesRepository_;
@@ -63,6 +65,7 @@ class CSSTransition {
   Observer &observer_;
 
   CSSTransitionRouting routing_;
+  TransitionProperties pseudoLockedProperties_;
   std::unique_ptr<CSSPlatformTransition> platformTransition_;
   std::shared_ptr<CSSLoopTransition> loopTransition_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -39,6 +39,14 @@ void CSSTransitionsRegistry::run(
   recordInitialUpdate(transition, initialUpdate);
 }
 
+void CSSTransitionsRegistry::setPseudoLockedProperties(const Tag viewTag, const TransitionProperties &properties) {
+  react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
+  const auto it = registry_.find(viewTag);
+  if (it != registry_.end()) {
+    it->second->setPseudoLockedProperties(properties);
+  }
+}
+
 void CSSTransitionsRegistry::flushUpdates(UpdatesBatch &updatesBatch) {
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   const auto tags = std::exchange(updatedTags_, {});

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -28,6 +28,8 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
       CSSTransitionConfig &&config);
   void run(const std::shared_ptr<const ShadowNode> &shadowNode, const PropertyValueDynamicDiffsMap &propertyDiffs);
 
+  void setPseudoLockedProperties(Tag viewTag, const TransitionProperties &properties);
+
   void flushUpdates(UpdatesBatch &updatesBatch);
 #if REACT_NATIVE_VERSION_MINOR >= 85
   void flushUpdates(UpdatesBatchAnimatedProps &updatesBatch);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
@@ -55,17 +55,20 @@ void PseudoStylesRegistry::registerPseudoStyle(
 
   auto &entry = registry_[tag];
   entry.shadowNode = shadowNode;
+  const bool isNewSelector = !entry.selectors.contains(selector);
   entry.selectors[selector] = {selectorStyle, defaultStyle};
   entry.precomputedStyles = recomputeAllStyles(entry);
 
-  attachFn_(
-      tag,
-      selector,
-      [weakThis = std::weak_ptr<PseudoStylesRegistry>(shared_from_this()), tag, selector](bool isActive) {
-        if (auto strongThis = weakThis.lock()) {
-          strongThis->onSelectorStateChanged(tag, selector, isActive);
-        }
-      });
+  if (isNewSelector) {
+    attachFn_(
+        tag,
+        selector,
+        [weakThis = std::weak_ptr<PseudoStylesRegistry>(shared_from_this()), tag, selector](bool isActive) {
+          if (auto strongThis = weakThis.lock()) {
+            strongThis->onSelectorStateChanged(tag, selector, isActive);
+          }
+        });
+  }
 }
 
 void PseudoStylesRegistry::remove(Tag tag) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
@@ -100,6 +100,19 @@ void PseudoStylesRegistry::onSelectorStateChanged(Tag tag, PseudoSelector select
   const auto &fromStyle = entry.precomputedStyles[oldMask];
   const auto &toStyle = entry.precomputedStyles[entry.activeMask];
 
+  css::TransitionProperties lockedProperties;
+  for (const auto &[sel, data] : entry.selectors) {
+    if (!(entry.activeMask & (1u << static_cast<int>(sel)))) {
+      continue;
+    }
+    for (const auto &[propKey, val] : data.selectorStyle.items()) {
+      if (!val.isNull()) {
+        lockedProperties.insert(propKey.asString());
+      }
+    }
+  }
+  cssTransitionsRegistry_->setPseudoLockedProperties(tag, lockedProperties);
+
   css::PropertyValueDynamicDiffsMap valueChanges;
   for (const auto &[propKey, toVal] : toStyle.items()) {
     const auto propName = propKey.asString();

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -47,15 +47,23 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     ) {
       return;
     }
+    const removedSelector = hasRemovedNativeSelector(
+      this.prevPseudoStylesBySelector,
+      pseudoStylesBySelector
+    );
+
     this.prevPseudoStylesBySelector = pseudoStylesBySelector;
     this.prevTransitionProperties = transitionProperties;
 
-    if (this.isRegistered) {
-      this.detach();
+    if (!pseudoStylesBySelector) {
+      if (this.isRegistered) {
+        this.detach();
+      }
+      return;
     }
 
-    if (!pseudoStylesBySelector) {
-      return;
+    if (this.isRegistered && removedSelector) {
+      this.detach();
     }
 
     const normalizedTransition = transitionProperties
@@ -138,6 +146,21 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
       transition,
     };
   }
+}
+
+function hasRemovedNativeSelector(
+  prev: PseudoStylesBySelector | null,
+  next: PseudoStylesBySelector | null
+): boolean {
+  if (!prev) {
+    return false;
+  }
+  const nextKeys = next ? new Set(Object.keys(next)) : new Set<string>();
+  return Object.keys(prev).some(
+    (selector) =>
+      NATIVE_PSEUDO_SELECTORS.has(selector as NativePseudoSelectorKey) &&
+      !nextKeys.has(selector)
+  );
 }
 
 function nullifyUndefinedValues(style: UnknownRecord): void {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -326,7 +326,7 @@ describe('CSSPseudoStylesManager', () => {
       expect(unregisterPseudoStyle).not.toHaveBeenCalled();
     });
 
-    test('detaches and re-registers when selector style changes', () => {
+    test('updates in place without detaching when only selector style changes', () => {
       pushStyle(manager, {
         opacity: { default: 0, ':hover': 1 },
       });
@@ -336,7 +336,7 @@ describe('CSSPseudoStylesManager', () => {
         opacity: { default: 0, ':hover': 0.5 },
       });
 
-      expect(unregisterPseudoStyle).toHaveBeenCalledWith(viewTag);
+      expect(unregisterPseudoStyle).not.toHaveBeenCalled();
       expect(registerPseudoStyle).toHaveBeenCalledWith(
         shadowNodeWrapper,
         expect.objectContaining({
@@ -345,7 +345,7 @@ describe('CSSPseudoStylesManager', () => {
       );
     });
 
-    test('detaches and re-registers when only the transition changes', () => {
+    test('updates in place without detaching when only the transition changes', () => {
       pushStyle(manager, {
         opacity: { default: 0, ':hover': 1 },
         transitionProperty: 'opacity',
@@ -359,7 +359,7 @@ describe('CSSPseudoStylesManager', () => {
         transitionDuration: '500ms',
       });
 
-      expect(unregisterPseudoStyle).toHaveBeenCalledWith(viewTag);
+      expect(unregisterPseudoStyle).not.toHaveBeenCalled();
       expect(registerPseudoStyle).toHaveBeenCalledWith(
         shadowNodeWrapper,
         expect.objectContaining({
@@ -368,6 +368,20 @@ describe('CSSPseudoStylesManager', () => {
           },
         })
       );
+    });
+
+    test('detaches and re-registers when a selector is removed', () => {
+      pushStyle(manager, {
+        opacity: { default: 0, ':hover': 1, ':active': 0.5 },
+      });
+      jest.clearAllMocks();
+
+      pushStyle(manager, {
+        opacity: { default: 0, ':hover': 1 },
+      });
+
+      expect(unregisterPseudoStyle).toHaveBeenCalledWith(viewTag);
+      expect(registerPseudoStyle).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

Currently changing the style of an object with pseudoselector during render will overwrite the effect of pseudoselector. It's not something that happens on web - pseudoselector (tagged with !important as in our web implementation) should be more important.

This PR tries to fix that. 

## Test plan

 CSS -> Transitions -> Pseudoselectors -> 
<img width="328" height="59" alt="image" src="https://github.com/user-attachments/assets/bf7c182b-e554-4213-b726-b2ba368cc774" />
