### PR TITLE
fix: Android crash on empty CSS strokeDasharray from the default keyframe endpoint

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -38,6 +38,15 @@ SVGStrokeDashArray SVGStrokeDashArray::interpolate(
   return SVGStrokeDashArray(result);
 }
 
+folly::dynamic SVGStrokeDashArray::toDynamic() const {
+  // Empty means "no dashing" - emit null instead of [], which react-native-svg
+  // would feed to Android's DashPathEffect that requires at least 2 intervals.
+  if (values.empty()) {
+    return nullptr;
+  }
+  return CSSLengthVector::toDynamic();
+}
+
 #ifndef NDEBUG
 
 std::ostream &operator<<(std::ostream &os, const SVGStrokeDashArray &strokeDashArray) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
@@ -12,6 +12,8 @@ struct SVGStrokeDashArray : public CSSLengthVector<SVGStrokeDashArray> {
       const SVGStrokeDashArray &to,
       const ResolvableValueInterpolationContext &context) const override;
 
+  folly::dynamic toDynamic() const override;
+
 #ifndef NDEBUG
   friend std::ostream &operator<<(std::ostream &os, const SVGStrokeDashArray &strokeDashArray);
 #endif // NDEBUG


### PR DESCRIPTION
## Summary

Animating `strokeDasharray` with an implicit default keyframe endpoint ships an empty array to react-native-svg (the default `SVGStrokeDashArray()` serializes to `[]`), which crashes Android's `DashPathEffect` - it requires at least 2 intervals. #9719 does not cover this case because 0 is an even length.

Per CSS, the initial `stroke-dasharray` is `none` (a solid stroke), so serialize the empty array as `null`, which react-native-svg renders as a solid stroke.

## Test plan

Open the CSS app > Animated Properties > SVG > Stroke on Android. Before: a release build crashes within seconds of opening the screen. After: all examples render correctly and survive restart + scroll soaks. Recordings below.