### PR TITLE
docs: render inline code bold inside bold text

### DIFF
--- a/docs/docs-reanimated/src/css/typography.css
+++ b/docs/docs-reanimated/src/css/typography.css
@@ -159,6 +159,11 @@ code {
   padding: 0.25rem;
 }
 
+strong code,
+b code {
+  font-weight: 700;
+}
+
 .markdown a code {
   text-decoration: underline;
   text-underline-offset: 2px;

--- a/docs/docs-worklets/src/css/typography.css
+++ b/docs/docs-worklets/src/css/typography.css
@@ -164,6 +164,11 @@ code {
   padding: 0.25rem;
 }
 
+strong code,
+b code {
+  font-weight: 700;
+}
+
 .markdown a code {
   text-decoration: underline;
   text-underline-offset: 2px;


### PR DESCRIPTION
## Summary

Inline `code` inside **bold** text rendered at normal weight because `code { font-weight: 400 }` overrode the inherited `<strong>` bold. Added `strong code, b code { font-weight: 700 }` so it renders bold. Applied to both the Reanimated and Worklets docs.

## Test plan

Reanimated `/docs/guides/animating-svg` (the `useAnimatedProps` bullet) and Worklets `/docs/memory/createSerializable`: inline code inside bold now renders bold in light and dark. `docusaurus build` passes for both sites.
