### PR TITLE
cherry-pick(4.4-stable): synchronous event animation cancel and recursive-loop fix (#9732, #9769)

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/LiquidSwipe.tsx
@@ -35,7 +35,6 @@ export default function LiquidSwipe() {
   const isBack = useSharedValue(false);
   const centerY = useSharedValue(initialWaveCenter);
   const progress = useSharedValue(0);
-  const dragX = useSharedValue(0);
   const startY = useSharedValue(0);
 
   const maxDist = width - initialSideWidth;
@@ -45,7 +44,6 @@ export default function LiquidSwipe() {
       // stop animating progress, this will also place "isBack" value in the
       // final state (we update isBack in progress animation callback)
       cancelAnimation(progress);
-      dragX.value = 0;
       startY.value = isBack.value ? event.y : centerY.value;
     })
     .onChange((event) => {

--- a/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/Weave.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LiquidSwipe/Weave.tsx
@@ -62,7 +62,7 @@ export default function Weave({
             (progress.value / p1) * (maxHorRadius - initialHorRadius);
     }
     const t = (progress.value - p1) / (1.0 - p1);
-    const A = isBack ? 2 * initialHorRadius : maxHorRadius;
+    const A = isBack.value ? 2 * initialHorRadius : maxHorRadius;
     const r = 40;
     const m = 9.8;
     const beta = r / (2 * m);

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/RuntimeTestsExample.tsx
@@ -98,6 +98,7 @@ export default function RuntimeTestsExample() {
             // TODO: update expected values
             // require('./tests/core/cancelAnimation.test');
             // TODO: speed up useSharedValue tests, they have unnecessarily long delays
+            require('./tests/core/useSharedValue/animationAssigning.test');
             require('./tests/core/useSharedValue/synchronization.test');
             require('./tests/core/useSharedValue/numbers.test');
             require('./tests/core/useSharedValue/arrays.test');

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/animationAssigning.test.ts
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/core/useSharedValue/animationAssigning.test.ts
@@ -1,0 +1,88 @@
+import { makeMutable, withTiming } from 'react-native-reanimated';
+
+import {
+  describe,
+  expect,
+  notify,
+  test,
+  waitForNotification,
+  beforeEach,
+} from '../../../ReJest/RuntimeTestsApi';
+import { scheduleOnRN } from 'react-native-worklets';
+
+const NOTIFY_FIRST_CALLBACK = 'NOTIFY_FIRST_CALLBACK';
+const NOTIFY_SECOND_CALLBACK = 'NOTIFY_SECOND_CALLBACK';
+
+describe('Test animation reassignments on mutable', () => {
+  let firstCanceled = false;
+  let secondCanceled = false;
+  const notifyFirst = (finished: boolean) => {
+    firstCanceled = !finished;
+    notify(NOTIFY_FIRST_CALLBACK);
+  };
+
+  const notifySecond = (finished: boolean) => {
+    secondCanceled = !finished;
+    notify(NOTIFY_SECOND_CALLBACK);
+  };
+
+  beforeEach(() => {
+    firstCanceled = false;
+    secondCanceled = false;
+  });
+
+  test('previous animation is canceled on direct assignment', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+    });
+
+    requestAnimationFrame(() => {
+      mutable.value = withTiming(200, {}, (finished) => {
+        scheduleOnRN(notifySecond, finished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(true);
+    expect(secondCanceled).toBe(false);
+  });
+
+  test('reassignment in callback', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+      mutable.value = withTiming(200, {}, (innerFinished) => {
+        scheduleOnRN(notifySecond, innerFinished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(false);
+    expect(secondCanceled).toBe(false);
+  });
+
+  test('reassignment both directly and in callback', async () => {
+    const mutable = makeMutable(0);
+    mutable.value = withTiming(100, {}, (finished) => {
+      scheduleOnRN(notifyFirst, finished!);
+      mutable.value = withTiming(200, {});
+    });
+
+    requestAnimationFrame(() => {
+      mutable.value = withTiming(300, {}, (finished) => {
+        scheduleOnRN(notifySecond, finished!);
+      });
+    });
+
+    await waitForNotification(NOTIFY_FIRST_CALLBACK);
+    await waitForNotification(NOTIFY_SECOND_CALLBACK);
+
+    expect(firstCanceled).toBe(true);
+    expect(secondCanceled).toBe(false);
+  });
+});

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -10,6 +10,7 @@ export function valueSetter<Value>(
   const previousAnimation = mutable._animation;
   if (previousAnimation) {
     previousAnimation.cancelled = true;
+    previousAnimation.callback?.(false);
     mutable._animation = null;
   }
   if (
@@ -48,15 +49,11 @@ export function valueSetter<Value>(
 
     const step = (timestamp: number) => {
       if (animation.cancelled) {
-        animation.callback?.(false /* finished */);
         return;
       }
       const finished = animation.onFrame(animation, timestamp);
       animation.finished = true;
       animation.timestamp = timestamp;
-      // TODO TYPESCRIPT
-      // For now I'll assume that `animation.current` is always defined
-      // but actually need to dive into animations to understand it
       mutable._value = animation.current!;
       if (finished) {
         animation.callback?.(true /* finished */);

--- a/packages/react-native-reanimated/src/valueSetter.ts
+++ b/packages/react-native-reanimated/src/valueSetter.ts
@@ -9,9 +9,11 @@ export function valueSetter<Value>(
   'worklet';
   const previousAnimation = mutable._animation;
   if (previousAnimation) {
-    previousAnimation.cancelled = true;
-    previousAnimation.callback?.(false);
     mutable._animation = null;
+    if (!previousAnimation.finished) {
+      previousAnimation.cancelled = true;
+      previousAnimation.callback?.(false);
+    }
   }
   if (
     typeof value === 'function' ||
@@ -52,10 +54,10 @@ export function valueSetter<Value>(
         return;
       }
       const finished = animation.onFrame(animation, timestamp);
-      animation.finished = true;
       animation.timestamp = timestamp;
       mutable._value = animation.current!;
       if (finished) {
+        animation.finished = true;
         animation.callback?.(true /* finished */);
       } else {
         requestAnimationFrame(step);


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9732
- #9769

#9732 makes a cancelled animation fire its callback synchronously, fixing the late-callback regression introduced by #9244 (which is on 4.4-stable), e.g. the LiquidSwipe flicker. #9769 must accompany it: without it, #9732's synchronous callback recurses infinitely when a shared value is reassigned inside an animation callback (#9750).