### PR TITLE
docs: fix invalid 'infinity' value in animationIterationCount docs

### DIFF
--- a/docs/docs-reanimated/docs/css-animations/animation-iteration-count.mdx
+++ b/docs/docs-reanimated/docs/css-animations/animation-iteration-count.mdx
@@ -44,7 +44,7 @@ function App() {
 
 ### Values
 
-#### `infinity`
+#### `infinite`
 
 Animation will repeat forever.
 
@@ -58,7 +58,7 @@ An array of animation iteration count values. The order in this array correspond
 
 ```typescript
 // highlight-next-line
-animationIterationCount: ['infinity', 1, 60];
+animationIterationCount: ['infinite', 1, 60];
 animationName: [bounceIn, move, slide];
 ```
 


### PR DESCRIPTION
## Summary

The `animationIterationCount` page uses the value `'infinity'` in two places: the "Values" section heading and the array code example:

    animationIterationCount: ['infinity', 1, 60];

The correct value is `'infinite'`. `'infinity'` is not accepted by the library:

- The type allows only `'infinite'` or a number: `CSSAnimationIterationCount = 'infinite' | number` (`src/css/types/animation.ts`). The type definitions block on the same docs page already shows the correct value.
- At runtime, passing `'infinity'` throws: `[Reanimated] Invalid iteration count "infinity". Expected a number or "infinite".` (`src/css/native/normalization/animation/settings.ts`)

So copying the example from the docs crashes the app. This PR changes both places to `'infinite'`, so the docs match the type and the actual behavior.

## Test plan

Documentation only change. No code is affected. Both the heading and the example now match the `CSSAnimationIterationCount` type definition shown on the same page.
