### PR TITLE
chore: Tidy up CSS example app navigation and platform labels

### DIFF
--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -105,16 +105,17 @@ const routes = {
   TestExamples: {
     CardComponent: routeCards.TestExamplesCard,
     name: 'Test Examples',
+    /* eslint-disable perfectionist/sort-objects -- Keep the Playground first for quick access */
     routes: {
+      Playground: {
+        Component: testExamples.Playground,
+        name: 'Playground',
+      },
       IterationCountAndFillMode: {
         Component: testExamples.IterationCountAndFillMode,
         displayed: !IS_WEB,
         labelTypes: ['needsFix'],
         name: 'Iteration Count and Fill Mode',
-      },
-      Playground: {
-        Component: testExamples.Playground,
-        name: 'Playground',
       },
       RelativeMargins: {
         Component: testExamples.RelativeMargins,
@@ -123,6 +124,7 @@ const routes = {
         name: 'Relative Margins',
       },
     },
+    /* eslint-enable perfectionist/sort-objects */
   },
 } satisfies Routes;
 

--- a/apps/common-app/src/apps/css/examples/animations/routes/index.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/index.ts
@@ -105,7 +105,7 @@ const routes = {
   TestExamples: {
     CardComponent: routeCards.TestExamplesCard,
     name: 'Test Examples',
-    /* eslint-disable perfectionist/sort-objects -- Keep the Playground first for quick access */
+    /* eslint-disable perfectionist/sort-objects */
     routes: {
       Playground: {
         Component: testExamples.Playground,

--- a/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
@@ -117,7 +117,7 @@ const layoutAndPositioningRoutes = {
     Component: baseAnimatedProperties.layoutAndPositioning.Paddings,
     name: 'Paddings',
   },
-  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  // eslint-disable-next-line perfectionist/sort-objects
   Others: {
     name: 'Others',
     routes: {
@@ -325,7 +325,7 @@ const appearanceRoutes = {
       },
     },
   },
-  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  // eslint-disable-next-line perfectionist/sort-objects
   Others: {
     name: 'Others',
     routes: {
@@ -425,7 +425,7 @@ const typographyRoutes = {
       },
     },
   },
-  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  // eslint-disable-next-line perfectionist/sort-objects
   Others: {
     name: 'Others',
     routes: {
@@ -482,7 +482,7 @@ export const basePropertiesRoutes = {
     name: 'Typography',
     routes: typographyRoutes,
   },
-  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  // eslint-disable-next-line perfectionist/sort-objects
   Others: {
     name: 'Others',
     routes: othersRoutes,

--- a/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
+++ b/apps/common-app/src/apps/css/examples/animations/routes/properties/base.ts
@@ -113,6 +113,11 @@ const layoutAndPositioningRoutes = {
     Component: baseAnimatedProperties.layoutAndPositioning.Margins,
     name: 'Margins',
   },
+  Paddings: {
+    Component: baseAnimatedProperties.layoutAndPositioning.Paddings,
+    name: 'Paddings',
+  },
+  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
   Others: {
     name: 'Others',
     routes: {
@@ -143,10 +148,6 @@ const layoutAndPositioningRoutes = {
         name: 'Z-index',
       },
     },
-  },
-  Paddings: {
-    Component: baseAnimatedProperties.layoutAndPositioning.Paddings,
-    name: 'Paddings',
   },
 } satisfies Routes;
 
@@ -184,23 +185,6 @@ const appearanceRoutes = {
   Filter: {
     Component: baseAnimatedProperties.appearance.Filter,
     name: 'Filter',
-  },
-  Others: {
-    name: 'Others',
-    routes: {
-      BackfaceVisibility: {
-        Component: baseAnimatedProperties.appearance.others.BackfaceVisibility,
-        name: 'Backface Visibility',
-      },
-      MixBlendMode: {
-        Component: baseAnimatedProperties.appearance.others.MixBlendMode,
-        name: 'Mix Blend Mode',
-      },
-      Opacity: {
-        Component: baseAnimatedProperties.appearance.others.Opacity,
-        name: 'Opacity',
-      },
-    },
   },
   Outlines: {
     name: 'Outlines',
@@ -341,6 +325,24 @@ const appearanceRoutes = {
       },
     },
   },
+  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  Others: {
+    name: 'Others',
+    routes: {
+      BackfaceVisibility: {
+        Component: baseAnimatedProperties.appearance.others.BackfaceVisibility,
+        name: 'Backface Visibility',
+      },
+      MixBlendMode: {
+        Component: baseAnimatedProperties.appearance.others.MixBlendMode,
+        name: 'Mix Blend Mode',
+      },
+      Opacity: {
+        Component: baseAnimatedProperties.appearance.others.Opacity,
+        name: 'Opacity',
+      },
+    },
+  },
 } satisfies Routes;
 
 const typographyRoutes = {
@@ -366,21 +368,6 @@ const typographyRoutes = {
       FontWeight: {
         Component: baseAnimatedProperties.typography.font.FontWeight,
         name: 'Font Weight',
-      },
-    },
-  },
-  Others: {
-    name: 'Others',
-    routes: {
-      IncludeFontPadding: {
-        Component: baseAnimatedProperties.typography.others.IncludeFontPadding,
-        labelTypes: ['Android'],
-        name: 'Include Font Padding',
-      },
-      UserSelect: {
-        Component: baseAnimatedProperties.typography.others.UserSelect,
-        labelTypes: ['web'],
-        name: 'User Select',
       },
     },
   },
@@ -438,6 +425,22 @@ const typographyRoutes = {
       },
     },
   },
+  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  Others: {
+    name: 'Others',
+    routes: {
+      IncludeFontPadding: {
+        Component: baseAnimatedProperties.typography.others.IncludeFontPadding,
+        labelTypes: ['Android'],
+        name: 'Include Font Padding',
+      },
+      UserSelect: {
+        Component: baseAnimatedProperties.typography.others.UserSelect,
+        labelTypes: ['web'],
+        name: 'User Select',
+      },
+    },
+  },
 } satisfies Routes;
 
 const othersRoutes = {
@@ -475,12 +478,13 @@ export const basePropertiesRoutes = {
     name: 'Layout and Positioning',
     routes: layoutAndPositioningRoutes,
   },
-  Others: {
-    name: 'Others',
-    routes: othersRoutes,
-  },
   Typography: {
     name: 'Typography',
     routes: typographyRoutes,
+  },
+  // eslint-disable-next-line perfectionist/sort-objects -- "Others" stays last
+  Others: {
+    name: 'Others',
+    routes: othersRoutes,
   },
 } satisfies Routes;

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/transforms/transformProperties/Skew.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/transforms/transformProperties/Skew.tsx
@@ -58,7 +58,6 @@ export default function Skew() {
               to: [{ skewY: `${Math.PI / 3}rad` }],
             },
           ],
-          labelTypes: ['iOS', 'web'],
           title: 'Y skew',
         },
       ]}

