### PR TITLE
fix(Reanimated): jest environment detection

### DIFF
--- a/packages/react-native-reanimated/src/common/constants/platform.ts
+++ b/packages/react-native-reanimated/src/common/constants/platform.ts
@@ -13,7 +13,8 @@ export const IS_ANDROID: boolean = /* @__PURE__ */ (() =>
   Platform?.OS === 'android')();
 export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform?.OS === 'ios')();
 export const IS_WEB: boolean = Platform?.OS === 'web';
-export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;
+export const IS_JEST: boolean =
+  typeof globalThis.jest !== 'undefined' || process.env.NODE_ENV === 'test';
 /** @knipIgnore */
 export const IS_WINDOWS: boolean = Platform?.OS === 'windows';
 

--- a/packages/react-native-worklets/src/platformChecker.ts
+++ b/packages/react-native-worklets/src/platformChecker.ts
@@ -1,3 +1,4 @@
 'use strict';
 
-export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;
+export const IS_JEST: boolean =
+  typeof globalThis.jest !== 'undefined' || process.env.NODE_ENV === 'test';


### PR DESCRIPTION
## Summary

Fixing an issue with Reanimated and `react-native-dotenv` conflicts. Reanimated used **runtime check of process.env.JEST_WORKER_ID** to check if it's in Jest environment.

However, in expo setup the bundler uses jest workers to parallelize the process. Running `react-native-dotenv` there would result in wrongly swapping `JEST_WORKER_ID` to an actual number, resulting in undefined behavior since sometimes a test implementation would be pulled at runtime.

## Test plan

I tested this change with `react-native-dotenv` plugin and an Expo55 app and the check was no longer butchered.
