### PR TITLE
fix: prevent recursive loops when setting values in callbacks

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -107,6 +107,7 @@ export default function RuntimeTestsExample() {
             // TODO: update expected values
             // require('./tests/core/cancelAnimation.test');
             // TODO: speed up useSharedValue tests, they have unnecessarily long delays
+            require('./tests/core/useSharedValue/animationAssigning.test');
             require('./tests/core/useSharedValue/synchronization.test');
             require('./tests/core/useSharedValue/numbers.test');
             require('./tests/core/useSharedValue/arrays.test');

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/animationAssigning.test.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/animationAssigning.test.ts
@@ -1,0 +1,88 @@
+import { makeMutable, withTiming } from 'react-native-reanimated';
+
+import {
+  describe,
+  expect,
+  notify,
+  test,
+  waitForNotification,
+  beforeEach,
+} from '../../../ReJest/RuntimeTestsApi';
+import { scheduleOnRN } from 'react-native-worklets';
+
+const NOTIFY_FIRST_CALLBACK = 'NOTIFY_FIRST_CALLBACK';
+const NOTIFY_SECOND_CALLBACK = 'NOTIFY_SECOND_CALLBACK';
+
+describe('Test animation reassignments on mutable', () => {
+  let firstCanceled = false;
+  let secondCanceled = false;
+  const notifyFirst = (finished: boolean) => {
+    firstCanceled = !finished;
+    notify(NOTIFY_FIRST_CALLBACK);
+  };
+
+  const notifySecond = (finished: boolean) => {
+    secondCanceled = !finished;
+    notify(NOTIFY_SECOND_CALLBACK);
+  };
+
+  beforeEach(() => {
+    firstCanceled = false;
+    secondCanceled = false;
+  });
+
+  test('previous animation is canceled on direct assignment', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+    });
+
+    requestAnimationFrame(() => {
+      mutable.value = withTiming(200, {}, (finished) => {
+        scheduleOnRN(notifySecond, finished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(true);
+    expect(secondCanceled).toBe(false);
+  });
+
+  test('reassignment in callback', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+      mutable.value = withTiming(200, {}, (innerFinished) => {
+        scheduleOnRN(notifySecond, innerFinished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(false);
+    expect(secondCanceled).toBe(false);
+  });
+
+  test('reassignment both directly and in callback', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+      mutable.value = withTiming(200, {});
+    });
+
+    requestAnimationFrame(() => {
+      mutable.value = withTiming(300, {}, (finished) => {
+        scheduleOnRN(notifySecond, finished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(true);
+    expect(secondCanceled).toBe(false);
+  });
+});

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -9,9 +9,9 @@ export function valueSetter<Value>(
   'worklet';
   const previousAnimation = mutable._animation;
   if (previousAnimation) {
+    mutable._animation = null;
     previousAnimation.cancelled = true;
     previousAnimation.callback?.(false);
-    mutable._animation = null;
   }
   if (
     typeof value === 'function' ||

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -10,8 +10,10 @@ export function valueSetter<Value>(
   const previousAnimation = mutable._animation;
   if (previousAnimation) {
     mutable._animation = null;
-    previousAnimation.cancelled = true;
-    previousAnimation.callback?.(false);
+    if (!previousAnimation.finished) {
+      previousAnimation.cancelled = true;
+      previousAnimation.callback?.(false);
+    }
   }
   if (
     typeof value === 'function' ||
@@ -52,10 +54,10 @@ export function valueSetter<Value>(
         return;
       }
       const finished = animation.onFrame(animation, timestamp);
-      animation.finished = true;
       animation.timestamp = timestamp;
       mutable._value = animation.current!;
       if (finished) {
+        animation.finished = true;
         animation.callback?.(true /* finished */);
       } else {
         requestAnimationFrame(step);


### PR DESCRIPTION
## Summary

Address #9750 by cleaning the animation before executing the callback

## Test plan

```tsx
import { useEffect } from 'react';
import { View } from 'react-native';
import { useSharedValue, withTiming } from 'react-native-reanimated';

export function Repro() {
  const value = useSharedValue(0);

  useEffect(() => {
    value.value = withTiming(1, { duration: 1000 }, (finished) => {
      console.log('first animation callback', finished);

      if (!finished) {
        value.value = withTiming(0, { duration: 1000 });
      }
    });

    setTimeout(() => {
      value.value = withTiming(0, { duration: 1000 });
    }, 100);
  }, [value]);

  return <View />;
}
```
crashed before, works now