### PR TITLE
chore: group pseudo-selector examples into sections

### DIFF
--- a/apps/common-app/src/apps/css/examples/transitions/routes.ts
+++ b/apps/common-app/src/apps/css/examples/transitions/routes.ts
@@ -89,46 +89,36 @@ const routes = {
     },
   },
   PseudoSelectors: {
+    flatten: true,
     name: 'Pseudo Selectors',
     CardComponent: routeCards.PseudoSelectorsCard,
     routes: {
-      PseudoHover: {
-        name: ':hover',
-        Component: pseudoSelectors.Hover,
+      Selectors: {
+        name: 'Selectors',
+        routes: {
+          PseudoHover: {
+            name: ':hover',
+            Component: pseudoSelectors.Hover,
+          },
+          PseudoActive: {
+            name: ':active',
+            Component: pseudoSelectors.Active,
+          },
+          PseudoActiveDeepest: {
+            name: ':active-deepest',
+            Component: pseudoSelectors.ActiveDeepest,
+          },
+          PseudoFocus: {
+            name: ':focus',
+            Component: pseudoSelectors.Focus,
+          },
+          PseudoFocusWithin: {
+            name: ':focus-within',
+            Component: pseudoSelectors.FocusWithin,
+          },
+        },
       },
-      PseudoActive: {
-        name: ':active',
-        Component: pseudoSelectors.Active,
-      },
-      PseudoActiveBlocksRender: {
-        name: 'selectors block render transition',
-        Component: pseudoSelectors.ActiveBlocksRender,
-      },
-      PseudoActiveDeepest: {
-        name: ':active-deepest',
-        Component: pseudoSelectors.ActiveDeepest,
-      },
-      PseudoFocus: {
-        name: ':focus',
-        Component: pseudoSelectors.Focus,
-      },
-      PseudoFocusWithin: {
-        name: ':focus-within',
-        Component: pseudoSelectors.FocusWithin,
-      },
-      PseudoHoverWithLoop: {
-        name: 'Looping transition + :hover',
-        Component: pseudoSelectors.HoverWithLoop,
-      },
-      PseudoPerStateTransitionConfig: {
-        name: 'Per-state transition configs',
-        Component: pseudoSelectors.PerStateTransitionConfig,
-      },
-      PseudoArbitraryWebSelectors: {
-        name: 'Arbitrary web selectors',
-        Component: pseudoSelectors.ArbitraryWebSelectors,
-      },
-      PseudoShowcase: {
+      Showcase: {
         name: 'Showcase',
         routes: {
           PseudoShowcaseForm: {
@@ -138,6 +128,27 @@ const routes = {
           PseudoShowcasePlanets: {
             name: 'Planets',
             Component: pseudoSelectors.Planets,
+          },
+        },
+      },
+      TestExamples: {
+        name: 'Test Examples',
+        routes: {
+          PseudoActiveBlocksRender: {
+            name: 'selectors block render transition',
+            Component: pseudoSelectors.ActiveBlocksRender,
+          },
+          PseudoHoverWithLoop: {
+            name: 'Looping transition + :hover',
+            Component: pseudoSelectors.HoverWithLoop,
+          },
+          PseudoPerStateTransitionConfig: {
+            name: 'Per-state transition configs',
+            Component: pseudoSelectors.PerStateTransitionConfig,
+          },
+          PseudoArbitraryWebSelectors: {
+            name: 'Arbitrary web selectors',
+            Component: pseudoSelectors.ArbitraryWebSelectors,
           },
         },
       },

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -245,25 +245,25 @@ transform: {
             code={`// r needs a base prop value, otherwise it renders at 0.
 <AnimatedCircle
   cx={25} cy={25} fill={colors.primary}
-  r={12}
+  r={24}
   style={{
-    r: { default: 12, ':active': 24 },
+    r: { default: 24, ':active': 12 },
     transitionDuration: '200ms',
   }}
   onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`r: {
-  default: 12,
-  ':active': 24,
+  default: 24,
+  ':active': 12,
 },`}>
             <Svg height={sizes.md} width={sizes.md}>
               <AnimatedCircle
                 cx={sizes.md / 2}
                 cy={sizes.md / 2}
                 fill={colors.primary}
-                r={sizes.md / 4}
+                r={sizes.md / 2 - 2}
                 style={{
-                  r: { ':active': sizes.md / 2 - 2, default: sizes.md / 4 },
+                  r: { ':active': sizes.md / 4, default: sizes.md / 2 - 2 },
                   transitionDuration: '200ms',
                 }}
                 onStartShouldSetResponder={() => true}

--- a/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
+++ b/apps/common-app/src/apps/css/examples/transitions/screens/pseudoSelectors/Active.tsx
@@ -244,16 +244,16 @@ transform: {
             title="SVG radius"
             code={`// r needs a base prop value, otherwise it renders at 0.
 <AnimatedCircle
-  cx={25} cy={25} fill={colors.primary}
-  r={24}
+  cx={24} cy={24} fill={colors.primary}
+  r={22}
   style={{
-    r: { default: 24, ':active': 12 },
+    r: { default: 22, ':active': 12 },
     transitionDuration: '200ms',
   }}
   onStartShouldSetResponder={() => true}
 />`}
             collapsedCode={`r: {
-  default: 24,
+  default: 22,
   ':active': 12,
 },`}>
             <Svg height={sizes.md} width={sizes.md}>


### PR DESCRIPTION
Groups the Pseudo Selectors screen into Selectors, Showcase and Test Examples, which were previously interleaved, using the same `flatten` grouping as the Base Properties screen.

Also flips the SVG radius example to start large and shrink on press, and syncs its code sample with the values it renders.

<img width="2584" height="2100" alt="9908-before-after" src="https://github.com/user-attachments/assets/0857f047-ac32-4f98-a019-5361087a2a83" />
