### PR TITLE
cherry-pick(4.5-stable): Re-register pseudo selectors after a component remount (#9765)

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSPseudoStylesManager.ts
@@ -110,6 +110,8 @@ export default class CSSPseudoStylesManager implements ICSSPseudoStylesManager {
     if (this.isRegistered) {
       this.detach();
     }
+    this.prevPseudoStylesBySelector = null;
+    this.prevTransitionProperties = null;
   }
 
   private detach() {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSPseudoStylesManager.test.ts
@@ -457,5 +457,22 @@ describe('CSSPseudoStylesManager', () => {
 
       expect(unregisterPseudoStyles).not.toHaveBeenCalled();
     });
+
+    test('re-registers identical styles after unmountCleanup (reused instance remount)', () => {
+      const style: CSSStyle = {
+        opacity: { default: 0, ':hover': 1 },
+      };
+
+      pushStyle(manager, style);
+      manager.unmountCleanup();
+      jest.clearAllMocks();
+
+      // The same manager instance is reused (e.g. a frozen subtree thaws and the
+      // AnimatedComponent's CSSManager is kept). An identical-styles update must not
+      // be swallowed by the deepEqual early-return; it has to re-register natively.
+      pushStyle(manager, { ...style });
+
+      expect(registerPseudoStyles).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.5.1 release
- #9765