### PR TITLE
fix(Worklets): Normalize Windows paths in bundle mode module IDs

### DIFF
--- a/packages/react-native-worklets/bundleMode/index.js
+++ b/packages/react-native-worklets/bundleMode/index.js
@@ -151,7 +151,10 @@ function getBundleModeMetroConfig(/** @type {any} */ config) {
 function bundleModeCreateModuleIdFactory() {
   let nextId = 0;
   const idFileMap = new Map();
-  return (/** @type {string} */ moduleName) => {
+  return (/** @type {string} */ moduleNameRaw) => {
+    // moduleName is a resolved file path, so normalize Windows separators to
+    // match the posix entry/dir paths built above.
+    const moduleName = moduleNameRaw.replace(/\\/g, '/');
     if (idFileMap.has(moduleName)) {
       return idFileMap.get(moduleName);
     }

--- a/packages/react-native-worklets/bundleMode/index.js
+++ b/packages/react-native-worklets/bundleMode/index.js
@@ -152,8 +152,6 @@ function bundleModeCreateModuleIdFactory() {
   let nextId = 0;
   const idFileMap = new Map();
   return (/** @type {string} */ moduleNameRaw) => {
-    // moduleName is a resolved file path, so normalize Windows separators to
-    // match the posix entry/dir paths built above.
     const moduleName = moduleNameRaw.replace(/\\/g, '/');
     if (idFileMap.has(moduleName)) {
       return idFileMap.get(moduleName);


### PR DESCRIPTION
On Windows, Metro resolves module paths with backslashes, but the worklets bundle-mode `createModuleIdFactory` compares them against POSIX-separated entry/dir constants, so the checks never match. The worklets entry then never gets its fixed `-2` module id, and bundling a worklets app crashes at runtime with `Requiring unknown module -2`.

This normalizes the path separators before the comparisons, so worklets bundle mode works when bundling on Windows (it already worked on macOS/Linux/CI).