### PR TITLE
fix: Freezing animations after bump to RN 0.86.0-rc.3

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -820,6 +820,10 @@ void ReanimatedModuleProxy::performOperations() {
 void ReanimatedModuleProxy::performNonLayoutOperations() {
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performNonLayoutOperations");
 
+  if constexpr (!shouldUseSynchronousUpdatesInPerformOperations()) {
+    return;
+  }
+
   UpdatesBatch updatesBatch;
   {
     auto lock = updatesRegistryManager_->lock();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -820,10 +820,6 @@ void ReanimatedModuleProxy::performOperations() {
 void ReanimatedModuleProxy::performNonLayoutOperations() {
   ReanimatedSystraceSection s("ReanimatedModuleProxy::performNonLayoutOperations");
 
-  if constexpr (!shouldUseSynchronousUpdatesInPerformOperations()) {
-    return;
-  }
-
   UpdatesBatch updatesBatch;
   {
     auto lock = updatesRegistryManager_->lock();

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -108,6 +108,12 @@ if (project != rootProject) {
 val packageDir: File = project.projectDir.parentFile
 val reactNativeRootDir: File = resolveReactNativeDirectory()
 val REACT_NATIVE_VERSION: String = getReactNativeVersion()
+val IS_REACT_NATIVE_86_OR_NEWER: Boolean = run {
+    val parts = REACT_NATIVE_VERSION.split(".")
+    val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+    val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+    major > 0 || minor >= 86
+}
 val REANIMATED_VERSION: String = getReanimatedVersion()
 val IS_REANIMATED_EXAMPLE_APP: Boolean = safeAppExtGet("isReanimatedExampleApp", false)?.toString()?.toBoolean() ?: false
 val REANIMATED_PROFILING: Boolean = safeAppExtGet("enableReanimatedProfiling", false)?.toString()?.toBoolean() ?: false
@@ -171,6 +177,7 @@ android {
         buildConfigField("String", "REANIMATED_VERSION_JAVA", "\"$REANIMATED_VERSION\"")
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
+        buildConfigField("boolean", "IS_REACT_NATIVE_86_OR_NEWER", IS_REACT_NATIVE_86_OR_NEWER.toString())
 
         @Suppress("UnstableApiUsage")
         externalNativeBuild {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -230,9 +230,10 @@ open class NativeProxy {
     }
 
     private val updatePropsSynchronouslyMethod by lazy {
-        mountingManager.javaClass.methods.first {
-            it.name.startsWith("updatePropsSynchronously") && it.parameterTypes.size == 2
-        }.apply { isAccessible = true }
+        mountingManager.javaClass.methods
+            .first {
+                it.name.startsWith("updatePropsSynchronously") && it.parameterTypes.size == 2
+            }.apply { isAccessible = true }
     }
 
     @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -242,24 +242,16 @@ open class NativeProxy {
             }.apply { isAccessible = true }
     }
 
-    private val getViewExistsMethod by lazy {
-        mountingManager.javaClass.methods
-            .first {
-                it.name.startsWith("getViewExists") && it.parameterTypes.size == 1
-            }.apply { isAccessible = true }
-    }
-
     @DoNotStrip
     fun synchronouslyUpdateUIProps(
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
-            if (getViewExistsMethod.invoke(mountingManager, viewTag) == true) {
-                try {
-                    updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
-                } catch (ignored: Exception) {
-                }
+            try {
+                updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
+            } catch (e: Exception) {
+                Log.w("Reanimated", "synchronouslyUpdateUIProps failed for tag $viewTag", e)
             }
         }
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -3,6 +3,7 @@ package com.swmansion.reanimated
 import android.content.ContentResolver
 import android.os.SystemClock
 import android.provider.Settings
+import android.util.Log
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.NativeModule
@@ -222,6 +223,11 @@ open class NativeProxy {
         return true
     }
 
+    // TODO(#9681): Temporary workaround. Since RN 0.86, overrideBySynchronousMountPropsAtMountingAndroid
+    // defaults on, so RN's only public synchronous-update API (synchronouslyUpdateViewOnUIThread) seeds
+    // the tagToSynchronousMountProps cache that then clamps later commits and freezes animations. We call
+    // MountingManager.updatePropsSynchronously directly (apply without seeding) via reflection because
+    // MountingManager is internal. Remove once RN exposes a non-seeding synchronous-update API.
     private val mountingManager: Any by lazy {
         FabricUIManager::class.java.getDeclaredField("mMountingManager").run {
             isAccessible = true
@@ -236,13 +242,25 @@ open class NativeProxy {
             }.apply { isAccessible = true }
     }
 
+    private val getViewExistsMethod by lazy {
+        mountingManager.javaClass.methods
+            .first {
+                it.name.startsWith("getViewExists") && it.parameterTypes.size == 1
+            }.apply { isAccessible = true }
+    }
+
     @DoNotStrip
     fun synchronouslyUpdateUIProps(
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
-            updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
+            if (getViewExistsMethod.invoke(mountingManager, viewTag) == true) {
+                try {
+                    updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
+                } catch (ignored: Exception) {
+                }
+            }
         }
     }
 

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -223,11 +223,14 @@ open class NativeProxy {
         return true
     }
 
-    // TODO(#9681): Temporary workaround. Since RN 0.86, overrideBySynchronousMountPropsAtMountingAndroid
-    // defaults on, so RN's only public synchronous-update API (synchronouslyUpdateViewOnUIThread) seeds
-    // the tagToSynchronousMountProps cache that then clamps later commits and freezes animations. We call
-    // MountingManager.updatePropsSynchronously directly (apply without seeding) via reflection because
-    // MountingManager is internal. Remove once RN exposes a non-seeding synchronous-update API.
+    // TODO(#9681): Temporary workaround for RN >= 0.86. Since RN 0.86,
+    // overrideBySynchronousMountPropsAtMountingAndroid defaults on, so RN's only public
+    // synchronous-update API (synchronouslyUpdateViewOnUIThread) seeds the tagToSynchronousMountProps
+    // cache that then clamps later commits and freezes animations. On RN >= 0.86 we instead call
+    // MountingManager.updatePropsSynchronously directly (apply without cache seeding) via reflection, since
+    // MountingManager is internal. On older RN the flag is off, so we keep the original RN path
+    // unchanged (gated by BuildConfig.IS_REACT_NATIVE_86_OR_NEWER, derived from the RN version at
+    // build time). Remove once RN exposes a non-seeding synchronous-update API.
     private val mountingManager: Any by lazy {
         FabricUIManager::class.java.getDeclaredField("mMountingManager").run {
             isAccessible = true
@@ -248,10 +251,14 @@ open class NativeProxy {
         doubleBuffer: DoubleArray,
     ) {
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
-            try {
-                updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
-            } catch (e: Exception) {
-                Log.w("Reanimated", "synchronouslyUpdateUIProps failed for tag $viewTag", e)
+            if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
+                try {
+                    updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
+                } catch (e: Exception) {
+                    Log.w("Reanimated", "synchronouslyUpdateUIProps failed for tag $viewTag", e)
+                }
+            } else {
+                mFabricUIManager.synchronouslyUpdateViewOnUIThread(viewTag, props)
             }
         }
     }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -222,13 +222,26 @@ open class NativeProxy {
         return true
     }
 
+    private val mountingManager: Any by lazy {
+        FabricUIManager::class.java.getDeclaredField("mMountingManager").run {
+            isAccessible = true
+            get(mFabricUIManager)
+        }
+    }
+
+    private val updatePropsSynchronouslyMethod by lazy {
+        mountingManager.javaClass.methods.first {
+            it.name.startsWith("updatePropsSynchronously") && it.parameterTypes.size == 2
+        }.apply { isAccessible = true }
+    }
+
     @DoNotStrip
     fun synchronouslyUpdateUIProps(
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
-            mFabricUIManager.synchronouslyUpdateViewOnUIThread(viewTag, props)
+            updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
         }
     }
 


### PR DESCRIPTION
## Summary

In React Native 0.86 they changed `overrideBySynchronousMountPropsAtMountingAndroid` to true by default, which causes some freezes (#9681). This PR provides a workaround for that problem. 

This is a temporary measure that won't be necessary as soon as the animation backend is fully supported.   

## Test plan

- Put those changes on top of the example for 0.86.0-rc.3
- run bokeh 
- tap the screen (it would freeze before my changes).
