### PR TITLE
chore: remove onStartShouldSetResponder workaround from :active examples

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -54,7 +54,6 @@ export default function Active() {
                   transitionTimingFunction: 'ease-in-out',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -84,7 +83,6 @@ export default function Active() {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -126,7 +124,6 @@ borderWidth: {
                   transitionDuration: '120ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -157,7 +154,6 @@ borderWidth: {
                   transitionDuration: '120ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -201,7 +197,6 @@ transform: {
                   transitionTimingFunction: 'ease-in-out',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -302,7 +297,6 @@ transform: {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
 
@@ -331,7 +325,6 @@ transform: {
                   transitionDuration: '150ms',
                 },
               ]}
-              onStartShouldSetResponder={() => true}
             />
           </VerticalExampleCard>
         </Section>

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/ActiveDeepest.tsx
@@ -97,8 +97,7 @@ transform: {
                         },
                         transitionDuration: '120ms',
                       },
-                    ]}
-                    onStartShouldSetResponder={() => true}>
+                    ]}>
                     <Text style={{ color: colors.white }} variant="label3">
                       Press me
                     </Text>
@@ -172,8 +171,7 @@ transform: {
                         },
                         transitionDuration: '120ms',
                       },
-                    ]}
-                    onStartShouldSetResponder={() => true}>
+                    ]}>
                     <Text style={{ color: colors.white }} variant="label3">
                       Press me
                     </Text>
@@ -267,8 +265,7 @@ transform: {
                           },
                           transitionDuration: '120ms',
                         },
-                      ]}
-                      onStartShouldSetResponder={() => true}>
+                      ]}>
                       <Text style={{ color: colors.white }} variant="label3">
                         Layer 4 (:active-deepest)
                       </Text>


### PR DESCRIPTION
Removes the `onStartShouldSetResponder={() => true}` workaround from the regular-view `:active` / `:active-deepest` examples, now that Android press pseudo-selectors are driven from the window observer (stacked on #9879).

The four SVG examples keep the prop until SVG `:active` without a responder is checked on device.