### PR TITLE
fix: guard handleHoverGesture behind !TARGET_OS_TV to unbreak tvOS build

### DIFF
--- a/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/pseudoSelectors/REAPseudoSelectorObserver.mm
@@ -304,6 +304,7 @@ static int _focusObserverContext;
   }
 }
 
+#if !TARGET_OS_TV
 - (void)handleHoverGesture:(UIHoverGestureRecognizer *)recognizer
 {
   switch (recognizer.state) {
@@ -319,6 +320,7 @@ static int _focusObserverContext;
       break;
   }
 }
+#endif
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {


### PR DESCRIPTION
`UIHoverGestureRecognizer` is unavailable on tvOS, but `handleHoverGesture:` in `REAPseudoSelectorObserver.mm` was declared without a `#if !TARGET_OS_TV` guard (its call site already had one), breaking the tvOS build. This adds the missing guard.

Failing job: https://github.com/software-mansion/react-native-reanimated/actions/runs/28991893251/job/86033355439

Verified locally: `tvos-example` now builds for the tvOS Simulator