### PR TITLE
feat: Route the transform CSS transition to Core Animation on iOS

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -2,6 +2,8 @@
 
 #include <react/debug/react_native_assert.h>
 
+#include <jsi/JSIDynamic.h>
+
 #include <utility>
 
 namespace reanimated::css {
@@ -10,11 +12,13 @@ CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
     CSSCanRoutePropertyFunction canRoute,
     CSSApplyTransitionJSIFunction applyJSI,
     CSSApplyTransitionDynamicFunction applyDynamic,
-    CSSRemoveTransitionFunction removeTransition)
+    CSSRemoveTransitionFunction removeTransition,
+    CSSAnimateTransformFunction animateTransform)
     : canRoute_(std::move(canRoute)),
       applyJSI_(std::move(applyJSI)),
       applyDynamic_(std::move(applyDynamic)),
-      removeTransition_(std::move(removeTransition)) {}
+      removeTransition_(std::move(removeTransition)),
+      animateTransform_(std::move(animateTransform)) {}
 
 bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
   return canRoute_ && canRoute_(propertyName, easing);
@@ -40,10 +44,136 @@ bool CSSPlatformTransitionProxy::apply(
   return applyDynamic_ && applyDynamic_(viewTag, propertyName, fromValue, toValue, timestamp);
 }
 
+bool CSSPlatformTransitionProxy::applyTransform(
+    const Tag viewTag,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue,
+    const CSSTransitionPropertySettings &settings,
+    const double timestamp,
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    const folly::dynamic &lastUpdates) const {
+  if (!animateTransform_ || !isTransformRoutable(fromValue, toValue)) {
+    return false;
+  }
+
+  const std::string propertyName = "transform";
+  const std::string componentName = shadowNode->getComponentName();
+
+  TransformTransitionState *active = findTransformState(viewTag, propertyName);
+
+  // Declared endpoints (reversal-bookkeeping values), materialized once.
+  auto [declaredFrom, declaredTo] =
+      resolveTransformEndpoints(shadowNode, componentName, viewStylesRepository, fromValue, toValue);
+
+  // Sampling-from value on a retarget: continue an in-flight transition from its
+  // exact current value computed with the loop's interpolation (a presentation
+  // matrix would collapse rotation count); otherwise prefer the loop's last
+  // written frame (a transition migrating loop -> platform mid-flight). The guard
+  // uses linear progress - overshooting easings can exceed 1 mid-flight.
+  folly::dynamic samplingFrom = declaredFrom;
+  const double linearProgress =
+      active != nullptr && !active->fromDynamic.isNull() ? linearProgressAt(active->reversing, timestamp) : 1.0;
+  if (linearProgress < 1.0) {
+    samplingFrom = interpolateTransformValueAt(
+        shadowNode,
+        componentName,
+        viewStylesRepository,
+        active->fromDynamic,
+        active->toDynamic,
+        getEasingFunctionFromConfig(active->reversing.easing)(linearProgress));
+  } else if (lastUpdates.isObject()) {
+    const auto lastIt = lastUpdates.find(propertyName);
+    if (lastIt != lastUpdates.items().end() && !lastIt->second.isNull()) {
+      samplingFrom = lastIt->second;
+    }
+  }
+
+  // Targeting the in-flight transition's start value means this is a reversal.
+  TransformTransitionState *previous =
+      (active != nullptr && declaredTo == active->adjustedStart) ? active : nullptr;
+  ReversingState reversing = previous
+      ? reverseShorten(previous->reversing, timestamp, settings.duration, settings.delay, settings.easingConfig)
+      : makeReversingState(timestamp, settings.duration, settings.delay, settings.easingConfig);
+
+  folly::dynamic adjustedStart = previous ? previous->toDynamic : declaredFrom;
+
+  const auto plan =
+      buildTransformAnimationPlan(shadowNode, componentName, viewStylesRepository, samplingFrom, declaredTo);
+
+  animateTransform_(viewTag, plan, reversing.duration, reversing.startTimestamp, settings.easingConfig);
+
+  TransformTransitionState entry;
+  entry.adjustedStart = std::move(adjustedStart);
+  entry.fromDynamic = std::move(samplingFrom);
+  entry.toDynamic = std::move(declaredTo);
+  entry.reversing = std::move(reversing);
+  entry.settings = settings;
+  entry.componentName = componentName;
+  transformStates_[viewTag][propertyName] = std::move(entry);
+  return true;
+}
+
+CSSPlatformTransitionProxy::TransformTransitionState *CSSPlatformTransitionProxy::findTransformState(
+    const Tag viewTag,
+    const std::string &propertyName) const {
+  const auto statesIt = transformStates_.find(viewTag);
+  if (statesIt == transformStates_.end()) {
+    return nullptr;
+  }
+  const auto stateIt = statesIt->second.find(propertyName);
+  return stateIt != statesIt->second.end() ? &stateIt->second : nullptr;
+}
+
 void CSSPlatformTransitionProxy::remove(const Tag viewTag, const std::string &propertyName) const {
+  const auto statesIt = transformStates_.find(viewTag);
+  if (statesIt != transformStates_.end()) {
+    statesIt->second.erase(propertyName);
+    if (statesIt->second.empty()) {
+      transformStates_.erase(statesIt);
+    }
+  }
   if (removeTransition_) {
     removeTransition_(viewTag, propertyName);
   }
+}
+
+folly::dynamic CSSPlatformTransitionProxy::getTargetValue(const Tag viewTag, const std::string &propertyName) const {
+  // Only transform carries a common-side target; scalars return null (they are
+  // distinguished by the platform's CALayer model, not by a recorded value).
+  const auto *state = findTransformState(viewTag, propertyName);
+  return state != nullptr ? state->toDynamic : folly::dynamic();
+}
+
+void CSSPlatformTransitionProxy::migrateToLoop(
+    const Tag viewTag,
+    const std::string &propertyName,
+    const double timestamp,
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    folly::dynamic &lastUpdates) const {
+  // Read the exact in-flight value before cancelling so the loop continues from
+  // it (mirrors the loop reading its last written frame on retarget). Only
+  // transform supplies a value here; scalars rely on the presentation layer.
+  // The reversing snapshot drives the re-derivation; the presentation-layer
+  // matrix would collapse rotation count and so can't be used.
+  const auto *state = findTransformState(viewTag, propertyName);
+  if (state != nullptr && !state->fromDynamic.isNull()) {
+    auto currentValue = interpolateTransformValueAt(
+        shadowNode,
+        state->componentName,
+        viewStylesRepository,
+        state->fromDynamic,
+        state->toDynamic,
+        easedProgressAt(state->reversing, timestamp));
+    if (!currentValue.isNull()) {
+      if (!lastUpdates.isObject()) {
+        lastUpdates = folly::dynamic::object();
+      }
+      lastUpdates[propertyName] = std::move(currentValue);
+    }
+  }
+  remove(viewTag, propertyName);
 }
 
 CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
@@ -51,7 +181,10 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
     const Tag viewTag,
     const CSSTransitionConfig &config,
     CSSTransitionRouting &routing,
