### PR TITLE
fix: Compile CSS Core Animation platform props on macOS

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformProps.mm
@@ -25,7 +25,12 @@ id idFromPlatformValue(const PlatformValue &value)
     return @(*scalar);
   }
   if (const auto *size = std::get_if<std::array<double, 2>>(&value)) {
+    // +[NSValue valueWithCGSize:] is UIKit-only; AppKit boxes the same CGSize via valueWithSize:.
+#if TARGET_OS_OSX
+    return [NSValue valueWithSize:NSMakeSize((*size)[0], (*size)[1])];
+#else
     return [NSValue valueWithCGSize:CGSizeMake((*size)[0], (*size)[1])];
+#endif
   }
   const auto &color = std::get<std::array<double, 4>>(value);
   const CGFloat components[4] = {color[0], color[1], color[2], color[3]};


### PR DESCRIPTION
`+[NSValue valueWithCGSize:]` is a UIKit-only category, so the CSS Core Animation platform-props code added in #9689 does not compile on macOS (AppKit), where the selector does not exist:

```
REACSSPlatformProps.mm:154: no known class method for selector 'valueWithCGSize:'
```

This guards the `shadowOffset` boxing with `TARGET_OS_OSX` and uses AppKit's `+[NSValue valueWithSize:]`. `NSSize` is layout-identical to `CGSize` (same `{CGSize=dd}` encoding), so CALayer reads the boxed value identically.

Verified on macos-example with an otherwise-identical build: BUILD FAILED at this line before, BUILD SUCCEEDED after. The macOS build CI is currently disabled, which is why this was not caught.
