### PR TITLE
fix: CSS perspective interpolation NaN from the infinity default

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/interpolation/transforms/TransformOperationInterpolator.cpp
@@ -5,6 +5,8 @@
 #include <reanimated/CSS/interpolation/transforms/operations/skew.h>
 #include <reanimated/CSS/interpolation/transforms/operations/translate.h>
 
+#include <cmath>
+#include <limits>
 #include <utility>
 
 namespace reanimated::css {
@@ -31,14 +33,19 @@ std::unique_ptr<StyleOperation> TransformOperationInterpolator<PerspectiveOperat
     const std::shared_ptr<StyleOperation> &from,
     const std::shared_ptr<StyleOperation> &to,
     const StyleOperationsInterpolationContext & /* context */) const {
-  // TODO - check if this implementation is correct
   const auto &fromValue = std::static_pointer_cast<PerspectiveOperation>(from)->value;
   const auto &toValue = std::static_pointer_cast<PerspectiveOperation>(to)->value;
 
-  if (fromValue.value == 0)
-    return std::make_unique<PerspectiveOperation>(toValue);
-  if (toValue.value == 0)
-    return std::make_unique<PerspectiveOperation>(fromValue);
+  // The default "no perspective" is infinity, so interpolating the distance
+  // directly gives inf + t*(d - inf) = NaN. Interpolate in reciprocal space
+  // instead (1/inf = 0, matching how perspective enters the matrix as -1/d).
+  if (std::isinf(fromValue.value) || std::isinf(toValue.value)) {
+    const double fromReciprocal = 1.0 / fromValue.value;
+    const double toReciprocal = 1.0 / toValue.value;
+    const double reciprocal = fromReciprocal + progress * (toReciprocal - fromReciprocal);
+    return std::make_unique<PerspectiveOperation>(
+        reciprocal == 0.0 ? std::numeric_limits<double>::infinity() : 1.0 / reciprocal);
+  }
 
   return std::make_unique<PerspectiveOperation>(fromValue.interpolate(progress, toValue));
 }


### PR DESCRIPTION
## Summary

Animating a `transform` whose `perspective` falls back to the default (no perspective, represented internally as `infinity`) evaluated `inf + t * (d - inf) = NaN`, which poisoned the transform matrix and made the view disappear.

Perspective is now interpolated in reciprocal space (`1/inf = 0`), matching how it enters the matrix (`-1/d`) and the spec's matrix interpolation. Finite-to-finite perspective is unchanged. The old `value == 0` guards were dead code - `sanitizePerspectiveValue` forces `|value| >= 1`, so perspective can never be `0` - so they are removed.

## Before / After

Verified on the Android emulator across several CSS animations that interpolate `perspective` from/to the default (no-perspective) endpoint - the case this fixes:

- `[]` -> `[{ perspective: 100 }, { rotateY: '50deg' }]`
- `[]` -> `[{ perspective: 100 }, { rotateX: '50deg' }]`
- `[{ perspective: 100 }, { rotateY: '50deg' }]` -> `[]`

https://github.com/user-attachments/assets/1d7ca900-72fd-48e9-a7fc-ef141e22c14c
