### PR TITLE
fix: point reanimated release checks at renamed reusable workflows

### DIFF
--- a/.github/workflows/reanimated-release-checks.yml
+++ b/.github/workflows/reanimated-release-checks.yml
@@ -18,7 +18,7 @@ jobs:
   docs_reanimated_build_check:
     if: github.repository == 'software-mansion/react-native-reanimated'
     name: Docs Reanimated build check
-    uses: ./.github/workflows/docs-reanimated-build-check.yml
+    uses: ./.github/workflows/docs-build.yml
 
   example_android_build_check:
     if: github.repository == 'software-mansion/react-native-reanimated'
@@ -43,17 +43,12 @@ jobs:
   reanimated_android_validation:
     if: github.repository == 'software-mansion/react-native-reanimated'
     name: Reanimated Android validation
-    uses: ./.github/workflows/reanimated-android-validation.yml
+    uses: ./.github/workflows/android-validation.yml
 
   reanimated_apple_validation:
     if: github.repository == 'software-mansion/react-native-reanimated'
     name: Reanimated Apple validation
-    uses: ./.github/workflows/reanimated-apple-validation.yml
-
-  reanimated_common_build_check:
-    if: github.repository == 'software-mansion/react-native-reanimated'
-    name: Reanimated Common build check
-    uses: ./.github/workflows/reanimated-common-validation.yml
+    uses: ./.github/workflows/apple-validation.yml
 
   reanimated_compatibility_check_nightly:
     if: github.repository == 'software-mansion/react-native-reanimated'


### PR DESCRIPTION
The `Reanimated release checks` workflow called four reusable workflows by paths that no longer exist, so GitHub failed to parse it (`failed to fetch workflow: workflow was not found`) whenever it was evaluated on a release branch.

Example failing run: https://github.com/software-mansion/react-native-reanimated/actions/runs/28698825410

Earlier refactors renamed or removed those reusable workflows without updating this caller:

- `docs-reanimated-build-check.yml` -> `docs-build.yml`
- `reanimated-android-validation.yml` -> `android-validation.yml`
- `reanimated-apple-validation.yml` -> `apple-validation.yml`
- `reanimated-common-validation.yml` was removed in #9497, so its `reanimated_common_build_check` job is dropped.
