### PR TITLE
fix: align sidebar logo with navbar in Worklets docs

### DIFF
--- a/docs/docs-worklets/src/css/overrides.css
+++ b/docs/docs-worklets/src/css/overrides.css
@@ -150,6 +150,10 @@ button[class*='DocSearch-Button'] {
   display: flex;
 }
 
+[class*='sidebar'] [class*='navbar__title'] {
+  margin-left: 0;
+}
+
 @media (max-width: 996px) {
   .navbar .navbar__title {
     display: none;

--- a/docs/docs-worklets/src/css/overrides.css
+++ b/docs/docs-worklets/src/css/overrides.css
@@ -1,6 +1,8 @@
 :root {
   --swm-expandable-transition: transform 200ms ease;
   --doc-sidebar-width: 410px !important;
+  --swm-logo-height: 40px;
+  --swm-logo-title-width: 120px;
 }
 
 table {
@@ -150,8 +152,16 @@ button[class*='DocSearch-Button'] {
   display: flex;
 }
 
-[class*='sidebar'] [class*='navbar__title'] {
-  margin-left: 0;
+@media (min-width: 996px) {
+  [class*='sidebar'] [class*='navbar__logo'][class*='sidebarLogo'] {
+    height: var(--ifm-navbar-height);
+  }
+
+  [class*='sidebar'] [class*='navbar__title'] {
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+  }
 }
 
 @media (max-width: 996px) {


### PR DESCRIPTION
## Summary

In the Worklets docs, the sidebar logo is revealed in place of the navbar logo when the navbar hides on scroll (`hideOnScroll`), so the two copies must share the same position and size or the logo jumps during the transition. The sidebar copy was off on three counts:

- **Horizontal** - the sidebar wordmark kept the theme's default `1em` left margin while the navbar copy resets it to `0`.
- **Size** - the theme sizes the wordmark via `--swm-logo-height` / `--swm-logo-title-width`, but docs-worklets never defined them, so the navbar stretched the wordmark to `40px` while the sidebar fell back to its intrinsic `32px`.
- **Vertical** - the theme sizes the sidebar logo box at `57px` while the navbar is `--ifm-navbar-height` (`60px`), leaving the centered logo ~1.5px too high.

## Fix

- Define `--swm-logo-height` / `--swm-logo-title-width` (the logo's real dimensions) so the theme sizes the wordmark identically in the navbar and the sidebar.
- Match the sidebar logo box height to `--ifm-navbar-height` and center the wordmark, so the whole brand lands at the same vertical position as the navbar.
- Reset the sidebar wordmark's `margin-left` to `0`.

Rules are scoped to `min-width: 996px` so they don't leak into the mobile drawer, where the wordmark is intentionally hidden.

## Test plan

Open any Worklets docs page, scroll down until the navbar hides, and confirm the sidebar logo lines up exactly with the navbar logo - same position and size, no horizontal or vertical shift. Verified with Playwright that the sidebar icon and wordmark match the navbar copies on all four edges across multiple pages.
