### PR TITLE
fix: Pass -fno-pch-timestamp so ccache can reuse the Android PCH

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -56,6 +56,12 @@ add_library(
 target_precompile_headers(reanimated PRIVATE
                           "${ANDROID_CPP_DIR}/ReanimatedPCH.h")
 
+# Stop Clang from embedding a build timestamp in the .pch. Without this the PCH
+# is non-reproducible across builds, so ccache can't reuse it and translation
+# units reject a restored PCH as "modified since built".
+target_compile_options(reanimated PRIVATE
+                       "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>")
+
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
   include(
     "${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -60,6 +60,12 @@ add_library(worklets SHARED ${WORKLETS_COMMON_CPP_SOURCES}
 
 target_precompile_headers(worklets PRIVATE "${ANDROID_CPP_DIR}/WorkletsPCH.h")
 
+# Stop Clang from embedding a build timestamp in the .pch. Without this the PCH
+# is non-reproducible across builds, so ccache can't reuse it and translation
+# units reject a restored PCH as "modified since built".
+target_compile_options(worklets PRIVATE
+                       "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>")
+
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
   include(
     "${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")


### PR DESCRIPTION
## Summary

Android C++ builds use precompiled headers for both the reanimated and worklets targets. By default, Clang embeds a build timestamp in the generated .pch binary, making the PCH non-reproducible across builds. As a result, ccache can't reuse a cached PCH, since its content differs on every build. You can find more context in the ccache documentation -  https://ccache.dev/manual/4.9.html#_precompiled_headers

This PR passes `-Xclang -fno-pch-timestamp` to the C++ compiler for both targets, so Clang stops embedding the timestamp.

This mirrors the same fix applied in Expo expo/expo#46915.

## Test plan

- build fabric-example ✅ 