### PR TITLE
chore: run web-example e2e on an automatically picked free port

### DIFF
--- a/apps/web-example/package.json
+++ b/apps/web-example/package.json
@@ -11,9 +11,9 @@
     "build": "",
     "lint": "eslint . --max-warnings 0",
     "type:check": "tsc --noEmit",
-    "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e": "node scripts/run-e2e.mjs",
+    "test:e2e:ui": "node scripts/run-e2e.mjs --ui",
+    "test:e2e:headed": "node scripts/run-e2e.mjs --headed"
   },
   "dependencies": {
     "common-app": "workspace:*",

--- a/apps/web-example/playwright.config.ts
+++ b/apps/web-example/playwright.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 const HOST = '127.0.0.1';
-// The port is picked automatically by `scripts/run-e2e.mjs` (a currently-free
-// one) and passed via EXPO_WEB_PORT so every Playwright process agrees on it.
-// Falls back to 8099 when `playwright test` is invoked directly - still off
-// Metro's default 8081, so a foreign dev server is never reused by accident.
+// The port is picked automatically by `scripts/run-e2e.mjs`
 const PORT = process.env.EXPO_WEB_PORT ?? '8099';
 
 export default defineConfig({

--- a/apps/web-example/playwright.config.ts
+++ b/apps/web-example/playwright.config.ts
@@ -1,14 +1,22 @@
 import { defineConfig } from '@playwright/test';
 
+const HOST = '127.0.0.1';
+// The port is picked automatically by `scripts/run-e2e.mjs` (a currently-free
+// one) and passed via EXPO_WEB_PORT so every Playwright process agrees on it.
+// Falls back to 8099 when `playwright test` is invoked directly - still off
+// Metro's default 8081, so a foreign dev server is never reused by accident.
+const PORT = process.env.EXPO_WEB_PORT ?? '8099';
+
 export default defineConfig({
   testDir: './e2e',
   use: {
-    baseURL: 'http://localhost:8081',
+    baseURL: `http://${HOST}:${PORT}`,
   },
   webServer: {
-    command: 'yarn start',
-    url: 'http://localhost:8081',
-    reuseExistingServer: true,
+    command: `yarn expo start --web --port ${PORT}`,
+    url: `http://${HOST}:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
   },
   // Retry failed tests once in CI
   retries: process.env.CI ? 1 : 0,

--- a/apps/web-example/scripts/run-e2e.mjs
+++ b/apps/web-example/scripts/run-e2e.mjs
@@ -1,0 +1,20 @@
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+
+// Pick a currently-free port once, then hand it to every Playwright process
+// via EXPO_WEB_PORT so the config, web server, and workers all agree on it.
+const port = await new Promise((resolve, reject) => {
+  const srv = createServer();
+  srv.once('error', reject);
+  srv.listen(0, '127.0.0.1', () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+});
+
+const child = spawn('yarn', ['playwright', 'test', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: { ...process.env, EXPO_WEB_PORT: String(port) },
+  shell: process.platform === 'win32',
+});
+child.on('exit', (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary

`apps/web-example`'s Playwright config hardcoded port 8081 with `reuseExistingServer: true`, so it silently reused whatever dev server sat on 8081 (a native `react-native start`, or another checkout) instead of starting its own - causing flaky, false failures. `yarn test:e2e` now goes through `scripts/run-e2e.mjs`, which picks a currently-free port automatically and hands it to all Playwright processes via `EXPO_WEB_PORT` (the port cannot be computed inside the config, since Playwright re-evaluates it per worker).

## Test plan

`yarn test:e2e` in `apps/web-example` - two consecutive runs, 11/11 pass each