### PR TITLE
docs: remove deprecated createAnimatedPropAdapter from useAnimatedProps

### DIFF
--- a/docs/docs-reanimated/docs/core/useAnimatedProps.mdx
+++ b/docs/docs-reanimated/docs/core/useAnimatedProps.mdx
@@ -55,20 +55,18 @@ Only relevant when using Reanimated [without the Babel plugin on the Web](https:
 
 An optional function or an array of functions.
 
-Sometimes when working with third-party libraries properties might be named differently on the API surface from what they really represent on the native side. Adapters make it possible to handle these cases by defining a way to convert these props.
+Sometimes when working with third-party libraries properties might be named differently on the API surface from what they really represent on the native side. Adapters make it possible to handle these cases by defining a way to convert these props before they reach the native side.
 
-Reanimated comes with two built-in adapters:
+Define an adapter as a [worklet](/docs/fundamentals/glossary#worklet) function and pass it directly to `useAnimatedProps`:
 
-- [`SVGAdapter`](https://github.com/software-mansion/react-native-reanimated/blob/Reanimated2/src/reanimated2/PropAdapters.ts#L19) for handling `transform` property in `react-native-svg`
-- [`TextInputAdapter`](https://github.com/software-mansion/react-native-reanimated/blob/Reanimated2/src/reanimated2/PropAdapters.ts#L57).
+```jsx
+const adapter = (props) => {
+  'worklet';
+  // reshape props here
+};
 
-You can create your own adapters using `createAnimatedPropAdapter` function.
-
-Here's an example of adapting `fill` and `stroke` properties from `react-native-svg` to be able to animate them with Reanimated.
-
-import AnimatedPropAdapterSrc from '!!raw-loader!@site/src/examples/AnimatedPropAdapter';
-
-<CollapsibleCode showLines={[13, 25]} src={AnimatedPropAdapterSrc}/>
+const animatedProps = useAnimatedProps(updater, [], adapter);
+```
 
 ### Color-related properties
 


### PR DESCRIPTION
## Summary

The `adapters` section of the `useAnimatedProps` docs was out of date for Reanimated 4:

- It taught `createAnimatedPropAdapter`, which is now deprecated (a no-op that only logs a warning).
- It listed the built-in adapters `SVGAdapter` and `TextInputAdapter`, which no longer exist in v4.
- Its example adapted SVG `fill`/`stroke` colors, which v4 now processes automatically.

This PR rewrites the section to show the v4 approach: define an adapter as a `'worklet'` function and pass it directly to `useAnimatedProps`. Only the current (v4) docs are changed; the 2.x/3.x versioned docs are left as-is.

## Test plan

- `yarn workspace docs-reanimated build` passes (MDX compiles, broken-link check clean).
- The `adapters` section renders correctly on the `useAnimatedProps` page.
