### PR TITLE
refactor(ci): migrate workflow helper scripts to TypeScript

### DIFF
--- a/.github/workflows/expo-devclient-build-check-nightly.yml
+++ b/.github/workflows/expo-devclient-build-check-nightly.yml
@@ -1,7 +1,7 @@
 name: Expo DevClient build check [Nightly]
 env:
   YARN_ENABLE_HARDENED_MODE: 0
-  SCRIPT_PATH: ${{github.workspace}}/.github/workflows/helper/configureDevClient.js
+  SCRIPT_PATH: ${{github.workspace}}/.github/workflows/helper/configureDevClient.ts
 on:
   pull_request:
     paths:
@@ -28,6 +28,12 @@ jobs:
     steps:
       - name: Check out reanimated repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: .github/workflows/helper
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
       - name: Setup Java 17
         if: ${{ matrix.platform == 'Android' }}
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62
@@ -51,7 +57,7 @@ jobs:
         run: npm install expo@${{ env.EXPO_TAG }}
       - name: Setup configuration
         working-directory: ${{ env.APP_NAME }}
-        run: node ${{ env.SCRIPT_PATH }} setBundleIdentifier
+        run: node --experimental-strip-types ${{ env.SCRIPT_PATH }} setBundleIdentifier
       - name: Install Reanimated
         working-directory: ${{ env.APP_NAME }}
         run: npm install react-native-reanimated@nightly

--- a/.github/workflows/helper/configureDevClient.ts
+++ b/.github/workflows/helper/configureDevClient.ts
@@ -1,6 +1,6 @@
-const fs = require('fs');
+import fs from 'node:fs';
 
