### PR TITLE
docs: fix incorrect duration values in CSS duration examples

### DIFF
--- a/docs/docs-reanimated/docs/css-animations/animation-duration.mdx
+++ b/docs/docs-reanimated/docs/css-animations/animation-duration.mdx
@@ -81,7 +81,7 @@ animationDuration: ['3s', '150ms', 500];
 animationName: [bounceIn, move, slide];
 ```
 
-In the following example, it would take 3 seconds for the `bounceIn` keyframe to animate, 100 milliseconds for the `move`, and 500 milliseconds for the `slide`.
+In the following example, it would take 3 seconds for the `bounceIn` keyframe to animate, 150 milliseconds for the `move`, and 500 milliseconds for the `slide`.
 
 ## Example
 

--- a/docs/docs-reanimated/docs/css-transitions/transition-duration.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/transition-duration.mdx
@@ -77,7 +77,7 @@ transitionDuration: ['3s', '150ms', 500];
 transitionProperty: ['width', 'transform', 'borderRadius'];
 ```
 
-In the following example, it would take 3 seconds for the `width` property to transition, 100 milliseconds for the `transform`, and 500 milliseconds for the `borderRadius`.
+In the following example, it would take 3 seconds for the `width` property to transition, 150 milliseconds for the `transform`, and 500 milliseconds for the `borderRadius`.
 
 ## Example
 


### PR DESCRIPTION
## Summary

The same mismatch appears in two docs files. In both `animation-duration` and `transition-duration`, the array example uses `'150ms'` as the second value:

    animationDuration: ['3s', '150ms', 500];
    transitionDuration: ['3s', '150ms', 500];

but the text below it says "100 milliseconds". This PR changes both to "150 milliseconds" so the text matches the code.

## Test plan

Documentation only change. No code is affected. The text in both files now matches the value used in the example (`'150ms'`).