### PR TITLE
fix: Android crash on odd-length CSS strokeDasharray

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stroke.test.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stroke.test.ts
@@ -3,9 +3,9 @@ import { ERROR_MESSAGES, processStrokeDashArray } from '../stroke';
 
 describe(processStrokeDashArray, () => {
   describe('single value', () => {
-    test('converts length value to a single-element array', () => {
-      expect(processStrokeDashArray(10)).toEqual([10]);
-      expect(processStrokeDashArray('10%')).toEqual(['10%']);
+    test('duplicates a length value to an even-length array', () => {
+      expect(processStrokeDashArray(10)).toEqual([10, 10]);
+      expect(processStrokeDashArray('10%')).toEqual(['10%', '10%']);
     });
 
     test('returns "none" for "none" value', () => {
@@ -28,9 +28,9 @@ describe(processStrokeDashArray, () => {
       );
     });
 
-    describe('duplicates the array if it has an odd number of elements (only if there are more than 2 elements)', () => {
+    describe('duplicates the array if it has an odd number of elements', () => {
       test.each([
-        [[10], [10]],
+        [[10], [10, 10]],
         [
           [10, 20],
           [10, 20],

--- a/packages/react-native-reanimated/src/css/svg/native/processors/stroke.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/stroke.ts
@@ -18,16 +18,19 @@ export const processStrokeDashArray: ValueProcessor<
   if (isLength(value)) {
     result = [value];
   } else if (Array.isArray(value)) {
-    // We have to repeat the same pattern twice if the number of elements is odd
-    // "If the number of values is odd, the pattern behaves as if it was duplicated
-    // to yield an even number of values"
-    // (https://www.w3.org/TR/fill-stroke-3/#valdef-stroke-dasharray-length-percentage)
-    result =
-      value.length % 2 === 0 || value.length < 3 ? value : value.concat(value);
+    result = [...value];
   } else if (value === 'none') {
     return 'none';
   } else {
     throw new Error(`[Reanimated] ${ERROR_MESSAGES.invalidDashArray(value)}`);
+  }
+
+  // Per the SVG spec an odd-length dash array is repeated to an even length.
+  // react-native-svg's extractStroke does this, but animated values bypass it
+  // and an odd-length array crashes Android's DashPathEffect, so we repeat here.
+  // https://www.w3.org/TR/fill-stroke-3/#valdef-stroke-dasharray-length-percentage
+  if (result.length % 2 === 1) {
+    result = result.concat(result);
   }
 
   if (__DEV__) {


### PR DESCRIPTION
## Summary

A single or odd-length animated `strokeDasharray` (e.g. `strokeDasharray: 10`) reached native as an odd-length array and crashed Android's `DashPathEffect`, which requires an even number of intervals (>= 2). The CSS-animated value bypasses react-native-svg's own `extractStroke`, so we now repeat odd-length arrays to an even length here too, per the SVG spec, matching `extractStroke`.

Note on scope: the previous logic already duplicated odd-length arrays of length >= 3; its only gap was the single-value / length-1 case (the `length < 3` exception). This collapses the logic into one `odd -> duplicate` rule that covers every odd length on every platform - which is what `extractStroke` does. iOS already tolerated the odd length (CoreGraphics cycles the array), so duplicating there is a harmless no-op; keeping the processor platform-agnostic is intentional.

## Test plan

- `processStrokeDashArray` unit test updated and passing.
- Android emulator: opening the SVG > Stroke CSS example previously crashed the app with `java.lang.ArrayIndexOutOfBoundsException` at `android.graphics.DashPathEffect.<init>` (from `com.horcrux.svg.RenderableView.setupStrokePaint`). After the fix, the single-value and array `strokeDasharray` examples render dashed strokes without crashing. (Recording attached.)
