### PR TITLE
cherry-pick(4.4-stable): re-add LightNode before starting exiting animation (#9646)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp
@@ -515,8 +515,8 @@ bool LayoutAnimationsProxy_Experimental::startAnimationsRecursively(
 
   if (hasExitAnimation) {
     node->state = ANIMATING;
-    startExitingAnimation(node);
     lightNodes_[node->current.tag] = node;
+    startExitingAnimation(node);
   } else {
     // TODO (future): add proper cleanup
     //    layoutAnimationsManager_->clearLayoutAnimationConfig(node->tag);


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9646