### PR TITLE
feat: Run background and border CSS transitions on Core Animation

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
@@ -29,6 +29,9 @@ id idFromPlatformValue(const PlatformValue &value);
 
 CAMediaTimingFunction *makeCSSTimingFunction(const EasingConfig &easing);
 
+/// Maps a CSS property name to its CALayer keyPath (borderRadius -> cornerRadius).
+NSString *keyPathForCSSProperty(const std::string &propertyName);
+
 } // namespace reanimated::css
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
@@ -29,8 +29,7 @@ id idFromPlatformValue(const PlatformValue &value);
 
 CAMediaTimingFunction *makeCSSTimingFunction(const EasingConfig &easing);
 
-/// Maps a CSS property name to its CALayer keyPath (borderRadius -> cornerRadius).
-NSString *keyPathForCSSProperty(const std::string &propertyName);
+NSString *caLayerKeyPathForCSSProperty(const std::string &propertyName);
 
 } // namespace reanimated::css
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -15,8 +15,7 @@ using namespace facebook;
 
 namespace {
 
-// kTransparentColor is consumed once backgroundColor / borderColor land (deferred).
-[[maybe_unused]] constexpr std::array<double, 4> kTransparentColor = {0, 0, 0, 0};
+constexpr std::array<double, 4> kTransparentColor = {0, 0, 0, 0};
 constexpr std::array<double, 4> kBlackColor = {0, 0, 0, 1};
 
 enum class CSSValueKind : std::uint8_t { Scalar, Color, Size };
@@ -33,11 +32,14 @@ const CSSPropertyTraits *traitsFor(const std::string &propertyName)
 {
   static const std::unordered_map<std::string, CSSPropertyTraits> kProperties = {
       {"opacity", {CSSValueKind::Scalar, 1.0}},
+      {"backgroundColor", {CSSValueKind::Color, kTransparentColor}},
+      {"borderColor", {CSSValueKind::Color, kBlackColor}},
+      {"borderRadius", {CSSValueKind::Scalar, 0.0}},
+      {"borderWidth", {CSSValueKind::Scalar, 0.0}},
       {"shadowColor", {CSSValueKind::Color, kBlackColor}},
       {"shadowOpacity", {CSSValueKind::Scalar, 0.0}},
       {"shadowRadius", {CSSValueKind::Scalar, 0.0}},
       {"shadowOffset", {CSSValueKind::Size, std::array<double, 2>{0.0, 0.0}}},
-      // TODO: backgroundColor + border* need eligibility + commit-hook re-routing.
   };
   const auto it = kProperties.find(propertyName);
   return it != kProperties.end() ? &it->second : nullptr;
@@ -75,6 +77,11 @@ bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &ea
   if (traitsFor(propertyName) == nullptr) {
     return false;
   }
+  // TODO: backgroundColor and border{Color,Width,Radius} are routed unconditionally,
+  // but RN rasterizes the border (stripping the CA animation, so the value snaps)
+  // whenever a view fails useCoreAnimationBorderRendering. Gate them on committed
+  // ViewProps eligibility + commit-hook re-routing so platform animation only starts
+  // when it can produce correct results (follow-up PR).
   // CAMediaTimingFunction can express only linear and cubic-bezier curves;
   // steps / linear-stops easings have to interpolate per-frame on the loop.
   return std::holds_alternative<LinearEasing>(easing) || std::holds_alternative<CubicBezierEasing>(easing);
@@ -161,6 +168,16 @@ CAMediaTimingFunction *makeCSSTimingFunction(const EasingConfig &easing)
     return [CAMediaTimingFunction functionWithControlPoints:(float)cb.x1:(float)cb.y1:(float)cb.x2:(float)cb.y2];
   }
   return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+}
+
+NSString *keyPathForCSSProperty(const std::string &propertyName)
+{
+  // CALayer names rounded corners "cornerRadius"; every other routed property maps
+  // to its CALayer keyPath 1:1.
+  if (propertyName == "borderRadius") {
+    return @"cornerRadius";
+  }
+  return [NSString stringWithUTF8String:propertyName.c_str()];
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -168,7 +168,7 @@ CAMediaTimingFunction *makeCSSTimingFunction(const EasingConfig &easing)
   return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
 }
 
