### PR TITLE
docs: link previous major versions to their compatibility pages

### DIFF
--- a/docs/docs-reanimated/docs/guides/compatibility.mdx
+++ b/docs/docs-reanimated/docs/guides/compatibility.mdx
@@ -6,7 +6,7 @@ sidebar_label: Compatibility
 # Compatibility table
 
 :::info
-Reanimated 4 works only with the React Native New Architecture. If your app still uses the old architecture, you can use Reanimated in version 3 (which is no longer actively maintained).
+Reanimated 4 works only with the React Native New Architecture. If your app still uses the old architecture, you can use Reanimated in [version 3](/docs/3.x/) (which is no longer actively maintained).
 :::
 
 **The tables assume you're using the latest patch of each Reanimated minor version.**<br/>
@@ -21,3 +21,10 @@ For example, `4.2.x` shows support for React Native `0.84` because Reanimated `4
 `react-native-worklets` is a dependency of Reanimated 4. However, Reanimated 3 will not work with `react-native-worklets` installed. Make sure to have a correct version of `react-native-worklets` installed when using Reanimated 4.
 
 <WorkletsCompatibility/>
+
+## Previous versions
+
+Looking for the compatibility table for an older major version?
+
+- [Reanimated 3.x](/docs/3.x/guides/compatibility)
+- [Reanimated 2.x](/docs/2.x/guide/compatibility)


### PR DESCRIPTION
## Summary

Adds a "Previous versions" section below the compatibility tables that links to the **compatibility page of each older major version**, so a reader can jump straight to the compatibility table for the version they're on (per maintainer feedback: *"if you're looking for compatibility for 3.x, look here"*).

- Reanimated 3.x → `/docs/3.x/guides/compatibility`
- Reanimated 2.x → `/docs/2.x/guide/compatibility`

1.x is omitted because it has no compatibility page. Also links the inline "version 3" mention in the info box to the 3.x docs.

## Test plan

Open `/docs/guides/compatibility`; under "Previous versions" the links open each older version's compatibility table. `docusaurus build` passes with no broken links.