-    const double timestamp) const {
+    const double timestamp,
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    folly::dynamic &lastUpdates) const {
   CSSTransitionConfig loopConfig;
   size_t matchedValues = 0;
 
@@ -64,7 +197,19 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
 
     bool routable = canRoute(propertyName, settings.easingConfig);
     if (routable && hasValue) {
-      routable = apply(rt, viewTag, propertyName, valueIt->second.first, valueIt->second.second, settings, timestamp);
+      if (propertyName == "transform") {
+        routable = applyTransform(
+            viewTag,
+            jsi::dynamicFromValue(rt, valueIt->second.first),
+            jsi::dynamicFromValue(rt, valueIt->second.second),
+            settings,
+            timestamp,
+            shadowNode,
+            viewStylesRepository,
+            lastUpdates);
+      } else {
+        routable = apply(rt, viewTag, propertyName, valueIt->second.first, valueIt->second.second, settings, timestamp);
+      }
     } else if (routable) {
       // Settings-only: stay on the platform only if already animating there.
       routable = routing.platform.contains(propertyName);
@@ -77,9 +222,10 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       }
       routing.platform.insert(propertyName);
     } else {
-      // platform -> loop migration cancels on the platform side.
+      // platform -> loop migration cancels on the platform side, after capturing
+      // the in-flight value so the loop run picks it up as the from value.
       if (routing.platform.erase(propertyName) > 0) {
-        remove(viewTag, propertyName);
+        migrateToLoop(viewTag, propertyName, timestamp, shadowNode, viewStylesRepository, lastUpdates);
       }
       routing.loop.insert(propertyName);
       if (hasValue) {
@@ -110,17 +256,40 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     const Tag viewTag,
     const PropertyValueDynamicDiffsMap &propertyDiffs,
     CSSTransitionRouting &routing,
-    const double timestamp) const {
+    const double timestamp,
+    const std::shared_ptr<const ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    folly::dynamic &lastUpdates) const {
   PropertyValueDynamicDiffsMap loopDiffs;
   for (const auto &[propertyName, propertyDiff] : propertyDiffs) {
     // A platform-routed property keeps animating natively while the platform can
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
-      if (apply(viewTag, propertyName, propertyDiff.first, propertyDiff.second, timestamp)) {
+      bool applied = false;
+      if (propertyName == "transform") {
+        // The toggle path carries no settings of its own; reuse the ones the
+        // config apply stored on the transform state. No stored state means no
+        // config apply ran, so there is nothing to toggle natively.
+        const auto *state = findTransformState(viewTag, propertyName);
+        if (state != nullptr) {
+          applied = applyTransform(
+              viewTag,
+              propertyDiff.first,
+              propertyDiff.second,
+              state->settings,
+              timestamp,
+              shadowNode,
+              viewStylesRepository,
+              lastUpdates);
+        }
+      } else {
+        applied = apply(viewTag, propertyName, propertyDiff.first, propertyDiff.second, timestamp);
+      }
+      if (applied) {
         continue;
       }
       routing.platform.erase(propertyName);
-      remove(viewTag, propertyName);
+      migrateToLoop(viewTag, propertyName, timestamp, shadowNode, viewStylesRepository, lastUpdates);
       routing.loop.insert(propertyName);
     }
     loopDiffs.emplace(propertyName, propertyDiff);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -3,13 +3,19 @@
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingConfigs.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <reanimated/CSS/utils/reversingShortening.h>
+#include <reanimated/CSS/utils/transformAnimation.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ShadowNode.h>
 
 #include <functional>
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace reanimated::css {
 
@@ -18,9 +24,11 @@ using namespace react;
 
 /// Whether the platform can animate the property natively for the given easing.
 using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
-/// Animates a routed property natively; a false (no-op) return means the platform
-/// can't express the value, so it falls back to the loop. The jsi overload is the
-/// config path (carries a runtime + settings); the folly overload, the toggle path.
+/// Animates a routed SCALAR property natively; a false (no-op) return means the
+/// platform can't express the value, so it falls back to the loop. The jsi
+/// overload is the config path (carries a runtime + settings); the folly
+/// overload, the toggle path. Transform never goes through these hooks - its plan
+/// is built in common C++ and handed to the platform via CSSAnimateTransformFunction.
 using CSSApplyTransitionJSIFunction = std::function<bool(
     jsi::Runtime &rt,
     Tag viewTag,
@@ -29,14 +37,14 @@ using CSSApplyTransitionJSIFunction = std::function<bool(
     const jsi::Value &toValue,
     const CSSTransitionPropertySettings &settings,
     double timestamp)>;
-using CSSApplyTransitionDynamicFunction = std::function<bool(
-    Tag viewTag,
-    const std::string &propertyName,
-    const folly::dynamic &fromValue,
-    const folly::dynamic &toValue,
-    double timestamp)>;
+using CSSApplyTransitionDynamicFunction = std::function<
+    bool(Tag viewTag, const std::string &propertyName, const folly::dynamic &fromValue, const folly::dynamic &toValue, double timestamp)>;
 /// Cancels the property's native transition and drops its platform-side state.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
+/// Drives a finished transform plan through Core Animation. The plan, timing and
+/// easing are fully computed in common C++; the platform only orchestrates CA.
+using CSSAnimateTransformFunction = std::function<
+    void(Tag viewTag, const TransformAnimationPlan &plan, double durationMs, double startTimeMs, const EasingConfig &easing)>;
 
 /// A view's transition partition: which properties animate on the platform vs the
 /// C++ loop. Owned per-view by CSSTransition; updated by the proxy on migrations.
@@ -45,39 +53,74 @@ struct CSSTransitionRouting {
   TransitionProperties loop;
 };
 
-/// Stateless, shared routing engine: per property it routes a view's CSS transition
-/// to the platform (animated natively via the hooks above) or the C++ loop, never
-/// seeing the value - it forwards the raw JS source to the platform. Per-view routing
-/// state is passed in; an absent hook keeps that property on the loop.
+/// Shared routing engine: per property it routes a view's CSS transition to the
+/// platform (animated natively via the hooks above) or the C++ loop. For scalars
+/// it forwards the raw JS source to the platform. For transform it owns the value
+/// model (endpoints, reversal bookkeeping, in-flight sampling) and hands the
+/// platform a finished plan. Per-view routing state is passed in; an absent hook
+/// keeps that property on the loop.
 class CSSPlatformTransitionProxy {
  public:
   CSSPlatformTransitionProxy(
       CSSCanRoutePropertyFunction canRoute,
       CSSApplyTransitionJSIFunction applyJSI,
       CSSApplyTransitionDynamicFunction applyDynamic,
-      CSSRemoveTransitionFunction removeTransition);
+      CSSRemoveTransitionFunction removeTransition,
+      CSSAnimateTransformFunction animateTransform);
 
   /// Routes the config between platform and loop, updating `routing` and returning
-  /// the loop-routed remainder to run.
+  /// the loop-routed remainder to run. shadowNode + viewStylesRepository drive the
+  /// native plan for view-dependent properties; `lastUpdates` is updated in place
+  /// with the in-flight values of properties migrating platform -> loop, so the
+  /// loop run continues without a visual jump.
   CSSTransitionConfig processConfig(
       jsi::Runtime &rt,
       Tag viewTag,
       const CSSTransitionConfig &config,
       CSSTransitionRouting &routing,
-      double timestamp) const;
+      double timestamp,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+      folly::dynamic &lastUpdates) const;
 
   /// Re-routes pseudo-selector toggle diffs: a property the platform can no longer
-  /// express migrates to the loop. Updates `routing`, returns the loop diffs.
+  /// express migrates to the loop. Updates `routing`, returns the loop diffs, and
+  /// records in-flight migration values into `lastUpdates`.
   PropertyValueDynamicDiffsMap processDynamicDiffs(
       Tag viewTag,
       const PropertyValueDynamicDiffsMap &propertyDiffs,
       CSSTransitionRouting &routing,
-      double timestamp) const;
+      double timestamp,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+      folly::dynamic &lastUpdates) const;
+
+  /// The native transition's current target value for the property (operations
+  /// array for transform), or null. Forwarded to the registry's prune/pin logic.
+  folly::dynamic getTargetValue(Tag viewTag, const std::string &propertyName) const;
 
   /// Cancels the native transition of every given property (teardown).
   void cancelAll(Tag viewTag, const TransitionProperties &properties) const;
 
  private:
+  /// Per-property transform transition state, owned in common C++ (transform is
+  /// not a PlatformValue). fromDynamic/toDynamic are the raw endpoints the plan
+  /// was sampled from (kept for in-flight re-derivation); `reversing` drives
+  /// reverse-shortening on interruption; `settings` are reused on the runtime-free
+  /// toggle path (which carries no settings of its own); componentName is captured
+  /// for plan/value re-derivation. adjustedStart is the reversal-bookkeeping start.
+  struct TransformTransitionState {
+    folly::dynamic adjustedStart;
+    folly::dynamic fromDynamic;
+    folly::dynamic toDynamic;
+    ReversingState reversing;
+    CSSTransitionPropertySettings settings;
+    std::string componentName;
+  };
+
+  /// The active transform transition for the tag/property, or nullptr.
+  TransformTransitionState *findTransformState(Tag viewTag, const std::string &propertyName) const;
+
   bool canRoute(const std::string &propertyName, const EasingConfig &easing) const;
   bool apply(
       jsi::Runtime &rt,
@@ -93,12 +136,41 @@ class CSSPlatformTransitionProxy {
       const folly::dynamic &fromValue,
       const folly::dynamic &toValue,
       double timestamp) const;
+  /// Builds and drives a transform transition from raw dynamic endpoints,
+  /// recording the per-transition state. Returns false (= run on the loop) when
+  /// the value is not natively expressible. Mirrors the scalar apply() return
+  /// contract.
+  bool applyTransform(
+      Tag viewTag,
+      const folly::dynamic &fromValue,
+      const folly::dynamic &toValue,
+      const CSSTransitionPropertySettings &settings,
+      double timestamp,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+      const folly::dynamic &lastUpdates) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
+  /// Captures the in-flight value of a property about to migrate platform -> loop
+  /// into `lastUpdates`, then cancels the native transition. shadowNode + repo are
+  /// needed to re-derive an in-flight transform value with the loop's interpolation.
+  void migrateToLoop(
+      Tag viewTag,
+      const std::string &propertyName,
+      double timestamp,
+      const std::shared_ptr<const ShadowNode> &shadowNode,
+      const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+      folly::dynamic &lastUpdates) const;
 
   CSSCanRoutePropertyFunction canRoute_;
   CSSApplyTransitionJSIFunction applyJSI_;
   CSSApplyTransitionDynamicFunction applyDynamic_;
   CSSRemoveTransitionFunction removeTransition_;
+  CSSAnimateTransformFunction animateTransform_;
+
+  // viewTag -> propertyName -> transform state. Only "transform" is stored here;
+  // scalars keep no common value state (they migrate via the CALayer presentation
+  // layer on the platform side). mutable: the public apply/migrate path is const.
+  mutable std::unordered_map<Tag, std::unordered_map<std::string, TransformTransitionState>> transformStates_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.cpp
@@ -32,7 +32,11 @@ TransitionProperties CSSTransition::getProperties() const {
 folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config, const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
-  auto loopConfig = platformTransitionProxy_->processConfig(rt, getViewTag(), config, routing_, timestamp);
+  // Mutable copy so the proxy can record the in-flight values of properties
+  // migrating platform -> loop; the loop run below reads them as from values.
+  folly::dynamic loopLastUpdates = lastUpdates;
+  auto loopConfig = platformTransitionProxy_->processConfig(
+      rt, getViewTag(), config, routing_, timestamp, shadowNode_, viewStylesRepository_, loopLastUpdates);
   if (loopConfig.empty()) {
     return folly::dynamic::object();
   }
@@ -45,7 +49,7 @@ folly::dynamic CSSTransition::run(jsi::Runtime &rt, CSSTransitionConfig &&config
     return folly::dynamic::object();
   }
 
-  auto initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, lastUpdates, timestamp);
+  auto initialUpdate = loopTransition.run(rt, shadowNode_, loopConfig.changedProperties, loopLastUpdates, timestamp);
   scheduleLoop(timestamp);
   return initialUpdate;
 }
@@ -55,14 +59,24 @@ folly::dynamic CSSTransition::run(
     const folly::dynamic &lastUpdates) {
   const auto timestamp = loop_->resolveTimestamp();
 
-  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(getViewTag(), propertyDiffs, routing_, timestamp);
+  folly::dynamic loopLastUpdates = lastUpdates;
+  auto loopDiffs = platformTransitionProxy_->processDynamicDiffs(
+      getViewTag(), propertyDiffs, routing_, timestamp, shadowNode_, viewStylesRepository_, loopLastUpdates);
   if (loopDiffs.empty() && !loopTransition_) {
     return folly::dynamic::object();
   }
 
-  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, lastUpdates, timestamp);
+  auto initialUpdate = ensureLoopTransition().run(shadowNode_, loopDiffs, loopLastUpdates, timestamp);
   scheduleLoop(timestamp);
   return initialUpdate;
+}
+
+TransitionProperties CSSTransition::getPlatformRoutedProperties() const {
+  return routing_.platform;
+}
+
+folly::dynamic CSSTransition::getPlatformTargetValue(const std::string &propertyName) const {
+  return platformTransitionProxy_->getTargetValue(getViewTag(), propertyName);
 }
 
 folly::dynamic CSSTransition::computeCurrentLoopStyle() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSTransition.h
@@ -44,6 +44,15 @@ class CSSTransition {
 
   TransitionProperties getProperties() const;
 
+  /// Properties currently animating on the platform (renderer) side. The registry
+  /// uses this to keep their pinned target values out of the loop-frame pruning.
+  TransitionProperties getPlatformRoutedProperties() const;
+
+  /// Current target value of the property's platform run (operations array for
+  /// transform), or null. Distinguishes pseudo-state pins (which re-assert the
+  /// renderer-committed value on RN re-commits) from stale loop frames.
+  folly::dynamic getPlatformTargetValue(const std::string &propertyName) const;
+
   folly::dynamic computeCurrentLoopStyle();
 
   /// Applies a config: routes props between the platform and loop sides and runs them.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h
@@ -15,7 +15,9 @@ class TransformsStyleInterpolator final : public OperationsStyleInterpolatorBase
       const std::shared_ptr<StyleOperationInterpolators> &interpolators,
       const std::shared_ptr<ViewStylesRepository> &viewStylesRepository);
 
- protected:
+  /// Public (unlike the protected base declaration): the platform transition path
+  /// reuses the exact pairing logic to decide how a transform transition maps to
+  /// Core Animation primitives (see utils/transformAnimation.cpp).
   std::optional<std::pair<StyleOperations, StyleOperations>> createInterpolationPair(
       const StyleOperations &fromOperations,
       const StyleOperations &toOperations) const override;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -74,6 +74,40 @@ folly::dynamic ViewStylesRepository::getStyleProp(const Tag tag, const PropertyP
   return getPropertyValue(staticPropsRegistry_->get(tag), propertyPath);
 }
 
+std::optional<std::array<double, 3>> ViewStylesRepository::getTransformOriginOffset(
+    const std::shared_ptr<const ShadowNode> &shadowNode) {
+  auto &cachedNode = shadowNodeCache_[shadowNode->getTag()];
+  updateCacheIfNeeded(cachedNode, shadowNode);
+  // No cached props means the node isn't mounted yet; transitions only
+  // trigger on prop changes of mounted views, so assume the default origin.
+  if (cachedNode.viewProps == nullptr || !cachedNode.viewProps->transformOrigin.isSet()) {
+    return std::nullopt;
+  }
+
+  // Mirror RN's getTranslateForTransformOrigin (BaseViewProps.cpp): resolve each
+  // axis against the laid-out frame, then express it relative to the view center
+  // - the layer's default anchor point, about which the transform stack pivots.
+  const auto &origin = cachedNode.viewProps->transformOrigin;
+  const std::array<double, 2> dimensions = {
+      cachedNode.layoutMetrics.frame.size.width, cachedNode.layoutMetrics.frame.size.height};
+  std::array<double, 3> offset = {0.0, 0.0, origin.z};
+  for (size_t i = 0; i < dimensions.size(); ++i) {
+    const double center = dimensions[i] / 2.0;
+    double resolved = center;
+    if (origin.xy[i].unit == UnitType::Point) {
+      resolved = origin.xy[i].value;
+    } else if (origin.xy[i].unit == UnitType::Percent) {
+      resolved = dimensions[i] * origin.xy[i].value / 100.0;
+    }
+    offset[i] = resolved - center;
+  }
+
+  if (offset[0] == 0.0 && offset[1] == 0.0 && offset[2] == 0.0) {
+    return std::nullopt;
+  }
+  return offset;
+}
+
 void ViewStylesRepository::clearNodesCache() {
   shadowNodeCache_.clear();
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -8,7 +8,9 @@
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/dom/DOM.h>
 
+#include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -35,6 +37,12 @@ class ViewStylesRepository {
   jsi::Value getNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   jsi::Value getParentNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   folly::dynamic getStyleProp(Tag tag, const PropertyPath &propertyPath);
+  /// The view's transform-origin expressed as a translate relative to the layer
+  /// center (the default anchor point), resolved against the laid-out frame -
+  /// mirrors RN's getTranslateForTransformOrigin. Returns nullopt for the
+  /// default/center origin so callers skip the no-op bake.
+  std::optional<std::array<double, 3>> getTransformOriginOffset(
+      const std::shared_ptr<const ShadowNode> &shadowNode);
 
   void clearNodesCache();
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.cpp
@@ -27,6 +27,9 @@ void CSSTransitionsRegistry::updateConfigOrRun(
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   const auto &transition = getOrCreateTransition(shadowNode);
   auto initialUpdate = transition->run(rt, std::move(config), getUpdatesFromRegistry(transition->getViewTag()));
+  // Drop stale loop frames of platform-routed props left pinned in the registry;
+  // they would otherwise override the React-committed final value on later commits.
+  prunePlatformPropertiesFromRegistry(transition);
   recordInitialUpdate(transition, initialUpdate);
 }
 
@@ -36,6 +39,7 @@ void CSSTransitionsRegistry::run(
   react_native_assert(UpdatesRegistryManager::isLockedByCurrentThread());
   const auto &transition = getOrCreateTransition(shadowNode);
   auto initialUpdate = transition->run(propertyDiffs, getUpdatesFromRegistry(transition->getViewTag()));
+  prunePlatformPropertiesFromRegistry(transition);
   recordInitialUpdate(transition, initialUpdate);
 }
 
@@ -104,16 +108,24 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   const auto &shadowNode = transition->getShadowNode();
   const auto &lastUpdates = getUpdatesFromRegistry(shadowNode->getTag());
   const auto &transitionProperties = transition->getProperties();
+  const auto &platformProperties = transition->getPlatformRoutedProperties();
 
   folly::dynamic filteredUpdates = folly::dynamic::object;
 
   if (!lastUpdates.empty()) {
     // Otherwise, we keep only allowed properties from the last updates
-    // and update the object with the new transition starting values
+    // and update the object with the new transition starting values.
+    // Platform-routed properties are kept only when they hold the platform
+    // run's current target (a pseudo-state pin that must survive RN commits);
+    // anything else is a stale loop frame and gets dropped.
     for (const auto &prop : transitionProperties) {
-      if (lastUpdates.count(prop)) {
-        filteredUpdates[prop] = lastUpdates[prop];
+      if (!lastUpdates.count(prop)) {
+        continue;
       }
+      if (platformProperties.contains(prop) && lastUpdates[prop] != transition->getPlatformTargetValue(prop)) {
+        continue;
+      }
+      filteredUpdates[prop] = lastUpdates[prop];
     }
   }
 
@@ -121,6 +133,39 @@ void CSSTransitionsRegistry::updateInUpdatesRegistry(
   // to do additional filtering here
   filteredUpdates.update(updates);
   setInUpdatesRegistry(shadowNode->getFamilyShared(), filteredUpdates);
+}
+
+void CSSTransitionsRegistry::prunePlatformPropertiesFromRegistry(const std::shared_ptr<CSSTransition> &transition) {
+  const auto &platformProperties = transition->getPlatformRoutedProperties();
+  if (platformProperties.empty()) {
+    return;
+  }
+
+  auto lastUpdates = getUpdatesFromRegistry(transition->getViewTag());
+  if (!lastUpdates.isObject()) {
+    return;
+  }
+
+  size_t erasedCount = 0;
+  for (const auto &propertyName : platformProperties) {
+    // Keep values matching the platform run's current target - those are
+    // pseudo-state pins that re-assert the renderer-committed value when RN
+    // re-commits the view; only stale loop frames are dropped.
+    if (lastUpdates.count(propertyName) &&
+        lastUpdates[propertyName] == transition->getPlatformTargetValue(propertyName)) {
+      continue;
+    }
+    erasedCount += lastUpdates.erase(propertyName);
+  }
+  if (erasedCount == 0) {
+    return;
+  }
+
+  if (lastUpdates.empty()) {
+    removeFromUpdatesRegistry(transition->getViewTag());
+  } else {
+    setInUpdatesRegistry(transition->getShadowNodeFamily(), lastUpdates);
+  }
 }
 
 const std::shared_ptr<CSSTransition> &CSSTransitionsRegistry::getOrCreateTransition(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/CSSTransitionsRegistry.h
@@ -58,6 +58,10 @@ class CSSTransitionsRegistry : public UpdatesRegistry {
   void removeTag(Tag viewTag) override;
   const std::shared_ptr<CSSTransition> &getOrCreateTransition(const std::shared_ptr<const ShadowNode> &shadowNode);
   void updateInUpdatesRegistry(const std::shared_ptr<CSSTransition> &transition, const folly::dynamic &updates);
+  /// Drops stale loop-written values of platform-routed properties from the
+  /// updates registry; left pinned, they would override the React-committed
+  /// final value on later commits.
+  void prunePlatformPropertiesFromRegistry(const std::shared_ptr<CSSTransition> &transition);
   void recordInitialUpdate(const std::shared_ptr<CSSTransition> &transition, const folly::dynamic &initialUpdate);
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/reversingShortening.h
@@ -23,15 +23,27 @@ inline ReversingState makeReversingState(double timestamp, double duration, doub
   return {1.0, timestamp + delay, duration, delay, std::move(easing)};
 }
 
+/// Linear progress of the transition described by `state` at `timestamp`,
+/// clamped to [0, 1].
+inline double linearProgressAt(const ReversingState &state, double timestamp) {
+  const double elapsed = std::clamp(timestamp - state.startTimestamp, 0.0, state.duration);
+  return state.duration > 0 ? elapsed / state.duration : 1.0;
+}
+
+/// Eased progress of the transition described by `state` at `timestamp`.
+/// Resolves the easing function on every call - use only on transition
+/// retargets, not per frame.
+inline double easedProgressAt(const ReversingState &state, double timestamp) {
+  return getEasingFunctionFromConfig(state.easing)(linearProgressAt(state, timestamp));
+}
+
 // When a transition reverses an in-flight one, the new transition's duration
 // (and negative delay) shorten by an accumulating factor based on how far the
 // running transition had progressed.
 // See https://drafts.csswg.org/css-transitions/#reversing
 inline ReversingState
 reverseShorten(const ReversingState &previous, double timestamp, double duration, double delay, EasingConfig easing) {
-  const double elapsed = std::clamp(timestamp - previous.startTimestamp, 0.0, previous.duration);
-  const double linearProgress = previous.duration > 0 ? elapsed / previous.duration : 1.0;
-  const double easedProgress = getEasingFunctionFromConfig(previous.easing)(linearProgress);
+  const double easedProgress = easedProgressAt(previous, timestamp);
   const double factor = easedProgress * previous.factor + (1 - previous.factor);
   duration *= factor;
   if (delay < 0) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/transformAnimation.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/transformAnimation.cpp
@@ -1,0 +1,402 @@
+#include <reanimated/CSS/utils/transformAnimation.h>
+
+#include <reanimated/CSS/InterpolatorRegistry.h>
+#include <reanimated/CSS/common/transforms/TransformMatrix3D.h>
+#include <reanimated/CSS/interpolation/transforms/TransformOperation.h>
+#include <reanimated/CSS/interpolation/transforms/TransformsStyleInterpolator.h>
+#include <reanimated/CSS/interpolation/transforms/operations/matrix.h>
+#include <reanimated/CSS/interpolation/transforms/operations/rotate.h>
+#include <reanimated/CSS/interpolation/transforms/operations/scale.h>
+#include <reanimated/CSS/interpolation/transforms/operations/translate.h>
+#include <reanimated/CSS/progress/KeyframeProgressProvider.h>
+#include <reanimated/CSS/utils/interpolators.h>
+
+#include <array>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace reanimated::css {
+
+namespace {
+
+// Drives a single PropertyInterpolator::interpolate call to a fixed point on
+// the from-to curve. The progress provider API is built for keyframed
+// animations spanning multiple offsets; transitions only ever have a single
+// keyframe pair, so both methods return the same value.
+class FixedProgressProvider final : public KeyframeProgressProvider {
+ public:
+  explicit FixedProgressProvider(const double progress) : progress_(progress) {}
+
+  double getGlobalProgress() const override {
+    return progress_;
+  }
+
+  double getKeyframeProgress(const double fromOffset, const double toOffset) const override {
+    if (toOffset == fromOffset) {
+      return 0;
+    }
+    return (progress_ - fromOffset) / (toOffset - fromOffset);
+  }
+
+ private:
+  const double progress_;
+};
+
+// CSS spec maps translate-percent to "self width" for X, "self height" for Y.
+// Mirrors the relative-property config registered for `transform` in
+// InterpolatorRegistry.cpp.
+const std::string *dimensionPropertyForTranslate(const std::string &operationName) {
+  static const std::string kWidth = "width";
+  static const std::string kHeight = "height";
+  if (operationName == "translateX") {
+    return &kWidth;
+  }
+  if (operationName == "translateY") {
+    return &kHeight;
+  }
+  return nullptr;
+}
+
+// Percent translates in transition endpoints are routed to the loop, but they
+// can still surface here through a missing endpoint whose view-style fallback
+// contains a percent translate. Core Animation can't resolve those, so
+// substitute an absolute value computed against the live frame dimension -
+// the same source the loop side reads, just resolved once at run time.
+folly::dynamic resolveTranslatePercentInPlace(
+    folly::dynamic operation,
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
+  if (!operation.isObject() || operation.size() != 1) {
+    return operation;
+  }
+  const auto &item = *operation.items().begin();
+  const auto &name = item.first.getString();
+  const auto &value = item.second;
+  if (!value.isString()) {
+    return operation;
+  }
+  const auto *dimensionProp = dimensionPropertyForTranslate(name);
+  if (dimensionProp == nullptr) {
+    return operation;
+  }
+  const auto &str = value.getString();
+  if (str.empty() || str.back() != '%') {
+    return operation;
+  }
+  const double percent = std::stod(str.substr(0, str.size() - 1)) / 100.0;
+  const jsi::Value dimensionValue = viewStylesRepository->getNodeProp(shadowNode, *dimensionProp);
+  const double resolved = dimensionValue.isNumber() ? percent * dimensionValue.getNumber() : 0.0;
+  return folly::dynamic::object(name, resolved);
+}
+
+TransformOperations parseResolvedOperations(
+    const folly::dynamic &value,
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
+  TransformOperations result;
+  result.reserve(value.size());
+  for (const auto &operation : value) {
+    result.emplace_back(
+        TransformOperation::fromDynamic(resolveTranslatePercentInPlace(operation, shadowNode, viewStylesRepository)));
+  }
+  return result;
+}
+
+std::shared_ptr<TransformsStyleInterpolator> createTransformInterpolator(
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository) {
+  // The "transform" factory always produces a TransformsStyleInterpolator
+  // (the transforms(...) record in InterpolatorRegistry).
+  return std::static_pointer_cast<TransformsStyleInterpolator>(
+      createPropertyInterpolator("transform", {}, getComponentInterpolators(componentName), viewStylesRepository));
+}
+
+folly::dynamic interpolateAt(
+    const std::shared_ptr<PropertyInterpolator> &interpolator,
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const double easedProgress) {
+  const auto progressProvider = std::make_shared<FixedProgressProvider>(easedProgress);
+  return interpolator->interpolate(shadowNode, progressProvider, 0.0);
+}
+
+TransformMatrixArray matrixToArray(const TransformMatrix3D &matrix) {
+  TransformMatrixArray result;
+  for (size_t i = 0; i < result.size(); ++i) {
+    result[i] = matrix[i];
+  }
+  return result;
+}
+
+// Identity matrix translated by `offset` - the building block for baking a
+// transform-origin into the composed matrices and per-operation stack.
+TransformMatrix3D translationMatrix(const std::array<double, 3> &offset) {
+  TransformMatrix3D matrix;
+  matrix.translate3d(Vector3D(offset[0], offset[1], offset[2]));
+  return matrix;
+}
+
+template <typename TOperation>
+double operationValue(const StyleOperation &operation) {
+  return static_cast<const TOperation &>(operation).value.value;
+}
+
+TransformMatrixArray operationMatrix(const StyleOperation &operation) {
+  const auto matrix = static_cast<const TransformOperation &>(operation).toMatrix(/* force3D */ true);
+  return matrixToArray(static_cast<const TransformMatrix3D &>(*matrix));
+}
+
+// Appends the segments for one interpolation pair. Returns false only for
+// matrix operations, which appear in paired output solely as the pairing's
+// whole-list fallback marker - the whole transition then animates as composed
+// matrices.
+bool appendFunctionSegments(
+    std::vector<TransformSegment> &segments,
+    const StyleOperation &fromOperation,
+    const StyleOperation &toOperation) {
+  switch (static_cast<TransformOp>(fromOperation.type)) {
+    case TransformOp::Rotate:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::RotateZ,
+              operationValue<RotateOperation>(fromOperation),
+              operationValue<RotateOperation>(toOperation)});
+      return true;
+    case TransformOp::RotateZ:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::RotateZ,
+              operationValue<RotateZOperation>(fromOperation),
+              operationValue<RotateZOperation>(toOperation)});
+      return true;
+    case TransformOp::RotateX:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::RotateX,
+              operationValue<RotateXOperation>(fromOperation),
+              operationValue<RotateXOperation>(toOperation)});
+      return true;
+    case TransformOp::RotateY:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::RotateY,
+              operationValue<RotateYOperation>(fromOperation),
+              operationValue<RotateYOperation>(toOperation)});
+      return true;
+    case TransformOp::Scale:
+      // Uniform scale must keep the z axis (RN renders {scale: v} as
+      // diag(v, v, v)) - the renderer maps it to the 3-component
+      // kCAValueFunctionScale.
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::Scale,
+              operationValue<ScaleOperation>(fromOperation),
+              operationValue<ScaleOperation>(toOperation)});
+      return true;
+    case TransformOp::ScaleX:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::ScaleX,
+              operationValue<ScaleXOperation>(fromOperation),
+              operationValue<ScaleXOperation>(toOperation)});
+      return true;
+    case TransformOp::ScaleY:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::ScaleY,
+              operationValue<ScaleYOperation>(fromOperation),
+              operationValue<ScaleYOperation>(toOperation)});
+      return true;
+    case TransformOp::TranslateX:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::TranslateX,
+              operationValue<TranslateXOperation>(fromOperation),
+              operationValue<TranslateXOperation>(toOperation)});
+      return true;
+    case TransformOp::TranslateY:
+      segments.push_back(
+          TransformScalarSegment{
+              TransformFunctionType::TranslateY,
+              operationValue<TranslateYOperation>(fromOperation),
+              operationValue<TranslateYOperation>(toOperation)});
+      return true;
+    case TransformOp::SkewX:
+    case TransformOp::SkewY:
+    case TransformOp::Perspective:
+      // No CAValueFunction exists for these - their endpoint matrices animate
+      // additively in place, keeping the rest of the list per-operation.
+      segments.push_back(TransformMatrixSegment{operationMatrix(fromOperation), operationMatrix(toOperation)});
+      return true;
+    case TransformOp::Matrix:
+      return false;
+  }
+  return false;
+}
+
+bool buildFunctionSegments(
+    std::vector<TransformSegment> &segments,
+    const StyleOperations &fromOperations,
+    const StyleOperations &toOperations) {
+  segments.reserve(fromOperations.size());
+  for (size_t i = 0; i < fromOperations.size(); ++i) {
+    // Paired operations always have matching types (conversions applied by
+    // the pairing) - bail to matrices if that invariant ever breaks.
+    if (fromOperations[i]->type != toOperations[i]->type ||
+        !appendFunctionSegments(segments, *fromOperations[i], *toOperations[i])) {
+      segments.clear();
+      return false;
+    }
+  }
+  return true;
+}
+
+// True when any transform operation can't be expressed in the additive
+// CAValueFunction stack: percent translates (need per-frame dimension
+// resolution) or perspective (non-affine m34 term).
+bool transformOperationsRoutable(const TransformOperations &operations) {
+  for (const auto &operation : operations) {
+    if (operation->shouldResolve() || static_cast<TransformOp>(operation->type) == TransformOp::Perspective) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Parses a transform endpoint array; nullopt means parse failure or an
+// unroutable operation. A null endpoint is the "none" default - an empty
+// (and therefore routable) operation list.
+std::optional<bool> transformEndpointRoutable(const folly::dynamic &value) {
+  if (value.isNull()) {
+    return true;
+  }
+  if (!value.isArray()) {
+    return std::nullopt;
+  }
+  // Parse failures (unknown operation, malformed value) make the value
+  // unroutable rather than throwing; the loop side surfaces such errors.
+  try {
+    TransformOperations operations;
+    operations.reserve(value.size());
+    for (const auto &operation : value) {
+      operations.emplace_back(TransformOperation::fromDynamic(operation));
+    }
+    return transformOperationsRoutable(operations);
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+} // namespace
+
+bool isTransformRoutable(const folly::dynamic &fromValue, const folly::dynamic &toValue) {
+  const auto fromRoutable = transformEndpointRoutable(fromValue);
+  const auto toRoutable = transformEndpointRoutable(toValue);
+  return fromRoutable.value_or(false) && toRoutable.value_or(false);
+}
+
+TransformAnimationPlan buildTransformAnimationPlan(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue) {
+  auto fromOperations = parseResolvedOperations(fromValue, shadowNode, viewStylesRepository);
+  auto toOperations = parseResolvedOperations(toValue, shadowNode, viewStylesRepository);
+
+  // A transform-origin moves the pivot away from the layer center. RN bakes it
+  // as Translate(+offset) * M * Translate(-offset) (BaseViewProps::resolveTransform);
+  // we apply the same bake to the composed matrices and, on the per-operation
+  // path, bracket the stack with the matching translate segments. The offset is
+  // resolved against the current frame once per transition (unlike the loop, a
+  // mid-transition resize is not re-baked - the same trade-off as percent translates).
+  const auto originOffset = viewStylesRepository->getTransformOriginOffset(shadowNode);
+  std::optional<TransformMatrix3D> originPositive;
+  std::optional<TransformMatrix3D> originNegative;
+  if (originOffset) {
+    originPositive = translationMatrix(*originOffset);
+    originNegative = translationMatrix({-(*originOffset)[0], -(*originOffset)[1], -(*originOffset)[2]});
+  }
+  const auto bakeOrigin = [&](const TransformMatrix3D &matrix) -> TransformMatrixArray {
+    return originOffset ? matrixToArray(*originPositive * matrix * *originNegative) : matrixToArray(matrix);
+  };
+
+  TransformAnimationPlan plan;
+  plan.targetMatrix = bakeOrigin(matrixFromOperations3D(toOperations));
+
+  const auto interpolator = createTransformInterpolator(componentName, viewStylesRepository);
+  const auto interpolationPair = interpolator->createInterpolationPair(
+      StyleOperations(fromOperations.begin(), fromOperations.end()),
+      StyleOperations(toOperations.begin(), toOperations.end()));
+
+  if (interpolationPair.has_value() &&
+      buildFunctionSegments(plan.segments, interpolationPair->first, interpolationPair->second)) {
+    if (!originOffset) {
+      return plan;
+    }
+    const auto &offset = *originOffset;
+    if (offset[2] == 0.0) {
+      // Bracket the additive stack with the origin translate so the operations
+      // pivot about the origin, matching the baked targetMatrix above. The
+      // bracket uses value-function translate segments (matrix segments do not
+      // compose reliably in CA's additive stack); empirically the stack composes
+      // them so that the leading segment is the OUTER (post-rotation) factor, so
+      // a leading T(+offset) and a trailing T(-offset) render as
+      // Translate(+offset) * M * Translate(-offset).
+      plan.segments.insert(
+          plan.segments.begin(), TransformScalarSegment{TransformFunctionType::TranslateY, offset[1], offset[1]});
+      plan.segments.insert(
+          plan.segments.begin(), TransformScalarSegment{TransformFunctionType::TranslateX, offset[0], offset[0]});
+      plan.segments.push_back(TransformScalarSegment{TransformFunctionType::TranslateX, -offset[0], -offset[0]});
+      plan.segments.push_back(TransformScalarSegment{TransformFunctionType::TranslateY, -offset[1], -offset[1]});
+      return plan;
+    }
+    // A z-origin can't ride the value-function translate bracket; drop to the
+    // baked-matrix fallback below, which carries the full 3D offset.
+    plan.segments.clear();
+  }
+
+  plan.fromMatrix = bakeOrigin(matrixFromOperations3D(fromOperations));
+  return plan;
+}
+
+std::pair<folly::dynamic, folly::dynamic> resolveTransformEndpoints(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    folly::dynamic fromValue,
+    folly::dynamic toValue) {
+  // Empty arrays parse to the same "missing" state as null inside the
+  // interpolator (parseStyleOperations returns nullopt for both).
+  const auto isMissing = [](const folly::dynamic &value) {
+    return value.isNull() || (value.isArray() && value.empty());
+  };
+  const auto fromMissing = isMissing(fromValue);
+  const auto toMissing = isMissing(toValue);
+  if (!fromMissing && !toMissing) {
+    return {std::move(fromValue), std::move(toValue)};
+  }
+  const auto interpolator = createTransformInterpolator(componentName, viewStylesRepository);
+  interpolator->updateKeyframes(fromValue, toValue);
+  if (fromMissing) {
+    fromValue = interpolateAt(interpolator, shadowNode, 0.0);
+  }
+  if (toMissing) {
+    toValue = interpolateAt(interpolator, shadowNode, 1.0);
+  }
+  return {std::move(fromValue), std::move(toValue)};
+}
+
+folly::dynamic interpolateTransformValueAt(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue,
+    const double easedProgress) {
+  const auto interpolator = createTransformInterpolator(componentName, viewStylesRepository);
+  interpolator->updateKeyframes(fromValue, toValue);
+  return interpolateAt(interpolator, shadowNode, easedProgress);
+}
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/transformAnimation.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/utils/transformAnimation.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <reanimated/CSS/common/definitions.h>
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/ShadowNode.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace reanimated::css {
+
+using TransformMatrixArray = std::array<double, 16>;
+
+/// Transform functions expressible as a CAValueFunction-driven animation on
+/// the renderer side. Scale is the uniform variant - it scales all three axes
+/// (matching RN's diag(v, v, v) for the `scale` style operation), unlike
+/// ScaleX/ScaleY.
+enum class TransformFunctionType : uint8_t {
+  RotateX,
+  RotateY,
+  RotateZ,
+  Scale,
+  ScaleX,
+  ScaleY,
+  TranslateX,
+  TranslateY,
+};
+
+/// One per-function animation of a transform transition: the value
+/// interpolates from -> to and a CAValueFunction turns it into a matrix
+/// (radians for rotations, points for translations, factors for scales).
+struct TransformScalarSegment {
+  TransformFunctionType type;
+  double fromValue;
+  double toValue;
+};
+
+/// Segment for operations without a CAValueFunction (skew, perspective): the
+/// operation's own endpoint matrices animate additively in place within the
+/// stack. Core Animation interpolates the pair in decomposed (shear / m34)
+/// space - same endpoints as the loop's per-op angle/distance interpolation,
+/// marginally different path.
+struct TransformMatrixSegment {
+  TransformMatrixArray fromMatrix;
+  TransformMatrixArray toMatrix;
+};
+
+using TransformSegment = std::variant<TransformScalarSegment, TransformMatrixSegment>;
+
+/// How the renderer should animate a transform transition.
+/// - segments non-empty: a stack of additive per-operation animations over a
+///   non-additive identity base, in declaration order. This preserves arbitrary
+///   operation order, duplicates, and multi-turn rotations, matching the loop's
+///   per-operation interpolation.
+/// - segments empty: a single fromMatrix -> targetMatrix animation using Core
+///   Animation's decomposed matrix interpolation. Used exactly where the loop
+///   also falls back to matrix interpolation (matrix values, incompatible or
+///   reordered lists).
+/// targetMatrix is always the final value committed to the layer model.
+struct TransformAnimationPlan {
+  std::vector<TransformSegment> segments;
+  TransformMatrixArray fromMatrix{};
+  TransformMatrixArray targetMatrix{};
+};
+
+/// Value-level routing gate for `transform`, consulted after the name + easing
+/// gate. The proxy converts the jsi endpoints to dynamics before calling this.
+/// Returns false (= run on the loop) when either endpoint fails to parse, holds
+/// a percent translate (interpolates in percent space, stays responsive to
+/// resize), or a Perspective op (non-affine, can't compose in the additive
+/// value-function stack). A transform-origin is baked into the plan at transition
+/// start (see buildTransformAnimationPlan), so it animates natively and no longer
+/// forces the loop.
+bool isTransformRoutable(const folly::dynamic &fromValue, const folly::dynamic &toValue);
+
+/// Builds the renderer-side animation plan for a transform transition. Pairs
+/// the endpoint operation lists with the loop's own pairing logic
+/// (TransformsStyleInterpolator::createInterpolationPair); when every pair is
+/// expressible as a CAValueFunction the plan carries per-function segments in
+/// declaration order, otherwise it carries the composed endpoint matrices.
+/// Endpoints must be materialized (see resolveTransformEndpoints).
+TransformAnimationPlan buildTransformAnimationPlan(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue);
+
+/// Replaces null/empty endpoints with the concrete operation lists the
+/// interpolator resolves them to (view style fallback -> identity padding),
+/// evaluated once at run time, so plan building and later in-flight
+/// re-derivation work with materialized values.
+std::pair<folly::dynamic, folly::dynamic> resolveTransformEndpoints(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    folly::dynamic fromValue,
+    folly::dynamic toValue);
+
+/// Evaluates a single point on the from-to transform curve and returns it as an
+/// operations array (the loop's per-frame output format). Used to continue an
+/// interrupted platform transform transition from its exact in-flight value -
+/// reading the presentation-layer matrix instead would collapse rotation count.
+folly::dynamic interpolateTransformValueAt(
+    const std::shared_ptr<const facebook::react::ShadowNode> &shadowNode,
+    const std::string &componentName,
+    const std::shared_ptr<ViewStylesRepository> &viewStylesRepository,
+    const folly::dynamic &fromValue,
+    const folly::dynamic &toValue,
+    double easedProgress);
+
+} // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -224,7 +224,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
               platformDepMethodsHolder.cssCanRouteProperty,
               platformDepMethodsHolder.cssApplyTransitionJSI,
               platformDepMethodsHolder.cssApplyTransitionDynamic,
-              platformDepMethodsHolder.cssRemoveTransition))),
+              platformDepMethodsHolder.cssRemoveTransition,
+              platformDepMethodsHolder.cssAnimateTransform))),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,
           platformDepMethodsHolder.detachPseudoSelector,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -74,6 +74,7 @@ struct PlatformDepMethodsHolder {
   css::CSSApplyTransitionJSIFunction cssApplyTransitionJSI;
   css::CSSApplyTransitionDynamicFunction cssApplyTransitionDynamic;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
+  css::CSSAnimateTransformFunction cssAnimateTransform;
   // Last so platform initializers that don't supply it (iOS, Android today)
   // can omit it and rely on value-init (= null shared_ptr).
   std::shared_ptr<css::CSSPlatformAnimationFactory> platformAnimationFactory;

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
+#import <memory>
 #import <optional>
 #import <string>
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -20,11 +20,16 @@ namespace {
 [[maybe_unused]] constexpr std::array<double, 4> kTransparentColor = {0, 0, 0, 0};
 [[maybe_unused]] constexpr std::array<double, 4> kBlackColor = {0, 0, 0, 1};
 
-enum class CSSValueKind : std::uint8_t { Scalar, Color, Size };
+// Transform is special-cased: it is not a PlatformValue (the renderer receives a
+// pre-built TransformAnimationPlan from common C++). The Transform kind only flags
+// the property as routable for canRouteCSSProperty; parsePlatformValue returns
+// nullopt and the common-C++ transform path handles the value.
+enum class CSSValueKind : std::uint8_t { Scalar, Color, Size, Transform };
 
 struct CSSPropertyTraits {
   CSSValueKind kind;
-  // CSS-spec default applied when an endpoint is null.
+  // CSS-spec default applied when an endpoint is null. Unused for the Transform
+  // kind (transform endpoints resolve through the C++ interpolator instead).
   PlatformValue defaultValue;
 };
 
@@ -34,6 +39,9 @@ const CSSPropertyTraits *traitsFor(const std::string &propertyName)
 {
   static const std::unordered_map<std::string, CSSPropertyTraits> kProperties = {
       {"opacity", {CSSValueKind::Scalar, 1.0}},
+      // Placeholder default; never read (transform "none" is materialized by
+      // resolveTransformEndpoints). See the Transform note above.
+      {"transform", {CSSValueKind::Transform, 0.0}},
   };
   const auto it = kProperties.find(propertyName);
   return it != kProperties.end() ? &it->second : nullptr;
@@ -103,6 +111,10 @@ parsePlatformValue(jsi::Runtime &rt, const std::string &propertyName, const jsi:
           height.isNumber() ? height.asNumber() : 0.0,
       };
     }
+    case CSSValueKind::Transform:
+      // Transform is not a PlatformValue; the common-C++ transform path builds a
+      // plan and hands it to REACSSPlatformTransitions (see CSSPlatformTransitionProxy).
+      return std::nullopt;
   }
   return std::nullopt;
 }
