### PR TITLE
cherry-pick(4.5-stable): restore opacity for flaky entering animations under Reduce Motion on iOS (#9772)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -413,7 +413,13 @@ void LayoutAnimationsProxy_Legacy::addOngoingAnimations(SurfaceId surfaceId, Sha
 
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
-    if (layoutAnimationIt == layoutAnimations_.end() || layoutAnimationIt->second.isSettled()) {
+    if (layoutAnimationIt == layoutAnimations_.end() ||
+        // A settled animation is normally cleaned up without applying further
+        // updates. The exception is a flaky entering animation whose opacity was
+        // never restored (the view wasn't mounted in time) - we still need to
+        // apply that pending opacity, otherwise the view stays invisible. Only
+        // entering animations carry an opacity value.
+        (layoutAnimationIt->second.isSettled() && !layoutAnimationIt->second.opacity.has_value())) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.5.1 release
- #9772