### PR TITLE
chore: use `findProperty` to determine the NDK configuration

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -149,13 +149,14 @@ android {
 
     namespace = "com.swmansion.reanimated"
 
-    if (rootProject.hasProperty("ndkPath")) {
-        ndkPath = rootProject.extensions.extraProperties.get("ndkPath") as String
+    val resolvedNdkPath = rootProject.findProperty("ndkPath") as? String
+    if (!resolvedNdkPath.isNullOrEmpty()) {
+        ndkPath = resolvedNdkPath
     }
-    if (rootProject.hasProperty("ndkVersion")) {
-        ndkVersion = rootProject.extensions.extraProperties.get("ndkVersion") as String
-    } else if (safeExtGet('ndkVersion', null)) {
-        ndkVersion = safeExtGet("ndkVersion", null)
+
+    val resolvedNdkVersion = rootProject.findProperty("ndkVersion") as? String
+    if (!resolvedNdkVersion.isNullOrEmpty()) {
+        ndkVersion = resolvedNdkVersion
     }
 
     buildFeatures {

--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -154,6 +154,8 @@ android {
     }
     if (rootProject.hasProperty("ndkVersion")) {
         ndkVersion = rootProject.extensions.extraProperties.get("ndkVersion") as String
+    } else if (safeExtGet('ndkVersion', null)) {
+        ndkVersion = safeExtGet("ndkVersion", null)
     }
 
     buildFeatures {

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -159,13 +159,14 @@ android {
 
     namespace = "com.swmansion.worklets"
 
-    if (rootProject.hasProperty("ndkPath")) {
-        ndkPath = rootProject.extensions.extraProperties.get("ndkPath") as String
+    val resolvedNdkPath = rootProject.findProperty("ndkPath") as? String
+    if (!resolvedNdkPath.isNullOrEmpty()) {
+        ndkPath = resolvedNdkPath
     }
-    if (rootProject.hasProperty("ndkVersion")) {
-        ndkVersion = rootProject.extensions.extraProperties.get("ndkVersion") as String
-    } else if (safeExtGet('ndkVersion', null)) {
-        ndkVersion = safeExtGet("ndkVersion", null)
+
+    val resolvedNdkVersion = rootProject.findProperty("ndkVersion") as? String
+    if (!resolvedNdkVersion.isNullOrEmpty()) {
+        ndkVersion = resolvedNdkVersion
     }
 
     buildFeatures {

--- a/packages/react-native-worklets/android/build.gradle.kts
+++ b/packages/react-native-worklets/android/build.gradle.kts
@@ -164,6 +164,8 @@ android {
     }
     if (rootProject.hasProperty("ndkVersion")) {
         ndkVersion = rootProject.extensions.extraProperties.get("ndkVersion") as String
+    } else if (safeExtGet('ndkVersion', null)) {
+        ndkVersion = safeExtGet("ndkVersion", null)
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary

For some configurations in monorepos, using rootProject.extensions.extraProperties may not be sufficient. The findProperty method also checks properties in rootProject.extensions.extraProperties, so it is more robust than just checking extraProperties directly.

Here is the documentation: https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#findProperty(java.lang.String)
