### PR TITLE
cherry-pick(4.5-stable): Only reject empty-object style values for supported props (#9746)

### DIFF
--- a/packages/react-native-reanimated/src/common/style/__tests__/registry.test.ts
+++ b/packages/react-native-reanimated/src/common/style/__tests__/registry.test.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+import {
+  isSupportedStyleProp,
+  registerComponentPropsBuilder,
+} from '../registry';
+
+describe(isSupportedStyleProp, () => {
+  test('returns true for a base style property', () => {
+    expect(isSupportedStyleProp('opacity')).toBe(true);
+    expect(isSupportedStyleProp('backgroundColor')).toBe(true);
+  });
+
+  test('returns false for a foreign metadata key', () => {
+    // Keys that other libraries attach to style objects as metadata
+    expect(isSupportedStyleProp('someForeignMetadataKey')).toBe(false);
+  });
+
+  test('includes props contributed by a registered component builder', () => {
+    expect(isSupportedStyleProp('customSvgProp')).toBe(false);
+
+    registerComponentPropsBuilder('RNTestComponent', {
+      customSvgProp: true,
+    });
+
+    expect(isSupportedStyleProp('customSvgProp')).toBe(true);
+  });
+});

--- a/packages/react-native-reanimated/src/common/style/registry.ts
+++ b/packages/react-native-reanimated/src/common/style/registry.ts
@@ -1,5 +1,6 @@
 'use strict';
 import type { UnknownRecord } from '../types';
+import { STYLE_PROPERTIES_CONFIG } from './config';
 import {
   createNativePropsBuilder,
   type NativePropsBuilder,
@@ -24,6 +25,14 @@ const PATTERN_PROPS_BUILDERS: Array<{
   matcher: RegExp | ((name: string) => boolean);
   entry: PropsBuilderEntry;
 }> = [];
+
+const SUPPORTED_BUILDER_PROPS = new Set<string>(
+  Object.keys(STYLE_PROPERTIES_CONFIG)
+);
+
+export function isSupportedStyleProp(prop: string): boolean {
+  return SUPPORTED_BUILDER_PROPS.has(prop);
+}
 
 function findEntry(compoundComponentName: string): PropsBuilderEntry | null {
   const [reactViewName] = compoundComponentName.split('$');
@@ -69,6 +78,10 @@ export function registerComponentPropsBuilder<P extends UnknownRecord>(
     separatelyInterpolatedNestedProperties?: readonly string[];
   } = {}
 ) {
+  for (const prop in config) {
+    SUPPORTED_BUILDER_PROPS.add(prop);
+  }
+
   const entry: PropsBuilderEntry = {
     builder: createNativePropsBuilder(config),
     separatelyInterpolatedNestedProperties: options

--- a/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
+++ b/packages/react-native-reanimated/src/css/utils/__tests__/props.test.ts
@@ -273,6 +273,18 @@ describe(filterCSSAndStyleProperties, () => {
       ).not.toThrow();
     });
 
+    test('does not throw for an empty object on an unrecognized property', () => {
+      // Libraries like Unistyles attach metadata keys (e.g. `unistyles_<hash>`)
+      // to style objects - an empty object on such a foreign key must not crash.
+      const foreignKey = 'unistyles_abc123';
+      const style = { opacity: 0.5, [foreignKey]: {} } as never;
+
+      expect(() => filterCSSAndStyleProperties(style)).not.toThrow();
+
+      const [, , , , filteredStyle] = filterCSSAndStyleProperties(style);
+      expect(filteredStyle).toStrictEqual({ opacity: 0.5, [foreignKey]: {} });
+    });
+
     test('mixes pseudoselector and regular props with transition config', () => {
       const style: CSSStyle = {
         transitionDuration: '150ms',

--- a/packages/react-native-reanimated/src/css/utils/props.ts
+++ b/packages/react-native-reanimated/src/css/utils/props.ts
@@ -1,6 +1,6 @@
 'use strict';
 import type { UnknownRecord } from '../../common';
-import { isEmptyObject, logger } from '../../common';
+import { isEmptyObject, isSupportedStyleProp, logger } from '../../common';
 import { isSharedValue } from '../../isSharedValue';
 import type {
   CSSAnimationProperties,
@@ -84,7 +84,7 @@ export function filterCSSAndStyleProperties<S extends object>(
         branch.selectorStyle[prop] = selectorValue;
         branch.defaultStyle[prop] = defaultValue;
       }
-    } else if (isEmptyObject(value)) {
+    } else if (isEmptyObject(value) && isSupportedStyleProp(prop)) {
       throw new Error(
         `[Reanimated] Invalid value for "${prop}": an empty object is not a valid style value.`
       );


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.5.1 release
- #9746