@@ -132,6 +144,8 @@ std::optional<PlatformValue> parsePlatformValue(const std::string &propertyName,
           height != nullptr && height->isNumber() ? height->asDouble() : 0.0,
       };
     }
+    case CSSValueKind::Transform:
+      return std::nullopt;
   }
   return std::nullopt;
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #import <reanimated/CSS/configs/CSSTransitionConfig.h>
+#import <reanimated/CSS/easing/EasingConfigs.h>
+#import <reanimated/CSS/utils/transformAnimation.h>
 
 #import <React/RCTSurfacePresenter.h>
 
@@ -18,9 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
-/// Config path: animates the property natively and remembers its settings for
-/// later toggles. Returns NO if the value can't be animated natively, in which
-/// case it runs on the loop instead.
+/// Scalar config path. Parses the jsi endpoints, animates the property natively
+/// (reverse-shortening against any in-flight transition) and stores the settings
+/// for later toggles. Returns NO when the value can't be expressed natively, so
+/// the property falls back to the loop. Transform is handled in common C++ and
+/// reaches the platform through animateTransformForTag:plan: instead.
 - (BOOL)applyTransitionForTag:(facebook::react::Tag)viewTag
                  propertyName:(const std::string &)propertyName
                     fromValue:(const facebook::jsi::Value &)fromValue
