### PR TITLE
fix(Reanimated): delay on synchronous event animation cancel

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
@@ -35,7 +35,6 @@ export default function LiquidSwipe() {
   const isBack = useSharedValue(false);
   const centerY = useSharedValue(initialWaveCenter);
   const progress = useSharedValue(0);
-  const dragX = useSharedValue(0);
   const startY = useSharedValue(0);
 
   const maxDist = width - initialSideWidth;
@@ -45,7 +44,6 @@ export default function LiquidSwipe() {
       // stop animating progress, this will also place "isBack" value in the
       // final state (we update isBack in progress animation callback)
       cancelAnimation(progress);
-      dragX.value = 0;
       startY.value = isBack.value ? event.y : centerY.value;
     })
     .onChange((event) => {

--- a/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/Weave.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/Weave.tsx
@@ -62,7 +62,7 @@ export default function Weave({
             (progress.value / p1) * (maxHorRadius - initialHorRadius);
     }
     const t = (progress.value - p1) / (1.0 - p1);
-    const A = isBack ? 2 * initialHorRadius : maxHorRadius;
+    const A = isBack.value ? 2 * initialHorRadius : maxHorRadius;
     const r = 40;
     const m = 9.8;
     const beta = r / (2 * m);

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -10,6 +10,7 @@ export function valueSetter<Value>(
   const previousAnimation = mutable._animation;
   if (previousAnimation) {
     previousAnimation.cancelled = true;
+    previousAnimation.callback?.(false);
     mutable._animation = null;
   }
   if (
@@ -48,15 +49,11 @@ export function valueSetter<Value>(
 
     const step = (timestamp: number) => {
       if (animation.cancelled) {
-        animation.callback?.(false /* finished */);
         return;
       }
       const finished = animation.onFrame(animation, timestamp);
       animation.finished = true;
       animation.timestamp = timestamp;
-      // TODO TYPESCRIPT
-      // For now I'll assume that `animation.current` is always defined
-      // but actually need to dive into animations to understand it
       mutable._value = animation.current!;
       if (finished) {
         animation.callback?.(true /* finished */);


### PR DESCRIPTION
## Summary

In #9244 we made it so synchronous events no longer called a run of `rAF` queue. This means, that cancelling an animation inside an event will trigger its callback in the next frame, instead of synchronously.

This PR makes it so cancelling an animation triggers the callback immediately (what makes sense anyway).

## Test plan

LiquidSwipe works without flickers again.
