### PR TITLE
chore: deduplicate web CSS callback-listener lifecycle

### DIFF
--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -22,6 +22,7 @@ import { insertCSSAnimation, removeCSSAnimation } from '../domUtils';
 import { CSSKeyframesRuleImpl } from '../keyframes';
 import { normalizeIterationCount } from '../normalization';
 import { maybeAddSuffixes, parseTimingFunction } from '../utils';
+import { CSSCallbackListeners } from './CSSCallbackListeners';
 
 const ANIMATION_EVENT_NAME: Record<CSSAnimationCallbackProp, string> = {
   onAnimationStart: 'animationstart',
@@ -29,10 +30,6 @@ const ANIMATION_EVENT_NAME: Record<CSSAnimationCallbackProp, string> = {
   onAnimationIteration: 'animationiteration',
   onAnimationCancel: 'animationcancel',
 };
-
-const CALLBACK_PROPS = Object.keys(
-  ANIMATION_EVENT_NAME
-) as CSSAnimationCallbackProp[];
 
 const isCSSKeyframesRuleImpl = (
   keyframes: ExistingCSSAnimationProperties['animationName']
@@ -56,22 +53,33 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   private attachedAnimations: Record<string, ProcessedAnimation> = {};
   private unmountCleanupCalled = false;
 
-  private callbacks: CSSAnimationCallbacks = {};
-  private readonly attachedStateListeners = new Map<
+  private readonly callbackListeners: CSSCallbackListeners<
     CSSAnimationCallbackProp,
-    EventListener
-  >();
+    CSSAnimationEvent
+  >;
 
   constructor(element: ReanimatedHTMLElement, svgElementTag = '') {
     this.element = element;
     this.svgElementTag = svgElementTag;
+    this.callbackListeners = new CSSCallbackListeners<
+      CSSAnimationCallbackProp,
+      CSSAnimationEvent
+    >(element, ANIMATION_EVENT_NAME, (event) => {
+      const animationEvent = event as AnimationEvent;
+      return {
+        animationName: animationEvent.animationName,
+        elapsedTime: animationEvent.elapsedTime,
+      };
+    });
   }
 
   update(
     animationProperties: ExistingCSSAnimationProperties | null,
     callbacks: CSSAnimationCallbacks | null = null
   ) {
-    this.syncStateListeners(callbacks ?? {});
+    // Keep listeners tied to callback presence (not animation presence) so an
+    // `animationcancel` emitted while detaching still reaches the user.
+    this.callbackListeners.sync(callbacks ?? {});
 
     if (!animationProperties) {
       this.detach();
@@ -138,7 +146,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
   }
 
   unmountCleanup(): void {
-    this.syncStateListeners({});
+    this.callbackListeners.detach();
 
     if (!this.unmountCleanupCalled) {
       this.unmountCleanupCalled = true;
@@ -166,40 +174,6 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     this.removeAnimationsFromStyleSheet(attachedAnimations);
     this.unmountCleanupCalled = false;
     this.attachedAnimations = {};
-  }
-
-  private syncStateListeners(callbacks: CSSAnimationCallbacks) {
-    this.callbacks = callbacks;
-
-    for (const prop of CALLBACK_PROPS) {
-      const eventName = ANIMATION_EVENT_NAME[prop];
-      const hasCallback = typeof callbacks[prop] === 'function';
-      const listener = this.attachedStateListeners.get(prop);
-
-      if (hasCallback && !listener) {
-        const newListener = this.createStateListener(prop);
-        this.attachedStateListeners.set(prop, newListener);
-        this.element.addEventListener(eventName, newListener);
-      } else if (!hasCallback && listener) {
-        this.element.removeEventListener(eventName, listener);
-        this.attachedStateListeners.delete(prop);
-      }
-    }
-  }
-
-  private createStateListener(prop: CSSAnimationCallbackProp): EventListener {
-    return (event: Event) => {
-      const animationEvent = event as AnimationEvent;
-      if (animationEvent.target !== this.element) {
-        return;
-      }
-
-      const payload: CSSAnimationEvent = {
-        animationName: animationEvent.animationName,
-        elapsedTime: animationEvent.elapsedTime,
-      };
-      this.callbacks[prop]?.(payload);
-    };
   }
 
   private updateAttachedAnimations(processedAnimations: ProcessedAnimation[]) {

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -1,0 +1,58 @@
+'use strict';
+import type { ReanimatedHTMLElement } from '../../../ReanimatedModule/js-reanimated';
+
+type CallbackMap<Prop extends string, Payload> = Partial<
+  Record<Prop, ((payload: Payload) => void) | undefined>
+>;
+
+/**
+ * Backs CSS animation/transition callbacks with DOM event listeners on a single
+ * element. The lifecycle is shared between the two kinds; only the event names
+ * and the payload shape differ, so those are injected.
+ */
+export class CSSCallbackListeners<Prop extends string, Payload> {
+  private callbacks: CallbackMap<Prop, Payload> = {};
+  private readonly attachedListeners = new Map<Prop, EventListener>();
+  private readonly props: Prop[];
+
+  constructor(
+    private readonly element: ReanimatedHTMLElement,
+    private readonly eventNameByProp: Record<Prop, string>,
+    private readonly buildPayload: (event: Event) => Payload
+  ) {
+    this.props = Object.keys(eventNameByProp) as Prop[];
+  }
+
+  sync(callbacks: CallbackMap<Prop, Payload>): void {
+    this.callbacks = callbacks;
+
+    for (const prop of this.props) {
+      const eventName = this.eventNameByProp[prop];
+      const hasCallback = typeof callbacks[prop] === 'function';
+      const listener = this.attachedListeners.get(prop);
+
+      if (hasCallback && !listener) {
+        const newListener = this.createListener(prop);
+        this.attachedListeners.set(prop, newListener);
+        this.element.addEventListener(eventName, newListener);
+      } else if (!hasCallback && listener) {
+        this.element.removeEventListener(eventName, listener);
+        this.attachedListeners.delete(prop);
+      }
+    }
+  }
+
+  detach(): void {
+    this.sync({});
+  }
+
+  private createListener(prop: Prop): EventListener {
+    return (event: Event) => {
+      // Animation/transition events bubble; only handle this element's own.
+      if (event.target !== this.element) {
+        return;
+      }
+      this.callbacks[prop]?.(this.buildPayload(event));
+    };
+  }
+}

--- a/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSCallbackListeners.ts
@@ -5,11 +5,6 @@ type CallbackMap<Prop extends string, Payload> = Partial<
   Record<Prop, ((payload: Payload) => void) | undefined>
 >;
 
-/**
- * Backs CSS animation/transition callbacks with DOM event listeners on a single
- * element. The lifecycle is shared between the two kinds; only the event names
- * and the payload shape differ, so those are injected.
- */
 export class CSSCallbackListeners<Prop extends string, Payload> {
   private callbacks: CallbackMap<Prop, Payload> = {};
   private readonly attachedListeners = new Map<Prop, EventListener>();

--- a/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSTransitionsManager.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types';
 import { normalizeCSSTransitionProperties } from '../normalization';
 import { maybeAddSuffixes, parseTimingFunction } from '../utils';
+import { CSSCallbackListeners } from './CSSCallbackListeners';
 
 const TRANSITION_EVENT_NAME: Record<CSSTransitionCallbackProp, string> = {
   onTransitionRun: 'transitionrun',
@@ -18,22 +19,27 @@ const TRANSITION_EVENT_NAME: Record<CSSTransitionCallbackProp, string> = {
   onTransitionCancel: 'transitioncancel',
 };
 
-const CALLBACK_PROPS = Object.keys(
-  TRANSITION_EVENT_NAME
-) as CSSTransitionCallbackProp[];
-
 export default class CSSTransitionsManager implements ICSSTransitionsManager {
   private readonly element: ReanimatedHTMLElement;
   private isAttached = false;
 
-  private callbacks: CSSTransitionCallbacks = {};
-  private readonly attachedStateListeners = new Map<
+  private readonly callbackListeners: CSSCallbackListeners<
     CSSTransitionCallbackProp,
-    EventListener
-  >();
+    CSSTransitionEvent
+  >;
 
   constructor(element: ReanimatedHTMLElement) {
     this.element = element;
+    this.callbackListeners = new CSSCallbackListeners<
+      CSSTransitionCallbackProp,
+      CSSTransitionEvent
+    >(element, TRANSITION_EVENT_NAME, (event) => {
+      const transitionEvent = event as TransitionEvent;
+      return {
+        propertyName: camelizeKebabCase(transitionEvent.propertyName),
+        elapsedTime: transitionEvent.elapsedTime,
+      };
+    });
   }
 
   update(
@@ -42,7 +48,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   ) {
     // Keep listeners tied to callback presence (not transition presence) so a
     // `transitioncancel` emitted while detaching still reaches the user.
-    this.syncStateListeners(callbacks ?? {});
+    this.callbackListeners.sync(callbacks ?? {});
 
     if (!transitionProperties) {
       this.detach();
@@ -54,7 +60,7 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
   }
 
   unmountCleanup() {
-    this.syncStateListeners({});
+    this.callbackListeners.detach();
   }
 
   private detach() {
@@ -71,41 +77,6 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     this.element.style.transitionBehavior = '';
 
     this.isAttached = false;
-  }
-
-  private syncStateListeners(callbacks: CSSTransitionCallbacks) {
-    this.callbacks = callbacks;
-
-    for (const prop of CALLBACK_PROPS) {
-      const eventName = TRANSITION_EVENT_NAME[prop];
-      const hasCallback = typeof callbacks[prop] === 'function';
-      const listener = this.attachedStateListeners.get(prop);
-
-      if (hasCallback && !listener) {
-        const newListener = this.createStateListener(prop);
-        this.attachedStateListeners.set(prop, newListener);
-        this.element.addEventListener(eventName, newListener);
-      } else if (!hasCallback && listener) {
-        this.element.removeEventListener(eventName, listener);
-        this.attachedStateListeners.delete(prop);
-      }
-    }
-  }
-
-  private createStateListener(prop: CSSTransitionCallbackProp): EventListener {
-    return (event: Event) => {
-      const transitionEvent = event as TransitionEvent;
-      // Transition events bubble; only handle this element's own transitions.
-      if (transitionEvent.target !== this.element) {
-        return;
-      }
-
-      const payload: CSSTransitionEvent = {
-        propertyName: camelizeKebabCase(transitionEvent.propertyName),
-        elapsedTime: transitionEvent.elapsedTime,
-      };
-      this.callbacks[prop]?.(payload);
-    };
   }
 
   private setElementTransition(transitionProperties: CSSTransitionProperties) {

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSCallbackListeners.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSCallbackListeners.web.test.ts
@@ -1,0 +1,109 @@
+'use strict';
+import type { ReanimatedHTMLElement } from '../../../../ReanimatedModule/js-reanimated';
+import { CSSCallbackListeners } from '../CSSCallbackListeners';
+
+type Prop = 'onFoo' | 'onBar';
+
+const EVENT_NAME: Record<Prop, string> = { onFoo: 'foo', onBar: 'bar' };
+
+type Payload = { detail: string };
+
+const buildPayload = (event: Event): Payload => ({
+  detail: (event as CustomEvent).detail as string,
+});
+
+const namedEvent = (type: string, detail: string): Event =>
+  Object.assign(new Event(type, { bubbles: true }), { detail });
+
+describe('CSSCallbackListeners (web)', () => {
+  let element: ReanimatedHTMLElement;
+  let listeners: CSSCallbackListeners<Prop, Payload>;
+
+  beforeEach(() => {
+    element = document.createElement('div') as unknown as ReanimatedHTMLElement;
+    listeners = new CSSCallbackListeners<Prop, Payload>(
+      element,
+      EVENT_NAME,
+      buildPayload
+    );
+  });
+
+  test('subscribes to the mapped event on the first callback and forwards the built payload', () => {
+    const onFoo = jest.fn();
+    const addSpy = jest.spyOn(element, 'addEventListener');
+
+    listeners.sync({ onFoo });
+    expect(addSpy).toHaveBeenCalledWith('foo', expect.any(Function));
+
+    element.dispatchEvent(namedEvent('foo', 'hello'));
+    expect(onFoo).toHaveBeenCalledWith({ detail: 'hello' });
+  });
+
+  test('unsubscribes with the same listener reference when the callback is removed', () => {
+    const addSpy = jest.spyOn(element, 'addEventListener');
+    const removeSpy = jest.spyOn(element, 'removeEventListener');
+
+    listeners.sync({ onFoo: jest.fn() });
+    listeners.sync({});
+
+    expect(removeSpy.mock.calls).toEqual(addSpy.mock.calls);
+  });
+
+  test('uses the latest callback without re-subscribing on re-sync', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const addSpy = jest.spyOn(element, 'addEventListener');
+
+    listeners.sync({ onFoo: first });
+    listeners.sync({ onFoo: second });
+    expect(addSpy.mock.calls.filter(([name]) => name === 'foo')).toHaveLength(
+      1
+    );
+
+    element.dispatchEvent(namedEvent('foo', 'x'));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores events that bubble up from descendant nodes', () => {
+    const onFoo = jest.fn();
+    listeners.sync({ onFoo });
+
+    const child = document.createElement('div');
+    element.appendChild(child);
+    child.dispatchEvent(namedEvent('foo', 'x'));
+
+    expect(onFoo).not.toHaveBeenCalled();
+  });
+
+  test('detach removes every listener, and a later sync re-attaches a fresh one', () => {
+    const onFoo = jest.fn();
+    listeners.sync({ onFoo });
+
+    listeners.detach();
+    element.dispatchEvent(namedEvent('foo', 'a'));
+    expect(onFoo).not.toHaveBeenCalled();
+
+    const onFooAgain = jest.fn();
+    listeners.sync({ onFoo: onFooAgain });
+    element.dispatchEvent(namedEvent('foo', 'b'));
+    expect(onFooAgain).toHaveBeenCalledWith({ detail: 'b' });
+  });
+
+  test('only manages props present in the event-name map', () => {
+    const addSpy = jest.spyOn(element, 'addEventListener');
+
+    listeners.sync({ onBaz: jest.fn() } as never);
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  test('removes the listener when a callback becomes undefined', () => {
+    const removeSpy = jest.spyOn(element, 'removeEventListener');
+
+    listeners.sync({ onFoo: jest.fn() });
+    listeners.sync({ onFoo: undefined });
+
+    expect(removeSpy).toHaveBeenCalledWith('foo', expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the DOM event-listener lifecycle that was duplicated between the web `CSSAnimationsManager` and `CSSTransitionsManager` (subscribe on the first callback, unsubscribe with the same listener reference, reuse the latest callback across re-renders, and the per-view bubbling filter) into a single composed helper, `CSSCallbackListeners`. Each manager keeps only its own event-name map and payload builder, which are injected. Behavior is unchanged.