@@ -29,14 +33,23 @@ NS_ASSUME_NONNULL_BEGIN
                      settings:(const reanimated::css::CSSTransitionPropertySettings &)settings
                     timestamp:(double)timestamp;
 
-/// Toggle path: a runtime-free version that reuses the settings stored by the
-/// config apply. Returns NO if there are no stored settings or the value can't be
-/// animated natively.
+/// Scalar toggle path. The runtime-free folly counterpart; reuses the settings
+/// stored by the config apply. Returns NO when the value can't be expressed
+/// natively or the property was never config-applied (so no settings are known).
 - (BOOL)applyDynamicTransitionForTag:(facebook::react::Tag)viewTag
                         propertyName:(const std::string &)propertyName
                            fromValue:(const folly::dynamic &)fromValue
                              toValue:(const folly::dynamic &)toValue
                            timestamp:(double)timestamp;
+
+/// Transform path. Drives a finished plan (built in common C++ from the live
+/// view) through the additive Core Animation stack. timing + easing are computed
+/// by the proxy; this method only orchestrates Core Animation.
+- (void)animateTransformForTag:(facebook::react::Tag)viewTag
+                          plan:(const reanimated::css::TransformAnimationPlan &)plan
+                    durationMs:(double)durationMs
+                   startTimeMs:(double)startTimeMs
+                        easing:(const reanimated::css::EasingConfig &)easing;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -352,7 +352,9 @@ void removeTransformAnimations(CALayer *layer, NSString *keyPath)
       // opposite to what presentation.transform reports via KVC), so adding
       // op[N-1] first down to op[0] last makes the GPU render
       // op[N-1] * ... * op[0] = matrixFromOperations3D, matching the loop and
