### PR TITLE
cherry-pick(4.3-stable): jest environment detection (#9703)

### DIFF
--- a/packages/react-native-reanimated/src/common/constants/platform.ts
+++ b/packages/react-native-reanimated/src/common/constants/platform.ts
@@ -13,7 +13,8 @@ export const IS_ANDROID: boolean = /* @__PURE__ */ (() =>
   Platform?.OS === 'android')();
 export const IS_IOS: boolean = /* @__PURE__ */ (() => Platform?.OS === 'ios')();
 export const IS_WEB: boolean = Platform?.OS === 'web';
-export const IS_JEST: boolean = !!process.env.JEST_WORKER_ID;
+export const IS_JEST: boolean =
+  typeof globalThis.jest !== 'undefined' || process.env.NODE_ENV === 'test';
 /** @knipIgnore */
 export const IS_WINDOWS: boolean = Platform?.OS === 'windows';
 


### PR DESCRIPTION
## Summary

Cherry-picking for Reanimated 4.3.2 release
- #9703

Only the `react-native-reanimated` hunk is picked - the worklets part can't ship through a Reanimated release.
