### PR TITLE
cherry-pick(4.4-stable): Freezing animations after bump to RN 0.86.0-rc.3 (#9694)

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -109,6 +109,12 @@ if (project != rootProject) {
 val packageDir: File = project.projectDir.parentFile
 val reactNativeRootDir: File = resolveReactNativeDirectory()
 val REACT_NATIVE_VERSION: String = getReactNativeVersion()
+val IS_REACT_NATIVE_86_OR_NEWER: Boolean = run {
+    val parts = REACT_NATIVE_VERSION.split(".")
+    val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+    val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+    major > 0 || minor >= 86
+}
 val REANIMATED_VERSION: String = getReanimatedVersion()
 val IS_REANIMATED_EXAMPLE_APP: Boolean = safeAppExtGet("isReanimatedExampleApp", false)?.toString()?.toBoolean() ?: false
 val REANIMATED_PROFILING: Boolean = safeAppExtGet("enableReanimatedProfiling", false)?.toString()?.toBoolean() ?: false
@@ -172,6 +178,7 @@ android {
         buildConfigField("String", "REANIMATED_VERSION_JAVA", "\"$REANIMATED_VERSION\"")
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
+        buildConfigField("boolean", "IS_REACT_NATIVE_86_OR_NEWER", IS_REACT_NATIVE_86_OR_NEWER.toString())
 
         @Suppress("UnstableApiUsage")
         externalNativeBuild {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -3,6 +3,7 @@ package com.swmansion.reanimated
 import android.content.ContentResolver
 import android.os.SystemClock
 import android.provider.Settings
+import android.util.Log
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.NativeModule
@@ -222,13 +223,43 @@ open class NativeProxy {
         return true
     }
 
+    // TODO(#9681): Temporary workaround for RN >= 0.86. Since RN 0.86,
+    // overrideBySynchronousMountPropsAtMountingAndroid defaults on, so RN's only public
+    // synchronous-update API (synchronouslyUpdateViewOnUIThread) seeds the tagToSynchronousMountProps
+    // cache that then clamps later commits and freezes animations. On RN >= 0.86 we instead call
+    // MountingManager.updatePropsSynchronously directly (apply without cache seeding) via reflection, since
+    // MountingManager is internal. On older RN the flag is off, so we keep the original RN path
+    // unchanged (gated by BuildConfig.IS_REACT_NATIVE_86_OR_NEWER, derived from the RN version at
+    // build time). Remove once RN exposes a non-seeding synchronous-update API.
+    private val mountingManager: Any by lazy {
+        FabricUIManager::class.java.getDeclaredField("mMountingManager").run {
+            isAccessible = true
+            get(mFabricUIManager)
+        }
+    }
+
+    private val updatePropsSynchronouslyMethod by lazy {
+        mountingManager.javaClass.methods
+            .first {
+                it.name.startsWith("updatePropsSynchronously") && it.parameterTypes.size == 2
+            }.apply { isAccessible = true }
+    }
+
     @DoNotStrip
     fun synchronouslyUpdateUIProps(
         intBuffer: IntArray,
         doubleBuffer: DoubleArray,
     ) {
         SynchronousPropsBufferParser.parse(intBuffer, doubleBuffer) { viewTag, props ->
-            mFabricUIManager.synchronouslyUpdateViewOnUIThread(viewTag, props)
+            if (BuildConfig.IS_REACT_NATIVE_86_OR_NEWER) {
+                try {
+                    updatePropsSynchronouslyMethod.invoke(mountingManager, viewTag, props)
+                } catch (e: Exception) {
+                    Log.w("Reanimated", "synchronouslyUpdateUIProps failed for tag $viewTag", e)
+                }
+            } else {
+                mFabricUIManager.synchronouslyUpdateViewOnUIThread(viewTag, props)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9694

4.4.x declares RN 0.86 support while `synchronouslyUpdateUIProps` still calls `synchronouslyUpdateViewOnUIThread` unguarded, so 4.4 users on RN 0.86 Android hit frozen animations (#9681).