-      // preserving operation order, duplicates and rotation count.
+      // preserving operation order, duplicates and rotation count. This ordering
+      // is observed Core Animation behavior, not a documented contract - it was
+      // pinned down by on-device pixel testing; re-verify on device if it regresses.
       CABasicAnimation *base = [CABasicAnimation animationWithKeyPath:keyPath];
       base.fromValue = base.toValue = [NSValue valueWithCATransform3D:CATransform3DIdentity];
       configureTiming(base);

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -1,6 +1,7 @@
 #import <reanimated/apple/CSS/REACSSPlatformTransitions.h>
 
 #import <reanimated/CSS/utils/reversingShortening.h>
+#import <reanimated/CSS/utils/transformAnimation.h>
 #import <reanimated/apple/CSS/REACSSPlatformProps.h>
 #import <reanimated/apple/CSS/REACSSPlatformValue.h>
 #import <reanimated/apple/REAUIView.h>
@@ -11,11 +12,16 @@
 #import <React/RCTSurfacePresenter.h>
 #import <React/RCTUtils.h>
 
+#import <folly/dynamic.h>
+#import <jsi/jsi.h>
+
 #import <QuartzCore/QuartzCore.h>
 
+#import <memory>
 #import <string>
 #import <unordered_map>
 #import <utility>
