### PR TITLE
docs: constrain the draggable hero label to the viewport

### DIFF
--- a/docs/docs-reanimated/src/components/Hero/SelectedLabel/index.tsx
+++ b/docs/docs-reanimated/src/components/Hero/SelectedLabel/index.tsx
@@ -4,8 +4,10 @@ import styles from './styles.module.css';
 import SelectionBox, { DraggableId } from './SelectionBox';
 import {
   DynamicStyles,
+  SelectionBounds,
   StaticStyles,
   TextScaleStyles,
+  clampMovementDelta,
   computeSelectionStyles,
   computeTextStyles,
 } from './utils';
@@ -71,15 +73,42 @@ const SelectedLabel: React.FC<{
     textLabelRef.current.className = clsx(styles.interactiveHeaderText);
   }, [isInteractive]);
 
+  const getSelectionBounds = (): SelectionBounds => {
+    const container = selectionContainerRef.current;
+    const entries = [container, ...container.querySelectorAll('*')].map(
+      (element) => ({ element, rect: element.getBoundingClientRect() })
+    );
+    const frameEntries = entries.filter(
+      (entry) => entry.element !== textLabelRef.current
+    );
+
+    return {
+      left: Math.min(...entries.map((entry) => entry.rect.left)),
+      top: Math.min(...frameEntries.map((entry) => entry.rect.top)),
+      right: Math.max(...entries.map((entry) => entry.rect.right)),
+      bottom: Math.max(...frameEntries.map((entry) => entry.rect.bottom)),
+    };
+  };
+
   const movementPropagator = (
     movementDelta: { x: number; y: number },
     draggableIdentifier: DraggableId
   ) => {
     if (!isInteractive) return;
 
+    const clampedDelta = clampMovementDelta(
+      movementDelta,
+      draggableIdentifier,
+      getSelectionBounds(),
+      {
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
+      }
+    );
+
     applyDynamicStyles(
       computeSelectionStyles(
-        movementDelta,
+        clampedDelta,
         draggableIdentifier,
         dynamicStyles.current
       )
@@ -91,7 +120,7 @@ const SelectedLabel: React.FC<{
 
   return (
     <span ref={selectionRef} className={styles.selection}>
-      <DndContext>
+      <DndContext autoScroll={false}>
         <div ref={selectionContainerRef} className={styles.selectionContainer}>
           <SelectionBox
             propagationFunction={movementPropagator}

--- a/docs/docs-reanimated/src/components/Hero/SelectedLabel/utils.ts
+++ b/docs/docs-reanimated/src/components/Hero/SelectedLabel/utils.ts
@@ -17,8 +17,42 @@ export type TextScaleStyles = {
   y: number;
 };
 
+export type SelectionBounds = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
 const SCALING_OFFSET_X = 1.0;
 const SCALING_OFFSET_Y = 1.22;
+
+export const clampMovementDelta = (
+  movementDelta: { x: number; y: number },
+  draggableIdentifier: DraggableId,
+  selectionBounds: SelectionBounds,
+  viewport: { width: number; height: number }
+): { x: number; y: number } => {
+  const isLeft =
+    draggableIdentifier === DraggableId.BOTTOM_LEFT ||
+    draggableIdentifier === DraggableId.TOP_LEFT;
+  const isTop =
+    draggableIdentifier === DraggableId.TOP_LEFT ||
+    draggableIdentifier === DraggableId.TOP_RIGHT;
+  const isCenter = draggableIdentifier === DraggableId.CENTER;
+
+  let x = movementDelta.x;
+  let y = movementDelta.y;
+
+  if (isCenter || isLeft) x = Math.max(x, -selectionBounds.left);
+  if (isCenter || !isLeft)
+    x = Math.min(x, viewport.width - selectionBounds.right);
+  if (isCenter || isTop) y = Math.max(y, -selectionBounds.top);
+  if (isCenter || !isTop)
+    y = Math.min(y, viewport.height - selectionBounds.bottom);
+
+  return { x, y };
+};
 
 export const computeSelectionStyles = (
   position: { x: number; y: number },

--- a/docs/docs-reanimated/src/components/Hero/StartScreen/styles.module.css
+++ b/docs/docs-reanimated/src/components/Hero/StartScreen/styles.module.css
@@ -5,6 +5,7 @@
   height: 100vh;
   min-height: 70vw;
   background-color: transparent;
+  overflow-x: clip;
 }
 
 .heading {


### PR DESCRIPTION
## Summary

Fixes #8805.

The draggable "Reanimated" hero label on the docs landing page could be dragged and resized far outside the viewport.

- clamp drag deltas to the viewport, based on the measured on-screen footprint of the selection (frame, handles, scaled text)
- disable dnd-kit page auto-scroll while dragging
- `overflow-x: clip` on the hero section, so handles hover-scaled at the edge don't create a horizontal scrollbar

## Test plan

`cd docs/docs-reanimated && yarn start`, then drag and resize the hero label: no part of it can leave the viewport, no horizontal scrollbar appears and small drags behave exactly like before. Verified with Playwright pointer-drag scripts and manually; `yarn typecheck` and `yarn lint` pass.
