### PR TITLE
chore(Worklets): update Bundle Mode setup docs

### DIFF
--- a/docs/docs-worklets/docs/bundleMode/setup.mdx
+++ b/docs/docs-worklets/docs/bundleMode/setup.mdx
@@ -9,27 +9,9 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Setup
 
-## Package installation
-
-Install `react-native-worklets` package with the `bundle-mode-preview` tag:
-
-<Tabs groupId="package-managers">
-  <TabItem value="npm" label="NPM">
-    ```bash
-    npm i react-native-worklets@bundle-mode-preview
-    ```
-  </TabItem>
-
-  <TabItem value="yarn" label="YARN">
-    ```bash
-    yarn add react-native-worklets@bundle-mode-preview
-    ```
-  </TabItem>
-</Tabs>
+To use `react-native-worklets`'s Bundle Mode feature, you need to make the following changes in your repository:
 
 ## Configure Babel
-
-To use `react-native-worklets`'s Bundle Mode feature, you need to make the following changes in your repository:
 
 1. **Modify your Babel configuration**. [Worklets Babel Plugin](/docs/worklets-babel-plugin/about) needs to know that it has to prepare your code for the Bundle Mode. This is also the source of truth for your app to know if the Bundle Mode is enabled. In your `babel.config.js` file, add the following:
 


### PR DESCRIPTION
## Summary

Since it's stable there's no longer for a separate NPM tag.

## Test plan
