### PR TITLE
fix: avoid Android stack overflow in Shadow Nodes Cloning example

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/ShadowNodesCloningExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/ShadowNodesCloningExample.tsx
@@ -75,7 +75,7 @@ function RecursiveView(props: { depth: number; extraChildrenCount: number }) {
 export default function ShadowNodesCloningExample() {
   return (
     <View style={styles.container}>
-      <RecursiveView depth={100} extraChildrenCount={100} />
+      <RecursiveView depth={30} extraChildrenCount={100} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary

The Shadow Nodes Cloning example crashes the example app on **Android** after the RN 0.86 bump (#9669) - a native **stack overflow** on the JS thread, not a Reanimated bug.

## Root cause

The example forces a 100-level-deep native view tree (`collapsable={false}` on every level defeats view-flattening). On mount, React Native's Differentiator (`calculateShadowViewMutations`) recurses once per nesting level on the JS thread, which has only ~1 MB of stack on Android (iOS doubles it). RN 0.86's LIS-based differentiator (facebook/react-native#56094) added stack-heavy locals to that function; the feature is gated off by default, but the debug (`-O0`) build still reserves stack for them. Measured on the shipped `libreactnative.so`, the recursive frame grew from ~8.6 KB to ~14 KB, lowering the safe nesting depth from ~120 to ~74 - so the example's depth=100 now overflows. Reanimated is not on the crashing stack; a plain RN tree of the same depth crashes identically.

## Fix

Lower the example's nesting depth from 100 to 30 - well under the ~74 limit, while still exercising shadow-node cloning. Verified on-device: depth=100 reproduces the SIGSEGV, depth=30 mounts and animates cleanly, iOS unaffected.