+#import <variant>
 
 using namespace facebook;
 using namespace facebook::react;
@@ -23,15 +29,102 @@ using namespace reanimated::css;
 
 namespace {
 
-// Per-property state for an in-flight native transition. adjustedStart/adjustedEnd
-// and the reversing snapshot handle interruptions; settings are reused by the
-// toggle path.
+// Per-scalar-property native transition state. The platform owns it (shared
+// code is value-agnostic for scalars): adjustedStart/adjustedEnd + the reversing
+// snapshot drive reverse-shortening when a transition is interrupted, and
+// settings are reused on the runtime-free toggle path (which carries no settings
+// of its own). Transform keeps no platform-side state - its value model lives in
+// common C++ (CSSPlatformTransitionProxy), which hands this object a finished plan.
 struct ActiveTransition {
   PlatformValue adjustedStart;
   PlatformValue adjustedEnd;
   ReversingState reversing;
   CSSTransitionPropertySettings settings;
 };
+
+CATransform3D caTransform3DFromMatrixArray(const TransformMatrixArray &matrix)
+{
+  // TransformMatrix3D is row-major with translation at indices 12-14 -
+  // bit-compatible with CATransform3D's m11..m44 field order, matching how RN
+  // consumes the 16-element `matrix` transform style value.
+  CATransform3D transform;
+  transform.m11 = matrix[0];
+  transform.m12 = matrix[1];
+  transform.m13 = matrix[2];
+  transform.m14 = matrix[3];
+  transform.m21 = matrix[4];
+  transform.m22 = matrix[5];
+  transform.m23 = matrix[6];
+  transform.m24 = matrix[7];
+  transform.m31 = matrix[8];
+  transform.m32 = matrix[9];
+  transform.m33 = matrix[10];
+  transform.m34 = matrix[11];
+  transform.m41 = matrix[12];
+  transform.m42 = matrix[13];
+  transform.m43 = matrix[14];
+  transform.m44 = matrix[15];
+  return transform;
+}
+
+CAValueFunctionName valueFunctionName(TransformFunctionType type)
+{
+  switch (type) {
+    case TransformFunctionType::RotateX:
+      return kCAValueFunctionRotateX;
+    case TransformFunctionType::RotateY:
+      return kCAValueFunctionRotateY;
+    case TransformFunctionType::RotateZ:
+      return kCAValueFunctionRotateZ;
+    case TransformFunctionType::Scale:
+      return kCAValueFunctionScale;
+    case TransformFunctionType::ScaleX:
+      return kCAValueFunctionScaleX;
+    case TransformFunctionType::ScaleY:
+      return kCAValueFunctionScaleY;
+    case TransformFunctionType::TranslateX:
+      return kCAValueFunctionTranslateX;
+    case TransformFunctionType::TranslateY:
+      return kCAValueFunctionTranslateY;
+  }
+}
+
+// kCAValueFunctionScale takes three inputs; everything else is a scalar.
+id segmentAnimationValue(TransformFunctionType type, double value)
+{
+  if (type == TransformFunctionType::Scale) {
+    return @[ @(value), @(value), @(value) ];
+  }
+  return @(value);
+}
+
+// Shared timing setup for both the scalar and transform paths: local-clock
+// beginTime conversion (so an ancestor's speed/timeOffset, e.g. RN Screens during
+// navigation, doesn't shift it) plus backwards fill (paints the from state during
+// the delay window) and self-removal on completion (the layer then reads the
+// committed model value with no snap). Callers add the value function / from-to
+// pair / timing function themselves.
+void configureAnimationTiming(CABasicAnimation *anim, CALayer *layer, double durationSec, CFTimeInterval beginTime)
+{
+  anim.duration = durationSec;
+  anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
+  anim.fillMode = kCAFillModeBackwards;
+  anim.removedOnCompletion = YES;
+}
+
+// Animation keys used for transform: "transform" for the base/matrix
+// animation plus "transform#i" per function segment. Segment counts change
+// between runs, so retargets and cancels remove every prefixed key instead of
+// relying on same-key replacement.
+void removeTransformAnimations(CALayer *layer, NSString *keyPath)
+{
+  NSString *segmentPrefix = [keyPath stringByAppendingString:@"#"];
+  for (NSString *key in [layer.animationKeys copy]) {
+    if ([key isEqualToString:keyPath] || [key hasPrefix:segmentPrefix]) {
+      [layer removeAnimationForKey:key];
+    }
+  }
+}
 
 } // namespace
 
