### PR TITLE
cherry-pick(4.3-stable): guard StaticPropsRegistry against cross-thread access (#9495)

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.cpp
@@ -7,16 +7,26 @@ namespace reanimated::css {
 void StaticPropsRegistry::set(jsi::Runtime &rt, const Tag viewTag, const jsi::Value &props) {
   if (props.isNull() || props.isUndefined()) {
     remove(viewTag);
-  } else {
-    const auto newProps = dynamicFromValue(rt, props);
-    if (has(viewTag)) {
-      notifyObservers(viewTag, get(viewTag), newProps);
+    return;
+  }
+
+  const auto newProps = dynamicFromValue(rt, props);
+  folly::dynamic oldProps;
+  {
+    std::lock_guard<std::mutex> lock{mutex_};
+    const auto it = registry_.find(viewTag);
+    if (it != registry_.end()) {
+      oldProps = it->second;
     }
     registry_[viewTag] = newProps;
+  }
+  if (!oldProps.isNull()) {
+    notifyObservers(viewTag, oldProps, newProps);
   }
 }
 
 folly::dynamic StaticPropsRegistry::get(const Tag viewTag) const {
+  std::lock_guard<std::mutex> lock{mutex_};
   auto it = registry_.find(viewTag);
   if (it == registry_.end()) {
     return nullptr;
@@ -25,14 +35,17 @@ folly::dynamic StaticPropsRegistry::get(const Tag viewTag) const {
 }
 
 bool StaticPropsRegistry::has(const Tag viewTag) const {
+  std::lock_guard<std::mutex> lock{mutex_};
   return registry_.find(viewTag) != registry_.end();
 }
 
 void StaticPropsRegistry::remove(const Tag viewTag) {
+  std::lock_guard<std::mutex> lock{mutex_};
   registry_.erase(viewTag);
 }
 
 bool StaticPropsRegistry::isEmpty() const {
+  std::lock_guard<std::mutex> lock{mutex_};
   return registry_.empty() && observers_.empty();
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/CSS/registries/StaticPropsRegistry.h
@@ -2,6 +2,7 @@
 
 #include <react/renderer/core/ShadowNode.h>
 
+#include <mutex>
 #include <unordered_map>
 
 namespace reanimated::css {
@@ -24,6 +25,10 @@ class StaticPropsRegistry {
   void removeObserver(Tag viewTag);
 
  private:
+  /// registry_ is written on the JS thread (setViewStyle) and read on the UI
+  /// thread during interpolation and on the commit/mount thread during node
+  /// removals, so it needs its own guard. observers_ is JS-thread-only.
+  mutable std::mutex mutex_;
   std::unordered_map<Tag, folly::dynamic> registry_;
   std::unordered_map<Tag, PropsObserver> observers_;
 


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.3.2 release
- #9495

#9489/#9495 don't apply to 4.3 wholesale, so this ports just the `StaticPropsRegistry` part - it was the only registry still left without a lock. Adds a mutex around its map, matching the per-registry locking 4.3 already uses.
