### PR TITLE
refactor(LayoutAnimations): stop taking over UIManagerAnimationDelegate

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h
@@ -62,11 +62,11 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
       const SharedComponentDescriptorRegistry &componentDescriptorRegistry,
       const std::shared_ptr<const ContextContainer> &contextContainer,
       jsi::Runtime &uiRuntime,
-      const std::shared_ptr<UIScheduler> &uiScheduler
+      const std::shared_ptr<UIScheduler> &uiScheduler,
+      const std::shared_ptr<facebook::react::UIManager> &uiManager
 #ifdef ANDROID
       ,
       const PreserveMountedTagsFunction &filterUnmountedTagsFunction,
-      const std::shared_ptr<facebook::react::UIManager> &uiManager,
       const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker
 #endif
       )
@@ -74,11 +74,11 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
         contextContainer_(contextContainer),
         componentDescriptorRegistry_(componentDescriptorRegistry),
         uiRuntime_(uiRuntime),
-        uiScheduler_(uiScheduler)
+        uiScheduler_(uiScheduler),
+        uiManager_(uiManager)
 #ifdef ANDROID
         ,
         preserveMountedTags_(filterUnmountedTagsFunction),
-        uiManager_(uiManager),
         jsInvoker_(jsInvoker)
 #endif
   {
@@ -98,10 +98,10 @@ class LayoutAnimationsProxyCommon : public facebook::react::MountingOverrideDele
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   jsi::Runtime &uiRuntime_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
+  std::shared_ptr<facebook::react::UIManager> uiManager_;
   PreserveMountedTagsFunction preserveMountedTags_;
 
 #ifdef ANDROID
-  std::shared_ptr<facebook::react::UIManager> uiManager_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
 
   void restoreOpacityInCaseOfFlakyEnteringAnimation(SurfaceId surfaceId) const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.h
@@ -67,11 +67,11 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
       const SharedComponentDescriptorRegistry &componentDescriptorRegistry,
       const std::shared_ptr<const ContextContainer> &contextContainer,
       jsi::Runtime &uiRuntime,
-      const std::shared_ptr<UIScheduler> &uiScheduler
+      const std::shared_ptr<UIScheduler> &uiScheduler,
+      const std::shared_ptr<UIManager> &uiManager
 #ifdef ANDROID
       ,
       const PreserveMountedTagsFunction &filterUnmountedTagsFunction,
-      const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<CallInvoker> &jsInvoker
 #endif
       )
@@ -80,11 +80,11 @@ struct LayoutAnimationsProxy_Experimental : public LayoutAnimationsProxyCommon,
             componentDescriptorRegistry,
             contextContainer,
             uiRuntime,
-            uiScheduler
+            uiScheduler,
+            uiManager
 #ifdef ANDROID
             ,
             filterUnmountedTagsFunction,
-            uiManager,
             jsInvoker
 #endif
             ),

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1,6 +1,7 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h>
 
 #include <react/debug/react_native_assert.h>
+#include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 
 #include <memory>
@@ -62,8 +63,15 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 
   parseRemoveMutations(movedViews, mutations, roots);
 
-  auto surfaceDropped = surfacesToRemove_.contains(surfaceId);
-  surfacesToRemove_.erase(surfaceId);
+  // We recognize dropped surfaces by the presence of a Remove mutation for a root child. This can produce false
+  // positives. Ideal solution will be to introduce an appropriate API in RN
+  auto surfaceDropped = false;
+  const auto removesRootChildren = std::ranges::any_of(mutations, [surfaceId](const auto &mutation) {
+    return mutation.type == ShadowViewMutation::Remove && mutation.parentTag == surfaceId;
+  });
+  if (removesRootChildren) {
+    surfaceDropped = surfacesToRemove_.erase(surfaceId) != 0;
+  }
   const bool flushDeadNodes = shouldFlushDeadNodes(surfaceDropped);
   handleRemovals(filteredMutations, roots, deadNodes, surfaceDropped, flushDeadNodes);
 #ifdef ANDROID
@@ -1060,23 +1068,22 @@ SurfaceContext &LayoutAnimationsProxy_Legacy::getSurfaceContext(const SurfaceId 
   return it->second;
 }
 
-// UIManagerAnimationDelegate
+// UIManagerCommitHook
 
