### PR TITLE
fix(LayoutAnimations): deadlock in ReanimatedCommitHook surface initialization

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -20,43 +20,48 @@ ReanimatedCommitHook::ReanimatedCommitHook(
       updatesRegistryManager_(updatesRegistryManager),
       layoutAnimationsProxy_(layoutAnimationsProxy) {
   uiManager_->registerCommitHook(*this);
+  uiManager_->registerMountHook(*this);
+  // Pick up surfaces that existed before Reanimated initialized. We're not
+  // on a commit stack here, so reading the registry is safe.
+  uiManager_->getShadowTreeRegistry().enumerate(
+      [this](const ShadowTree &shadowTree, bool & /*stop*/) { maybeInitializeLayoutAnimations(shadowTree); });
 }
 
 ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
+  uiManager_->unregisterMountHook(*this);
   uiManager_->unregisterCommitHook(*this);
 }
 
-void ReanimatedCommitHook::maybeInitializeLayoutAnimations(SurfaceId surfaceId) {
-  auto lock = std::unique_lock<std::mutex>(mutex_);
-  if (surfaceId > currentMaxSurfaceId_) {
-    // when a new surfaceId is observed we call setMountingOverrideDelegate
-    // for all yet unseen surfaces
-    uiManager_->getShadowTreeRegistry().enumerate(
-        [strongThis = shared_from_this()](const ShadowTree &shadowTree, bool &stop) {
-          // Executed synchronously.
-          if (shadowTree.getSurfaceId() <= strongThis->currentMaxSurfaceId_) {
-            // the set function actually adds our delegate to a list, so we
-            // shouldn't invoke it twice for the same surface
-            return;
-          }
-          // TODO: We should consider registering a new instance of proxy for each surface.
-          // The current approach will encounter problems on platforms where it is more common to have multiple
-          // surfaces.
-          strongThis->layoutAnimationsProxy_->startSurface(shadowTree.getSurfaceId());
-          shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(strongThis->layoutAnimationsProxy_);
-        });
-    currentMaxSurfaceId_ = surfaceId;
+void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &shadowTree) {
+  {
+    auto lock = std::unique_lock<std::mutex>(mutex_);
+    if (!seenSurfaces_.insert(shadowTree.getSurfaceId()).second) {
+      return;
+    }
   }
+  // Don't read the ShadowTreeRegistry here — commits run under its shared
+  // lock and a nested acquisition deadlocks with a queued writer (#8579).
+  // TODO: We should consider registering a new instance of proxy for each surface.
+  // The current approach will encounter problems on platforms where it is more common to have multiple
+  // surfaces.
+  layoutAnimationsProxy_->startSurface(shadowTree.getSurfaceId());
+  shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(layoutAnimationsProxy_);
+}
+
+void ReanimatedCommitHook::shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp /*unmountTime*/) noexcept {
+  // Forget stopped surfaces so a reused surface id registers again.
+  auto lock = std::unique_lock<std::mutex>(mutex_);
+  seenSurfaces_.erase(surfaceId);
 }
 
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
-    ShadowTree const &,
+    ShadowTree const &shadowTree,
     RootShadowNode::Shared const &,
     RootShadowNode::Unshared const &newRootShadowNode,
     const ShadowTreeCommitOptions &commitOptions) noexcept {
   ReanimatedSystraceSection s("ReanimatedCommitHook::shadowTreeWillCommit");
 
-  maybeInitializeLayoutAnimations(newRootShadowNode->getSurfaceId());
+  maybeInitializeLayoutAnimations(shadowTree);
 
   if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
     return newRootShadowNode;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -15,12 +15,13 @@ namespace reanimated {
 ReanimatedCommitHook::ReanimatedCommitHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy)
+    const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+    const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker)
     : uiManager_(uiManager),
       updatesRegistryManager_(updatesRegistryManager),
