### PR TITLE
fix: make iOS Core Animation transitions persistent for pseudo selectors

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -172,11 +172,13 @@ struct ActiveTransition {
     }
 
     CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:keyPath];
-    // On interruption, start from the live presentation value; the implicit
-    // fromValue would race RN's model commit.
+    // Interrupting a running animation: continue from where the layer actually is (its live
+    // presentation value). If the presentation isn't available yet (a rapid re-trigger before the
+    // render server produced a frame), fall back to the model value - never to fromId, which is the
+    // settled pseudo target and would make a quick tap jump to the full value before animating back.
     if ([[layer animationForKey:keyPath] isKindOfClass:[CABasicAnimation class]]) {
       id presentationValue = [[layer presentationLayer] valueForKeyPath:keyPath];
-      anim.fromValue = presentationValue ?: fromId;
+      anim.fromValue = presentationValue ?: [layer valueForKeyPath:keyPath];
     } else {
       anim.fromValue = fromId;
     }
@@ -189,12 +191,15 @@ struct ActiveTransition {
     anim.fillMode = persistent ? kCAFillModeBoth : kCAFillModeBackwards;
     anim.removedOnCompletion = persistent ? NO : YES;
 
-    // Commit toValue to the model and add the animation in one transaction
-    // (implicit actions off): on auto-removal the layer shows the final model
-    // value with no snap, and recycled layers carry no stale animated state.
+    // Add the animation (implicit actions off). Non-persistent transitions also commit toValue to
+    // the model so the layer shows the settled value once they self-remove. Persistent (pseudo)
+    // animations hold their value via fillMode instead, so we leave the model at the base value -
+    // committing the target there would only make the interruption fallback above read it back.
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [layer setValue:toId forKeyPath:keyPath];
+    if (!persistent) {
+      [layer setValue:toId forKeyPath:keyPath];
+    }
     [layer addAnimation:anim forKey:keyPath];
     [CATransaction commit];
   });

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -186,10 +186,6 @@ struct ActiveTransition {
     // speed/timeOffset (e.g. RN Screens during navigation) from shifting it.
     anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
     anim.timingFunction = timing;
-    // Backwards fill covers the delay window. Non-persistent transitions self-remove on completion
-    // and the layer reads the model below; persistent ones (pseudo selectors, which always take
-    // priority) keep their presentation so an RN re-commit of the base prop can't snap the value
-    // back to the rendered default once the animation ends.
     anim.fillMode = persistent ? kCAFillModeBoth : kCAFillModeBackwards;
     anim.removedOnCompletion = persistent ? NO : YES;
 

--- a/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/CSS/REACSSPlatformTransitions.mm
@@ -65,6 +65,7 @@ struct ActiveTransition {
             toValue:(const PlatformValue &)toValue
            settings:(const CSSTransitionPropertySettings &)settings
           timestamp:(double)timestamp
+         persistent:(BOOL)persistent
 {
   auto &properties = _active[viewTag];
   const auto activeIt = properties.find(propertyName);
@@ -82,7 +83,8 @@ struct ActiveTransition {
            toValue:toValue
         durationMs:reversing.duration
        startTimeMs:reversing.startTimestamp
-            easing:settings.easingConfig];
+            easing:settings.easingConfig
+        persistent:persistent];
   properties[propertyName] = ActiveTransition{adjustedStart, toValue, std::move(reversing), settings};
 }
 
@@ -104,7 +106,8 @@ struct ActiveTransition {
           fromValue:*from
             toValue:*to
            settings:settings
-          timestamp:timestamp];
+          timestamp:timestamp
+         persistent:NO];
   return YES;
 }
 
@@ -135,7 +138,8 @@ struct ActiveTransition {
           fromValue:*from
             toValue:*to
            settings:settings
-          timestamp:timestamp];
+          timestamp:timestamp
+         persistent:YES];
   return YES;
 }
 
@@ -146,6 +150,7 @@ struct ActiveTransition {
         durationMs:(double)durationMs
        startTimeMs:(double)startTimeMs
             easing:(const EasingConfig &)easing
+        persistent:(BOOL)persistent
 {
   // Capture everything up front; CALayer access must happen on the main thread.
   NSString *keyPath = caLayerKeyPathForCSSProperty(propertyName);
@@ -181,10 +186,12 @@ struct ActiveTransition {
     // speed/timeOffset (e.g. RN Screens during navigation) from shifting it.
     anim.beginTime = [layer convertTime:beginTime fromLayer:nil];
     anim.timingFunction = timing;
-    // Backwards fill paints fromValue during the delay window; the animation
-    // self-removes on completion and the layer reads the model below.
-    anim.fillMode = kCAFillModeBackwards;
-    anim.removedOnCompletion = YES;
+    // Backwards fill covers the delay window. Non-persistent transitions self-remove on completion
+    // and the layer reads the model below; persistent ones (pseudo selectors, which always take
+    // priority) keep their presentation so an RN re-commit of the base prop can't snap the value
+    // back to the rendered default once the animation ends.
+    anim.fillMode = persistent ? kCAFillModeBoth : kCAFillModeBackwards;
+    anim.removedOnCompletion = persistent ? NO : YES;
 
     // Commit toValue to the model and add the animation in one transaction
     // (implicit actions off): on auto-removal the layer shows the final model


### PR DESCRIPTION
Stacked on #9775. Replaces #9809.

On iOS, CSS properties routed to Core Animation animate as a one-shot `CABasicAnimation` that self-removes on completion, after which the layer falls back to its model value — the value React keeps committing. So while `:active` is held past the transition duration, the rendered base value reclaims the layer and the pseudo value snaps back.

Since pseudo selectors always take priority, this makes their platform animation persistent (`fillMode = kCAFillModeBoth`, `removedOnCompletion = NO`) so it keeps its presentation over React's re-commits. Regular render-driven transitions stay non-persistent and unchanged; no C++ change; no-op on Android.

Verified on the iOS simulator: `:active` holds over the render loop with no flicker, and press/release animates in and eases back out instead of snapping to the settled value.
