### PR TITLE
docs: fix outdated spring modifier default values in layout animations docs

### DIFF
--- a/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/entering-exiting-animations.mdx
@@ -183,9 +183,9 @@ FadeInUp.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -539,9 +539,9 @@ FlipInXUp.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -686,9 +686,9 @@ LightSpeedInLeft.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -823,9 +823,9 @@ PinwheelIn.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -967,9 +967,9 @@ RollInLeft.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -1135,9 +1135,9 @@ RotateInUpLeft.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -1293,9 +1293,9 @@ SlideInUp.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -1443,9 +1443,9 @@ StretchInX.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 
@@ -1659,9 +1659,9 @@ ZoomInRotate.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
-- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `100`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
+- `.stiffness(value: number)` decides how bouncy the spring is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 

--- a/docs/docs-reanimated/docs/layout-animations/layout-transitions.mdx
+++ b/docs/docs-reanimated/docs/layout-animations/layout-transitions.mdx
@@ -67,11 +67,11 @@ LinearTransition.springify()
 ```
 
 - `.springify()` enables the spring-based animation configuration.
-- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `10`.
-- `.dampingRatio(value: number)` decides how damped the spring is. Value `1` means the spring is critically damped, and value `>1` means the spring is overdamped. Defaults to `0.5`.
-- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `1`.
+- `.damping(value: number)` decides how quickly a spring stops moving. Higher damping means the spring will come to rest faster. Defaults to `120`.
+- `.dampingRatio(value: number)` decides how damped the spring is. Value `1` means the spring is critically damped, and value `>1` means the spring is overdamped. Defaults to `1`.
+- `.mass(value: number)` is the weight of the spring. Reducing this value makes the animation faster. Defaults to `4`.
 - `.rotate(degree: string)` lets you rotate the element.
-- `.stiffness(value: number)` decides how bouncy the spring is - the higher the number, the less bouncy it is. Defaults to `100`.
+- `.stiffness(value: number)` decides how bouncy the spring is - the higher the number, the less bouncy it is. Defaults to `900`.
 - `.overshootClamping(value: boolean)` decides whether a spring can bounce over the designated position. Defaults to `false`.
 - `.energyThreshold(value: number)` decides relative energy threshold below which the spring will snap without further oscillations. Defaults to `6e-9`.
 


### PR DESCRIPTION
## Summary

The Entering/Exiting animations and Layout transitions pages list default values for the spring-based modifiers that come from Reanimated 3:

- `.damping()` - "Defaults to `10`"
- `.mass()` - "Defaults to `1`"
- `.stiffness()` - "Defaults to `100`"
- `.dampingRatio()` - "Defaults to `0.5`" (Layout transitions page)

These are the old Reanimated 3 defaults, which still exist in the source only as the legacy `Reanimated3DefaultSpringConfig` export.

In Reanimated 4 the defaults changed. Spring-based layout animation modifiers rely on `withSpring`, and the animation builder forwards only the values set explicitly by the user (`getAnimationAndConfig` in `src/layoutReanimation/animationBuilder/ComplexAnimationBuilder.ts`). Everything else falls back to the `withSpring` defaults: damping `120`, mass `4`, stiffness `900`, dampingRatio `1` (`GentleSpringConfig` and `GentleSpringConfigWithDuration` in `src/animation/spring/springConfigs.ts`).

The `withSpring` docs page already lists the correct values, so this change also makes all three pages consistent.

This PR updates only the numbers: 27 places in `entering-exiting-animations.mdx` (the modifier list is repeated in each animation section) and 4 in `layout-transitions.mdx`.

## Test plan

Documentation only change. No code is affected. The updated values match the defaults in `packages/react-native-reanimated/src/animation/spring/springConfigs.ts` and the defaults already documented on the `withSpring` page.
