### PR TITLE
fix: Clear touch :hover on a blank tap inside an Android Modal

### DIFF
--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NativeProxy.kt
@@ -93,7 +93,7 @@ open class NativeProxy {
 
         mFabricUIManager =
             UIManagerHelper.getUIManager(context, UIManagerType.FABRIC) as FabricUIManager
-        pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager)
+        pseudoSelectorManager = PseudoSelectorManager(mFabricUIManager, mContext)
 
         val callInvokerHolder = context.jsCallInvokerHolder as CallInvokerHolderImpl
         mHybridData =

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/ExtraWindowObserverBridge.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/ExtraWindowObserverBridge.kt
@@ -1,0 +1,59 @@
+package com.swmansion.reanimated.pseudoSelectors
+
+import android.util.Log
+import android.view.Window
+import com.facebook.react.bridge.ReactContext
+import java.lang.reflect.Proxy
+
+internal class ExtraWindowObserverBridge(
+    private val reactContext: ReactContext,
+    private val hover: TouchHoverCoordinator,
+) {
+    private var listener: Any? = null
+
+    fun install() {
+        if (listener != null) {
+            return
+        }
+        try {
+            val listenerClass = Class.forName(LISTENER_CLASS)
+            val proxy =
+                Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { self, method, args ->
+                    when (method.name) {
+                        "onExtraWindowCreate" -> hover.observeExtraWindow(args!![0] as Window)
+                        "onExtraWindowDestroy" -> hover.stopObservingExtraWindow(args!![0] as Window)
+                        "equals" -> return@newProxyInstance self === args!![0]
+                        "hashCode" -> return@newProxyInstance System.identityHashCode(self)
+                        "toString" ->
+                            return@newProxyInstance "ReanimatedExtraWindowListener@" +
+                                Integer.toHexString(System.identityHashCode(self))
+                    }
+                    null
+                }
+            reactContext.javaClass
+                .getMethod("addExtraWindowEventListener", listenerClass)
+                .invoke(reactContext, proxy)
+            listener = proxy
+        } catch (e: Throwable) {
+            Log.w(TAG, "ExtraWindowEventListener unavailable; modal :hover uses the per-view fallback", e)
+        }
+    }
+
+    fun uninstall() {
+        val proxy = listener ?: return
+        listener = null
+        try {
+            val listenerClass = Class.forName(LISTENER_CLASS)
+            reactContext.javaClass
+                .getMethod("removeExtraWindowEventListener", listenerClass)
+                .invoke(reactContext, proxy)
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to remove ExtraWindowEventListener", e)
+        }
+    }
+
+    private companion object {
+        const val LISTENER_CLASS = "com.facebook.react.interfaces.ExtraWindowEventListener"
+        const val TAG = "Reanimated"
+    }
+}

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/PseudoSelectorManager.kt
@@ -4,6 +4,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewParent
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.UiThreadUtil
@@ -11,11 +12,14 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.IllegalViewOperationException
 import com.facebook.react.uimanager.ReactCompoundView
+import com.swmansion.reanimated.BuildConfig
 import com.swmansion.reanimated.nativeProxy.PseudoSelectorCallback
