### PR TITLE
cherry-pick(4.4-stable): Android crash on empty CSS strokeDasharray from the default keyframe endpoint (#9845)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/svg/values/SVGStrokeDashArray.cpp
@@ -43,6 +43,11 @@ bool SVGStrokeDashArray::canConstruct(const folly::dynamic &value) {
 }
 
 folly::dynamic SVGStrokeDashArray::toDynamic() const {
+  // Empty means "no dashing" - emit null instead of [], which react-native-svg
+  // would feed to Android's DashPathEffect that requires at least 2 intervals.
+  if (values.empty()) {
+    return nullptr;
+  }
   folly::dynamic array = folly::dynamic::array;
   array.reserve(values.size());
   for (const auto &value : values) {


### PR DESCRIPTION
Cherry-pick of #9845 (empty CSS `strokeDasharray` crashing Android's `DashPathEffect`) for the 4.4.2 release, adapted to this branch's file shape (guard inside the existing `toDynamic`).