### PR TITLE
Fix: Scrolling after :hover on iOS

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/TouchHoverCoordinator.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/TouchHoverCoordinator.kt
@@ -61,7 +61,9 @@ class TouchHoverCoordinator {
 
     /**
      * Mirrors CSS hit-testing: turns :hover on for the topmost view at the touch and its registered
-     * ancestors, off for the rest.
+     * ancestors, off for the rest. Views that merely overlap the hit branch (which a plain bounds
+     * test would all activate) stay off, because only the hit branch is hovered. Rooted on the
+     * touched view's own window so it works inside a Modal/Dialog (a separate window from the Activity).
      */
     fun recompute(
         sourceView: View,

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -16,8 +16,11 @@
 @implementation REATouchHoverEntry
 @end
 
-/// Passive key-window touch observer. It never leaves `.possible`, so it never claims the gesture
-/// or interferes with the per-view `:active` / `:active-deepest` recognizers.
+/// Passive key-window touch observer. It only ever transitions to `.failed` (once every finger of a
+/// sequence has lifted), so it never claims the gesture or interferes with the per-view `:active` /
+/// `:active-deepest` recognizers. Reaching that terminal state each sequence is essential: UIKit only
+/// runs `-reset` after a terminal transition, and an observer that stays `.possible` forever is never
+/// reset, wedging the key window's gesture environment so a UIScrollView pan can no longer begin.
 @interface REAHoverTouchObserver : UIGestureRecognizer
 @property (nonatomic, weak) REATouchHoverCoordinator *coordinator;
 @end
@@ -37,9 +40,23 @@
 {
   [self.coordinator observeTouchMoved:touches.anyObject];
 }
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [self failIfSequenceEnded:event];
+}
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [self.coordinator observeTouchCancelled];
+  [self failIfSequenceEnded:event];
+}
+- (void)failIfSequenceEnded:(UIEvent *)event
+{
+  for (UITouch *touch in event.allTouches) {
+    if (touch.phase != UITouchPhaseEnded && touch.phase != UITouchPhaseCancelled) {
+      return;
+    }
+  }
+  self.state = UIGestureRecognizerStateFailed;
 }
 @end
 


### PR DESCRIPTION
#9731 should be merged first.
## Summary

There was a bug where after activating :hover on iOS one couldn't scroll anymore. This should fix it. 
## Test plan

Compile for iOS, go to CSS -> Transitions -> Pseudoselectors -> Hover, tap any exapmle and then try to scroll.
