### PR TITLE
fix: Re-register pseudo selectors after a component remount

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -110,8 +110,6 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     if (this.isRegistered) {
       this.detach();
     }
-    // Reset the baseline so a reused instance (e.g. a frozen subtree thawing) re-registers
-    // on the next identical `update` instead of hitting the `deepEqual` early-return.
     this.prevPseudoStylesBySelector = null;
     this.prevTransitionProperties = null;
   }

--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -110,6 +110,10 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     if (this.isRegistered) {
       this.detach();
     }
+    // Reset the baseline so a reused instance (e.g. a frozen subtree thawing) re-registers
+    // on the next identical `update` instead of hitting the `deepEqual` early-return.
+    this.prevPseudoStylesBySelector = null;
+    this.prevTransitionProperties = null;
   }
 
   private detach() {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -457,5 +457,22 @@ describe('CSSPseudoStylesManager', () => {
 
       expect(unregisterPseudoStyles).not.toHaveBeenCalled();
     });
+
+    test('re-registers identical styles after unmountCleanup (reused instance remount)', () => {
+      const style: CSSStyle = {
+        opacity: { default: 0, ':hover': 1 },
+      };
+
+      pushStyle(manager, style);
+      manager.unmountCleanup();
+      jest.clearAllMocks();
+
+      // The same manager instance is reused (e.g. a frozen subtree thaws and the
+      // AnimatedComponent's CSSManager is kept). An identical-styles update must not
+      // be swallowed by the deepEqual early-return; it has to re-register natively.
+      pushStyle(manager, { ...style });
+
+      expect(registerPseudoStyles).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
`CSSPseudoStylesManager.unmountCleanup` unregistered the pseudo styles but kept the cached previous styles, so a reused `AnimatedComponent` instance (e.g. a frozen subtree thawing) hit `update`'s `deepEqual` early-return on the next identical update and never re-registered. Clear the cached baseline so it re-registers.