### PR TITLE
feat: animate SVG props in CSS pseudo selectors on native

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -4,7 +4,7 @@ import Animated from 'react-native-reanimated';
 // TODO: Fix me
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
-import { Circle, Svg } from 'react-native-svg';
+import { Circle, G, Svg } from 'react-native-svg';
 
 import {
   Screen,
@@ -206,8 +206,6 @@ transform: {
           </VerticalExampleCard>
 
           <VerticalExampleCard
-            description="Currenlty Pseudoselectors in SVG are only supported on the Web."
-            labelTypes={['web']}
             title="SVG fill"
             code={`// Base geometry stays as real props so it renders at rest;
 // the ':active' style only swaps the changing prop.
@@ -218,7 +216,6 @@ transform: {
     fill: { default: colors.primary, ':active': colors.primaryDark },
     transitionDuration: '200ms',
   }}
-  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`fill: {
   default: colors.primary,
@@ -237,40 +234,102 @@ transform: {
                   },
                   transitionDuration: '200ms',
                 }}
-                onStartShouldSetResponder={() => true}
               />
             </Svg>
           </VerticalExampleCard>
 
           <VerticalExampleCard
-            labelTypes={['web']}
             title="SVG radius"
             code={`// r needs a base prop value, otherwise it renders at 0.
 <AnimatedCircle
-  cx={25} cy={25} fill={colors.primary}
-  r={12}
+  cx={30} cy={30} fill={colors.primary}
+  r={20}
   style={{
-    r: { default: 12, ':active': 24 },
+    r: { default: 20, ':active': 28 },
     transitionDuration: '200ms',
   }}
-  onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`r: {
-  default: 12,
-  ':active': 24,
+  default: 20,
+  ':active': 28,
 },`}>
-            <Svg height={sizes.md} width={sizes.md}>
+            <Svg height={sizes.lg} width={sizes.lg}>
+              <AnimatedCircle
+                cx={sizes.lg / 2}
+                cy={sizes.lg / 2}
+                fill={colors.primary}
+                r={sizes.lg / 3}
+                style={{
+                  r: { ':active': sizes.lg / 2 - 2, default: sizes.lg / 3 },
+                  transitionDuration: '200ms',
+                }}
+              />
+            </Svg>
+          </VerticalExampleCard>
+
+          <VerticalExampleCard
+            collapsedCode={`// two circles, each with its own ':active' fill`}
+            description="Two shapes under one Svg - pressing one animates only that shape."
+            title="Multiple SVG shapes (independent)"
+            code={`<Svg>
+  <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
+  <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
+</Svg>`}>
+            <Svg height={sizes.md} width={sizes.xl}>
               <AnimatedCircle
                 cx={sizes.md / 2}
                 cy={sizes.md / 2}
                 fill={colors.primary}
-                r={sizes.md / 4}
+                r={sizes.md / 2 - 2}
                 style={{
-                  r: { ':active': sizes.md / 2 - 2, default: sizes.md / 4 },
+                  fill: {
+                    ':active': colors.primaryDark,
+                    default: colors.primary,
+                  },
                   transitionDuration: '200ms',
                 }}
-                onStartShouldSetResponder={() => true}
               />
+              <AnimatedCircle
+                cx={sizes.xl - sizes.md / 2}
+                cy={sizes.md / 2}
+                fill={colors.primary}
+                r={sizes.md / 2 - 2}
+                style={{
+                  fill: {
+                    ':active': colors.primaryDark,
+                    default: colors.primary,
+                  },
+                  transitionDuration: '200ms',
+                }}
+              />
+            </Svg>
+          </VerticalExampleCard>
+
+          <VerticalExampleCard
+            collapsedCode="<G><AnimatedCircle ... /></G>"
+            description="A circle nested inside a <G> still resolves ':active' through the SvgView host."
+            title="SVG nested group"
+            code={`<Svg>
+  <G>
+    <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
+  </G>
+</Svg>`}>
+            <Svg height={sizes.md} width={sizes.md}>
+              <G>
+                <AnimatedCircle
+                  cx={sizes.md / 2}
+                  cy={sizes.md / 2}
+                  fill={colors.primary}
+                  r={sizes.md / 2 - 2}
+                  style={{
+                    fill: {
+                      ':active': colors.primaryDark,
+                      default: colors.primary,
+                    },
+                    transitionDuration: '200ms',
+                  }}
+                />
+              </G>
             </Svg>
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -4,7 +4,7 @@ import Animated from 'react-native-reanimated';
 // TODO: Fix me
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
-import { Circle, G, Svg } from 'react-native-svg';
+import { Circle, Svg } from 'react-native-svg';
 
 import {
   Screen,
@@ -264,72 +264,6 @@ transform: {
                   transitionDuration: '200ms',
                 }}
               />
-            </Svg>
-          </VerticalExampleCard>
-
-          <VerticalExampleCard
-            collapsedCode={`// two circles, each with its own ':active' fill`}
-            description="Two shapes under one Svg - pressing one animates only that shape."
-            title="Multiple SVG shapes (independent)"
-            code={`<Svg>
-  <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
-  <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
-</Svg>`}>
-            <Svg height={sizes.md} width={sizes.xl}>
-              <AnimatedCircle
-                cx={sizes.md / 2}
-                cy={sizes.md / 2}
-                fill={colors.primary}
-                r={sizes.md / 2 - 2}
-                style={{
-                  fill: {
-                    ':active': colors.primaryDark,
-                    default: colors.primary,
-                  },
-                  transitionDuration: '200ms',
-                }}
-              />
-              <AnimatedCircle
-                cx={sizes.xl - sizes.md / 2}
-                cy={sizes.md / 2}
-                fill={colors.primary}
-                r={sizes.md / 2 - 2}
-                style={{
-                  fill: {
-                    ':active': colors.primaryDark,
-                    default: colors.primary,
-                  },
-                  transitionDuration: '200ms',
-                }}
-              />
-            </Svg>
-          </VerticalExampleCard>
-
-          <VerticalExampleCard
-            collapsedCode="<G><AnimatedCircle ... /></G>"
-            description="A circle nested inside a <G> still resolves ':active' through the SvgView host."
-            title="SVG nested group"
-            code={`<Svg>
-  <G>
-    <AnimatedCircle ... style={{ fill: { default, ':active' } }} />
-  </G>
-</Svg>`}>
-            <Svg height={sizes.md} width={sizes.md}>
-              <G>
-                <AnimatedCircle
-                  cx={sizes.md / 2}
-                  cy={sizes.md / 2}
-                  fill={colors.primary}
-                  r={sizes.md / 2 - 2}
-                  style={{
-                    fill: {
-                      ':active': colors.primaryDark,
-                      default: colors.primary,
-                    },
-                    transitionDuration: '200ms',
-                  }}
-                />
-              </G>
             </Svg>
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
@@ -4,7 +4,7 @@ import Animated from 'react-native-reanimated';
 // TODO: Fix me
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
-import { Circle, G, Rect, Svg } from 'react-native-svg';
+import { Circle, Svg } from 'react-native-svg';
 
 import {
   Screen,
@@ -18,9 +18,6 @@ import { colors, radius, sizes, spacing } from '@/theme';
 const AnimatedCircle = Animated.createAnimatedComponent(
   Circle
 ) as ComponentType<Record<string, unknown>>;
-const AnimatedRect = Animated.createAnimatedComponent(Rect) as ComponentType<
-  Record<string, unknown>
->;
 
 function LayerLabel({ children }: { children: string }) {
   return (
@@ -330,73 +327,6 @@ transform: {
                   transitionDuration: '200ms',
                 }}
               />
-            </Svg>
-          </VerticalExampleCard>
-
-          <VerticalExampleCard
-            collapsedCode={`// rect + overlapping circle, each ':active-deepest'`}
-            description="A small Circle drawn on top of a Rect, both ':active-deepest'. Pressing inside the circle activates only the circle; pressing the rect elsewhere activates only the rect."
-            title="Circle over Rect (per-path)"
-            code={`<Svg>
-  <AnimatedRect ... style={{ fill: { default, ':active-deepest' } }} />
-  <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
-</Svg>`}>
-            <Svg height={sizes.lg} width={sizes.lg}>
-              <AnimatedRect
-                height={sizes.lg}
-                rx={radius.sm}
-                width={sizes.lg}
-                x={0}
-                y={0}
-                style={{
-                  fill: {
-                    ':active-deepest': '#ef9a9a',
-                    default: '#ffcdd2',
-                  },
-                  transitionDuration: '200ms',
-                }}
-              />
-              <AnimatedCircle
-                cx={sizes.lg / 2}
-                cy={sizes.lg / 2}
-                fill="#e53935"
-                r={sizes.lg / 4}
-                style={{
-                  fill: {
-                    ':active-deepest': '#b71c1c',
-                    default: '#e53935',
-                  },
-                  transitionDuration: '200ms',
-                }}
-              />
-            </Svg>
-          </VerticalExampleCard>
-
-          <VerticalExampleCard
-            collapsedCode="<G><AnimatedCircle ... /></G>"
-            description="A circle nested inside a <G> still resolves ':active-deepest' through the SvgView host's per-path hit-test."
-            title="SVG nested group"
-            code={`<Svg>
-  <G>
-    <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
-  </G>
-</Svg>`}>
-            <Svg height={sizes.md} width={sizes.md}>
-              <G>
-                <AnimatedCircle
-                  cx={sizes.md / 2}
-                  cy={sizes.md / 2}
-                  fill="#e53935"
-                  r={sizes.md / 2 - 2}
-                  style={{
-                    fill: {
-                      ':active-deepest': '#b71c1c',
-                      default: '#e53935',
-                    },
-                    transitionDuration: '200ms',
-                  }}
-                />
-              </G>
             </Svg>
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
@@ -1,5 +1,10 @@
+import type { ComponentType } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
+// TODO: Fix me
+/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+// @ts-ignore RNSVG doesn't export types for web, see https://github.com/software-mansion/react-native-svg/pull/2801
+import { Circle, G, Rect, Svg } from 'react-native-svg';
 
 import {
   Screen,
@@ -8,7 +13,14 @@ import {
   Text,
   VerticalExampleCard,
 } from '@/apps/css/components';
-import { colors, radius, spacing } from '@/theme';
+import { colors, radius, sizes, spacing } from '@/theme';
+
+const AnimatedCircle = Animated.createAnimatedComponent(
+  Circle
+) as ComponentType<Record<string, unknown>>;
+const AnimatedRect = Animated.createAnimatedComponent(Rect) as ComponentType<
+  Record<string, unknown>
+>;
 
 function LayerLabel({ children }: { children: string }) {
   return (
@@ -277,6 +289,115 @@ transform: {
                 </Animated.View>
               </Animated.View>
             </View>
+          </VerticalExampleCard>
+        </Section>
+
+        <Section
+          description="With SVG, ':active-deepest' resolves through the SvgView host's per-path hit-test, so only the topmost shape under the press activates - not the axis-aligned bounding box. (Android; iOS per-path deepest arbitration for SVG is a follow-up.)"
+          title="SVG :active-deepest">
+          <VerticalExampleCard
+            collapsedCode={`// two overlapping circles, each ':active-deepest'`}
+            description="Two equal circles overlapping in a lens region, both ':active-deepest'; the right circle is drawn on top. Pressing the overlap activates only the top (right) circle - proving per-path top-most arbitration, not bounding-box (both boxes cover the overlap). Each crescent activates only its own circle."
+            title="Overlapping circles (deepest wins)"
+            code={`<Svg>
+  <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
+  <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
+</Svg>`}>
+            <Svg height={sizes.md} width={sizes.xl}>
+              <AnimatedCircle
+                cx={sizes.md / 2 + 10}
+                cy={sizes.md / 2}
+                fill="#ffcdd2"
+                r={sizes.md / 2 - 2}
+                style={{
+                  fill: {
+                    ':active-deepest': '#ef9a9a',
+                    default: '#ffcdd2',
+                  },
+                  transitionDuration: '200ms',
+                }}
+              />
+              <AnimatedCircle
+                cx={sizes.xl - sizes.md / 2 - 10}
+                cy={sizes.md / 2}
+                fill="#e53935"
+                r={sizes.md / 2 - 2}
+                style={{
+                  fill: {
+                    ':active-deepest': '#b71c1c',
+                    default: '#e53935',
+                  },
+                  transitionDuration: '200ms',
+                }}
+              />
+            </Svg>
+          </VerticalExampleCard>
+
+          <VerticalExampleCard
+            collapsedCode={`// rect + overlapping circle, each ':active-deepest'`}
+            description="A small Circle drawn on top of a Rect, both ':active-deepest'. Pressing inside the circle activates only the circle; pressing the rect elsewhere activates only the rect."
+            title="Circle over Rect (per-path)"
+            code={`<Svg>
+  <AnimatedRect ... style={{ fill: { default, ':active-deepest' } }} />
+  <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
+</Svg>`}>
+            <Svg height={sizes.lg} width={sizes.lg}>
+              <AnimatedRect
+                height={sizes.lg}
+                rx={radius.sm}
+                width={sizes.lg}
+                x={0}
+                y={0}
+                style={{
+                  fill: {
+                    ':active-deepest': '#ef9a9a',
+                    default: '#ffcdd2',
+                  },
+                  transitionDuration: '200ms',
+                }}
+              />
+              <AnimatedCircle
+                cx={sizes.lg / 2}
+                cy={sizes.lg / 2}
+                fill="#e53935"
+                r={sizes.lg / 4}
+                style={{
+                  fill: {
+                    ':active-deepest': '#b71c1c',
+                    default: '#e53935',
+                  },
+                  transitionDuration: '200ms',
+                }}
+              />
+            </Svg>
+          </VerticalExampleCard>
+
+          <VerticalExampleCard
+            collapsedCode="<G><AnimatedCircle ... /></G>"
+            description="A circle nested inside a <G> still resolves ':active-deepest' through the SvgView host's per-path hit-test."
+            title="SVG nested group"
+            code={`<Svg>
+  <G>
+    <AnimatedCircle ... style={{ fill: { default, ':active-deepest' } }} />
+  </G>
+</Svg>`}>
+            <Svg height={sizes.md} width={sizes.md}>
+              <G>
+                <AnimatedCircle
+                  cx={sizes.md / 2}
+                  cy={sizes.md / 2}
+                  fill="#e53935"
+                  r={sizes.md / 2 - 2}
+                  style={{
+                    fill: {
+                      ':active-deepest': '#b71c1c',
+                      default: '#e53935',
+                    },
+                    transitionDuration: '200ms',
+                  }}
+                />
+              </G>
+            </Svg>
           </VerticalExampleCard>
         </Section>
       </Scroll>

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -18,11 +18,22 @@ class PseudoSelectorManager(
 
     private val activeDeepestViews = LinkedHashSet<View>()
 
-    // For "virtual" children that don't receive native touches themselves (e.g.
-    // react-native-svg elements): the compound host view (the SvgView) -> map of
-    // react tag -> (childView, callback). One touch listener per host dispatches
-    // to the right child via `reactTagForTouch`.
-    private val compoundActive = HashMap<View, HashMap<Int, Pair<View, PseudoSelectorCallback>>>()
+    // "Virtual" children (react-native-svg shapes) get no native touches, so we listen on
+    // their compound host: host -> tag -> entry, one listener routing presses via
+    // `reactTagForTouch`. :active and :active-deepest share it (one OnTouchListener per host).
+    private class CompoundActiveEntry(
+        val child: View,
+        val callback: PseudoSelectorCallback,
+        val isDeepest: Boolean,
+    )
+
+    private val compoundActive = HashMap<View, HashMap<Int, CompoundActiveEntry>>()
+
+    private val compoundHover = HashMap<View, HashMap<Int, Pair<View, PseudoSelectorCallback>>>()
+
+    // A shape can carry several selectors (e.g. :active and :hover), each marking it
+    // "responsible". Ref-count so detaching one doesn't unmark it while another needs it.
+    private val responsibleRefCounts = HashMap<View, Int>()
 
     fun attach(
         tag: Int,
@@ -37,16 +48,15 @@ class PseudoSelectorManager(
                 1 -> attachFocus(view, key, callback)
                 2 -> attachHoverWhenReady(tag, view, key, callback)
                 3 -> attachActiveWhenReady(tag, view, key, callback)
-                4 -> attachActiveDeepest(view, key, callback)
+                4 -> attachActiveDeepestWhenReady(tag, view, key, callback)
             }
         }
     }
 
     /**
-     * Returns the nearest ancestor that owns touch handling for "virtual" children
-     * (a [ReactCompoundView], e.g. react-native-svg's SvgView), or null when the
-     * view receives touches itself. Virtual children such as RNSVGCircle are not
-     * real touchable Android views, so a listener attached to them never fires.
+     * Nearest [ReactCompoundView] ancestor (e.g. react-native-svg's SvgView) that owns
+     * touch handling, or null if the view receives touches itself. Virtual children like
+     * RNSVGCircle aren't touchable Android views, so a listener on them never fires.
      */
     private fun compoundTouchHost(view: View): View? {
         var parent: ViewParent? = view.parent
@@ -60,11 +70,9 @@ class PseudoSelectorManager(
     }
 
     /**
-     * Routes _:active_ either to the compound host (for virtual SVG children) or to
-     * the view itself. When the view has not yet been inserted into its host (which
-     * is common at registration time, before the mounting layer attaches it), the
-     * decision is deferred until the view attaches to the window so the host chain
-     * is resolvable.
+     * Routes :active to the compound host (virtual SVG children) or the view itself.
+     * At registration the view often isn't attached yet, so the choice is deferred
+     * until it attaches and its host chain is resolvable.
      */
     private fun attachActiveWhenReady(
         tag: Int,
@@ -97,9 +105,27 @@ class PseudoSelectorManager(
     }
 
     /**
-     * Invokes [action] with the compound touch host once it can be resolved. If the
-     * view is already attached, runs synchronously; otherwise waits for the view to
-     * attach so a virtual child's host (the SvgView) is present in its parent chain.
+     * Routes :active-deepest to the compound host (virtual SVG children) or the view itself,
+     * deferring the choice until the view attaches and its host chain is resolvable.
+     */
+    private fun attachActiveDeepestWhenReady(
+        tag: Int,
+        view: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        whenHostResolvable(view, key) { host ->
+            if (host != null) {
+                attachActiveDeepestCompound(tag, view, host, key, callback)
+            } else {
+                attachActiveDeepest(view, key, callback)
+            }
+        }
+    }
+
+    /**
+     * Invokes [action] with the compound touch host once resolvable: synchronously if
+     * the view is attached, otherwise after it attaches and its host is in the parent chain.
      */
     private fun whenHostResolvable(
         view: View,
@@ -124,22 +150,50 @@ class PseudoSelectorManager(
     }
 
     /**
-     * react-native-svg only resolves a touch to an individual shape once that shape is
-     * marked "responsible" - normally the side effect of attaching a touch handler such
-     * as `onStartShouldSetResponder`. A pseudo selector targets the shape directly, so we
-     * set the flag ourselves through the public `setResponsible` hook and invalidate the
-     * host to rebuild its hit-testing state. Reflection avoids a hard dependency on
-     * react-native-svg; the call is a no-op for any other kind of compound child.
+     * react-native-svg only hit-tests a shape once marked "responsible" (normally via
+     * `onStartShouldSetResponder`, which a pseudo selector doesn't add), so we set it and
+     * invalidate the host. Reflection avoids a hard rn-svg dependency; no-op for other hosts.
      */
     private fun enableCompoundHitTesting(
         host: View,
         child: View,
     ) {
+        val count = responsibleRefCounts.getOrDefault(child, 0)
+        responsibleRefCounts[child] = count + 1
+        if (count > 0) {
+            return
+        }
+        setChildResponsible(child, true)
+        host.invalidate()
+    }
+
+    /**
+     * Reverts [enableCompoundHitTesting]'s `setResponsible(true)` when the child's last selector
+     * detaches; otherwise the shape stays touch-responsible forever, altering app hit-testing.
+     * SvgView's `mResponsible` latch can't be cleared, so reverting the child is all we can undo.
+     */
+    private fun disableCompoundHitTesting(
+        host: View,
+        child: View,
+    ) {
+        val count = responsibleRefCounts.getOrDefault(child, 0)
+        if (count <= 1) {
+            responsibleRefCounts.remove(child)
+            setChildResponsible(child, false)
+            host.invalidate()
+        } else {
+            responsibleRefCounts[child] = count - 1
+        }
+    }
+
+    private fun setChildResponsible(
+        child: View,
+        responsible: Boolean,
+    ) {
         try {
             child.javaClass
                 .getMethod("setResponsible", java.lang.Boolean.TYPE)
-                .invoke(child, true)
-            host.invalidate()
+                .invoke(child, responsible)
         } catch (e: Exception) {
         }
     }
@@ -151,20 +205,48 @@ class PseudoSelectorManager(
         key: String,
         callback: PseudoSelectorCallback,
     ) {
-        // Keep the child in activeCallbacks so :active still propagates up the tree.
-        activeCallbacks[childView] = callback
+        registerCompoundActiveEntry(tag, childView, host, key, callback, isDeepest = false)
+    }
+
+    private fun attachActiveDeepestCompound(
+        tag: Int,
+        childView: View,
+        host: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        registerCompoundActiveEntry(tag, childView, host, key, callback, isDeepest = true)
+    }
+
+    private fun registerCompoundActiveEntry(
+        tag: Int,
+        childView: View,
+        host: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+        isDeepest: Boolean,
+    ) {
+        // :active entries live in activeCallbacks (fired by fireActiveCallbacksUpTree); :active-deepest
+        // entries fire their own callback explicitly and only propagate to ANCESTOR :active views, so
+        // they stay out of activeCallbacks (mirrors the plain-view model; also avoids a double-fire).
+        if (!isDeepest) {
+            activeCallbacks[childView] = callback
+        }
         enableCompoundHitTesting(host, childView)
         val byTag =
             compoundActive.getOrPut(host) {
-                val map = HashMap<Int, Pair<View, PseudoSelectorCallback>>()
+                val map = HashMap<Int, CompoundActiveEntry>()
                 host.setOnTouchListener(compoundActiveListener(host, map))
                 map
             }
-        byTag[tag] = childView to callback
+        // Keyed by tag: a shape carrying BOTH :active and :active-deepest keeps only the
+        // last-registered entry. That combo is near-redundant, so it isn't supported.
+        byTag[tag] = CompoundActiveEntry(childView, callback, isDeepest)
         detachActions[key] =
             Runnable {
                 activeCallbacks.remove(childView)
                 byTag.remove(tag)
+                disableCompoundHitTesting(host, childView)
                 if (byTag.isEmpty()) {
                     compoundActive.remove(host)
                     host.setOnTouchListener(null)
@@ -172,24 +254,39 @@ class PseudoSelectorManager(
             }
     }
 
+    /**
+     * One touch listener per host, shared by :active and :active-deepest. SvgView's
+     * `reactTagForTouch` gives the deepest responsible shape under the point (per-path, z-order) -
+     * the natural :active-deepest arbiter, no bounds needed. On DOWN: ancestor :active views light
+     * up via [fireActiveCallbacksUpTree] from the hit shape, and the hit shape's :active-deepest
+     * fires only if that shape is itself a deepest entry.
+     */
     private fun compoundActiveListener(
         host: View,
-        byTag: Map<Int, Pair<View, PseudoSelectorCallback>>,
+        byTag: Map<Int, CompoundActiveEntry>,
     ): View.OnTouchListener {
+        val compound = host as ReactCompoundView
         var activeChild: View? = null
+        var deepestCallback: PseudoSelectorCallback? = null
         return View.OnTouchListener { _, event ->
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
-                    val hitTag = (host as ReactCompoundView).reactTagForTouch(event.x, event.y)
+                    val hitTag = compound.reactTagForTouch(event.x, event.y)
                     val entry = byTag[hitTag]
                     if (entry != null) {
-                        activeChild = entry.first
-                        fireActiveCallbacksUpTree(entry.first, true)
+                        activeChild = entry.child
+                        fireActiveCallbacksUpTree(entry.child, true)
+                        if (entry.isDeepest) {
+                            deepestCallback = entry.callback
+                            entry.callback.onSelectorStateChanged(true)
+                        }
                     }
                 }
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                     activeChild?.let { fireActiveCallbacksUpTree(it, false) }
+                    deepestCallback?.onSelectorStateChanged(false)
                     activeChild = null
+                    deepestCallback = null
                 }
             }
             false
@@ -203,25 +300,46 @@ class PseudoSelectorManager(
         key: String,
         callback: PseudoSelectorCallback,
     ) {
-        var isHovered = false
-        val listener =
-            View.OnHoverListener { _, event ->
-                val hitTag = (host as ReactCompoundView).reactTagForTouch(event.x, event.y)
-                val over =
-                    hitTag == tag &&
-                        event.actionMasked != MotionEvent.ACTION_HOVER_EXIT
-                if (over && !isHovered) {
-                    isHovered = true
-                    callback.onSelectorStateChanged(true)
-                } else if (!over && isHovered) {
-                    isHovered = false
-                    callback.onSelectorStateChanged(false)
-                }
-                false
-            }
         enableCompoundHitTesting(host, childView)
-        host.setOnHoverListener(listener)
-        detachActions[key] = Runnable { host.setOnHoverListener(null) }
+        val byTag =
+            compoundHover.getOrPut(host) {
+                val map = HashMap<Int, Pair<View, PseudoSelectorCallback>>()
+                host.setOnHoverListener(compoundHoverListener(host, map))
+                map
+            }
+        byTag[tag] = childView to callback
+        detachActions[key] =
+            Runnable {
+                byTag.remove(tag)
+                disableCompoundHitTesting(host, childView)
+                if (byTag.isEmpty()) {
+                    compoundHover.remove(host)
+                    host.setOnHoverListener(null)
+                }
+            }
+    }
+
+    private fun compoundHoverListener(
+        host: View,
+        byTag: Map<Int, Pair<View, PseudoSelectorCallback>>,
+    ): View.OnHoverListener {
+        val compound = host as ReactCompoundView
+        var hoveredTag: Int? = null
+        return View.OnHoverListener { _, event ->
+            val hitTag =
+                if (event.actionMasked == MotionEvent.ACTION_HOVER_EXIT) {
+                    null
+                } else {
+                    compound.reactTagForTouch(event.x, event.y)
+                }
+            val newTag = if (hitTag != null && byTag.containsKey(hitTag)) hitTag else null
+            if (newTag != hoveredTag) {
+                hoveredTag?.let { byTag[it]?.second?.onSelectorStateChanged(false) }
+                newTag?.let { byTag[it]?.second?.onSelectorStateChanged(true) }
+                hoveredTag = newTag
+            }
+            false
+        }
     }
 
     private fun attachFocusWithin(
@@ -347,9 +465,8 @@ class PseudoSelectorManager(
     }
 
     /**
-     * Returns true if any view in `activeDeepestViews` is a strict descendant of `ancestor`
-     * and contains the screen point (`rawX`, `rawY`).
-     * Used by _:active-deepest_ to yield priority to deeper registered views.
+     * True if any `activeDeepestViews` entry is a strict descendant of `ancestor` and
+     * contains (`rawX`, `rawY`). Lets :active-deepest yield to deeper registered views.
      */
     private fun hasDeepestDescendantAt(
         ancestor: View,
@@ -357,7 +474,7 @@ class PseudoSelectorManager(
         rawY: Float,
     ): Boolean {
         val loc = IntArray(2)
-        // TODO: Optimize so we don't iterate over all the views with :active-deepest every time.
+        // TODO: O(n) per touch; also wrong for SVG (hit area is per-path, not view bounds).
         for (candidate in activeDeepestViews) {
             if (candidate === ancestor) continue
             if (!isDescendantOf(candidate, ancestor)) continue
@@ -372,8 +489,7 @@ class PseudoSelectorManager(
     }
 
     /**
-     * Walk up its ancestor chain and fire
-     * the callback for every ancestor that has _:active_ registered.
+     * Fire the callback for `source` and every ancestor that has :active registered.
      */
     private fun fireActiveCallbacksUpTree(
         source: View,

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewParent
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.fabric.FabricUIManager
+import com.facebook.react.uimanager.ReactCompoundView
 import com.swmansion.reanimated.nativeProxy.PseudoSelectorCallback
 
 class PseudoSelectorManager(
@@ -17,6 +18,12 @@ class PseudoSelectorManager(
 
     private val activeDeepestViews = LinkedHashSet<View>()
 
+    // For "virtual" children that don't receive native touches themselves (e.g.
+    // react-native-svg elements): the compound host view (the SvgView) -> map of
+    // react tag -> (childView, callback). One touch listener per host dispatches
+    // to the right child via `reactTagForTouch`.
+    private val compoundActive = HashMap<View, HashMap<Int, Pair<View, PseudoSelectorCallback>>>()
+
     fun attach(
         tag: Int,
         selector: Int,
@@ -28,11 +35,193 @@ class PseudoSelectorManager(
             when (selector) {
                 0 -> attachFocusWithin(view, key, callback)
                 1 -> attachFocus(view, key, callback)
-                2 -> attachHover(view, key, callback)
-                3 -> attachActive(view, key, callback)
+                2 -> attachHoverWhenReady(tag, view, key, callback)
+                3 -> attachActiveWhenReady(tag, view, key, callback)
                 4 -> attachActiveDeepest(view, key, callback)
             }
         }
+    }
+
+    /**
+     * Returns the nearest ancestor that owns touch handling for "virtual" children
+     * (a [ReactCompoundView], e.g. react-native-svg's SvgView), or null when the
+     * view receives touches itself. Virtual children such as RNSVGCircle are not
+     * real touchable Android views, so a listener attached to them never fires.
+     */
+    private fun compoundTouchHost(view: View): View? {
+        var parent: ViewParent? = view.parent
+        while (parent != null) {
+            if (parent is ReactCompoundView && parent is View) {
+                return parent
+            }
+            parent = parent.parent
+        }
+        return null
+    }
+
+    /**
+     * Routes _:active_ either to the compound host (for virtual SVG children) or to
+     * the view itself. When the view has not yet been inserted into its host (which
+     * is common at registration time, before the mounting layer attaches it), the
+     * decision is deferred until the view attaches to the window so the host chain
+     * is resolvable.
+     */
+    private fun attachActiveWhenReady(
+        tag: Int,
+        view: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        whenHostResolvable(view, key) { host ->
+            if (host != null) {
+                attachActiveCompound(tag, view, host, key, callback)
+            } else {
+                attachActive(view, key, callback)
+            }
+        }
+    }
+
+    private fun attachHoverWhenReady(
+        tag: Int,
+        view: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        whenHostResolvable(view, key) { host ->
+            if (host != null) {
+                attachHoverCompound(tag, view, host, key, callback)
+            } else {
+                attachHover(view, key, callback)
+            }
+        }
+    }
+
+    /**
+     * Invokes [action] with the compound touch host once it can be resolved. If the
+     * view is already attached, runs synchronously; otherwise waits for the view to
+     * attach so a virtual child's host (the SvgView) is present in its parent chain.
+     */
+    private fun whenHostResolvable(
+        view: View,
+        key: String,
+        action: (View?) -> Unit,
+    ) {
+        if (view.isAttachedToWindow) {
+            action(compoundTouchHost(view))
+            return
+        }
+        val listener =
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) {
+                    v.removeOnAttachStateChangeListener(this)
+                    action(compoundTouchHost(v))
+                }
+
+                override fun onViewDetachedFromWindow(v: View) {}
+            }
+        view.addOnAttachStateChangeListener(listener)
+        detachActions[key] = Runnable { view.removeOnAttachStateChangeListener(listener) }
+    }
+
+    /**
+     * react-native-svg only resolves a touch to an individual shape once that shape is
+     * marked "responsible" - normally the side effect of attaching a touch handler such
+     * as `onStartShouldSetResponder`. A pseudo selector targets the shape directly, so we
+     * set the flag ourselves through the public `setResponsible` hook and invalidate the
+     * host to rebuild its hit-testing state. Reflection avoids a hard dependency on
+     * react-native-svg; the call is a no-op for any other kind of compound child.
+     */
+    private fun enableCompoundHitTesting(
+        host: View,
+        child: View,
+    ) {
+        try {
+            child.javaClass
+                .getMethod("setResponsible", java.lang.Boolean.TYPE)
+                .invoke(child, true)
+            host.invalidate()
+        } catch (e: Exception) {
+        }
+    }
+
+    private fun attachActiveCompound(
+        tag: Int,
+        childView: View,
+        host: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        // Keep the child in activeCallbacks so :active still propagates up the tree.
+        activeCallbacks[childView] = callback
+        enableCompoundHitTesting(host, childView)
+        val byTag =
+            compoundActive.getOrPut(host) {
+                val map = HashMap<Int, Pair<View, PseudoSelectorCallback>>()
+                host.setOnTouchListener(compoundActiveListener(host, map))
+                map
+            }
+        byTag[tag] = childView to callback
+        detachActions[key] =
+            Runnable {
+                activeCallbacks.remove(childView)
+                byTag.remove(tag)
+                if (byTag.isEmpty()) {
+                    compoundActive.remove(host)
+                    host.setOnTouchListener(null)
+                }
+            }
+    }
+
+    private fun compoundActiveListener(
+        host: View,
+        byTag: Map<Int, Pair<View, PseudoSelectorCallback>>,
+    ): View.OnTouchListener {
+        var activeChild: View? = null
+        return View.OnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    val hitTag = (host as ReactCompoundView).reactTagForTouch(event.x, event.y)
+                    val entry = byTag[hitTag]
+                    if (entry != null) {
+                        activeChild = entry.first
+                        fireActiveCallbacksUpTree(entry.first, true)
+                    }
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    activeChild?.let { fireActiveCallbacksUpTree(it, false) }
+                    activeChild = null
+                }
+            }
+            false
+        }
+    }
+
+    private fun attachHoverCompound(
+        tag: Int,
+        childView: View,
+        host: View,
+        key: String,
+        callback: PseudoSelectorCallback,
+    ) {
+        var isHovered = false
+        val listener =
+            View.OnHoverListener { _, event ->
+                val hitTag = (host as ReactCompoundView).reactTagForTouch(event.x, event.y)
+                val over =
+                    hitTag == tag &&
+                        event.actionMasked != MotionEvent.ACTION_HOVER_EXIT
+                if (over && !isHovered) {
+                    isHovered = true
+                    callback.onSelectorStateChanged(true)
+                } else if (!over && isHovered) {
+                    isHovered = false
+                    callback.onSelectorStateChanged(false)
+                }
+                false
+            }
+        enableCompoundHitTesting(host, childView)
+        host.setOnHoverListener(listener)
+        detachActions[key] = Runnable { host.setOnHoverListener(null) }
     }
 
     private fun attachFocusWithin(

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -25,11 +25,9 @@ typedef NSGestureRecognizer REAGestureRecognizer;
 
 @implementation REAPseudoSelectorObserver {
   __weak REAUIView *_view;
-  // The view the gesture recognizer is actually attached to. Usually `_view`,
-  // but for views that are never user-interactive themselves (e.g. SVG elements
-  // like RNSVGCircle, whose `isUserInteractionEnabled` is hardcoded to NO) it is
-  // the nearest interactive ancestor; touches are then scoped back to `_view`'s
-  // bounds in the gesture handlers.
+  // View the recognizer is attached to: `_view` for normal views, or the nearest
+  // interactive ancestor for non-interactive ones (e.g. SVG elements). See
+  // `interactionViewForView:`.
   __weak REAUIView *_interactionView;
   reanimated::PseudoSelector _selector;
 #if !TARGET_OS_OSX
@@ -85,24 +83,20 @@ typedef NSGestureRecognizer REAGestureRecognizer;
   }
 }
 
-// Returns the view the gesture recognizer should be attached to.
+// Returns the view the recognizer should attach to.
 //
-// react-native-svg elements never receive touches on their own (their
-// `isUserInteractionEnabled` getter is hardcoded to NO), and react-native-svg's
-// container views swallow touches that don't hit a "responsible" node, so a
-// recognizer attached to them (or to the SVG elements) never fires. To make
-// pseudo selectors work on SVG elements without requiring the user to add a
-// responder prop, we attach the recognizer to the nearest regular (non-SVG)
-// interactive ancestor - which reliably receives the touch - and scope the
-// gesture back to the element's bounds in `isTouchInScope:`. For regular views
-// this resolves to the view itself, preserving the existing behaviour.
+// SVG elements force `isUserInteractionEnabled` to NO and their container
+// swallows touches that miss a "responsible" node, so a recognizer on the SVG
+// element never fires. To support pseudo selectors on SVG without a responder
+// prop, attach to the nearest non-SVG interactive ancestor and scope the touch
+// back to the element's bounds in `isTouchInScope:`. Regular views resolve to
+// themselves.
 - (REAUIView *)interactionViewForView:(REAUIView *)view
 {
 #if !TARGET_OS_OSX
   REAUIView *candidate = view;
   while (candidate != nil &&
-         (!candidate.isUserInteractionEnabled ||
-          [NSStringFromClass([candidate class]) hasPrefix:@"RNSVG"])) {
+         (!candidate.isUserInteractionEnabled || [NSStringFromClass([candidate class]) hasPrefix:@"RNSVG"])) {
     candidate = candidate.superview;
   }
   return candidate ?: view;
@@ -111,9 +105,9 @@ typedef NSGestureRecognizer REAGestureRecognizer;
 #endif
 }
 
-// When the recognizer is attached to an ancestor (the SVG case), only treat the
-// gesture as targeting this element when the touch falls within the element's
-// bounds. For directly-attached recognizers there is nothing to scope.
+// When the recognizer is on an ancestor (SVG case), the gesture targets this
+// element only if the touch lands within its bounds. Directly-attached
+// recognizers are always in scope.
 - (BOOL)isTouchInScope:(REAGestureRecognizer *)recognizer
 {
   REAUIView *element = _view;
@@ -162,10 +156,10 @@ typedef NSGestureRecognizer REAGestureRecognizer;
 }
 
 #if !TARGET_OS_OSX
-// Fires only when this view's own text input gains focus.
-// On iOS, resolveView returns the Fabric wrapper (RCTTextInputComponentView), not the inner
-// UITextField/UITextView. The notification object is always the inner UITextField/UITextView,
-// which is always a direct child of the wrapper - so superview == strongView is sufficient.
+// Fires only when this view's own text input gains focus. resolveView returns
+// the Fabric wrapper (RCTTextInputComponentView); the notification object is
+// the inner UITextField/UITextView, a direct child of the wrapper, so
+// `superview == strongView` is the right test.
 - (void)attachFocusToView:(REAUIView *)view
 {
   __weak REAUIView *weakView = view;
@@ -305,9 +299,8 @@ static int _focusObserverContext;
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan:
     case UIGestureRecognizerStateChanged:
-      // When attached to an ancestor (SVG case) the pointer can move on and off
-      // the element while still inside the ancestor, so re-evaluate scope on
-      // every change. For directly-attached recognizers isTouchInScope is YES.
+      // The pointer can move on and off the element within the ancestor, so
+      // re-evaluate scope on every change (always YES when directly attached).
       _callback([self isTouchInScope:recognizer]);
       break;
     case UIGestureRecognizerStateEnded:
@@ -367,25 +360,23 @@ static int _focusObserverContext;
 
 #endif // TARGET_OS_OSX
 
-#if !TARGET_OS_OSX
-- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
-#else
-- (BOOL)gestureRecognizerShouldBegin:(NSGestureRecognizer *)gestureRecognizer
-#endif
+- (BOOL)gestureRecognizerShouldBegin:(REAGestureRecognizer *)gestureRecognizer
 {
   REAUIView *view = _view;
   if (!view) {
     return NO;
   }
-  // The descendant walk below is only meaningful for :active-deepest.
-  // :active always allows, and any other selector (e.g. :hover, which shares
-  // this delegate) never participates in deepest arbitration.
+  // The descendant walk is only for :active-deepest; every other selector
+  // sharing this delegate (e.g. :active, :hover) always allows.
   if (_selector != reanimated::PseudoSelector::ActiveDeepest) {
     return YES;
   }
-  // for :active-deepest walk up from the hit view: if any descendant
-  // already has an :active-deepest or :active gesture recognizer, that descendant
-  // owns the touch.
+  // TODO: doesn't arbitrate :active-deepest among overlapping/nested SVG shapes. For SVG,
+  // _interactionView is a shared ancestor and [view hitTest:] is per-path (self-or-nil), so no
+  // descendant recognizer is found and every SVG observer returns YES (all overlapping fire).
+  // Fix via RNSVGSvgView's child-walking hit-test (as Android does); needs on-device check. Follow-up.
+  // Walk up from the hit view: if a descendant already has an :active-deepest
+  // or :active recognizer, it owns the touch.
   CGPoint location = [gestureRecognizer locationInView:view];
 #if !TARGET_OS_OSX
   UIView *current = [view hitTest:location withEvent:nil];
@@ -415,21 +406,14 @@ static int _focusObserverContext;
   return YES;
 }
 
-#if !TARGET_OS_OSX
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-#else
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer
-    shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
-#endif
+- (BOOL)gestureRecognizer:(REAGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(REAGestureRecognizer *)otherGestureRecognizer
 {
   return YES;
 }
 
 - (void)detach
 {
-  // The recognizer is attached to _interactionView (which equals _view for
-  // normal views, or an ancestor for SVG elements).
   REAUIView *gestureHost = _interactionView ?: _view;
   if (_gestureRecognizer && gestureHost) {
     [gestureHost removeGestureRecognizer:_gestureRecognizer];

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -2,8 +2,10 @@
 
 #if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+typedef UIGestureRecognizer REAGestureRecognizer;
 #else
 #import <AppKit/AppKit.h>
+typedef NSGestureRecognizer REAGestureRecognizer;
 #endif
 
 #if !TARGET_OS_OSX
@@ -23,6 +25,12 @@
 
 @implementation REAPseudoSelectorObserver {
   __weak REAUIView *_view;
+  // The view the gesture recognizer is actually attached to. Usually `_view`,
+  // but for views that are never user-interactive themselves (e.g. SVG elements
+  // like RNSVGCircle, whose `isUserInteractionEnabled` is hardcoded to NO) it is
+  // the nearest interactive ancestor; touches are then scoped back to `_view`'s
+  // bounds in the gesture handlers.
+  __weak REAUIView *_interactionView;
   reanimated::PseudoSelector _selector;
 #if !TARGET_OS_OSX
   UIGestureRecognizer *_gestureRecognizer;
@@ -51,13 +59,15 @@
 
 - (void)attachSelector:(reanimated::PseudoSelector)selector toView:(REAUIView *)view
 {
+  REAUIView *interactionView = [self interactionViewForView:view];
+  _interactionView = interactionView;
   switch (selector) {
     case reanimated::PseudoSelector::Active:
     case reanimated::PseudoSelector::ActiveDeepest:
-      [self attachActiveGestureRecognizerToView:view];
+      [self attachActiveGestureRecognizerToView:interactionView];
       break;
     case reanimated::PseudoSelector::Hover:
-      [self attachHoverToView:view];
+      [self attachHoverToView:interactionView];
       break;
 #if !TARGET_OS_OSX
     case reanimated::PseudoSelector::Focus:
@@ -73,6 +83,45 @@
       break;
 #endif
   }
+}
+
+// Returns the view the gesture recognizer should be attached to.
+//
+// react-native-svg elements never receive touches on their own (their
+// `isUserInteractionEnabled` getter is hardcoded to NO), and react-native-svg's
+// container views swallow touches that don't hit a "responsible" node, so a
+// recognizer attached to them (or to the SVG elements) never fires. To make
+// pseudo selectors work on SVG elements without requiring the user to add a
+// responder prop, we attach the recognizer to the nearest regular (non-SVG)
+// interactive ancestor - which reliably receives the touch - and scope the
+// gesture back to the element's bounds in `isTouchInScope:`. For regular views
+// this resolves to the view itself, preserving the existing behaviour.
+- (REAUIView *)interactionViewForView:(REAUIView *)view
+{
+#if !TARGET_OS_OSX
+  REAUIView *candidate = view;
+  while (candidate != nil &&
+         (!candidate.isUserInteractionEnabled ||
+          [NSStringFromClass([candidate class]) hasPrefix:@"RNSVG"])) {
+    candidate = candidate.superview;
+  }
+  return candidate ?: view;
+#else
+  return view;
+#endif
+}
+
+// When the recognizer is attached to an ancestor (the SVG case), only treat the
+// gesture as targeting this element when the touch falls within the element's
+// bounds. For directly-attached recognizers there is nothing to scope.
+- (BOOL)isTouchInScope:(REAGestureRecognizer *)recognizer
+{
+  REAUIView *element = _view;
+  if (!element || element == _interactionView) {
+    return YES;
+  }
+  CGPoint location = [recognizer locationInView:element];
+  return CGRectContainsPoint(element.bounds, location);
 }
 
 - (void)attachActiveGestureRecognizerToView:(REAUIView *)view
@@ -255,7 +304,11 @@ static int _focusObserverContext;
 {
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan:
-      _callback(true);
+    case UIGestureRecognizerStateChanged:
+      // When attached to an ancestor (SVG case) the pointer can move on and off
+      // the element while still inside the ancestor, so re-evaluate scope on
+      // every change. For directly-attached recognizers isTouchInScope is YES.
+      _callback([self isTouchInScope:recognizer]);
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
@@ -272,7 +325,7 @@ static int _focusObserverContext;
 {
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan:
-      _callback(true);
+      _callback([self isTouchInScope:recognizer]);
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
@@ -375,8 +428,11 @@ static int _focusObserverContext;
 
 - (void)detach
 {
-  if (_gestureRecognizer && _view) {
-    [_view removeGestureRecognizer:_gestureRecognizer];
+  // The recognizer is attached to _interactionView (which equals _view for
+  // normal views, or an ancestor for SVG elements).
+  REAUIView *gestureHost = _interactionView ?: _view;
+  if (_gestureRecognizer && gestureHost) {
+    [gestureHost removeGestureRecognizer:_gestureRecognizer];
   }
   _gestureRecognizer = nil;
 #if TARGET_OS_OSX


### PR DESCRIPTION
Makes CSS pseudo selectors (`:active`, `:hover`) animate react-native-svg props such as `fill` on iOS and Android, matching existing Web behavior. Previously these only fired for SVG shapes when the element opted in with `onStartShouldSetResponder`.

- iOS: attaches the pseudo gesture recognizers to the nearest interactive ancestor and hit-tests the shape bounds, since RNSVG shapes are not user-interactive views.
- Android: routes `:active`/`:hover` through the shape's compound host (`SvgView`) via `reactTagForTouch`, defers host resolution until the shape attaches, and enables per-shape hit testing through `setResponsible`.

Draft pending broader validation (hover on Android, lint/tests, and example-screen cleanup).