### PR TITLE
fix: deactivate active pseudo selectors on unregistration

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -192,7 +192,13 @@ void TransitionProgressProvider::setPropertySettings(const PropertiesSettingsMap
 }
 
 CSSTransitionPropertySettings TransitionProgressProvider::getPropertySettings(const std::string &propertyName) const {
-  return propertySettings_.at(propertyName);
+  const auto it = propertySettings_.find(propertyName);
+  if (it == propertySettings_.end()) {
+    // A pseudo toggle can run a property whose settings never parsed (e.g. a discrete
+    // property without allowDiscrete); fall back to instant settings instead of throwing.
+    return CSSTransitionPropertySettings{};
+  }
+  return it->second;
 }
 
 } // namespace reanimated::css

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -116,7 +116,9 @@ void TransitionProgressProvider::runProgressProvider(
     const bool isReversed,
     const double timestamp) {
 
-  const auto &settings = propertySettings_.at(propertyName);
+  // Routed through the accessor so this path gets the same missing-settings fallback instead of
+  // throwing std::out_of_range on the platform UI thread.
+  const auto settings = getPropertySettings(propertyName);
 
   const auto providerIt = propertyProgressProviders_.find(propertyName);
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/progress/TransitionProgressProvider.cpp
@@ -116,8 +116,6 @@ void TransitionProgressProvider::runProgressProvider(
     const bool isReversed,
     const double timestamp) {
 
-  // Routed through the accessor so this path gets the same missing-settings fallback instead of
-  // throwing std::out_of_range on the platform UI thread.
   const auto settings = getPropertySettings(propertyName);
 
   const auto providerIt = propertyProgressProviders_.find(propertyName);
@@ -196,8 +194,8 @@ void TransitionProgressProvider::setPropertySettings(const PropertiesSettingsMap
 CSSTransitionPropertySettings TransitionProgressProvider::getPropertySettings(const std::string &propertyName) const {
   const auto it = propertySettings_.find(propertyName);
   if (it == propertySettings_.end()) {
-    // A pseudo toggle can run a property whose settings never parsed (e.g. a discrete
-    // property without allowDiscrete); fall back to instant settings instead of throwing.
+    // A pseudo toggle can run a property whose settings never parsed, e.g. a discrete
+    // property without allowDiscrete.
     return CSSTransitionPropertySettings{};
   }
   return it->second;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
@@ -78,10 +78,28 @@ void PseudoStylesRegistry::remove(Tag tag) {
   if (it == registry_.end()) {
     return;
   }
-  auto selectorsToDetach = std::move(it->second.selectors);
+  TagEntry entry = std::move(it->second);
   registry_.erase(it);
 
-  for (const auto &[selector, data] : selectorsToDetach) {
+  // The gesture listeners are going away, so an active selector would stay applied forever
+  // (and its lock would keep filtering render transitions); run the deactivation transition
+  // and drop the lock before detaching.
+  if (entry.activeMask != 0) {
+    cssTransitionsRegistry_->setPseudoLockedProperties(tag, {});
+    if (entry.shadowNode) {
+      const auto &fromStyle = entry.precomputedStyles[entry.activeMask];
+      const auto &toStyle = entry.precomputedStyles[0];
+      css::PropertyValueDynamicDiffsMap valueChanges;
+      for (const auto &[propKey, toVal] : toStyle.items()) {
+        const auto propName = propKey.asString();
+        const folly::dynamic &fromVal = fromStyle.count(propName) ? fromStyle[propName] : toVal;
+        valueChanges.emplace(propName, std::make_pair(fromVal, toVal));
+      }
+      cssTransitionsRegistry_->run(entry.shadowNode, valueChanges);
+    }
+  }
+
+  for (const auto &[selector, data] : entry.selectors) {
     detachFn_(tag, selector);
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
@@ -81,22 +81,19 @@ void PseudoStylesRegistry::remove(Tag tag) {
   TagEntry entry = std::move(it->second);
   registry_.erase(it);
 
-  // The gesture listeners are going away, so an active selector would stay applied forever
-  // (and its lock would keep filtering render transitions); run the deactivation transition
-  // and drop the lock before detaching.
+  // The listeners are going away, so an active selector would stay applied forever and its
+  // lock would keep filtering render transitions.
   if (entry.activeMask != 0) {
     cssTransitionsRegistry_->setPseudoLockedProperties(tag, {});
-    if (entry.shadowNode) {
-      const auto &fromStyle = entry.precomputedStyles[entry.activeMask];
-      const auto &toStyle = entry.precomputedStyles[0];
-      css::PropertyValueDynamicDiffsMap valueChanges;
-      for (const auto &[propKey, toVal] : toStyle.items()) {
-        const auto propName = propKey.asString();
-        const folly::dynamic &fromVal = fromStyle.count(propName) ? fromStyle[propName] : toVal;
-        valueChanges.emplace(propName, std::make_pair(fromVal, toVal));
-      }
-      cssTransitionsRegistry_->run(entry.shadowNode, valueChanges);
+    const auto &fromStyle = entry.precomputedStyles[entry.activeMask];
+    const auto &toStyle = entry.precomputedStyles[0];
+    css::PropertyValueDynamicDiffsMap valueChanges;
+    for (const auto &[propKey, toVal] : toStyle.items()) {
+      const auto propName = propKey.asString();
+      const folly::dynamic &fromVal = fromStyle.count(propName) ? fromStyle[propName] : toVal;
+      valueChanges.emplace(propName, std::make_pair(fromVal, toVal));
     }
+    cssTransitionsRegistry_->run(entry.shadowNode, valueChanges);
   }
 
   for (const auto &[selector, data] : entry.selectors) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/PseudoStyles/PseudoStylesRegistry.cpp
@@ -81,8 +81,7 @@ void PseudoStylesRegistry::remove(Tag tag) {
   TagEntry entry = std::move(it->second);
   registry_.erase(it);
 
-  // The listeners are going away, so an active selector would stay applied forever and its
-  // lock would keep filtering render transitions.
+  // The listeners are going away, so an active selector would stay applied forever.
   if (entry.activeMask != 0) {
     cssTransitionsRegistry_->setPseudoLockedProperties(tag, {});
     const auto &fromStyle = entry.precomputedStyles[entry.activeMask];


### PR DESCRIPTION
Unregistering pseudo styles while a selector is still active left the held value and the pseudo lock in place, so the view stayed stuck at the pseudo value indefinitely.

## Example recordings

### Android

<img width="600" src="https://github.com/user-attachments/assets/08737922-2272-4325-83dc-14b55ef47ece" />

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a886a3dc-6601-476c-9a17-0ea7660fbade"></video> | <video src="https://github.com/user-attachments/assets/35cf2e82-58c5-4284-abc3-1e99ea30129f"></video> |

### iOS

<img width="600" src="https://github.com/user-attachments/assets/f4e869a7-08bb-463b-8cf1-4a2b9347c765" />

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/30037c6a-0fbf-400e-869a-11b7b7e2bbb0"></video> | <video src="https://github.com/user-attachments/assets/57f51c62-15a5-4872-a67f-a6a4114a9519"></video> |
