### PR TITLE
cherry-pick(4.4-stable): layout animation cancellation fixes (#9621, #9660)

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ExitingTagReuseStressExample.tsx
@@ -1,0 +1,343 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  getStaticFeatureFlag,
+  ZoomIn,
+  ZoomOut,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+
+const SPIKE_COUNT = 60;
+const SPIKE_INTERVAL_MS = 700;
+const ITEM_LOOP_INTERVAL_MS = 40;
+const ITEM_VISIBLE_MS = 100;
+const ITEM_COUNT = 12;
+
+const COLORS = [
+  '#FF6B6B',
+  '#FFD93D',
+  '#6BCB77',
+  '#4D96FF',
+  '#C77DFF',
+  '#FF9F45',
+  '#00C9A7',
+  '#F72585',
+  '#4CC9F0',
+  '#7209B7',
+];
+
+function SpikeNode({ index, onDone }: { index: number; onDone: () => void }) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withRepeat(
+      withTiming(1, { duration: 200 + (index % 8) * 50 }),
+      -1,
+      true
+    );
+
+    const timeout = setTimeout(onDone, 32);
+    return () => clearTimeout(timeout);
+  }, [index, onDone, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: 0.15 + progress.value * 0.1,
+    transform: [{ scale: 0.95 + progress.value * 0.1 }],
+  }));
+
+  return <Animated.View style={[styles.stressNode, animatedStyle]} />;
+}
+
+export default function ExitingTagReuseStressExample() {
+  const sharedElementTransitionsEnabled = getStaticFeatureFlag(
+    'ENABLE_SHARED_ELEMENT_TRANSITIONS'
+  );
+  const [visibleIds, setVisibleIds] = useState<Set<number>>(() => new Set());
+  const [spikeIds, setSpikeIds] = useState<number[]>([]);
+  const [running, setRunning] = useState(true);
+  const cursorRef = useRef(0);
+  const spikeCounterRef = useRef(0);
+  const itemIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const spikeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const mountNext = useCallback(() => {
+    const id = cursorRef.current;
+    cursorRef.current = (cursorRef.current + 1) % ITEM_COUNT;
+
+    setVisibleIds((prev) => new Set(prev).add(id));
+
+    const timeout = setTimeout(() => {
+      setVisibleIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      timeoutsRef.current = timeoutsRef.current.filter((t) => t !== timeout);
+    }, ITEM_VISIBLE_MS);
+
+    timeoutsRef.current.push(timeout);
+  }, []);
+
+  const fireSpike = useCallback(() => {
+    const ids = Array.from(
+      { length: SPIKE_COUNT },
+      () => spikeCounterRef.current++
+    );
+    setSpikeIds((prev) => [...prev, ...ids]);
+  }, []);
+
+  const removeSpikeId = useCallback((id: number) => {
+    setSpikeIds((prev) => prev.filter((value) => value !== id));
+  }, []);
+
+  useEffect(() => {
+    if (!running) {
+      if (itemIntervalRef.current) {
+        clearInterval(itemIntervalRef.current);
+        itemIntervalRef.current = null;
+      }
+
+      setVisibleIds(new Set());
+      return;
+    }
+
+    itemIntervalRef.current = setInterval(mountNext, ITEM_LOOP_INTERVAL_MS);
+
+    return () => {
+      if (itemIntervalRef.current) {
+        clearInterval(itemIntervalRef.current);
+        itemIntervalRef.current = null;
+      }
+    };
+  }, [mountNext, running]);
+
+  useEffect(() => {
+    if (!running) {
+      if (spikeIntervalRef.current) {
+        clearInterval(spikeIntervalRef.current);
+        spikeIntervalRef.current = null;
+      }
+
+      setSpikeIds([]);
+      return;
+    }
+
+    spikeIntervalRef.current = setInterval(fireSpike, SPIKE_INTERVAL_MS);
+
+    return () => {
+      if (spikeIntervalRef.current) {
+        clearInterval(spikeIntervalRef.current);
+        spikeIntervalRef.current = null;
+      }
+    };
+  }, [fireSpike, running]);
+
+  useEffect(() => {
+    return () => {
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+    };
+  }, []);
+
+  return (
+    <View style={styles.root}>
+      <View pointerEvents="none" style={styles.stressContainer}>
+        {spikeIds.map((id) => (
+          <SpikeNode index={id} key={id} onDone={() => removeSpikeId(id)} />
+        ))}
+      </View>
+
+      <View style={styles.header}>
+        <Text style={styles.title}>Exiting Tag Reuse Stress Test</Text>
+        <Text style={styles.hint}>
+          Reuses the same tags under heavy entering/exiting churn to catch stale
+          cleanup bugs.
+        </Text>
+        <Text style={styles.debugLine}>
+          JS flag ENABLE_SHARED_ELEMENT_TRANSITIONS ={' '}
+          {String(sharedElementTransitionsEnabled)}
+        </Text>
+      </View>
+
+      <View style={styles.controls}>
+        <Pressable
+          disabled={running}
+          onPress={() => setRunning(true)}
+          style={[
+            styles.button,
+            styles.startButton,
+            running && styles.disabled,
+          ]}>
+          <Text style={styles.buttonText}>Start</Text>
+        </Pressable>
+        <Pressable
+          disabled={!running}
+          onPress={() => setRunning(false)}
+          style={[
+            styles.button,
+            styles.stopButton,
+            !running && styles.disabled,
+          ]}>
+          <Text style={styles.buttonText}>Stop</Text>
+        </Pressable>
+      </View>
+
+      <Text style={styles.spikeLabel}>
+        {running ? `Running - spike every ${SPIKE_INTERVAL_MS}ms` : 'Stopped'}
+      </Text>
+
+      <ScrollView contentContainerStyle={styles.grid}>
+        {Array.from({ length: ITEM_COUNT }, (_, index) => {
+          const isVisible = visibleIds.has(index);
+
+          return (
+            <View key={index} style={styles.slot}>
+              <View style={styles.slotPlaceholder}>
+                <Text style={styles.slotIndex}>{index}</Text>
+              </View>
+              {isVisible && (
+                <Animated.View
+                  entering={ZoomIn}
+                  exiting={ZoomOut}
+                  style={[
+                    styles.itemFill,
+                    { backgroundColor: COLORS[index % COLORS.length] },
+                  ]}>
+                  <Text style={styles.itemText}>{index}</Text>
+                </Animated.View>
+              )}
+            </View>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#000',
+    paddingTop: 60,
+  },
+  stressContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    overflow: 'hidden',
+  },
+  stressNode: {
+    width: 4,
+    height: 4,
+    backgroundColor: '#fff',
+  },
+  header: {
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  hint: {
+    color: '#ff9f45',
+    fontSize: 12,
+  },
+  debugLine: {
+    color: '#8fd3ff',
+    fontSize: 12,
+    marginTop: 6,
+  },
+  controls: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  button: {
+    height: 52,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  startButton: {
+    backgroundColor: '#6BCB77',
+  },
+  stopButton: {
+    backgroundColor: '#FF6B6B',
+  },
+  disabled: {
+    opacity: 0.35,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  spikeLabel: {
+    color: '#ffd93d',
+    fontSize: 13,
+    fontWeight: '600',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingBottom: 40,
+  },
+  slot: {
+    width: 64,
+    height: 64,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  slotPlaceholder: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#333',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 0,
+  },
+  slotIndex: {
+    color: '#444',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  itemFill: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+  },
+  itemText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/InterruptedExitingExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/InterruptedExitingExample.tsx
@@ -1,0 +1,120 @@
+"use strict";
+import React, { useEffect, useState } from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import Animated, {
+  FadeOut,
+  LayoutAnimationConfig,
+} from "react-native-reanimated";
+import { runOnUI } from "react-native-worklets";
+
+// Repro for https://github.com/software-mansion/react-native-reanimated/issues/7493
+//
+// Each cycle:
+//   1. the UI thread is blocked for ~600ms by a busy-wait worklet, standing in
+//      for a real-world main-thread stall (GC, heavy mount, bitmap decode...),
+//   2. while it's blocked, a view with an `exiting` animation is unmounted —
+//      the animation start is scheduled onto the (blocked) UI thread,
+//   3. still while it's blocked, the whole subtree is force-ended in a
+//      separate commit by unmounting the `skipExiting` wrapper — the same
+//      code path a react-native-screens screen pop takes. The cancellation
+//      finds no animation to cancel (the start hasn't run yet) and the
+//      item's Remove+Delete are queued for mounting.
+//
+// When the UI thread wakes up, the stale animation start used to re-create
+// the animation for the already-removed view, and the first progress update
+// raced the queued Delete in the mounting layer:
+//
+//   RetryableMountingLayerException: Unable to find viewState for tag X
+//
+// Without the fix this crashes within a few cycles (scrolling the list makes
+// it even more likely, since reanimated then mounts synchronously from event
+// handling). With the fix the cancellation invalidates the pending start and
+// this screen can run indefinitely.
+export default function InterruptedExitingExample() {
+  const [showScreen, setShowScreen] = useState(false);
+  const [showItem, setShowItem] = useState(false);
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCycle((c) => c + 1);
+      setShowScreen(true);
+      setShowItem(true);
+      setTimeout(() => {
+        // Stall the UI thread. Everything below happens on the JS thread
+        // before the UI thread gets to run again.
+        runOnUI(() => {
+          "worklet";
+          const start = performance.now();
+          while (performance.now() - start < 600) {
+            // burn
+          }
+        })();
+        // Unmount the item — its exiting animation start gets scheduled
+        // behind the busy-wait above. The screen is unmounted from an effect
+        // below, so it lands in a separate, later commit.
+        setShowItem(false);
+      }, 250);
+    }, 1487);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    // Runs right after the item-removal commit (still while the UI thread is
+    // blocked) — unmounting the skipExiting wrapper in a separate commit
+    // force-ends the item before its animation had a chance to start.
+    if (!showItem && showScreen) {
+      setShowScreen(false);
+    }
+  }, [showItem, showScreen]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>
+        Cycle {cycle} — keep scrolling the list while the box blinks!
+      </Text>
+      <View style={styles.stage}>
+        {showScreen && (
+          <LayoutAnimationConfig skipExiting>
+            <View collapsable={false} style={styles.screen}>
+              {showItem && (
+                <Animated.View
+                  exiting={FadeOut.duration(800)}
+                  style={styles.box}
+                />
+              )}
+            </View>
+          </LayoutAnimationConfig>
+        )}
+      </View>
+      <ScrollView style={styles.scroll}>
+        {Array.from({ length: 200 }, (_, i) => (
+          <Text key={i} style={styles.row}>
+            {i}
+          </Text>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  title: { padding: 16, fontWeight: "bold" },
+  stage: { height: 130, alignItems: "center", justifyContent: "center" },
+  screen: {
+    width: 220,
+    height: 120,
+    backgroundColor: "#eee",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  box: {
+    width: 90,
+    height: 90,
+    backgroundColor: "rebeccapurple",
+    borderRadius: 8,
+  },
+  scroll: { flex: 1 },
+  row: { padding: 14, borderBottomWidth: StyleSheet.hairlineWidth },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -171,6 +171,11 @@ const DurationZeroExample: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/DurationZero').default as React.FC
   );
+const ExitingTagReuseStressExample: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/ExitingTagReuseStressExample')
+      .default as React.FC
+  );
 const DynamicColorIOSExample: React.FC = () =>
   React.createElement(require('./DynamicColorIOSExample').default as React.FC);
 const EmojiWaterfallExample: React.FC = () =>
@@ -1198,6 +1203,10 @@ export const EXAMPLES: Record<string, Example> = {
   DurationZeroExample: {
     title: '[LA] Duration zero',
     screen: DurationZeroExample,
+  },
+  ExitingTagReuseStressExample: {
+    title: '[LA] Exiting tag reuse stress',
+    screen: ExitingTagReuseStressExample,
   },
   DefaultAnimationsOverrides: {
     title: '[LA] Default layout animations overrides',

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -238,6 +238,10 @@ const InvalidValueAccessExample: React.FC = () =>
   React.createElement(
     require('./InvalidValueAccessExample').default as React.FC
   );
+const InterruptedExitingExample: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/InterruptedExitingExample').default as React.FC
+  );
 const InvertedFlatListExample: React.FC = () =>
   React.createElement(require('./InvertedFlatListExample').default as React.FC);
 const KeyframeAnimation: React.FC = () =>
@@ -1071,6 +1075,10 @@ export const EXAMPLES: Record<string, Example> = {
   DeleteAncestorOfExiting: {
     title: '[LA] Deleting view with an exiting animation',
     screen: DeleteAncestorOfExiting,
+  },
+  InterruptedExiting: {
+    title: '[LA] Interrupted exiting animation (#7493)',
+    screen: InterruptedExitingExample,
   },
   NestedNativeStacksWithLayout: {
     title: '[LA] Nested NativeStacks with layout',

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.cpp
@@ -37,8 +37,12 @@ const facebook::react::ShadowNode *findInShadowTreeByTag(const facebook::react::
 
 void LayoutAnimationsProxyCommon::restoreOpacityInCaseOfFlakyEnteringAnimation(SurfaceId surfaceId) const {
   std::vector<std::pair<double, Tag>> opacityToRestore;
-  for (const auto tag : finishedAnimationTags_) {
-    const auto &opacity = layoutAnimations_[tag].opacity;
+  for (const auto tag : maybeSettledAnimationTags_) {
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    const auto &opacity = layoutAnimationIt->second.opacity;
     if (opacity.has_value()) {
       opacityToRestore.emplace_back(std::pair<double, Tag>{opacity.value(), tag});
     }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -28,6 +29,31 @@ struct LayoutAnimation {
     return count == 0;
   }
 };
+
+#ifdef ANDROID
+// Bookkeeping for animation starts that were scheduled onto the UI thread but
+// haven't run yet — see `pendingStarts_` below.
+struct PendingStart {
+  int count = 0;
+  uint64_t handle = 0;
+};
+
+// Removes one pending start for the given tag and returns whether it was
+// cancelled since it was scheduled (i.e. its handle is no longer current).
+// Call under the proxy mutex.
+inline bool
+consumeIsCancelled(std::unordered_map<Tag, PendingStart> &pendingStarts, const Tag tag, const uint64_t handle) {
+  const auto it = pendingStarts.find(tag);
+  // every scheduled start keeps its entry alive until it is consumed —
+  // cancellations only bump the handle, they never erase
+  react_native_assert(it != pendingStarts.end() && "PendingStart not found");
+  const bool isCancelled = it->second.handle != handle;
+  if (--it->second.count == 0) {
+    pendingStarts.erase(it);
+  }
+  return isCancelled;
+}
+#endif
 
 class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDelegate {
  public:
@@ -80,6 +106,18 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
 
   void restoreOpacityInCaseOfFlakyEnteringAnimation(SurfaceId surfaceId) const;
 
+  // On Android pullTransaction can run on the JS thread, so animation starts
+  // are scheduled onto the UI thread. If `maybeCancelAnimation` is called between the
+  // start was scheduled and the lambda runs, it
+  // finds no `layoutAnimations_` entry to erase (the start lambda hasn't created it
+  // yet) and the cancellation is lost — the stale start would later
+  // "resurrect" the animation for a view whose Remove+Delete are already on
+  // their way to the mounting layer
+  // (https://github.com/software-mansion/react-native-reanimated/issues/7493).
+
+  // To work around this, we keep a separate `pendingStarts_` map that tracks scheduled starts by tag,
+  //  with a generation counter to detect cancellations.
+  mutable std::unordered_map<Tag, PendingStart> pendingStarts_;
 #endif
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace reanimated {
@@ -22,6 +23,10 @@ struct LayoutAnimation {
   bool isViewAlreadyMounted = false;
   int count = 1;
   LayoutAnimation &operator=(const LayoutAnimation &other) = default;
+
+  bool isSettled() const {
+    return count == 0;
+  }
 };
 
 class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDelegate {
@@ -60,7 +65,7 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   virtual void startSurface(const SurfaceId surfaceId);
 
  protected:
-  mutable std::vector<Tag> finishedAnimationTags_;
+  mutable std::unordered_set<Tag> maybeSettledAnimationTags_;
   mutable std::unordered_map<Tag, LayoutAnimation> layoutAnimations_;
   std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager_;
   std::shared_ptr<const ContextContainer> contextContainer_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -276,11 +276,10 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Experimental::endLayoutAnimation(
   // one after the other, so we need to keep count of how many
   // were actually triggered, so that we don't cleanup necessary
   // structures too early
-  if (layoutAnimation.count > 1) {
-    layoutAnimation.count--;
+  if (--layoutAnimation.count > 0) {
     return {};
   }
-  finishedAnimationTags_.push_back(tag);
+  maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
   if (sharedTransitionManager_->tagToName_.contains(tag)) {
@@ -397,7 +396,7 @@ void LayoutAnimationsProxy_Experimental::addOngoingAnimations(SurfaceId surfaceI
 
     const auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end()) {
+    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
       continue;
     }
 
@@ -532,10 +531,15 @@ void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int 
 }
 
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
-  if (!layoutAnimations_.contains(tag)) {
+  const auto layoutAnimationIt = layoutAnimations_.find(tag);
+  if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  layoutAnimations_.erase(tag);
+  if (layoutAnimationIt->second.isSettled()) {
+    // Already settled - cleanupAnimations will erase it together with its updateMap entry.
+    return;
+  }
+  layoutAnimations_.erase(layoutAnimationIt);
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {
@@ -625,12 +629,17 @@ void LayoutAnimationsProxy_Experimental::cleanupAnimations(
 #ifdef ANDROID
   restoreOpacityInCaseOfFlakyEnteringAnimation(surfaceId);
 #endif // ANDROID
-  for (const auto tag : finishedAnimationTags_) {
-    auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
-    layoutAnimations_.erase(tag);
+  auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+  for (const auto tag : maybeSettledAnimationTags_) {
+    // Skip tags re-animated since they settled (count back above 0).
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    layoutAnimations_.erase(layoutAnimationIt);
     updateMap.erase(tag);
   }
-  finishedAnimationTags_.clear();
+  maybeSettledAnimationTags_.clear();
 }
 
 // MARK: Start Animation

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -531,6 +531,13 @@ void LayoutAnimationsProxy_Experimental::updateOngoingAnimationTarget(const int 
 }
 
 void LayoutAnimationsProxy_Experimental::maybeCancelAnimation(const int tag) const {
+#ifdef ANDROID
+  // also invalidate animation starts that are scheduled but haven't run yet,
+  // so they don't re-create the animation after this cancellation
+  if (const auto it = pendingStarts_.find(tag); it != pendingStarts_.end()) {
+    it->second.handle++;
+  }
+#endif
   const auto layoutAnimationIt = layoutAnimations_.find(tag);
   if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
@@ -685,9 +692,24 @@ void LayoutAnimationsProxy_Experimental::startEnteringAnimation(const std::share
   const auto &parent = node->parent.lock();
   react_native_assert(parent && "Parent node is nullptr");
   const auto parentTag = parent->current.tag;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[newChildShadowView.tag].handle;
+  pendingStarts_[newChildShadowView.tag].count++;
+#endif
 
   scheduleOnUI(
-      uiScheduler_, [weakThis = weak_from_this(), finalView, currentView, newChildShadowView, parentTag, opacity]() {
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       finalView,
+       currentView,
+       newChildShadowView,
+       parentTag,
+       opacity
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
@@ -697,6 +719,12 @@ void LayoutAnimationsProxy_Experimental::startEnteringAnimation(const std::share
         const auto tag = newChildShadowView.tag;
         {
           auto lock = std::unique_lock<std::recursive_mutex>(strongThis->mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed before this start could run
+            return;
+          }
+#endif
           strongThis->layoutAnimations_[tag] = {
               .finalView = newChildShadowView,
               .currentView = newChildShadowView,
@@ -730,51 +758,23 @@ void LayoutAnimationsProxy_Experimental::startExitingAnimation(const std::shared
   const auto &parent = node->parent.lock();
   react_native_assert(parent && "Parent node is nullptr");
   const auto parentTag = parent->current.tag;
-
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag, parentTag, oldChildShadowView, surfaceId]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
-
-    auto oldView = oldChildShadowView;
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      oldView = strongThis->maybeCreateLayoutAnimation(oldView, oldView, parentTag);
-      window = strongThis->surfaceManager.getWindow(surfaceId);
-    }
-
-    const Snapshot values(oldView, window);
-
-    auto &uiRuntime = strongThis->uiRuntime_;
-    const jsi::Object yogaValues(uiRuntime);
-    yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
-    yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
-    yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-    yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-    strongThis->layoutAnimationsManager_->startLayoutAnimation(
-        uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
-    strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
-  });
-}
-
-void LayoutAnimationsProxy_Experimental::startLayoutAnimation(const std::shared_ptr<LightNode> &node) const {
-  auto oldChildShadowView = node->previous;
-  auto newChildShadowView = node->current;
-  auto surfaceId = oldChildShadowView.surfaceId;
-  const auto tag = oldChildShadowView.tag;
-  const auto &parent = node->parent.lock();
-  react_native_assert(parent && "Parent node is nullptr");
-  const auto parentTag = parent->current.tag;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[tag].handle;
+  pendingStarts_[tag].count++;
+#endif
 
   scheduleOnUI(
-      uiScheduler_, [weakThis = weak_from_this(), surfaceId, oldChildShadowView, newChildShadowView, parentTag, tag]() {
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       tag,
+       parentTag,
+       oldChildShadowView,
+       surfaceId
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
         auto strongThis = weakThis.lock();
         if (!strongThis) {
           return;
@@ -785,6 +785,80 @@ void LayoutAnimationsProxy_Experimental::startLayoutAnimation(const std::shared_
         {
           auto &mutex = strongThis->mutex;
           auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed (e.g. its subtree was force-ended by a screen
+            // pop) before this start could run — its Remove+Delete are already on
+            // their way to the mounting layer, so starting the animation now
+            // would emit updates for a view that's about to be deleted
+            strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
+            return;
+          }
+#endif
+          oldView = strongThis->maybeCreateLayoutAnimation(oldView, oldView, parentTag);
+          window = strongThis->surfaceManager.getWindow(surfaceId);
+        }
+
+        const Snapshot values(oldView, window);
+
+        auto &uiRuntime = strongThis->uiRuntime_;
+        const jsi::Object yogaValues(uiRuntime);
+        yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
+        yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
+        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
+        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
+        strongThis->layoutAnimationsManager_->startLayoutAnimation(
+            uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
+        strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
+      });
+}
+
+void LayoutAnimationsProxy_Experimental::startLayoutAnimation(const std::shared_ptr<LightNode> &node) const {
+  auto oldChildShadowView = node->previous;
+  auto newChildShadowView = node->current;
+  auto surfaceId = oldChildShadowView.surfaceId;
+  const auto tag = oldChildShadowView.tag;
+  const auto &parent = node->parent.lock();
+  react_native_assert(parent && "Parent node is nullptr");
+  const auto parentTag = parent->current.tag;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[tag].handle;
+  pendingStarts_[tag].count++;
+#endif
+
+  scheduleOnUI(
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       surfaceId,
+       oldChildShadowView,
+       newChildShadowView,
+       parentTag,
+       tag
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
+
+        auto oldView = oldChildShadowView;
+        Rect window{};
+        {
+          auto &mutex = strongThis->mutex;
+          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed before this start could run
+            return;
+          }
+#endif
           oldView = strongThis->maybeCreateLayoutAnimation(oldView, newChildShadowView, parentTag);
           window = strongThis->surfaceManager.getWindow(surfaceId);
         }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -640,38 +640,60 @@ void LayoutAnimationsProxy_Legacy::startEnteringAnimation(const int tag, ShadowV
 
   auto &viewProps = static_cast<const ViewProps &>(*mutation.newChildShadowView.props);
   auto opacity = viewProps.opacity;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[tag].handle;
+  pendingStarts_[tag].count++;
+#endif
 
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), finalView, current, mutation, opacity, tag]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
+  scheduleOnUI(
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       finalView,
+       current,
+       mutation,
+       opacity,
+       tag
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
 
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      strongThis->layoutAnimations_.insert_or_assign(
-          tag,
-          LayoutAnimation{
-              .finalView = finalView, .currentView = current, .parentTag = mutation.parentTag, .opacity = opacity});
-      window = strongThis->surfaceManager.getWindow(mutation.newChildShadowView.surfaceId);
-    }
+        Rect window{};
+        {
+          auto &mutex = strongThis->mutex;
+          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed before this start could run
+            return;
+          }
+#endif
+          strongThis->layoutAnimations_.insert_or_assign(
+              tag,
+              LayoutAnimation{
+                  .finalView = finalView, .currentView = current, .parentTag = mutation.parentTag, .opacity = opacity});
+          window = strongThis->surfaceManager.getWindow(mutation.newChildShadowView.surfaceId);
+        }
 
-    Snapshot values(mutation.newChildShadowView, window);
-    auto &uiRuntime = strongThis->uiRuntime_;
-    jsi::Object yogaValues(uiRuntime);
-    yogaValues.setProperty(uiRuntime, "targetOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "targetOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "targetWidth", values.width);
-    yogaValues.setProperty(uiRuntime, "targetHeight", values.height);
-    yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-    yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-    strongThis->layoutAnimationsManager_->startLayoutAnimation(
-        uiRuntime, tag, LayoutAnimationType::ENTERING, yogaValues);
-  });
+        Snapshot values(mutation.newChildShadowView, window);
+        auto &uiRuntime = strongThis->uiRuntime_;
+        jsi::Object yogaValues(uiRuntime);
+        yogaValues.setProperty(uiRuntime, "targetOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "targetOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "targetWidth", values.width);
+        yogaValues.setProperty(uiRuntime, "targetHeight", values.height);
+        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
+        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
+        strongThis->layoutAnimationsManager_->startLayoutAnimation(
+            uiRuntime, tag, LayoutAnimationType::ENTERING, yogaValues);
+      });
 }
 
 void LayoutAnimationsProxy_Legacy::startExitingAnimation(const int tag, ShadowViewMutation &mutation) const {
@@ -679,38 +701,62 @@ void LayoutAnimationsProxy_Legacy::startExitingAnimation(const int tag, ShadowVi
   LOG(INFO) << "start exiting animation for tag " << tag << std::endl;
 #endif
   auto surfaceId = mutation.oldChildShadowView.surfaceId;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[tag].handle;
+  pendingStarts_[tag].count++;
+#endif
 
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag, mutation, surfaceId]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
+  scheduleOnUI(
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       tag,
+       mutation,
+       surfaceId
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
 
-    auto oldView = mutation.oldChildShadowView;
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      strongThis->createLayoutAnimation(mutation, oldView, surfaceId, tag);
-      window = strongThis->surfaceManager.getWindow(surfaceId);
-    }
+        auto oldView = mutation.oldChildShadowView;
+        Rect window{};
+        {
+          auto &mutex = strongThis->mutex;
+          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed (e.g. its subtree was force-ended by a screen
+            // pop) before this start could run — its Remove+Delete are already on
+            // their way to the mounting layer, so starting the animation now
+            // would emit updates for a view that's about to be deleted
+            strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
+            return;
+          }
+#endif
+          strongThis->createLayoutAnimation(mutation, oldView, surfaceId, tag);
+          window = strongThis->surfaceManager.getWindow(surfaceId);
+        }
 
-    Snapshot values(oldView, window);
+        Snapshot values(oldView, window);
 
-    auto &uiRuntime = strongThis->uiRuntime_;
-    jsi::Object yogaValues(uiRuntime);
-    yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
-    yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
-    yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
-    yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
-    yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
-    yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
-    strongThis->layoutAnimationsManager_->startLayoutAnimation(
-        uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
-    strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
-  });
+        auto &uiRuntime = strongThis->uiRuntime_;
+        jsi::Object yogaValues(uiRuntime);
+        yogaValues.setProperty(uiRuntime, "currentOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", values.x);
+        yogaValues.setProperty(uiRuntime, "currentOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", values.y);
+        yogaValues.setProperty(uiRuntime, "currentWidth", values.width);
+        yogaValues.setProperty(uiRuntime, "currentHeight", values.height);
+        yogaValues.setProperty(uiRuntime, "windowWidth", values.windowWidth);
+        yogaValues.setProperty(uiRuntime, "windowHeight", values.windowHeight);
+        strongThis->layoutAnimationsManager_->startLayoutAnimation(
+            uiRuntime, tag, LayoutAnimationType::EXITING, yogaValues);
+        strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
+      });
 }
 
 void LayoutAnimationsProxy_Legacy::startLayoutAnimation(const int tag, const ShadowViewMutation &mutation) const {
@@ -718,43 +764,64 @@ void LayoutAnimationsProxy_Legacy::startLayoutAnimation(const int tag, const Sha
   LOG(INFO) << "start layout animation for tag " << tag << std::endl;
 #endif
   auto surfaceId = mutation.oldChildShadowView.surfaceId;
+#ifdef ANDROID
+  const auto handle = pendingStarts_[tag].handle;
+  pendingStarts_[tag].count++;
+#endif
 
-  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), mutation, surfaceId, tag]() {
-    auto strongThis = weakThis.lock();
-    if (!strongThis) {
-      return;
-    }
+  scheduleOnUI(
+      uiScheduler_,
+      [weakThis = weak_from_this(),
+       mutation,
+       surfaceId,
+       tag
+#ifdef ANDROID
+       ,
+       handle
+#endif
+  ]() {
+        auto strongThis = weakThis.lock();
+        if (!strongThis) {
+          return;
+        }
 
-    auto oldView = mutation.oldChildShadowView;
-    Rect window{};
-    {
-      auto &mutex = strongThis->mutex;
-      auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-      strongThis->createLayoutAnimation(mutation, oldView, surfaceId, tag);
-      window = strongThis->surfaceManager.getWindow(surfaceId);
-    }
+        auto oldView = mutation.oldChildShadowView;
+        Rect window{};
+        {
+          auto &mutex = strongThis->mutex;
+          auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+#ifdef ANDROID
+          if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
+            // the view was removed before this start could run
+            return;
+          }
+#endif
+          strongThis->createLayoutAnimation(mutation, oldView, surfaceId, tag);
+          window = strongThis->surfaceManager.getWindow(surfaceId);
+        }
 
-    Snapshot currentValues(oldView, window);
-    Snapshot targetValues(mutation.newChildShadowView, window);
+        Snapshot currentValues(oldView, window);
+        Snapshot targetValues(mutation.newChildShadowView, window);
 
-    auto &uiRuntime = strongThis->uiRuntime_;
-    jsi::Object yogaValues(uiRuntime);
-    yogaValues.setProperty(uiRuntime, "currentOriginX", currentValues.x);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", currentValues.x);
-    yogaValues.setProperty(uiRuntime, "currentOriginY", currentValues.y);
-    yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", currentValues.y);
-    yogaValues.setProperty(uiRuntime, "currentWidth", currentValues.width);
-    yogaValues.setProperty(uiRuntime, "currentHeight", currentValues.height);
-    yogaValues.setProperty(uiRuntime, "targetOriginX", targetValues.x);
-    yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", targetValues.x);
-    yogaValues.setProperty(uiRuntime, "targetOriginY", targetValues.y);
-    yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", targetValues.y);
-    yogaValues.setProperty(uiRuntime, "targetWidth", targetValues.width);
-    yogaValues.setProperty(uiRuntime, "targetHeight", targetValues.height);
-    yogaValues.setProperty(uiRuntime, "windowWidth", targetValues.windowWidth);
-    yogaValues.setProperty(uiRuntime, "windowHeight", targetValues.windowHeight);
-    strongThis->layoutAnimationsManager_->startLayoutAnimation(uiRuntime, tag, LayoutAnimationType::LAYOUT, yogaValues);
-  });
+        auto &uiRuntime = strongThis->uiRuntime_;
+        jsi::Object yogaValues(uiRuntime);
+        yogaValues.setProperty(uiRuntime, "currentOriginX", currentValues.x);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginX", currentValues.x);
+        yogaValues.setProperty(uiRuntime, "currentOriginY", currentValues.y);
+        yogaValues.setProperty(uiRuntime, "currentGlobalOriginY", currentValues.y);
+        yogaValues.setProperty(uiRuntime, "currentWidth", currentValues.width);
+        yogaValues.setProperty(uiRuntime, "currentHeight", currentValues.height);
+        yogaValues.setProperty(uiRuntime, "targetOriginX", targetValues.x);
+        yogaValues.setProperty(uiRuntime, "targetGlobalOriginX", targetValues.x);
+        yogaValues.setProperty(uiRuntime, "targetOriginY", targetValues.y);
+        yogaValues.setProperty(uiRuntime, "targetGlobalOriginY", targetValues.y);
+        yogaValues.setProperty(uiRuntime, "targetWidth", targetValues.width);
+        yogaValues.setProperty(uiRuntime, "targetHeight", targetValues.height);
+        yogaValues.setProperty(uiRuntime, "windowWidth", targetValues.windowWidth);
+        yogaValues.setProperty(uiRuntime, "windowHeight", targetValues.windowHeight);
+        strongThis->layoutAnimationsManager_->startLayoutAnimation(
+            uiRuntime, tag, LayoutAnimationType::LAYOUT, yogaValues);
+      });
 }
 
 void LayoutAnimationsProxy_Legacy::updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation)
@@ -764,6 +831,12 @@ void LayoutAnimationsProxy_Legacy::updateOngoingAnimationTarget(const int tag, c
 }
 
 void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
+#ifdef ANDROID
+  // invalidate animation starts that are scheduled but haven't run yet
+  if (const auto it = pendingStarts_.find(tag); it != pendingStarts_.end()) {
+    it->second.handle++;
+  }
+#endif
   const auto layoutAnimationIt = layoutAnimations_.find(tag);
   if (layoutAnimationIt == layoutAnimations_.end()) {
     return;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
 #include <memory>
@@ -42,12 +43,18 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 #ifdef ANDROID
   restoreOpacityInCaseOfFlakyEnteringAnimation(surfaceId);
 #endif // ANDROID
-  for (const auto tag : finishedAnimationTags_) {
-    auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
-    layoutAnimations_.erase(tag);
+  auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+  for (const auto tag : maybeSettledAnimationTags_) {
+    const auto layoutAnimationIt = layoutAnimations_.find(tag);
+    if (layoutAnimationIt == layoutAnimations_.end() || !layoutAnimationIt->second.isSettled()) {
+      continue;
+    }
+    layoutAnimations_.erase(layoutAnimationIt);
     updateMap.erase(tag);
   }
-  finishedAnimationTags_.clear();
+  maybeSettledAnimationTags_.clear();
+  // Past this point no animation can be settled - we hold the mutex for the whole
+  // transaction, so no end callback can run until we return.
 
   parseRemoveMutations(movedViews, mutations, roots);
 
@@ -109,11 +116,10 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   // one after the other, so we need to keep count of how many
   // were actually triggered, so that we don't cleanup necessary
   // structures too early
-  if (layoutAnimation.count > 1) {
-    layoutAnimation.count--;
+  if (--layoutAnimation.count > 0) {
     return {};
   }
-  finishedAnimationTags_.push_back(tag);
+  maybeSettledAnimationTags_.insert(tag);
   auto surfaceId = layoutAnimation.finalView.surfaceId;
 
   if (!shouldRemove || !nodeForTag_.contains(tag)) {
@@ -121,6 +127,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   }
 
   auto node = nodeForTag_[tag];
+  react_native_assert(node->isMutationNode() && "exiting tag must map to a MutationNode");
   auto mutationNode = std::static_pointer_cast<MutationNode>(node);
   mutationNode->state = ExitingState_Legacy::DEAD;
   auto &[deadNodes] = surfaceContext_[surfaceId];
@@ -406,7 +413,7 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
 
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end()) {
+    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
       continue;
     }
 
@@ -757,10 +764,11 @@ void LayoutAnimationsProxy_Legacy::updateOngoingAnimationTarget(const int tag, c
 }
 
 void LayoutAnimationsProxy_Legacy::maybeCancelAnimation(const int tag) const {
-  if (!layoutAnimations_.contains(tag)) {
+  const auto layoutAnimationIt = layoutAnimations_.find(tag);
+  if (layoutAnimationIt == layoutAnimations_.end()) {
     return;
   }
-  layoutAnimations_.erase(tag);
+  layoutAnimations_.erase(layoutAnimationIt);
   scheduleOnUI(uiScheduler_, [weakThis = weak_from_this(), tag]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/SharedTransitions.cpp
@@ -210,7 +210,11 @@ Tag LayoutAnimationsProxy_Experimental::getOrCreateContainer(
     ShadowViewMutationList &filteredMutations,
     SurfaceId surfaceId) const {
   auto containerTag = sharedTransitionManager_->containerTags_[sharedTag];
-  auto shouldCreateContainer = (containerTag == -1 || !layoutAnimations_.contains(containerTag));
+  auto shouldCreateContainer = true;
+  if (containerTag != -1) {
+    const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
+    shouldCreateContainer = layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled();
+  }
 
   if (shouldCreateContainer) {
     containerTag = containerTag_;
@@ -264,11 +268,12 @@ void LayoutAnimationsProxy_Experimental::handleSharedTransitionsStart(
       auto &[_, after] = transition.snapshot;
 
       auto containerTag = sharedTransitionManager_->containerTags_[sharedTag];
-      if (!layoutAnimations_.contains(containerTag)) {
+      const auto layoutAnimationIt = layoutAnimations_.find(containerTag);
+      if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
         continue;
       }
       after.tag = containerTag;
-      const auto &la = layoutAnimations_[containerTag];
+      const auto &la = layoutAnimationIt->second;
       if (la.finalView.layoutMetrics != after.layoutMetrics) {
         overrideTransform(after, transition.transform[AFTER], propsParserContext);
         startSharedTransition(containerTag, la.currentView, after, surfaceId);


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release. #9660 depends on #9621, so both are included in this single PR (cherry-picked in order).
- #9621
- #9660