### PR TITLE
docs(Reanimated): update getRelativeCoords example to the v4 Gesture API

### DIFF
--- a/docs/docs-reanimated/docs/utilities/getRelativeCoords.mdx
+++ b/docs/docs-reanimated/docs/utilities/getRelativeCoords.mdx
@@ -9,28 +9,31 @@ sidebar_position: 4
 ## Reference
 
 ```tsx
-import { getRelativeCoords } from 'react-native-reanimated';
+import Animated, {
+  getRelativeCoords,
+  useAnimatedRef,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 const Comp = () => {
   const animatedRef = useAnimatedRef();
   // ...
 
-  const gestureHandler = useAnimatedGestureHandler({
-    onEnd: (event) => {
-      const coords = getRelativeCoords(
-        animatedRef,
-        event.absoluteX,
-        event.absoluteY
-      );
-    },
+  const panGesture = Gesture.Pan().onEnd((event) => {
+    const coords = getRelativeCoords(
+      animatedRef,
+      event.absoluteX,
+      event.absoluteY
+    );
+    if (coords) {
+      // use coords.x and coords.y
+    }
   });
 
   return (
-    <View ref={animatedRef}>
-      <PanGestureHandler onGestureEvent={gestureHandler}>
-        <Animated.View style={[styles.box]} />
-      </PanGestureHandler>
-    </View>
+    <GestureDetector gesture={panGesture}>
+      <Animated.View ref={animatedRef} style={[styles.box]} />
+    </GestureDetector>
   );
 };
 ```
@@ -68,7 +71,7 @@ Number which is an absolute `y` coordinate.
 
 ### Returns
 
-Object which contains relative coordinates
+An object which contains the relative coordinates, or `null` if the measurement fails.
 
 - `x`
 - `y`


### PR DESCRIPTION
## Summary

The `getRelativeCoords` page still shows its example using `useAnimatedGestureHandler` and `<PanGestureHandler>`, both of which were removed in Reanimated 4 (see [Migration from 3.x](https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x/#removed-useanimatedgesturehandler)). Following the old snippet no longer works on v4.

This updates the Reference example to the current Gesture Handler 2 API used across the rest of the docs: a `Gesture.Pan()` passed to `<GestureDetector>`, matching the pattern in the page's own interactive example (`src/examples/RelativeCoords.tsx`) and the gesture tutorial. The result of `getRelativeCoords` is now guarded since it can be `null`, and the Returns section was updated to mention that case.

No API changes, docs only.

## Test plan

- The example imports only symbols that are currently exported from `react-native-reanimated` (`getRelativeCoords`, `useAnimatedRef`, `Animated`) and `react-native-gesture-handler` (`Gesture`, `GestureDetector`).
- Diffed against the existing interactive example on the same page to keep the usage consistent.
- MDX structure unchanged otherwise (only the Reference code block and the Returns line were touched).