### PR TITLE
docs: add Overview pages for CSS Animations and CSS Transitions

### DIFF
--- a/docs/docs-reanimated/docs/css-animations/overview.mdx
+++ b/docs/docs-reanimated/docs/css-animations/overview.mdx
@@ -13,7 +13,7 @@ Let's make a box that gently pulses forever. We define a set of _keyframes_ that
 import AnimationNameBasic from '@site/src/examples/css-animations/AnimationNameBasic';
 import AnimationNameBasicSrc from '!!raw-loader!@site/src/examples/css-animations/AnimationNameBasic';
 
-<InteractiveExample src={AnimationNameBasicSrc} component={AnimationNameBasic} />
+<InteractiveExample src={AnimationNameBasicSrc} component={AnimationNameBasic}/>
 
 The heart of the animation is a keyframes object and a duration:
 
@@ -51,9 +51,11 @@ There's no button and no state here - the animation starts as soon as the compon
 You describe an animation in two parts:
 
 1. **Keyframes** - [`animationName`](/docs/css-animations/animation-name) takes an object that maps offsets (`from`, `to`, or percentages like `50%`) to the styles at that point in the timeline.
-2. **Timing** - properties like [`animationDuration`](/docs/css-animations/animation-duration), [`animationIterationCount`](/docs/css-animations/animation-iteration-count), and [`animationDirection`](/docs/css-animations/animation-direction) control how that timeline plays.
+1. **Timing** - properties like [`animationDuration`](/docs/css-animations/animation-duration), [`animationIterationCount`](/docs/css-animations/animation-iteration-count), and [`animationDirection`](/docs/css-animations/animation-direction) control how that timeline plays.
 
 Reanimated interpolates between your keyframes and plays them back on the timeline you set.
+
+Passing an object to a prop called `animationName` might look surprising at first. The name comes from CSS on the web, where you declare keyframes under a named `@keyframes` rule and then reference that name from the `animation-name` property. React Native has no global stylesheet to hold named rules, so instead of a name you pass the keyframes object directly to `animationName`.
 
 Not every style property can be animated. See [Supported style properties](/docs/guides/supported-properties) for the full list and where each one works.
 

--- a/docs/docs-reanimated/docs/css-animations/overview.mdx
+++ b/docs/docs-reanimated/docs/css-animations/overview.mdx
@@ -1,0 +1,94 @@
+---
+sidebar_position: 0
+---
+
+# Overview
+
+CSS animations let you play a sequence of style keyframes over time. Unlike a transition, which animates a single change from one value to another, an animation follows a timeline you define. It can run through multiple steps, repeat, and even start on its own. If you've written `@keyframes` in CSS on the web, you already know the idea.
+
+## Your first animation
+
+Let's make a box that gently pulses forever. We define a set of _keyframes_ that describe how the box looks at each step, then tell Reanimated how long one cycle should last.
+
+import AnimationNameBasic from '@site/src/examples/css-animations/AnimationNameBasic';
+import AnimationNameBasicSrc from '!!raw-loader!@site/src/examples/css-animations/AnimationNameBasic';
+
+<InteractiveExample src={AnimationNameBasicSrc} component={AnimationNameBasic} />
+
+The heart of the animation is a keyframes object and a duration:
+
+```jsx
+const pulse = {
+  from: {
+    transform: [{ scale: 0.8 }, { rotateZ: '-15deg' }],
+  },
+  to: {
+    transform: [{ scale: 1.2 }, { rotateZ: '15deg' }],
+  },
+};
+
+function App() {
+  return (
+    <Animated.View
+      style={{
+        // highlight-start
+        animationName: pulse,
+        animationDuration: '1s',
+        animationIterationCount: 'infinite',
+        animationTimingFunction: 'ease-in-out',
+        animationDirection: 'alternate',
+        // highlight-end
+      }}
+    />
+  );
+}
+```
+
+There's no button and no state here - the animation starts as soon as the component mounts, and it keeps going because `animationIterationCount` is set to `'infinite'`.
+
+## How it works
+
+You describe an animation in two parts:
+
+1. **Keyframes** - [`animationName`](/docs/css-animations/animation-name) takes an object that maps offsets (`from`, `to`, or percentages like `50%`) to the styles at that point in the timeline.
+2. **Timing** - properties like [`animationDuration`](/docs/css-animations/animation-duration), [`animationIterationCount`](/docs/css-animations/animation-iteration-count), and [`animationDirection`](/docs/css-animations/animation-direction) control how that timeline plays.
+
+Reanimated interpolates between your keyframes and plays them back on the timeline you set.
+
+Not every style property can be animated. See [Supported style properties](/docs/guides/supported-properties) for the full list and where each one works.
+
+:::info
+
+You can define keyframes inline, or pull them out into a separate variable and reuse the same animation across several components. See [`animationName`](/docs/css-animations/animation-name) for all the ways to define keyframes.
+
+:::
+
+This is the main difference from a [CSS transition](/docs/css-transitions/overview): a transition animates a single change from A to B when a value changes, while an animation follows a defined, repeatable timeline.
+
+## When should I use CSS animations?
+
+Use CSS animations for self-contained, declarative motion: loading spinners, pulsing badges, looping attention-grabbers, or any multi-step animation that plays on its own. Like transitions, this is the recommended starting point for most animations.
+
+When you need frame-by-frame control (gesture-driven or scroll-driven motion, or animations orchestrated from live values), reach for the shared values API with [`useAnimatedStyle`](/docs/core/useAnimatedStyle).
+
+## Summary
+
+- A CSS animation plays a sequence of keyframes over a timeline you define.
+- Describe the steps with [`animationName`](/docs/css-animations/animation-name) and control playback with properties like [`animationDuration`](/docs/css-animations/animation-duration) and [`animationIterationCount`](/docs/css-animations/animation-iteration-count).
+- Animations can loop and start on mount, unlike transitions, which run once per change.
+- Use CSS animations for declarative, self-running motion, and [`useAnimatedStyle`](/docs/core/useAnimatedStyle) for interactive, value-driven animations.
+
+## What's next?
+
+Explore the properties that shape your animations:
+
+- [`animationName`](/docs/css-animations/animation-name)
+- [`animationDuration`](/docs/css-animations/animation-duration)
+- [`animationTimingFunction`](/docs/css-animations/animation-timing-function)
+- [`animationDelay`](/docs/css-animations/animation-delay)
+- [`animationIterationCount`](/docs/css-animations/animation-iteration-count)
+- [`animationDirection`](/docs/css-animations/animation-direction)
+- [`animationFillMode`](/docs/css-animations/animation-fill-mode)
+- [`animationPlayState`](/docs/css-animations/animation-play-state)
+
+Animating something in response to a state change instead? See [CSS Transitions](/docs/css-transitions/overview).

