### PR TITLE
fix: support touch `:hover` on `opacity:0` views on iOS

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Planets.tsx
@@ -66,15 +66,14 @@ export default function Planets() {
   }}>
   <Animated.View
     style={{
-      opacity: { default: 0.02, ':hover': 1 },
+      opacity: { default: 0, ':hover': 1 },
       transitionDuration: '200ms',
-    }}
-    onStartShouldSetResponder={() => true}>
+    }}>
     <Text>{name}</Text>
   </Animated.View>
 </Animated.View>`}
             collapsedCode={`opacity: {
-  default: 0.02,
+  default: 0,
   ':hover': 1,
 },
 transform: {
@@ -118,11 +117,10 @@ boxShadow: {
                       style={[
                         styles.nameWrapper,
                         {
-                          opacity: { ':hover': 1, default: 0.02 },
+                          opacity: { ':hover': 1, default: 0 },
                           transitionDuration: '200ms',
                         },
-                      ]}
-                      onStartShouldSetResponder={() => true}>
+                      ]}>
                       <Text style={styles.name}>{planet.name}</Text>
                     </Animated.View>
                   </Animated.View>

--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REATouchHoverCoordinator.mm
@@ -214,15 +214,42 @@ static const CGFloat kTouchHoverSlop = 10.0;
   }
 }
 
+// UIKit's -hitTest: skips views with alpha below ~0.01, so an `opacity: 0` view is unreachable. Bump each
+// near-zero registered view over the threshold for the hit-test, restoring before compositing (never drawn).
+- (UIView *)hitTestInWindow:(UIWindow *)window atPoint:(CGPoint)point
+{
+  static const CGFloat kHitTestableAlpha = 0.02;
+  NSMutableArray<UIView *> *lifted = nil;
+  NSMutableArray<NSNumber *> *savedAlphas = nil;
+  for (REATouchHoverEntry *entry in _entries) {
+    UIView *view = entry->view;
+    if (view == nil || view.alpha >= kHitTestableAlpha || [lifted containsObject:view]) {
+      continue;
+    }
+    if (lifted == nil) {
+      lifted = [NSMutableArray array];
+      savedAlphas = [NSMutableArray array];
+    }
+    [lifted addObject:view];
+    [savedAlphas addObject:@(view.alpha)];
+    view.alpha = kHitTestableAlpha;
+  }
+  UIView *hit = [window hitTest:point withEvent:nil];
+  [lifted enumerateObjectsUsingBlock:^(UIView *view, NSUInteger index, BOOL *stop) {
+    view.alpha = savedAlphas[index].floatValue;
+  }];
+  return hit;
+}
+
 - (void)recomputeAtWindowPoint:(CGPoint)inWindow
 {
   // Hit-test the topmost view: :hover applies to it and its ancestors only (matching CSS), so views
   // that merely overlap the hit branch no longer all activate. hitTest already honors z-order,
-  // userInteractionEnabled, hidden and alpha, and returns nil over blank space (clears all :hover).
+  // userInteractionEnabled and hidden, and returns nil over blank space (clears all :hover).
   UIView *hit = nil;
   UIWindow *window = _observedWindow;
   if (window != nil) {
-    hit = [window hitTest:inWindow withEvent:nil];
+    hit = [self hitTestInWindow:window atPoint:inWindow];
   }
   NSMutableArray<REATouchHoverEntry *> *dead = nil;
   for (REATouchHoverEntry *entry in _entries) {


### PR DESCRIPTION
## Description

### The issue

On iOS, UIKit's hit-testing ignores views with `alpha < 0.01`, so an `opacity: 0` view could never receive touch `:hover`, unlike web and Android, where it stays hit-testable. 

### The fix

The `:hover` coordinator now briefly lifts each near-zero registered view above that threshold for the single hit-test and restores it before the next compositing pass, so `opacity: 0` views become hoverable with no visual change.