### PR TITLE
chore(4.4-stable): align runtime tests with worklets 0.10 behavior

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -296,6 +296,88 @@ describe('Test createSerializable', () => {
         expect(result).toBe(true);
       });
 
+      test('createSerializableTypedArray', async () => {
+        const typedArrayValue = new Uint8Array(4);
+        typedArrayValue[0] = 1;
+        typedArrayValue[1] = 2;
+        typedArrayValue[2] = 3;
+        typedArrayValue[3] = 4;
+        scheduleOnTarget(() => {
+          'worklet';
+          const checks = [
+            typedArrayValue instanceof Uint8Array,
+            typedArrayValue.length === 4,
+            typedArrayValue[0] === 1,
+            typedArrayValue[1] === 2,
+            typedArrayValue[2] === 3,
+            typedArrayValue[3] === 4,
+          ];
+          scheduleOnRN(callbackPass, checks.every(Boolean));
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
+      });
+
+      test('createSerializableInt32Array', async () => {
+        const typedArrayValue = new Int32Array(2);
+        typedArrayValue[0] = -1;
+        typedArrayValue[1] = 42;
+        scheduleOnTarget(() => {
+          'worklet';
+          const checks = [
+            typedArrayValue instanceof Int32Array,
+            typedArrayValue.length === 2,
+            typedArrayValue[0] === -1,
+            typedArrayValue[1] === 42,
+          ];
+          scheduleOnRN(callbackPass, checks.every(Boolean));
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
+      });
+
+      test('createSerializableTypedArraySubrange', async () => {
+        const buf = new ArrayBuffer(16);
+        const full = new Uint16Array(buf);
+        for (let i = 0; i < full.length; i++) {
+          full[i] = i + 1;
+        }
+        const typedArrayValue = new Uint16Array(buf, 4, 2);
+        scheduleOnTarget(() => {
+          'worklet';
+          const checks = [
+            typedArrayValue instanceof Uint16Array,
+            typedArrayValue.length === 2,
+            typedArrayValue.byteOffset === 4,
+            typedArrayValue.buffer.byteLength === 16,
+            typedArrayValue[0] === 3,
+            typedArrayValue[1] === 4,
+          ];
+          scheduleOnRN(callbackPass, checks.every(Boolean));
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
+      });
+
+      test('createSerializableDataView', async () => {
+        const buf = new ArrayBuffer(4);
+        const dataViewValue = new DataView(buf);
+        dataViewValue.setUint8(0, 0xab);
+        dataViewValue.setUint8(1, 0xcd);
+        scheduleOnTarget(() => {
+          'worklet';
+          const checks = [
+            dataViewValue instanceof DataView,
+            dataViewValue.byteLength === 4,
+            dataViewValue.getUint8(0) === 0xab,
+            dataViewValue.getUint8(1) === 0xcd,
+          ];
+          scheduleOnRN(callbackPass, checks.every(Boolean));
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
+      });
+
       test('createSerializableSet', async () => {
         const setValue = new Set([1, '1', true]);
         scheduleOnTarget(() => {
@@ -536,22 +618,9 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        scheduleOnTarget(() => {
-          'worklet';
-          try {
-            inaccessibleObject.access();
-            scheduleOnRN(callbackPass, false);
-          } catch (error) {
-            scheduleOnRN(
-              callbackFail,
-              error instanceof Error ? error.message : String(error)
-            );
-          }
-        });
-        await waitForNotification(FAIL_NOTIFICATION);
-        expect(errorMessage).toInclude(
-          '[Worklets] Trying to access property `access` of an object which cannot be sent to the UI runtime.'
-        );
+        await expect(() => {
+          createSerializable(inaccessibleObject);
+        }).toThrow('Cannot copy value of type `Inaccessible`.');
       });
 
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {
@@ -607,7 +676,18 @@ if (__DEV__) {
       const promise = Promise.resolve();
       await expect(() => {
         createSerializable(promise);
-      }).toThrow('Promises cannot be converted to serializable.');
+      }).toThrow(
+        globalThis._WORKLETS_BUNDLE_MODE_ENABLED
+          ? 'Cannot copy value of type `Promise`'
+          : 'Promises cannot be converted to serializable.'
+      );
+    });
+
+    test('throws when trying to serialize a Proxy', async () => {
+      const proxy = new Proxy({ a: 1 }, { getPrototypeOf: () => null });
+      await expect(() => {
+        createSerializable(proxy);
+      }).toThrow('Cannot copy value of type');
     });
   });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -283,6 +283,75 @@ describe('Test createSerializableOnUI', () => {
     expect(regExpValue.test('FOO-BAR')).toBe(true);
   });
 
+  test('createSerializableOnUITypedArray', () => {
+    const typedArrayValue = runOnUISync(() => {
+      'worklet';
+      const arr = new Uint8Array(4);
+      arr[0] = 1;
+      arr[1] = 2;
+      arr[2] = 3;
+      arr[3] = 4;
+      return arr;
+    });
+
+    expect(typedArrayValue instanceof Uint8Array).toBe(true);
+    expect(typedArrayValue.length).toBe(4);
+    expect(typedArrayValue[0]).toBe(1);
+    expect(typedArrayValue[1]).toBe(2);
+    expect(typedArrayValue[2]).toBe(3);
+    expect(typedArrayValue[3]).toBe(4);
+  });
+
+  test('createSerializableOnUIInt32Array', () => {
+    const typedArrayValue = runOnUISync(() => {
+      'worklet';
+      const arr = new Int32Array(2);
+      arr[0] = -1;
+      arr[1] = 42;
+      return arr;
+    });
+
+    expect(typedArrayValue instanceof Int32Array).toBe(true);
+    expect(typedArrayValue.length).toBe(2);
+    expect(typedArrayValue[0]).toBe(-1);
+    expect(typedArrayValue[1]).toBe(42);
+  });
+
+  test('createSerializableOnUITypedArraySubrange', () => {
+    const typedArrayValue = runOnUISync(() => {
+      'worklet';
+      const buf = new ArrayBuffer(16);
+      const full = new Uint16Array(buf);
+      for (let i = 0; i < full.length; i++) {
+        full[i] = i + 1;
+      }
+      return new Uint16Array(buf, 4, 2);
+    });
+
+    expect(typedArrayValue instanceof Uint16Array).toBe(true);
+    expect(typedArrayValue.length).toBe(2);
+    expect(typedArrayValue.byteOffset).toBe(4);
+    expect(typedArrayValue.buffer.byteLength).toBe(16);
+    expect(typedArrayValue[0]).toBe(3);
+    expect(typedArrayValue[1]).toBe(4);
+  });
+
+  test('createSerializableOnUIDataView', () => {
+    const dataViewValue = runOnUISync(() => {
+      'worklet';
+      const buf = new ArrayBuffer(4);
+      const view = new DataView(buf);
+      view.setUint8(0, 0xab);
+      view.setUint8(1, 0xcd);
+      return view;
+    });
+
+    expect(dataViewValue instanceof DataView).toBe(true);
+    expect(dataViewValue.byteLength).toBe(4);
+    expect(dataViewValue.getUint8(0)).toBe(0xab);
+    expect(dataViewValue.getUint8(1)).toBe(0xcd);
+  });
+
   test('createSerializableOnUIPlainObject', () => {
     // Arrange & Act
     enum key {
@@ -454,7 +523,6 @@ describe('Test createSerializableOnUI', () => {
   // });
 
   test('createSerializableOnUIInaccessibleObject', async () => {
-    // Arrange
     const clazz = runOnUISync(() => {
       'worklet';
       class Clazz {
@@ -464,7 +532,6 @@ describe('Test createSerializableOnUI', () => {
       return new Clazz();
     });
 
-    // Act & Assert
     await expect(() => {
       clazz.method();
     }).toThrow();
@@ -503,7 +570,7 @@ describe('Test createSerializableOnUI', () => {
           'worklet';
           return Promise.resolve();
         })
-      ).toThrow('Promises cannot be converted to serializable.');
+      ).toThrow('Cannot copy value of type `Promise`');
     });
   }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/isSerializableRef.test.tsx
@@ -166,7 +166,10 @@ describe('Test isSerializableRef', () => {
     expect(isSerializableRef(serializableRef)).toBe(true);
   });
 
-  test('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
+  // TODO: `__reanimatedModuleProxy` is no longer a HostObject after the
+  // `toOptimizedObject` refactor, so setting it as a prototype no longer
+  // makes the object TurboModule-like. Rework using an actual host object.
+  test.skip('check if createSerializable<TurboModule-like object> returns serializable ref', () => {
     const proto = globalThis.__reanimatedModuleProxy;
     const obj = {
       a: 1,

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/plugin/fileWorkletization.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/plugin/fileWorkletization.test.tsx
@@ -1,80 +1,58 @@
-import React, { useEffect } from 'react';
-import { View } from 'react-native';
-import { useSharedValue } from 'react-native-reanimated';
+import { scheduleOnRN, scheduleOnUI } from 'react-native-worklets';
 
 import {
+  beforeEach,
   describe,
   expect,
-  getRegisteredValue,
-  registerValue,
-  render,
+  notify,
   test,
-  wait,
+  waitForNotification,
 } from '../../ReJest/RuntimeTestsApi';
 import {
   getThree,
   implicitContextObject,
   ImplicitWorkletClass,
 } from './fileWorkletization';
-import { scheduleOnUI } from 'react-native-worklets';
-
-const SHARED_VALUE_REF = 'SHARED_VALUE_REF';
 
 describe('Test file workletization', () => {
+  const PASS_NOTIFICATION = 'PASS';
+  let result: number | null = null;
+
+  const callbackPass = (value: number) => {
+    result = value;
+    notify(PASS_NOTIFICATION);
+  };
+
+  beforeEach(() => {
+    result = null;
+  });
+
   test('Functions and methods are workletized', async () => {
-    const ExampleComponent = () => {
-      const output = useSharedValue<number | null>(null);
-      registerValue(SHARED_VALUE_REF, output);
-
-      useEffect(() => {
-        scheduleOnUI(() => {
-          output.value = getThree();
-        });
-      });
-
-      return <View />;
-    };
-    await render(<ExampleComponent />);
-    await wait(100);
-    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
-    expect(sharedValue.onUI).toBe(3);
+    scheduleOnUI(() => {
+      'worklet';
+      scheduleOnRN(callbackPass, getThree());
+    });
+    await waitForNotification(PASS_NOTIFICATION);
+    expect(result).toBe(3);
   });
 
   test('WorkletContextObjects are workletized', async () => {
-    const ExampleComponent = () => {
-      const output = useSharedValue<number | null>(null);
-      registerValue(SHARED_VALUE_REF, output);
-
-      useEffect(() => {
-        scheduleOnUI(() => {
-          output.value = implicitContextObject.getFive();
-        });
-      });
-
-      return <View />;
-    };
-    await render(<ExampleComponent />);
-    await wait(100);
-    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
-    expect(sharedValue.onUI).toBe(5);
+    scheduleOnUI(() => {
+      'worklet';
+      scheduleOnRN(callbackPass, implicitContextObject.getFive());
+    });
+    await waitForNotification(PASS_NOTIFICATION);
+    expect(result).toBe(5);
   });
 
-  test('WorkletClasses are workletized', async () => {
-    const ExampleComponent = () => {
-      const output = useSharedValue<number | null>(null);
-      registerValue(SHARED_VALUE_REF, output);
-
-      useEffect(() => {
-        scheduleOnUI(() => {
-          output.value = new ImplicitWorkletClass().getSeven();
-        });
+  if (!globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+    test('WorkletClasses are workletized', async () => {
+      scheduleOnUI(() => {
+        'worklet';
+        scheduleOnRN(callbackPass, new ImplicitWorkletClass().getSeven());
       });
-
-      return <View />;
-    };
-    await render(<ExampleComponent />);
-    await wait(100);
-    const sharedValue = await getRegisteredValue(SHARED_VALUE_REF);
-    expect(sharedValue.onUI).toBe(7);
-  });
+      await waitForNotification(PASS_NOTIFICATION);
+      expect(result).toBe(7);
+    });
+  }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/runLoop/executionOrder.test.tsx
@@ -71,11 +71,14 @@ describe('Test mixed order of execution', () => {
       // Act
       scheduleOnRuntime(rt, () => {
         'worklet';
+        // Stay busy until the second task below is enqueued.
+        const busyUntil = performance.now() + 10;
+        while (performance.now() < busyUntil) {
+          // Do nothing.
+        }
         getMethodMap()[firstMethodName](() =>
           order(firstMethodOrder, notification1)
         );
-        // heavy task, to make sure that next scheduleOnRuntime will schedule task on async queue
-        new Array(100000).map((_v, i) => (i / 2) * i * 9 + 7);
       });
       scheduleOnRuntime(rt, () => {
         'worklet';


### PR DESCRIPTION
## Summary

Syncs runtime test files with main so the suite passes with both worklets 0.9 and 0.10. The old memory tests relied on 0.9 behavior for inaccessible objects, which changed in 0.10 (#9532).

Test-only, no library changes. Files are identical with main and include test updates from #9532, #9475, #9633, #9698 and #9798.

## Test plan

Run the affected suites (memory, run loop, babel plugin) against both worklets 0.9.1 and 0.10.1 - all green (memory previously crashed on 0.10).