### PR TITLE
chore: Route CSS transitions in common with a single platform apply hook

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.cpp
@@ -7,42 +7,44 @@
 namespace reanimated::css {
 
 CSSPlatformTransitionProxy::CSSPlatformTransitionProxy(
-    CSSCanRoutePropertyFunction canRoute,
-    CSSApplyTransitionJSIFunction applyJSI,
-    CSSApplyTransitionDynamicFunction applyDynamic,
+    CSSApplyPlatformTransitionFunction applyTransition,
     CSSRemoveTransitionFunction removeTransition)
-    : canRoute_(std::move(canRoute)),
-      applyJSI_(std::move(applyJSI)),
-      applyDynamic_(std::move(applyDynamic)),
-      removeTransition_(std::move(removeTransition)) {}
+    : applyTransition_(std::move(applyTransition)), removeTransition_(std::move(removeTransition)) {}
 
-bool CSSPlatformTransitionProxy::canRoute(const std::string &propertyName, const EasingConfig &easing) const {
-  return canRoute_ && canRoute_(propertyName, easing);
-}
-
-bool CSSPlatformTransitionProxy::apply(
-    jsi::Runtime &rt,
+void CSSPlatformTransitionProxy::applyPlatform(
     const Tag viewTag,
     const std::string &propertyName,
-    const jsi::Value &fromValue,
-    const jsi::Value &toValue,
+    const PlatformValue &fromValue,
+    const PlatformValue &toValue,
     const CSSTransitionPropertySettings &settings,
     const double timestamp) const {
-  return applyJSI_ && applyJSI_(rt, viewTag, propertyName, fromValue, toValue, settings, timestamp);
-}
+  auto &properties = activeTransitions_[viewTag];
+  const auto activeIt = properties.find(propertyName);
+  // Targeting the in-flight transition's start value means this is a reversal.
+  const ActiveTransition *previous =
+      (activeIt != properties.end() && toValue == activeIt->second.adjustedStart) ? &activeIt->second : nullptr;
+  ReversingState reversing = previous
+      ? reverseShorten(previous->reversing, timestamp, settings.duration, settings.delay, settings.easingConfig)
+      : makeReversingState(timestamp, settings.duration, settings.delay, settings.easingConfig);
 
-bool CSSPlatformTransitionProxy::apply(
-    const Tag viewTag,
-    const std::string &propertyName,
-    const folly::dynamic &fromValue,
-    const folly::dynamic &toValue,
-    const double timestamp) const {
-  return applyDynamic_ && applyDynamic_(viewTag, propertyName, fromValue, toValue, timestamp);
+  const PlatformValue adjustedStart = previous ? previous->adjustedEnd : fromValue;
+  if (applyTransition_) {
+    applyTransition_(
+        viewTag, propertyName, fromValue, toValue, reversing.duration, reversing.startTimestamp, settings.easingConfig);
+  }
+  properties[propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), settings};
 }
 
 void CSSPlatformTransitionProxy::remove(const Tag viewTag, const std::string &propertyName) const {
   if (removeTransition_) {
     removeTransition_(viewTag, propertyName);
+  }
+  const auto tagIt = activeTransitions_.find(viewTag);
+  if (tagIt != activeTransitions_.end()) {
+    tagIt->second.erase(propertyName);
+    if (tagIt->second.empty()) {
+      activeTransitions_.erase(tagIt);
+    }
   }
 }
 
@@ -62,9 +64,16 @@ CSSTransitionConfig CSSPlatformTransitionProxy::processConfig(
       ++matchedValues;
     }
 
-    bool routable = canRoute(propertyName, settings.easingConfig);
+    bool routable = canRouteCSSProperty(propertyName, settings.easingConfig);
     if (routable && hasValue) {
-      routable = apply(rt, viewTag, propertyName, valueIt->second.first, valueIt->second.second, settings, timestamp);
+      const auto from = parsePlatformValue(rt, propertyName, valueIt->second.first);
+      const auto to = parsePlatformValue(rt, propertyName, valueIt->second.second);
+      if (from && to) {
+        applyPlatform(viewTag, propertyName, *from, *to, settings, timestamp);
+      } else {
+        // Can't be expressed natively, so it runs on the loop instead.
+        routable = false;
+      }
     } else if (routable) {
       // Settings-only: stay on the platform only if already animating there.
       routable = routing.platform.contains(propertyName);
@@ -116,8 +125,22 @@ PropertyValueDynamicDiffsMap CSSPlatformTransitionProxy::processDynamicDiffs(
     // A platform-routed property keeps animating natively while the platform can
     // still express the toggled value; otherwise it migrates to the loop.
     if (routing.platform.contains(propertyName)) {
-      if (apply(viewTag, propertyName, propertyDiff.first, propertyDiff.second, timestamp)) {
-        continue;
+      const ActiveTransition *active = nullptr;
+      if (const auto tagIt = activeTransitions_.find(viewTag); tagIt != activeTransitions_.end()) {
+        if (const auto activeIt = tagIt->second.find(propertyName); activeIt != tagIt->second.end()) {
+          active = &activeIt->second;
+        }
+      }
+      if (active != nullptr) {
+        const auto from = parsePlatformValue(propertyName, propertyDiff.first);
+        const auto to = parsePlatformValue(propertyName, propertyDiff.second);
+        if (from && to) {
+          // Copy: applyPlatform re-assigns this property's active entry below. The
+          // toggle diff carries no settings of its own, so reuse the stored ones.
+          const CSSTransitionPropertySettings settings = active->settings;
+          applyPlatform(viewTag, propertyName, *from, *to, settings, timestamp);
+          continue;
+        }
       }
       routing.platform.erase(propertyName);
       remove(viewTag, propertyName);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/core/transition/CSSPlatformTransitionProxy.h
@@ -3,6 +3,8 @@
 #include <reanimated/CSS/common/definitions.h>
 #include <reanimated/CSS/configs/CSSTransitionConfig.h>
 #include <reanimated/CSS/easing/EasingConfigs.h>
+#include <reanimated/CSS/utils/platform.h>
+#include <reanimated/CSS/utils/reversingShortening.h>
 
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
@@ -10,32 +12,25 @@
 
 #include <functional>
 #include <string>
+#include <unordered_map>
 
 namespace reanimated::css {
 
 using namespace facebook;
 using namespace react;
 
-/// Whether the platform can animate the property natively for the given easing.
-using CSSCanRoutePropertyFunction = std::function<bool(const std::string &propertyName, const EasingConfig &easing)>;
-/// Animates a routed property natively; a false (no-op) return means the platform
-/// can't express the value, so it falls back to the loop. The jsi overload is the
-/// config path (carries a runtime + settings); the folly overload, the toggle path.
-using CSSApplyTransitionJSIFunction = std::function<bool(
-    jsi::Runtime &rt,
+/// Animates a property natively to its parsed target value over the given window.
+/// The proxy does the parsing, routing, and reverse-shortening; the platform only
+/// drives the native animation. An absent hook keeps every property on the loop.
+using CSSApplyPlatformTransitionFunction = std::function<void(
     Tag viewTag,
     const std::string &propertyName,
-    const jsi::Value &fromValue,
-    const jsi::Value &toValue,
-    const CSSTransitionPropertySettings &settings,
-    double timestamp)>;
-using CSSApplyTransitionDynamicFunction = std::function<bool(
-    Tag viewTag,
-    const std::string &propertyName,
-    const folly::dynamic &fromValue,
-    const folly::dynamic &toValue,
-    double timestamp)>;
-/// Cancels the property's native transition and drops its platform-side state.
+    const PlatformValue &fromValue,
+    const PlatformValue &toValue,
+    double durationMs,
+    double startTimeMs,
+    const EasingConfig &easing)>;
+/// Cancels the property's native transition.
 using CSSRemoveTransitionFunction = std::function<void(Tag viewTag, const std::string &propertyName)>;
 
 /// A view's transition partition: which properties animate on the platform vs the
@@ -45,16 +40,15 @@ struct CSSTransitionRouting {
   TransitionProperties loop;
 };
 
-/// Stateless, shared routing engine: per property it routes a view's CSS transition
-/// to the platform (animated natively via the hooks above) or the C++ loop, never
-/// seeing the value - it forwards the raw JS source to the platform. Per-view routing
-/// state is passed in; an absent hook keeps that property on the loop.
+/// Shared routing engine: per property it routes a view's CSS transition to the
+/// platform or to the C++ loop. For platform-routed properties it parses the JS
+/// endpoints into native values, reverse-shortens interruptions, and owns the
+/// in-flight native transition state per view; the platform hook only animates.
+/// A property that can't be expressed natively migrates to the loop.
 class CSSPlatformTransitionProxy {
  public:
   CSSPlatformTransitionProxy(
-      CSSCanRoutePropertyFunction canRoute,
-      CSSApplyTransitionJSIFunction applyJSI,
-      CSSApplyTransitionDynamicFunction applyDynamic,
+      CSSApplyPlatformTransitionFunction applyTransition,
       CSSRemoveTransitionFunction removeTransition);
 
   /// Routes the config between platform and loop, updating `routing` and returning
@@ -78,27 +72,33 @@ class CSSPlatformTransitionProxy {
   void cancelAll(Tag viewTag, const TransitionProperties &properties) const;
 
  private:
-  bool canRoute(const std::string &propertyName, const EasingConfig &easing) const;
-  bool apply(
-      jsi::Runtime &rt,
+  /// In-flight native transition for one property. adjustedStart/adjustedEnd and
+  /// the reversing snapshot drive interruption handling; settings are reused by
+  /// the toggle path, which carries none of its own.
+  struct ActiveTransition {
+    PlatformValue adjustedStart;
+    PlatformValue adjustedEnd;
+    ReversingState reversing;
+    CSSTransitionPropertySettings settings;
+  };
+
+  /// Reverse-shortens against any in-flight transition, animates natively, and
+  /// records the new active state. fromValue/toValue are already parsed.
+  void applyPlatform(
       Tag viewTag,
       const std::string &propertyName,
-      const jsi::Value &fromValue,
-      const jsi::Value &toValue,
+      const PlatformValue &fromValue,
+      const PlatformValue &toValue,
       const CSSTransitionPropertySettings &settings,
-      double timestamp) const;
-  bool apply(
-      Tag viewTag,
-      const std::string &propertyName,
-      const folly::dynamic &fromValue,
-      const folly::dynamic &toValue,
       double timestamp) const;
   void remove(Tag viewTag, const std::string &propertyName) const;
 
-  CSSCanRoutePropertyFunction canRoute_;
-  CSSApplyTransitionJSIFunction applyJSI_;
-  CSSApplyTransitionDynamicFunction applyDynamic_;
+  CSSApplyPlatformTransitionFunction applyTransition_;
   CSSRemoveTransitionFunction removeTransition_;
+
+  // viewTag -> propertyName -> active transition. Accessed only on the thread that
+  // drives routing.
+  mutable std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> activeTransitions_;
 };
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -221,9 +221,7 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
           viewStylesRepository_,
           operationsLoop_,
           std::make_shared<CSSPlatformTransitionProxy>(
-              platformDepMethodsHolder.cssCanRouteProperty,
-              platformDepMethodsHolder.cssApplyTransitionJSI,
-              platformDepMethodsHolder.cssApplyTransitionDynamic,
+              platformDepMethodsHolder.cssApplyTransition,
               platformDepMethodsHolder.cssRemoveTransition))),
       pseudoStylesRegistry_(std::make_shared<PseudoStylesRegistry>(
           platformDepMethodsHolder.attachPseudoSelector,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -70,9 +70,7 @@ struct PlatformDepMethodsHolder {
   MaybeFlushUIUpdatesQueueFunction maybeFlushUIUpdatesQueueFunction;
   PlatformAttachPseudoSelectorFunction attachPseudoSelector;
   PlatformDetachPseudoSelectorFunction detachPseudoSelector;
-  css::CSSCanRoutePropertyFunction cssCanRouteProperty;
-  css::CSSApplyTransitionJSIFunction cssApplyTransitionJSI;
-  css::CSSApplyTransitionDynamicFunction cssApplyTransitionDynamic;
+  css::CSSApplyPlatformTransitionFunction cssApplyTransition;
   css::CSSRemoveTransitionFunction cssRemoveTransition;
   // Last so platform initializers that don't supply it (iOS, Android today)
   // can omit it and rely on value-init (= null shared_ptr).

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#import <reanimated/CSS/configs/CSSTransitionConfig.h>
+#import <reanimated/CSS/easing/EasingConfigs.h>
+#import <reanimated/CSS/utils/platform.h>
 
 #import <React/RCTSurfacePresenter.h>
 
-#import <folly/dynamic.h>
-#import <jsi/jsi.h>
 #import <react/renderer/core/ReactPrimitives.h>
 
 #import <Foundation/Foundation.h>
@@ -18,25 +17,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter;
 
-/// Config path: animates the property natively and remembers its settings for
-/// later toggles. Returns NO if the value can't be animated natively, in which
-/// case it runs on the loop instead.
-- (BOOL)applyTransitionForTag:(facebook::react::Tag)viewTag
-                 propertyName:(const std::string &)propertyName
-                    fromValue:(const facebook::jsi::Value &)fromValue
-                      toValue:(const facebook::jsi::Value &)toValue
-                      runtime:(facebook::jsi::Runtime &)runtime
-                     settings:(const reanimated::css::CSSTransitionPropertySettings &)settings
-                    timestamp:(double)timestamp;
-
-/// Toggle path: a runtime-free version that reuses the settings stored by the
-/// config apply. Returns NO if there are no stored settings or the value can't be
-/// animated natively.
-- (BOOL)applyDynamicTransitionForTag:(facebook::react::Tag)viewTag
-                        propertyName:(const std::string &)propertyName
-                           fromValue:(const folly::dynamic &)fromValue
-                             toValue:(const folly::dynamic &)toValue
-                           timestamp:(double)timestamp;
+/// Animates the property natively from `fromValue` to `toValue` over the given
+/// window. Parsing, routing, and reverse-shortening already happened in common;
+/// this only drives Core Animation.
+- (void)animateForTag:(facebook::react::Tag)viewTag
+         propertyName:(const std::string &)propertyName
+            fromValue:(const reanimated::css::PlatformValue &)fromValue
+              toValue:(const reanimated::css::PlatformValue &)toValue
+           durationMs:(double)durationMs
+          startTimeMs:(double)startTimeMs
+               easing:(const reanimated::css::EasingConfig &)easing;
 
 - (void)removeTransitionForTag:(facebook::react::Tag)viewTag propertyName:(const std::string &)propertyName;
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -1,7 +1,6 @@
 #import <reanimated/apple/CSS/REACSSPlatformTransitions.h>
 
 #import <reanimated/CSS/utils/platform.h>
-#import <reanimated/CSS/utils/reversingShortening.h>
 #import <reanimated/apple/CSS/REACSSPlatformProps.h>
 #import <reanimated/apple/REAUIView.h>
 
@@ -14,32 +13,13 @@
 #import <QuartzCore/QuartzCore.h>
 
 #import <string>
-#import <unordered_map>
-#import <utility>
 
 using namespace facebook;
 using namespace facebook::react;
 using namespace reanimated::css;
 
-namespace {
-
-// Per-property state for an in-flight native transition. adjustedStart/adjustedEnd
-// and the reversing snapshot handle interruptions; settings are reused by the
-// toggle path.
-struct ActiveTransition {
-  PlatformValue adjustedStart;
-  PlatformValue adjustedEnd;
-  ReversingState reversing;
-  CSSTransitionPropertySettings settings;
-};
-
-} // namespace
-
 @implementation REACSSPlatformTransitions {
   __weak RCTSurfacePresenter *_surfacePresenter;
-  // viewTag -> propertyName -> active transition. Accessed only on the thread
-  // that drives routing; the CALayer work below hops to the main queue.
-  std::unordered_map<Tag, std::unordered_map<std::string, ActiveTransition>> _active;
 }
 
 - (instancetype)initWithSurfacePresenter:(RCTSurfacePresenter *)surfacePresenter
@@ -57,95 +37,13 @@ struct ActiveTransition {
   return view.layer;
 }
 
-// Reverse-shortens against any in-flight transition, animates natively, and
-// records the new active state. fromValue/toValue are already parsed.
-- (void)applyForTag:(Tag)viewTag
-       propertyName:(const std::string &)propertyName
-          fromValue:(const PlatformValue &)fromValue
-            toValue:(const PlatformValue &)toValue
-           settings:(const CSSTransitionPropertySettings &)settings
-          timestamp:(double)timestamp
-{
-  auto &properties = _active[viewTag];
-  const auto activeIt = properties.find(propertyName);
-  // Targeting the in-flight transition's start value means this is a reversal.
-  const ActiveTransition *previous =
-      (activeIt != properties.end() && toValue == activeIt->second.adjustedStart) ? &activeIt->second : nullptr;
-  ReversingState reversing = previous
-      ? reverseShorten(previous->reversing, timestamp, settings.duration, settings.delay, settings.easingConfig)
-      : makeReversingState(timestamp, settings.duration, settings.delay, settings.easingConfig);
-
-  const PlatformValue adjustedStart = previous ? previous->adjustedEnd : fromValue;
-  [self animateTag:viewTag
-      propertyName:propertyName
-         fromValue:fromValue
-           toValue:toValue
-        durationMs:reversing.duration
-       startTimeMs:reversing.startTimestamp
-            easing:settings.easingConfig];
-  properties[propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), settings};
-}
-
-- (BOOL)applyTransitionForTag:(Tag)viewTag
-                 propertyName:(const std::string &)propertyName
-                    fromValue:(const jsi::Value &)fromValue
-                      toValue:(const jsi::Value &)toValue
-                      runtime:(jsi::Runtime &)runtime
-                     settings:(const CSSTransitionPropertySettings &)settings
-                    timestamp:(double)timestamp
-{
-  const auto from = parsePlatformValue(runtime, propertyName, fromValue);
-  const auto to = parsePlatformValue(runtime, propertyName, toValue);
-  if (!from || !to) {
-    return NO;
-  }
-  [self applyForTag:viewTag
-       propertyName:propertyName
-          fromValue:*from
-            toValue:*to
-           settings:settings
-          timestamp:timestamp];
-  return YES;
-}
-
-- (BOOL)applyDynamicTransitionForTag:(Tag)viewTag
-                        propertyName:(const std::string &)propertyName
-                           fromValue:(const folly::dynamic &)fromValue
-                             toValue:(const folly::dynamic &)toValue
-                           timestamp:(double)timestamp
-{
-  const auto propertiesIt = _active.find(viewTag);
-  if (propertiesIt == _active.end()) {
-    return NO;
-  }
-  const auto activeIt = propertiesIt->second.find(propertyName);
-  if (activeIt == propertiesIt->second.end()) {
-    // No config apply ran for this property, so there are no settings to reuse.
-    return NO;
-  }
-  const auto from = parsePlatformValue(propertyName, fromValue);
-  const auto to = parsePlatformValue(propertyName, toValue);
-  if (!from || !to) {
-    return NO;
-  }
-  // Copy: applyForTag re-assigns this property's active entry below.
-  const CSSTransitionPropertySettings settings = activeIt->second.settings;
-  [self applyForTag:viewTag
-       propertyName:propertyName
-          fromValue:*from
-            toValue:*to
-           settings:settings
-          timestamp:timestamp];
-  return YES;
-}
-
-- (void)animateTag:(Tag)viewTag
-      propertyName:(const std::string &)propertyName
-         fromValue:(const PlatformValue &)fromValue
-           toValue:(const PlatformValue &)toValue
-        durationMs:(double)durationMs
-       startTimeMs:(double)startTimeMs
-            easing:(const EasingConfig &)easing
+- (void)animateForTag:(Tag)viewTag
+         propertyName:(const std::string &)propertyName
+            fromValue:(const PlatformValue &)fromValue
+              toValue:(const PlatformValue &)toValue
+           durationMs:(double)durationMs
+          startTimeMs:(double)startTimeMs
+               easing:(const EasingConfig &)easing
 {
   // Capture everything up front; CALayer access must happen on the main thread.
   NSString *keyPath = caLayerKeyPathForCSSProperty(propertyName);
@@ -199,14 +97,6 @@ struct ActiveTransition {
 
 - (void)removeTransitionForTag:(Tag)viewTag propertyName:(const std::string &)propertyName
 {
-  const auto propertiesIt = _active.find(viewTag);
-  if (propertiesIt != _active.end()) {
-    propertiesIt->second.erase(propertyName);
-    if (propertiesIt->second.empty()) {
-      _active.erase(propertiesIt);
-    }
-  }
-
   NSString *keyPath = caLayerKeyPathForCSSProperty(propertyName);
   __weak __typeof__(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -127,44 +127,23 @@ KeyboardEventUnsubscribeFunction makeUnsubscribeFromKeyboardEventsFunction(REAKe
   return unsubscribeFromKeyboardEventsFunction;
 }
 
-css::CSSCanRoutePropertyFunction makeCSSCanRouteProperty()
-{
-  return &css::canRouteCSSProperty;
-}
-
-css::CSSApplyTransitionJSIFunction makeCSSApplyTransitionJSI(REACSSPlatformTransitions *platformTransitions)
-{
-  return [platformTransitions](
-             jsi::Runtime &rt,
-             Tag viewTag,
-             const std::string &propertyName,
-             const jsi::Value &fromValue,
-             const jsi::Value &toValue,
-             const css::CSSTransitionPropertySettings &settings,
-             double timestamp) {
-    return [platformTransitions applyTransitionForTag:viewTag
-                                         propertyName:propertyName
-                                            fromValue:fromValue
-                                              toValue:toValue
-                                              runtime:rt
-                                             settings:settings
-                                            timestamp:timestamp];
-  };
-}
-
-css::CSSApplyTransitionDynamicFunction makeCSSApplyTransitionDynamic(REACSSPlatformTransitions *platformTransitions)
+css::CSSApplyPlatformTransitionFunction makeCSSApplyTransition(REACSSPlatformTransitions *platformTransitions)
 {
   return [platformTransitions](
              Tag viewTag,
              const std::string &propertyName,
-             const folly::dynamic &fromValue,
-             const folly::dynamic &toValue,
-             double timestamp) {
-    return [platformTransitions applyDynamicTransitionForTag:viewTag
-                                                propertyName:propertyName
-                                                   fromValue:fromValue
-                                                     toValue:toValue
-                                                   timestamp:timestamp];
+             const css::PlatformValue &fromValue,
+             const css::PlatformValue &toValue,
+             double durationMs,
+             double startTimeMs,
+             const css::EasingConfig &easing) {
+    [platformTransitions animateForTag:viewTag
+                          propertyName:propertyName
+                             fromValue:fromValue
+                               toValue:toValue
+                            durationMs:durationMs
+                           startTimeMs:startTimeMs
+                                easing:easing];
   };
 }
 
@@ -238,9 +217,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
 
   REACSSPlatformTransitions *platformTransitions =
       [[REACSSPlatformTransitions alloc] initWithSurfacePresenter:nodesManager.surfacePresenter];
-  auto cssCanRouteProperty = makeCSSCanRouteProperty();
-  auto cssApplyTransitionJSI = makeCSSApplyTransitionJSI(platformTransitions);
-  auto cssApplyTransitionDynamic = makeCSSApplyTransitionDynamic(platformTransitions);
+  auto cssApplyTransition = makeCSSApplyTransition(platformTransitions);
   auto cssRemoveTransition = makeCSSRemoveTransition(platformTransitions);
 
   PlatformDepMethodsHolder platformDepMethodsHolder = {
@@ -256,9 +233,7 @@ PlatformDepMethodsHolder makePlatformDepMethodsHolder(RCTModuleRegistry *moduleR
       maybeFlushUIUpdatesQueueFunction,
       attachPseudoSelectorFunction,
       detachPseudoSelectorFunction,
-      cssCanRouteProperty,
-      cssApplyTransitionJSI,
-      cssApplyTransitionDynamic,
+      cssApplyTransition,
       cssRemoveTransition,
   };
   return platformDepMethodsHolder;


### PR DESCRIPTION
> Stacked on #9696 (review/merge that first). Base will retarget to `main` once #9696 lands.

## Summary

Unifies the CSS-transition platform-routing boundary. Previously the platform exposed four hooks (`canRoute`, two value-blind apply paths, `remove`) and owned both the endpoint parsing and the reverse-shortening state. This moves all of that into the common `CSSPlatformTransitionProxy`:

- the proxy calls `canRouteCSSProperty` and `parsePlatformValue` directly (no hooks),
- it reverse-shortens interruptions and owns the per-view in-flight transition state,
- the platform is left with a single parsing-free hook, `cssApplyTransition` (animate a resolved value over a window), plus `cssRemoveTransition`.

So the holder's four css hooks collapse to two, and the iOS layer (`REACSSPlatformTransitions`) only drives Core Animation now.

## Purpose

Localizes parsing, routing, and reverse-shortening in shared code, leaving the platform with pure native-animation orchestration. This is the foundation the transform-on-Core-Animation work will plug into (a transform-aware sibling of the same apply hook).

## Test plan

- `CSSPlatformTransitionProxy.cpp` compiles on Android (real NDK flags, `-Werror -Wpedantic`) and iOS (host clang, iOS headers).
- The routing and reverse-shortening logic is a verbatim port of the previous Apple implementation (same reversal detection, `reverseShorten`, and resolved duration/start handed to Core Animation), so behavior is unchanged.
- Android holder construction is unaffected (the css fields stay trailing and value-init to null); iOS holder construction updated to the two-hook set.
- clang-format clean (pinned 19.1.7).
