### PR TITLE
fix: jsProps not animating on native

### DIFF
--- a/packages/react-native-reanimated/src/updateProps/updateProps.ts
+++ b/packages/react-native-reanimated/src/updateProps/updateProps.ts
@@ -112,7 +112,7 @@ type NativePropsOperation = {
 function createUpdatePropsManager() {
   'worklet';
   const nativeOperations: NativePropsOperation[] = [];
-  const jsOperations: JSPropsOperation[] = [];
+  let jsOperations: JSPropsOperation[] = [];
 
   let flushPending = false;
 
@@ -165,8 +165,9 @@ function createUpdatePropsManager() {
         nativeOperations.length = 0;
       }
       if (jsOperations.length) {
+        // Fresh array each flush: scheduleOnRN caches serialized args by identity.
         scheduleOnRN(updateJSProps, jsOperations);
-        jsOperations.length = 0;
+        jsOperations = [];
       }
       flushPending = false;
       if (!USE_ANIMATION_BACKEND) {


### PR DESCRIPTION
## Summary

Props passed via `jsProps` (applied on the JS thread with `setNativeProps`, e.g. `react-native-svg` `Polygon`'s `points`) stopped animating on native: they froze on their first-frame value while native animated props on the same component kept updating.

`createUpdatePropsManager` reused a single `jsOperations` array and cleared it in place after each `scheduleOnRN`. In bundle mode the worklets serializer (`createSerializable`) caches the serialized clone by object identity and freezes the source array, so every flush after the first reused the first frame's snapshot. Allocating a fresh array per flush fixes it. Native props are unaffected because they go straight through `_updateProps` without serialization.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/1ed2bb5f-0321-4b2c-b7d9-135fa4fe4e28" /> | <video src="https://github.com/user-attachments/assets/8e0de539-8c8b-426f-8396-296653df55d9" /> |

## Test plan

In the example app open `Third party components`, scroll to "With vs without JS props" (`SvgPolygonsDemo`). The left triangle (`points` is a jsProp) should animate its shape. Before this change it stayed frozen while its stroke color kept animating.