@@ -83,7 +176,13 @@ struct ActiveTransition {
         durationMs:reversing.duration
        startTimeMs:reversing.startTimestamp
             easing:settings.easingConfig];
-  properties[propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), settings};
+
+  ActiveTransition entry;
+  entry.adjustedStart = adjustedStart;
+  entry.adjustedEnd = toValue;
+  entry.reversing = std::move(reversing);
+  entry.settings = settings;
+  properties[propertyName] = std::move(entry);
 }
 
 - (BOOL)applyTransitionForTag:(Tag)viewTag
@@ -123,13 +222,14 @@ struct ActiveTransition {
     // No config apply ran for this property, so there are no settings to reuse.
     return NO;
   }
+  // Copy: the apply path re-assigns this property's active entry below.
+  const CSSTransitionPropertySettings settings = activeIt->second.settings;
+
   const auto from = parsePlatformValue(propertyName, fromValue);
   const auto to = parsePlatformValue(propertyName, toValue);
   if (!from || !to) {
     return NO;
   }
-  // Copy: applyForTag re-assigns this property's active entry below.
-  const CSSTransitionPropertySettings settings = activeIt->second.settings;
   [self applyForTag:viewTag
        propertyName:propertyName
           fromValue:*from
@@ -176,15 +276,8 @@ struct ActiveTransition {
       anim.fromValue = fromId;
     }
     anim.toValue = toId;
-    anim.duration = durationSec;
-    // beginTime is in the layer's local clock; converting keeps ancestor
-    // speed/timeOffset (e.g. RN Screens during navigation) from shifting it.
-    anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
     anim.timingFunction = timing;
-    // Backwards fill paints fromValue during the delay window; the animation
-    // self-removes on completion and the layer reads the model below.
-    anim.fillMode = kCAFillModeBackwards;
-    anim.removedOnCompletion = YES;
+    configureAnimationTiming(anim, layer, durationSec, beginTime);
 
     // Commit toValue to the model and add the animation in one transaction
     // (implicit actions off): on auto-removal the layer shows the final model
@@ -193,6 +286,108 @@ struct ActiveTransition {
     [CATransaction setDisableActions:YES];
     [layer setValue:toId forKeyPath:keyPath];
     [layer addAnimation:anim forKey:keyPath];
+    [CATransaction commit];
+  });
+}
+
+- (void)animateTransformForTag:(Tag)viewTag
+                          plan:(const TransformAnimationPlan &)planValue
+                    durationMs:(double)durationMs
+                   startTimeMs:(double)startTimeMs
+                        easing:(const EasingConfig &)easing
+{
+  NSString *keyPath = @"transform";
+  const auto plan = planValue;
+  double durationSec = durationMs / 1000.0;
+  CFTimeInterval beginTime = startTimeMs / 1000.0;
+  CAMediaTimingFunction *timing = makeCSSTimingFunction(easing);
+  CATransform3D targetMatrix = caTransform3DFromMatrixArray(plan.targetMatrix);
+
+  __weak __typeof__(self) weakSelf = self;
+  RCTExecuteOnMainQueue(^{
+    __typeof__(self) strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
+    }
+    CALayer *layer = [strongSelf layerForTag:viewTag];
+    if (!layer) {
+      return;
+    }
+
+    // Guard against a zero duration so Core Animation still runs the (instant)
+    // animation window and the additive stack composes for one frame.
+    const double safeDurationSec = MAX(durationSec, 0.0001);
+    const auto configureTiming = ^(CABasicAnimation *anim) {
+      configureAnimationTiming(anim, layer, safeDurationSec, beginTime);
+    };
+
+    // Commit the final matrix to the model and add the animations in one
+    // transaction (implicit actions off), same rationale as the scalar path.
+    // Unlike that path there is no presentation-value substitution on
+    // retargeting: the C++ side already rebuilt the plan from the exact
+    // in-flight value (a presentation matrix would collapse rotation count).
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    removeTransformAnimations(layer, keyPath);
+    [layer setValue:[NSValue valueWithCATransform3D:targetMatrix] forKeyPath:keyPath];
+
+    if (plan.segments.empty()) {
+      // Matrix fallback: Core Animation interpolates the decomposed matrices
+      // (translation lerp + shortest-path rotation) - the same cases where
+      // the loop also interpolates decomposed matrices.
+      CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:keyPath];
+      anim.fromValue = [NSValue valueWithCATransform3D:caTransform3DFromMatrixArray(plan.fromMatrix)];
+      anim.toValue = [NSValue valueWithCATransform3D:targetMatrix];
+      anim.timingFunction = timing;
+      configureTiming(anim);
+      [layer addAnimation:anim forKey:keyPath];
+    } else {
+      // Per-operation stack: a non-additive identity base replaces the model
+      // for the animation window, then one additive animation per operation
+      // rebuilds the full transform - scalar segments via their CAValueFunction,
+      // skew/perspective via matrix endpoint pairs.
+      //
+      // Segments are added in REVERSE declaration order: Core Animation
+      // composites the additive transform stack opposite to add-order (and
+      // opposite to what presentation.transform reports via KVC), so adding
+      // op[N-1] first down to op[0] last makes the GPU render
+      // op[N-1] * ... * op[0] = matrixFromOperations3D, matching the loop and
+      // preserving operation order, duplicates and rotation count.
+      CABasicAnimation *base = [CABasicAnimation animationWithKeyPath:keyPath];
+      base.fromValue = base.toValue = [NSValue valueWithCATransform3D:CATransform3DIdentity];
+      configureTiming(base);
+      [layer addAnimation:base forKey:keyPath];
+
+      __block NSUInteger segmentKey = 0;
+      CAMediaTimingFunction *segmentTiming = timing;
+      void (^addAdditive)(id, id, CAValueFunction *) = ^(id fromValue, id toValue, CAValueFunction *valueFunction) {
+        CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:keyPath];
+        anim.valueFunction = valueFunction;
+        anim.fromValue = fromValue;
+        anim.toValue = toValue;
+        anim.additive = YES;
+        anim.timingFunction = segmentTiming;
+        configureTiming(anim);
+        [layer addAnimation:anim forKey:[NSString stringWithFormat:@"%@#%lu", keyPath, (unsigned long)segmentKey++]];
+      };
+
+      for (size_t r = 0; r < plan.segments.size(); ++r) {
+        const size_t i = plan.segments.size() - 1 - r;
+        if (const auto *scalarSegment = std::get_if<TransformScalarSegment>(&plan.segments[i])) {
+          addAdditive(
+              segmentAnimationValue(scalarSegment->type, scalarSegment->fromValue),
+              segmentAnimationValue(scalarSegment->type, scalarSegment->toValue),
+              [CAValueFunction functionWithName:valueFunctionName(scalarSegment->type)]);
+        } else {
+          const auto &matrixSegment = std::get<TransformMatrixSegment>(plan.segments[i]);
+          addAdditive(
+              [NSValue valueWithCATransform3D:caTransform3DFromMatrixArray(matrixSegment.fromMatrix)],
+              [NSValue valueWithCATransform3D:caTransform3DFromMatrixArray(matrixSegment.toMatrix)],
+              nil);
+        }
+      }
+    }
+
     [CATransaction commit];
   });
 }