-      layoutAnimationsProxy_(layoutAnimationsProxy) {
+      layoutAnimationsProxy_(layoutAnimationsProxy),
+      surfaceTracker_(surfaceTracker) {
   uiManager_->registerCommitHook(*this);
-  uiManager_->registerMountHook(*this);
   // Pick up surfaces that existed before Reanimated initialized. We're not
   // on a commit stack here, so reading the registry is safe.
   uiManager_->getShadowTreeRegistry().enumerate(
@@ -28,16 +29,12 @@ ReanimatedCommitHook::ReanimatedCommitHook(
 }
 
 ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
-  uiManager_->unregisterMountHook(*this);
   uiManager_->unregisterCommitHook(*this);
 }
 
 void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &shadowTree) {
-  {
-    auto lock = std::unique_lock<std::mutex>(mutex_);
-    if (!seenSurfaces_.insert(shadowTree.getSurfaceId()).second) {
-      return;
-    }
+  if (!surfaceTracker_->add(shadowTree.getSurfaceId())) {
+    return;
   }
   // Don't read the ShadowTreeRegistry here — commits run under its shared
   // lock and a nested acquisition deadlocks with a queued writer (#8579).
@@ -46,12 +43,6 @@ void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &sha
   // surfaces.
   layoutAnimationsProxy_->startSurface(shadowTree.getSurfaceId());
   shadowTree.getMountingCoordinator()->setMountingOverrideDelegate(layoutAnimationsProxy_);
-}
-
-void ReanimatedCommitHook::shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp /*unmountTime*/) noexcept {
-  // Forget stopped surfaces so a reused surface id registers again.
-  auto lock = std::unique_lock<std::mutex>(mutex_);
-  seenSurfaces_.erase(surfaceId);
 }
 
 RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -33,6 +33,9 @@ ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
 }
 
 void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &shadowTree) {
+  if (!layoutAnimationsProxy_) {
+    return;
+  }
   if (!surfaceTracker_->add(shadowTree.getSurfaceId())) {
     return;
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -33,14 +33,9 @@ ReanimatedCommitHook::~ReanimatedCommitHook() noexcept {
 }
 
 void ReanimatedCommitHook::maybeInitializeLayoutAnimations(const ShadowTree &shadowTree) {
-  if (!layoutAnimationsProxy_) {
-    return;
-  }
   if (!surfaceTracker_->add(shadowTree.getSurfaceId())) {
     return;
   }
-  // Don't read the ShadowTreeRegistry here — commits run under its shared
-  // lock and a nested acquisition deadlocks with a queued writer (#8579).
   // TODO: We should consider registering a new instance of proxy for each surface.
   // The current approach will encounter problems on platforms where it is more common to have multiple
   // surfaces.

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -4,14 +4,16 @@
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
+#include <react/renderer/uimanager/UIManagerMountHook.h>
 
 #include <memory>
+#include <unordered_set>
 
 using namespace facebook::react;
 
 namespace reanimated {
 
-class ReanimatedCommitHook : public UIManagerCommitHook, public std::enable_shared_from_this<ReanimatedCommitHook> {
+class ReanimatedCommitHook : public UIManagerCommitHook, public UIManagerMountHook {
  public:
   ReanimatedCommitHook(
       const std::shared_ptr<UIManager> &uiManager,
@@ -24,7 +26,7 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public std::enable_shar
 
   void commitHookWasUnregistered(UIManager const &) noexcept override {}
 
-  void maybeInitializeLayoutAnimations(SurfaceId surfaceId);
+  void maybeInitializeLayoutAnimations(const ShadowTree &shadowTree);
 
   RootShadowNode::Unshared shadowTreeWillCommit(
       ShadowTree const &shadowTree,
@@ -32,14 +34,19 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public std::enable_shar
       RootShadowNode::Unshared const &newRootShadowNode,
       const ShadowTreeCommitOptions &commitOptions) noexcept override;
 
+  void shadowTreeDidMount(RootShadowNode::Shared const &, HighResTimeStamp) noexcept override {}
+
+  void shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp unmountTime) noexcept override;
+
  private:
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
 
-  SurfaceId currentMaxSurfaceId_ = -1;
+  // Surfaces whose MountingCoordinator already has our override delegate.
+  std::unordered_set<SurfaceId> seenSurfaces_;
 
-  std::mutex mutex_; // Protects `currentMaxSurfaceId_`.
+  std::mutex mutex_; // Protects `seenSurfaces_`.
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.h
@@ -1,24 +1,24 @@
 #pragma once
 
+#include <reanimated/Fabric/ReanimatedSurfaceTracker.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxyCommon.h>
 
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
-#include <react/renderer/uimanager/UIManagerMountHook.h>
 
 #include <memory>
-#include <unordered_set>
 
 using namespace facebook::react;
 
 namespace reanimated {
 
-class ReanimatedCommitHook : public UIManagerCommitHook, public UIManagerMountHook {
+class ReanimatedCommitHook : public UIManagerCommitHook {
  public:
   ReanimatedCommitHook(
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
-      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy);
+      const std::shared_ptr<LayoutAnimationsProxyCommon> &layoutAnimationsProxy,
+      const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker);
 
   ~ReanimatedCommitHook() noexcept override;
 
@@ -34,19 +34,11 @@ class ReanimatedCommitHook : public UIManagerCommitHook, public UIManagerMountHo
       RootShadowNode::Unshared const &newRootShadowNode,
       const ShadowTreeCommitOptions &commitOptions) noexcept override;
 
-  void shadowTreeDidMount(RootShadowNode::Shared const &, HighResTimeStamp) noexcept override {}
-
-  void shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp unmountTime) noexcept override;
-
  private:
   std::shared_ptr<UIManager> uiManager_;
   std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   std::shared_ptr<LayoutAnimationsProxyCommon> layoutAnimationsProxy_;
-
-  // Surfaces whose MountingCoordinator already has our override delegate.
-  std::unordered_set<SurfaceId> seenSurfaces_;
-
-  std::mutex mutex_; // Protects `seenSurfaces_`.
+  std::shared_ptr<ReanimatedSurfaceTracker> surfaceTracker_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -1,5 +1,6 @@
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
+#include <reanimated/Tools/FeatureFlags.h>
 #include <reanimated/Tools/ReanimatedSystraceSection.h>
 
 #include <memory>
@@ -10,10 +11,12 @@ ReanimatedMountHook::ReanimatedMountHook(
     const std::shared_ptr<UIManager> &uiManager,
     const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
     const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
+    const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker,
     const std::function<void()> &requestFlush)
     : uiManager_(uiManager),
       updatesRegistryManager_(updatesRegistryManager),
       viewStylesRepository_(viewStylesRepository),
+      surfaceTracker_(surfaceTracker),
       requestFlush_(requestFlush) {
   uiManager_->registerMountHook(*this);
 }
@@ -26,6 +29,11 @@ void ReanimatedMountHook::shadowTreeDidMount(
     const RootShadowNode::Shared &rootShadowNode,
     HighResTimeStamp mountTime) noexcept {
   ReanimatedSystraceSection s("ReanimatedMountHook::shadowTreeDidMount");
+
+  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
+    // With the animation backend this hook only tracks surface unmounts.
+    return;
+  }
 
   auto reaShadowNode = std::reinterpret_pointer_cast<ReanimatedCommitShadowNode>(
       std::const_pointer_cast<RootShadowNode>(rootShadowNode));
@@ -59,6 +67,11 @@ void ReanimatedMountHook::shadowTreeDidMount(
       }
     }
   }
+}
+
+void ReanimatedMountHook::shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp /*unmountTime*/) noexcept {
+  // Forget stopped surfaces so a reused surface id registers again.
+  surfaceTracker_->remove(surfaceId);
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <reanimated/CSS/misc/ViewStylesRepository.h>
+#include <reanimated/Fabric/ReanimatedSurfaceTracker.h>
 #include <reanimated/Fabric/ShadowTreeCloner.h>
 #include <reanimated/Fabric/updates/UpdatesRegistryManager.h>
 
@@ -18,15 +19,19 @@ class ReanimatedMountHook : public UIManagerMountHook {
       const std::shared_ptr<UIManager> &uiManager,
       const std::shared_ptr<UpdatesRegistryManager> &updatesRegistryManager,
       const std::shared_ptr<css::ViewStylesRepository> &viewStylesRepository,
+      const std::shared_ptr<ReanimatedSurfaceTracker> &surfaceTracker,
       const std::function<void()> &requestFlush);
   ~ReanimatedMountHook() noexcept override;
 
   void shadowTreeDidMount(RootShadowNode::Shared const &rootShadowNode, HighResTimeStamp mountTime) noexcept override;
 
+  void shadowTreeDidUnmount(SurfaceId surfaceId, HighResTimeStamp unmountTime) noexcept override;
+
  private:
   const std::shared_ptr<UIManager> uiManager_;
   const std::shared_ptr<UpdatesRegistryManager> updatesRegistryManager_;
   const std::shared_ptr<css::ViewStylesRepository> viewStylesRepository_;
+  const std::shared_ptr<ReanimatedSurfaceTracker> surfaceTracker_;
   const std::function<void()> requestFlush_;
 };
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedSurfaceTracker.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedSurfaceTracker.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <react/renderer/core/ReactPrimitives.h>
+
+#include <mutex>
+#include <unordered_set>
+
+namespace reanimated {
+
+// Tracks surfaces that already have the LayoutAnimations mounting override
+// delegate registered. The commit hook adds, the mount hook removes on unmount.
+class ReanimatedSurfaceTracker {
+ public:
+  // Returns true if the surface wasn't tracked yet.
+  bool add(facebook::react::SurfaceId surfaceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return seenSurfaces_.insert(surfaceId).second;
+  }
+
+  void remove(facebook::react::SurfaceId surfaceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    seenSurfaces_.erase(surfaceId);
+  }
+
+ private:
+  std::mutex mutex_;
+  std::unordered_set<facebook::react::SurfaceId> seenSurfaces_;
+};
+
+} // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1208,15 +1208,15 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
     strongThis->requestFlushRegistry();
   };
 
-  if constexpr (StaticFeatureFlags::getFlag("USE_ANIMATION_BACKEND")) {
-    // TODO: we don't use the mount hook here, but we still need a way to handleNodeRemovals
-    // for now we leave this to leak the memory, a fix will come in a follow-up
-  } else {
-    mountHook_ =
-        std::make_shared<ReanimatedMountHook>(uiManager_, updatesRegistryManager_, viewStylesRepository_, request);
-  }
+  const auto surfaceTracker = std::make_shared<ReanimatedSurfaceTracker>();
 
-  commitHook_ = std::make_shared<ReanimatedCommitHook>(uiManager_, updatesRegistryManager_, layoutAnimationsProxy_);
+  commitHook_ = std::make_shared<ReanimatedCommitHook>(
+      uiManager_, updatesRegistryManager_, layoutAnimationsProxy_, surfaceTracker);
+
+  // TODO: with the animation backend we still need a way to handleNodeRemovals,
+  // for now we leave this to leak the memory, a fix will come in a follow-up
+  mountHook_ = std::make_shared<ReanimatedMountHook>(
+      uiManager_, updatesRegistryManager_, viewStylesRepository_, surfaceTracker, request);
 }
 
 void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1225,44 +1225,46 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
       scheduler->getContextContainer()
           ->at<std::weak_ptr<const ComponentDescriptorRegistry>>("ComponentDescriptorRegistry_DO_NOT_USE_PRETTY_PLEASE")
           .lock();
