### PR TITLE
docs: compare UI runtime scheduling functions and fix stale call tables

### DIFF
--- a/docs/docs-worklets/docs/guides/running-on-the-ui-runtime.mdx
+++ b/docs/docs-worklets/docs/guides/running-on-the-ui-runtime.mdx
@@ -1,0 +1,24 @@
+---
+id: running-on-the-ui-runtime
+sidebar_label: Running worklets on the UI runtime
+---
+
+# Running worklets on the UI runtime
+
+Worklets provides three functions for running a [worklet](/docs/fundamentals/glossary#worklet) on the [UI Runtime](/docs/fundamentals/runtimeKinds#ui-runtime) from the [RN Runtime](/docs/fundamentals/runtimeKinds#rn-runtime): [`scheduleOnUI`](/docs/threading/scheduleOnUI), [`runOnUIAsync`](/docs/threading/runOnUIAsync) and [`runOnUISync`](/docs/threading/runOnUISync).
+They differ in whether the worklet runs asynchronously or synchronously, and in what they return to the caller.
+Use the table below to pick the one that fits your case.
+
+## Comparison
+
+|  | [`scheduleOnUI`](/docs/threading/scheduleOnUI) | [`runOnUIAsync`](/docs/threading/runOnUIAsync) | [`runOnUISync`](/docs/threading/runOnUISync) |
+| --- | --- | --- | --- |
+| **Execution** | Asynchronous | Asynchronous | Synchronous, blocks the caller until the worklet returns |
+| **Returns** | Nothing | A `Promise` that resolves with the worklet's return value | The worklet's return value directly |
+| **Web support** | ✅ | ✅ | ❌ |
+| **Use when** | You want to run a worklet on the UI Runtime and don't need its result back | You need the worklet's result back, but don't want to block the calling thread | You need the worklet's result immediately, within the same synchronous flow |
+
+The values returned by `runOnUIAsync` and `runOnUISync` have to be [serializable](/docs/memory/serializable).
+
+All three functions can be called from the [RN Runtime](/docs/fundamentals/runtimeKinds#rn-runtime), and additionally from the [UI](/docs/fundamentals/runtimeKinds#ui-runtime) and [Worker](/docs/fundamentals/runtimeKinds#worker-runtime) Runtimes when [Bundle Mode](/docs/bundleMode) is enabled.
+See [Call tables](/docs/guides/call-tables) for the full matrix.

--- a/docs/docs-worklets/docs/threading/_category_.json
+++ b/docs/docs-worklets/docs/threading/_category_.json
@@ -2,6 +2,7 @@
   "label": "Threading",
   "position": 3,
   "link": {
-    "type": "generated-index"
+    "type": "generated-index",
+    "description": "Reference for the threading functions. To choose between scheduleOnUI, runOnUIAsync and runOnUISync, see [Running worklets on the UI runtime](/docs/guides/running-on-the-ui-runtime)."
   }
 }

--- a/docs/docs-worklets/docs/threading/runOnRuntimeAsync.mdx
+++ b/docs/docs-worklets/docs/threading/runOnRuntimeAsync.mdx
@@ -71,8 +71,8 @@ Arguments to the function you want to execute on the [Worker Runtime](/docs/fund
 <CallTable
   bundleMode={{
 rnRuntime: true,
-uiRuntime: false,
-workerRuntime: false,
+uiRuntime: true,
+workerRuntime: true,
 }}
   noBundleMode={{
 rnRuntime: true,

--- a/docs/docs-worklets/docs/threading/runOnRuntimeAsyncWithId.mdx
+++ b/docs/docs-worklets/docs/threading/runOnRuntimeAsyncWithId.mdx
@@ -70,8 +70,8 @@ Arguments to the function you want to execute on the [Worklet Runtime](/docs/fun
 <CallTable
   bundleMode={{
 rnRuntime: true,
-uiRuntime: false,
-workerRuntime: false,
+uiRuntime: true,
+workerRuntime: true,
 }}
   noBundleMode={{
 rnRuntime: true,

--- a/docs/docs-worklets/docs/threading/runOnUIAsync.mdx
+++ b/docs/docs-worklets/docs/threading/runOnUIAsync.mdx
@@ -7,6 +7,8 @@ sidebar_position: 42 # Use alphabetical order
 `runOnUIAsync` lets you asynchronously run [workletized](/docs/fundamentals/glossary#to-workletize) functions on the [UI thread](/docs/fundamentals/glossary#ui-thread).
 It returns a Promise of the worklet's return value. The Promise is resolved asynchronously, not immediately after the callback execution.
 
+To compare it with [`scheduleOnUI`](/docs/threading/scheduleOnUI) and [`runOnUISync`](/docs/threading/runOnUISync), see [Running worklets on the UI runtime](/docs/guides/running-on-the-ui-runtime).
+
 ## Reference
 
 ```javascript
@@ -49,8 +51,8 @@ A reference to a function you want to execute on the UI thread. Arguments to you
 <CallTable
   bundleMode={{
 rnRuntime: true,
-uiRuntime: false,
-workerRuntime: false,
+uiRuntime: true,
+workerRuntime: true,
 }}
   noBundleMode={{
 rnRuntime: true,

--- a/docs/docs-worklets/docs/threading/runOnUISync.mdx
+++ b/docs/docs-worklets/docs/threading/runOnUISync.mdx
@@ -6,6 +6,8 @@ sidebar_position: 42 # Use alphabetical order
 
 `runOnUISync` lets you run a [workletized](/docs/fundamentals/glossary#to-workletize) function synchronously on the [UI Runtime](/docs/fundamentals/runtimeKinds#ui-runtime).
 
+To compare it with [`scheduleOnUI`](/docs/threading/scheduleOnUI) and [`runOnUIAsync`](/docs/threading/runOnUIAsync), see [Running worklets on the UI runtime](/docs/guides/running-on-the-ui-runtime).
+
 ## Reference
 
 ```javascript

--- a/docs/docs-worklets/docs/threading/scheduleOnUI.mdx
+++ b/docs/docs-worklets/docs/threading/scheduleOnUI.mdx
@@ -6,6 +6,8 @@ sidebar_position: 42 # Use alphabetical order
 
 `scheduleOnUI` lets you schedule a function to be executed on the [UI Runtime](/docs/fundamentals/runtimeKinds#ui-runtime). The callback executes asynchronously and doesn't return a value.
 
+To compare it with [`runOnUIAsync`](/docs/threading/runOnUIAsync) and [`runOnUISync`](/docs/threading/runOnUISync), see [Running worklets on the UI runtime](/docs/guides/running-on-the-ui-runtime).
+
 ## Reference
 
 ```javascript


### PR DESCRIPTION
## Summary

Adds a guide comparing the three functions for running a worklet on the UI runtime, and fixes stale Call tables found while writing it.

**New guide.** `guides/running-on-the-ui-runtime` compares `scheduleOnUI`, `runOnUIAsync` and `runOnUISync` across execution (asynchronous vs synchronous), return value, web support and when to use each. It is linked from the Threading section index and cross-linked from the three reference pages.

**Call table fixes.** `runOnUIAsync`, `runOnRuntimeAsync` and `runOnRuntimeAsyncWithId` listed the UI and Worker runtimes as unsupported in Bundle Mode. All three receive the same `addNoBundleModeGuardImplementation` guard as their `*Sync` and `scheduleOn*` siblings (`threads.native.ts`, `runtimes.native.ts`), and that guard only blocks calls from Worklet Runtimes when Bundle Mode is disabled. In Bundle Mode they are callable from every runtime, so the tables now match their siblings.

## Test plan

`yarn workspace docs-worklets docusaurus build` passes; broken link and anchor checks are configured to `throw`. The new guide, the Threading section link and the corrected Call tables were also verified locally with `yarn workspace docs-worklets start`.
