### PR TITLE
fix: make LayoutAnimation.configureNext work alongside Reanimated layout animations

### DIFF
--- a/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ConfigureNextCompatExample.tsx
+++ b/apps/common-app/src/apps/reanimated/examples/LayoutAnimations/ConfigureNextCompatExample.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Button, LayoutAnimation, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated';
+
+export default function ConfigureNextCompatExample() {
+  const [rnState, setRnState] = React.useState(false);
+  const [reaVisible, setReaVisible] = React.useState(true);
+  const [callbackCount, setCallbackCount] = React.useState(0);
+
+  const configureNext = () => {
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(1000, 'easeInEaseOut', 'opacity'),
+      () => setCallbackCount((count) => count + 1)
+    );
+    setRnState(!rnState);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>React Native LayoutAnimation</Text>
+      <Button onPress={configureNext} title="configureNext + toggle" />
+      <Text>{`success callback fired ${callbackCount} times`}</Text>
+      <View style={[styles.box, rnState && styles.boxMoved]} />
+
+      <Text>Reanimated layout animations</Text>
+      <Button
+        onPress={() => setReaVisible(!reaVisible)}
+        title="Toggle Reanimated view"
+      />
+      {reaVisible && (
+        <Animated.View
+          entering={FadeIn.duration(500)}
+          exiting={FadeOut.duration(500)}
+          layout={LinearTransition}
+          style={[styles.box, styles.reanimatedBox]}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 100,
+  },
+  box: {
+    width: 100,
+    height: 100,
+    backgroundColor: 'blue',
+  },
+  boxMoved: {
+    marginLeft: 200,
+    backgroundColor: 'red',
+  },
+  reanimatedBox: {
+    backgroundColor: 'green',
+  },
+});

--- a/apps/common-app/src/apps/reanimated/examples/index.ts
+++ b/apps/common-app/src/apps/reanimated/examples/index.ts
@@ -117,6 +117,10 @@ const CombinedTest: React.FC = () =>
   React.createElement(
     require('./LayoutAnimations/Combined').default as React.FC
   );
+const ConfigureNextCompatExample: React.FC = () =>
+  React.createElement(
+    require('./LayoutAnimations/ConfigureNextCompatExample').default as React.FC
+  );
 const ComposedHandlerConditionalExample: React.FC = () =>
   React.createElement(
     require('./ComposedHandlerConditionalExample').default as React.FC
@@ -1107,6 +1111,10 @@ export const EXAMPLES: Record<string, Example> = {
   CombinedLayoutAnimations: {
     title: '[LA] Entering and Exiting with Layout',
     screen: CombinedTest,
+  },
+  ConfigureNextCompat: {
+    title: '[LA] LayoutAnimation.configureNext compatibility',
+    screen: ConfigureNextCompatExample,
   },
   DefaultAnimations: {
     title: '[LA] Default layout animations',

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -15,10 +15,12 @@ namespace reanimated {
 ReanimatedCommitHook::ReanimatedCommitHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy)
+    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+    const std::shared_ptr<const MountingOverrideDelegate> &coreLayoutAnimationsDriver)
     : uiManager_(uiManager),
       updatesRegistryManager_(updatesRegistryManager),
-      layoutAnimationsProxy_(layoutAnimationsProxy) {
+      layoutAnimationsProxy_(layoutAnimationsProxy),
+      coreLayoutAnimationsDriver_(coreLayoutAnimationsDriver) {
   uiManager_->registerCommitHook(*this);
 }
 
@@ -43,6 +45,11 @@ void ReanimatedCommitHook::maybeInitializeLayoutAnimations(SurfaceId surfaceId) 
           // The current approach will encounter problems on platforms where it is more common to have multiple
           // surfaces.
           strongThis->layoutAnimationsProxy_->startSurface(shadowTree.getSurfaceId());
+          if (strongThis->coreLayoutAnimationsDriver_) {
+            // Register the core LayoutAnimation driver first so our proxy
+            // receives its interpolated mutations and passes them through.
+            shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(strongThis->coreLayoutAnimationsDriver_);
+          }
           shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(strongThis->layoutAnimationsProxy_);
         });
     currentMaxSurfaceId_ = surfaceId;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -16,7 +16,8 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public std::enable_shar
   ReanimatedCommitHook(
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy);
+      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+      const std::shared_ptr<const MountingOverrideDelegate> &coreLayoutAnimationsDriver);
 
   ~ReanimatedCommitHook() noexcept override;
 