--- a/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/transforms/transformProperties/Skew.tsx
+++ b/apps/common-app/src/apps/css/examples/animations/screens/animatedProperties/base/appearance/transforms/transformProperties/Skew.tsx
@@ -41,6 +41,7 @@ export default function Skew() {
               to: [{ skewX: `-${Math.PI / 3}rad` }],
             },
           ],
+          labelTypes: ['iOS', 'web'],
           title: 'X skew',
         },
         {
@@ -57,6 +58,7 @@ export default function Skew() {
               to: [{ skewY: `${Math.PI / 3}rad` }],
             },
           ],
+          labelTypes: ['iOS', 'web'],
           title: 'Y skew',
         },
       ]}

--- a/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
+++ b/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
@@ -82,16 +82,17 @@ export default function BottomTabBar({
     []
   );
 
-  // The gradient veils list content scrolling behind the floating tab bar on
-  // navigation screens. On final example screens there is no list to veil, so we
-  // fade it out to keep the example unobstructed.
+  // On navigation screens the gradient hides list content scrolling behind the
+  // floating tab bar. Example screens have no such list, so we fade it out.
+  // Paths are stored as an array rather than a Set: a Set is not preserved when
+  // captured into a worklet on native, so the check uses `includes`.
   const exampleScreenPaths = useMemo(
-    () => getExampleScreenPaths(routes),
+    () => [...getExampleScreenPaths(routes)],
     [routes]
   );
   const isExampleScreen = useDerivedValue(() => {
     const path = currentRoute.value;
-    return path !== undefined && exampleScreenPaths.has(path);
+    return path !== undefined && exampleScreenPaths.includes(path);
   });
   const gradientStyle = useAnimatedStyle(() => ({
     opacity: withTiming(isExampleScreen.value ? 0 : 1),

--- a/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
+++ b/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
@@ -19,6 +19,7 @@ import type { TabRoute } from '@/apps/css/navigation/types';
 import { colors, flex, spacing, text } from '@/theme';
 
 import { useLocalNavigationRef } from './LocalNavigationProvider';
+import { getExampleScreenPaths } from './utils';
 
 const TABS_GAP = spacing.xxs;
 
@@ -81,6 +82,21 @@ export default function BottomTabBar({
     []
   );
 
+  // The gradient veils list content scrolling behind the floating tab bar on
+  // navigation screens. On final example screens there is no list to veil, so we
+  // fade it out to keep the example unobstructed.
+  const exampleScreenPaths = useMemo(
+    () => getExampleScreenPaths(routes),
+    [routes]
+  );
+  const isExampleScreen = useDerivedValue(() => {
+    const path = currentRoute.value;
+    return path !== undefined && exampleScreenPaths[path] === true;
+  });
+  const gradientStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(isExampleScreen.value ? 0 : 1),
+  }));
+
   const handleMeasure = useCallback(
     (width: number, idx: number) => {
       scheduleOnUI(() => {
@@ -98,9 +114,11 @@ export default function BottomTabBar({
 
   return (
     <View style={[styles.wrapper, { height: BOTTOM_BAR_HEIGHT + inset }]}>
-      <View pointerEvents="none" style={styles.gradient}>
+      <Animated.View
+        pointerEvents="none"
+        style={[styles.gradient, gradientStyle]}>
         {gradient}
-      </View>
+      </Animated.View>
       <View style={styles.container}>
         <View style={[flex.row, { gap: TABS_GAP }]}>
           <Animated.View

--- a/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
+++ b/apps/common-app/src/apps/css/navigation/BottomTabBar.tsx
@@ -91,7 +91,7 @@ export default function BottomTabBar({
   );
   const isExampleScreen = useDerivedValue(() => {
     const path = currentRoute.value;
-    return path !== undefined && exampleScreenPaths[path] === true;
+    return path !== undefined && exampleScreenPaths.has(path);
   });
   const gradientStyle = useAnimatedStyle(() => ({
     opacity: withTiming(isExampleScreen.value ? 0 : 1),

--- a/apps/common-app/src/apps/css/navigation/utils.ts
+++ b/apps/common-app/src/apps/css/navigation/utils.ts
@@ -1,7 +1,34 @@
-import type { Route, RouteWithRoutes } from './types';
+import type { Route, Routes, RouteWithRoutes, TabRoute } from './types';
 
 export function isRouteWithRoutes(route: Route): route is RouteWithRoutes {
   return route && typeof route === 'object' && 'routes' in route;
+}
+
+// Collects the navigation paths of all leaf example screens (routes that render
+// a component rather than a nested list), keyed for O(1) worklet lookup. Used to
+// tell apart final example screens from the navigation list screens. The path
+// prefix matches the focused route name set in the navigator (`<tab>/<...keys>`).
+export function getExampleScreenPaths(
+  tabRoutes: Array<TabRoute>
+): Record<string, true> {
+  const paths: Record<string, true> = {};
+
+  const collect = (routes: Routes, prefix: string) => {
+    for (const [key, route] of Object.entries(routes)) {
+      const path = `${prefix}/${key}`;
+      if (isRouteWithRoutes(route)) {
+        collect(route.routes, path);
+      } else {
+        paths[path] = true;
+      }
+    }
+  };
+
+  for (const tab of tabRoutes) {
+    collect(tab.routes, tab.name);
+  }
+
+  return paths;
 }
 
 const isUpperCase = (char: string) => char && char === char.toUpperCase();

--- a/apps/common-app/src/apps/css/navigation/utils.ts
+++ b/apps/common-app/src/apps/css/navigation/utils.ts
@@ -4,14 +4,8 @@ export function isRouteWithRoutes(route: Route): route is RouteWithRoutes {
   return route && typeof route === 'object' && 'routes' in route;
 }
 
-// Collects the navigation paths of all leaf example screens (routes that render
-// a component rather than a nested list), keyed for O(1) worklet lookup. Used to
-// tell apart final example screens from the navigation list screens. The path
-// prefix matches the focused route name set in the navigator (`<tab>/<...keys>`).
-export function getExampleScreenPaths(
-  tabRoutes: Array<TabRoute>
-): Record<string, true> {
-  const paths: Record<string, true> = {};
+export function getExampleScreenPaths(tabRoutes: Array<TabRoute>): Set<string> {
+  const paths = new Set<string>();
 
   const collect = (routes: Routes, prefix: string) => {
     for (const [key, route] of Object.entries(routes)) {
@@ -19,7 +13,7 @@ export function getExampleScreenPaths(
       if (isRouteWithRoutes(route)) {
         collect(route.routes, path);
       } else {
-        paths[path] = true;
+        paths.add(path);
       }
     }
   };


### PR DESCRIPTION
Small cleanups for the CSS examples app:

- Show Playground first in the Animations > Test Examples list.
- Hide the bottom tab bar gradient on the final example screens. It stays on the navigation/list screens, where it veils content scrolling behind the floating tab bar.
- Move the "Others" group to the end of each Animated Properties route group instead of leaving it in the middle.
- Label the skew transform examples as iOS/Web only, since Android does not support the skew transform.