--- a/docs/docs-reanimated/docs/css-transitions/overview.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/overview.mdx
@@ -10,20 +10,20 @@ Instead of driving an animation by hand, you declare _which_ properties should a
 
 ## Your first transition
 
-Let's build a box that grows and changes color every time you press a button. Notice that we never animate anything manually - we just change `width` and `backgroundColor` based on state and let a transition do the rest.
+Let's build a box that resizes and changes color every time you press a button. Notice that we never animate anything manually - we just change `width` and `backgroundColor` based on state and let a transition do the rest.
 
 import TransitionPropertyBasic from '@site/src/examples/css-transitions/TransitionPropertyBasic';
 import TransitionPropertyBasicSrc from '!!raw-loader!@site/src/examples/css-transitions/TransitionPropertyBasic';
 
-<InteractiveExample src={TransitionPropertyBasicSrc} component={TransitionPropertyBasic} />
+<InteractiveExample src={TransitionPropertyBasicSrc} component={TransitionPropertyBasic}/>
 
 There are only two ingredients that turn a plain style change into a smooth transition:
 
 ```jsx
 <Animated.View
   style={{
-    width: isToggled ? 240 : 120,
-    backgroundColor: isToggled ? '#fa7f7c' : '#87cce8',
+    width,
+    backgroundColor,
     // highlight-start
     transitionProperty: ['width', 'backgroundColor'],
     transitionDuration: 500,
@@ -35,7 +35,7 @@ There are only two ingredients that turn a plain style change into a smooth tran
 - [`transitionProperty`](/docs/css-transitions/transition-property) tells Reanimated which style properties to watch.
 - [`transitionDuration`](/docs/css-transitions/transition-duration) sets how long the change takes.
 
-When `isToggled` flips, `width` and `backgroundColor` get new values, and Reanimated smoothly animates between the old and new ones.
+Whenever `width` and `backgroundColor` get new values, Reanimated smoothly animates between the old and new ones.
 
 ## How it works
 
@@ -44,11 +44,11 @@ The idea behind a CSS transition is simple: a transition runs when a watched pro
 That means two things have to be true for a transition to fire:
 
 1. The style is applied to an [Animated component](/docs/fundamentals/glossary#animated-component), such as `Animated.View`.
-2. The new value comes from a re-render - typically a React state or prop change.
+1. The new value comes from a re-render - typically a React state or prop change.
 
 Not every style property can be transitioned, and some (like `flexDirection` or `justifyContent`) change discretely instead of animating smoothly. See [Supported style properties](/docs/guides/supported-properties) for what can be animated, and [`transitionBehavior`](/docs/css-transitions/transition-behavior) for how discrete properties are handled.
 
-:::caution
+:::note
 
 A transition only reacts to values that change between renders. Passing an inline [shared value](/docs/fundamentals/glossary#shared-value) won't trigger a transition, because updating a shared value doesn't re-render the component. For shared-value-driven animations, use [`useAnimatedStyle`](/docs/core/useAnimatedStyle) instead.
 

--- a/docs/docs-reanimated/docs/css-transitions/overview.mdx
+++ b/docs/docs-reanimated/docs/css-transitions/overview.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_position: 0
+---
+
+# Overview
+
+CSS transitions let you smoothly animate a style property whenever its value changes. If you've used transitions in CSS on the web, this will feel instantly familiar - and if you haven't, don't worry, we'll cover everything you need to know.
+
+Instead of driving an animation by hand, you declare _which_ properties should animate and _how long_ the change should take. Then you update the style the way you normally would, and Reanimated animates between the old and new values for you.
+
+## Your first transition
+
+Let's build a box that grows and changes color every time you press a button. Notice that we never animate anything manually - we just change `width` and `backgroundColor` based on state and let a transition do the rest.
+
+import TransitionPropertyBasic from '@site/src/examples/css-transitions/TransitionPropertyBasic';
+import TransitionPropertyBasicSrc from '!!raw-loader!@site/src/examples/css-transitions/TransitionPropertyBasic';
+
+<InteractiveExample src={TransitionPropertyBasicSrc} component={TransitionPropertyBasic} />
+
+There are only two ingredients that turn a plain style change into a smooth transition:
+
+```jsx
+<Animated.View
+  style={{
+    width: isToggled ? 240 : 120,
+    backgroundColor: isToggled ? '#fa7f7c' : '#87cce8',
+    // highlight-start
+    transitionProperty: ['width', 'backgroundColor'],
+    transitionDuration: 500,
+    // highlight-end
+  }}
+/>
+```
+
+- [`transitionProperty`](/docs/css-transitions/transition-property) tells Reanimated which style properties to watch.
+- [`transitionDuration`](/docs/css-transitions/transition-duration) sets how long the change takes.
+
+When `isToggled` flips, `width` and `backgroundColor` get new values, and Reanimated smoothly animates between the old and new ones.
+
+## How it works
+
+The idea behind a CSS transition is simple: a transition runs when a watched property changes _between renders_.
+
+That means two things have to be true for a transition to fire:
+
+1. The style is applied to an [Animated component](/docs/fundamentals/glossary#animated-component), such as `Animated.View`.
+2. The new value comes from a re-render - typically a React state or prop change.
+
+Not every style property can be transitioned, and some (like `flexDirection` or `justifyContent`) change discretely instead of animating smoothly. See [Supported style properties](/docs/guides/supported-properties) for what can be animated, and [`transitionBehavior`](/docs/css-transitions/transition-behavior) for how discrete properties are handled.
+
+:::caution
+
+A transition only reacts to values that change between renders. Passing an inline [shared value](/docs/fundamentals/glossary#shared-value) won't trigger a transition, because updating a shared value doesn't re-render the component. For shared-value-driven animations, use [`useAnimatedStyle`](/docs/core/useAnimatedStyle) instead.
+
+:::
+
+## When should I use CSS transitions?
+
+Reach for CSS transitions whenever an animation is driven by _state_: toggling a menu, expanding and collapsing a section, switching a theme, or showing and hiding an element. This covers most everyday UI animations, and it's the recommended place to start.
+
+When you need frame-by-frame control (gesture-driven or scroll-driven interactions, screen transitions, or several animations orchestrated together), use the shared values API with [`useAnimatedStyle`](/docs/core/useAnimatedStyle).
+
+<details>
+  <summary>Why start with CSS?</summary>
+
+  CSS transitions are _declarative_: you describe the result you want, not the steps to get there. That means less code (there are no hooks or shared values to wire up), a familiar mental model if you're coming from the web, and animations that run in Reanimated's core, off the JavaScript thread. Because Reanimated knows exactly which properties are animating, a declarative API also leaves more room to optimize under the hood over time.
+</details>
+
+## Summary
+
+- A CSS transition animates a style property when its value changes between renders.
+- You need [`transitionProperty`](/docs/css-transitions/transition-property) to say what to watch and [`transitionDuration`](/docs/css-transitions/transition-duration) to say how long it takes.
+- Transitions run on [Animated components](/docs/fundamentals/glossary#animated-component) and react to state or prop changes, not to shared value updates.
+- Use CSS transitions for state-driven animations, and [`useAnimatedStyle`](/docs/core/useAnimatedStyle) for gesture-driven or orchestrated ones.
+
+## What's next?
+
+Now that you've got the basics, explore the individual properties to fine-tune your transitions:
+
+- [`transitionProperty`](/docs/css-transitions/transition-property)
+- [`transitionDuration`](/docs/css-transitions/transition-duration)
+- [`transitionTimingFunction`](/docs/css-transitions/transition-timing-function)
+- [`transitionDelay`](/docs/css-transitions/transition-delay)
+- [`transitionBehavior`](/docs/css-transitions/transition-behavior)
+
+Looking for animations that play on their own or loop through multiple steps? Head over to [CSS Animations](/docs/css-animations/overview).

--- a/docs/docs-reanimated/src/examples/css-transitions/TransitionPropertyBasic.tsx
+++ b/docs/docs-reanimated/src/examples/css-transitions/TransitionPropertyBasic.tsx
@@ -1,9 +1,17 @@
-import React, { useReducer } from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, View, Button } from 'react-native';
 import Animated from 'react-native-reanimated';
 
+const COLORS = ['#87cce8', '#fa7f7c', '#82cab2', '#b58df1', '#ffd25f'];
+
 export default function App() {
-  const [isToggled, toggle] = useReducer((s) => !s, false);
+  const [width, setWidth] = useState(120);
+  const [backgroundColor, setBackgroundColor] = useState(COLORS[0]);
+
+  const randomize = () => {
+    setWidth(120 + Math.round(Math.random() * 140));
+    setBackgroundColor(COLORS[Math.floor(Math.random() * COLORS.length)]);
+  };
 
   return (
     <View style={styles.container}>
@@ -11,15 +19,15 @@ export default function App() {
         style={[
           styles.box,
           {
-            width: isToggled ? 240 : 120,
-            backgroundColor: isToggled ? '#fa7f7c' : '#87cce8',
+            width,
+            backgroundColor,
             // highlight-next-line
             transitionProperty: ['width', 'backgroundColor'],
             transitionDuration: 500,
           },
         ]}
       />
-      <Button onPress={toggle} title="Click me" />
+      <Button onPress={randomize} title="Randomize" />
     </View>
   );
 }


### PR DESCRIPTION
## Summary

The **CSS Transitions** and **CSS Animations** documentation sections currently contain only per-property API reference (`transitionProperty`, `animationName`, and friends). There's no conceptual entry point that explains what these features are, shows a first example, or helps a reader decide when to reach for them - both category pages simply fall back to the auto-generated index.

This PR adds a short, beginner-friendly **Overview** page to each section:

| Section | New page |
| --- | --- |
| CSS Transitions | `docs/css-transitions/overview.mdx` |
| CSS Animations | `docs/css-animations/overview.mdx` |

Each page follows the existing docs rhythm - **intro → live example → how it works → when to use → Summary → What's next** - and covers:

- **What it is.** A CSS transition animates a style property when its value changes; a CSS animation plays a keyframe timeline that can repeat and start on mount.
- **A first live example.** Reuses the existing interactive demos (`TransitionPropertyBasic`, `AnimationNameBasic`) - no new example components are introduced.
- **How it works.** The core mental model (a transition fires when a watched prop changes *between renders*; an animation plays the keyframes you declare), plus a pointer to **Supported style properties** for what can actually be animated.
- **When to use CSS vs. the shared-value API.** CSS is presented as the recommended starting point for state-driven animations, while `useAnimatedStyle` (shared values / worklets) stays the tool for gesture- and scroll-driven, screen-transition, and orchestrated animations. This mirrors the framing in the [Reanimated 4 stable release post](https://blog.swmansion.com/reanimated-4-stable-release-the-future-of-react-native-animations-ba68210c3713).

**Notes for reviewers**

- **Purely additive.** Both pages use `sidebar_position: 0`, so they land at the top of their section and no existing prop page is renumbered.
- No new example components - existing demos are reused.
- Adds the first cross-links from the CSS sections into the **Supported style properties** guide, which previously wasn't linked from anywhere.
- Messaging deliberately avoids claiming CSS runs via native platform animations, since that path is still behind the experimental, default-off `IOS_CSS_CORE_ANIMATION` flag.

## Test plan

This is a documentation-only change. To preview locally:

```bash
yarn workspace docs-reanimated start
```

Then open:

- `/docs/css-transitions/overview`
- `/docs/css-animations/overview`

Verify:

- Both pages render and match the surrounding section layout.
- The embedded interactive examples animate (a tap-to-grow/recolor box for transitions; a self-pulsing box for animations).
- All cross-links resolve - the prop pages, `useAnimatedStyle`, Supported style properties, and the two Overview pages linking to each other.

A production build passes with no broken links (the site sets `onBrokenLinks: 'throw'`):

```bash
yarn workspace docs-reanimated build
```
