### PR TITLE
cherry-pick(4.4-stable): Pass -fno-pch-timestamp so ccache can reuse the Android PCH (#9749)

### DIFF
--- a/packages/react-native-reanimated/android/CMakeLists.txt
+++ b/packages/react-native-reanimated/android/CMakeLists.txt
@@ -49,6 +49,12 @@ add_library(reanimated SHARED ${REANIMATED_COMMON_CPP_SOURCES}
 target_precompile_headers(reanimated PRIVATE
                           "${ANDROID_CPP_DIR}/ReanimatedPCH.h")
 
+# Stop Clang from embedding a build timestamp in the .pch. Without this the PCH
+# is non-reproducible across builds, so ccache can't reuse it and translation
+# units reject a restored PCH as "modified since built".
+target_compile_options(reanimated PRIVATE
+                       "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>")
+
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
   include(
     "${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")

--- a/packages/react-native-worklets/android/CMakeLists.txt
+++ b/packages/react-native-worklets/android/CMakeLists.txt
@@ -55,6 +55,12 @@ add_library(worklets SHARED ${WORKLETS_COMMON_CPP_SOURCES}
 
 target_precompile_headers(worklets PRIVATE "${ANDROID_CPP_DIR}/WorkletsPCH.h")
 
+# Stop Clang from embedding a build timestamp in the .pch. Without this the PCH
+# is non-reproducible across builds, so ccache can't reuse it and translation
+# units reject a restored PCH as "modified since built".
+target_compile_options(worklets PRIVATE
+                       "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>")
+
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
   include(
     "${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake")


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.4.2 release
- #9749