### PR TITLE
fix: web crash-loop under strict ESM bundlers caused by require() in webUtils.web.ts

### DIFF
--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/index.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/index.ts
@@ -67,7 +67,7 @@ export const _updatePropsJS = (
       // React Native Web 0.19+ no longer provides setNativeProps function,
       // so we need to update DOM nodes directly.
       updatePropsDOM(component, rawStyles, isAnimatedProps);
-    } else if (Object.keys(component.props).length > 0) {
+    } else if (component.props && Object.keys(component.props).length > 0) {
       Object.keys(component.props).forEach((key) => {
         if (!rawStyles[key]) {
           return;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
@@ -1,32 +1,28 @@
 'use strict';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let createReactDOMStyle: (style: any) => any;
+// This module is resolved only on web, where react-native-web is always
+// present, so the helpers can be imported statically. Loading them with a
+// runtime require() breaks under strict ESM bundlers (webpack, Rollup,
+// esbuild): a module with ESM exports gets no CommonJS require at runtime,
+// so the helpers stayed undefined and _updatePropsJS crashed on every
+// animation frame (#9844). Only Metro tolerated the previous mixed form.
+// The .js extensions keep the imports fully specified, which strict ESM
+// bundlers require when resolving from the ESM build output.
+
+// @ts-ignore react-native-web internals have no type declarations.
+// eslint-disable-next-line n/no-unpublished-import
+import createReactDOMStyleRNW from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle.js';
+// @ts-ignore react-native-web internals have no type declarations.
+// eslint-disable-next-line n/no-unpublished-import
+import * as preprocessRNW from 'react-native-web/dist/exports/StyleSheet/preprocess.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let createTransformValue: (transform: any) => any;
+export const createReactDOMStyle: (style: any) => any = createReactDOMStyleRNW;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let createTextShadowValue: (style: any) => void | string;
+export const createTransformValue: (transform: any) => any =
+  preprocessRNW.createTransformValue;
 
-try {
-  createReactDOMStyle =
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-    require('react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle').default;
-  // eslint-disable-next-line no-empty
-} catch (_e) {}
-
-try {
-  // React Native Web 0.19+
-  createTransformValue =
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-    require('react-native-web/dist/exports/StyleSheet/preprocess').createTransformValue;
-  // eslint-disable-next-line no-empty
-} catch (_e) {}
-
-try {
-  createTextShadowValue =
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, n/no-unpublished-require
-    require('react-native-web/dist/exports/StyleSheet/preprocess').createTextShadowValue;
-  // eslint-disable-next-line no-empty
-} catch (_e) {}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const createTextShadowValue: (style: any) => void | string =
+  preprocessRNW.createTextShadowValue;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
@@ -6,23 +6,34 @@
 // esbuild): a module with ESM exports gets no CommonJS require at runtime,
 // so the helpers stayed undefined and _updatePropsJS crashed on every
 // animation frame (#9844). Only Metro tolerated the previous mixed form.
-// The .js extensions keep the imports fully specified, which strict ESM
-// bundlers require when resolving from the ESM build output.
+//
+// The imports point at react-native-web's CommonJS build with fully
+// specified .js extensions. SSR frameworks (e.g. Next.js) externalize
+// react-native-web and load it with Node's native ESM resolver, which
+// rejects the extensionless relative imports inside the ESM build in
+// dist/exports, while the CommonJS build loads everywhere.
 
 // @ts-ignore react-native-web internals have no type declarations.
 // eslint-disable-next-line n/no-unpublished-import
-import createReactDOMStyleRNW from 'react-native-web/dist/exports/StyleSheet/compiler/createReactDOMStyle.js';
+import * as createReactDOMStyleModule from 'react-native-web/dist/cjs/exports/StyleSheet/compiler/createReactDOMStyle.js';
 // @ts-ignore react-native-web internals have no type declarations.
 // eslint-disable-next-line n/no-unpublished-import
-import * as preprocessRNW from 'react-native-web/dist/exports/StyleSheet/preprocess.js';
+import * as preprocessModule from 'react-native-web/dist/cjs/exports/StyleSheet/preprocess.js';
+
+// Node's CJS-ESM interop and bundler interop expose a transpiled default
+// export under `.default`; fall back to the namespace itself just in case.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const interopDefault = (module: any) => module.default ?? module;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const createReactDOMStyle: (style: any) => any = createReactDOMStyleRNW;
+export const createReactDOMStyle: (style: any) => any = interopDefault(
+  createReactDOMStyleModule
+);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createTransformValue: (transform: any) => any =
-  preprocessRNW.createTransformValue;
+  preprocessModule.createTransformValue;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createTextShadowValue: (style: any) => void | string =
-  preprocessRNW.createTextShadowValue;
+  preprocessModule.createTextShadowValue;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/webUtils.web.ts
@@ -1,17 +1,11 @@
 'use strict';
 
-// This module is resolved only on web, where react-native-web is always
-// present, so the helpers can be imported statically. Loading them with a
-// runtime require() breaks under strict ESM bundlers (webpack, Rollup,
-// esbuild): a module with ESM exports gets no CommonJS require at runtime,
-// so the helpers stayed undefined and _updatePropsJS crashed on every
-// animation frame (#9844). Only Metro tolerated the previous mixed form.
-//
-// The imports point at react-native-web's CommonJS build with fully
-// specified .js extensions. SSR frameworks (e.g. Next.js) externalize
-// react-native-web and load it with Node's native ESM resolver, which
-// rejects the extensionless relative imports inside the ESM build in
-// dist/exports, while the CommonJS build loads everywhere.
+// Static imports so that strict ESM bundlers (webpack, Rollup, esbuild)
+// resolve the helpers at build time - a runtime require() is not available
+// in ESM modules there, which left the helpers undefined (#9844). The
+// CommonJS build is used because SSR frameworks load externalized
+// react-native-web with Node's ESM resolver, which rejects the
+// extensionless relative imports inside the dist/exports ESM build.
 
 // @ts-ignore react-native-web internals have no type declarations.
 // eslint-disable-next-line n/no-unpublished-import
@@ -20,8 +14,8 @@ import * as createReactDOMStyleModule from 'react-native-web/dist/cjs/exports/St
 // eslint-disable-next-line n/no-unpublished-import
 import * as preprocessModule from 'react-native-web/dist/cjs/exports/StyleSheet/preprocess.js';
 
-// Node's CJS-ESM interop and bundler interop expose a transpiled default
-// export under `.default`; fall back to the namespace itself just in case.
+// Node exposes a transpiled CJS default export as `.default`, bundlers as
+// the module itself.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const interopDefault = (module: any) => module.default ?? module;
 


### PR DESCRIPTION
## Summary

Fixes #9844.

`webUtils.web.ts` mixed ESM exports with a runtime `require()`. Spec-compliant ESM bundlers (webpack, Rollup, esbuild) do not provide `require` inside a module that uses ESM syntax, so the try/catch silently swallowed a ReferenceError and `createReactDOMStyle` / `createTransformValue` / `createTextShadowValue` stayed `undefined`. `_updatePropsJS` then skipped the DOM branch and crashed on `Object.keys(component.props)` on every animation frame. Only Metro tolerated the mixed form.

The helpers are now imported statically from react-native-web's CommonJS build (`dist/cjs`) with fully specified `.js` extensions:
- the `.web` platform file only ships to web, where react-native-web is always present, so a static import is safe;
- the CommonJS build (rather than `dist/exports`) matters for SSR frameworks like Next.js, which externalize react-native-web and load it with Node's native ESM resolver - that resolver rejects the extensionless relative imports inside the ESM build, while the CommonJS build loads everywhere;
- the `.js` extensions are required because the published `lib/module` output is strict ESM, where webpack demands fully specified deep paths.

Also guards the `component.props` fall-through branch (the crash line itself) so refs with neither `setNativeProps`, `style` nor `props` hit the existing "It's not possible to manipulate the component" warning instead of throwing (reported in #9854).

## Test plan

- webpack probe against the built `lib/module` output: before the fix all three helpers bundle to `undefined` (reproduces #9844); after the fix all three are functions.
- raw `node --input-type=module` import of the built `webUtils.web.js` (the Next.js SSR external-module case): all three helpers resolve to functions.
- `yarn workspace next-example build:next` passes (reproduced the CI failure locally first, byte-identical error).
- `yarn tsc --noEmit` (native + web tsconfigs), `yarn eslint` on the touched files, `yarn jest` (all passing).
- web-example playwright e2e (Metro path): 11/11.