### PR TITLE
chore: restore pull_request_target

### DIFF
--- a/.github/workflows/github-pull-request-description-format.yml
+++ b/.github/workflows/github-pull-request-description-format.yml
@@ -1,6 +1,6 @@
 name: GitHub Pull Request description format
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 

--- a/.github/workflows/github-pull-request-label-format.yml
+++ b/.github/workflows/github-pull-request-label-format.yml
@@ -1,6 +1,6 @@
 name: GitHub Pull Request label format
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary

After analysis it's safe to use `pull_request_target` in these actions as they don't have access to any caches nor can extract secrets.

## Test plan

CI
