### PR TITLE
cherry-pick(4.3-stable): flashing to default style when a CSS transition detaches on Android (#9728)

### DIFF
--- a/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSManager.ts
@@ -61,20 +61,20 @@ export default class CSSManager implements ICSSManager {
         ? this.propsBuilder.build(filteredStyle)
         : undefined;
 
+    const transitionDetached = this.cssTransitionsManager.update(
+      transitionProperties,
+      normalizedStyle ?? {}
+    );
+
+    // Record the committed style as the base so animations and (on Android) a
+    // detaching transition can revert to it instead of interpolator defaults.
     if (
       normalizedStyle &&
-      (hasAnimation ||
-        // We also need to update the current style on Android when the
-        // transition is detached.
-        (IS_ANDROID && !hasTransition && this.hadTransitionLastUpdate))
+      (hasAnimation || (IS_ANDROID && transitionDetached))
     ) {
       setViewStyle(this.viewTag, normalizedStyle);
     }
 
-    this.cssTransitionsManager.update(
-      transitionProperties,
-      normalizedStyle ?? {}
-    );
     this.cssAnimationsManager.update(animationProperties);
 
     this.hadTransitionLastUpdate = hasTransition;

--- a/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/CSSTransitionsManager.ts
@@ -30,10 +30,14 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     this.shadowNodeWrapper = shadowNodeWrapper;
   }
 
+  /**
+   * @returns Whether this update detached a running transition (its props were
+   *   removed, or normalized to an empty config, e.g. when duration is 0).
+   */
   update(
     transitionProperties: CSSTransitionProperties | null,
     nextProps: UnknownRecord = {}
-  ): void {
+  ): boolean {
     const transitionConfig =
       transitionProperties &&
       normalizeCSSTransitionProperties(transitionProperties);
@@ -47,8 +51,9 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
     if (!prevProps || !transitionConfig) {
       if (this.hasTransition) {
         this.detach();
+        return true;
       }
-      return;
+      return false;
     }
 
     // Trigger transition for changed properties only
@@ -62,6 +67,8 @@ export default class CSSTransitionsManager implements ICSSTransitionsManager {
       runCSSTransition(this.shadowNodeWrapper, config);
       this.hasTransition = true;
     }
+
+    return false;
   }
 
   unmountCleanup(): void {

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.android.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.android.test.ts
@@ -1,0 +1,99 @@
+'use strict';
+import type { ShadowNodeWrapper } from '../../../../commonTypes';
+import { setViewStyle } from '../../proxy';
+import CSSManager from '../CSSManager';
+
+jest.mock('../../proxy');
+
+const viewTag = 1;
+const newManager = () =>
+  new CSSManager(
+    {
+      shadowNodeWrapper: {} as ShadowNodeWrapper,
+      viewTag,
+      reactViewName: 'RCTView',
+    },
+    'View'
+  );
+
+const TRANSITION = {
+  transitionProperty: 'opacity',
+  transitionDuration: '300ms',
+} as const;
+
+// Runs in the android jest project (Platform.OS === 'android'), so IS_ANDROID is
+// true. The revert subsystem is Android-only, so unlike other platforms a
+// transition detach records the committed style via the props setter
+// (setViewStyle) for the native revert to restore.
+describe('CSSManager (Android)', () => {
+  let manager: CSSManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = newManager();
+  });
+
+  const attachRunningTransition = () => {
+    manager.update({ opacity: 0, ...TRANSITION });
+    manager.update({ opacity: 1, ...TRANSITION });
+  };
+
+  test('records the committed base style when an animation is attached', () => {
+    manager.update({
+      opacity: 0.5,
+      animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
+      animationDuration: '1s',
+    });
+
+    expect(setViewStyle).toHaveBeenCalledWith(
+      viewTag,
+      expect.objectContaining({ opacity: 0.5 })
+    );
+  });
+
+  test('does not call the props setter for a plain style update', () => {
+    manager.update({ opacity: 0.5 });
+
+    expect(setViewStyle).not.toHaveBeenCalled();
+  });
+
+  // The base is recorded only on a detach, not for every transition update, so a
+  // still-running transition must stay silent even on Android.
+  test('does not call the props setter while a transition keeps running', () => {
+    manager.update({ opacity: 0, ...TRANSITION });
+    jest.clearAllMocks();
+
+    manager.update({ opacity: 1, ...TRANSITION });
+
+    expect(setViewStyle).not.toHaveBeenCalled();
+  });
+
+  test('records the committed style when a 0ms config detaches a running transition', () => {
+    attachRunningTransition();
+    jest.clearAllMocks();
+
+    // Props are still present, but the 0ms duration normalizes to an empty config.
+    manager.update({
+      opacity: 0,
+      transitionProperty: 'opacity',
+      transitionDuration: '0ms',
+    });
+
+    expect(setViewStyle).toHaveBeenCalledWith(
+      viewTag,
+      expect.objectContaining({ opacity: 0 })
+    );
+  });
+
+  test('records the committed style when transition props are removed', () => {
+    attachRunningTransition();
+    jest.clearAllMocks();
+
+    manager.update({ opacity: 1 });
+
+    expect(setViewStyle).toHaveBeenCalledWith(
+      viewTag,
+      expect.objectContaining({ opacity: 1 })
+    );
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSManager.test.ts
@@ -1,0 +1,77 @@
+'use strict';
+import type { ShadowNodeWrapper } from '../../../../commonTypes';
+import { setViewStyle } from '../../proxy';
+import CSSManager from '../CSSManager';
+
+jest.mock('../../proxy');
+
+const viewTag = 1;
+const newManager = () =>
+  new CSSManager(
+    {
+      shadowNodeWrapper: {} as ShadowNodeWrapper,
+      viewTag,
+      reactViewName: 'RCTView',
+    },
+    'View'
+  );
+
+const TRANSITION = {
+  transitionProperty: 'opacity',
+  transitionDuration: '300ms',
+} as const;
+
+describe('CSSManager', () => {
+  let manager: CSSManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = newManager();
+  });
+
+  test('records the committed base style when an animation is attached', () => {
+    manager.update({
+      opacity: 0.5,
+      animationName: { from: { opacity: 0 }, to: { opacity: 1 } },
+      animationDuration: '1s',
+    });
+
+    expect(setViewStyle).toHaveBeenCalledWith(
+      viewTag,
+      expect.objectContaining({ opacity: 0.5 })
+    );
+  });
+
+  test('does not call the props setter for a plain style update', () => {
+    manager.update({ opacity: 0.5 });
+
+    expect(setViewStyle).not.toHaveBeenCalled();
+  });
+
+  test('does not call the props setter while a transition is running', () => {
+    manager.update({ opacity: 0, ...TRANSITION });
+    jest.clearAllMocks();
+
+    // Triggers a running transition - there is no base to record for it.
+    manager.update({ opacity: 1, ...TRANSITION });
+
+    expect(setViewStyle).not.toHaveBeenCalled();
+  });
+
+  // The same detach records a base on Android (see CSSManager.android.test.ts);
+  // here the revert subsystem is absent, so the platform gate keeps it silent.
+  test('does not call the props setter when a transition detaches (non-Android)', () => {
+    manager.update({ opacity: 0, ...TRANSITION });
+    manager.update({ opacity: 1, ...TRANSITION });
+    jest.clearAllMocks();
+
+    // The 0ms duration normalizes to an empty config and detaches the transition.
+    manager.update({
+      opacity: 1,
+      transitionProperty: 'opacity',
+      transitionDuration: '0ms',
+    });
+
+    expect(setViewStyle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
+++ b/packages/react-native-reanimated/src/css/native/managers/__tests__/CSSTransitionsManager.test.ts
@@ -237,22 +237,39 @@ describe('CSSTransitionsManager', () => {
       });
 
       describe('detach via null config', () => {
-        test('unregisters after a transition has run', () => {
+        test('unregisters and reports the detach after a transition has run', () => {
           manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 });
           manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 });
           jest.clearAllMocks();
 
-          manager.update(null);
+          expect(manager.update(null)).toBe(true);
 
           expect(runCSSTransition).not.toHaveBeenCalled();
           expect(unregisterCSSTransition).toHaveBeenCalledWith(viewTag);
         });
 
-        test('does not unregister when no transition has ever run', () => {
+        // The props are still present, but the 0ms config normalizes to empty, so
+        // CSSManager (which only sees the props) relies on this returned flag to
+        // record the revert base.
+        test('reports the detach when the config normalizes to empty (0ms)', () => {
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 });
+          manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 1 });
+          jest.clearAllMocks();
+
+          const detached = manager.update(
+            { transitionProperty: 'opacity', transitionDuration: '0ms' },
+            { opacity: 1 }
+          );
+
+          expect(detached).toBe(true);
+          expect(unregisterCSSTransition).toHaveBeenCalledWith(viewTag);
+        });
+
+        test('does not unregister or report a detach when none has run', () => {
           manager.update(DEFAULT_TRANSITION_CONFIG, { opacity: 0 });
           jest.clearAllMocks();
 
-          manager.update(null);
+          expect(manager.update(null)).toBe(false);
 
           expect(runCSSTransition).not.toHaveBeenCalled();
           expect(unregisterCSSTransition).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.3.2 release
- #9728