-void LayoutAnimationsProxy_Legacy::uiManagerDidConfigureNextLayoutAnimation(
-    jsi::Runtime &runtime,
-    const RawValue &config,
-    const jsi::Value &successCallbackValue,
-    const jsi::Value &failureCallbackValue) const {}
-
-void LayoutAnimationsProxy_Legacy::setComponentDescriptorRegistry(
-    const SharedComponentDescriptorRegistry &componentDescriptorRegistry) {}
-
-bool LayoutAnimationsProxy_Legacy::shouldAnimateFrame() const {
-  return false;
-}
-
-void LayoutAnimationsProxy_Legacy::stopSurface(SurfaceId surfaceId) {
-  surfacesToRemove_.insert(surfaceId);
+// Surface teardown commits an empty root (SurfaceHandler::stop) before the
+// teardown transaction is pulled — mark it so pullTransaction skips exit
+// animations. Reading the ShadowTreeRegistry here instead would deadlock.
+RootShadowNode::Unshared LayoutAnimationsProxy_Legacy::shadowTreeWillCommit(
+    const ShadowTree &shadowTree,
+    const RootShadowNode::Shared & /*oldRootShadowNode*/,
+    const RootShadowNode::Unshared &newRootShadowNode) noexcept {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  if (newRootShadowNode->getChildren().empty()) {
+    surfacesToRemove_.insert(shadowTree.getSurfaceId());
+  } else {
+    surfacesToRemove_.erase(shadowTree.getSurfaceId());
+  }
+  return newRootShadowNode;
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -82,7 +82,26 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 
   addOngoingAnimations(surfaceId, filteredMutations);
 
+  dropUpdatesForDeletedViews(filteredMutations);
+
   return MountingTransaction{surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
+}
+
+// The LayoutAnimationDriver can pair a final keyframe update with the withheld
+// Remove/Delete it replays in the same transaction; we emit removals first, so
+// the update would reach the mounting layer after its view was deleted.
+void LayoutAnimationsProxy_Legacy::dropUpdatesForDeletedViews(ShadowViewMutationList &filteredMutations) const {
+  std::unordered_set<Tag> deletedTags;
+  for (const auto &mutation : filteredMutations) {
+    if (mutation.type == ShadowViewMutation::Delete) {
+      deletedTags.insert(mutation.oldChildShadowView.tag);
+    }
+  }
+  if (!deletedTags.empty()) {
+    std::erase_if(filteredMutations, [&deletedTags](const auto &mutation) {
+      return mutation.type == ShadowViewMutation::Update && deletedTags.contains(mutation.newChildShadowView.tag);
+    });
+  }
 }
 
 // If React re-creates or re-inserts a tag whose exiting removal we are still

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -1078,10 +1078,13 @@ inline bool MutationNode::isMutationNode() {
 
 void LayoutAnimationsProxy_Legacy::startSurface(const SurfaceId surfaceId) {
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
-  surfaceContext_[surfaceId] = SurfaceContext{};
+  surfaceContext_.try_emplace(surfaceId);
 }
 
 SurfaceContext &LayoutAnimationsProxy_Legacy::getSurfaceContext(const SurfaceId surfaceId) const {
+  // startSurface() creates the entry for a surface before any other method
+  // uses it. The proxy does not remove entries during its lifetime. Thus a
+  // missing entry is an initialization bug, not a stopped surface.
   const auto it = surfaceContext_.find(surfaceId);
   react_native_assert(it != surfaceContext_.end() && "surface must be registered by startSurface");
   return it->second;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -138,8 +138,9 @@ void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
   }
 }
 
-// We don't change the view hierarchy when on the main thread unless the surface is dropped. This is won't be necessary
-// under the pull model
+// On android mutations that alter the view hierarchy are only produced on the JS thread (the push model), so to not
+// race with those, we apply the dead nodes cleanup only on the JS thread, unless there is a surface drop, in which case
+// we can safely cleanup on the UI thread since the surface is gone and no more mutations will be produced for it.
 bool LayoutAnimationsProxy_Legacy::shouldFlushDeadNodes([[maybe_unused]] const bool surfaceDropped) const {
 #ifdef ANDROID
   return surfaceDropped || std::this_thread::get_id() != uiThreadId_;
@@ -1099,11 +1100,12 @@ RootShadowNode::Unshared LayoutAnimationsProxy_Legacy::shadowTreeWillCommit(
     const ShadowTree &shadowTree,
     const RootShadowNode::Shared & /*oldRootShadowNode*/,
     const RootShadowNode::Unshared &newRootShadowNode) noexcept {
+  const auto surfaceId = shadowTree.getSurfaceId();
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   if (newRootShadowNode->getChildren().empty()) {
-    surfacesToRemove_.insert(shadowTree.getSurfaceId());
+    surfacesToRemove_.insert(surfaceId);
   } else {
-    surfacesToRemove_.erase(shadowTree.getSurfaceId());
+    surfacesToRemove_.erase(surfaceId);
   }
   return newRootShadowNode;
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.cpp
@@ -7,6 +7,7 @@
 #include <ranges>
 #include <set>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -33,7 +34,8 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
   auto lock = std::unique_lock<std::recursive_mutex>(mutex);
   PropsParserContext propsParserContext{surfaceId, *contextContainer_};
   ShadowViewMutationList filteredMutations;
-  auto &[deadNodes] = surfaceContext_[surfaceId];
+  auto &surfaceCtx = getSurfaceContext(surfaceId);
+  auto &deadNodes = surfaceCtx.deadNodes;
 
   std::vector<std::shared_ptr<MutationNode>> roots;
   std::unordered_map<Tag, Tag> movedViews;
@@ -60,9 +62,13 @@ std::optional<MountingTransaction> LayoutAnimationsProxy_Legacy::pullTransaction
 
   parseRemoveMutations(movedViews, mutations, roots);
 
-  auto shouldAnimate = !surfacesToRemove_.contains(surfaceId);
+  auto surfaceDropped = surfacesToRemove_.contains(surfaceId);
   surfacesToRemove_.erase(surfaceId);
-  handleRemovals(filteredMutations, roots, deadNodes, shouldAnimate);
+  const bool flushDeadNodes = shouldFlushDeadNodes(surfaceDropped);
+  handleRemovals(filteredMutations, roots, deadNodes, surfaceDropped, flushDeadNodes);
+#ifdef ANDROID
+  maybeScheduleCleanupPull(surfaceCtx, surfaceId, flushDeadNodes);
+#endif // ANDROID
 
   handleUpdatesAndEnterings(filteredMutations, movedViews, mutations, propsParserContext, surfaceId);
 
@@ -83,7 +89,7 @@ void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
     ShadowViewMutationList &mutations,
     ShadowViewMutationList &filteredMutations,
     SurfaceId surfaceId) const {
-  auto &[deadNodes] = surfaceContext_[surfaceId];
+  auto &deadNodes = getSurfaceContext(surfaceId).deadNodes;
   for (auto &mutation : mutations) {
     if (mutation.type != ShadowViewMutation::Type::Create && mutation.type != ShadowViewMutation::Type::Insert) {
       continue;
@@ -104,6 +110,44 @@ void LayoutAnimationsProxy_Legacy::reconcileContradictedRemovals(
     deadNodes.erase(node);
   }
 }
+
+// We don't change the view hierarchy when on the main thread unless the surface is dropped. This is won't be necessary
+// under the pull model
+bool LayoutAnimationsProxy_Legacy::shouldFlushDeadNodes([[maybe_unused]] const bool surfaceDropped) const {
+#ifdef ANDROID
+  return surfaceDropped || std::this_thread::get_id() != uiThreadId_;
+#else
+  return true;
+#endif
+}
+
+#ifdef ANDROID
+// We schedule a pullTransaction call to happen on the JS thread so it can safely remove dead nodes after exiting
+// finished
+void LayoutAnimationsProxy_Legacy::maybeScheduleCleanupPull(
+    SurfaceContext &surfaceCtx,
+    const SurfaceId surfaceId,
+    const bool flushedDeadNodes) const {
+  if (flushedDeadNodes) {
+    surfaceCtx.cleanupPullScheduled = false;
+  } else if (!surfaceCtx.deadNodes.empty() && !surfaceCtx.cleanupPullScheduled) {
+    surfaceCtx.cleanupPullScheduled = true;
+    scheduleDeferredCleanupPull(surfaceId);
+  }
+}
+
+void LayoutAnimationsProxy_Legacy::scheduleDeferredCleanupPull(SurfaceId surfaceId) const {
+  const std::weak_ptr<UIManager> weakUiManager = uiManager_;
+  jsInvoker_->invokeAsync([weakUiManager, surfaceId](jsi::Runtime &) {
+    auto uiManager = weakUiManager.lock();
+    if (!uiManager) {
+      return;
+    }
+    uiManager->getShadowTreeRegistry().visit(
+        surfaceId, [](ShadowTree const &shadowTree) { shadowTree.notifyDelegatesOfUpdates(); });
+  });
+}
+#endif
 
 std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::progressLayoutAnimation(int tag, const jsi::Object &newStyle) {
 #ifdef LAYOUT_ANIMATIONS_LOGS
@@ -169,7 +213,7 @@ std::optional<SurfaceId> LayoutAnimationsProxy_Legacy::endLayoutAnimation(int ta
   }
   auto mutationNode = std::static_pointer_cast<MutationNode>(node);
   mutationNode->state = ExitingState_Legacy::DEAD;
-  auto &[deadNodes] = surfaceContext_[surfaceId];
+  auto &deadNodes = getSurfaceContext(surfaceId).deadNodes;
   deadNodes.insert(mutationNode);
 
   return surfaceId;
@@ -281,12 +325,13 @@ void LayoutAnimationsProxy_Legacy::handleRemovals(
     ShadowViewMutationList &filteredMutations,
     std::vector<std::shared_ptr<MutationNode>> &roots,
     std::unordered_set<std::shared_ptr<MutationNode>> &deadNodes,
-    bool shouldAnimate) const {
+    bool surfaceDropped,
+    bool flushDeadNodes) const {
   // iterate from the end, so that children
   // with higher indices appear first in the mutations list
   for (auto it = roots.rbegin(); it != roots.rend(); it++) {
     auto &node = *it;
-    if (!startAnimationsRecursively(node, true, shouldAnimate, false, filteredMutations)) {
+    if (!startAnimationsRecursively(node, true, !surfaceDropped, false, filteredMutations)) {
       filteredMutations.push_back(node->mutation);
       node->unflattenedParent->removeChildFromUnflattenedTree(node); //???
       if (node->state != ExitingState_Legacy::MOVED) {
@@ -301,6 +346,10 @@ void LayoutAnimationsProxy_Legacy::handleRemovals(
     }
   }
 
+  if (!flushDeadNodes) {
+    // Deferred - the host still has these views mounted, bookkeeping stays.
+    return;
+  }
   for (const auto &node : deadNodes) {
     if (node->state != ExitingState_Legacy::DELETED) {
       endAnimationsRecursively(node, filteredMutations);
@@ -713,6 +762,7 @@ void LayoutAnimationsProxy_Legacy::startEnteringAnimation(const int tag, ShadowV
           auto &mutex = strongThis->mutex;
           auto lock = std::unique_lock<std::recursive_mutex>(mutex);
 #ifdef ANDROID
+          strongThis->uiThreadId_ = std::this_thread::get_id();
           if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
             // the view was removed before this start could run
             return;
@@ -773,12 +823,12 @@ void LayoutAnimationsProxy_Legacy::startExitingAnimation(const int tag, ShadowVi
           auto &mutex = strongThis->mutex;
           auto lock = std::unique_lock<std::recursive_mutex>(mutex);
 #ifdef ANDROID
+          strongThis->uiThreadId_ = std::this_thread::get_id();
           if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
-            // the view was removed (e.g. its subtree was force-ended by a screen
-            // pop) before this start could run — its Remove+Delete are already on
-            // their way to the mounting layer, so starting the animation now
-            // would emit updates for a view that's about to be deleted
-            strongThis->layoutAnimationsManager_->clearLayoutAnimationConfig(tag);
+            // The view was removed before this start could run. Deliberately no
+            // clearLayoutAnimationConfig: with tag reuse the config maps already
+            // describe the re-created view, and wiping them would leave it mounted
+            // at opacity 0. A dead tag's stale configs can never fire again.
             return;
           }
 #endif
@@ -836,6 +886,7 @@ void LayoutAnimationsProxy_Legacy::startLayoutAnimation(const int tag, const Sha
           auto &mutex = strongThis->mutex;
           auto lock = std::unique_lock<std::recursive_mutex>(mutex);
 #ifdef ANDROID
+          strongThis->uiThreadId_ = std::this_thread::get_id();
           if (consumeIsCancelled(strongThis->pendingStarts_, tag, handle)) {
             // the view was removed before this start could run
             return;
@@ -996,6 +1047,17 @@ inline bool Node::isMutationNode() {
 
 inline bool MutationNode::isMutationNode() {
   return true;
+}
+
+void LayoutAnimationsProxy_Legacy::startSurface(const SurfaceId surfaceId) {
+  auto lock = std::unique_lock<std::recursive_mutex>(mutex);
+  surfaceContext_[surfaceId] = SurfaceContext{};
+}
+
+SurfaceContext &LayoutAnimationsProxy_Legacy::getSurfaceContext(const SurfaceId surfaceId) const {
+  const auto it = surfaceContext_.find(surfaceId);
+  react_native_assert(it != surfaceContext_.end() && "surface must be registered by startSurface");
+  return it->second;
 }
 
 // UIManagerAnimationDelegate

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -3,8 +3,8 @@
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/scheduler/Scheduler.h>
-#include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <reanimated/Compat/WorkletsApi.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
@@ -108,7 +108,7 @@ struct SurfaceContext {
 };
 
 struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
-                                      public UIManagerAnimationDelegate,
+                                      public UIManagerCommitHook,
                                       public std::enable_shared_from_this<LayoutAnimationsProxy_Legacy> {
   mutable std::unordered_map<Tag, std::shared_ptr<Node>> nodeForTag_;
   mutable std::recursive_mutex mutex;
@@ -129,11 +129,11 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       const SharedComponentDescriptorRegistry &componentDescriptorRegistry,
       const std::shared_ptr<const ContextContainer> &contextContainer,
       jsi::Runtime &uiRuntime,
-      const std::shared_ptr<UIScheduler> &uiScheduler
+      const std::shared_ptr<UIScheduler> &uiScheduler,
+      const std::shared_ptr<UIManager> &uiManager
 #ifdef ANDROID
       ,
       const PreserveMountedTagsFunction &filterUnmountedTagsFunction,
-      const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<CallInvoker> &jsInvoker
 #endif
       )
@@ -142,14 +142,19 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
             componentDescriptorRegistry,
             contextContainer,
             uiRuntime,
-            uiScheduler
+            uiScheduler,
+            uiManager
 #ifdef ANDROID
             ,
             filterUnmountedTagsFunction,
-            uiManager,
             jsInvoker
 #endif
         ) {
+    uiManager->registerCommitHook(*this);
+  }
+
+  ~LayoutAnimationsProxy_Legacy() override {
+    uiManager_->unregisterCommitHook(*this);
   }
 
   void startEnteringAnimation(const int tag, ShadowViewMutation &mutation) const;
@@ -222,19 +227,15 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       const TransactionTelemetry &telemetry,
       ShadowViewMutationList mutations) const override;
 
-  // UIManagerAnimationDelegate
+  // UIManagerCommitHook
 
-  void uiManagerDidConfigureNextLayoutAnimation(
-      jsi::Runtime &runtime,
-      const RawValue &config,
-      const jsi::Value &successCallbackValue,
-      const jsi::Value &failureCallbackValue) const override;
+  void commitHookWasRegistered(const UIManager &uiManager) noexcept override {}
+  void commitHookWasUnregistered(const UIManager &uiManager) noexcept override {}
 
-  void setComponentDescriptorRegistry(const SharedComponentDescriptorRegistry &componentDescriptorRegistry) override;
-
-  bool shouldAnimateFrame() const override;
-
-  void stopSurface(SurfaceId surfaceId) override;
+  RootShadowNode::Unshared shadowTreeWillCommit(
+      const ShadowTree &shadowTree,
+      const RootShadowNode::Shared &oldRootShadowNode,
+      const RootShadowNode::Unshared &newRootShadowNode) noexcept override;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -230,8 +230,8 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
 
   // UIManagerCommitHook
 
-  void commitHookWasRegistered(const UIManager &uiManager) noexcept override {}
-  void commitHookWasUnregistered(const UIManager &uiManager) noexcept override {}
+  void commitHookWasRegistered(const UIManager &) noexcept override {}
+  void commitHookWasUnregistered(const UIManager &) noexcept override {}
 
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree &shadowTree,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -190,6 +190,7 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       const PropsParserContext &propsParserContext,
       SurfaceId surfaceId) const;
   void addOngoingAnimations(SurfaceId surfaceId, ShadowViewMutationList &mutations) const;
+  void dropUpdatesForDeletedViews(ShadowViewMutationList &filteredMutations) const;
   void updateOngoingAnimationTarget(const int tag, const ShadowViewMutation &mutation) const;
   std::shared_ptr<ShadowView> cloneViewWithoutOpacity(
       facebook::react::ShadowViewMutation &mutation,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Legacy.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -97,8 +98,13 @@ static inline void mergeAndSwap(
   std::swap(A, merged);
 }
 
+// Created by startSurface before the proxy can pull for that surface.
+// Entries are never erased, so stray pulls after teardown always find state.
 struct SurfaceContext {
   mutable std::unordered_set<std::shared_ptr<MutationNode>> deadNodes;
+#ifdef ANDROID
+  mutable bool cleanupPullScheduled = false;
+#endif
 };
 
 struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
@@ -110,6 +116,13 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   mutable std::unordered_map<SurfaceId, SurfaceContext> surfaceContext_;
   mutable std::unordered_map<Tag, int> leastRemoved;
   mutable std::unordered_set<SurfaceId> surfacesToRemove_;
+  bool shouldFlushDeadNodes(bool surfaceDropped) const;
+#ifdef ANDROID
+  mutable std::thread::id uiThreadId_;
+
+  void maybeScheduleCleanupPull(SurfaceContext &surfaceCtx, SurfaceId surfaceId, bool flushedDeadNodes) const;
+  void scheduleDeferredCleanupPull(SurfaceId surfaceId) const;
+#endif
 
   LayoutAnimationsProxy_Legacy(
       const std::shared_ptr<LayoutAnimationsManager> &layoutAnimationsManager,
@@ -146,6 +159,8 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
   void transferConfigFromNativeID(const std::string &nativeId, const int tag) const;
   std::optional<SurfaceId> progressLayoutAnimation(int tag, const jsi::Object &newStyle) override;
   std::optional<SurfaceId> endLayoutAnimation(int tag, bool shouldRemove) override;
+  void startSurface(const SurfaceId surfaceId) override;
+  SurfaceContext &getSurfaceContext(SurfaceId surfaceId) const;
   void maybeCancelAnimation(const int tag) const;
 
   void reconcileContradictedRemovals(
@@ -160,7 +175,8 @@ struct LayoutAnimationsProxy_Legacy : public LayoutAnimationsProxyCommon,
       ShadowViewMutationList &filteredMutations,
       std::vector<std::shared_ptr<MutationNode>> &roots,
       std::unordered_set<std::shared_ptr<MutationNode>> &deadNodes,
-      bool shouldAnimate) const;
+      bool surfaceDropped,
+      bool flushDeadNodes) const;
 
   void handleUpdatesAndEnterings(
       ShadowViewMutationList &filteredMutations,

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1234,11 +1234,11 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
           componentDescriptorRegistry,
           scheduler->getContextContainer(),
           getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-          uiScheduler_
+          uiScheduler_,
+          uiManager_
 #ifdef ANDROID
           ,
           filterUnmountedTagsFunction_,
-          uiManager_,
           jsInvoker_
 #endif
       );
@@ -1247,22 +1247,19 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
 #endif
       layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
     } else {
-      auto layoutAnimationsProxyLegacy = std::make_shared<LayoutAnimationsProxy_Legacy>(
+      layoutAnimationsProxy_ = std::make_shared<LayoutAnimationsProxy_Legacy>(
           layoutAnimationsManager_,
           componentDescriptorRegistry,
           scheduler->getContextContainer(),
           getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-          uiScheduler_
+          uiScheduler_,
+          uiManager_
 #ifdef ANDROID
           ,
           filterUnmountedTagsFunction_,
-          uiManager_,
           jsInvoker_
 #endif
       );
-      // TODO (future): support in experimental
-      uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
-      layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);
     }
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1236,11 +1236,11 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
         componentDescriptorRegistry,
         scheduler->getContextContainer(),
         getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-        uiScheduler_
+        uiScheduler_,
+        uiManager_
 #ifdef ANDROID
         ,
         filterUnmountedTagsFunction_,
-        uiManager_,
         jsInvoker_
 #endif
     );
@@ -1249,22 +1249,19 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
 #endif
     layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
   } else {
-    auto layoutAnimationsProxyLegacy = std::make_shared<LayoutAnimationsProxy_Legacy>(
+    layoutAnimationsProxy_ = std::make_shared<LayoutAnimationsProxy_Legacy>(
         layoutAnimationsManager_,
         componentDescriptorRegistry,
         scheduler->getContextContainer(),
         getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-        uiScheduler_
+        uiScheduler_,
+        uiManager_
 #ifdef ANDROID
         ,
         filterUnmountedTagsFunction_,
-        uiManager_,
         jsInvoker_
 #endif
     );
-    // TODO (future): support in experimental
-    uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
-    layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);
   }
 }
 


### PR DESCRIPTION
## Summary

We register `LayoutAnimationsProxy_Legacy` as the `UIManagerAnimationDelegate` only to receive `stopSurface` callback. Occupying that slot overwrites the `LayoutAnimationDriver` that RN installs there, which silently kills `LayoutAnimation.configureNext` for the whole app.

The proxy now detects teardown itself: it registers a commit hook and marks a surface in `surfacesToRemove_` whenever a commit's root has no children. This could be a false positive if everything actually gets unmounted. As one of the next steps we should add a callback on the RN side that we can use the same way RN's `LayoutAnimation` api does.

The check deliberately doesn't read the `ShadowTreeRegistry` as `pullTransaction`/commit hooks can run under the registry's shared lock, and re-locking there deadlocks with a pending writer (#8579 is that exact bug elsewhere).

Freeing the slot restores `configureNext` to stock RN behavior per platform: it animates on iOS (`enableLayoutAnimationsOnIOS` defaults to true) and on Android when the app enables `enableLayoutAnimationsOnAndroid` (off by default in RN core - without it `configureNext` snaps in stock RN too). The `MountingCoordinator` chains RN's driver and our override delegate; the driver's own `stopSurface` flushes its withheld removals into the teardown transaction, so the consume condition always holds there.

## Test plan

Run both our and RN LA's in the same app

<details>
<summary>Minimal testing example</summary>

Paste into a Fabric app built with `ENABLE_SHARED_ELEMENT_TRANSITIONS=false` (legacy proxy). On Android, RN's `enableLayoutAnimationsOnAndroid` feature flag must be force-enabled — it's off by default in RN core, and without it `configureNext` snaps in stock RN too.

```tsx
import React, { useState } from 'react';
import { Button, LayoutAnimation, View } from 'react-native';
import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';

export default function ConfigureNextExample() {
  const [rows, setRows] = useState([0, 1, 2]);
  const [visible, setVisible] = useState(true);

  return (
    <View style={{ flex: 1, padding: 32 }}>
      <Button
        title="configureNext: toggle rows"
        onPress={() => {
          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
          setRows(rows.length ? [] : [0, 1, 2]);
        }}
      />
      <Button
        title="reanimated: toggle box"
        onPress={() => setVisible(!visible)}
      />
      {rows.map((i) => (
        <View
          key={i}
          style={{ height: 40, margin: 4, backgroundColor: 'skyblue' }}
        />
      ))}
      {visible && (
        <Animated.View
          entering={FadeIn}
          exiting={FadeOut}
          style={{ height: 80, margin: 4, backgroundColor: 'plum' }}
        />
      )}
    </View>
  );
}
```

Expected:
- "configureNext: toggle rows" animates the rows in and out (before this PR the transition snapped; the removal direction crashed when the driver replayed the withheld delete together with a final keyframe update)
- "reanimated: toggle box" runs the entering/exiting animations as before — both systems coexist in the same app

</details>

<details>
<summary> AI gibberish </summary>

fabric-example with `ENABLE_SHARED_ELEMENT_TRANSITIONS=false` (legacy proxy), iOS sim + Android emulator (with `enableLayoutAnimationsOnAndroid` force-enabled on Android):
- `configureNext` animates: video frame measurements show full easeInEaseOut interpolation on both platforms (iOS: 119 frames, 180→720px; Android: 158→275→388→468→514→630px)
- `configureNext` delete animations (transitions that remove views): the driver replays withheld Remove/Delete together with a final keyframe update; our reordering used to mount that update after the delete and abort (found in the Bluesky app, deterministic). Fixed in the second commit; covered by the bench's remove-views button on both platforms
- Reanimated entering/exiting/layout animations unchanged
- Reload teardown: exit animations skipped (single-frame removal), clean registry teardown, animations work on the fresh surface
- Adversarial pass: reloads fired at 0/60/150/350ms into exit animations, mount/unmount storms, concurrent reload requests, background/foreground with exits in flight, LogBox surface churn, `configureNext` mid-flight at teardown — 11/11 teardowns skipped exits with zero false positives on live surfaces, no crashes/ANRs/ghost views
- Rendering `null` at the app root: exits animate normally (surface alive), UI recovers

</details>

