### PR TITLE
chore: Switch CSS example tabs on horizontal swipe

### DIFF
--- a/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
+++ b/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
@@ -25,14 +25,11 @@ import { typedMemo } from '@/utils';
 import Text from '../core/Text';
 
 const TABS_GAP = spacing.xxxs;
-// Extra horizontal stretch applied to the selection pill mid-travel (peaks
-// halfway between two tabs, settles back to 1 when resting on a tab).
 const PILL_SQUASH = 0.12;
 
 type TabSelectorProps<T extends string> = {
   tabs: Readonly<Array<T>>;
   selectedTab: T;
-  // Live, fractional tab index driving the sliding selection pill.
   tabProgress: SharedValue<number>;
   onSelectTab: (tab: T) => void;
 };
@@ -58,7 +55,6 @@ function TabSelector<T extends string>({
   );
 
   const tabCount = tabs.length;
-  // True once every tab has reported its width, so the pill can be positioned.
   const widthsReady = useDerivedValue(
     () =>
       tabWidths.value.length === tabCount &&
@@ -110,7 +106,7 @@ function TabSelector<T extends string>({
     const widths = tabWidths.value;
 
     const lastIndex = tabCount - 1;
-    // Geometry stays within the valid tab range while the content rubber-bands.
+    // Clamp so rubber-band overshoot can't index past the first / last tab.
     const progress = Math.min(Math.max(tabProgress.value, 0), lastIndex);
     const from = Math.floor(progress);
     const to = Math.min(from + 1, lastIndex);
@@ -258,7 +254,6 @@ type TabProps = {
 
 function Tab({ index, onMeasure, onPress, tabProgress, title }: TabProps) {
   const animatedTextStyle = useAnimatedStyle(() => {
-    // 1 when the pill fully covers this tab, 0 once a full tab away.
     const coverage = Math.min(
       Math.max(1 - Math.abs(index - tabProgress.value), 0),
       1

--- a/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
+++ b/apps/common-app/src/apps/css/components/inputs/TabSelector.tsx
@@ -6,7 +6,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import type { ComponentRef } from 'react';
 import { useEffect, useMemo } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
+  interpolateColor,
   scrollTo,
   useAnimatedRef,
   useAnimatedStyle,
@@ -23,16 +25,22 @@ import { typedMemo } from '@/utils';
 import Text from '../core/Text';
 
 const TABS_GAP = spacing.xxxs;
+// Extra horizontal stretch applied to the selection pill mid-travel (peaks
+// halfway between two tabs, settles back to 1 when resting on a tab).
+const PILL_SQUASH = 0.12;
 
 type TabSelectorProps<T extends string> = {
   tabs: Readonly<Array<T>>;
   selectedTab: T;
+  // Live, fractional tab index driving the sliding selection pill.
+  tabProgress: SharedValue<number>;
   onSelectTab: (tab: T) => void;
 };
 
 function TabSelector<T extends string>({
   onSelectTab,
   selectedTab,
+  tabProgress,
   tabs,
 }: TabSelectorProps<T>) {
   const scrollViewRef = useAnimatedRef<ComponentRef<Animated.ScrollView>>();
@@ -47,6 +55,14 @@ function TabSelector<T extends string>({
       (containerWidth.value -
         (tabWidths.value[tabWidths.value.length - 1] ?? 0)) /
       2
+  );
+
+  const tabCount = tabs.length;
+  // True once every tab has reported its width, so the pill can be positioned.
+  const widthsReady = useDerivedValue(
+    () =>
+      tabWidths.value.length === tabCount &&
+      tabWidths.value.every((width) => width > 0)
   );
 
   const activeTabIndex = useMemo(
@@ -67,8 +83,10 @@ function TabSelector<T extends string>({
     });
   }, [activeTabIndex, scrollViewRef, tabWidths]);
 
+  // Keep the whole selector hidden until the tabs are measured, so the active
+  // label never flashes white-on-white before the pill behind it can render.
   const animatedStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(+(containerWidth.value > 0)),
+    opacity: withTiming(+(containerWidth.value > 0 && widthsReady.value)),
   }));
 
   const paddingBeforeAnimatedStyle = useAnimatedStyle(() => ({
@@ -78,6 +96,50 @@ function TabSelector<T extends string>({
   const paddingAfterAnimatedStyle = useAnimatedStyle(() => ({
     width: paddingAfter.value,
   }));
+
+  const pillAnimatedStyle = useAnimatedStyle(() => {
+    // Always return the same set of keys so a not-ready -> ready (or back)
+    // transition can never leave a stale width / transform applied.
+    if (!widthsReady.value) {
+      return {
+        opacity: 0,
+        transform: [{ translateX: 0 }, { scaleX: 1 }],
+        width: 0,
+      };
+    }
+    const widths = tabWidths.value;
+
+    const lastIndex = tabCount - 1;
+    // Geometry stays within the valid tab range while the content rubber-bands.
+    const progress = Math.min(Math.max(tabProgress.value, 0), lastIndex);
+    const from = Math.floor(progress);
+    const to = Math.min(from + 1, lastIndex);
+    const fraction = progress - from;
+
+    let offsetFrom = 0;
+    for (let index = 0; index < from; index++) {
+      offsetFrom += widths[index] + TABS_GAP;
+    }
+    const offsetTo =
+      from === to ? offsetFrom : offsetFrom + widths[from] + TABS_GAP;
+
+    const centerFrom = offsetFrom + widths[from] / 2;
+    const centerTo = offsetTo + widths[to] / 2;
+    const center = centerFrom + (centerTo - centerFrom) * fraction;
+    const width = widths[from] + (widths[to] - widths[from]) * fraction;
+
+    // 0 when resting on a tab, 1 at the midpoint between two tabs.
+    const transit = 1 - Math.abs(2 * fraction - 1);
+
+    return {
+      opacity: 1,
+      transform: [
+        { translateX: center - width / 2 },
+        { scaleX: 1 + PILL_SQUASH * transit },
+      ],
+      width,
+    };
+  });
 
   const gradient = useMemo(
     () => (
@@ -141,10 +203,15 @@ function TabSelector<T extends string>({
         }}>
         <Animated.View style={paddingBeforeAnimatedStyle} />
         <View style={styles.tabs}>
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.pill, pillAnimatedStyle]}
+          />
           {tabs.map((tab, index) => (
             <Tab
+              index={index}
               key={tab}
-              selected={tab === selectedTab}
+              tabProgress={tabProgress}
               title={tab}
               onPress={() => onSelectTab(tab)}
               onMeasure={(widthArg) =>
@@ -183,35 +250,45 @@ function TabSelector<T extends string>({
 
 type TabProps = {
   title: string;
-  selected: boolean;
+  index: number;
+  tabProgress: SharedValue<number>;
   onPress: () => void;
   onMeasure: (width: number) => void;
 };
 
-function Tab({ onMeasure, onPress, selected, title }: TabProps) {
+function Tab({ index, onMeasure, onPress, tabProgress, title }: TabProps) {
+  const animatedTextStyle = useAnimatedStyle(() => {
+    // 1 when the pill fully covers this tab, 0 once a full tab away.
+    const coverage = Math.min(
+      Math.max(1 - Math.abs(index - tabProgress.value), 0),
+      1
+    );
+    return {
+      color: interpolateColor(
+        coverage,
+        [0, 1],
+        [colors.foreground2, colors.white]
+      ),
+    };
+  });
+
   return (
     <Pressable
-      style={[styles.tab, selected && styles.activeTab]}
+      style={styles.tab}
       onPress={onPress}
       onLayout={({
         nativeEvent: {
           layout: { width },
         },
       }) => onMeasure(width)}>
-      <Text style={selected && styles.activeTabText} variant="label2">
-        {title}
+      <Text variant="label2">
+        <Animated.Text style={animatedTextStyle}>{title}</Animated.Text>
       </Text>
     </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
-  activeTab: {
-    backgroundColor: colors.primary,
-  },
-  activeTabText: {
-    color: colors.white,
-  },
   buttons: {
     ...(StyleSheet.absoluteFill as object),
     alignItems: 'center',
@@ -221,6 +298,14 @@ const styles = StyleSheet.create({
   },
   disabledButton: {
     opacity: 0.5,
+  },
+  pill: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.full,
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    top: 0,
   },
   tab: {
     borderRadius: radius.full,

--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -11,12 +11,14 @@ import {
   useState,
 } from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 import { colors, flex, sizes, spacing } from '@/theme';
 import { IS_WEB } from '@/utils';
@@ -24,6 +26,17 @@ import { IS_WEB } from '@/utils';
 import TabSelector from '../inputs/TabSelector';
 
 const WINDOW_WIDTH = Dimensions.get('screen').width;
+
+// Horizontal finger travel before the swipe takes over the touch (keeps taps
+// and the inner vertical scroll working).
+const SWIPE_ACTIVATION_DISTANCE = 15;
+// Vertical finger travel that hands the touch back to the inner scroll view.
+const SWIPE_FAIL_DISTANCE = 15;
+// How far / fast a swipe must be on release to commit to the neighbouring tab.
+const SWIPE_DISTANCE_THRESHOLD = WINDOW_WIDTH * 0.2;
+const SWIPE_VELOCITY_THRESHOLD = 500;
+// Rubber-band factor applied when dragging past the first / last tab.
+const EDGE_RESISTANCE = 0.2;
 
 type TabProps = PropsWithChildren<{
   name: string;
@@ -34,10 +47,12 @@ type TabPropsInternal = {
   rendered: boolean;
   selectedTabIndex: SharedValue<number>;
   previousSelectedTabIndex: SharedValue<number>;
+  dragTranslateX: SharedValue<number>;
 } & TabProps;
 
 const Tab = memo(function Tab({
   children,
+  dragTranslateX,
   index,
   previousSelectedTabIndex,
   rendered,
@@ -46,14 +61,17 @@ const Tab = memo(function Tab({
   const animatedTabStyle = useAnimatedStyle(() => ({
     opacity:
       index === selectedTabIndex.value ||
-      index === previousSelectedTabIndex.value
+      index === previousSelectedTabIndex.value ||
+      // While swiping, also reveal the neighbour the finger is dragging towards.
+      (dragTranslateX.value !== 0 &&
+        Math.abs(index - selectedTabIndex.value) === 1)
         ? 1
         : 0,
     transform: [
       {
-        translateX: withTiming(
-          Math.sign(index - selectedTabIndex.value) * WINDOW_WIDTH
-        ),
+        translateX:
+          withTiming(Math.sign(index - selectedTabIndex.value) * WINDOW_WIDTH) +
+          dragTranslateX.value,
       },
       {
         translateY: withTiming(-sizes.md * +(index !== selectedTabIndex.value)),
@@ -100,6 +118,8 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
 
   const previousSelectedTabIndex = useSharedValue(0);
   const selectedTabIndex = useSharedValue(0);
+  // Live horizontal offset of the finger while swiping between tabs.
+  const dragTranslateX = useSharedValue(0);
 
   const handleSelectTab = useCallback(
     (name: string) => {
@@ -108,6 +128,55 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
       setSelectedTabName(name);
     },
     [tabNames, previousSelectedTabIndex, selectedTabIndex]
+  );
+
+  const numberOfTabs = tabNames.length;
+
+  const swipeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(numberOfTabs > 1)
+        .activeOffsetX([-SWIPE_ACTIVATION_DISTANCE, SWIPE_ACTIVATION_DISTANCE])
+        .failOffsetY([-SWIPE_FAIL_DISTANCE, SWIPE_FAIL_DISTANCE])
+        .onUpdate((event) => {
+          const atStart = selectedTabIndex.value === 0;
+          const atEnd = selectedTabIndex.value === numberOfTabs - 1;
+          const overscrolling =
+            (atStart && event.translationX > 0) ||
+            (atEnd && event.translationX < 0);
+          dragTranslateX.value = overscrolling
+            ? event.translationX * EDGE_RESISTANCE
+            : event.translationX;
+        })
+        .onEnd((event) => {
+          const current = selectedTabIndex.value;
+          const goNext =
+            (-event.translationX > SWIPE_DISTANCE_THRESHOLD ||
+              -event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
+            current < numberOfTabs - 1;
+          const goPrev =
+            (event.translationX > SWIPE_DISTANCE_THRESHOLD ||
+              event.velocityX > SWIPE_VELOCITY_THRESHOLD) &&
+            current > 0;
+
+          const target = goNext ? current + 1 : goPrev ? current - 1 : current;
+
+          if (target !== current) {
+            // Retarget the slide on the UI thread so it continues seamlessly
+            // from the finger position, then sync the React state.
+            previousSelectedTabIndex.value = current;
+            selectedTabIndex.value = target;
+            scheduleOnRN(setSelectedTabName, tabNames[target]);
+          }
+          dragTranslateX.value = withTiming(0);
+        }),
+    [
+      numberOfTabs,
+      tabNames,
+      dragTranslateX,
+      previousSelectedTabIndex,
+      selectedTabIndex,
+    ]
   );
 
   useEffect(() => {
@@ -128,17 +197,20 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
           onSelectTab={handleSelectTab}
         />
       </View>
-      <View style={flex.fill}>
-        {childrenArray.map((child, index) =>
-          cloneElement(child, {
-            index,
-            key: index,
-            previousSelectedTabIndex,
-            rendered: index === 0 || screenTransitionFinished,
-            selectedTabIndex,
-          })
-        )}
-      </View>
+      <GestureDetector gesture={swipeGesture}>
+        <View style={flex.fill}>
+          {childrenArray.map((child, index) =>
+            cloneElement(child, {
+              dragTranslateX,
+              index,
+              key: index,
+              previousSelectedTabIndex,
+              rendered: index === 0 || screenTransitionFinished,
+              selectedTabIndex,
+            })
+          )}
+        </View>
+      </GestureDetector>
     </>
   );
 };

--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -14,6 +14,7 @@ import { Dimensions, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 import Animated, {
+  cancelAnimation,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -37,6 +38,13 @@ const SWIPE_DISTANCE_THRESHOLD = WINDOW_WIDTH * 0.2;
 const SWIPE_VELOCITY_THRESHOLD = 500;
 // Rubber-band factor applied when dragging past the first / last tab.
 const EDGE_RESISTANCE = 0.2;
+// Scale applied to a tab one screen away from the active one.
+const INACTIVE_TAB_SCALE = 0.9;
+
+function clamp(value: number, min: number, max: number): number {
+  'worklet';
+  return Math.min(Math.max(value, min), max);
+}
 
 type TabProps = PropsWithChildren<{
   name: string;
@@ -45,42 +53,32 @@ type TabProps = PropsWithChildren<{
 type TabPropsInternal = {
   index: number;
   rendered: boolean;
-  selectedTabIndex: SharedValue<number>;
-  previousSelectedTabIndex: SharedValue<number>;
-  dragTranslateX: SharedValue<number>;
+  tabProgress: SharedValue<number>;
 } & TabProps;
 
 const Tab = memo(function Tab({
   children,
-  dragTranslateX,
   index,
-  previousSelectedTabIndex,
   rendered,
-  selectedTabIndex,
+  tabProgress,
 }: TabPropsInternal): ReactElement {
-  const animatedTabStyle = useAnimatedStyle(() => ({
-    opacity:
-      index === selectedTabIndex.value ||
-      index === previousSelectedTabIndex.value ||
-      // While swiping, also reveal the neighbour the finger is dragging towards.
-      (dragTranslateX.value !== 0 &&
-        Math.abs(index - selectedTabIndex.value) === 1)
-        ? 1
-        : 0,
-    transform: [
-      {
-        translateX:
-          withTiming(Math.sign(index - selectedTabIndex.value) * WINDOW_WIDTH) +
-          dragTranslateX.value,
-      },
-      {
-        translateY: withTiming(-sizes.md * +(index !== selectedTabIndex.value)),
-      },
-      {
-        scale: withTiming(index === selectedTabIndex.value ? 1 : 0.9),
-      },
-    ],
-  }));
+  const animatedTabStyle = useAnimatedStyle(() => {
+    // Signed distance (in tabs) between this tab and the live active position.
+    // Clamped so tabs further than one screen away stay parked off-screen
+    // instead of sliding arbitrarily far during multi-tab transitions.
+    const distance = clamp(index - tabProgress.value, -1, 1);
+    const offset = Math.abs(distance);
+
+    return {
+      // Fade neighbours out as they move away from the active position.
+      opacity: 1 - offset,
+      transform: [
+        { translateX: distance * WINDOW_WIDTH },
+        { translateY: -sizes.md * offset },
+        { scale: 1 - (1 - INACTIVE_TAB_SCALE) * offset },
+      ],
+    };
+  });
 
   return (
     <Animated.View style={[styles.tab, animatedTabStyle]}>
@@ -116,18 +114,23 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
   const [screenTransitionFinished, setScreenTransitionFinished] =
     useState(IS_WEB);
 
-  const previousSelectedTabIndex = useSharedValue(0);
+  // Committed tab index. Drives the tab-bar selection and the swipe logic.
   const selectedTabIndex = useSharedValue(0);
-  // Live horizontal offset of the finger while swiping between tabs.
-  const dragTranslateX = useSharedValue(0);
+  // Live, fractional tab index that all the tab animations interpolate from.
+  // Animated with timing on tap / swipe release, set directly while dragging.
+  const tabProgress = useSharedValue(0);
+  // tabProgress at the moment a drag starts, so an interrupted animation
+  // continues from where it was instead of snapping to the committed index.
+  const dragStartProgress = useSharedValue(0);
 
   const handleSelectTab = useCallback(
     (name: string) => {
-      previousSelectedTabIndex.value = selectedTabIndex.value;
-      selectedTabIndex.value = tabNames.indexOf(name);
+      const index = tabNames.indexOf(name);
+      selectedTabIndex.value = index;
+      tabProgress.value = withTiming(index);
       setSelectedTabName(name);
     },
-    [tabNames, previousSelectedTabIndex, selectedTabIndex]
+    [tabNames, selectedTabIndex, tabProgress]
   );
 
   const numberOfTabs = tabNames.length;
@@ -138,15 +141,25 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
         .enabled(numberOfTabs > 1)
         .activeOffsetX([-SWIPE_ACTIVATION_DISTANCE, SWIPE_ACTIVATION_DISTANCE])
         .failOffsetY([-SWIPE_FAIL_DISTANCE, SWIPE_FAIL_DISTANCE])
+        .onStart(() => {
+          // Take over any in-flight settle so the drag continues seamlessly.
+          cancelAnimation(tabProgress);
+          dragStartProgress.value = tabProgress.value;
+        })
         .onUpdate((event) => {
-          const atStart = selectedTabIndex.value === 0;
-          const atEnd = selectedTabIndex.value === numberOfTabs - 1;
-          const overscrolling =
-            (atStart && event.translationX > 0) ||
-            (atEnd && event.translationX < 0);
-          dragTranslateX.value = overscrolling
-            ? event.translationX * EDGE_RESISTANCE
-            : event.translationX;
+          const lastIndex = numberOfTabs - 1;
+          // Dragging left (negative translation) moves towards the next tab.
+          const raw =
+            dragStartProgress.value - event.translationX / WINDOW_WIDTH;
+          // Rubber-band the part of the drag that goes before the first or past
+          // the last tab.
+          if (raw < 0) {
+            tabProgress.value = raw * EDGE_RESISTANCE;
+          } else if (raw > lastIndex) {
+            tabProgress.value = lastIndex + (raw - lastIndex) * EDGE_RESISTANCE;
+          } else {
+            tabProgress.value = raw;
+          }
         })
         .onEnd((event) => {
           const current = selectedTabIndex.value;
@@ -162,21 +175,13 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
           const target = goNext ? current + 1 : goPrev ? current - 1 : current;
 
           if (target !== current) {
-            // Retarget the slide on the UI thread so it continues seamlessly
-            // from the finger position, then sync the React state.
-            previousSelectedTabIndex.value = current;
             selectedTabIndex.value = target;
             scheduleOnRN(setSelectedTabName, tabNames[target]);
           }
-          dragTranslateX.value = withTiming(0);
+          // Settle onto the target tab, continuing from the finger position.
+          tabProgress.value = withTiming(target);
         }),
-    [
-      numberOfTabs,
-      tabNames,
-      dragTranslateX,
-      previousSelectedTabIndex,
-      selectedTabIndex,
-    ]
+    [numberOfTabs, tabNames, tabProgress, dragStartProgress, selectedTabIndex]
   );
 
   useEffect(() => {
@@ -193,6 +198,7 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
       <View style={styles.tabBar}>
         <TabSelector
           selectedTab={selectedTabName}
+          tabProgress={tabProgress}
           tabs={tabNames}
           onSelectTab={handleSelectTab}
         />
@@ -201,12 +207,10 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
         <View style={flex.fill}>
           {childrenArray.map((child, index) =>
             cloneElement(child, {
-              dragTranslateX,
               index,
               key: index,
-              previousSelectedTabIndex,
               rendered: index === 0 || screenTransitionFinished,
-              selectedTabIndex,
+              tabProgress,
             })
           )}
         </View>

--- a/apps/common-app/src/apps/css/components/layout/TabView.tsx
+++ b/apps/common-app/src/apps/css/components/layout/TabView.tsx
@@ -28,17 +28,11 @@ import TabSelector from '../inputs/TabSelector';
 
 const WINDOW_WIDTH = Dimensions.get('screen').width;
 
-// Horizontal finger travel before the swipe takes over the touch (keeps taps
-// and the inner vertical scroll working).
 const SWIPE_ACTIVATION_DISTANCE = 15;
-// Vertical finger travel that hands the touch back to the inner scroll view.
 const SWIPE_FAIL_DISTANCE = 15;
-// How far / fast a swipe must be on release to commit to the neighbouring tab.
 const SWIPE_DISTANCE_THRESHOLD = WINDOW_WIDTH * 0.2;
 const SWIPE_VELOCITY_THRESHOLD = 500;
-// Rubber-band factor applied when dragging past the first / last tab.
 const EDGE_RESISTANCE = 0.2;
-// Scale applied to a tab one screen away from the active one.
 const INACTIVE_TAB_SCALE = 0.9;
 
 function clamp(value: number, min: number, max: number): number {
@@ -63,14 +57,12 @@ const Tab = memo(function Tab({
   tabProgress,
 }: TabPropsInternal): ReactElement {
   const animatedTabStyle = useAnimatedStyle(() => {
-    // Signed distance (in tabs) between this tab and the live active position.
-    // Clamped so tabs further than one screen away stay parked off-screen
-    // instead of sliding arbitrarily far during multi-tab transitions.
+    // Clamped so tabs more than one screen away stay parked off-screen rather
+    // than sliding arbitrarily far during multi-tab transitions.
     const distance = clamp(index - tabProgress.value, -1, 1);
     const offset = Math.abs(distance);
 
     return {
-      // Fade neighbours out as they move away from the active position.
       opacity: 1 - offset,
       transform: [
         { translateX: distance * WINDOW_WIDTH },
@@ -114,13 +106,12 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
   const [screenTransitionFinished, setScreenTransitionFinished] =
     useState(IS_WEB);
 
-  // Committed tab index. Drives the tab-bar selection and the swipe logic.
+  // Committed integer index; drives the tab bar and the swipe decisions.
   const selectedTabIndex = useSharedValue(0);
-  // Live, fractional tab index that all the tab animations interpolate from.
-  // Animated with timing on tap / swipe release, set directly while dragging.
+  // Live fractional index every tab animation reads (timing on tap/release,
+  // set directly while dragging).
   const tabProgress = useSharedValue(0);
-  // tabProgress at the moment a drag starts, so an interrupted animation
-  // continues from where it was instead of snapping to the committed index.
+  // Captured at drag start so an interrupted settle continues from where it is.
   const dragStartProgress = useSharedValue(0);
 
   const handleSelectTab = useCallback(
@@ -142,17 +133,14 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
         .activeOffsetX([-SWIPE_ACTIVATION_DISTANCE, SWIPE_ACTIVATION_DISTANCE])
         .failOffsetY([-SWIPE_FAIL_DISTANCE, SWIPE_FAIL_DISTANCE])
         .onStart(() => {
-          // Take over any in-flight settle so the drag continues seamlessly.
           cancelAnimation(tabProgress);
           dragStartProgress.value = tabProgress.value;
         })
         .onUpdate((event) => {
           const lastIndex = numberOfTabs - 1;
-          // Dragging left (negative translation) moves towards the next tab.
           const raw =
             dragStartProgress.value - event.translationX / WINDOW_WIDTH;
-          // Rubber-band the part of the drag that goes before the first or past
-          // the last tab.
+          // Rubber-band past the first / last tab.
           if (raw < 0) {
             tabProgress.value = raw * EDGE_RESISTANCE;
           } else if (raw > lastIndex) {
@@ -178,7 +166,6 @@ const TabView: TabViewComponent = ({ children }: TabViewProps) => {
             selectedTabIndex.value = target;
             scheduleOnRN(setSelectedTabName, tabNames[target]);
           }
-          // Settle onto the target tab, continuing from the finger position.
           tabProgress.value = withTiming(target);
         }),
     [numberOfTabs, tabNames, tabProgress, dragStartProgress, selectedTabIndex]


### PR DESCRIPTION
## Summary

Adds horizontal swipe support to the CSS example `TabView`: swiping left/right in the tab content switches to the previous/next tab, with the active tab following the finger and a rubber-band effect at the first/last tab. Tapping the tab bar still works.

The pan gesture uses `activeOffsetX`/`failOffsetY` so it does not interfere with taps and presses inside the content or with the inner vertical scrolling.

## Example recording

https://github.com/user-attachments/assets/ab4e7191-167f-4fb7-a497-2afdbcf3e809