+import java.lang.ref.WeakReference
 
 @OptIn(UnstableReactNativeAPI::class)
 class PseudoSelectorManager(
     private val fabricUIManager: FabricUIManager,
+    private val reactContext: WeakReference<ReactApplicationContext>,
 ) {
     private val detachActions = HashMap<String, Runnable>()
 
@@ -29,6 +33,8 @@ class PseudoSelectorManager(
     private val gestureDownPoint = HashMap<View, FloatArray>()
 
     private val hover = TouchHoverCoordinator()
+
+    private var extraWindowBridge: ExtraWindowObserverBridge? = null
 
     private val pendingAttaches = LinkedHashMap<String, PendingAttach>()
     private var mountListenerRegistered = false
@@ -164,11 +170,20 @@ class PseudoSelectorManager(
         val host = findTouchHost(view)
         acquireTouchListener(host)
         hover.register(view, callback)
+        ensureExtraWindowBridge()
         detachActions[key] =
             Runnable {
                 hover.unregister(view)
                 releaseTouchListener(host)
             }
+    }
+
+    private fun ensureExtraWindowBridge() {
+        if (!BuildConfig.IS_REACT_NATIVE_86_OR_NEWER || extraWindowBridge != null) {
+            return
+        }
+        val context = reactContext.get() ?: return
+        extraWindowBridge = ExtraWindowObserverBridge(context, hover).also { it.install() }
     }
 
     private fun attachActive(
@@ -268,7 +283,7 @@ class PseudoSelectorManager(
             MotionEvent.ACTION_CANCEL ->
                 if (event.findPointerIndex(0) >= 0) {
                     onHostRelease(host)
-                    hover.onViewTouchCancel(event)
+                    hover.onViewTouchCancel(host, event)
                 }
         }
         return false

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/TouchHoverCoordinator.kt
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/pseudoSelectors/TouchHoverCoordinator.kt
@@ -18,13 +18,28 @@ class TouchHoverCoordinator {
     private val tmpLocation = IntArray(2)
     private val tmpCoords = FloatArray(2)
 
-    private var observedGestureDownTime = Long.MIN_VALUE
-
     private var settledGestureDownTime = Long.MIN_VALUE
 
-    private var observedWindow: WeakReference<Window>? = null
-    private var originalWindowCallback: WeakReference<Window.Callback>? = null
-    private var wrappedWindowCallback: WeakReference<Window.Callback>? = null
+    private val observedWindows = mutableListOf<WeakReference<WindowObserver>>()
+
+    private inner class WindowObserver(
+        window: Window,
+        val original: Window.Callback,
+    ) : Window.Callback by original {
+        val windowRef = WeakReference(window)
+
+        override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+            val root = windowRef.get()?.decorView as? ViewGroup
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> reconcile(root, event.rawX, event.rawY)
+                MotionEvent.ACTION_UP ->
+                    if (event.findPointerIndex(0) >= 0) settleHover(root, event)
+                MotionEvent.ACTION_POINTER_UP ->
+                    if (event.getPointerId(event.actionIndex) == 0) settleHover(root, event)
+            }
+            return original.dispatchTouchEvent(event)
+        }
+    }
 
     fun register(
         view: View,
@@ -49,8 +64,17 @@ class TouchHoverCoordinator {
             callback?.onSelectorStateChanged(false)
         }
         if (hoverCallbacks.isEmpty()) {
-            removeWindowObserver()
+            removeAllWindowObservers()
         }
+    }
+
+    fun observeExtraWindow(window: Window) {
+        installObserverOnWindow(window)
+    }
+
+    fun stopObservingExtraWindow(window: Window) {
+        removeObserverFromWindow(window)
+        clearHoverForWindow(window)
     }
 
     fun recompute(
@@ -65,7 +89,7 @@ class TouchHoverCoordinator {
         sourceView: View,
         event: MotionEvent,
     ) {
-        if (event.downTime == observedGestureDownTime || isGestureSettled(event)) {
+        if (isWindowObserved(sourceView) || isGestureSettled(event)) {
             return
         }
         reconcile(sourceView.rootView as? ViewGroup, event.rawX, event.rawY)
@@ -75,14 +99,17 @@ class TouchHoverCoordinator {
         sourceView: View,
         event: MotionEvent,
     ) {
-        if (event.downTime == observedGestureDownTime) {
+        if (isWindowObserved(sourceView)) {
             return
         }
         settleHover(sourceView.rootView as? ViewGroup, event)
     }
 
-    fun onViewTouchCancel(event: MotionEvent) {
-        if (event.downTime == observedGestureDownTime || isGestureSettled(event)) {
+    fun onViewTouchCancel(
+        sourceView: View,
+        event: MotionEvent,
+    ) {
+        if (isWindowObserved(sourceView) || isGestureSettled(event)) {
             return
         }
         settledGestureDownTime = event.downTime
@@ -90,13 +117,6 @@ class TouchHoverCoordinator {
     }
 
     fun isGestureSettled(event: MotionEvent) = event.downTime == settledGestureDownTime
-
-    fun recompute(
-        screenX: Float,
-        screenY: Float,
-    ) {
-        reconcile(hoverRootViewGroup(), screenX, screenY)
-    }
 
     private fun reconcile(
         root: ViewGroup?,
@@ -147,17 +167,24 @@ class TouchHoverCoordinator {
         return targets.mapTo(HashSet(targets.size)) { it.getViewId() }
     }
 
-    private fun hoverRootViewGroup(): ViewGroup? {
-        val window = observedWindow?.get() ?: hoverCallbacks.keys.firstOrNull()?.activityWindow()
-        return window?.decorView as? ViewGroup
-    }
-
     private fun clearAll() {
         if (hoveredViews.isEmpty()) {
             return
         }
         for (view in hoveredViews.toList()) {
             hoverCallbacks[view]?.let { setHovered(view, it, false) }
+        }
+    }
+
+    private fun clearHoverForWindow(window: Window) {
+        if (hoveredViews.isEmpty()) {
+            return
+        }
+        val decor = window.decorView
+        for (view in hoveredViews.toList()) {
+            if (view.rootView === decor) {
+                hoverCallbacks[view]?.let { setHovered(view, it, false) }
+            }
         }
     }
 
@@ -175,47 +202,64 @@ class TouchHoverCoordinator {
 
     private fun ensureWindowObserver(view: View) {
         val window = view.activityWindow() ?: return
-        if (observedWindow?.get() === window) {
-            return
-        }
-        removeWindowObserver()
-        val original = window.callback ?: return
-        val wrapper =
-            object : Window.Callback by original {
-                override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-                    when (event.actionMasked) {
-                        MotionEvent.ACTION_DOWN -> {
-                            observedGestureDownTime = event.downTime
-                            recompute(event.rawX, event.rawY)
-                        }
-                        MotionEvent.ACTION_UP ->
-                            if (event.findPointerIndex(0) >= 0) {
-                                settleHover(hoverRootViewGroup(), event)
-                            }
-                        MotionEvent.ACTION_POINTER_UP ->
-                            if (event.getPointerId(event.actionIndex) == 0) {
-                                settleHover(hoverRootViewGroup(), event)
-                            }
-                    }
-                    return original.dispatchTouchEvent(event)
-                }
-            }
-        originalWindowCallback = WeakReference(original)
-        wrappedWindowCallback = WeakReference(wrapper)
-        observedWindow = WeakReference(window)
-        window.callback = wrapper
+        installObserverOnWindow(window)
     }
 
-    private fun removeWindowObserver() {
-        val window = observedWindow?.get()
-        val wrapper = wrappedWindowCallback?.get()
-        if (window != null && wrapper != null && window.callback === wrapper) {
-            window.callback = originalWindowCallback?.get()
+    private fun installObserverOnWindow(window: Window) {
+        pruneObservers()
+        if (isObserving(window)) {
+            return
         }
-        observedWindow = null
-        originalWindowCallback = null
-        wrappedWindowCallback = null
+        val original = window.callback ?: return
+        val observer = WindowObserver(window, original)
+        observedWindows.add(WeakReference(observer))
+        window.callback = observer
+    }
+
+    private fun removeObserverFromWindow(window: Window) {
+        val iterator = observedWindows.iterator()
+        while (iterator.hasNext()) {
+            val observer = iterator.next().get()
+            if (observer == null) {
+                iterator.remove()
+                continue
+            }
+            if (observer.windowRef.get() === window) {
+                if (window.callback === observer) {
+                    window.callback = observer.original
+                }
+                iterator.remove()
+            }
+        }
+    }
+
+    private fun removeAllWindowObservers() {
+        for (reference in observedWindows) {
+            val observer = reference.get() ?: continue
+            val window = observer.windowRef.get() ?: continue
+            if (window.callback === observer) {
+                window.callback = observer.original
+            }
+        }
+        observedWindows.clear()
         clearAll()
+    }
+
+    private fun isObserving(window: Window) = observedWindows.any { it.get()?.windowRef?.get() === window }
+
+    private fun isWindowObserved(view: View): Boolean {
+        val decor = view.rootView
+        return observedWindows.any {
+            it
+                .get()
+                ?.windowRef
+                ?.get()
+                ?.decorView === decor
+        }
+    }
+
+    private fun pruneObservers() {
+        observedWindows.removeAll { it.get()?.windowRef?.get() == null }
     }
 
     private fun View.activityWindow(): Window? {


### PR DESCRIPTION
Clear touch `:hover` on a blank-space tap inside an Android Modal/Dialog - a separate OS window the Activity-window observer couldn't see. iOS already handles this via its key-window observer.

## Demo

### A blank tap inside a `Modal` clears a stuck `:hover`

Open the modal, tap the box to hover it (turns orange), then tap the blank space.

**Before**, the blank tap inside the `Modal`/`Dialog` window leaves `:hover` stuck (the Activity-window observer is blind to that window).

**After**, the blank tap clears it. Recorded on an Android emulator; the crosshair and yellow touch dot are the system pointer overlay showing each tap.

| Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/05159701-e1a6-410d-be9c-2f22d231fc81" /> | <video src="https://github.com/user-attachments/assets/eb54ee0f-6e8e-4445-b510-d6352c9d96af" />|

<details>
<summary>Example source</summary>

```tsx
import React, { useState } from 'react';
import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
import Animated from 'react-native-reanimated';

export default function EmptyExample() {
  const [open, setOpen] = useState(false);

  return (
    <View style={styles.container}>
      {/* A `:hover` element must be registered before the modal opens so the
          extra-window observer is installed in time. This tiny always-mounted
          view is enough. */}
      <Animated.View
        style={{
          width: 1,
          height: 1,
          backgroundColor: { default: 'transparent', ':hover': 'transparent' },
        }}
      />

      <Pressable style={styles.button} onPress={() => setOpen(true)}>
        <Text style={styles.buttonText}>Open modal</Text>
      </Pressable>

      <Modal transparent visible={open} onRequestClose={() => setOpen(false)}>
        <View style={styles.backdrop}>
          <View style={styles.card}>
            {/* Tap this box to hover it (turns orange)... */}
            <Animated.View
              onStartShouldSetResponder={() => true}
              style={{
                width: 160,
                height: 160,
                borderRadius: 24,
                backgroundColor: { default: '#3b82f6', ':hover': '#f76707' },
                transitionDuration: '150ms',
              }}
            />

            {/* ...then tap this blank space: it clears the hover */}
            <View style={styles.blankSpace} />

            <Pressable style={styles.button} onPress={() => setOpen(false)}>
              <Text style={styles.buttonText}>Close</Text>
            </Pressable>
          </View>
        </View>
      </Modal>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 20,
  },
  button: {
    paddingVertical: 12,
    paddingHorizontal: 24,
    borderRadius: 12,
    backgroundColor: '#3b82f6',
  },
  buttonText: {
    color: 'white',
    fontWeight: '600',
  },
  backdrop: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    backgroundColor: 'rgba(0, 0, 0, 0.4)',
  },
  card: {
    padding: 28,
    gap: 20,
    borderRadius: 22,
    alignItems: 'center',
    backgroundColor: '#0b1020',
  },
  blankSpace: {
    height: 120,
    width: '80%',
  },
});
```

</details>
