### PR TITLE
fix: Add missing version setter script variable

### DIFF
--- a/packages/react-native-reanimated/RELEASE.md
+++ b/packages/react-native-reanimated/RELEASE.md
@@ -29,7 +29,7 @@ Reanimated follows [semver](https://semver.org/) whenever applicable.
 
 1. Set the new version by running the following script in the repository root:
 
-   - `cd packages/react-native-reanimated && yarn set-version x.y.z`
+   - `cd packages/react-native-reanimated && yarn set-version --version x.y.z`
 
 1. Update the **Compatibility** in `packages/react-native-reanimated/compatibility.json`
 


### PR DESCRIPTION
## Summary

The `--version` variable was missing from the mentioned command in RELEASE.md, which resulted in this error:

```sh
> yarn set-version 4.5.1

Unknown arguments:  [ { value: '4.5.1', handled: false } ]
```
