### PR TITLE
redesign: removed erroring when can't createSerializable

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -618,7 +618,7 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        expect(() => {
+        await expect(() => {
           createSerializable(inaccessibleObject);
         }).not.toThrow();
 
@@ -681,14 +681,14 @@ if (__DEV__) {
   describe('createSerializable for unsupported types', () => {
     test('does not throw when trying to serialize a Promise', async () => {
       const promise = Promise.resolve();
-      expect(() => {
+      await expect(() => {
         createSerializable(promise);
       }).not.toThrow();
     });
 
     test('does not throw when trying to serialize a Proxy', async () => {
       const proxy = new Proxy({ a: 1 }, { getPrototypeOf: () => null });
-      expect(() => {
+      await expect(() => {
         createSerializable(proxy);
       }).not.toThrow();
     });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializable.test.tsx
@@ -618,9 +618,16 @@ describe('Test createSerializable', () => {
         }
         const inaccessibleObject = new Inaccessible();
 
-        await expect(() => {
+        expect(() => {
           createSerializable(inaccessibleObject);
-        }).toThrow('Cannot copy value of type `Inaccessible`.');
+        }).not.toThrow();
+
+        scheduleOnTarget(() => {
+          'worklet';
+          scheduleOnRN(callbackPass, inaccessibleObject === undefined);
+        });
+        await waitForNotification(PASS_NOTIFICATION);
+        expect(result).toBe(true);
       });
 
       test('createSerializableRemoteNamedFunctionSyncCall', async () => {
@@ -672,22 +679,18 @@ describe('Test createSerializable', () => {
 
 if (__DEV__) {
   describe('createSerializable for unsupported types', () => {
-    test('throws when trying to serialize a Promise', async () => {
+    test('does not throw when trying to serialize a Promise', async () => {
       const promise = Promise.resolve();
-      await expect(() => {
+      expect(() => {
         createSerializable(promise);
-      }).toThrow(
-        globalThis._WORKLETS_BUNDLE_MODE_ENABLED
-          ? 'Cannot copy value of type `Promise`'
-          : 'Promises cannot be converted to serializable.'
-      );
+      }).not.toThrow();
     });
 
-    test('throws when trying to serialize a Proxy', async () => {
+    test('does not throw when trying to serialize a Proxy', async () => {
       const proxy = new Proxy({ a: 1 }, { getPrototypeOf: () => null });
-      await expect(() => {
+      expect(() => {
         createSerializable(proxy);
-      }).toThrow('Cannot copy value of type');
+      }).not.toThrow();
     });
   });
 

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -532,9 +532,7 @@ describe('Test createSerializableOnUI', () => {
       return new Clazz();
     });
 
-    await expect(() => {
-      clazz.method();
-    }).toThrow();
+    expect(clazz).toBe(undefined);
   });
 
   test('createSerializableOnUIRemoteNamedFunctionSyncCall', async () => {
@@ -564,13 +562,12 @@ describe('Test createSerializableOnUI', () => {
   });
 
   if (__DEV__) {
-    test('throws when trying to serialize a Promise', async () => {
-      await expect(() =>
-        runOnUISync(() => {
-          'worklet';
-          return Promise.resolve();
-        })
-      ).toThrow('Cannot copy value of type `Promise`');
+    test('replaces an unsupported Promise with undefined', async () => {
+      const value = runOnUISync(() => {
+        'worklet';
+        return Promise.resolve();
+      });
+      expect(value).toBe(undefined);
     });
   }
 });

--- a/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/RuntimeTests/tests/memory/createSerializableOnUI.test.tsx
@@ -522,7 +522,7 @@ describe('Test createSerializableOnUI', () => {
   //   expect('magicKey' in Object.getPrototypeOf(obj)).toBe(true);
   // });
 
-  test('createSerializableOnUIInaccessibleObject', async () => {
+  test('createSerializableOnUIInaccessibleObject', () => {
     const clazz = runOnUISync(() => {
       'worklet';
       class Clazz {
@@ -562,7 +562,7 @@ describe('Test createSerializableOnUI', () => {
   });
 
   if (__DEV__) {
-    test('replaces an unsupported Promise with undefined', async () => {
+    test('replaces an unsupported Promise with undefined', () => {
       const value = runOnUISync(() => {
         'worklet';
         return Promise.resolve();

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -209,14 +209,7 @@ export function createSerializable<TValue>(
       return cloneCustom(value, pack, i) as SerializableRef<TValue>;
     }
   }
-  const constructorName =
-    (value as { constructor?: { name?: string } })?.constructor?.name ||
-    'unknown';
-  if (__DEV__) {
-    console.warn(
-      `[Worklets] Cannot copy value of type \`${constructorName}\`. It will be replaced with \`undefined\` in the UI runtime.`
-    );
-  }
+
   return cloneUndefined() as SerializableRef<TValue>;
 }
 

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -212,9 +212,12 @@ export function createSerializable<TValue>(
   const constructorName =
     (value as { constructor?: { name?: string } })?.constructor?.name ||
     'unknown';
-  throw new Error(
-    `[Worklets] Cannot copy value of type \`${constructorName}\`.`
-  );
+  if (__DEV__) {
+    console.warn(
+      `[Worklets] Cannot copy value of type \`${constructorName}\`. It will be replaced with \`undefined\` in the UI runtime.`
+    );
+  }
+  return cloneUndefined() as SerializableRef<TValue>;
 }
 
 if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {


### PR DESCRIPTION


## Summary

Straight up error proved to be too harsh in real app migrations
For the time being, we will just return undefined for cases where we can't createSerializable

## Test plan

No error