### PR TITLE
cherry-pick(4.4-stable): Require `onStart` in `valueSetter` animation detection (#9526)

### DIFF
--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -17,7 +17,8 @@ export function valueSetter<Value>(
     (value !== null &&
       typeof value === 'object' &&
       // TODO TYPESCRIPT fix this after fixing AnimationObject type
-      (value as unknown as AnimationObject).onFrame !== undefined)
+      (value as unknown as AnimationObject).onFrame !== undefined &&
+      (value as unknown as AnimationObject).onStart !== undefined)
   ) {
     const animation: AnimationObject<Value> =
       typeof value === 'function'


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9526