### PR TITLE
cherry-pick(4.3-stable): Android crash on odd-length CSS strokeDasharray (#9719)

### DIFF
--- a/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stroke.test.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/__tests__/stroke.test.ts
@@ -4,9 +4,9 @@ import { ERROR_MESSAGES, processStrokeDashArray } from '../stroke';
 
 describe(processStrokeDashArray, () => {
   describe('single value', () => {
-    test('converts length value to a single-element array', () => {
-      expect(processStrokeDashArray(10)).toEqual([10]);
-      expect(processStrokeDashArray('10%')).toEqual(['10%']);
+    test('duplicates a length value to an even-length array', () => {
+      expect(processStrokeDashArray(10)).toEqual([10, 10]);
+      expect(processStrokeDashArray('10%')).toEqual(['10%', '10%']);
     });
 
     test('returns "none" for "none" value', () => {
@@ -27,9 +27,9 @@ describe(processStrokeDashArray, () => {
       );
     });
 
-    describe('duplicates the array if it has an odd number of elements (only if there are more than 2 elements)', () => {
+    describe('duplicates the array if it has an odd number of elements', () => {
       test.each([
-        [[10], [10]],
+        [[10], [10, 10]],
         [
           [10, 20],
           [10, 20],

--- a/packages/react-native-reanimated/src/css/svg/native/processors/stroke.ts
+++ b/packages/react-native-reanimated/src/css/svg/native/processors/stroke.ts
@@ -19,16 +19,19 @@ export const processStrokeDashArray: ValueProcessor<
   if (isLength(value)) {
     result = [value];
   } else if (Array.isArray(value)) {
-    // We have to repeat the same pattern twice if the number of elements is odd
-    // "If the number of values is odd, the pattern behaves as if it was duplicated
-    // to yield an even number of values"
-    // (https://www.w3.org/TR/fill-stroke-3/#valdef-stroke-dasharray-length-percentage)
-    result =
-      value.length % 2 === 0 || value.length < 3 ? value : value.concat(value);
+    result = [...value];
   } else if (value === 'none') {
     return 'none';
   } else {
     throw new ReanimatedError(ERROR_MESSAGES.invalidDashArray(value));
+  }
+
+  // Per the SVG spec an odd-length dash array is repeated to an even length.
+  // react-native-svg's extractStroke does this, but animated values bypass it
+  // and an odd-length array crashes Android's DashPathEffect, so we repeat here.
+  // https://www.w3.org/TR/fill-stroke-3/#valdef-stroke-dasharray-length-percentage
+  if (result.length % 2 === 1) {
+    result = result.concat(result);
   }
 
   if (__DEV__) {


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.3.2 release
- #9719
