### PR TITLE
fix(Worklets): networking in Bundle Mode on some setups

### DIFF
--- a/apps/fabric-example/babel.config.js
+++ b/apps/fabric-example/babel.config.js
@@ -1,9 +1,12 @@
 /** @type {import('react-native-worklets/plugin').PluginOptions} */
 const workletsPluginOptions = {
-  strictGlobal: true,
   bundleMode: true,
+  strictGlobal: true,
   hermesBytecode: false,
   getHBCBinary,
+  importForwarding: {
+    moduleNames: ['axios'],
+  },
 };
 
 /** @type {import('@babel/core').TransformOptions} */

--- a/packages/react-native-worklets/RNWorklets.podspec
+++ b/packages/react-native-worklets/RNWorklets.podspec
@@ -57,7 +57,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-jsi'
   s.dependency 'React-hermes'
-  
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
     "DEFINES_MODULE" => "YES",
@@ -70,6 +69,7 @@ Pod::Spec.new do |s|
       '"$(PODS_ROOT)/DoubleConversion"',
       '"$(PODS_ROOT)/Headers/Private/React-Core"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"',
+      '"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers/react/utils/platform/ios"',
     ].join(' '),
     "FRAMEWORK_SEARCH_PATHS" => '"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes"',
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",

--- a/packages/react-native-worklets/apple/worklets/apple/Networking/WorkletsNetworking.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/Networking/WorkletsNetworking.mm
@@ -5,9 +5,9 @@
 
 #import <mutex>
 
-#import <FBReactNativeSpec/FBReactNativeSpec.h>
-#import <React-Core/React/RCTFollyConvert.h>
-#import <React-jsi/jsi/JSIDynamic.h>
+#import <ReactCommon/RCTTurboModule.h>
+#import <react/utils/FollyConvert.h>
+#import <jsi/JSIDynamic.h>
 #import <React/RCTAssert.h>
 #import <React/RCTConvert.h>
 #import <React/RCTHTTPRequestHandler.h>

--- a/packages/react-native-worklets/apple/worklets/apple/Networking/WorkletsNetworking.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/Networking/WorkletsNetworking.mm
@@ -5,9 +5,6 @@
 
 #import <mutex>
 
-#import <ReactCommon/RCTTurboModule.h>
-#import <react/utils/FollyConvert.h>
-#import <jsi/JSIDynamic.h>
 #import <React/RCTAssert.h>
 #import <React/RCTConvert.h>
 #import <React/RCTHTTPRequestHandler.h>
@@ -17,7 +14,10 @@
 #import <React/RCTNetworkTask.h>
 #import <React/RCTNetworking.h>
 #import <React/RCTUtils.h>
+#import <ReactCommon/RCTTurboModule.h>
+#import <jsi/JSIDynamic.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
+#import <react/utils/FollyConvert.h>
 
 #import <worklets/WorkletRuntime/WorkletRuntime.h>
 #import <worklets/apple/Networking/WorkletsNetworking.h>

--- a/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
+++ b/packages/react-native-worklets/apple/worklets/apple/WorkletsModule.mm
@@ -13,7 +13,6 @@
 #import <React/RCTCallInvoker.h>
 
 #ifdef WORKLETS_FETCH_PREVIEW_ENABLED
-#import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTNetworking.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import <worklets/apple/Networking/WorkletsNetworking.h>

--- a/packages/react-native-worklets/bundleMode/shims/turboModuleRegistryShim.js
+++ b/packages/react-native-worklets/bundleMode/shims/turboModuleRegistryShim.js
@@ -33,7 +33,7 @@ if (
   function getPolyfill(/** @type {string} */ name) {
     if (__DEV__ && !TurboModulesPolyfill?.has(name)) {
       throw new Error(
-        '[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes.'
+        `[Worklets] Accessing TurboModules is not allowed on Worklet Runtimes. Requested: "${String(name)}".`
       );
     } else {
       return TurboModulesPolyfill?.get(name);

--- a/packages/react-native-worklets/src/bundleMode/network.native.ts
+++ b/packages/react-native-worklets/src/bundleMode/network.native.ts
@@ -6,6 +6,8 @@
  * The NetworkingModule itself is injected via C++.
  */
 export function initializeNetworking() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('react-native/Libraries/TurboModule/TurboModuleRegistry');
   const TurboModules = globalThis.TurboModules;
 
   TurboModules.set('FileReaderModule', makeMockTurboModule('FileReaderModule'));
@@ -14,6 +16,10 @@ export function initializeNetworking() {
     makeMockTurboModule('PlatformConstants')
   );
   TurboModules.set('WebSocketModule', makeMockTurboModule('WebSocketModule'));
+  TurboModules.set(
+    'NativeReactNativeFeatureFlagsCxx',
+    new Proxy({}, { get: () => () => undefined })
+  );
   TurboModules.set(
     'BlobModule',
     makeMockTurboModule('BlobModule', ['addNetworkingHandler'])

--- a/scripts/patches/fabric-example-babel-config.patch
+++ b/scripts/patches/fabric-example-babel-config.patch
@@ -1,13 +1,12 @@
 diff --git a/apps/fabric-example/babel.config.js b/apps/fabric-example/babel.config.js
-index a696887cc7..3d189bf4a2 100644
+index ec37dacc04..1782f028e2 100644
 --- a/apps/fabric-example/babel.config.js
 +++ b/apps/fabric-example/babel.config.js
-@@ -1,7 +1,7 @@
+@@ -1,6 +1,6 @@
  /** @type {import('react-native-worklets/plugin').PluginOptions} */
  const workletsPluginOptions = {
-   strictGlobal: true,
 -  bundleMode: false,
 +  bundleMode: true,
+   strictGlobal: true,
    hermesBytecode: false,
    getHBCBinary,
- };


### PR DESCRIPTION
## Summary

Fixing current fetch preview on main.

## Test plan

Fetch example works again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Worklet runtime networking initialization by ensuring TurboModule registry availability and safely handling feature-flag lookups.
  * Enhanced error messages to clearly indicate which TurboModule name is unavailable.
  * Updated React Native Worklets networking integration to use newer React/JSI/utility headers (no behavior change).
* **Configuration**
  * Enabled bundled Worklet processing in the Fabric example’s Babel setup.
  * Added import forwarding for Axios to improve Worklets compatibility.
  * Adjusted iOS CocoaPods build configuration for React-utils header paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->