### PR TITLE
cherry-pick(4.4-stable): Remove use-after-move in `makeJWorkletRuntimeWrapper` (#9580)

### DIFF
--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.cpp
@@ -13,10 +13,10 @@ using namespace facebook::jni;
 
 local_ref<JWorkletRuntimeWrapper::JavaPart> JWorkletRuntimeWrapper::makeJWorkletRuntimeWrapper(
     std::shared_ptr<WorkletRuntime> workletRuntime) {
-  return JWorkletRuntimeWrapper::newObjectCxxArgs(std::move(workletRuntime), workletRuntime->getRuntimeId());
+  return JWorkletRuntimeWrapper::newObjectCxxArgs(std::move(workletRuntime));
 }
 
-JWorkletRuntimeWrapper::JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime, uint64_t runtimeId)
+JWorkletRuntimeWrapper::JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime)
     : workletRuntime_(std::move(workletRuntime)) {}
 
 void JWorkletRuntimeWrapper::cxxEmitDeviceEvent(

--- a/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.h
+++ b/packages/react-native-worklets/android/src/main/cpp/worklets/android/JWorkletRuntimeWrapper.h
@@ -33,7 +33,7 @@ class JWorkletRuntimeWrapper : public jni::HybridClass<JWorkletRuntimeWrapper> {
  private:
   friend HybridBase;
 
-  JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime, uint64_t runtimeId);
+  explicit JWorkletRuntimeWrapper(std::shared_ptr<WorkletRuntime> workletRuntime);
 
   const std::shared_ptr<WorkletRuntime> workletRuntime_;
 };


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9580