### PR TITLE
docs(Reanimated): fix deprecated babel plugin names and an escaped link

### DIFF
--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -151,20 +151,4 @@ cd ios && pod install && cd ..
 
 For building apps that target web using [react-native-web](https://www.npmjs.com/package/react-native-web) we highly recommend to use [Expo](https://expo.dev/).
 
-No extra Babel plugins are required for the web. Just make sure the `react-native-worklets/plugin` you already added is listed in your `babel.config.js`.
-
-```js {7}
-  module.exports = {
-      presets: [
-        ... // don't add it here :)
-      ],
-      plugins: [
-          ...
-          'react-native-worklets/plugin',
-      ],
-  };
-```
-
-Make sure to list `react-native-worklets/plugin` last.
-
 More advanced use cases such as running Reanimated with `webpack` or with `Next.js` are explained in a separate [Web Support](/docs/guides/web-support) guide.

--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -151,18 +151,18 @@ cd ios && pod install && cd ..
 
 For building apps that target web using [react-native-web](https://www.npmjs.com/package/react-native-web) we highly recommend to use [Expo](https://expo.dev/).
 
-To use Reanimated on the web all you need to do is to install and add [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from) Babel plugin to your `babel.config.js`.
+To use Reanimated on the web all you need to do is to install and add [`@babel/plugin-transform-export-namespace-from`](https://babeljs.io/docs/babel-plugin-transform-export-namespace-from) Babel plugin to your `babel.config.js`.
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="NPM">
     ```bash
-    npm install @babel/plugin-proposal-export-namespace-from
+    npm install @babel/plugin-transform-export-namespace-from
     ```
   </TabItem>
 
   <TabItem value="yarn" label="YARN">
     ```bash
-    yarn add @babel/plugin-proposal-export-namespace-from
+    yarn add @babel/plugin-transform-export-namespace-from
     ```
   </TabItem>
 </Tabs>
@@ -174,7 +174,7 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
       ],
       plugins: [
           ...
-          '@babel/plugin-proposal-export-namespace-from',
+          '@babel/plugin-transform-export-namespace-from',
           'react-native-worklets/plugin',
       ],
   };

--- a/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
+++ b/docs/docs-reanimated/docs/fundamentals/getting-started.mdx
@@ -151,21 +151,7 @@ cd ios && pod install && cd ..
 
 For building apps that target web using [react-native-web](https://www.npmjs.com/package/react-native-web) we highly recommend to use [Expo](https://expo.dev/).
 
-To use Reanimated on the web all you need to do is to install and add [`@babel/plugin-transform-export-namespace-from`](https://babeljs.io/docs/babel-plugin-transform-export-namespace-from) Babel plugin to your `babel.config.js`.
-
-<Tabs groupId="package-managers">
-  <TabItem value="npm" label="NPM">
-    ```bash
-    npm install @babel/plugin-transform-export-namespace-from
-    ```
-  </TabItem>
-
-  <TabItem value="yarn" label="YARN">
-    ```bash
-    yarn add @babel/plugin-transform-export-namespace-from
-    ```
-  </TabItem>
-</Tabs>
+No extra Babel plugins are required for the web. Just make sure the `react-native-worklets/plugin` you already added is listed in your `babel.config.js`.
 
 ```js {7}
   module.exports = {
@@ -174,7 +160,6 @@ To use Reanimated on the web all you need to do is to install and add [`@babel/p
       ],
       plugins: [
           ...
-          '@babel/plugin-transform-export-namespace-from',
           'react-native-worklets/plugin',
       ],
   };

--- a/docs/docs-reanimated/docs/guides/web-support.mdx
+++ b/docs/docs-reanimated/docs/guides/web-support.mdx
@@ -53,7 +53,7 @@ module.exports = {
           options: {
             presets: [
               '@babel/preset-react',
-              { plugins: ['@babel/plugin-proposal-class-properties'] },
+              { plugins: ['@babel/plugin-transform-class-properties'] },
             ],
           },
         },

--- a/docs/docs-reanimated/docs/guides/web-support.mdx
+++ b/docs/docs-reanimated/docs/guides/web-support.mdx
@@ -53,7 +53,6 @@ module.exports = {
           options: {
             presets: [
               '@babel/preset-react',
-              { plugins: ['@babel/plugin-transform-class-properties'] },
             ],
           },
         },

--- a/docs/docs-reanimated/docs/scroll/useScrollOffset.mdx
+++ b/docs/docs-reanimated/docs/scroll/useScrollOffset.mdx
@@ -47,7 +47,7 @@ function App() {
 
 #### `animatedRef`
 
-An [animated ref](/docs/core/useAnimatedRef#returns) connected to the scrollable component you'd want to scroll on. The animated ref has to be passed either to an \[Animated component]\(/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
+An [animated ref](/docs/core/useAnimatedRef#returns) connected to the scrollable component you'd want to scroll on. The animated ref has to be passed either to an [Animated component](/docs/fundamentals/glossary#animated-component) or a React Native built-in component.
 
 #### `providedOffset` <Optional/>
 


### PR DESCRIPTION
## Summary

Two small documentation fixes in the Reanimated docs.

**1. Deprecated Babel plugin names in the Web setup docs (Fixes #7098).**

Babel renamed these plugins in 7.18.0 and dropped the `proposal` stage from the names (the `-proposal-` form is now a deprecated alias). The Web setup instructions still use the old names:

- `docs/fundamentals/getting-started.mdx` (#### Web): `@babel/plugin-proposal-export-namespace-from` -> `@babel/plugin-transform-export-namespace-from` in the prose, the npm/yarn install commands, and the `babel.config.js` snippet. The `babeljs.io` link is updated to the current page as well.
- `docs/guides/web-support.mdx`: `@babel/plugin-proposal-class-properties` -> `@babel/plugin-transform-class-properties`.

This matches what the repository itself already uses: `packages/react-native-worklets/package.json` depends on the `@babel/plugin-transform-*` names (e.g. `@babel/plugin-transform-class-properties`), not the `-proposal-` aliases.

This is just the rename; it does not claim the plugin is unnecessary.

**2. Escaped markdown link in `docs/scroll/useScrollOffset.mdx`.**

The "Animated component" link in the `animatedRef` description was backslash-escaped (`\[Animated component]\(...\)`), so it rendered as literal text instead of linking to the glossary. Removed the three stray backslashes. The sibling `[animated ref](...)` link in the same sentence was already correct and is unchanged.

## Test plan

Documentation-only text change (no code). Verified by reading the rendered Markdown:

- The plugin names in the prose, install commands, and `babel.config.js` snippet now read `@babel/plugin-transform-export-namespace-from` / `@babel/plugin-transform-class-properties`.
- The `useScrollOffset` "Animated component" reference is now a proper Markdown link (`[Animated component](/docs/fundamentals/glossary#animated-component)`) rather than escaped literal text.