### PR TITLE
fix: restore opacity for flaky entering animations under Reduce Motion on iOS

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -413,7 +413,13 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
 
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
+    if (layoutAnimationIt == layoutAnimations_.end() ||
+        // A settled animation is normally cleaned up without applying further
+        // updates. The exception is a flaky entering animation whose opacity was
+        // never restored (the view wasn't mounted in time) - we still need to
+        // apply that pending opacity, otherwise the view stays invisible. Only
+        // entering animations carry an opacity value.
+        (layoutAnimationIt->second.isSettled() && !layoutAnimationIt->second.opacity.has_value())) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #9771.

On iOS, a view with an `entering` animation stays invisible (stuck at the temporary `opacity: 0`) when Reduce Motion is enabled and `ENABLE_SHARED_ELEMENT_TRANSITIONS` is disabled.

The legacy proxy temporarily sets a newly entering view's opacity to 0 and restores it once the animation progresses. #9621 started skipping ongoing-animation updates for settled animations. Under Reduce Motion the entering animation settles in the same frame, so its opacity-restore update is dropped and the view never becomes visible. Android is unaffected because the `restoreOpacityInCaseOfFlakyEnteringAnimation` safety net is gated `#ifdef ANDROID`.

This keeps applying the pending opacity for a settled entering animation whose opacity hasn't been restored yet. Only entering animations carry an opacity value, and on the normal path that value is cleared once the view mounts, so regular entering and exiting animations are unaffected.

## Test plan

1. Enable Reduce Motion on an iOS simulator.
2. Set `ENABLE_SHARED_ELEMENT_TRANSITIONS: false` in the reanimated `staticFeatureFlags`.
3. Render a view with an entering animation:
   ```tsx
   <Animated.View entering={FadeIn}>
     <Text>This text should be visible</Text>
   </Animated.View>
   ```

Before: the view is invisible. After: the view is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
