### PR TITLE
fix(android): don't force Spotless plugin onto consumers

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle.kts
+++ b/packages/react-native-reanimated/android/build.gradle.kts
@@ -1,13 +1,29 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
 import groovy.json.JsonSlurper
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 import javax.inject.Inject
 
+buildscript {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    dependencies {
+        // Spotless is only applied when this module is the root project, to lint
+        // Reanimated's own sources (see the `project == rootProject` block below).
+        // It's put on the buildscript classpath and applied conditionally instead of
+        // declared in the plugins {} block: a versioned plugins {} entry fails in
+        // consumer apps that already have Spotless on their root buildscript classpath
+        // with "plugin ... already on the classpath with an unknown version".
+        classpath("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")
+    }
+}
+
 plugins {
     id("com.android.library")
     id("maven-publish")
-    id("com.diffplug.spotless") version "8.4.0"
     id("org.jetbrains.kotlin.android")
 }
 
@@ -134,7 +150,8 @@ fun reactNativeArchitectures(): List<String> {
 }
 
 if (project == rootProject) {
-    spotless {
+    apply(plugin = "com.diffplug.spotless")
+    configure<SpotlessExtension> {
         kotlin {
             target("src/**/*.kt")
             ktlint()


### PR DESCRIPTION
## Summary

Fixes #9915.

The Android module declares Spotless in the `plugins {}` block with a pinned version:

```kotlin
plugins {
    id("com.android.library")
    id("maven-publish")
    id("com.diffplug.spotless") version "8.4.0"   // <-- here
    id("org.jetbrains.kotlin.android")
}
```

But Spotless is only ever *used* when this module is the root project:

```kotlin
if (project == rootProject) {
    spotless { kotlin { target("src/**/*.kt"); ktlint() } }
}
```

In a consumer app the module is a **subproject**, so the plugin is applied but never does anything. Worse, a **versioned** `plugins {}` request fails the build for any app that already has Spotless on its **root `buildscript` classpath** (a common setup):

```
Error resolving plugin [id: 'com.diffplug.spotless', version: '8.4.0']
> The request for this plugin could not be satisfied because the plugin is already
  on the classpath with an unknown version, so compatibility cannot be checked.
```

A plugin loaded via `buildscript { classpath ... }` has an "unknown version" from Gradle's plugin-management perspective, so a versioned `plugins {}` request in a subproject can't be reconciled and aborts the build.

## Why not simpler fixes

- **Dropping the version** (`id("com.diffplug.spotless")`) is not safe: versionless `plugins {}` entries only work when the plugin is guaranteed on the classpath (like `com.android.library`, where AGP is always present). Spotless is *not* on every consumer's classpath, so this would break consumers that don't use Spotless.
- **`apply false`** still resolves the versioned request, so it hits the same conflict.

## Change

Move Spotless off the `plugins {}` block: put it on the `buildscript` classpath and apply it conditionally, mirroring the existing `apply(plugin = "com.facebook.react")` pattern already in this file. Because it's no longer applied via `plugins {}`, the type-safe `spotless { }` accessor isn't generated, so the config uses `configure<SpotlessExtension>`.

```kotlin
buildscript {
    repositories { mavenCentral(); gradlePluginPortal() }
    dependencies {
        classpath("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")
    }
}

// ...

if (project == rootProject) {
    apply(plugin = "com.diffplug.spotless")
    configure<SpotlessExtension> {
        kotlin { target("src/**/*.kt"); ktlint() }
    }
}
```

Result: consumers no longer get the Spotless plugin imposed on their build (no version conflict), while standalone linting of Reanimated's own sources is unchanged.

Trade-off worth flagging: the Spotless plugin JAR is still resolved on the module's buildscript classpath for consumers (it just isn't applied). That's a negligible cost and doesn't fail the build; happy to gate it further if you'd prefer it fully absent for consumers.

## Test plan

- [ ] Standalone build of `packages/react-native-reanimated/android` (root-project case) still exposes the Spotless tasks and lints `src/**/*.kt`.
- [ ] A consumer app that has `com.diffplug.spotless` on its root `buildscript` classpath builds Android successfully (previously failed at `build.gradle.kts` line 7).

Note: I verified the reasoning and the diff against `main`, but I wasn't able to run Reanimated's full Android build locally, so I'd appreciate CI confirming both cases.
