### PR TITLE
chore: Re-add planets showcase and example with hover overlap

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -126,7 +126,16 @@ const routes = {
       },
       PseudoShowcase: {
         name: 'Showcase',
-        Component: pseudoSelectors.Showcase,
+        routes: {
+          PseudoShowcaseForm: {
+            name: 'Form',
+            Component: pseudoSelectors.Form,
+          },
+          PseudoShowcasePlanets: {
+            name: 'Planets',
+            Component: pseudoSelectors.Planets,
+          },
+        },
       },
     },
   },

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Form.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Form.tsx
@@ -139,7 +139,7 @@ function Card({
   );
 }
 
-export default function Showcase() {
+export default function Form() {
   return (
     <Screen>
       <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Hover.tsx
@@ -5,6 +5,7 @@ import {
   Screen,
   Scroll,
   Section,
+  Text,
   VerticalExampleCard,
 } from '@/apps/css/components';
 import { colors, radius, sizes, spacing } from '@/theme';
@@ -198,6 +199,76 @@ shadowOpacity: {
               />
             </View>
           </VerticalExampleCard>
+
+          <VerticalExampleCard
+            collapsedExampleHeight={180}
+            description="Touch ':hover' hit-tests the topmost view, so only one of two overlapping circles reacts. Tap the lens where the front circle covers the back one: only the front (blue) circle highlights, even though the touch is inside the back circle's bounds too."
+            title="Overlapping views"
+            code={`<View style={{ flexDirection: 'row' }}>
+  {/* Back circle - drawn first, so it sits underneath */}
+  <Animated.View
+    style={{
+      backgroundColor: { default: '#fca5a5', ':hover': '#dc2626' },
+      transform: { default: [{ scale: 1 }], ':hover': [{ scale: 1.05 }] },
+      transitionDuration: '150ms',
+    }}
+  />
+  {/* Front circle - drawn last (on top), pulled left to overlap */}
+  <Animated.View
+    style={{
+      marginLeft: -56,
+      backgroundColor: { default: '#93c5fd', ':hover': '#2563eb' },
+      transform: { default: [{ scale: 1 }], ':hover': [{ scale: 1.05 }] },
+      transitionDuration: '150ms',
+    }}
+  />
+</View>`}
+            collapsedCode={`backgroundColor: {
+  default: '#93c5fd',
+  ':hover': '#2563eb',
+},`}>
+            <View style={styles.stage}>
+              <Animated.View
+                style={[
+                  styles.circle,
+                  {
+                    backgroundColor: {
+                      ':hover': '#dc2626',
+                      default: '#fca5a5',
+                    },
+                    transform: {
+                      ':hover': [{ scale: 1.05 }],
+                      default: [{ scale: 1 }],
+                    },
+                    transitionDuration: '150ms',
+                  },
+                ]}>
+                <Text style={styles.circleLabel} variant="label2">
+                  Back
+                </Text>
+              </Animated.View>
+              <Animated.View
+                style={[
+                  styles.circle,
+                  styles.frontCircle,
+                  {
+                    backgroundColor: {
+                      ':hover': '#2563eb',
+                      default: '#93c5fd',
+                    },
+                    transform: {
+                      ':hover': [{ scale: 1.05 }],
+                      default: [{ scale: 1 }],
+                    },
+                    transitionDuration: '150ms',
+                  },
+                ]}>
+                <Text style={styles.circleLabel} variant="label2">
+                  Front
+                </Text>
+              </Animated.View>
+            </View>
+          </VerticalExampleCard>
         </Section>
       </Scroll>
     </Screen>
@@ -210,10 +281,31 @@ const styles = StyleSheet.create({
     height: sizes.md,
     width: sizes.md,
   },
+  circle: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    height: 140,
+    justifyContent: 'center',
+    width: 140,
+  },
+  circleLabel: {
+    color: colors.white,
+  },
   content: {
     gap: spacing.xs,
   },
+  frontCircle: {
+    // Overlap ~40% of the diameter so the two circles share a clear lens.
+    marginLeft: -56,
+  },
   shadowHost: {
     padding: spacing.md,
+  },
+  stage: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    height: 180,
+    justifyContent: 'center',
+    width: '100%',
   },
 });

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
@@ -1,0 +1,151 @@
+import { StyleSheet, Text } from 'react-native';
+import Animated, { css } from 'react-native-reanimated';
+
+import {
+  Screen,
+  Scroll,
+  Section,
+  VerticalExampleCard,
+} from '@/apps/css/components';
+import { colors, spacing } from '@/theme';
+
+const ORBIT_RX = 90;
+const ORBIT_RY = 40;
+const ORBIT_DURATION = '12s';
+const ORBIT_STEPS = 36;
+
+const PLANETS = [
+  { color: colors.danger, name: 'Mars', size: 44 },
+  { color: colors.primary, name: 'Venus', size: 60 },
+  { color: colors.primaryDark, name: 'Jupiter', size: 78 },
+];
+
+const MAX_PLANET_SIZE = Math.max(...PLANETS.map((planet) => planet.size));
+const PLANE_WIDTH = 2 * ORBIT_RX + MAX_PLANET_SIZE;
+const PLANE_HEIGHT = 2 * ORBIT_RY + MAX_PLANET_SIZE;
+const CENTER_X = PLANE_WIDTH / 2;
+const CENTER_Y = PLANE_HEIGHT / 2;
+
+function makeOrbit(offsetDeg: number, size: number) {
+  const frames: Record<string, { left: number; top: number }> = {};
+  for (let step = 0; step <= ORBIT_STEPS; step++) {
+    const percent = ((step / ORBIT_STEPS) * 100).toFixed(4);
+    const angle = ((offsetDeg + (360 * step) / ORBIT_STEPS) * Math.PI) / 180;
+    frames[`${percent}%`] = {
+      left: CENTER_X + ORBIT_RX * Math.cos(angle) - size / 2,
+      top: CENTER_Y + ORBIT_RY * Math.sin(angle) - size / 2,
+    };
+  }
+  return css.keyframes(frames);
+}
+
+const ORBITS = PLANETS.map((planet, index) =>
+  makeOrbit((360 / PLANETS.length) * index, planet.size)
+);
+
+export default function Planets() {
+  return (
+    <Screen>
+      <Scroll contentContainerStyle={styles.content} withBottomBarSpacing>
+        <Section
+          description="Three differently sized planets orbit the screen center on a tilted (elliptical) path. Each planet's name is hidden until you hover; active enlarges it with a colored glow."
+          title="Planets">
+          <VerticalExampleCard
+            title="Hover a planet to reveal its name"
+            code={`<Animated.View
+  style={{
+    // 0.02 not 0: iOS skips alpha<0.01 views in hit-testing
+    opacity: { default: 0.02, ':hover': 1 },
+    transitionDuration: '200ms',
+  }}
+  onStartShouldSetResponder={() => true}>
+  <Text>{name}</Text>
+</Animated.View>`}
+            collapsedCode={`opacity: {
+  default: 0.02,
+  ':hover': 1,
+},`}>
+            <Animated.View style={styles.stage}>
+              <Animated.View style={styles.orbitPlane}>
+                {PLANETS.map((planet, index) => (
+                  <Animated.View
+                    key={planet.name}
+                    style={[
+                      styles.orbiter,
+                      {
+                        animationDuration: ORBIT_DURATION,
+                        animationIterationCount: 'infinite',
+                        animationName: ORBITS[index],
+                        animationTimingFunction: 'linear',
+                      },
+                      {
+                        backgroundColor: planet.color,
+                        borderRadius: planet.size / 2,
+                        elevation: { ':active': 12, default: 0 },
+                        height: planet.size,
+                        shadowColor: planet.color,
+                        shadowOpacity: { ':active': 0.9, default: 0 },
+                        shadowRadius: { ':active': 18, default: 0 },
+                        transform: {
+                          ':active': [{ scale: 1.1 }],
+                          default: [{ scale: 1 }],
+                        },
+                        transitionDuration: '200ms',
+                        width: planet.size,
+                      },
+                    ]}>
+                    <Animated.View
+                      style={[
+                        styles.nameWrapper,
+                        {
+                          opacity: { ':hover': 1, default: 0.02 },
+                          transitionDuration: '200ms',
+                        },
+                      ]}
+                      onStartShouldSetResponder={() => true}>
+                      <Text style={styles.name}>{planet.name}</Text>
+                    </Animated.View>
+                  </Animated.View>
+                ))}
+              </Animated.View>
+            </Animated.View>
+          </VerticalExampleCard>
+        </Section>
+      </Scroll>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    gap: spacing.xs,
+  },
+  name: {
+    color: colors.white,
+    fontSize: 12,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  nameWrapper: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  orbiter: {
+    position: 'absolute',
+    shadowOffset: { height: 0, width: 0 },
+  },
+  orbitPlane: {
+    height: PLANE_HEIGHT,
+    width: PLANE_WIDTH,
+  },
+  stage: {
+    alignItems: 'center',
+    height: PLANE_HEIGHT + spacing.xl,
+    justifyContent: 'center',
+  },
+});

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/index.ts
@@ -3,10 +3,11 @@ import ActiveDeepest from './ActiveDeepest';
 import ArbitraryWebSelectors from './ArbitraryWebSelectors';
 import Focus from './Focus';
 import FocusWithin from './FocusWithin';
+import Form from './Form';
 import Hover from './Hover';
 import HoverWithLoop from './HoverWithLoop';
 import PerStateTransitionConfig from './PerStateTransitionConfig';
-import Showcase from './Showcase';
+import Planets from './Planets';
 
 export default {
   Active,
@@ -14,8 +15,9 @@ export default {
   ArbitraryWebSelectors,
   Focus,
   FocusWithin,
+  Form,
   Hover,
   HoverWithLoop,
   PerStateTransitionConfig,
-  Showcase,
+  Planets,
 };


### PR DESCRIPTION
## Summary

This PR re-adds planets showcase (IDK how it disappeared, I must have force pushed something badly) and adds an example which helps us notice the regression with hover overlap (which we will fix in: #9731).
## Test plan

Open those examples: CSS -> Transitions -> Pseudoselectors -> Hover | Showcase