### PR TITLE
cherry-pick(4.5-stable): Android crash on empty CSS strokeDasharray from the default keyframe endpoint (#9845)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -38,6 +38,15 @@ SVGStrokeDashArray SVGStrokeDashArray::interpolate(
   return SVGStrokeDashArray(result);
 }
 
+folly::dynamic SVGStrokeDashArray::toDynamic() const {
+  // Empty means "no dashing" - emit null instead of [], which react-native-svg
+  // would feed to Android's DashPathEffect that requires at least 2 intervals.
+  if (values.empty()) {
+    return nullptr;
+  }
+  return CSSLengthVector::toDynamic();
+}
+
 #ifndef NDEBUG
 
 std::ostream &operator<<(std::ostream &os, const SVGStrokeDashArray &strokeDashArray) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.h
@@ -12,6 +12,8 @@ struct SVGStrokeDashArray : public CSSLengthVector<SVGStrokeDashArray> {
       const SVGStrokeDashArray &to,
       const ResolvableValueInterpolationContext &context) const override;
 
+  folly::dynamic toDynamic() const override;
+
 #ifndef NDEBUG
   friend std::ostream &operator<<(std::ostream &os, const SVGStrokeDashArray &strokeDashArray);
 #endif // NDEBUG


### PR DESCRIPTION
Clean cherry-pick of #9845 (empty CSS `strokeDasharray` crashing Android's `DashPathEffect`) for the 4.5.1 release.