### PR TITLE
docs: add --reset-cache advice to Reanimated troubleshooting

### DIFF
--- a/docs/docs-reanimated/docs/guides/troubleshooting.mdx
+++ b/docs/docs-reanimated/docs/guides/troubleshooting.mdx
@@ -22,7 +22,7 @@ All of them are supposed to work correctly only within the same minor version. T
 
 **Problem:** This usually happens when Reanimated is not properly installed, e.g. forgetting to include the Worklets Babel plugin in `babel.config.js`.
 
-**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#react-native-community-cli for more information.
+**Solution:** See installation docs at https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#react-native-community-cli for more information. If the Worklets Babel plugin is already set up correctly, your Metro bundler cache may be stale - reset it with `yarn start --reset-cache`, `npm start -- --reset-cache` or `expo start -c` and run the app again.
 
 ### Native part of Reanimated doesn't seem to be initialized
 


### PR DESCRIPTION
## Summary

The Worklets troubleshooting page suggests resetting the Metro bundler cache, but the Reanimated one didn't. Added the same `--reset-cache` advice to the "Failed to create a worklet" entry - the Reanimated-side symptom of a stale Worklets Babel plugin transform.

## Test plan

Open `/docs/guides/troubleshooting`, "Failed to create a worklet": the solution now suggests resetting the Metro cache with `--reset-cache` / `expo start -c`. `docusaurus build` passes.
