### PR TITLE
fix: animate react-native-svg via CSS on web in minified builds

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/init.web.ts
+++ b/packages/react-native-reanimated/src/css/svg/init.web.ts
@@ -9,27 +9,27 @@ import {
   SVG_RECT_WEB_PROPERTIES_CONFIG,
 } from './web';
 
-// Components with no CSS-animatable geometry on web: any geometry they expose is
+// SVG tags with no CSS-animatable geometry on web: any geometry they expose is
 // an SVG attribute, not a CSS property. They fall back to the shared common config.
-const COMMON_ONLY_COMPONENTS = [
-  'G',
-  'Line',
-  'Pattern',
-  'Polygon',
-  'Polyline',
-  'Text',
-  'LinearGradient',
-  'RadialGradient',
+const COMMON_ONLY_TAGS = [
+  'g',
+  'line',
+  'pattern',
+  'polygon',
+  'polyline',
+  'text',
+  'linearGradient',
+  'radialGradient',
 ] as const;
 
 export function initSvgCssSupport() {
-  registerWebSvgPropsBuilder('Circle', SVG_CIRCLE_WEB_PROPERTIES_CONFIG);
-  registerWebSvgPropsBuilder('Ellipse', SVG_ELLIPSE_WEB_PROPERTIES_CONFIG);
-  registerWebSvgPropsBuilder('Image', SVG_IMAGE_WEB_PROPERTIES_CONFIG);
-  registerWebSvgPropsBuilder('Path', SVG_PATH_WEB_PROPERTIES_CONFIG);
-  registerWebSvgPropsBuilder('Rect', SVG_RECT_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('circle', SVG_CIRCLE_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('ellipse', SVG_ELLIPSE_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('image', SVG_IMAGE_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('path', SVG_PATH_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('rect', SVG_RECT_WEB_PROPERTIES_CONFIG);
 
-  for (const componentName of COMMON_ONLY_COMPONENTS) {
-    registerWebSvgPropsBuilder(componentName, SVG_COMMON_WEB_PROPERTIES_CONFIG);
+  for (const tag of COMMON_ONLY_TAGS) {
+    registerWebSvgPropsBuilder(tag, SVG_COMMON_WEB_PROPERTIES_CONFIG);
   }
 }

--- a/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
+++ b/packages/react-native-reanimated/src/css/web/__tests__/animationParser.test.ts
@@ -8,7 +8,7 @@ import { processKeyframeDefinitions } from '../animationParser';
 
 beforeAll(() => {
   registerWebSvgPropsBuilder('TestStroke', SVG_COMMON_WEB_PROPERTIES_CONFIG);
-  registerWebSvgPropsBuilder('Path', SVG_PATH_WEB_PROPERTIES_CONFIG);
+  registerWebSvgPropsBuilder('path', SVG_PATH_WEB_PROPERTIES_CONFIG);
 });
 
 describe(processKeyframeDefinitions, () => {
@@ -24,7 +24,7 @@ describe(processKeyframeDefinitions, () => {
   test('pads a trailing Z so an open->closed path morph interpolates', () => {
     const result = processKeyframeDefinitions(
       { from: { d: 'M0,0 L10,10' }, to: { d: 'M0,0 L20,5 Z' } },
-      'Path'
+      'path'
     );
     expect(result).toContain('from { d: path("M0,0 L10,10Z") }');
     expect(result).toContain('to { d: path("M0,0 L20,5 Z") }');

--- a/packages/react-native-reanimated/src/css/web/animationParser.ts
+++ b/packages/react-native-reanimated/src/css/web/animationParser.ts
@@ -11,9 +11,9 @@ import { parseTimingFunction } from './utils';
 
 export function processKeyframeDefinitions<TStyle extends object>(
   definitions: CSSAnimationKeyframes<TStyle>,
-  componentName = ''
+  svgElementTag = ''
 ) {
-  const propsBuilder = getWebSvgPropsBuilder(componentName) ?? webPropsBuilder;
+  const propsBuilder = getWebSvgPropsBuilder(svgElementTag) ?? webPropsBuilder;
 
   // Whole-set fixups (strokeDasharray endpoints, open/closed path Z-padding)
   // before serializing each block.

--- a/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSAnimationsManager.ts
@@ -50,7 +50,7 @@ type ProcessedSettings = ConvertValuesToArrays<CSSAnimationSettings>;
 
 export default class CSSAnimationsManager implements ICSSAnimationsManager {
   private readonly element: ReanimatedHTMLElement;
-  private readonly componentName: string;
+  private readonly svgElementTag: string;
 
   // Keys are processed keyframes
   private attachedAnimations: Record<string, ProcessedAnimation> = {};
@@ -62,9 +62,9 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
     EventListener
   >();
 
-  constructor(element: ReanimatedHTMLElement, componentName = '') {
+  constructor(element: ReanimatedHTMLElement, svgElementTag = '') {
     this.element = element;
-    this.componentName = componentName;
+    this.svgElementTag = svgElementTag;
   }
 
   update(
@@ -104,7 +104,7 @@ export default class CSSAnimationsManager implements ICSSAnimationsManager {
         const keyframes = definition as CSSAnimationKeyframes;
         const processedKeyframes = processKeyframeDefinitions(
           keyframes,
-          this.componentName
+          this.svgElementTag
         );
 
         // If the animation with the same keyframes was already attached, we can reuse it

--- a/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSManager.ts
@@ -18,15 +18,13 @@ export default class CSSManager implements ICSSManager {
     configureWebCSS();
 
     const element = viewInfo.DOMElement as ReanimatedHTMLElement;
+    const svgElementTag = element?.tagName ?? componentDisplayName;
 
-    this.animationsManager = new CSSAnimationsManager(
-      element,
-      componentDisplayName
-    );
+    this.animationsManager = new CSSAnimationsManager(element, svgElementTag);
     this.transitionsManager = new CSSTransitionsManager(element);
     this.pseudoSelectorsManager = new CSSPseudoSelectorsManager(
       element,
-      componentDisplayName
+      svgElementTag
     );
   }
 

--- a/packages/react-native-reanimated/src/css/web/managers/CSSPseudoSelectorsManager.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/CSSPseudoSelectorsManager.ts
@@ -78,13 +78,13 @@ function buildRules(
 
 export default class CSSPseudoSelectorsManager {
   private readonly element: ReanimatedHTMLElement;
-  private readonly componentName: string;
+  private readonly svgElementTag: string;
   private viewId: string | null = null;
   private prevPseudoStylesBySelector: PseudoStylesBySelector | null = null;
 
-  constructor(element: ReanimatedHTMLElement, componentName = '') {
+  constructor(element: ReanimatedHTMLElement, svgElementTag = '') {
     this.element = element;
-    this.componentName = componentName;
+    this.svgElementTag = svgElementTag;
   }
 
   update(pseudoStylesBySelector: PseudoStylesBySelector | null): void {
@@ -99,7 +99,7 @@ export default class CSSPseudoSelectorsManager {
     }
 
     const propsBuilder =
-      getWebSvgPropsBuilder(this.componentName) ?? webPropsBuilder;
+      getWebSvgPropsBuilder(this.svgElementTag) ?? webPropsBuilder;
 
     const viewId = this.ensureViewId();
     this.syncActiveMarker(pseudoStylesBySelector);

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSAnimationsManager.web.test.ts
@@ -93,10 +93,11 @@ describe('CSSAnimationsManager (web)', () => {
 
     test('builds SVG keyframes with the SVG props builder for SVG components', () => {
       // Path wraps `d` in path() - a transform only the SVG builder does - so
-      // this verifies the manager threads its componentName into the keyframe
-      // pipeline for SVG components (not just the generic one).
-      registerWebSvgPropsBuilder('Path', SVG_PATH_WEB_PROPERTIES_CONFIG);
-      const svgManager = new CSSAnimationsManager(element, 'Path');
+      // this verifies the manager threads its svgElementTag into the keyframe
+      // pipeline for SVG components (not just the generic one). The tag is the
+      // rendered element's lowercase DOM tag name (`<path>`).
+      registerWebSvgPropsBuilder('path', SVG_PATH_WEB_PROPERTIES_CONFIG);
+      const svgManager = new CSSAnimationsManager(element, 'path');
 
       svgManager.update({
         animationName: {

--- a/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSManager.web.test.ts
+++ b/packages/react-native-reanimated/src/css/web/managers/__tests__/CSSManager.web.test.ts
@@ -1,0 +1,36 @@
+'use strict';
+import type { ViewInfo } from '../../../../createAnimatedComponent/commonTypes';
+import CSSAnimationsManager from '../CSSAnimationsManager';
+import CSSManager from '../CSSManager';
+
+jest.mock('../../domUtils');
+jest.mock('../CSSAnimationsManager');
+jest.mock('../CSSPseudoSelectorsManager');
+jest.mock('../CSSTransitionsManager');
+
+const builderKey = () => jest.mocked(CSSAnimationsManager).mock.calls[0][1];
+
+const viewInfo = (DOMElement: ViewInfo['DOMElement']): ViewInfo => ({
+  viewTag: null,
+  shadowNodeWrapper: null,
+  DOMElement,
+});
+
+describe('CSSManager (web) SVG props builder key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Production bundlers mangle a component's class name, so the SVG props builder
+  // must be keyed on the rendered element's tag (never mangled), not the class name.
+  test('uses the element tag, ignoring the minifiable class name', () => {
+    const element = document.createElement('circle');
+    new CSSManager(viewInfo(element), 'h');
+    expect(builderKey()).toBe(element.tagName);
+  });
+
+  test('falls back to the class name when there is no rendered element', () => {
+    new CSSManager(viewInfo(null), 'Circle');
+    expect(builderKey()).toBe('Circle');
+  });
+});


### PR DESCRIPTION
## Summary

On web, the SVG CSS props builder was keyed on the component's JS class name, which production minifiers mangle - so SVG geometry props were dropped from the generated `@keyframes` and CSS animations/transitions for SVG silently did nothing in minified builds (e.g. the docs) while working in dev. This keys the lookup on the rendered element's `tagName` instead, which minification never touches, so behavior is now identical in dev and minified production.

## Before / After

`Animating SVG` examples in a minified build:

|  | Before (`main`) | After (this PR) |
| --- | --- | --- |
| **Circle** (`r`) | <img width="220" src="https://raw.githubusercontent.com/software-mansion/react-native-reanimated/2cc714627a554a4cd5bff5a18e13e0f8dacc5b70/before-circle.gif" /> | <img width="220" src="https://raw.githubusercontent.com/software-mansion/react-native-reanimated/2cc714627a554a4cd5bff5a18e13e0f8dacc5b70/after-circle.gif" /> |
| **Path** (`d` morph) | <img width="220" src="https://raw.githubusercontent.com/software-mansion/react-native-reanimated/2cc714627a554a4cd5bff5a18e13e0f8dacc5b70/before-morph.gif" /> | <img width="220" src="https://raw.githubusercontent.com/software-mansion/react-native-reanimated/2cc714627a554a4cd5bff5a18e13e0f8dacc5b70/after-morph.gif" /> |
