### PR TITLE
cherry-pick(4.4-stable): guard preserveMountedTags against resolveView throwing (#9649)

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import com.facebook.react.uimanager.IllegalViewOperationException
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.soloader.SoLoader
@@ -201,7 +202,19 @@ open class NativeProxy {
         }
 
         for (i in tags.indices) {
-            if (mFabricUIManager.resolveView(tags[i]) == null) {
+            try {
+                if (mFabricUIManager.resolveView(tags[i]) == null) {
+                    tags[i] = -1
+                }
+            } catch (e: IllegalViewOperationException) {
+                // `resolveView` is expected to return `null` for a tag without a
+                // mounted view, but it instead throws when the tag's `ViewState` is
+                // already registered while the Android view hasn't been created yet.
+                // This happens when a view is mid-preallocation and a third-party view
+                // manager (e.g. lottie-react-native) dispatches an event synchronously
+                // from within `createView`, re-entering this code path. Treat it the
+                // same as a missing view.
+                // See https://github.com/software-mansion/react-native-reanimated/issues/9636.
                 tags[i] = -1
             }
         }


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9649