-NSString *keyPathForCSSProperty(const std::string &propertyName)
+NSString *caLayerKeyPathForCSSProperty(const std::string &propertyName)
 {
   // CALayer names rounded corners "cornerRadius"; every other routed property maps
   // to its CALayer keyPath 1:1.

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -37,7 +37,7 @@ const CSSPropertyTraits *traitsFor(const std::string &propertyName)
       {"borderRadius", {CSSValueKind::Scalar, 0.0}},
       {"borderWidth", {CSSValueKind::Scalar, 0.0}},
       {"shadowColor", {CSSValueKind::Color, kBlackColor}},
-      {"shadowOpacity", {CSSValueKind::Scalar, 0.0}},
+      {"shadowOpacity", {CSSValueKind::Scalar, 1.0}},
       {"shadowRadius", {CSSValueKind::Scalar, 0.0}},
       {"shadowOffset", {CSSValueKind::Size, std::array<double, 2>{0.0, 0.0}}},
   };

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -77,11 +77,9 @@ bool canRouteCSSProperty(const std::string &propertyName, const EasingConfig &ea
   if (traitsFor(propertyName) == nullptr) {
     return false;
   }
-  // TODO: backgroundColor and border{Color,Width,Radius} are routed unconditionally,
-  // but RN rasterizes the border (stripping the CA animation, so the value snaps)
-  // whenever a view fails useCoreAnimationBorderRendering. Gate them on committed
-  // ViewProps eligibility + commit-hook re-routing so platform animation only starts
-  // when it can produce correct results (follow-up PR).
+  // TODO: border props route unconditionally, but snap when RN rasterizes the
+  // border (view fails useCoreAnimationBorderRendering); they should route only
+  // when the platform can render them correctly (follow-up PR).
   // CAMediaTimingFunction can express only linear and cubic-bezier curves;
   // steps / linear-stops easings have to interpolate per-frame on the loop.
   return std::holds_alternative<LinearEasing>(easing) || std::holds_alternative<CubicBezierEasing>(easing);

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -148,7 +148,7 @@ struct ActiveTransition {
             easing:(const EasingConfig &)easing
 {
   // Capture everything up front; CALayer access must happen on the main thread.
-  NSString *keyPath = [NSString stringWithUTF8String:propertyName.c_str()];
+  NSString *keyPath = keyPathForCSSProperty(propertyName);
   id fromId = idFromPlatformValue(fromValue);
   id toId = idFromPlatformValue(toValue);
   double durationSec = durationMs / 1000.0;
@@ -207,7 +207,7 @@ struct ActiveTransition {
     }
   }
 
-  NSString *keyPath = [NSString stringWithUTF8String:propertyName.c_str()];
+  NSString *keyPath = keyPathForCSSProperty(propertyName);
   __weak __typeof__(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{
     __typeof__(self) strongSelf = weakSelf;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -148,7 +148,7 @@ struct ActiveTransition {
             easing:(const EasingConfig &)easing
 {
   // Capture everything up front; CALayer access must happen on the main thread.
-  NSString *keyPath = keyPathForCSSProperty(propertyName);
+  NSString *keyPath = caLayerKeyPathForCSSProperty(propertyName);
   id fromId = idFromPlatformValue(fromValue);
   id toId = idFromPlatformValue(toValue);
   double durationSec = durationMs / 1000.0;
@@ -207,7 +207,7 @@ struct ActiveTransition {
     }
   }
 
-  NSString *keyPath = keyPathForCSSProperty(propertyName);
+  NSString *keyPath = caLayerKeyPathForCSSProperty(propertyName);
   __weak __typeof__(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{
     __typeof__(self) strongSelf = weakSelf;


### PR DESCRIPTION
Stacked on #9685.

Adds `backgroundColor`, `borderColor`, `borderWidth` and `borderRadius` to the CSS transition properties run on Core Animation (`borderRadius` maps to CALayer's `cornerRadius`).

Known limitation (TODO in code): these route unconditionally, but RN rasterizes the border and snaps the value when a view fails `useCoreAnimationBorderRendering`. A follow-up will run them on the platform only when it can produce a correct result.

Verified in the simulator: on a CA-eligible (clipping) view all four interpolate smoothly.