### PR TITLE
cherry-pick(4.4-stable): re-run mappers dirtied during a mapper run (#9644)

### DIFF
--- a/packages/react-native-reanimated/src/mappers.ts
+++ b/packages/react-native-reanimated/src/mappers.ts
@@ -103,13 +103,13 @@ function createMapperRegistry() {
         updateMappersOrder();
       }
       if (isAnyMapperDirty) {
+        isAnyMapperDirty = false;
         for (const mapper of sortedMappers) {
           if (mapper.dirty) {
             mapper.dirty = false;
             mapper.worklet();
           }
         }
-        isAnyMapperDirty = false;
       }
     } finally {
       processingMappers = false;


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9644