### PR TITLE
cherry-pick(4.4-stable): use optional chaining on Platform.OS to prevent crash in Bundle Mode (#9525)

### DIFF
--- a/packages/react-native-reanimated/src/common/constants/platform.ts
+++ b/packages/react-native-reanimated/src/common/constants/platform.ts
@@ -10,12 +10,12 @@ function isWindowAvailable() {
 }
 
 export const IS_ANDROID: boolean = /* @__PURE__ */ (() =>
-  Platform.OS === 'android')();
-export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform.OS === 'ios')();
-export const IS_WEB: boolean = Platform.OS === 'web';
+  Platform?.OS === 'android')();
+export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform?.OS === 'ios')();
+export const IS_WEB: boolean = Platform?.OS === 'web';
 export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;
 /** @knipIgnore */
-export const IS_WINDOWS: boolean = Platform.OS === 'windows';
+export const IS_WINDOWS: boolean = Platform?.OS === 'windows';
 
 export const IS_WINDOW_AVAILABLE: boolean = isWindowAvailable();
 


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9525