@@ -36,6 +37,7 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public std::enable_shar
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
+  std::shared_ptr<const MountingOverrideDelegate> coreLayoutAnimationsDriver_;
 
   SurfaceId currentMaxSurfaceId_ = -1;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -965,17 +965,28 @@ void LayoutAnimationsProxy_Legacy::uiManagerDidConfigureNextLayoutAnimation(
     jsi::Runtime &runtime,
     const RawValue &config,
     const jsi::Value &successCallbackValue,
-    const jsi::Value &failureCallbackValue) const {}
+    const jsi::Value &failureCallbackValue) const {
+  if (coreDriver_) {
+    coreDriver_->uiManagerDidConfigureNextLayoutAnimation(runtime, config, successCallbackValue, failureCallbackValue);
+  }
+}
 
 void LayoutAnimationsProxy_Legacy::setComponentDescriptorRegistry(
-    const SharedComponentDescriptorRegistry &componentDescriptorRegistry) {}
+    const SharedComponentDescriptorRegistry &componentDescriptorRegistry) {
+  if (coreDriver_) {
+    coreDriver_->setComponentDescriptorRegistry(componentDescriptorRegistry);
+  }
+}
 
 bool LayoutAnimationsProxy_Legacy::shouldAnimateFrame() const {
-  return false;
+  return coreDriver_ && coreDriver_->shouldAnimateFrame();
 }
 
 void LayoutAnimationsProxy_Legacy::stopSurface(SurfaceId surfaceId) {
   surfacesToRemove_.insert(surfaceId);
+  if (coreDriver_) {
+    coreDriver_->stopSurface(surfaceId);
+  }
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <react/renderer/animations/LayoutAnimationDriver.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/scheduler/Scheduler.h>
@@ -110,6 +111,10 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   mutable std::unordered_map<SurfaceId, SurfaceContext> surfaceContext_;
   mutable std::unordered_map<Tag, int> leastRemoved;
   mutable std::unordered_set<SurfaceId> surfacesToRemove_;
+  // Core driver handling React Native's LayoutAnimation.configureNext.
+  // We occupy the UIManager animation delegate slot (to receive stopSurface),
+  // so we forward the UIManagerAnimationDelegate calls to this driver.
+  std::shared_ptr<LayoutAnimationDriver> coreDriver_;
 
   LayoutAnimationsProxy_Legacy(
       const std::shared_ptr<LayoutAnimationsManager> &layoutAnimationsManager,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -391,6 +391,12 @@ void ReanimatedModuleProxy::init(const PlatformDepMethodsHolder &platformDepMeth
 }
 
 ReanimatedModuleProxy::~ReanimatedModuleProxy() {
+  if (coreLayoutAnimationsDriver_) {
+    coreLayoutAnimationsDriver_->setLayoutAnimationStatusDelegate(nullptr);
+    // We overwrote the animation delegate with the layout animations proxy
+    // which dies with this module, while UIManager may outlive it.
+    uiManager_->setAnimationDelegate(nullptr);
+  }
   // event handler registry and frame callbacks store some JSI values from UI
   // runtime, so they have to go away before we tear down the runtime
   eventHandlerRegistry_.reset();
@@ -1023,6 +1029,37 @@ void ReanimatedModuleProxy::applySynchronousUpdates(UpdatesBatch &updatesBatch, 
   updatesBatch = std::move(shadowTreeUpdatesBatch);
 }
 
+void ReanimatedModuleProxy::onAnimationStarted() {
+  // Called from the core driver's pullTransaction, which on Android may run
+  // on the JS thread — hop to the UI thread before starting the tick loop.
+  scheduleOnUI(uiScheduler_, [weakThis = weak_from_this()]() {
+    if (auto strongThis = weakThis.lock()) {
+      strongThis->scheduleCoreLayoutAnimationTick();
+    }
+  });
+}
+
+void ReanimatedModuleProxy::onAllAnimationsComplete() {
+  // The tick loop stops itself once the driver has no more animations.
+}
+
+void ReanimatedModuleProxy::scheduleCoreLayoutAnimationTick() {
+  requestRender_([weakThis = weak_from_this()](const double) {
+    auto strongThis = weakThis.lock();
+    if (!strongThis) {
+      return;
+    }
+    // Repull transactions so the core driver can emit interpolated frames.
+    // Not UIManager::animationTick, which would also tick NativeAnimated.
+    // TODO (future): enumerate -> visit
+    strongThis->uiManager_->getShadowTreeRegistry().enumerate(
+        [](const ShadowTree &shadowTree, bool &) { shadowTree.notifyDelegatesOfUpdates(); });
+    if (strongThis->coreLayoutAnimationsDriver_->shouldAnimateFrame()) {
+      strongThis->scheduleCoreLayoutAnimationTick();
+    }
+  });
+}
+
 void ReanimatedModuleProxy::requestFlushRegistry() {
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     shouldFlushRegistry_ = true;
@@ -1207,7 +1244,8 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
         std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
   }
 
-  commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
+  commitHook_ = std::make_shared<ReanimatedCommitHook>(
+      uiManager_, updatesRegistryManager_, layoutAnimationsProxy_, coreLayoutAnimationsDriver_);
 }
 
 void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
@@ -1250,6 +1288,21 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
           jsInvoker_
 #endif
       );
+      // Taking over the animation delegate slot (needed to receive
+      // stopSurface) would silently swallow LayoutAnimation.configureNext
+      // from React Native, so the delegate calls are forwarded to a
+      // Reanimated-owned core LayoutAnimationDriver, registered as another
+      // chained MountingOverrideDelegate in ReanimatedCommitHook.
+      auto contextContainer = scheduler->getContextContainer();
+      coreLayoutAnimationsDriver_ = std::make_shared<LayoutAnimationDriver>(
+          [jsInvoker = jsInvoker_](std::function<void(jsi::Runtime &)> &&callback) {
+            jsInvoker->invokeAsync(std::move(callback));
+          },
+          contextContainer,
+          this);
+      // Normally wired by the Scheduler, which already ran.
+      coreLayoutAnimationsDriver_->setComponentDescriptorRegistry(componentDescriptorRegistry);
+      layoutAnimationsProxyLegacy->coreDriver_ = coreLayoutAnimationsDriver_;
       // TODO (future): support in experimental
       uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -2,6 +2,7 @@
 
 #include <ReactCommon/CallInvoker.h>
 #include <cxxreact/ReactNativeVersion.h>
+#include <react/renderer/animations/LayoutAnimationDriver.h>
 #include <react/renderer/componentregistry/componentNameByReactViewName.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -62,7 +63,8 @@ enum class GrandCallbackSource : std::uint8_t {
   EventInAndroidDraw,
 };
 
