### PR TITLE
fix(Worklets): runloop tests flake

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
@@ -71,8 +71,11 @@ describe('Test mixed order of execution', () => {
       // Act
       scheduleOnRuntime(rt, () => {
         'worklet';
-        // heavy task, to make sure that next scheduleOnRuntime will schedule task on async queue
-        Array.from({ length: 100000 }, (_v, i) => (i / 2) * i * 9 + 7);
+        // Stay busy until the second task below is enqueued.
+        const busyUntil = performance.now() + 10;
+        while (performance.now() < busyUntil) {
+          // Do nothing.
+        }
         getMethodMap()[firstMethodName](() =>
           order(firstMethodOrder, notification1)
         );

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
@@ -71,11 +71,11 @@ describe('Test mixed order of execution', () => {
       // Act
       scheduleOnRuntime(rt, () => {
         'worklet';
+        // heavy task, to make sure that next scheduleOnRuntime will schedule task on async queue
+        Array.from({ length: 100000 }, (_v, i) => (i / 2) * i * 9 + 7);
         getMethodMap()[firstMethodName](() =>
           order(firstMethodOrder, notification1)
         );
-        // heavy task, to make sure that next scheduleOnRuntime will schedule task on async queue
-        new Array(100000).map((_v, i) => (i / 2) * i * 9 + 7);
       });
       scheduleOnRuntime(rt, () => {
         'worklet';


### PR DESCRIPTION
## Summary

Performing heavy-operation before scheduling a task with `getMethodMap` could result in flakiness since the next task from `scheduleOnRuntime` could land either before or after that task.

Moving the heavy op before fixes that issue.

## Test plan

runloop runtime tests pass
