### PR TITLE
fix(Worklets): bundle mode detection with expo tree shaking

### DIFF
--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
@@ -155,5 +155,3 @@ exports[`babel plugin in bundleMode worklet file emission written file path matc
 exports[`babel plugin in bundleMode worklet runtime entry-point toggle does not flip the flag in unrelated files 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
 
 exports[`babel plugin in bundleMode worklet runtime entry-point toggle does not flip the flag without bundleMode option 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
-
-exports[`babel plugin in bundleMode worklet runtime entry-point toggle flips _WORKLETS_BUNDLE_MODE_ENABLED to true in the entry-point 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = true;"`;

--- a/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
+++ b/packages/react-native-worklets/__tests__/__snapshots__/plugin-bundleMode.test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`babel plugin in bundleMode bundle mode flag toggle does not flip the flag in unrelated files 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
+
+exports[`babel plugin in bundleMode bundle mode flag toggle does not flip the flag without bundleMode option 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
+
 exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 1`] = `"const foo = require("react-native-worklets/.worklets/16646339867656.js").default({});"`;
 
 exports[`babel plugin in bundleMode nested worklets extracts each nested worklet into its own file 2`] = `
@@ -151,7 +155,3 @@ exports[`babel plugin in bundleMode worklet file emission written file content h
 `;
 
 exports[`babel plugin in bundleMode worklet file emission written file path matches the require path 1`] = `"const foo = require("react-native-worklets/.worklets/16618675255854.js").default({});"`;
-
-exports[`babel plugin in bundleMode worklet runtime entry-point toggle does not flip the flag in unrelated files 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;
-
-exports[`babel plugin in bundleMode worklet runtime entry-point toggle does not flip the flag without bundleMode option 1`] = `"globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;"`;

--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -319,7 +319,7 @@ describe('babel plugin in bundleMode', () => {
     });
   });
 
-  describe('worklet runtime entry-point toggle', () => {
+  describe('bundle mode flag toggle', () => {
     for (const [label, filename] of TOGGLE_PATH_CASES) {
       test(`flips _WORKLETS_BUNDLE_MODE_ENABLED to true in the ${label} file`, () => {
         const input = html`<script>

--- a/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
+++ b/packages/react-native-worklets/__tests__/plugin-bundleMode.test.ts
@@ -32,6 +32,16 @@ const MOCK_TSX_LOCATION = 'test.tsx';
 const MOCK_WORKLET_RUNTIME_ENTRY = 'react-native-worklets/src/index.ts';
 const MOCK_OTHER_FILE = 'someOtherFile.ts';
 
+const TOGGLE_PATH_CASES: ReadonlyArray<[label: string, filename: string]> = [
+  ['source entry-point', MOCK_WORKLET_RUNTIME_ENTRY],
+  ['source mode-check', 'react-native-worklets/src/debug/bundleMode.native.ts'],
+  ['built entry-point', 'react-native-worklets/lib/module/index.js'],
+  [
+    'built mode-check',
+    'react-native-worklets/lib/module/debug/bundleMode.native.js',
+  ],
+];
+
 const REQUIRE_PREFIX = 'require("react-native-worklets/.worklets/';
 
 function runPlugin(
@@ -310,14 +320,18 @@ describe('babel plugin in bundleMode', () => {
   });
 
   describe('worklet runtime entry-point toggle', () => {
-    test('flips _WORKLETS_BUNDLE_MODE_ENABLED to true in the entry-point', () => {
-      const input = html`<script>
-        globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
-      </script>`;
+    for (const [label, filename] of TOGGLE_PATH_CASES) {
+      test(`flips _WORKLETS_BUNDLE_MODE_ENABLED to true in the ${label} file`, () => {
+        const input = html`<script>
+          globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
+        </script>`;
 
-      const { code } = runPlugin(input, {}, {}, MOCK_WORKLET_RUNTIME_ENTRY);
-      expect(code).toMatchSnapshot();
-    });
+        const { code } = runPlugin(input, {}, {}, filename);
+        expect(code).toContain(
+          'globalThis._WORKLETS_BUNDLE_MODE_ENABLED = true;'
+        );
+      });
+    }
 
     test('does not flip the flag in unrelated files', () => {
       const input = html`<script>

--- a/packages/react-native-worklets/plugin/index.js
+++ b/packages/react-native-worklets/plugin/index.js
@@ -1583,11 +1583,20 @@ var require_bundleMode = __commonJS({
     exports2.toggleBundleMode = toggleBundleMode;
     var types_12 = require("@babel/types");
     var path_1 = require("path");
-    var WORKLETS_SRC_ENTRY_PATH = (0, path_1.join)("react-native-worklets", "src", "index.ts");
-    var WORKLETS_LIB_ENTRY_PATH = (0, path_1.join)("react-native-worklets", "lib", "module", "index.js");
+    var WORKLETS_PACKAGE = "react-native-worklets";
+    var WORKLETS_SRC_DIR = (0, path_1.join)(WORKLETS_PACKAGE, "src");
+    var WORKLETS_LIB_DIR = (0, path_1.join)(WORKLETS_PACKAGE, "lib", "module");
+    var togglePaths = [
+      (0, path_1.join)(WORKLETS_SRC_DIR, "index.ts"),
+      (0, path_1.join)(WORKLETS_SRC_DIR, "debug", "bundleMode.native.ts"),
+      (0, path_1.join)(WORKLETS_LIB_DIR, "index.js"),
+      (0, path_1.join)(WORKLETS_LIB_DIR, "debug", "bundleMode.native.js")
+    ];
     function toggleBundleMode(path, state) {
-      var _a, _b;
-      if (!state.opts.bundleMode || !((_a = state.filename) === null || _a === void 0 ? void 0 : _a.endsWith(WORKLETS_SRC_ENTRY_PATH)) && !((_b = state.filename) === null || _b === void 0 ? void 0 : _b.endsWith(WORKLETS_LIB_ENTRY_PATH))) {
+      if (!state.opts.bundleMode || !togglePaths.some((togglePath) => {
+        var _a;
+        return (_a = state.filename) === null || _a === void 0 ? void 0 : _a.endsWith(togglePath);
+      })) {
         return;
       }
       const expressionPath = path.get("expression");

--- a/packages/react-native-worklets/plugin/src/bundleMode.ts
+++ b/packages/react-native-worklets/plugin/src/bundleMode.ts
@@ -20,8 +20,8 @@ const togglePaths = [
  *
  * `globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;`
  *
- * With `true` in the Worklets' entry-point file when the `bundleMode` option is
- * enabled in the Babel plugin.
+ * With `true` in each of the Worklets' toggle-target files when the
+ * `bundleMode` option is enabled in the Babel plugin.
  *
  * This way Bundle Mode is not accidentally set up in eager import environments.
  */

--- a/packages/react-native-worklets/plugin/src/bundleMode.ts
+++ b/packages/react-native-worklets/plugin/src/bundleMode.ts
@@ -4,17 +4,16 @@ import { join } from 'path';
 
 import type { WorkletsPluginPass } from './types';
 
-const WORKLETS_SRC_ENTRY_PATH = join(
-  'react-native-worklets',
-  'src',
-  'index.ts'
-);
-const WORKLETS_LIB_ENTRY_PATH = join(
-  'react-native-worklets',
-  'lib',
-  'module',
-  'index.js'
-);
+const WORKLETS_PACKAGE = 'react-native-worklets';
+const WORKLETS_SRC_DIR = join(WORKLETS_PACKAGE, 'src');
+const WORKLETS_LIB_DIR = join(WORKLETS_PACKAGE, 'lib', 'module');
+
+const togglePaths = [
+  join(WORKLETS_SRC_DIR, 'index.ts'),
+  join(WORKLETS_SRC_DIR, 'debug', 'bundleMode.native.ts'),
+  join(WORKLETS_LIB_DIR, 'index.js'),
+  join(WORKLETS_LIB_DIR, 'debug', 'bundleMode.native.js'),
+];
 
 /**
  * This function replaces the `false` value in
@@ -32,8 +31,7 @@ export function toggleBundleMode(
 ) {
   if (
     !state.opts.bundleMode ||
-    (!state.filename?.endsWith(WORKLETS_SRC_ENTRY_PATH) &&
-      !state.filename?.endsWith(WORKLETS_LIB_ENTRY_PATH))
+    !togglePaths.some((togglePath) => state.filename?.endsWith(togglePath))
   ) {
     return;
   }

--- a/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
+++ b/packages/react-native-worklets/src/WorkletsModule/NativeWorklets.native.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isBundleModeEnabled } from '../debug/bundleMode';
 import { checkCppVersion } from '../debug/checkCppVersion';
 import { jsVersion } from '../debug/jsVersion';
 import { installCustomSerializableUnpacker } from '../memory/customSerializableUnpacker';
@@ -29,7 +30,7 @@ class NativeWorklets implements IWorkletsModule {
   #serializableFalse: SerializableRef<boolean>;
 
   constructor() {
-    const bundleModeEnabled = globalThis._WORKLETS_BUNDLE_MODE_ENABLED ?? false;
+    const bundleModeEnabled = isBundleModeEnabled();
     globalThis._WORKLETS_VERSION_JS = jsVersion;
     const onRNRuntime = isRNRuntime();
     if (globalThis.__workletsModuleProxy === undefined && onRNRuntime) {

--- a/packages/react-native-worklets/src/debug/bundleMode.native.ts
+++ b/packages/react-native-worklets/src/debug/bundleMode.native.ts
@@ -2,6 +2,8 @@
 
 import type { WorkletFunction } from '../types';
 
+// Worklets Babel Plugin replaces `false` with `true` here
+// when Bundle Mode is enabled.
 globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
 
 export function isBundleModeEnabled(): boolean {

--- a/packages/react-native-worklets/src/debug/bundleMode.native.ts
+++ b/packages/react-native-worklets/src/debug/bundleMode.native.ts
@@ -2,6 +2,8 @@
 
 import type { WorkletFunction } from '../types';
 
+globalThis._WORKLETS_BUNDLE_MODE_ENABLED = false;
+
 export function isBundleModeEnabled(): boolean {
   return (
     globalThis._WORKLETS_BUNDLE_MODE_ENABLED === true &&

--- a/packages/react-native-worklets/src/memory/serializable.native.ts
+++ b/packages/react-native-worklets/src/memory/serializable.native.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isBundleModeEnabled } from '../debug/bundleMode';
 import { registerWorkletStackDetails } from '../debug/errors';
 import { jsVersion } from '../debug/jsVersion';
 import { logger } from '../debug/logger';
@@ -217,7 +218,7 @@ export function createSerializable<TValue>(
   );
 }
 
-if (globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (isBundleModeEnabled()) {
   // TODO: Do it programmatically.
   createSerializable.__bundleData = {
     imported: 'createSerializable',
@@ -865,7 +866,7 @@ function makeShareableCloneOnUIRecursiveLEGACY<TValue>(
 
 /** @deprecated This function is no longer supported. */
 export const makeShareableCloneOnUIRecursive = (
-  globalThis._WORKLETS_BUNDLE_MODE_ENABLED
+  isBundleModeEnabled()
     ? createSerializable
     : makeShareableCloneOnUIRecursiveLEGACY
 ) as typeof makeShareableCloneOnUIRecursiveLEGACY;

--- a/packages/react-native-worklets/src/memory/shareable.native.ts
+++ b/packages/react-native-worklets/src/memory/shareable.native.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isBundleModeEnabled } from '../debug/bundleMode';
 import { addNoBundleModeGuardImplementation } from '../guardImplementation';
 import { isWorkletFunction } from '../workletFunction';
 import { WorkletsModule } from '../WorkletsModule/NativeWorklets';
@@ -62,6 +63,6 @@ export function createShareable<
   );
 }
 
-if (__DEV__ && !globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (__DEV__ && !isBundleModeEnabled()) {
   addNoBundleModeGuardImplementation(createShareable);
 }

--- a/packages/react-native-worklets/src/runtimes.native.ts
+++ b/packages/react-native-worklets/src/runtimes.native.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isBundleModeEnabled } from './debug/bundleMode';
 import { getStaticFeatureFlag } from './featureFlags/featureFlags';
 import { addNoBundleModeGuardImplementation } from './guardImplementation';
 import {
@@ -177,7 +178,7 @@ export function scheduleOnRuntime<Args extends unknown[], ReturnValue>(
   );
 }
 
-if (!globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (!isBundleModeEnabled()) {
   function scheduleOnRuntimeWorklet<Args extends unknown[], ReturnValue>(
     workletRuntime: WorkletRuntime,
     worklet: WorkletFunction<Args, ReturnValue>,
@@ -255,7 +256,7 @@ export function scheduleOnRuntimeWithId<Args extends unknown[], ReturnValue>(
   );
 }
 
-if (!globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (!isBundleModeEnabled()) {
   function scheduleOnRuntimeWithIdWorklet<Args extends unknown[], ReturnValue>(
     runtimeId: number,
     worklet: WorkletFunction<Args, ReturnValue>,
@@ -551,7 +552,7 @@ export function runOnRuntimeAsyncWithId<Args extends unknown[], ReturnValue>(
   });
 }
 
-if (__DEV__ && !globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (__DEV__ && !isBundleModeEnabled()) {
   /**
    * QoL guards to give a meaningful error message when the user tries to call
    * these functions on Worklet Runtimes outside of the Bundle Mode.

--- a/packages/react-native-worklets/src/threads.native.ts
+++ b/packages/react-native-worklets/src/threads.native.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { isBundleModeEnabled } from './debug/bundleMode';
 import { getStaticFeatureFlag } from './featureFlags/featureFlags';
 import { addNoBundleModeGuardImplementation } from './guardImplementation';
 import {
@@ -396,7 +397,7 @@ function flushUIQueue(): void {
   });
 }
 
-if (__DEV__ && !globalThis._WORKLETS_BUNDLE_MODE_ENABLED) {
+if (__DEV__ && !isBundleModeEnabled()) {
   /**
    * QoL guards to give a meaningful error message when the user tries to call
    * these functions on Worklet Runtimes outside of the Bundle Mode.


### PR DESCRIPTION
## Summary

Fixes #9904

With expo tree shaking enabled eager imports might kick-in and the top-level and NativeWorklets checks for `globalThis._WORKLETS_BUNDLE_MODE_ENABLED` can be evaluated before the variable is set.

This PR changes these code paths to use a function for detection, which is guaranteed to be ran after the constant is set - this is done by adding a second toggle checkpoint in its file.

I didn't change all raw checks for `globalThis._WORKLETS_BUNDLE_MODE_ENABLED` for performance reasons - the other uses require NativeWorklets to be set up beforehand, so it's impossible for them to read the unset constant.

## Test plan

I verified that it works with the reproduction provided in #9904 
