### PR TITLE
fix: Handle offscreen scrollToLocation in SectionList scrollTo example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ScrollToExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ScrollToExample.tsx
@@ -198,14 +198,16 @@ const AnimatedSectionList = Animated.createAnimatedComponent(
 
 const SectionListExample = ({ animated, ref }: ExampleProps) => {
   const aref = useAnimatedRef<typeof AnimatedSectionList>();
+  const lastTarget = useRef({ sectionIndex: 0, itemIndex: 0 });
 
   useImperativeHandle(ref, () => ({
     scrollFromJS() {
       console.log(getRuntimeKind());
-      aref.current?.scrollToLocation({
+      lastTarget.current = {
         sectionIndex: Math.floor((Math.random() * DATA.length) / 10),
         itemIndex: Math.floor((Math.random() * DATA.length) / 10),
-      });
+      };
+      aref.current?.scrollToLocation(lastTarget.current);
     },
     scrollFromUI() {
       scheduleOnUI(() => {
@@ -240,6 +242,20 @@ const SectionListExample = ({ animated, ref }: ExampleProps) => {
         <Text style={styles.header}>{title}</Text>
       )}
       stickySectionHeadersEnabled={false}
+      // scrollToLocation can target a row that is still offscreen and not yet
+      // measured; without getItemLayout the list cannot know its offset and
+      // would otherwise throw. Jump to an approximate offset so the row renders,
+      // then retry the precise scroll once it is measured.
+      onScrollToIndexFailed={({ averageItemLength, index }) => {
+        aref.current?.getScrollResponder()?.scrollTo({
+          y: averageItemLength * index,
+          animated: false,
+        });
+        setTimeout(
+          () => aref.current?.scrollToLocation(lastTarget.current),
+          50
+        );
+      }}
     />
   );
 };


### PR DESCRIPTION
## Description

The SectionList tab of the scrollTo example crashed with `scrollToIndex should be used in conjunction with getItemLayout or onScrollToIndexFailed` when "Scroll from JS" targeted a section/item outside the rendered window.

This is React Native's `VirtualizedList` contract for index-based scrolling to a row that has not been measured yet, not a Reanimated issue: a plain `SectionList` with a plain ref reproduces the identical crash (same invariant, same call stack), and it has been present since the example was added. Without `getItemLayout` or `onScrollToIndexFailed`, RN throws when the target index is beyond the highest measured cell.

This adds an `onScrollToIndexFailed` handler that scrolls to the approximate offset so the target row renders, then retries the precise `scrollToLocation`, so the scroll lands instead of throwing.

## Test plan

Open the scrollTo example, select the SectionList tab, and press "Scroll from JS" repeatedly. It now scrolls to the target section instead of throwing the red box.