+  // The Scheduler owns the registry and outlives this module, so the weak_ptr
+  // always locks here. Everything downstream (the commit hook included)
+  // relies on layoutAnimationsProxy_ being non-null.
+  react_native_assert(componentDescriptorRegistry && "ComponentDescriptorRegistry must be alive during initialization");
 
-  if (componentDescriptorRegistry) {
-    if constexpr (StaticFeatureFlags::getFlag("ENABLE_SHARED_ELEMENT_TRANSITIONS")) {
-      auto layoutAnimationsProxyExperimental = std::make_shared<LayoutAnimationsProxy_Experimental>(
-          layoutAnimationsManager_,
-          componentDescriptorRegistry,
-          scheduler->getContextContainer(),
-          getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-          uiScheduler_
+  if constexpr (StaticFeatureFlags::getFlag("ENABLE_SHARED_ELEMENT_TRANSITIONS")) {
+    auto layoutAnimationsProxyExperimental = std::make_shared<LayoutAnimationsProxy_Experimental>(
+        layoutAnimationsManager_,
+        componentDescriptorRegistry,
+        scheduler->getContextContainer(),
+        getJSIRuntimeFromWorkletRuntime(uiRuntime_),
+        uiScheduler_
 #ifdef ANDROID
-          ,
-          filterUnmountedTagsFunction_,
-          uiManager_,
-          jsInvoker_
+        ,
+        filterUnmountedTagsFunction_,
+        uiManager_,
+        jsInvoker_
 #endif
-      );
+    );
 #ifdef __APPLE__
-      layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
+    layoutAnimationsProxyExperimental->setForceScreenSnapshotFunction(forceScreenSnapshot_);
 #endif
-      layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
-    } else {
-      auto layoutAnimationsProxyLegacy = std::make_shared<LayoutAnimationsProxy_Legacy>(
-          layoutAnimationsManager_,
-          componentDescriptorRegistry,
-          scheduler->getContextContainer(),
-          getJSIRuntimeFromWorkletRuntime(uiRuntime_),
-          uiScheduler_
+    layoutAnimationsProxy_ = std::move(layoutAnimationsProxyExperimental);
+  } else {
+    auto layoutAnimationsProxyLegacy = std::make_shared<LayoutAnimationsProxy_Legacy>(
+        layoutAnimationsManager_,
+        componentDescriptorRegistry,
+        scheduler->getContextContainer(),
+        getJSIRuntimeFromWorkletRuntime(uiRuntime_),
+        uiScheduler_
 #ifdef ANDROID
-          ,
-          filterUnmountedTagsFunction_,
-          uiManager_,
-          jsInvoker_
+        ,
+        filterUnmountedTagsFunction_,
+        uiManager_,
+        jsInvoker_
 #endif
-      );
-      // TODO (future): support in experimental
-      uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
-      layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);
-    }
+    );
+    // TODO (future): support in experimental
+    uiManager_->setAnimationDelegate(layoutAnimationsProxyLegacy.get());
+    layoutAnimationsProxy_ = std::move(layoutAnimationsProxyLegacy);
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1210,13 +1210,13 @@ void ReanimatedModuleProxy::initializeFabric(const std::shared_ptr<UIManager> &u
 
   const auto surfaceTracker = std::make_shared<ReanimatedSurfaceTracker>();
 
-  commitHook_ = std::make_shared<ReanimatedCommitHook>(
-      uiManager_, updatesRegistryManager_, layoutAnimationsProxy_, surfaceTracker);
-
   // TODO: with the animation backend we still need a way to handleNodeRemovals,
   // for now we leave this to leak the memory, a fix will come in a follow-up
   mountHook_ = std::make_shared<ReanimatedMountHook>(
       uiManager_, updatesRegistryManager_, viewStylesRepository_, surfaceTracker, request);
+
+  commitHook_ = std::make_shared<ReanimatedCommitHook>(
+      uiManager_, updatesRegistryManager_, layoutAnimationsProxy_, surfaceTracker);
 }
 
 void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {


### PR DESCRIPTION
## Summary

Fixes #8579.

`maybeInitializeLayoutAnimations` enumerated the `ShadowTreeRegistry` from inside a commit hook. Commits usually execute inside `ShadowTreeRegistry::visit`, which already holds the registry's `shared_mutex` in shared mode, so the enumerate was a recursive shared acquisition. libc++ writers block new readers while draining existing ones, so a concurrent `startSurface`/`stopSurface` (a registry writer) on another thread turns that recursion into a permanent deadlock — the three-thread ANR in the issue (JS in `enumerate`, pool thread in `startSurface`, main in `constraintLayout`).

The registry is now read exactly once, at hook construction (module init — never a commit stack), to pick up surfaces that existed before Reanimated loaded (lazy init, brownfield). After that, the first commit of each new surface registers the mounting override delegate directly through the committing `ShadowTree` — no registry access on commit stacks at all. `currentMaxSurfaceId_` becomes a `seenSurfaces_` set, and a mount hook erases stopped surfaces from it. That last part is not hypothetical: a JS reload reuses the same surface id, so without the erase the recreated surface would never get the override delegate.

## Test plan

fabric-example, iOS sim + Android emulator:
- Layout animations run on the main surface (delegate registered via the commit-hook path) and on a LogBox surface created after init (the case a registry-free fix has to cover)
- 5×/10× reload churn (surface stop + start + first commits racing) with layout animations between reloads: responsive throughout, zero ANRs, stable pid
- Back-button surface stop + relaunch on Android, empty-root commits (render-null) — all clean
- The emulator still had ANR traces from the unfixed binary with the #8579 signature; the fixed binary produced none under the same and heavier churn