-function patchFile(path, find, replace) {
+function patchFile(path: string, find: string, replace: string): void {
   let data = fs.readFileSync(path, 'utf8');
   data = data.replace(find, replace);
   fs.writeFileSync(path, data);
@@ -19,21 +19,5 @@ if (command === 'setBundleIdentifier') {
     'app.json',
     '"android": {',
     '"android": {"package": "com.swmansion.app",'
-  );
-}
-
-if (command === 'setupFabricIOS') {
-  patchFile(
-    'ios/Podfile.properties.json',
-    '"expo.jsEngine"',
-    '"newArchEnabled":"true","expo.jsEngine"'
-  );
-}
-
-if (command === 'setupFabricAndroid') {
-  patchFile(
-    'android/gradle.properties',
-    'newArchEnabled=false',
-    'newArchEnabled=true'
   );
 }

--- a/.github/workflows/helper/nightly-fail-notification.ts
+++ b/.github/workflows/helper/nightly-fail-notification.ts
@@ -15,7 +15,6 @@ type BadgeResult = BadgeInfo & {
 };
 
 const GITHUB_ACTIONS_BADGE_REGEX =
-  // @ts-expect-error It's fine to use capture groups here.
   /\[!\[(?<name>(?:[^[\]]|\[[^\]]*\])+)\]\((?<badgeUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+\/badge\.svg[^)]*)\)\]\((?<workflowUrl>https:\/\/github\.com\/software-mansion\/react-native-reanimated\/actions\/workflows\/[^)]+)\)/g;
 
 function parseBadgeStatus(svg: string): BadgeStatus {

--- a/.github/workflows/helper/read-compatibility.ts
+++ b/.github/workflows/helper/read-compatibility.ts
@@ -1,8 +1,10 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const compatibilityPath = path.join(
-  __dirname,
+  currentDir,
   '..',
   '..',
   '..',
@@ -14,7 +16,7 @@ const compatibilityData = JSON.parse(
   fs.readFileSync(compatibilityPath, 'utf8')
 );
 
-const versions = compatibilityData['fabric']['nightly']['react-native'];
+const versions = compatibilityData.fabric.nightly['react-native'];
 const versionsJson = JSON.stringify(versions);
 
 const versionsWithNightly = [...versions, 'nightly'];

--- a/.github/workflows/helper/read-reanimated-worklets-compatibility.ts
+++ b/.github/workflows/helper/read-reanimated-worklets-compatibility.ts
@@ -1,8 +1,12 @@
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-function resolveNpmVersion(pkgName, versionRange) {
+function resolveNpmVersion(
+  pkgName: string,
+  versionRange: string
+): string | null {
   const spec = `${pkgName}@${versionRange}`;
   try {
     const rawOutput = execSync(`npm view "${spec}" version --json`, {
@@ -25,12 +29,14 @@ function resolveNpmVersion(pkgName, versionRange) {
   }
 }
 
-function toRange(version) {
+function toRange(version: string): string {
   return version.includes('x') ? version : `${version}.x`;
 }
 
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
 const compatibilityPath = path.join(
-  __dirname,
+  currentDir,
   '..',
   '..',
   '..',
@@ -40,7 +46,7 @@ const compatibilityPath = path.join(
 );
 
 const workletsCompatibilityPath = path.join(
-  __dirname,
+  currentDir,
   '..',
   '..',
   '..',
@@ -51,13 +57,13 @@ const workletsCompatibilityPath = path.join(
 
 const compatibilityData = JSON.parse(
   fs.readFileSync(compatibilityPath, 'utf8')
-);
+) as CompatibilityData;
 const workletsCompatibilityData = JSON.parse(
   fs.readFileSync(workletsCompatibilityPath, 'utf8')
-);
+) as WorkletsCompatibilityData;
 
 const fabricCompatibility = compatibilityData.fabric;
-const matrixEntries = [];
+const matrixEntries: MatrixEntry[] = [];
 
 for (const [reanimatedRange, details] of Object.entries(fabricCompatibility)) {
   if (reanimatedRange === 'nightly') {
@@ -131,7 +137,7 @@ for (const [reanimatedRange, details] of Object.entries(fabricCompatibility)) {
   }
 }
 
-const uniqueEntries = new Map();
+const uniqueEntries = new Map<string, MatrixEntry>();
 for (const entry of matrixEntries) {
   const key = `${entry.reactNativeVersion}-${entry.reanimatedVersion}-${entry.workletsVersion}`;
   uniqueEntries.set(key, entry);
@@ -143,3 +149,23 @@ fs.writeFileSync(
   '/tmp/reanimated-worklets-matrix.json',
   JSON.stringify(matrix)
 );
+
+type CompatibilityDetails = {
+  'react-native'?: string[];
+  'react-native-worklets'?: string[];
+};
+
+type CompatibilityData = {
+  fabric: Record<string, CompatibilityDetails>;
+};
+
+type WorkletsCompatibilityData = Record<
+  string,
+  { 'react-native'?: string[] } | undefined
+>;
+
+type MatrixEntry = {
+  reactNativeVersion: string;
+  reanimatedVersion: string;
+  workletsVersion: string;
+};

--- a/.github/workflows/helper/tsconfig.json
+++ b/.github/workflows/helper/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/.github/workflows/reanimated-compatibility-check-nightly.yml
+++ b/.github/workflows/reanimated-compatibility-check-nightly.yml
@@ -18,12 +18,18 @@ jobs:
       react-native-versions: ${{ steps.set-outputs.outputs.react-native-versions }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: |
+            /.nvmrc
+            /.github/workflows/helper
+            /packages/react-native-reanimated/compatibility.json
+          sparse-checkout-cone-mode: false
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version-file: '.nvmrc'
       - name: Read compatibility.json
-        run: node .github/workflows/helper/read-compatibility.js
+        run: node --experimental-strip-types .github/workflows/helper/read-compatibility.ts
       - name: Set outputs
         id: set-outputs
         run: |

--- a/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
+++ b/.github/workflows/reanimated-typescript-compatibility-test-nightly.yml
@@ -18,8 +18,18 @@ jobs:
       react-native-versions-with-nightly: ${{ steps.set-outputs.outputs.react-native-versions-with-nightly }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: |
+            /.nvmrc
+            /.github/workflows/helper
+            /packages/react-native-reanimated/compatibility.json
+          sparse-checkout-cone-mode: false
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
       - name: Read compatibility.json
-        run: node .github/workflows/helper/read-compatibility.js
+        run: node --experimental-strip-types .github/workflows/helper/read-compatibility.ts
       - name: Set outputs
         id: set-outputs
         run: |

--- a/.github/workflows/reanimated-worklets-compatibility-check.yml
+++ b/.github/workflows/reanimated-worklets-compatibility-check.yml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - '.github/workflows/reanimated-worklets-compatibility-check.yml'
-      - '.github/workflows/helper/read-reanimated-worklets-compatibility.js'
+      - '.github/workflows/helper/read-reanimated-worklets-compatibility.ts'
       - '.github/actions/create-rnc-cli-app/**'
   pull_request:
     paths:
       - '.github/workflows/reanimated-worklets-compatibility-check.yml'
-      - '.github/workflows/helper/read-reanimated-worklets-compatibility.js'
+      - '.github/workflows/helper/read-reanimated-worklets-compatibility.ts'
       - '.github/actions/create-rnc-cli-app/**'
   workflow_dispatch:
   schedule:
@@ -26,6 +26,13 @@ jobs:
       matrix-size: ${{ steps.set-outputs.outputs.matrix-size }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: |
+            /.nvmrc
+            /.github/workflows/helper
+            /packages/react-native-reanimated/compatibility.json
+            /packages/react-native-worklets/compatibility.json
+          sparse-checkout-cone-mode: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -33,7 +40,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Read and resolve compatibility matrix
-        run: node .github/workflows/helper/read-reanimated-worklets-compatibility.js
+        run: node --experimental-strip-types .github/workflows/helper/read-reanimated-worklets-compatibility.ts
 
       - name: Set outputs
         id: set-outputs


### PR DESCRIPTION
## Summary

Converting CI workflows helper scripts to typescript and doing a little cleanup of related workflows.

## Test plan

CI
