### PR TITLE
chore: update RNW peer dep

### DIFF
--- a/packages/react-native-reanimated/package.json
+++ b/packages/react-native-reanimated/package.json
@@ -102,7 +102,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "0.83 - 0.86",
-    "react-native-worklets": "*"
+    "react-native-worklets": "0.11.0-main"
   },
   "devDependencies": {
     "@babel/core": "7.28.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27957,7 +27957,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: 0.83 - 0.86
-    react-native-worklets: "*"
+    react-native-worklets: 0.11.0-main
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Changing peer-dependency on the main branch for RNW to match the value from main branch package.json. This way we don't accidentally leave it as a "*" when branch cutting - happened to me once.

No changes are needed for nightly releases etc. as they are skipped for pre-release versions.

## Test plan

#9085 