-class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModuleProxy> {
+class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModuleProxy>,
+                              public LayoutAnimationStatusDelegate {
  public:
   ReanimatedModuleProxy(
       const std::shared_ptr<worklets::WorkletRuntime> &uiRuntime,
@@ -77,7 +79,7 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   // is fully constructed.
   void init(const PlatformDepMethodsHolder &platformDepMethodsHolder);
 
-  ~ReanimatedModuleProxy();
+  ~ReanimatedModuleProxy() override;
 
   [[nodiscard]]
   jsi::Object toOptimizedObject(jsi::Runtime &rt);
@@ -162,6 +164,12 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
   void initializeFabric(const std::shared_ptr<UIManager> &uiManager);
 
   void initializeLayoutAnimationsProxy();
+
+  // LayoutAnimationStatusDelegate for coreLayoutAnimationsDriver_, which
+  // handles React Native's LayoutAnimation.configureNext.
+  void onAnimationStarted() override;
+  void onAllAnimationsComplete() override;
+  void scheduleCoreLayoutAnimationTick();
 
   std::string obtainPropFromShadowNode(
       jsi::Runtime &rt,
@@ -261,6 +269,11 @@ class ReanimatedModuleProxy : public std::enable_shared_from_this<ReanimatedModu
 
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
+  // Reanimated-owned instance of the core LayoutAnimation driver. Since we
+  // take over the UIManager animation delegate slot (to receive stopSurface),
+  // we forward the delegate calls here so LayoutAnimation.configureNext from
+  // React Native keeps working.
+  std::shared_ptr<LayoutAnimationDriver> coreLayoutAnimationsDriver_;
   std::shared_ptr<ReanimatedCommitHook> commitHook_;
   std::shared_ptr<ReanimatedMountHook> mountHook_;
   /// Access only on UI thread.


### PR DESCRIPTION
## Summary

With Reanimated installed, React Native's LayoutAnimation.configureNext silently does nothing and its success callback never fires. Reanimated takes over UIManager's single animation delegate slot (it needs the stopSurface callback) and stubs out the remaining UIManagerAnimationDelegate methods, so the config is swallowed and the animation tick path is dead.

This PR makes both layout animation systems work together, with no changes to React Native:

- Reanimated creates its own instance of core's LayoutAnimationDriver and forwards the UIManagerAnimationDelegate calls to it (config delivery, shouldAnimateFrame, stopSurface).
- The driver is registered as an additional chained MountingOverrideDelegate (supported since RN 0.75) ahead of the Reanimated proxy, so the proxy passes the driver's interpolated mutations through as regular unregistered-tag mutations.
- Frames are driven from Reanimated's existing requestRender loop (not UIManager::animationTick, which would also tick NativeAnimated).

Side effect: on Android, configureNext now works with Reanimated installed even though stock RN gates it behind enableLayoutAnimationsOnAndroid (default off).

Known limitation: a view driven by both systems in the same commit double-animates for that commit — use one system per view.

## Test plan

Open the new example: fabric-example → [LA] LayoutAnimation.configureNext compatibility (iOS and Android).

- Tap "configureNext + toggle": the box animates to its new position (previously it snapped) and the success callback counter increments (previously it never fired).
- Toggle the Reanimated view: FadeIn/FadeOut/LinearTransition still work, also while a configureNext animation is in flight.
- Rapidly tap "configureNext + toggle" several times: interrupted animations settle correctly and every callback fires.
- Restart the app: no crash on teardown; existing layout animation examples (e.g. Basic layout animation) behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)