### PR TITLE
fix: Android ANR deadlock between CSS updates-registry lock and Fabric commit

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -22,6 +22,13 @@ jsi::Value ViewStylesRepository::getNodeProp(
       newestNode ? dynamic_cast<const LayoutableShadowNode *>(newestNode.get()) : nullptr;
 
   if (propName == "width" || propName == "height" || propName == "top" || propName == "left") {
+    // The node can be missing from the last mounted tree while its CSS animation
+    // is still flushing: on unmount the view is only marked removable and the
+    // animation stays registered until handleNodeRemovals prunes it at the next
+    // non-Reanimated mount. Resolve relative lengths against a zero frame in that
+    // window; returning a number (not undefined) keeps resolve() from returning
+    // nullopt, which would make relative transform ops (translateX/Y %,
+    // transformOrigin %) throw.
     const auto layoutMetrics = layoutableShadowNode ? layoutableShadowNode->layoutMetrics_ : LayoutMetrics{};
 
     if (propName == "width") {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -32,6 +32,9 @@ jsi::Value ViewStylesRepository::getNodeProp(
     }
   } else {
     const auto &viewProps = cachedNode.viewProps;
+    if (!viewProps) {
+      return jsi::Value::undefined();
+    }
 
     if (propName == "opacity") {
       return {viewProps->opacity};
@@ -48,21 +51,47 @@ jsi::Value ViewStylesRepository::getNodeProp(
 jsi::Value ViewStylesRepository::getParentNodeProp(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::string &propName) {
-  const auto surfaceId = shadowNode->getSurfaceId();
-  const auto &shadowTreeRegistry = uiManager_->getShadowTreeRegistry();
-
-  std::shared_ptr<const ShadowNode> parentNode = nullptr;
-
-  shadowTreeRegistry.visit(surfaceId, [&](ShadowTree const &shadowTree) {
-    auto currentRevision = shadowTree.getCurrentRevision();
-    parentNode = dom::getParentNode(currentRevision.rootShadowNode, *shadowNode);
-  });
+  const auto parentNode = getParentNode(shadowNode);
 
   if (!parentNode) {
     return jsi::Value::undefined();
   }
 
   return getNodeProp(parentNode, propName);
+}
+
+std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
+    const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
+  if (it == lastMountedRootBySurface_.end()) {
+    return nullptr;
+  }
+  const auto &root = it->second;
+
+  if (ShadowNode::sameFamily(*root, *shadowNode)) {
+    return root;
+  }
+
+  const auto ancestors = shadowNode->getFamily().getAncestors(*root);
+  if (ancestors.empty()) {
+    return nullptr;
+  }
+
+  const auto &deepest = ancestors.back();
+  return deepest.first.get().getChildren().at(deepest.second);
+}
+
+std::shared_ptr<const ShadowNode> ViewStylesRepository::getParentNode(
+    const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
+  if (it == lastMountedRootBySurface_.end()) {
+    return nullptr;
+  }
+  return dom::getParentNode(it->second, *shadowNode);
+}
+
+void ViewStylesRepository::setLastMountedRoot(const RootShadowNode::Shared &rootShadowNode) {
+  lastMountedRootBySurface_[rootShadowNode->getSurfaceId()] = rootShadowNode;
 }
 
 folly::dynamic ViewStylesRepository::getStyleProp(const Tag tag, const PropertyPath &propertyPath) {
@@ -81,7 +110,11 @@ void ViewStylesRepository::clearNodesCache() {
 void ViewStylesRepository::updateCacheIfNeeded(
     CachedShadowNode &cachedNode,
     const std::shared_ptr<const ShadowNode> &shadowNode) {
-  auto newestCloneOfShadowNode = uiManager_->getNewestCloneOfShadowNode(*shadowNode);
+  // Resolve against the last mounted tree (captured by the mount hook) rather than
+  // the live ShadowTree. This avoids taking the ShadowTree revision lock here,
+  // which would deadlock against a Fabric commit that holds it and waits for the
+  // updates-registry lock we are holding.
+  auto newestCloneOfShadowNode = getNewestNode(shadowNode);
 
   // Check if newestCloneOfShadowNode is valid (is already mounted / not
   // yet unmounted)

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -13,11 +13,9 @@ ViewStylesRepository::ViewStylesRepository(
 jsi::Value ViewStylesRepository::getNodeProp(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::string &propName) {
-  // Resolve against the freshly mounted node (recorded by the mount hook); before the
-  // first mount snapshots this surface, or for a removed node, fall back to the passed
-  // node, which still carries its last layout.
-  const auto newestNode = getNewestNode(shadowNode);
-  const auto &resolvedNode = newestNode ? newestNode : shadowNode;
+  // Resolve against the freshly mounted node; getNewestNode falls back to the passed
+  // node before the first mount snapshots this surface (or for a removed node).
+  const auto resolvedNode = getNewestNode(shadowNode);
   const auto *layoutableShadowNode = dynamic_cast<const LayoutableShadowNode *>(resolvedNode.get());
 
   if (propName == "width" || propName == "height" || propName == "top" || propName == "left") {
@@ -67,13 +65,14 @@ jsi::Value ViewStylesRepository::getParentNodeProp(
 
 std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
     const std::shared_ptr<const ShadowNode> &shadowNode) const {
-  // Same walk as RN's UIManager::getShadowNodeInSubtree (which is private): find this
-  // family's node inside the given root. We resolve against the last mounted root
-  // rather than the live tree so we never take the ShadowTree lock that the public
-  // getNewestCloneOfShadowNode would (the AB-BA deadlock with Fabric commits).
+  // Find this family's node in the last mounted root (the same walk as RN's private
+  // UIManager::getShadowNodeInSubtree), so we never take the ShadowTree lock that the
+  // public getNewestCloneOfShadowNode would (the AB-BA deadlock with Fabric commits).
+  // Fall back to the passed node, which still holds its last layout, until the first
+  // mount snapshots this surface (or if it is no longer in the tree).
   const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
   if (it == lastMountedRootBySurface_.end()) {
-    return nullptr;
+    return shadowNode;
   }
   const auto &root = it->second;
 
@@ -83,7 +82,7 @@ std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
 
   const auto ancestors = shadowNode->getFamily().getAncestors(*root);
   if (ancestors.empty()) {
-    return nullptr;
+    return shadowNode;
   }
 
   const auto &deepest = ancestors.back();

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -13,8 +13,6 @@ ViewStylesRepository::ViewStylesRepository(
 jsi::Value ViewStylesRepository::getNodeProp(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::string &propName) {
-  // Resolve against the freshly mounted node; getNewestNode falls back to the passed
-  // node before the first mount snapshots this surface (or for a removed node).
   const auto resolvedNode = getNewestNode(shadowNode);
   const auto *layoutableShadowNode = dynamic_cast<const LayoutableShadowNode *>(resolvedNode.get());
 
@@ -65,11 +63,10 @@ jsi::Value ViewStylesRepository::getParentNodeProp(
 
 std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
     const std::shared_ptr<const ShadowNode> &shadowNode) const {
-  // Find this family's node in the last mounted root (the same walk as RN's private
-  // UIManager::getShadowNodeInSubtree), so we never take the ShadowTree lock that the
-  // public getNewestCloneOfShadowNode would (the AB-BA deadlock with Fabric commits).
-  // Fall back to the passed node, which still holds its last layout, until the first
-  // mount snapshots this surface (or if it is no longer in the tree).
+  // Resolve shadowNode against the last mounted root without the ShadowTree lock (the
+  // deadlock) that getNewestCloneOfShadowNode takes, falling back to the passed node.
+  // Mirrors RN's getShadowNodeInSubtree:
+  // https://github.com/facebook/react-native/blob/v0.86.0-rc.3/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp#L339
   const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
   if (it == lastMountedRootBySurface_.end()) {
     return shadowNode;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -13,19 +13,14 @@ ViewStylesRepository::ViewStylesRepository(
 jsi::Value ViewStylesRepository::getNodeProp(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::string &propName) {
-  // Resolve against the last mounted tree (captured by the mount hook) rather
-  // than the live ShadowTree. This avoids taking the ShadowTree revision lock
-  // here, which would deadlock against a Fabric commit that holds it and waits
-  // for the updates-registry lock we are holding.
+  // Resolve against the freshly mounted node (recorded by the mount hook); before the
+  // first mount snapshots this surface, or for a removed node, fall back to the passed
+  // node, which still carries its last layout.
   const auto newestNode = getNewestNode(shadowNode);
-  const auto *layoutableShadowNode =
-      newestNode ? dynamic_cast<const LayoutableShadowNode *>(newestNode.get()) : nullptr;
+  const auto &resolvedNode = newestNode ? newestNode : shadowNode;
+  const auto *layoutableShadowNode = dynamic_cast<const LayoutableShadowNode *>(resolvedNode.get());
 
   if (propName == "width" || propName == "height" || propName == "top" || propName == "left") {
-    // newestNode is null only before the first mount records a snapshot for this
-    // surface, or for a node already removed from the tree. Fall back to a zero
-    // frame; returning a number (not undefined) keeps resolve() from yielding
-    // nullopt, which would make relative transform ops throw.
     const auto layoutMetrics = layoutableShadowNode ? layoutableShadowNode->layoutMetrics_ : LayoutMetrics{};
 
     if (propName == "width") {
@@ -41,7 +36,7 @@ jsi::Value ViewStylesRepository::getNodeProp(
     if (!layoutableShadowNode) {
       return jsi::Value::undefined();
     }
-    const auto viewProps = std::static_pointer_cast<const ViewProps>(newestNode->getProps());
+    const auto viewProps = std::static_pointer_cast<const ViewProps>(resolvedNode->getProps());
     if (!viewProps) {
       return jsi::Value::undefined();
     }
@@ -72,6 +67,10 @@ jsi::Value ViewStylesRepository::getParentNodeProp(
 
 std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
     const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  // Same walk as RN's UIManager::getShadowNodeInSubtree (which is private): find this
+  // family's node inside the given root. We resolve against the last mounted root
+  // rather than the live tree so we never take the ShadowTree lock that the public
+  // getNewestCloneOfShadowNode would (the AB-BA deadlock with Fabric commits).
   const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
   if (it == lastMountedRootBySurface_.end()) {
     return nullptr;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -1,4 +1,5 @@
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <reanimated/Tools/FeatureFlags.h>
 
 #include <memory>
 #include <string>
@@ -63,6 +64,13 @@ jsi::Value ViewStylesRepository::getParentNodeProp(
 
 std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
     const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+    // Backend mode has no commit hook (it returns before taking the updates-registry
+    // lock), so reading the live tree here cannot deadlock and needs no snapshot.
+    const auto newestNode = uiManager_->getNewestCloneOfShadowNode(*shadowNode);
+    return newestNode ? newestNode : shadowNode;
+  }
+
   // Resolve shadowNode against the last mounted root without the ShadowTree lock (the
   // deadlock) that getNewestCloneOfShadowNode takes, falling back to the passed node.
   // Mirrors RN's getShadowNodeInSubtree:
@@ -88,6 +96,15 @@ std::shared_ptr<const ShadowNode> ViewStylesRepository::getNewestNode(
 
 std::shared_ptr<const ShadowNode> ViewStylesRepository::getParentNode(
     const std::shared_ptr<const ShadowNode> &shadowNode) const {
+  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+    // Backend mode resolves against the live tree (see getNewestNode).
+    std::shared_ptr<const ShadowNode> parentNode = nullptr;
+    uiManager_->getShadowTreeRegistry().visit(shadowNode->getSurfaceId(), [&](const ShadowTree &shadowTree) {
+      parentNode = dom::getParentNode(shadowTree.getCurrentRevision().rootShadowNode, *shadowNode);
+    });
+    return parentNode;
+  }
+
   const auto it = lastMountedRootBySurface_.find(shadowNode->getSurfaceId());
   if (it == lastMountedRootBySurface_.end()) {
     return nullptr;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -13,13 +13,16 @@ ViewStylesRepository::ViewStylesRepository(
 jsi::Value ViewStylesRepository::getNodeProp(
     const std::shared_ptr<const ShadowNode> &shadowNode,
     const std::string &propName) {
-  int tag = shadowNode->getTag();
-
-  auto &cachedNode = shadowNodeCache_[tag];
-  updateCacheIfNeeded(cachedNode, shadowNode);
+  // Resolve against the last mounted tree (captured by the mount hook) rather
+  // than the live ShadowTree. This avoids taking the ShadowTree revision lock
+  // here, which would deadlock against a Fabric commit that holds it and waits
+  // for the updates-registry lock we are holding.
+  const auto newestNode = getNewestNode(shadowNode);
+  const auto *layoutableShadowNode =
+      newestNode ? dynamic_cast<const LayoutableShadowNode *>(newestNode.get()) : nullptr;
 
   if (propName == "width" || propName == "height" || propName == "top" || propName == "left") {
-    const auto &layoutMetrics = cachedNode.layoutMetrics;
+    const auto layoutMetrics = layoutableShadowNode ? layoutableShadowNode->layoutMetrics_ : LayoutMetrics{};
 
     if (propName == "width") {
       return {layoutMetrics.frame.size.width};
@@ -31,7 +34,10 @@ jsi::Value ViewStylesRepository::getNodeProp(
       return {layoutMetrics.frame.origin.x};
     }
   } else {
-    const auto &viewProps = cachedNode.viewProps;
+    if (!layoutableShadowNode) {
+      return jsi::Value::undefined();
+    }
+    const auto viewProps = std::static_pointer_cast<const ViewProps>(newestNode->getProps());
     if (!viewProps) {
       return jsi::Value::undefined();
     }
@@ -101,34 +107,6 @@ folly::dynamic ViewStylesRepository::getStyleProp(const Tag tag, const PropertyP
   }
 
   return getPropertyValue(staticPropsRegistry_->get(tag), propertyPath);
-}
-
-void ViewStylesRepository::clearNodesCache() {
-  shadowNodeCache_.clear();
-}
-
-void ViewStylesRepository::updateCacheIfNeeded(
-    CachedShadowNode &cachedNode,
-    const std::shared_ptr<const ShadowNode> &shadowNode) {
-  // Resolve against the last mounted tree (captured by the mount hook) rather than
-  // the live ShadowTree. This avoids taking the ShadowTree revision lock here,
-  // which would deadlock against a Fabric commit that holds it and waits for the
-  // updates-registry lock we are holding.
-  auto newestCloneOfShadowNode = getNewestNode(shadowNode);
-
-  // Check if newestCloneOfShadowNode is valid (is already mounted / not
-  // yet unmounted)
-  if (!newestCloneOfShadowNode) {
-    return;
-  }
-
-  auto layoutableShadowNode = dynamic_cast<const LayoutableShadowNode *>(newestCloneOfShadowNode.get());
-  if (!layoutableShadowNode) {
-    return;
-  }
-
-  cachedNode.layoutMetrics = layoutableShadowNode->layoutMetrics_;
-  cachedNode.viewProps = std::static_pointer_cast<const ViewProps>(newestCloneOfShadowNode->getProps());
 }
 
 folly::dynamic ViewStylesRepository::getPropertyValue(const folly::dynamic &value, const PropertyPath &propertyPath) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.cpp
@@ -22,13 +22,10 @@ jsi::Value ViewStylesRepository::getNodeProp(
       newestNode ? dynamic_cast<const LayoutableShadowNode *>(newestNode.get()) : nullptr;
 
   if (propName == "width" || propName == "height" || propName == "top" || propName == "left") {
-    // The node can be missing from the last mounted tree while its CSS animation
-    // is still flushing: on unmount the view is only marked removable and the
-    // animation stays registered until handleNodeRemovals prunes it at the next
-    // non-Reanimated mount. Resolve relative lengths against a zero frame in that
-    // window; returning a number (not undefined) keeps resolve() from returning
-    // nullopt, which would make relative transform ops (translateX/Y %,
-    // transformOrigin %) throw.
+    // newestNode is null only before the first mount records a snapshot for this
+    // surface, or for a node already removed from the tree. Fall back to a zero
+    // frame; returning a number (not undefined) keeps resolve() from yielding
+    // nullopt, which would make relative transform ops throw.
     const auto layoutMetrics = layoutableShadowNode ? layoutableShadowNode->layoutMetrics_ : LayoutMetrics{};
 
     if (propName == "width") {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -18,11 +18,6 @@ namespace reanimated::css {
 using namespace facebook;
 using namespace react;
 
-struct CachedShadowNode {
-  LayoutMetrics layoutMetrics;
-  std::shared_ptr<const ViewProps> viewProps;
-};
-
 class ViewStylesRepository {
  public:
   ViewStylesRepository(
@@ -40,16 +35,12 @@ class ViewStylesRepository {
   /// (the AB-BA deadlock).
   void setLastMountedRoot(const RootShadowNode::Shared &rootShadowNode);
 
-  void clearNodesCache();
-
  private:
   std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
 
-  std::unordered_map<int, CachedShadowNode> shadowNodeCache_;
   std::unordered_map<SurfaceId, RootShadowNode::Shared> lastMountedRootBySurface_;
 
-  void updateCacheIfNeeded(CachedShadowNode &cachedNode, const std::shared_ptr<const ShadowNode> &shadowNode);
   std::shared_ptr<const ShadowNode> getNewestNode(const std::shared_ptr<const ShadowNode> &shadowNode) const;
   std::shared_ptr<const ShadowNode> getParentNode(const std::shared_ptr<const ShadowNode> &shadowNode) const;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -28,11 +28,6 @@ class ViewStylesRepository {
   jsi::Value getParentNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   folly::dynamic getStyleProp(Tag tag, const PropertyPath &propertyPath);
 
-  /// Records the latest mounted shadow tree for a surface. Called from the mount
-  /// hook (which holds the updates-registry lock). Relative-length resolution
-  /// reads layout from this snapshot instead of the live ShadowTree, so it never
-  /// takes the ShadowTree revision lock while the updates-registry lock is held
-  /// (the AB-BA deadlock).
   void setLastMountedRoot(const RootShadowNode::Shared &rootShadowNode);
 
  private:

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -8,6 +8,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/dom/DOM.h>
+#include <react/renderer/uimanager/UIManager.h>
 
 #include <memory>
 #include <string>
@@ -24,6 +25,10 @@ class ViewStylesRepository {
       const std::shared_ptr<StaticPropsRegistry> &staticPropsRegistry,
       const std::shared_ptr<AnimatedPropsRegistry> &animatedPropsRegistry);
 
+  void setUIManager(const std::shared_ptr<UIManager> &uiManager) {
+    uiManager_ = uiManager;
+  }
+
   jsi::Value getNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   jsi::Value getParentNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   folly::dynamic getStyleProp(Tag tag, const PropertyPath &propertyPath);
@@ -31,6 +36,7 @@ class ViewStylesRepository {
   void setLastMountedRoot(const RootShadowNode::Shared &rootShadowNode);
 
  private:
+  std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/misc/ViewStylesRepository.h
@@ -4,6 +4,7 @@
 #include <reanimated/CSS/registries/StaticPropsRegistry.h>
 #include <reanimated/Fabric/updates/AnimatedPropsRegistry.h>
 
+#include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <react/renderer/dom/DOM.h>
@@ -28,24 +29,29 @@ class ViewStylesRepository {
       const std::shared_ptr<StaticPropsRegistry> &staticPropsRegistry,
       const std::shared_ptr<AnimatedPropsRegistry> &animatedPropsRegistry);
 
-  void setUIManager(const std::shared_ptr<UIManager> &uiManager) {
-    uiManager_ = uiManager;
-  }
-
   jsi::Value getNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   jsi::Value getParentNodeProp(const std::shared_ptr<const ShadowNode> &shadowNode, const std::string &propName);
   folly::dynamic getStyleProp(Tag tag, const PropertyPath &propertyPath);
 
+  /// Records the latest mounted shadow tree for a surface. Called from the mount
+  /// hook (which holds the updates-registry lock). Relative-length resolution
+  /// reads layout from this snapshot instead of the live ShadowTree, so it never
+  /// takes the ShadowTree revision lock while the updates-registry lock is held
+  /// (the AB-BA deadlock).
+  void setLastMountedRoot(const RootShadowNode::Shared &rootShadowNode);
+
   void clearNodesCache();
 
  private:
-  std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
   std::shared_ptr<AnimatedPropsRegistry> animatedPropsRegistry_;
 
   std::unordered_map<int, CachedShadowNode> shadowNodeCache_;
+  std::unordered_map<SurfaceId, RootShadowNode::Shared> lastMountedRootBySurface_;
 
   void updateCacheIfNeeded(CachedShadowNode &cachedNode, const std::shared_ptr<const ShadowNode> &shadowNode);
+  std::shared_ptr<const ShadowNode> getNewestNode(const std::shared_ptr<const ShadowNode> &shadowNode) const;
+  std::shared_ptr<const ShadowNode> getParentNode(const std::shared_ptr<const ShadowNode> &shadowNode) const;
 
   static folly::dynamic getPropertyValue(const folly::dynamic &value, const PropertyPath &propertyPath);
 };

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -41,8 +41,7 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = updatesRegistryManager_->lock();
-    // Record the mounted tree for relative-length resolution. Must run for every mount,
-    // including Reanimated's own - during an animation those are usually the only mounts.
+    // Record the mounted tree for relative-length resolution.
     viewStylesRepository_->setLastMountedRoot(rootShadowNode);
 
     if (isReanimatedMount) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -9,8 +9,12 @@ namespace reanimated {
 ReanimatedMountHook::ReanimatedMountHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
+    const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
     const std::function<void()> &requestFlush)
-    : uiManager_(uiManager), updatesRegistryManager_(updatesRegistryManager), requestFlush_(requestFlush) {
+    : uiManager_(uiManager),
+      updatesRegistryManager_(updatesRegistryManager),
+      viewStylesRepository_(viewStylesRepository),
+      requestFlush_(requestFlush) {
   uiManager_->registerMountHook(*this);
 }
 
@@ -37,6 +41,10 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = updatesRegistryManager_->lock();
+    // Snapshot the freshly mounted (laid-out) tree under the updates-registry lock,
+    // so relative-length resolution can read layout from it without taking the
+    // ShadowTree revision lock (the AB-BA deadlock with Fabric commits).
+    viewStylesRepository_->setLastMountedRoot(rootShadowNode);
     updatesRegistryManager_->handleNodeRemovals(*rootShadowNode);
 
     // When commit from React Native has finished, we reset the skip commit flag

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -41,9 +41,8 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = updatesRegistryManager_->lock();
-    // Record the freshly mounted tree so relative-length resolution can read layout
-    // from it. This must run for every mount, including Reanimated's own: during an
-    // animation those are usually the only mounts, and they carry the latest layout.
+    // Record the mounted tree for relative-length resolution. Must run for every mount,
+    // including Reanimated's own - during an animation those are usually the only mounts.
     viewStylesRepository_->setLastMountedRoot(rootShadowNode);
 
     if (isReanimatedMount) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -41,11 +41,9 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = updatesRegistryManager_->lock();
-    // Record the freshly mounted (laid-out) tree under the updates-registry lock so
-    // relative-length resolution can read layout from it without taking the ShadowTree
-    // revision lock (the AB-BA deadlock with Fabric commits). This must run for every
-    // mount, including Reanimated's own: during an animation those carry the latest
-    // layout and are usually the only mounts there are.
+    // Record the freshly mounted tree so relative-length resolution can read layout
+    // from it. This must run for every mount, including Reanimated's own: during an
+    // animation those are usually the only mounts, and they carry the latest layout.
     viewStylesRepository_->setLastMountedRoot(rootShadowNode);
 
     if (isReanimatedMount) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -30,21 +30,28 @@ void ReanimatedMountHook::shadowTreeDidMount(
   auto reaShadowNode = std::reinterpret_pointer_cast<ReanimatedCommitShadowNode>(
       std::const_pointer_cast<RootShadowNode>(rootShadowNode));
 
-  if (reaShadowNode->hasReanimatedMountTrait()) {
+  const bool isReanimatedMount = reaShadowNode->hasReanimatedMountTrait();
+  if (isReanimatedMount) {
     // We mark reanimated commits with ReanimatedMountTrait. We don't want other
     // shadow nodes to use this trait, but since this rootShadowNode is Shared,
     // we don't have that guarantee. That's why we also unset this trait in the
     // commit hook. We remove it here mainly for the sake of cleanliness.
     reaShadowNode->unsetReanimatedMountTrait();
-    return;
   }
 
   {
     auto lock = updatesRegistryManager_->lock();
-    // Snapshot the freshly mounted (laid-out) tree under the updates-registry lock,
-    // so relative-length resolution can read layout from it without taking the
-    // ShadowTree revision lock (the AB-BA deadlock with Fabric commits).
+    // Record the freshly mounted (laid-out) tree under the updates-registry lock so
+    // relative-length resolution can read layout from it without taking the ShadowTree
+    // revision lock (the AB-BA deadlock with Fabric commits). This must run for every
+    // mount, including Reanimated's own: during an animation those carry the latest
+    // layout and are usually the only mounts there are.
     viewStylesRepository_->setLastMountedRoot(rootShadowNode);
+
+    if (isReanimatedMount) {
+      return;
+    }
+
     updatesRegistryManager_->handleNodeRemovals(*rootShadowNode);
 
     // When commit from React Native has finished, we reset the skip commit flag

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <reanimated/CSS/misc/ViewStylesRepository.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 
@@ -16,6 +17,7 @@ class ReanimatedMountHook : public UIManagerMountHook {
   ReanimatedMountHook(
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
+      const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
       const std::function<void()> &requestFlush);
   ~ReanimatedMountHook() noexcept override;
 
@@ -24,6 +26,7 @@ class ReanimatedMountHook : public UIManagerMountHook {
  private:
   const std::shared_ptr<UIManager> uiManager_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
+  const std::shared_ptr<css::ViewStylesRepository> viewStylesRepository_;
   const std::function<void()> requestFlush_;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1169,6 +1169,7 @@ jsi::Value ReanimatedModuleProxy::measure(jsi::Runtime &rt, const jsi::Value &sh
 
 void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &uiManager) {
   uiManager_ = uiManager;
+  viewStylesRepository_->setUIManager(uiManager_);
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     react_native_assert(
@@ -1198,15 +1199,10 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     strongThis->requestFlushRegistry();
   };
 
-  viewStylesRepository_->setUIManager(uiManager_);
-
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
-    // Backend mode resolves relative lengths against the live tree (its commit hook is
-    // disabled, so that can't deadlock), so it needs no mount hook for that.
-    // TODO: handleNodeRemovals is still missing here and leaks - fix in a follow-up.
+    // TODO: we don't use the mount hook here, but we still need a way to handleNodeRemovals
+    // for now we leave this to leak the memory, a fix will come in a follow-up
   } else {
-    // The mount hook records the last mounted tree so relative-length resolution can
-    // read layout from it without taking the ShadowTree lock, and runs handleNodeRemovals.
     mountHook_ =
         std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -810,11 +810,6 @@ void ReanimatedModuleProxy::performOperations() {
   }
 
   commitUpdates(uiRuntime, updatesBatch);
-
-  // Clear the entire cache after the commit
-  // (we don't know if the view is updated from outside of Reanimated
-  // so we have to clear the entire cache)
-  viewStylesRepository_->clearNodesCache();
 }
 
 void ReanimatedModuleProxy::performNonLayoutOperations() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1198,12 +1198,18 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     strongThis->requestFlushRegistry();
   };
 
-  // The mount hook records the last mounted tree (so relative CSS lengths resolve
-  // without taking the ShadowTree lock) and runs handleNodeRemovals; both are
-  // needed in every mode including the animation backend, so register it
-  // unconditionally.
-  mountHook_ =
-      std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
+  viewStylesRepository_->setUIManager(uiManager_);
+
+  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+    // Backend mode resolves relative lengths against the live tree (its commit hook is
+    // disabled, so that can't deadlock), so it needs no mount hook for that.
+    // TODO: handleNodeRemovals is still missing here and leaks - fix in a follow-up.
+  } else {
+    // The mount hook records the last mounted tree so relative-length resolution can
+    // read layout from it without taking the ShadowTree lock, and runs handleNodeRemovals.
+    mountHook_ =
+        std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
+  }
 
   commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1174,7 +1174,6 @@ jsi::Value ReanimatedModuleProxy::measure(jsi::Runtime &rt, const jsi::Value &sh
 
 void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &uiManager) {
   uiManager_ = uiManager;
-  viewStylesRepository_->setUIManager(uiManager_);
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     react_native_assert(
@@ -1208,7 +1207,8 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     // TODO: we don't use the mount hook here, but we still need a way to handleNodeRemovals
     // for now we leave this to leak the memory, a fix will come in a follow-up
   } else {
-    mountHook_ = std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, request);
+    mountHook_ =
+        std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
   }
 
   commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1198,13 +1198,12 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     strongThis->requestFlushRegistry();
   };
 
-  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
-    // TODO: we don't use the mount hook here, but we still need a way to handleNodeRemovals
-    // for now we leave this to leak the memory, a fix will come in a follow-up
-  } else {
-    mountHook_ =
-        std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
-  }
+  // The mount hook records the last mounted tree (so relative CSS lengths resolve
+  // without taking the ShadowTree lock) and runs handleNodeRemovals; both are
+  // needed in every mode including the animation backend, so register it
+  // unconditionally.
+  mountHook_ =
+      std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
 
   commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
 }


### PR DESCRIPTION
## Issue

On Android, screens using a relative CSS length (e.g. a `transformOrigin` mixing `%` and `px`) could freeze (ANR). Resolving the relative length read the live ShadowTree, which takes the ShadowTree commit lock, while holding Reanimated's updates-registry lock; a concurrent Fabric commit takes the same two locks in the opposite order, so they deadlock (AB-BA). Regression from #9495.

## Fix

Resolve relative lengths against the last mounted tree instead of the live ShadowTree, so the read path never takes the ShadowTree lock. `ReanimatedMountHook` records the mounted root per surface (under the registry lock it already holds), and `ViewStylesRepository` reads layout from that snapshot via a plain parent/child walk. With lock A gone from Reanimated's read path, the AB-BA cycle can't form.

Animation-backend mode keeps reading the live tree (its commit hook is disabled there, so there is no deadlock to avoid).

Verified on device: Android (deadlock gone) and iOS (relative resolution correct).