### PR TITLE
fix(deps): declare @babel/generator and @babel/traverse as dependencies

### DIFF
--- a/packages/react-native-worklets/package.json
+++ b/packages/react-native-worklets/package.json
@@ -63,6 +63,7 @@
     "react-native": "0.83 - 0.86"
   },
   "dependencies": {
+    "@babel/generator": "^7.27.1",
     "@babel/plugin-transform-arrow-functions": "^7.27.1",
     "@babel/plugin-transform-class-properties": "^7.28.6",
     "@babel/plugin-transform-classes": "^7.28.6",
@@ -72,6 +73,7 @@
     "@babel/plugin-transform-template-literals": "^7.27.1",
     "@babel/plugin-transform-unicode-regex": "^7.27.1",
     "@babel/preset-typescript": "^7.28.5",
+    "@babel/traverse": "^7.27.1",
     "@babel/types": "^7.27.1",
     "convert-source-map": "^2.0.0",
     "semver": "^7.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,7 +349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.25.9, @babel/generator@npm:^7.27.5, @babel/generator@npm:^7.28.3, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.29.0, @babel/generator@npm:^7.29.1, @babel/generator@npm:^7.29.7, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.25.9, @babel/generator@npm:^7.27.1, @babel/generator@npm:^7.27.5, @babel/generator@npm:^7.28.3, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.29.0, @babel/generator@npm:^7.29.1, @babel/generator@npm:^7.29.7, @babel/generator@npm:^7.7.2":
   version: 7.29.7
   resolution: "@babel/generator@npm:7.29.7"
   dependencies:
@@ -28890,6 +28890,7 @@ __metadata:
   dependencies:
     "@babel/cli": "npm:7.28.3"
     "@babel/core": "npm:7.28.4"
+    "@babel/generator": "npm:^7.27.1"
     "@babel/plugin-transform-arrow-functions": "npm:^7.27.1"
     "@babel/plugin-transform-class-properties": "npm:^7.28.6"
     "@babel/plugin-transform-classes": "npm:^7.28.6"
@@ -28899,6 +28900,7 @@ __metadata:
     "@babel/plugin-transform-template-literals": "npm:^7.27.1"
     "@babel/plugin-transform-unicode-regex": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.28.5"
+    "@babel/traverse": "npm:^7.27.1"
     "@babel/types": "npm:^7.27.1"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native/eslint-config": "npm:0.83.0"


### PR DESCRIPTION
## Summary

Fixes #9648. Follow-up to #9511.

The bundled Worklets Babel plugin keeps its Babel imports external (`packages: 'external'` in `plugin/bundle.js`), so the published bundle calls `require('@babel/generator')` and `require('@babel/traverse')` at runtime. Neither package is declared in `dependencies`, so package managers with an isolated layout (e.g. pnpm 11 with a global virtual store) fail to load the plugin with:

    Error: Cannot find module '@babel/generator'

This PR declares both packages as dependencies, the same way #9511 did for `@babel/types`. Both ranges resolve to versions already present in the dependency tree, so no new packages are pulled in.

## Test plan

Used the reproduction from #9648 (pnpm 11, `enableGlobalVirtualStore: true`, `node repro.js` loading `react-native-worklets/plugin`):

- `react-native-worklets` packed from `main` without this change: fails with `Cannot find module '@babel/generator'`
- packed with this change: `Plugin loaded successfully.`