@@ -208,6 +403,7 @@ struct ActiveTransition {
   }
 
   NSString *keyPath = [NSString stringWithUTF8String:propertyName.c_str()];
+  const bool isTransform = propertyName == "transform";
   __weak __typeof__(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{
     __typeof__(self) strongSelf = weakSelf;
@@ -218,12 +414,18 @@ struct ActiveTransition {
     if (!layer) {
       return;
     }
-    // Freeze the last visible frame into the model so the layer doesn't snap.
-    id presentationValue = [[layer presentationLayer] valueForKeyPath:keyPath];
-    if (presentationValue) {
-      [layer setValue:presentationValue forKeyPath:keyPath];
+    // Scalars (opacity): freeze the reliable presentation value into the model
+    // to avoid a snap on cancel. Transform skips this - presentation.transform
+    // reports the additive value-function stack in reversed composition order
+    // via KVC (it would freeze a reversed pose), so leave the already-committed
+    // target matrix and let the layer settle there (CSS after-change value).
+    if (!isTransform) {
+      id presentationValue = [[layer presentationLayer] valueForKeyPath:keyPath];
+      if (presentationValue) {
+        [layer setValue:presentationValue forKeyPath:keyPath];
+      }
     }
-    [layer removeAnimationForKey:keyPath];
+    removeTransformAnimations(layer, keyPath);
   });
 }
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -175,6 +175,22 @@ css::CSSRemoveTransitionFunction makeCSSRemoveTransition(REACSSPlatformTransitio
   };
 }
 
+css::CSSAnimateTransformFunction makeCSSAnimateTransform(REACSSPlatformTransitions *platformTransitions)
+{
+  return [platformTransitions](
+             Tag viewTag,
+             const css::TransformAnimationPlan &plan,
+             double durationMs,
+             double startTimeMs,
+             const css::EasingConfig &easing) {
+    [platformTransitions animateTransformForTag:viewTag
+                                           plan:plan
+                                     durationMs:durationMs
+                                    startTimeMs:startTimeMs
+                                         easing:easing];
+  };
+}
+
 ForceScreenSnapshotFunction makeForceScreenSnapshotFunction(REANodesManager *nodesManager)
 {
   auto forceScreenSnapshot = [=](Tag tag) {
@@ -242,6 +258,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
   auto cssApplyTransitionJSI = makeCSSApplyTransitionJSI(platformTransitions);
   auto cssApplyTransitionDynamic = makeCSSApplyTransitionDynamic(platformTransitions);
   auto cssRemoveTransition = makeCSSRemoveTransition(platformTransitions);
+  auto cssAnimateTransform = makeCSSAnimateTransform(platformTransitions);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
@@ -260,6 +277,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       cssApplyTransitionJSI,
       cssApplyTransitionDynamic,
       cssRemoveTransition,
+      cssAnimateTransform,
   };
   return platformDepMethodsHolder;
 }


### PR DESCRIPTION
## What

Adds native iOS Core Animation support for the `transform` CSS transition property. `transform` (and `transform-origin`) now animate on the render server through an additive Core Animation stack instead of the C++ loop, matching the loop's output. Cases Core Animation cannot express - percent translates, perspective, and steps / linear-stops easings - keep running on the loop.

Builds on #9654 (platform-routed CSS transitions).

## How it works

- All preprocessing and per-transition state live in common C++ (`CSSPlatformTransitionProxy`): endpoint resolution, the transform-origin bake, reverse-shortening, in-flight sampling and plan building.
- The platform layer is thin: it receives a finished, platform-agnostic `TransformAnimationPlan` and only orchestrates Core Animation (`animateTransformForTag:plan:`). No view, layout or interpolator state crosses the boundary.
- `transform-origin` is baked into the plan as `Translate(+offset) * M * Translate(-offset)`, mirroring RN's `BaseViewProps::resolveTransform`.
- Android keeps using the loop (no native path today), so the plan is the cross-platform contract a future Android implementation can consume.

## Testing

Verified on device (iPhone 16 Pro simulator) by running each transition on Core Animation (red) next to the loop (blue) and measuring per-frame box centroids: they track within a couple of pixels across rotate / scale / translate / skew, multi-op stacks, `transform-origin` corner pivots and mid-flight reversal.

## Comparison recordings

CA (red) vs loop (blue) - rotate + scale about the top-left origin:

_drag rf_min.mp4 here_

Mid-flight reversal (reverse-shortening):

_drag rfrev_min.mp4 here_
